### PR TITLE
Feat: Dockerized for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,4 @@ dist
 .react-email
 
 .sentryclirc
-.vscode/settings.json
 .pnpm-store/*

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ dist
 .react-email
 
 .sentryclirc
+.vscode/settings.json
+.pnpm-store/*

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pnpm install
+pnpm prisma migrate dev
+pnpm run dev 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000 -H 0.0.0.0",
     "build": "NODE_OPTIONS=--max_old_space_size=8192 prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3000 -H 0.0.0.0",
+    "dev": "next dev -H 0.0.0.0",
     "build": "NODE_OPTIONS=--max_old_space_size=8192 prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - database-data:/var/lib/postgresql/data/
     ports:
       - 5432:5432
+    network_mode: host
 
   redis:
     image: redis
@@ -30,6 +31,19 @@ services:
       SRH_MODE: env
       SRH_TOKEN: ${UPSTASH_REDIS_TOKEN}
       SRH_CONNECTION_STRING: "redis://redis:6379" # Using `redis` hostname since they're in the same Docker network.
+
+  web:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.web
+    env_file:
+      - ./.env
+    depends_on:
+      - db
+      # - redis
+    ports:
+      - 3000:3000
+    network_mode: host
 
 volumes:
   database-data:

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN npm install -g pnpm 
+
+COPY . .
+
+WORKDIR /app/apps/web
+
+CMD ["/bin/sh", "/app/apps/web/entrypoint.sh"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ncu": "ncu -u -ws"
   },
   "devDependencies": {
+    "prisma": "^4.0.0",
     "@turbo/gen": "^1.11.3",
     "eslint": "^8.56.0",
     "eslint-config-custom": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "ncu": "ncu -u -ws"
   },
   "devDependencies": {
-    "prisma": "^4.0.0",
     "@turbo/gen": "^1.11.3",
     "eslint": "^8.56.0",
     "eslint-config-custom": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -45,7 +45,8 @@
     "lint": {},
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "args": ["--host", "0.0.0.0"]
     }
   }
 }


### PR DESCRIPTION
Removes the need to set up node and pnpm and next etc.

To run:

set the `.env` file and

```
docker compose up -d
```

For docker desktop, you might need to enable this host networking

![image](https://github.com/elie222/inbox-zero/assets/6279035/1baa0e48-eb8c-4bfa-a2fa-c3dea62e734e)
