### PR TITLE
Fix HTML nesting hydration error in KnowledgeBase component

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/knowledge/KnowledgeBase.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/knowledge/KnowledgeBase.tsx
@@ -91,29 +91,30 @@ export function KnowledgeBase() {
               {data?.items.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={3}>
-                    <p className="mx-auto my-8 max-w-prose text-center">
-                      Knowledge base entries are used to help draft responses to
-                      emails.
-                      <br />
-                      Click "Add" to create one.
-                      <br />
-                      <br />
-                      <strong className="text-left">Notes:</strong>
-                      <ul className="list-disc text-left">
-                        <li>
-                          Placing all knowledge in one entry is perfectly fine.
-                        </li>
-                        <li>
-                          When our AI drafts replies it also has access to
-                          previous conversations with the person you're talking
-                          to.
-                        </li>
-                        <li>
-                          This information is only used to draft replies. You
-                          must click "Send" to send the reply.
-                        </li>
-                      </ul>
-                    </p>
+                    <div className="mx-auto my-8 max-w-prose text-center">
+                      <p>
+                        Knowledge base entries are used to help draft responses to emails.
+                        <br />
+                        Click "Add" to create one.
+                      </p>
+                      <div className="mt-4">
+                        <strong className="text-left">Notes:</strong>
+                        <ul className="list-disc text-left mt-2 space-y-1">
+                          <li>
+                            Placing all knowledge in one entry is perfectly fine.
+                          </li>
+                          <li>
+                            When our AI drafts replies it also has access to
+                            previous conversations with the person you're talking
+                            to.
+                          </li>
+                          <li>
+                            This information is only used to draft replies. You
+                            must click "Send" to send the reply.
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
                   </TableCell>
                 </TableRow>
               ) : (


### PR DESCRIPTION
# Fix HTML nesting hydration error in KnowledgeBase component

## Issue

![Screenshot 2025-06-11 173712](https://github.com/user-attachments/assets/e35dea13-3af8-4cdf-974c-a20a057d41a9)

The KnowledgeBase component was causing React hydration errors due to invalid HTML structure:
```
Warning: validateDOMNesting(...): <ul> cannot be a descendant of <p>.
```


## Root Cause
The empty state content had a `<ul>` element nested inside a `<p>` element, which violates HTML content model rules. The `<p>` element can only contain phrasing content, not block-level elements like `<ul>`.

### Before (problematic):
```jsx
<p className="mx-auto my-8 max-w-prose text-center">
  Knowledge base entries are used to help draft responses to emails.
  <br />
  Click "Add" to create one.
  <br />
  <br />
  <strong className="text-left">Notes:</strong>
  <ul className="list-disc text-left">  {/* Invalid nesting! */}
    <li>Placing all knowledge in one entry is perfectly fine.</li>
    <li>When our AI drafts replies it also has access to previous conversations with the person you're talking to.</li>
    <li>This information is only used to draft replies. You must click "Send" to send the reply.</li>
  </ul>
</p>
```

## Solution
Restructured the HTML to use proper semantic nesting by:
1. Replacing the outer `<p>` wrapper with a `<div>`
2. Separating the paragraph text from the list structure
3. Adding proper spacing with Tailwind classes

### After (fixed):
```jsx
<div className="mx-auto my-8 max-w-prose text-center">
  <p>
    Knowledge base entries are used to help draft responses to emails.
    <br />
    Click "Add" to create one.
  </p>
  <div className="mt-4">
    <strong className="text-left">Notes:</strong>
    <ul className="list-disc text-left mt-2 space-y-1">
      <li>Placing all knowledge in one entry is perfectly fine.</li>
      <li>When our AI drafts replies it also has access to previous conversations with the person you're talking to.</li>
      <li>This information is only used to draft replies. You must click "Send" to send the reply.</li>
    </ul>
  </div>
</div>
```

## What Changed?
- Replaced `<p>` wrapper with `<div>` for the container
- Moved paragraph text into its own `<p>` element
- Wrapped the notes section and list in a separate `<div>`
- Added `mt-4`, `mt-2`, and `space-y-1` classes for proper spacing

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and spacing of the empty state message in the knowledge base for better readability and visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->