### PR TITLE
Jump to next e-mail after archiving current one on inbox tab

### DIFF
--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -225,6 +225,12 @@ export function EmailList({
               undefined,
               (threadId) => {
                 refetch({ removedThreadIds: [threadId] });
+                // Automatically select the next email in the list
+                const nextEmail =
+                  threads[threads.findIndex((t) => t.id === thread.id) + 1];
+                if (nextEmail) {
+                  setOpenThreadId(nextEmail.id);
+                }
                 resolve();
               },
               reject,


### PR DESCRIPTION
### Updates

#### `apps/web/components/email-list/EmailList.tsx`:

- Added a `nextEmail` variable, storing the `id` of the next `thread` item in the `threads` list, that being the next e-mail shown on the inbox tag.

- `nextEmail` is used to immediately open said e-mail when archiving the one currently open in the panel. This new e-mail is immediately loaded in while the previous one is being archived in the background.

Closes #163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved email archiving interaction: after archiving an email, the interface now automatically selects the next available email, streamlining your workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->