### PR TITLE
feat: Mail: reply all button

### DIFF
--- a/apps/web/app/(app)/compose/ComposeEmailForm.tsx
+++ b/apps/web/app/(app)/compose/ComposeEmailForm.tsx
@@ -66,7 +66,7 @@ export const ComposeEmailForm = ({
       replyToEmail: replyingToEmail,
       subject: replyingToEmail?.subject,
       to: replyingToEmail?.to,
-      cc: replyingToEmail?.cc, // Initialize cc field
+      cc: replyingToEmail?.cc,
       messageHtml: replyingToEmail?.draftHtml,
     },
   });
@@ -116,7 +116,7 @@ export const ComposeEmailForm = ({
   );
 
   const [searchQuery, setSearchQuery] = React.useState("");
-  const [searchQueryCc, setSearchQueryCc] = React.useState(""); // New state for CC search
+  const [searchQueryCc, setSearchQueryCc] = React.useState("");
   const { data } = useSWR<ContactsResponse, { error: string }>(
     env.NEXT_PUBLIC_CONTACTS_ENABLED
       ? `/api/google/contacts?query=${searchQuery}`
@@ -126,8 +126,9 @@ export const ComposeEmailForm = ({
     },
   );
 
+  // TODO not in love with how this was implemented
   const selectedEmailAddresses = watch("to", "").split(",").filter(Boolean);
-  const selectedCcAddresses = (watch("cc") || "").split(",").filter(Boolean); // Watch CC field
+  const selectedCcAddresses = (watch("cc") || "").split(",").filter(Boolean);
 
   const onRemoveSelectedEmail = (emailAddress: string, field: "to" | "cc") => {
     const filteredEmailAddresses = (
@@ -136,6 +137,7 @@ export const ComposeEmailForm = ({
     setValue(field, filteredEmailAddresses.join(","));
   };
 
+  // this assumes last value given by combobox is user typed value
   const handleComboboxOnChange = (values: string[], field: "to" | "cc") => {
     const lastValue = values[values.length - 1];
 
@@ -170,7 +172,7 @@ export const ComposeEmailForm = ({
       } catch (error) {
         console.error("Failed to append content:", error);
         toastError({ description: "Failed to show full content" });
-        return;
+        return; // Don't set showFullContent to true if append failed
       }
     }
     setShowFullContent(true);
@@ -314,7 +316,6 @@ export const ComposeEmailForm = ({
                 </Combobox>
               </div>
 
-              {/* Add CC Combobox */}
               <div className="flex space-x-2">
                 <div className="mt-2">
                   <Label name="cc" label="CC" />

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -49,17 +49,17 @@ export function EmailMessage({
   generateNudge?: boolean;
 }) {
   const [showReply, setShowReply] = useState(defaultShowReply || false);
-  const [showReplyAll, setShowReplyAll] = useState(false); // New state for "Reply to All"
+  const [showReplyAll, setShowReplyAll] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
 
   const onReply = useCallback(() => setShowReply(true), []);
-  const onReplyAll = useCallback(() => setShowReplyAll(true), []); // New callback for "Reply to All"
+  const onReplyAll = useCallback(() => setShowReplyAll(true), []);
   const [showForward, setShowForward] = useState(false);
   const onForward = useCallback(() => setShowForward(true), []);
 
   const onCloseCompose = useCallback(() => {
     setShowReply(false);
-    setShowReplyAll(false); // Reset "Reply to All" state
+    setShowReplyAll(false);
     setShowForward(false);
   }, []);
 
@@ -84,7 +84,7 @@ export function EmailMessage({
         toggleDetails={toggleDetails}
         showReplyButton={showReplyButton}
         onReply={onReply}
-        onReplyAll={onReplyAll} // Pass the "Reply to All" callback
+        onReplyAll={onReplyAll}
         onForward={onForward}
       />
 
@@ -107,10 +107,10 @@ export function EmailMessage({
               onSendSuccess={onSendSuccess}
               onCloseCompose={onCloseCompose}
               defaultShowReply={defaultShowReply}
-              showReply={showReply || showReplyAll} // Pass the combined state
+              showReply={showReply || showReplyAll}
               draftMessage={draftMessage}
               generateNudge={generateNudge}
-              replyToAll={showReplyAll} // Pass the "Reply to All" state
+              replyToAll={showReplyAll}
             />
           )}
         </>
@@ -127,7 +127,7 @@ function TopBar({
   showReplyButton,
   onReply,
   onForward,
-  onReplyAll, // New prop for handling "Reply to All"
+  onReplyAll,
 }: {
   message: ParsedMessage;
   expanded: boolean;
@@ -136,7 +136,7 @@ function TopBar({
   showReplyButton: boolean;
   onReply: () => void;
   onForward: () => void;
-  onReplyAll: () => void; // New prop for handling "Reply to All"
+  onReplyAll: () => void;
 }) {
   return (
     <div className="sm:flex sm:items-center sm:justify-between">
@@ -208,7 +208,7 @@ function ReplyPanel({
   showReply,
   draftMessage,
   generateNudge,
-  replyToAll, // New prop for "Reply to All"
+  replyToAll,
 }: {
   message: ParsedMessage;
   refetch: () => void;
@@ -218,23 +218,23 @@ function ReplyPanel({
   showReply: boolean;
   draftMessage?: ThreadMessage;
   generateNudge?: boolean;
-  replyToAll?: boolean; // New prop for "Reply to All"
+  replyToAll?: boolean;
 }) {
   const replyRef = useRef<HTMLDivElement>(null);
 
   const [isGeneratingNudge, setIsGeneratingNudge] = useState(false);
   const [nudge, setNudge] = useState<string | null>(null);
 
-  // Scroll to the reply panel when it first opens
+  // scroll to the reply panel when it first opens
   useEffect(() => {
     if (defaultShowReply && replyRef.current) {
+      // hacky using setTimeout
       setTimeout(() => {
         replyRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
       }, 500);
     }
   }, [defaultShowReply]);
 
-  // Generate nudge if enabled
   useEffect(() => {
     async function loadNudge() {
       setIsGeneratingNudge(true);
@@ -267,12 +267,11 @@ function ReplyPanel({
     if (generateNudge) loadNudge();
   }, [generateNudge, message]);
 
-  // Prepare the email for replying or forwarding
   const replyingToEmail: ReplyingToEmail = useMemo(() => {
     if (showReply) {
       if (draftMessage) return prepareDraftReplyEmail(draftMessage);
 
-      // Use nudge if available
+      // use nudge if available
       if (nudge) {
         const nudgeHtml = nudge
           ? nudge
@@ -283,12 +282,12 @@ function ReplyPanel({
           : "";
 
         return replyToAll
-          ? prepareReplyToAllEmail(message, nudgeHtml) // Use "Reply to All" logic
+          ? prepareReplyToAllEmail(message, nudgeHtml)
           : prepareReplyingToEmail(message, nudgeHtml);
       }
 
       return replyToAll
-        ? prepareReplyToAllEmail(message) // Use "Reply to All" logic
+        ? prepareReplyToAllEmail(message)
         : prepareReplyingToEmail(message);
     }
     return prepareForwardingEmail(message);
@@ -333,7 +332,7 @@ function ReplyPanel({
 const prepareReplyingToEmail = (
   message: ParsedMessage,
   content = "",
-  replyToAll = false, // New parameter to handle "Reply to All"
+  replyToAll = false,
 ): ReplyingToEmail => {
   const sentFromUser = message.labelIds?.includes("SENT");
 


### PR DESCRIPTION
Fixes : #341 

https://www.loom.com/share/637268ad5b3e448194c96e50eed24035?sid=d02bddd3-f6f0-439b-9147-af9a7369c8fb


## Solution
When clicked on forward all, The function sets the CC of the reply to the CC of the email received. Let me know if need some improvement.
A loom video is also attached to show the respective function. Let me know for improvements

@elie222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced email composition: Users can now add CC addresses alongside the primary recipients.
	- Improved reply functionality: A new "Reply to All" option enables replying to all recipients with a single action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->