### PR TITLE
Update cursor-rules.mdc to fix unbalanced backticks

### DIFF
--- a/.cursor/rules/cursor-rules.mdc
+++ b/.cursor/rules/cursor-rules.mdc
@@ -37,7 +37,7 @@ How to add new cursor rules to the project
 
 5. Cursor rules have the following structure:
 
-```
+````
 ---
 description: Short description of the rule's purpose
 globs: optional/path/pattern/**/* 
@@ -63,3 +63,4 @@ function badExample() {
   // Implementation not following guidelines
 }
 ```
+````


### PR DESCRIPTION
You had 2 opening backticks without closing the outer set.

For nested backticks, you use 4 on the outer set.  See: https://python-markdown.github.io/extensions/fenced_code_blocks/

Not a biggie but just a little less thinking for Cursor to do if it's formatted correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the presentation of code blocks in documentation for enhanced readability.
	- Ensured proper formatting with a consistent structure across the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->