### PR TITLE
Add withHeader atribute to EmailThread. Add in EmailViewer so it show…

### DIFF
--- a/apps/web/components/EmailViewer.tsx
+++ b/apps/web/components/EmailViewer.tsx
@@ -66,6 +66,7 @@ export function ThreadContent({
             autoOpenReplyForMessageId={autoOpenReplyForMessageId}
             topRightComponent={topRightComponent}
             onSendSuccess={onSendSuccess}
+            withHeader
           />
         )}
       </LoadingContent>

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -9,6 +9,7 @@ export function EmailThread({
   autoOpenReplyForMessageId,
   topRightComponent,
   onSendSuccess,
+  withHeader,
 }: {
   messages: ThreadMessage[];
   refetch: () => void;
@@ -16,6 +17,7 @@ export function EmailThread({
   autoOpenReplyForMessageId?: string;
   topRightComponent?: React.ReactNode;
   onSendSuccess?: (messageId: string, threadId: string) => void;
+  withHeader?: boolean;
 }) {
   // Place draft messages as replies to their parent message
   const organizedMessages = useMemo(() => {
@@ -50,14 +52,16 @@ export function EmailThread({
 
   return (
     <div className="flex-1 overflow-auto bg-muted p-4">
-      <div className="flex items-center justify-between">
-        <div className="text-2xl font-semibold text-foreground">
-          {messages[0]?.headers.subject}
+      {withHeader && (
+        <div className="flex items-center justify-between">
+          <div className="text-2xl font-semibold text-foreground">
+            {messages[0]?.headers.subject}
+          </div>
+          {topRightComponent && (
+            <div className="flex items-center gap-2">{topRightComponent}</div>
+          )}
         </div>
-        {topRightComponent && (
-          <div className="flex items-center gap-2">{topRightComponent}</div>
-        )}
-      </div>
+      )}
       <ul className="mt-4 space-y-2 sm:space-y-4">
         {organizedMessages.map(({ message, draftMessage }) => {
           const defaultShowReply =


### PR DESCRIPTION
This pull request introduces a new attribute to conditionally display a header in the `EmailThread` component, rendering the header conditionally to this attribute (defaults to false). Then it pass it on EmailViewer so Reply Zero keeps showing it.

### Conditional Header in `EmailThread`

* [`apps/web/components/EmailViewer.tsx`](diffhunk://#diff-148ce93015f34c90270ef6ef46087dcbc24a8ae4280279759b4f30f9d2796c12R69): Added the `withHeader` prop to the `ThreadContent` component to enable conditional rendering of the header.

* `apps/web/components/email-list/EmailThread.tsx`: 
  * Added the `withHeader` prop to the `EmailThread` component's props definition.
  * Included conditional rendering logic to display the header if the `withHeader` prop is true. [[1]](diffhunk://#diff-09fee96f2b5d013104b2feeaadcd30829f0a3e846274fb57babbf4521a6495d9R55) [[2]](diffhunk://#diff-09fee96f2b5d013104b2feeaadcd30829f0a3e846274fb57babbf4521a6495d9R64)

closes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to display a header within email threads. When enabled, users can see additional contextual details, such as the email subject and related information, enhancing clarity and navigation during email viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->