### PR TITLE
compose: multiselect for recipient field

### DIFF
--- a/apps/web/app/(app)/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/compose/ComposeEmailForm.tsx
@@ -14,6 +14,7 @@ import { env } from "@/env.mjs";
 import { Editor as NovelEditor } from "novel";
 import { Combobox } from "@headlessui/react";
 import Image from "next/image";
+import { z } from "zod";
 
 export const ComposeEmailForm = () => {
   const {
@@ -61,6 +62,17 @@ export const ComposeEmailForm = () => {
     setValue("to", filteredEmailAddresses.join(","));
   };
 
+  const handleComboboxOnChange = (values: string[]) => {
+    // this assumes last value given by combobox is user typed value
+    const lastValue = values[values.length - 1];
+
+    const { success } = z.string().email().safeParse(lastValue);
+    if (success) {
+      setValue("to", values.join(","));
+      setSearchQuery("");
+    }
+  };
+
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       {env.NEXT_PUBLIC_CONTACTS_ENABLED ? (
@@ -68,10 +80,7 @@ export const ComposeEmailForm = () => {
           <Label name="to" label="Recipient" />
           <Combobox
             value={selectedEmailAddressses}
-            onChange={(value) => {
-              setValue("to", value.join(","));
-              setSearchQuery("");
-            }}
+            onChange={handleComboboxOnChange}
             multiple
             nullable={true}
           >
@@ -110,6 +119,10 @@ export const ComposeEmailForm = () => {
               />
             </div>
             <Combobox.Options className="mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+              <Combobox.Option
+                className="h-0 w-0 overflow-hidden"
+                value={searchQuery}
+              />
               {data?.result.map((contact) => {
                 const person = {
                   emailAddress: contact.person?.emailAddresses?.[0].value,

--- a/apps/web/app/(app)/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/compose/ComposeEmailForm.tsx
@@ -15,6 +15,8 @@ import { Editor as NovelEditor } from "novel";
 import { Combobox } from "@headlessui/react";
 import Image from "next/image";
 import { z } from "zod";
+import "./novelEditorStyles.css";
+import clsx from "clsx";
 
 export const ComposeEmailForm = () => {
   const {
@@ -84,11 +86,11 @@ export const ComposeEmailForm = () => {
             multiple
             nullable={true}
           >
-            <div className="border-1 flex border">
+            <div className="border-1 flex rounded-md border">
               {selectedEmailAddressses.map((emailAddress) => (
                 <span
                   key={emailAddress}
-                  className="m-2 inline-flex items-center rounded-md bg-gray-50 p-4 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
+                  className="m-2 inline-flex items-center rounded-md bg-gray-50 p-4 px-2 py-1 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10"
                 >
                   {emailAddress}
                   <button
@@ -114,11 +116,16 @@ export const ComposeEmailForm = () => {
 
               <Combobox.Input
                 value={searchQuery}
-                className="w-full border-none"
+                className="w-full rounded-md border-none py-1 text-lg outline-0 focus:border-none focus:ring-0"
                 onChange={(event) => setSearchQuery(event.target.value)}
               />
             </div>
-            <Combobox.Options className="mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+            <Combobox.Options
+              className={clsx(
+                data?.result && data.result.length === 0 && "hidden",
+                "mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm",
+              )}
+            >
               <Combobox.Option
                 className="h-0 w-0 overflow-hidden"
                 value={searchQuery}
@@ -164,13 +171,13 @@ export const ComposeEmailForm = () => {
                               <path
                                 className="fill-gray-500"
                                 d="M16.145,2.571c-0.272-0.273-0.718-0.273-0.99,0L6.92,10.804l-4.241-4.27
-                         c-0.272-0.274-0.715-0.274-0.989,0L0.204,8.019c-0.272,0.271-0.272,0.717,0,0.99l6.217,6.258c0.272,0.271,0.715,0.271,0.99,0
-                         L17.63,5.047c0.276-0.273,0.276-0.72,0-0.994L16.145,2.571z"
+                           c-0.272-0.274-0.715-0.274-0.989,0L0.204,8.019c-0.272,0.271-0.272,0.717,0,0.99l6.217,6.258c0.272,0.271,0.715,0.271,0.99,0
+                           L17.63,5.047c0.276-0.273,0.276-0.72,0-0.994L16.145,2.571z"
                               />
                             </g>
                           </svg>
                         )}
-                        <div className="mx-2 flex flex-col">
+                        <div className="mx-2 flex flex-col items-center justify-center">
                           <div>{person.name}</div>
                           <div>{person.emailAddress}</div>
                         </div>
@@ -195,21 +202,24 @@ export const ComposeEmailForm = () => {
       <Input
         type="text"
         name="subject"
-        label="Subject"
         registerProps={register("subject", { required: true })}
         error={errors.subject}
+        placeholder="Subject"
+        className="block w-full flex-1 rounded-md border-gray-300 py-1 text-lg outline-0 focus:border-gray-300 focus:ring-0"
       />
 
-      <NovelEditor
-        defaultValue=""
-        disableLocalStorage={true}
-        completionApi="api/ai/compose-autocomplete"
-        onUpdate={(editor) => {
-          editor = editor!;
-          setValue("messageText", editor.getText());
-          setValue("messageHtml", editor.getHTML());
-        }}
-      />
+      <div className="compose-novel">
+        <NovelEditor
+          defaultValue=""
+          disableLocalStorage={true}
+          completionApi="api/ai/compose-autocomplete"
+          onUpdate={(editor) => {
+            editor = editor!;
+            setValue("messageText", editor.getText());
+            setValue("messageHtml", editor.getHTML());
+          }}
+        />
+      </div>
 
       <Button
         type="submit"

--- a/apps/web/app/(app)/compose/novelEditorStyles.css
+++ b/apps/web/app/(app)/compose/novelEditorStyles.css
@@ -1,0 +1,8 @@
+.compose-novel .ProseMirror {
+  padding: 1rem 2rem;
+}
+
+.compose-novel .novel-max-w-screen-lg {
+  max-width: none;
+  margin: 0px;
+}

--- a/apps/web/components/Input.tsx
+++ b/apps/web/components/Input.tsx
@@ -21,6 +21,7 @@ export interface InputProps {
   leftText?: string;
   rightText?: string;
   condensed?: boolean;
+  className?: string;
   onClickAdd?: () => void;
   onClickRemove?: () => void;
 }
@@ -40,6 +41,7 @@ export const Input = (props: InputProps) => {
     max: props.max,
     step: props.step,
     disabled: props.disabled,
+    className: props.className,
     ...props.registerProps,
   };
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,6 +19,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "ph-avatars.imgix.net",
       },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
     ],
   },
   async redirects() {

--- a/apps/web/utils/gmail/contact.ts
+++ b/apps/web/utils/gmail/contact.ts
@@ -1,9 +1,15 @@
 import { people_v1 } from "googleapis";
 
 export async function searchContacts(client: people_v1.People, query: string) {
+  const readMasks: (keyof people_v1.Schema$Person)[] = [
+    "names",
+    "emailAddresses",
+    "photos",
+  ];
+
   const res = await client.people.searchContacts({
     query,
-    readMask: "names,emailAddresses",
+    readMask: readMasks.join(","),
     pageSize: 10,
   });
 


### PR DESCRIPTION
Added mutiselect for compose recipient field.

using headless ui as planned because shadcn doesn't support multi select in combobox.

i also noticed headless ui combobox doesn't support editable dropdown. we need that for typing or copy pasting email address :) Refer -> (https://github.com/tailwindlabs/headlessui/discussions/1228)

need to decide how to proceed from here for adding editable field -> try workaround or use another component

![Xnapper-2024-01-09-05 00 03](https://github.com/elie222/inbox-zero/assets/8388242/cc804a10-dc78-49ca-8892-4be2e63aa683)
