### PR TITLE
add AUTH_TRUST_HOST configuration to .env.example and env.ts

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,6 +3,7 @@ DIRECT_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=publi
 
 NEXTAUTH_SECRET= # Generate a random secret here: https://generate-secret.vercel.app/32
 NEXTAUTH_URL=http://localhost:3000
+AUTH_TRUST_HOST=true # See https://authjs.dev/getting-started/deployment#auth_trust_host
 
 # Gmail
 GOOGLE_CLIENT_ID=

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -18,6 +18,7 @@ export const env = createEnv({
     DATABASE_URL: z.string().url(),
     NEXTAUTH_SECRET: z.string().min(1),
     NEXTAUTH_URL: z.string().optional(),
+    AUTH_TRUST_HOST: z.coerce.boolean().optional(),
     GOOGLE_CLIENT_ID: z.string().min(1),
     GOOGLE_CLIENT_SECRET: z.string().min(1),
     GOOGLE_ENCRYPT_SECRET: z.string(),


### PR DESCRIPTION
This pull request introduces a new environment variable, `AUTH_TRUST_HOST` and adds it to the .env.example to reduce friction for first time users attempting to run this project locally.  The variable is required for [Next Auth](https://authjs.dev/getting-started/deployment#auth_trust_host) to run behind a reverse-proxy.

Related issues:
- #560 
- #438 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new optional environment variable, `AUTH_TRUST_HOST`, to the configuration example and environment schema for improved authentication setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->