### PR TITLE
fix: Fix invalidating gmail tokens

### DIFF
--- a/apps/web/utils/actions/permissions.ts
+++ b/apps/web/utils/actions/permissions.ts
@@ -27,7 +27,7 @@ export const checkPermissionsAction = actionClient
 
       const { hasAllPermissions, error } = await handleGmailPermissionsCheck({
         accessToken,
-        refreshToken: tokens.refreshToken ?? "",
+        refreshToken: tokens.refreshToken,
         emailAccountId,
       });
 
@@ -67,7 +67,7 @@ export const adminCheckPermissionsAction = adminActionClient
 
       const { hasAllPermissions, error } = await handleGmailPermissionsCheck({
         accessToken,
-        refreshToken: tokens.refreshToken ?? "",
+        refreshToken: tokens.refreshToken,
         emailAccountId,
       });
       if (error) throw new SafeError(error);

--- a/apps/web/utils/gmail/permissions.ts
+++ b/apps/web/utils/gmail/permissions.ts
@@ -78,7 +78,7 @@ export async function handleGmailPermissionsCheck({
   emailAccountId,
 }: {
   accessToken: string;
-  refreshToken: string;
+  refreshToken: string | null | undefined;
   emailAccountId: string;
 }) {
   const { hasAllPermissions, error, missingScopes } =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically refreshes Gmail access during permission checks when tokens are invalid/expired.
  - Retries permission verification after a successful refresh.
  - Aligns admin and user permission checks to support refresh tokens.

- Bug Fixes
  - Improves reliability of Gmail permission verification by handling expired tokens gracefully.
  - Provides clearer feedback when Gmail access has expired and required scopes are missing.
  - Cleans up stale credentials to prevent repeated failures.
  - Non-Google account flows remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->