### PR TITLE
Cursor Agent: Update cold email handling logic

### DIFF
--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -97,11 +97,17 @@ async function isKnownColdEmailSender({
         emailAccountId,
         fromEmail: from,
       },
-      status: ColdEmailStatus.AI_LABELED_COLD,
     },
-    select: { id: true },
+    select: { id: true, status: true },
   });
-  return !!coldEmail;
+  
+  // If the user has rejected this as a cold email, it's not a cold emailer
+  if (coldEmail?.status === ColdEmailStatus.USER_REJECTED_COLD) {
+    return false;
+  }
+  
+  // Only return true if it's labeled as cold by AI
+  return coldEmail?.status === ColdEmailStatus.AI_LABELED_COLD;
 }
 
 async function aiIsColdEmail(


### PR DESCRIPTION
The cold email blocking logic was updated to respect user feedback.

*   In `apps/web/utils/cold-email/is-cold-email.ts`, the `isKnownColdEmailSender` function was modified.
    *   It now fetches the `status` field from the `ColdEmail` record.
    *   If a sender's status is `USER_REJECTED_COLD`, the function explicitly returns `false`, ensuring emails from that sender are not blocked, overriding any AI classification.
    *   The function now only returns `true` if the status is `AI_LABELED_COLD`.
*   `apps/web/utils/cold-email/is-cold-email.test.ts` was updated with new test cases for the `isColdEmail` function.
    *   Tests now cover scenarios where a sender is marked as `USER_REJECTED_COLD` (expected: not cold), `AI_LABELED_COLD` (expected: cold), and when the sender is not found in the database (expected: AI check).

This ensures that once a user marks an email as "not cold," subsequent emails from that sender will not be blocked by the cold email blocker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of known cold email senders to better distinguish between user-rejected and AI-labeled cold emails.

- **Tests**
  - Added comprehensive tests for cold email identification, covering scenarios for user rejection, AI labeling, and new senders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->