### PR TITLE
Fix 'Usage' link

### DIFF
--- a/apps/web/components/TopNav.tsx
+++ b/apps/web/components/TopNav.tsx
@@ -44,7 +44,11 @@ function ProfileDropdown() {
   const { emailAccountId, emailAccount } = useAccount();
 
   const userNavigation = [
-    { name: "Usage", href: "/usage", icon: BarChartIcon },
+    {
+      name: "Usage",
+      href: prefixPath(emailAccountId, "/usage"),
+      icon: BarChartIcon,
+    },
     {
       name: "Mail (Beta)",
       href: prefixPath(emailAccountId, "/mail"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the "Usage" navigation link in the profile dropdown to dynamically include the email account ID in its URL for improved consistency with other navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->