### PR TITLE
Fix: Duplicate React Keys in Bulk Unsubscribe Component and Hydration Errors

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -135,14 +135,16 @@ export function BulkUnsubscribeSection({
   const { selected, isAllSelected, onToggleSelect, onToggleSelectAll } =
     useToggleSelect(rows?.map((item) => ({ id: item.name })) || []);
 
-  const unsortedTableRows = rows?.map((item) => {
+  const unsortedTableRows = rows?.map((item, index) => {
     const readPercentage = (item.readEmails / item.value) * 100;
     const archivedEmails = item.value - item.inboxEmails;
     const archivedPercentage = (archivedEmails / item.value) * 100;
 
+    const uniqueKey = `${item.name}-${item.value}-${item.inboxEmails}-${item.readEmails}-${index}`;
+
     const row = (
       <RowComponent
-        key={item.name}
+        key={uniqueKey}
         item={item}
         userEmail={userEmail}
         emailAccountId={emailAccountId}

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -135,16 +135,14 @@ export function BulkUnsubscribeSection({
   const { selected, isAllSelected, onToggleSelect, onToggleSelectAll } =
     useToggleSelect(rows?.map((item) => ({ id: item.name })) || []);
 
-  const unsortedTableRows = rows?.map((item, index) => {
+  const unsortedTableRows = rows?.map((item) => {
     const readPercentage = (item.readEmails / item.value) * 100;
     const archivedEmails = item.value - item.inboxEmails;
     const archivedPercentage = (archivedEmails / item.value) * 100;
 
-    const uniqueKey = `${item.name}-${item.value}-${item.inboxEmails}-${item.readEmails}-${index}`;
-
     const row = (
       <RowComponent
-        key={uniqueKey}
+        key={item.name}
         item={item}
         userEmail={userEmail}
         emailAccountId={emailAccountId}

--- a/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/TestRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/TestRules.tsx
@@ -16,7 +16,7 @@ import { Separator } from "@/components/ui/separator";
 import { AlertBasic } from "@/components/Alert";
 import { EmailMessageCell } from "@/components/EmailMessageCell";
 import { SearchForm } from "@/components/SearchForm";
-import { TableCell, TableRow } from "@/components/ui/table";
+import { TableCell, TableRow, Table, TableBody } from "@/components/ui/table";
 import { CardContent } from "@/components/ui/card";
 import { testColdEmailAction } from "@/utils/actions/cold-email";
 import type { ColdEmailBlockerBody } from "@/utils/actions/cold-email.validation";
@@ -57,17 +57,17 @@ export function TestRulesContent() {
 
       <LoadingContent loading={isLoading} error={error}>
         {data && (
-          <div>
-            {data.messages.map((message) => {
-              return (
+          <Table>
+            <TableBody>
+              {data.messages.map((message) => (
                 <TestRulesContentRow
                   key={message.id}
                   message={message}
                   userEmail={userEmail}
                 />
-              );
-            })}
-          </div>
+              ))}
+            </TableBody>
+          </Table>
         )}
       </LoadingContent>
     </div>

--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/EnableReplyTracker.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/EnableReplyTracker.tsx
@@ -38,9 +38,7 @@ export function EnableReplyTracker({ enabled }: { enabled: boolean }) {
       }
       extraDescription={
         <div className="mt-4 text-left">
-          <p>
-            <SectionDescription>We label your emails with:</SectionDescription>
-          </p>
+          <SectionDescription>We label your emails with:</SectionDescription>
 
           <SectionDescription>
             <Badge color="green">{NEEDS_REPLY_LABEL_NAME}</Badge> - emails you


### PR DESCRIPTION
## ✅ Solutions (Fixes #429 )

### 💡 Implementation

#### 1. Robust Key Generation
To resolve the key duplication issue:

```diff
- const unsortedTableRows = rows?.map((item) => {
+ const unsortedTableRows = rows?.map((item, index) => {
    // ...
-   const row = <RowComponent key={item.name} ... />
+   const uniqueKey = `${item.name}-${item.value}-${item.inboxEmails}-${item.readEmails}-${index}`;
+   const row = <RowComponent key={uniqueKey} ... />
```

#### 2. Fixed Nested Paragraph Structure
Removed the outer paragraph element that was causing invalid nesting:

```diff
extraDescription={
  <div className="mt-4 text-left">
-   <p>
    <SectionDescription>We label your emails with:</SectionDescription>
-   </p>
    <SectionDescription>
      <Badge color="green">{NEEDS_REPLY_LABEL_NAME}</Badge> - emails you
      need to reply to.
    </SectionDescription>
    // ...
  </div>
}
```

#### 3. Proper Table Structure
Replaced div with appropriate table elements:

```diff
<LoadingContent loading={isLoading} error={error}>
  {data && (
-   <div>
-     {data.messages.map((message) => {
-       return (
+   <Table>
+     <TableBody>
+       {data.messages.map((message) => (
          <TestRulesContentRow
            key={message.id}
            message={message}
            userEmail={userEmail}
          />
-       );
-     })}
-   </div>
+       ))}
+     </TableBody>
+   </Table>
  )}
</LoadingContent>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved uniqueness of row keys in the bulk unsubscribe section for more reliable rendering.
  - Updated message display in the cold email blocker test rules to use a semantic table structure for better accessibility and markup consistency.
  - Simplified the layout in the reply tracker enablement section by removing unnecessary wrapper elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->