### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ If you are using local ollama, you can set it to be default:
 DEFAULT_LLM_PROVIDER=ollama
 ```
 
+If this is the case you must also set the `ECONOMY_LLM_PROVIDER` environment variable.
+
 ### Redis and Postgres
 
 We use Postgres for the database.


### PR DESCRIPTION
When using ollama, ECONOMY_LLM_PROVIDER must be set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify that the ECONOMY_LLM_PROVIDER environment variable must be set when using local Ollama as the default LLM provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->