### PR TITLE
Replace <img /> with <Image /> component for user profile in TopNav

### DIFF
--- a/apps/web/components/TopNav.tsx
+++ b/apps/web/components/TopNav.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/Button";
 import { logOut } from "@/utils/user";
 import { env } from "@/env";
+import Image from "next/image";
 
 const userNavigation = [
   ...(env.NEXT_PUBLIC_DISABLE_TINYBIRD
@@ -83,9 +84,10 @@ function ProfileDropdown() {
         <MenuButton className="-m-1.5 flex items-center p-1.5">
           <span className="sr-only">Open user menu</span>
           {session.user.image ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              className="h-8 w-8 rounded-full bg-gray-50"
+            <Image
+              width={32}
+              height={32}
+              className="rounded-full bg-gray-50"
               src={session.user.image}
               alt="Profile"
             />


### PR DESCRIPTION
Replaced the <img> tag with Next.js Image component in the ProfileDropdown for optimized image rendering.

Key Changes
	•	Switched to next/image for user profile image.
	
before running locally with <img>:
<img width="65" alt="image" src="https://github.com/user-attachments/assets/0a1ab679-ae89-480c-908a-528d1dbedc08" />

after <Image /> component:
<img width="128" alt="image" src="https://github.com/user-attachments/assets/6f93e14f-72b2-41f3-ab4a-7622b4855b7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated profile image rendering to use Next.js `Image` component
  - Added rounded styling and background color to profile image
  - Optimized image display with specified width and height

<!-- end of auto-generated comment: release notes by coderabbit.ai -->