### PR TITLE
FIxed: Largest items in inbox size in NaN

### DIFF
--- a/apps/web/app/(app)/stats/LargestEmails.tsx
+++ b/apps/web/app/(app)/stats/LargestEmails.tsx
@@ -26,6 +26,7 @@ import { Button, ButtonLoader } from "@/components/ui/button";
 import { onTrashMessage } from "@/utils/actions/client";
 import { useState } from "react";
 import type { Attachment } from "@/utils/types";
+import { sumBy } from "lodash";
 export function LargestEmails(props: { refreshInterval: number }) {
   const session = useSession();
   const { data, isLoading, error, mutate } = useSWRImmutable<
@@ -39,12 +40,7 @@ export function LargestEmails(props: { refreshInterval: number }) {
 
   // Function to calculte total attachement size
   const calculateTotalAttachmentSize = (attachments?: Attachment[]): number => {
-    return (
-      attachments?.reduce(
-        (sum: number, attachment: Attachment) => sum + attachment.size,
-        0,
-      ) || 0
-    );
+    return sumBy(attachments, "size") || 0;
   };
 
   return (

--- a/apps/web/app/(app)/stats/LargestEmails.tsx
+++ b/apps/web/app/(app)/stats/LargestEmails.tsx
@@ -25,7 +25,7 @@ import { getGmailUrl } from "@/utils/url";
 import { Button, ButtonLoader } from "@/components/ui/button";
 import { onTrashMessage } from "@/utils/actions/client";
 import { useState } from "react";
-import { Attachment } from "@/utils/types";
+import type { Attachment } from "@/utils/types";
 export function LargestEmails(props: { refreshInterval: number }) {
   const session = useSession();
   const { data, isLoading, error, mutate } = useSWRImmutable<

--- a/apps/web/app/(app)/stats/LargestEmails.tsx
+++ b/apps/web/app/(app)/stats/LargestEmails.tsx
@@ -25,6 +25,7 @@ import { getGmailUrl } from "@/utils/url";
 import { Button, ButtonLoader } from "@/components/ui/button";
 import { onTrashMessage } from "@/utils/actions/client";
 import { useState } from "react";
+import { Attachment } from "@/utils/types";
 export function LargestEmails(props: { refreshInterval: number }) {
   const session = useSession();
   const { data, isLoading, error, mutate } = useSWRImmutable<
@@ -35,6 +36,16 @@ export function LargestEmails(props: { refreshInterval: number }) {
   });
 
   const { expanded, extra } = useExpanded();
+
+  // Function to calculte total attachement size
+  const calculateTotalAttachmentSize = (attachments?: Attachment[]): number => {
+    return (
+      attachments?.reduce(
+        (sum: number, attachment: Attachment) => sum + attachment.size,
+        0,
+      ) || 0
+    );
+  };
 
   return (
     <LoadingContent
@@ -60,6 +71,10 @@ export function LargestEmails(props: { refreshInterval: number }) {
               {data.largestEmails
                 .slice(0, expanded ? undefined : 5)
                 .map((item) => {
+                  // Calculate the total size of all attachements for each email
+                  const totalAttachmentSize = calculateTotalAttachmentSize(
+                    item.attachments,
+                  );
                   return (
                     <TableRow key={item.id}>
                       <TableCell>{item.headers.from}</TableCell>
@@ -73,7 +88,7 @@ export function LargestEmails(props: { refreshInterval: number }) {
                         })}
                       </TableCell>
                       <TableCell>
-                        {bytesToMegabytes(item.sizeEstimate!).toFixed(1)} MB
+                        {bytesToMegabytes(totalAttachmentSize).toFixed(1)} MB
                       </TableCell>
                       <TableCell>
                         <Button asChild variant="secondary" size="sm">

--- a/apps/web/utils/types.ts
+++ b/apps/web/utils/types.ts
@@ -50,7 +50,7 @@ export interface ParsedMessage extends gmail_v1.Schema$Message {
   textHtml?: string;
 }
 
-interface Attachment {
+export interface Attachment {
   filename: string;
   mimeType: string;
   size: number;


### PR DESCRIPTION
### Description
This PR fixes a feature to calculate the total size of email attachments and display it in the UI.

### Changes
- Added a function to calculate the total size of attachments.
- Updated the UI to display the total size of attachments in MB.


<img width="836" alt="Screenshot 2024-07-05 100212" src="https://github.com/elie222/inbox-zero/assets/141320957/8f5d428f-ecd9-4b87-8dd8-617eb2be50d1">

### Related Issue
Fixes #182 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced email statistics by adding a feature to calculate and display the total size of attachments for each email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->