### PR TITLE
Fix hydration errors for banner on /mail router.

### DIFF
--- a/apps/web/app/(app)/mail/page.tsx
+++ b/apps/web/app/(app)/mail/page.tsx
@@ -26,7 +26,7 @@ export default function Mail() {
 
   return (
     <>
-      {bannerVisible && typeof window !== "undefined" && (
+      {bannerVisible && (
         <Banner
           title="Beta"
           description="Mail is currently in beta. It is not intended to be a full replacement for your email client yet."

--- a/apps/web/app/(app)/newsletters/NewsletterStats.tsx
+++ b/apps/web/app/(app)/newsletters/NewsletterStats.tsx
@@ -94,7 +94,7 @@ export function NewsletterStats(props: {
         <div className="items-center justify-between px-6 pt-6 md:flex">
           <SectionHeader
             title="Which newsletters and marketing emails do you get the most?"
-            description="A list of are your email subscriptions. Quickly unsubscribe or view the emails in more detail."
+            description="A list of all your email subscriptions. Quickly unsubscribe or view the emails in more detail."
           />
           <div className="ml-4 mt-3 flex justify-end space-x-2 md:mt-0">
             <div className="hidden md:block">


### PR DESCRIPTION
This PR fixes :- 

- Hydration errors when user navigates to /mail route on the web app.

Before
<img width="1440" alt="Screenshot 2023-12-27 at 6 58 10 PM" src="https://github.com/elie222/inbox-zero/assets/85648738/456ef59c-0f07-4c14-881e-9675a1b011d9">

After
<img width="1437" alt="Screenshot 2023-12-27 at 6 56 13 PM" src="https://github.com/elie222/inbox-zero/assets/85648738/0b06c53a-1552-4145-ae98-66e8e9eaecd5">



