### PR TITLE
Hide congrats confetti when not on inbox tab

### DIFF
--- a/apps/web/components/Celebration.tsx
+++ b/apps/web/components/Celebration.tsx
@@ -6,32 +6,28 @@ import Image from "next/image";
 import { getCelebrationImage } from "@/utils/celebration";
 import { Button } from "@/components/Button";
 
-export function Celebration(props: { message: string; confetti?: boolean }) {
+export function Celebration(props: { message: string }) {
   const [active, setActive] = useState(false);
 
   useEffect(() => {
     setActive(true);
   }, []);
 
-  const isConfettiEnabled = props.confetti === true || props.confetti === undefined;
-
   return (
     <>
       <div className="flex items-center justify-center font-cal text-2xl text-primary">
-      {(isConfettiEnabled ? "Congrats! " : "") + props.message}
+        Congrats! {props.message}
       </div>
-      {isConfettiEnabled && (
-        <div className="flex items-center justify-center">
-          <Confetti
-            active={active}
-            config={{
-              duration: 3_000,
-              elementCount: 500,
-              spread: 200,
-            }}
-          />
-        </div>
-      )}
+      <div className="flex items-center justify-center">
+        <Confetti
+          active={active}
+          config={{
+            duration: 3_000,
+            elementCount: 500,
+            spread: 200,
+          }}
+        />
+      </div>
 
       <div className="mt-8 flex justify-center">
         <Button
@@ -57,7 +53,7 @@ export function Celebration(props: { message: string; confetti?: boolean }) {
           src={getCelebrationImage()}
           width={400}
           height={400}
-          alt={isConfettiEnabled ? "Congrats!" : "All done!"}
+          alt="Congrats!"
           unoptimized
         />
       </div>

--- a/apps/web/components/Celebration.tsx
+++ b/apps/web/components/Celebration.tsx
@@ -13,12 +13,14 @@ export function Celebration(props: { message: string; confetti?: boolean }) {
     setActive(true);
   }, []);
 
+  const isConfettiEnabled = props.confetti === true || props.confetti === undefined;
+
   return (
     <>
       <div className="flex items-center justify-center font-cal text-2xl text-primary">
-        {props.confetti !== false && "Congrats!"} {props.message}
+      {(isConfettiEnabled ? "Congrats! " : "") + props.message}
       </div>
-      {props.confetti !== false && (
+      {isConfettiEnabled && (
         <div className="flex items-center justify-center">
           <Confetti
             active={active}
@@ -55,7 +57,7 @@ export function Celebration(props: { message: string; confetti?: boolean }) {
           src={getCelebrationImage()}
           width={400}
           height={400}
-          alt="Congrats!"
+          alt={isConfettiEnabled ? "Congrats!" : "All done!"}
           unoptimized
         />
       </div>

--- a/apps/web/components/Celebration.tsx
+++ b/apps/web/components/Celebration.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { getCelebrationImage } from "@/utils/celebration";
 import { Button } from "@/components/Button";
 
-export function Celebration(props: { message: string }) {
+export function Celebration(props: { message: string; confetti?: boolean }) {
   const [active, setActive] = useState(false);
 
   useEffect(() => {
@@ -16,18 +16,20 @@ export function Celebration(props: { message: string }) {
   return (
     <>
       <div className="flex items-center justify-center font-cal text-2xl text-primary">
-        Congrats! {props.message}
+        {props.confetti !== false && "Congrats!"} {props.message}
       </div>
-      <div className="flex items-center justify-center">
-        <Confetti
-          active={active}
-          config={{
-            duration: 3_000,
-            elementCount: 500,
-            spread: 200,
-          }}
-        />
-      </div>
+      {props.confetti !== false && (
+        <div className="flex items-center justify-center">
+          <Confetti
+            active={active}
+            config={{
+              duration: 3_000,
+              elementCount: 500,
+              spread: 200,
+            }}
+          />
+        </div>
+      )}
 
       <div className="mt-8 flex justify-center">
         <Button

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -145,14 +145,13 @@ export function List({
         />
       ) : (
         <div className="mt-20">
-          <Celebration
-            message={
-              type === "inbox"
-                ? "You made it to Inbox Zero!"
-                : "All emails handled!"
-            }
-            confetti={type === "inbox"}
-          />
+          {type === "inbox" ? (
+            <Celebration message={"You made it to Inbox Zero!"} />
+          ) : (
+            <div className="flex items-center justify-center font-cal text-2xl text-primary">
+              No emails to display
+            </div>
+          )}
         </div>
       )}
     </>

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -151,7 +151,7 @@ export function List({
                 ? "You made it to Inbox Zero!"
                 : "All emails handled!"
             }
-            confetti={type !== "inbox"}
+            confetti={type === "inbox"}
           />
         </div>
       )}

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -151,6 +151,7 @@ export function List({
                 ? "You made it to Inbox Zero!"
                 : "All emails handled!"
             }
+            confetti={type !== "inbox"}
           />
         </div>
       )}


### PR DESCRIPTION
### Celebration Component Improvements

#### Component Updates:
- `apps/web/components/Celebration.tsx`:  
  - Added optional `confetti` prop to control the display of confetti.  
  - Conditionally render the "Congrats!" text and confetti based on the `confetti` prop.

#### Integration:
- `apps/web/components/email-list.tsx`:  
  - Updated to pass the `confetti` prop dynamically (`type !== "inbox"`) when using the `Celebration` component.

Closes #123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Updated the empty email list display: now shows a celebration message only for the inbox, while other folders display a neutral "No emails to display" message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->