### PR TITLE
fix(ui): Resolve focus trap issue with nested modals

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/SetDateDropdown.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/SetDateDropdown.tsx
@@ -23,7 +23,7 @@ export function SetDateDropdown({
   disabled?: boolean;
 }) {
   return (
-    <Popover>
+    <Popover modal={true}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"

--- a/apps/web/components/DatePickerWithRange.tsx
+++ b/apps/web/components/DatePickerWithRange.tsx
@@ -22,7 +22,7 @@ export function DatePickerWithRange({
   onSetDateRange: (dateRange?: DateRange) => void;
 }) {
   return (
-    <Popover>
+    <Popover modal={true}>
       <PopoverTrigger asChild>
         <Button
           id="date"


### PR DESCRIPTION
This pull request addresses an issue where calendar popovers (`SetDateDropdown` and `DatePickerWithRange`) were not interactive when opened from within a `Dialog` component in Firefox and Safari.

The root cause was the `Dialog`'s aggressive focus trap preventing the non-modal `Popover` from receiving focus.

The fix is to add the `modal={true}` prop to the `Popover` components. This creates a proper nested modal stack, ensuring the topmost modal correctly captures focus and making the component work as expected across all browsers.

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated date selection popovers to behave as modals, improving interaction and focus management in date-related dropdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->