### PR TITLE
Feat(web): Add ESlint rule to prevent use of 'process.env' within the source code.

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-process-env":"error"
+  }
 }


### PR DESCRIPTION
Since we are using 't3-env' to support typesafe environment variables across the web app.

This PR adds an ESlint rule in the apps/web project to avoid the direct access of environment variables in the source code.

During Development: 
![Screenshot 2023-11-27 at 5 09 09 AM](https://github.com/elie222/inbox-zero/assets/85648738/0bb8c034-dda8-4f73-90f6-11a0fc311a12)

After  `npm run lint`:

![Screenshot 2023-11-27 at 5 10 21 AM](https://github.com/elie222/inbox-zero/assets/85648738/0ce2ce66-eab1-4bdd-90c4-946b794b87f5)

