### PR TITLE
Move digest schema and fixes to Digest template

### DIFF
--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -6,21 +6,17 @@ import { captureException, SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
-import { camelCase } from "lodash";
 import { calculateNextScheduleDate } from "@/utils/schedule";
 import { getMessagesLargeBatch } from "@/utils/gmail/message";
 import type { ParsedMessage } from "@/utils/types";
-import {
-  sendDigestEmailBody,
-  type Digest,
-  digestEmailSummarySchema,
-} from "./validation";
+import { sendDigestEmailBody, type Digest } from "./validation";
 import { DigestStatus } from "@prisma/client";
 import { extractNameFromEmail } from "../../../../utils/email";
 import { RuleName } from "@/utils/rule/consts";
 import { getEmailAccountWithAiAndTokens } from "@/utils/user/get";
 import { getGmailClientWithRefresh } from "@/utils/gmail/client";
 import { verifySignatureAppRouter } from "@upstash/qstash/dist/nextjs";
+import { schema as digestEmailSummarySchema } from "@/utils/ai/digest/summarize-email-for-digest";
 
 export const maxDuration = 60;
 

--- a/apps/web/app/api/resend/digest/validation.ts
+++ b/apps/web/app/api/resend/digest/validation.ts
@@ -1,21 +1,5 @@
 import { z } from "zod";
-
-export const digestEmailSummarySchema = z.union([
-  z.object({
-    entries: z
-      .array(
-        z.object({
-          label: z.string().describe("The label of the summarized item"),
-          value: z.string().describe("The value of the summarized item"),
-        }),
-      )
-      .nullish()
-      .describe("An array of items summarizing the email content"),
-  }),
-  z.object({
-    summary: z.string().nullish().describe("A summary of the email content"),
-  }),
-]);
+import { schema as digestEmailSummarySchema } from "@/utils/ai/digest/summarize-email-for-digest";
 
 export type DigestEmailSummarySchema = z.infer<typeof digestEmailSummarySchema>;
 

--- a/apps/web/utils/ai/digest/summarize-email-for-digest.ts
+++ b/apps/web/utils/ai/digest/summarize-email-for-digest.ts
@@ -1,10 +1,26 @@
-import type { z } from "zod";
+import { z } from "zod";
 import { chatCompletionObject } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { createScopedLogger } from "@/utils/logger";
 import type { EmailForLLM } from "@/utils/types";
 import { stringifyEmailSimple } from "@/utils/stringify-email";
-import { digestEmailSummarySchema as schema } from "@/app/api/resend/digest/validation";
+
+export const schema = z.union([
+  z.object({
+    entries: z
+      .array(
+        z.object({
+          label: z.string().describe("The label of the summarized item"),
+          value: z.string().describe("The value of the summarized item"),
+        }),
+      )
+      .nullish()
+      .describe("An array of items summarizing the email content"),
+  }),
+  z.object({
+    summary: z.string().nullish().describe("A summary of the email content"),
+  }),
+]);
 
 const logger = createScopedLogger("summarize-digest-email");
 

--- a/packages/resend/emails/digest.tsx
+++ b/packages/resend/emails/digest.tsx
@@ -210,22 +210,33 @@ export default function DigestEmail(props: DigestEmailProps) {
             >
               <Link href={category.href} className="no-underline">
                 <div
-                  className={`${colorClasses[category.color as keyof typeof colorClasses].bg} p-[8px] rounded-[4px] flex justify-between items-center`}
+                  className={`${colorClasses[category.color as keyof typeof colorClasses].bg} p-[8px] rounded-[4px]`}
                 >
-                  <Text
-                    className={`text-[13px] font-medium ${colorClasses[category.color as keyof typeof colorClasses].text} m-0`}
-                  >
-                    {category.emoji} {category.name}
-                  </Text>
-                  <div
-                    className={`${colorClasses[category.color as keyof typeof colorClasses].bgAccent} px-[8px] py-[2px] ml-[8px] rounded-[12px]`}
-                  >
-                    <Text
-                      className={`text-[12px] font-bold ${colorClasses[category.color as keyof typeof colorClasses].text} m-0`}
+                  <Row>
+                    <Column
+                      style={{ textAlign: "left", verticalAlign: "middle" }}
                     >
-                      {category.count}
-                    </Text>
-                  </div>
+                      <Text
+                        className={`text-[13px] font-medium ${colorClasses[category.color as keyof typeof colorClasses].text} m-0`}
+                      >
+                        {category.emoji} {category.name}
+                      </Text>
+                    </Column>
+                    <Column
+                      style={{ textAlign: "right", verticalAlign: "middle" }}
+                    >
+                      <div
+                        className={`${colorClasses[category.color as keyof typeof colorClasses].bgAccent} px-[8px] py-[2px] rounded-[12px]`}
+                        style={{ display: "inline-block" }}
+                      >
+                        <Text
+                          className={`text-[12px] font-bold ${colorClasses[category.color as keyof typeof colorClasses].text} m-0`}
+                        >
+                          {category.count}
+                        </Text>
+                      </div>
+                    </Column>
+                  </Row>
                 </div>
               </Link>
             </Column>
@@ -341,10 +352,9 @@ export default function DigestEmail(props: DigestEmailProps) {
               </Text>
             </Section>
 
-            {getCategoriesWithItemsCount() > 0 && (
+            {getCategoriesWithItemsCount() > 1 && (
               <Section className="mb-[24px]">{renderCategoryGrid()}</Section>
             )}
-
             {Object.keys(digestData).map((categoryKey) =>
               Array.isArray(digestData[categoryKey]) &&
               digestData[categoryKey]?.length > 0 ? (
@@ -355,7 +365,6 @@ export default function DigestEmail(props: DigestEmailProps) {
                 />
               ) : null,
             )}
-
             <Hr className="border-solid border-gray-200 my-[24px]" />
             <Footer baseUrl={baseUrl} unsubscribeToken={unsubscribeToken} />
           </Container>


### PR DESCRIPTION
Mail received in Gmail:
<img width="610" height="70" alt="Screenshot 2025-07-28 at 06 58 37" src="https://github.com/user-attachments/assets/e7e235a2-d5f1-4b82-bce3-47b978de76f6" />
Mail rendered in preview:
<img width="583" height="55" alt="Screenshot 2025-07-28 at 07 02 47" src="https://github.com/user-attachments/assets/bda8b5f0-c845-4f1d-abd4-181bf9a2b3a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal schema management for digest email summaries to enhance consistency.
  * Updated the layout of the category grid in digest emails for better alignment and structure.
  * The category grid now displays only when there is more than one category with items, streamlining the email presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->