### PR TITLE
Add a service worker.

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -9,6 +9,7 @@ import { Inter } from "next/font/google";
 import localFont from "next/font/local";
 import { env } from "@/env.mjs";
 import Providers from "@/app/(app)/providers";
+import Script from "next/script";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -72,6 +73,7 @@ export default function RootLayout({
         </PostHogProvider>
         <SpeedInsights />
         <Analytics />
+        <Script src="/service-worker.js" strategy="beforeInteractive" />
         {env.NEXT_PUBLIC_GTM_ID ? (
           <GoogleTagManager gtmId={env.NEXT_PUBLIC_GTM_ID} />
         ) : null}

--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,13 @@
+function registerServiceWorker() {
+    console.log("registerServiceWorker fired");
+    if (typeof window !== "undefined") {
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("/sw.js").then((registration) => {
+          console.log("Service Worker registration successful:", registration);
+        });
+      }
+    }
+  }
+  
+  registerServiceWorker();
+  

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,63 @@
+const version = 1;
+const database = "inbox-zero";
+const dbVersion = 1;
+let DB = null;
+const LABEL_STORE = {
+    name: "labels",
+    key: "id",
+    indexes: [],
+};
+const EMAIL_STORE = {
+    name: "emails",
+    key: "gmailMessageId",
+    indexes: [{ name: "timestamp", property: "timestamp", params: {} }],
+};
+const ALL_STORES = [LABEL_STORE, EMAIL_STORE];
+
+self.addEventListener("install", (_event) => {
+    console.log(`Version ${version} installed`);
+    self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+    event.waitUntil(openDB());
+    console.log("activated");
+});
+  
+self.addEventListener("fetch", () => {
+  console.log("intercepted a fetch");
+});
+
+const openDB = () => {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(database, dbVersion);
+        req.onerror = (err) => {
+            //could not open db
+            console.warn(err);
+            DB = null;
+            reject(err);
+        };
+        req.onupgradeneeded = (ev) => {
+            const db = ev.target.result;
+            for (const store of ALL_STORES) {
+                const { name, key, indexes } = store;
+                if (!db.objectStoreNames.contains(name)) {
+                    const objectStore = db.createObjectStore(name, {
+                        keyPath: key,
+                    });
+
+                    for (const index of indexes) {
+                        const { name, property, params } = index;
+                        objectStore.createIndex(name, property, params);
+                    }
+                }
+            }
+        };
+        req.onsuccess = (ev) => {
+            DB = ev.target.result;
+            console.log("db opened and upgraded as needed");
+            resolve();
+        };
+    });
+};
+


### PR DESCRIPTION
Issue :- #54 

This PR adds :- 

1. A basic service worker at the top level app layout.
2. Creates indexeddb schema with specified indexes and a connection object to the database.

![Screenshot 2024-02-20 at 2 19 42 AM](https://github.com/elie222/inbox-zero/assets/85648738/01225961-ed60-4c81-bf16-d00dc59a682a)


Service worker is registered at the top level of app to ensure installation, activation and registration as soon as user uses the app.

This ensures :- 
- Service worker is running before the user logs into the app.
- The db connection object is available readily to respond with cached information since the first page of app.
- Since there is only one service worker allowed per scope, a root level service worker can be used to cache static resources from the very first page.