### PR TITLE
feat: Add double-click functionality to open newsletter rows

### DIFF
--- a/apps/web/app/(app)/bulk-unsubscribe/NewsletterStats.tsx
+++ b/apps/web/app/(app)/bulk-unsubscribe/NewsletterStats.tsx
@@ -185,6 +185,7 @@ export function NewsletterStats(props: {
                       onSelectRow={() => {
                         setSelectedRow(item);
                       }}
+                      onDoubleClick={setOpenedNewsletter(item)}
                       hasUnsubscribeAccess={hasUnsubscribeAccess}
                       refetchPremium={refetchPremium}
                       openPremiumModal={openModal}
@@ -261,6 +262,7 @@ function NewsletterRow(props: {
   mutate: () => Promise<any>;
   selected: boolean;
   onSelectRow: () => void;
+  onDoubleClick: () => void;
   hasUnsubscribeAccess: boolean;
   refetchPremium: () => Promise<any>;
   openPremiumModal: () => void;
@@ -277,6 +279,7 @@ function NewsletterRow(props: {
       aria-selected={props.selected || undefined}
       data-selected={props.selected || undefined}
       onMouseEnter={props.onSelectRow}
+      onDoubleClick={onDoubleClick}
     >
       <TableCell className="max-w-[250px] truncate pl-6 min-[1550px]:max-w-[300px] min-[1650px]:max-w-none">
         {item.name}


### PR DESCRIPTION
I need a way to quickly open/glimpse the details of a Newsletter row. I need to see more than just the sender to identify whether a newsletter is one I need to unsubscribe from or not.