### PR TITLE
Easier local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ Explore our upcoming features and improvements on our [Roadmap](https://www.geti
 
 - [Node.js](https://nodejs.org/en/) >= 18.0.0
 - [pnpm](https://pnpm.io/) >= 8.6.12
+- [Docker desktop](https://www.docker.com/products/docker-desktop/)
+
+The external services that are required are:
+
+- [OpenAI](https://platform.openai.com/api-keys)
+- [Google OAuth](https://console.cloud.google.com/apis/credentials)
+- [Google PubSub](https://console.cloud.google.com/cloudpubsub/topic/list) - see set up instructions below
+- [Upstash Redis](https://upstash.com/)
+- [Tinybird](https://www.tinybird.co/)
+
+We use Postgres for the database.
+
+You can run Postgres & Redis locally using `docker-compose`
+
+```bash
+docker-compose up -d # -d will run the services in the background
+```
 
 Create your own `.env` file:
 
@@ -64,15 +81,13 @@ pnpm install
 
 Set the environment variables in the newly created `.env`. You can see a list of required variables in: `apps/web/env.mjs`.
 
-The external services that are required are:
+The required environment variables:
 
-- [OpenAI](https://platform.openai.com/api-keys)
-- [Google OAuth](https://console.cloud.google.com/apis/credentials)
-- [Google PubSub](https://console.cloud.google.com/cloudpubsub/topic/list) - see set up instructions below
-- [Upstash Redis](https://upstash.com/)
-- [Tinybird](https://www.tinybird.co/)
-
-We use Postgres for the database.
+- `NEXTAUTH_SECRET` -- can be any random string (try using `openssl rand -hex 32` for a quick secure random string)
+- `GOOGLE_CLIENT_ID` -- Google OAuth client ID. More info [here](https://next-auth.js.org/providers/google)
+- `GOOGLE_CLIENT_SECRET` -- Google OAuth client secret. More info [here](https://next-auth.js.org/providers/google)
+- `TINYBIRD_TOKEN` -- Admin token for your Tinybird workspace (be sure to create an instance in the GCP `us-east4` region).
+- `OPENAI_API_KEY` -- Standard OpenAI API key.
 
 To run the migrations:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ turbo dev
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 To upgrade yourself to admin visit: [http://localhost:3000/admin](http://localhost:3000/admin).
 
+### Setting up Tinybird
+
+Follow the instructions [here](./packages/tinybird/README.md) to setup the `pipes` and `datasources`.
+
 ### Set up push notifications via Google PubSub to handle emails in real time
 
 Follow instructions [here](https://developers.google.com/gmail/api/guides/push).

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=public"
+DIRECT_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=public"
 
 NEXTAUTH_URL=http://localhost:3000
 # Generate a random secret here: https://generate-secret.vercel.app/32

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
-DATABASE_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=public"
-DIRECT_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=public"
+DATABASE_URL="postgresql://postgres:password@localhost:8009/inboxzero?schema=public"
+DIRECT_URL="postgresql://postgres:password@localhost:8009/inboxzero?schema=public"
 
 NEXTAUTH_URL=http://localhost:3000
 # Generate a random secret here: https://generate-secret.vercel.app/32
@@ -10,8 +10,8 @@ GOOGLE_CLIENT_SECRET=
 
 OPENAI_API_KEY=
 
-UPSTASH_REDIS_URL=
-UPSTASH_REDIS_TOKEN=
+UPSTASH_REDIS_URL=redis://localhost:6380
+UPSTASH_REDIS_TOKEN=''
 
 TINYBIRD_TOKEN=
 TINYBIRD_BASE_URL=https://api.us-east.tinybird.co/

--- a/apps/web/env.mjs
+++ b/apps/web/env.mjs
@@ -11,7 +11,7 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: z.string().min(1),
     OPENAI_API_KEY: z.string().min(1),
     UPSTASH_REDIS_URL: z.string().min(1),
-    UPSTASH_REDIS_TOKEN: z.string().min(1),
+    UPSTASH_REDIS_TOKEN: z.string().optional(),
     GOOGLE_PUBSUB_TOPIC_NAME: z.string().min(1),
     BASELIME_PROJECT_NAME: z.string().optional(),
     BASELIME_KEY: z.string().optional(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.5"
+services:
+  db:
+    image: "postgres"
+    restart: always
+    container_name: inbox-zero
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_DB: "inboxzero"
+      POSTGRES_PASSWORD: password
+    volumes:
+      - database-data:/var/lib/postgresql/data/
+    expose:
+      - 5432
+    ports:
+      - 8009:5432
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+  redis:
+    image: redis
+    ports:
+      - 6380:6379
+    expose:
+      - 6379
+    volumes:
+      - database-data:/data
+
+volumes:
+  database-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,6 @@ services:
     ports:
       - 8009:5432
 
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - 8080:8080
-
   redis:
     image: redis
     ports:


### PR DESCRIPTION
- Include a `docker-compose` file which can standup a local redis & postgres server
- Include a link to the Tinybird README, with a mention to it in the main README
- Updated the `.env.example` to include the required `DIRECT_URL` env var -- its required for the prisma migration tool
- Default the redis host env var to local redis
- Don't require redis token, given that you can use local redis which has no auth by default