### PR TITLE
Adding a key step -- to change into the packages/tinybird directory

### DIFF
--- a/packages/tinybird/README.md
+++ b/packages/tinybird/README.md
@@ -17,6 +17,12 @@ Thereafter:
 source .venv/bin/activate
 ```
 
+Then change into the directory
+
+```sh
+cd packages/tinybird
+```
+
 ### Docker
 
 You can also use the Docker image. This worked a lot better for me.


### PR DESCRIPTION
I was working through the install instructions and this step kept failing

tb push datasources
# or:
tb push datasources/email.datasource

The key requirement is to cd into packages/tinybird first.

This is a minor update that adds that step to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the "Getting Started" section of the Tinybird package README to include a new instruction for navigating to the `packages/tinybird` directory after activating the virtual environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->