### PR TITLE
fix: Point web service env_file to apps/web/.env (issue #401)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile.web
     env_file:
-      - ./.env
+      - ./apps/web/.env
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Resolves one part of issue #401 by simplifying the Docker Compose environment file handling.

**Problem:**
As described in #401, the `web` service in `docker-compose.yml` previously used `env_file: ./.env`. This required users running the full stack via Docker Compose to maintain a potentially redundant `.env` file in the project root, leading to confusion.

**Solution:**
This PR modifies the `docker-compose.yml` file to explicitly point the `web` service's `env_file` directive to `./apps/web/.env`. This makes `apps/web/.env` the single source of truth loaded via `env_file` for the Docker setup.

**Note:**
This PR only includes the change to `docker-compose.yml`. The corresponding update to `README.md` (removing the instruction to copy `.env` to the root) is also needed but is not included here.

This change allows the Docker setup to work correctly using only the `apps/web/.env` file for configuration loaded via `env_file`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the environment file location for the web service in the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->