### PR TITLE
Fix: Prevent minRows/maxRows props from reaching DOM elements

### DIFF
--- a/apps/web/components/Input.tsx
+++ b/apps/web/components/Input.tsx
@@ -43,9 +43,14 @@ export const Input = (props: InputProps) => {
     name: props.name,
     id: props.name,
     placeholder: props.placeholder,
-    rows: props.rows,
-    minRows: props.autosizeTextarea ? props.rows : undefined,
-    maxRows: props.autosizeTextarea ? props.maxRows : undefined,
+    ...(props.autosizeTextarea
+      ? {
+          minRows: props.rows,
+          maxRows: props.maxRows,
+        }
+      : {
+          rows: props.rows,
+        }),
     min: props.min,
     max: props.max,
     step: props.step,


### PR DESCRIPTION
# Fix React warnings for unrecognized props in Input component

## Issue
The Input component was causing React console warnings when using `autosizeTextarea` functionality:

```
React does not recognize the `minRows` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `minrows` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

React does not recognize the `maxRows` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `maxrows` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## Screenshot
![Screenshot 2025-05-27 151426](https://github.com/user-attachments/assets/23e512d4-f38d-408b-aa92-92ac4d433456)


## Root Cause
The `inputProps` object was unconditionally passing both:
- `minRows`/`maxRows` (TextareaAutosize-specific props)  
- `rows` (regular DOM textarea prop)

This caused React to complain when these TextareaAutosize-specific props were passed to regular DOM elements.

## Solution
Modified the `inputProps` construction to conditionally spread the appropriate props based on whether `autosizeTextarea` is enabled:

- When `autosizeTextarea` is `true`: Only include `minRows` and `maxRows`
- When `autosizeTextarea` is `false`: Only include `rows`


### Before :

```typescript
const inputProps = {
  type: props.type,
  name: props.name,
  id: props.name,
  placeholder: props.placeholder,
  rows: props.rows,
  minRows: props.autosizeTextarea ? props.rows : undefined,
  maxRows: props.autosizeTextarea ? props.maxRows : undefined,
  min: props.min,
  max: props.max,
  step: props.step,
  disabled: props.disabled,
  ...props.registerProps,
};
```

### After (fixed):

```typescript
const inputProps = {
  type: props.type,
  name: props.name,
  id: props.name,
  placeholder: props.placeholder,
  ...(props.autosizeTextarea
    ? {
        minRows: props.rows,
        maxRows: props.maxRows,
      }
    : {
        rows: props.rows,
      }),
  min: props.min,
  max: props.max,
  step: props.step,
  disabled: props.disabled,
  ...props.registerProps,
};
```

## What Changed?

The key change is replacing these lines:
```diff
- rows: props.rows,
- minRows: props.autosizeTextarea ? props.rows : undefined,
- maxRows: props.autosizeTextarea ? props.maxRows : undefined,
```

With this conditional spreading:
```diff
+ ...(props.autosizeTextarea
+   ? {
+       minRows: props.rows,
+       maxRows: props.maxRows,
+     }
+   : {
+       rows: props.rows,
+     }),
```

This ensures that:
- When `autosizeTextarea` is `true`: Only `minRows` and `maxRows` are passed (for TextareaAutosize)
- When `autosizeTextarea` is `false`: Only `rows` is passed (for regular DOM textarea)

## Impact
- ✅ Eliminates React console warnings
- ✅ Proper separation of concerns between TextareaAutosize and regular textarea props

This fix resolves the console warnings while maintaining full functionality for both TextareaAutosize and regular textarea usage.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of input field sizing to ensure correct behavior when adjusting text area rows and autosizing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->