### PR TITLE
Option to mark cold emails as read

### DIFF
--- a/apps/web/app/(app)/cold-email-blocker/ColdEmailSettings.tsx
+++ b/apps/web/app/(app)/cold-email-blocker/ColdEmailSettings.tsx
@@ -86,15 +86,19 @@ export function ColdEmailForm({
   }[] = useMemo(
     () => [
       {
+        value: ColdEmailSetting.ARCHIVE_AND_READ_AND_LABEL,
+        label: "Archive, Mark Read & Label",
+        description: "Archive cold emails, mark them as read, and label them",
+      },
+      {
         value: ColdEmailSetting.ARCHIVE_AND_LABEL,
         label: "Archive & Label",
-        description: "Automatically archive and label cold emails",
+        description: "Archive cold emails and label them",
       },
       {
         value: ColdEmailSetting.LABEL,
         label: "Label Only",
-        description:
-          "Label cold emails as 'Cold Email', but keep them in my inbox",
+        description: "Label cold emails, but keep them in my inbox",
       },
       {
         value: ColdEmailSetting.DISABLED,

--- a/apps/web/app/api/user/settings/cold-email/validation.ts
+++ b/apps/web/app/api/user/settings/cold-email/validation.ts
@@ -8,6 +8,7 @@ export const updateColdEmailSettingsBody = z.object({
       ColdEmailSetting.LIST,
       ColdEmailSetting.LABEL,
       ColdEmailSetting.ARCHIVE_AND_LABEL,
+      ColdEmailSetting.ARCHIVE_AND_READ_AND_LABEL,
     ])
     .nullish(),
   coldEmailPrompt: z.string().nullish(),

--- a/apps/web/prisma/migrations/20250130215802_read_cold_emails/migration.sql
+++ b/apps/web/prisma/migrations/20250130215802_read_cold_emails/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ColdEmailSetting" ADD VALUE 'ARCHIVE_AND_READ_AND_LABEL';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -412,6 +412,7 @@ enum ColdEmailSetting {
   LIST
   LABEL
   ARCHIVE_AND_LABEL
+  ARCHIVE_AND_READ_AND_LABEL
 }
 
 enum PremiumTier {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new cold email blocking option: Archive, Mark as Read, and Label
  - Enhanced cold email settings with more granular control

- **Improvements**
  - Refined descriptions for existing cold email blocking options
  - Updated email processing logic to support new setting

- **Technical Updates**
  - Added new enum value for cold email settings
  - Enforced unique account constraint for users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->