### PR TITLE
Update .gitignore to add docker compose override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ tasks/
 
 # prisma
 apps/web/generated
+
+# docker compose override file
+docker-compose.override.yaml
+docker-compose.override.yml


### PR DESCRIPTION
Very simple pull request. 

This allows people developing/testing the code to add their own tweaks to the docker compose config, without needing to directly edit docker-compose.override.yml itself and thus needing to git rebase/merge every time to get an update. 

Let's say I have a naming scheme for docker containers where I append "TEST" to the docker container name. I *could* directly edit docker-compose.yml and change the line `container_name: TEST-inbox-zero`... but that would make git unhappy. It'd be better for me to create docker-compose.override.yml and then add `container_name: TEST-inbox-zero` there. Then I can do `git pull` easily with no hassle. 

Lots of other projects do this; for example, see LibreChat doing this: https://github.com/danny-avila/LibreChat/blob/f7777a2723e8e51f3ff464d4e672db46905964a5/.gitignore#L98



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated ignored files to include Docker Compose override files, preventing them from being tracked by version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->