### PR TITLE
fix: Run filter reply when the reply rule is group matched

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -373,9 +373,7 @@ async function matchesCategoryRule(
 }
 
 export async function filterToReplyPreset(
-  potentialMatches: (RuleWithActionsAndCategories & {
-    instructions: string | null | undefined;
-  })[],
+  potentialMatches: (RuleWithActionsAndCategories & { instructions: string })[],
   message: ParsedMessage,
   client: EmailProvider,
 ): Promise<(RuleWithActionsAndCategories & { instructions: string })[]> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reply-based rules are now routed through a potential matches step, providing clearer suggestions before a rule is applied.
* **Bug Fixes**
  * Improved accuracy for reply-triggered automations by factoring in sender reply history and thresholds, reducing unintended matches and actions.
* **Refactor**
  * Streamlined rule-matching flow for reply-based scenarios to align with the potential-matches workflow without affecting other rule types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->