### PR TITLE
fix scroll issue in email thread

### DIFF
--- a/apps/web/components/email-list/EmailPanel.tsx
+++ b/apps/web/components/email-list/EmailPanel.tsx
@@ -181,7 +181,7 @@ function EmailMessage(props: {
               {formatShortDate(new Date(message.headers.date))}
             </time>
           </p>
-          <div className="flex items-center">
+          <div className="relative flex items-center">
             <Tooltip content="Reply">
               <Button variant="ghost" size="icon" onClick={onReply}>
                 <ReplyIcon className="h-4 w-4" />


### PR DESCRIPTION
The tooltip in the <li> in EmailPanel was causing this issue. 
Adding relative position fixed it and now it works as expected.

fixes #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved layout and positioning of elements within the Email Panel for better display and interaction.
  
- **Style**
	- Updated the structure of the Email Panel to enhance the visual representation and dynamics of child components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->