### PR TITLE
Allow dangerous linking

### DIFF
--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -104,6 +104,7 @@ export const getAuthOptions: () => NextAuthConfig = () => ({
     MicrosoftProvider({
       clientId: env.MICROSOFT_CLIENT_ID,
       clientSecret: env.MICROSOFT_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {
           scope: OUTLOOK_SCOPES.join(" "),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the ability to link accounts using the same email address when signing in with Microsoft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->