### PR TITLE
Fix resize handler positioning & add full screen by default in mail

### DIFF
--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -367,7 +367,7 @@ export function EmailList({
   return (
     <>
       {!(isEmpty && hideActionBarWhenEmpty) && (
-        <div className="flex items-center border-b border-l-4 border-border bg-background px-4 py-1">
+        <div className="flex h-12 items-center border-b border-l-4 border-border bg-background px-4 py-1">
           <div className="pl-1">
             <Checkbox checked={isAllSelected} onChange={onToggleSelectAll} />
           </div>
@@ -419,6 +419,7 @@ export function EmailList({
         </div>
       ) : (
         <ResizeGroup
+          onlyRight={!!openThreadId}
           left={
             <ul
               className="divide-y divide-border overflow-y-auto scroll-smooth"
@@ -509,21 +510,35 @@ export function EmailList({
 function ResizeGroup({
   left,
   right,
+  onlyRight = false,
 }: {
   left: React.ReactNode;
   right?: React.ReactNode;
+  onlyRight?: boolean;
 }) {
   if (!right) return left;
+  const leftSize = onlyRight ? 0 : 50;
+  const rightSize = onlyRight ? 100 : 50;
 
   return (
-    <ResizablePanelGroup direction="horizontal">
-      <ResizablePanel style={{ overflow: "auto" }} defaultSize={50} minSize={0}>
-        {left}
-      </ResizablePanel>
-      <ResizableHandle withHandle />
-      <ResizablePanel defaultSize={50} minSize={0}>
-        {right}
-      </ResizablePanel>
-    </ResizablePanelGroup>
+    <div className="flex max-h-[calc(100svh-theme(spacing.12)-theme(spacing.16))] overflow-hidden">
+      <ResizablePanelGroup direction="horizontal" className="w-full">
+        <ResizablePanel
+          defaultSize={leftSize}
+          minSize={0}
+          className="overflow-hidden"
+        >
+          <div className="h-full overflow-auto">{left}</div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel
+          defaultSize={rightSize}
+          minSize={0}
+          className="overflow-hidden"
+        >
+          <div className="h-full overflow-auto">{right}</div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
   );
 }


### PR DESCRIPTION
This pull request includes changes to the `EmailList` component in the `apps/web/components/email-list/EmailList.tsx` file. The main focus of these changes is:

- Make full screen by default (keeping the handler of the resizable group)

- Fix the positoning of the handler (it was being centered to the whole liste of emails instead of the ones in viewport, which made it not obvious). Now is centered.

- Make the resizeable pannels to scroll independently

Comment: Had to set the height of the wrapper around ActionButtonsBulk explicitly. Otherwise the app layout managed the scroll instead.

Enhancements to EmailList component:

* Adjusted the height of the action bar container to `h-12` for consistent sizing.
* Added a conditional `onlyRight` prop to the `ResizeGroup` component to control the visibility and size of the left and right panels based on whether a thread is open. [[1]](diffhunk://#diff-8a440eb2743cdcc3281780e0489d1805dd0d003196f5b017034acb35d64af5c0R422) [[2]](diffhunk://#diff-8a440eb2743cdcc3281780e0489d1805dd0d003196f5b017034acb35d64af5c0R513-R542)
* Modified the `ResizeGroup` component to dynamically set the sizes of the left and right panels, ensuring that the right panel takes up the full width when `onlyRight` is true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to control panel display, allowing for dynamic adjustment between two panels for a more flexible layout.
  
- **Style**
  - Updated the email list action bar with a fixed height for a consistent, refined visual experience.
  - Improved container styling to ensure content remains neatly contained during panel resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->