### PR TITLE
Cursor Agent: Skip reading messages functionality

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -61,8 +61,8 @@ export function BulkRunRules() {
             {data && (
               <>
                 <SectionDescription>
-                  This runs your rules on emails currently in your inbox (that
-                  have not been previously processed).
+                  This runs your rules on unread emails currently in your inbox
+                  (that have not been previously processed).
                 </SectionDescription>
 
                 {!!queue.size && (
@@ -159,7 +159,7 @@ async function onRun(
   const endDateInSeconds = endDate ? dateToSeconds(endDate) : "";
   const q = `after:${startDateInSeconds} ${
     endDate ? `before:${endDateInSeconds}` : ""
-  }`;
+  } is:unread`;
 
   let aborted = false;
 


### PR DESCRIPTION
The `BulkRunRules.tsx` file was updated to enable skipping of read messages during bulk rule processing.

*   The `onRun` function's Gmail search query was modified to include the `is:unread` filter. This ensures that only unread emails are considered, effectively skipping messages that have already been read.
*   Concurrently, the `SectionDescription` within `BulkRunRules.tsx` was updated to reflect this change, clarifying that the process now specifically targets "unread emails."

This modification streamlines the bulk rule execution by focusing solely on new or unaddressed messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the description in the bulk processing UI to clarify that rules apply only to unread emails currently in the inbox.
  - Adjusted email selection to ensure only unread emails are processed during bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->