### PR TITLE
chore: update gitignore and reduce maxDuration in admin page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ dist
 **/public/precache**
 
 # Sanity
+# Ignore context directory
+CONTEXT/
+
 .sanity
 
 TODO.md

--- a/apps/web/app/(app)/admin/page.tsx
+++ b/apps/web/app/(app)/admin/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/app/(app)/admin/AdminSyncStripe";
 
 // NOTE: Turn on Fluid Compute on Vercel to allow for 800 seconds max duration
-export const maxDuration = 800;
+export const maxDuration = 300;
 
 export default async function AdminPage() {
   const session = await auth();


### PR DESCRIPTION
Add CONTEXT/ to gitignore and decrease maxDuration from 800 to 300 seconds in admin page for better resource management and to comply with Vercel hobbyPlan max limit