### PR TITLE
Fix how we handle static conditions in chat

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,9 +1,4 @@
-import {
-  appendClientMessage,
-  appendResponseMessages,
-  type CoreAssistantMessage,
-  type CoreToolMessage,
-} from "ai";
+import { appendClientMessage, appendResponseMessages } from "ai";
 import { z } from "zod";
 import { withEmailAccount } from "@/utils/middleware";
 import { getEmailAccountWithAi } from "@/utils/user/get";
@@ -101,13 +96,13 @@ export const POST = withEmailAccount(async (request) => {
     emailAccountId,
     user,
     onFinish: async ({ response }) => {
-      const assistantId = getTrailingMessageId({
-        messages: response.messages.filter(
-          (message: { role: string }) => message.role === "assistant",
-        ),
-      });
+      const assistantMessages = response.messages.filter(
+        (message) => message.role === "assistant",
+      );
+      const assistantId = getTrailingMessageId(assistantMessages);
 
       if (!assistantId) {
+        logger.error("No assistant message found!", { response });
         throw new Error("No assistant message found!");
       }
 
@@ -181,14 +176,9 @@ function convertDbRoleToSdkRole(
   }
 }
 
-type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;
-type ResponseMessage = ResponseMessageWithoutId & { id: string };
-
-function getTrailingMessageId({
-  messages,
-}: {
-  messages: Array<ResponseMessage>;
-}): string | null {
+function getTrailingMessageId<T extends { id: string }>(
+  messages: Array<T>,
+): string | null {
   const trailingMessage = messages.at(-1);
 
   if (!trailingMessage) return null;

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -189,9 +189,16 @@ function UpdatedRuleConditions({
   args: UpdateRuleConditionSchema;
   ruleId: string;
 }) {
+  const staticConditions =
+    args.condition.static?.from ||
+    args.condition.static?.to ||
+    args.condition.static?.subject
+      ? args.condition.static
+      : null;
+
   const conditionsArray = [
     args.condition.aiInstructions,
-    args.condition.static,
+    staticConditions,
   ].filter(Boolean);
 
   return (
@@ -225,9 +232,6 @@ function UpdatedRuleConditions({
               )}
               {args.condition.static.subject && (
                 <li>Subject: {args.condition.static.subject}</li>
-              )}
-              {args.condition.static.body && (
-                <li>Body: {args.condition.static.body}</li>
               )}
             </ul>
           </div>

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -28,15 +28,14 @@ const updateRuleConditionSchema = z.object({
     aiInstructions: z.string().optional(),
     static: z
       .object({
-        from: z.string().optional(),
-        to: z.string().optional(),
-        subject: z.string().optional(),
-        body: z.string().optional(),
+        from: z.string().nullable(),
+        to: z.string().nullable(),
+        subject: z.string().nullable(),
       })
-      .optional(),
+      .nullable(),
     conditionalOperator: z
       .enum([LogicalOperator.AND, LogicalOperator.OR])
-      .optional(),
+      .nullable(),
   }),
 });
 export type UpdateRuleConditionSchema = z.infer<
@@ -151,7 +150,7 @@ You can use {{variables}} in the fields to insert AI generated content. For exam
 "Hi {{name}}, {{write a friendly reply}}, Best regards, Alice"
 
 Rule matching logic:
-- All static conditions (from, to, subject, body) use AND logic - meaning all static conditions must match
+- All static conditions (from, to, subject) use AND logic - meaning all static conditions must match
 - Top level conditions (AI instructions, static) can use either AND or OR logic, controlled by the "conditionalOperator" setting
 
 Best practices:
@@ -413,7 +412,6 @@ Examples:
                   from: true,
                   to: true,
                   subject: true,
-                  body: true,
                   conditionalOperator: true,
                   enabled: true,
                   automate: true,
@@ -452,7 +450,6 @@ Examples:
                 from: rule.from,
                 to: rule.to,
                 subject: rule.subject,
-                body: rule.body,
               });
 
               const staticConditions =
@@ -599,8 +596,7 @@ Examples:
               from: condition.static?.from,
               to: condition.static?.to,
               subject: condition.static?.subject,
-              body: condition.static?.body,
-              conditionalOperator: condition.conditionalOperator,
+              conditionalOperator: condition.conditionalOperator ?? undefined,
             },
           });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None.

- **Bug Fixes**
	- Static rule conditions now only include "from", "to", and "subject" fields, and no longer display or process the "body" field.
	- Improved handling of empty or null static conditions to avoid displaying unnecessary information.

- **Refactor**
	- Updated internal logic for filtering and processing assistant messages and rule conditions for improved clarity and maintainability.

- **Documentation**
	- Clarified documentation to reflect changes in static condition fields and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->