### PR TITLE
Default to reply all recipients

### DIFF
--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -95,7 +95,7 @@ const draft: ActionFunction<{
   to?: string | null;
   cc?: string | null;
   bcc?: string | null;
-}> = async ({ client, email, args, executedRule }) => {
+}> = async ({ client, email, args, userEmail, executedRule }) => {
   const draftArgs = {
     to: args.to ?? undefined,
     subject: args.subject ?? undefined,
@@ -119,6 +119,7 @@ const draft: ActionFunction<{
       attachments: email.attachments,
     },
     draftArgs,
+    userEmail,
     executedRule,
   );
   return { draftId: result.draftId };

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -278,12 +278,13 @@ export class GmailProvider implements EmailProvider {
   async draftEmail(
     email: ParsedMessage,
     args: { to?: string; subject?: string; content: string },
+    userEmail: string,
     executedRule?: { id: string; threadId: string; emailAccountId: string },
   ): Promise<{ draftId: string }> {
     if (executedRule) {
       // Run draft creation and previous draft deletion in parallel
       const [result] = await Promise.all([
-        draftEmail(this.client, email, args),
+        draftEmail(this.client, email, args, userEmail),
         handlePreviousDraftDeletion({
           client: this,
           executedRule,
@@ -292,7 +293,7 @@ export class GmailProvider implements EmailProvider {
       ]);
       return { draftId: result.data.id || "" };
     } else {
-      const result = await draftEmail(this.client, email, args);
+      const result = await draftEmail(this.client, email, args, userEmail);
       return { draftId: result.data.id || "" };
     }
   }

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -283,12 +283,13 @@ export class OutlookProvider implements EmailProvider {
   async draftEmail(
     email: ParsedMessage,
     args: { to?: string; subject?: string; content: string },
+    userEmail: string,
     executedRule?: { id: string; threadId: string; emailAccountId: string },
   ): Promise<{ draftId: string }> {
     if (executedRule) {
       // Run draft creation and previous draft deletion in parallel
       const [result] = await Promise.all([
-        draftEmail(this.client, email, args),
+        draftEmail(this.client, email, args, userEmail),
         handlePreviousDraftDeletion({
           client: this,
           executedRule,
@@ -297,7 +298,7 @@ export class OutlookProvider implements EmailProvider {
       ]);
       return { draftId: result.id || "" };
     } else {
-      const result = await draftEmail(this.client, email, args);
+      const result = await draftEmail(this.client, email, args, userEmail);
       return { draftId: result.id || "" };
     }
   }

--- a/apps/web/utils/email/reply-all.test.ts
+++ b/apps/web/utils/email/reply-all.test.ts
@@ -12,7 +12,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toContain("manager@company.com");
@@ -30,7 +34,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("noreply@example.com");
     expect(result.cc).toContain("user@company.com");
@@ -45,7 +53,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toContain("user@company.com");
@@ -61,7 +73,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toHaveLength(0);
@@ -76,7 +92,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toContain("colleague@company.com");
@@ -94,7 +114,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers, "override@example.com");
+    const result = buildReplyAllRecipients(
+      headers,
+      "override@example.com",
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("override@example.com");
     expect(result.cc).toContain("user@company.com");
@@ -111,7 +135,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toContain("user@company.com");
@@ -129,7 +157,11 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).toContain("user@company.com");
@@ -147,12 +179,191 @@ describe("buildReplyAllRecipients", () => {
       date: "2024-01-01",
     };
 
-    const result = buildReplyAllRecipients(headers);
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
 
     expect(result.to).toBe("sender@example.com");
     expect(result.cc).not.toContain("sender@example.com");
     expect(result.cc).toContain("user@company.com");
     expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should handle email addresses with display names", () => {
+    const headers: ParsedMessageHeaders = {
+      from: '"John Doe" <john@example.com>',
+      to: '"Alice Smith" <alice@company.com>, "Bob Jones" <bob@company.com>',
+      cc: '"Charlie Brown" <charlie@company.com>',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe('"John Doe" <john@example.com>');
+    expect(result.cc).toContain("alice@company.com");
+    expect(result.cc).toContain("bob@company.com");
+    expect(result.cc).toContain("charlie@company.com");
+    expect(result.cc).toHaveLength(3);
+  });
+
+  it("should deduplicate emails with different display names", () => {
+    const headers: ParsedMessageHeaders = {
+      from: '"John Doe" <john@example.com>',
+      to: '"Alice" <alice@company.com>, "Alice Smith" <alice@company.com>',
+      cc: 'alice@company.com, "Ms. Alice" <alice@company.com>',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe('"John Doe" <john@example.com>');
+    expect(result.cc).toContain("alice@company.com");
+    expect(result.cc).toHaveLength(1); // All duplicates should be removed
+  });
+
+  it("should exclude sender with display name from CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: '"John Doe" <john@example.com>',
+      to: 'john@example.com, "Alice" <alice@company.com>',
+      cc: '"John Doe" <john@example.com>, bob@company.com',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe('"John Doe" <john@example.com>');
+    expect(result.cc).not.toContain("john@example.com");
+    expect(result.cc).toContain("alice@company.com");
+    expect(result.cc).toContain("bob@company.com");
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should handle mixed email formats", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: '"Alice" <alice@company.com>, bob@company.com',
+      cc: 'charlie@company.com, "David Lee" <david@company.com>',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("alice@company.com");
+    expect(result.cc).toContain("bob@company.com");
+    expect(result.cc).toContain("charlie@company.com");
+    expect(result.cc).toContain("david@company.com");
+    expect(result.cc).toHaveLength(4);
+  });
+
+  it("should handle override TO with display name format", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com",
+      cc: "manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      '"Override User" <override@example.com>',
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe('"Override User" <override@example.com>');
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).not.toContain("override@example.com");
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should handle malformed email addresses gracefully", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: '"Invalid" <<double@brackets>>, valid@company.com',
+      cc: "not-an-email, real@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("valid@company.com");
+    expect(result.cc).toContain("real@company.com");
+    expect(result.cc).not.toContain(""); // Empty strings should be filtered out
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should exclude current user from CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "me@mycompany.com, colleague@company.com",
+      cc: "manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "me@mycompany.com",
+    );
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).not.toContain("me@mycompany.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should exclude current user with display name from CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: '"Alice" <alice@example.com>',
+      to: '"Me" <me@mycompany.com>, "Bob" <bob@company.com>',
+      cc: 'me@mycompany.com, "Charlie" <charlie@company.com>',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      '"My Name" <me@mycompany.com>',
+    );
+
+    expect(result.to).toBe('"Alice" <alice@example.com>');
+    expect(result.cc).not.toContain("me@mycompany.com");
+    expect(result.cc).toContain("bob@company.com");
+    expect(result.cc).toContain("charlie@company.com");
     expect(result.cc).toHaveLength(2);
   });
 });

--- a/apps/web/utils/email/reply-all.test.ts
+++ b/apps/web/utils/email/reply-all.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { buildReplyAllRecipients, formatCcList } from "./reply-all";
+import type { ParsedMessageHeaders } from "@/utils/types";
+
+describe("buildReplyAllRecipients", () => {
+  it("should handle simple reply-all with TO and CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com, colleague@company.com",
+      cc: "manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toHaveLength(3);
+  });
+
+  it("should use reply-to header when available", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      "reply-to": "noreply@example.com",
+      to: "user@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("noreply@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).not.toContain("noreply@example.com");
+  });
+
+  it("should handle no CC recipients", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com, colleague@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toHaveLength(2);
+  });
+
+  it("should handle single recipient (no CC needed)", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "sender@example.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toHaveLength(0);
+  });
+
+  it("should remove duplicates from CC list", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com, colleague@company.com",
+      cc: "colleague@company.com, manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toHaveLength(3);
+  });
+
+  it("should handle override TO parameter", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com",
+      cc: "manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers, "override@example.com");
+
+    expect(result.to).toBe("override@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).not.toContain("override@example.com");
+  });
+
+  it("should handle addresses with extra spaces", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: " user@company.com ,  colleague@company.com ",
+      cc: " manager@company.com ",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toHaveLength(3);
+  });
+
+  it("should filter out empty addresses", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "user@company.com, , colleague@company.com",
+      cc: ", manager@company.com, ",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("colleague@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toHaveLength(3);
+  });
+
+  it("should exclude the reply-to address from CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "sender@example.com, user@company.com",
+      cc: "manager@company.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).not.toContain("sender@example.com");
+    expect(result.cc).toContain("user@company.com");
+    expect(result.cc).toContain("manager@company.com");
+    expect(result.cc).toHaveLength(2);
+  });
+});
+
+describe("formatCcList", () => {
+  it("should format array of addresses as comma-separated string", () => {
+    const addresses = ["user1@example.com", "user2@example.com"];
+    const result = formatCcList(addresses);
+    expect(result).toBe("user1@example.com, user2@example.com");
+  });
+
+  it("should return undefined for empty array", () => {
+    const result = formatCcList([]);
+    expect(result).toBeUndefined();
+  });
+
+  it("should handle single address", () => {
+    const result = formatCcList(["user@example.com"]);
+    expect(result).toBe("user@example.com");
+  });
+});

--- a/apps/web/utils/email/reply-all.test.ts
+++ b/apps/web/utils/email/reply-all.test.ts
@@ -366,6 +366,29 @@ describe("buildReplyAllRecipients", () => {
     expect(result.cc).toContain("charlie@company.com");
     expect(result.cc).toHaveLength(2);
   });
+
+  it("should handle display names with commas correctly", () => {
+    const headers: ParsedMessageHeaders = {
+      from: '"Smith, John" <john@example.com>',
+      to: '"Doe, Jane" <jane@company.com>, "Johnson, Bob" <bob@company.com>',
+      cc: '"Williams, Mary" <mary@company.com>, simple@company.com',
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(
+      headers,
+      undefined,
+      "myemail@example.com",
+    );
+
+    expect(result.to).toBe('"Smith, John" <john@example.com>');
+    expect(result.cc).toContain("jane@company.com");
+    expect(result.cc).toContain("bob@company.com");
+    expect(result.cc).toContain("mary@company.com");
+    expect(result.cc).toContain("simple@company.com");
+    expect(result.cc).toHaveLength(4);
+  });
 });
 
 describe("formatCcList", () => {

--- a/apps/web/utils/email/reply-all.ts
+++ b/apps/web/utils/email/reply-all.ts
@@ -1,0 +1,58 @@
+import type { ParsedMessageHeaders } from "@/utils/types";
+
+export interface ReplyAllRecipients {
+  to: string;
+  cc: string[];
+}
+
+/**
+ * Builds reply-all recipients by including original TO and CC recipients.
+ * The reply goes to the original sender, and CC includes all other recipients.
+ *
+ * @param headers - Original email headers
+ * @param overrideTo - Optional override for the TO field (e.g., for drafts)
+ * @returns Object with TO and CC recipients for reply-all
+ */
+export function buildReplyAllRecipients(
+  headers: ParsedMessageHeaders,
+  overrideTo?: string,
+): ReplyAllRecipients {
+  // Determine the primary recipient (TO field)
+  const replyTo = overrideTo || headers["reply-to"] || headers.from;
+
+  // Build CC list for reply-all behavior
+  const ccSet = new Set<string>();
+
+  // Add original CC recipients if they exist
+  if (headers.cc) {
+    const originalCcAddresses = headers.cc
+      .split(",")
+      .map((addr) => addr.trim())
+      .filter((addr) => addr && addr !== replyTo);
+
+    originalCcAddresses.forEach((addr) => ccSet.add(addr));
+  }
+
+  // Add original TO recipients to CC (excluding the reply-to address)
+  if (headers.to) {
+    const originalToAddresses = headers.to
+      .split(",")
+      .map((addr) => addr.trim())
+      .filter((addr) => addr && addr !== replyTo);
+
+    originalToAddresses.forEach((addr) => ccSet.add(addr));
+  }
+
+  return {
+    to: replyTo,
+    cc: Array.from(ccSet),
+  };
+}
+
+/**
+ * Converts array of CC recipients to a comma-separated string.
+ * Returns undefined if the array is empty.
+ */
+export function formatCcList(ccList: string[]): string | undefined {
+  return ccList.length > 0 ? ccList.join(", ") : undefined;
+}

--- a/apps/web/utils/email/reply-all.ts
+++ b/apps/web/utils/email/reply-all.ts
@@ -30,7 +30,9 @@ export function buildReplyAllRecipients(
       .map((addr) => addr.trim())
       .filter((addr) => addr && addr !== replyTo);
 
-    originalCcAddresses.forEach((addr) => ccSet.add(addr));
+    for (const addr of originalCcAddresses) {
+      ccSet.add(addr);
+    }
   }
 
   // Add original TO recipients to CC (excluding the reply-to address)
@@ -40,7 +42,9 @@ export function buildReplyAllRecipients(
       .map((addr) => addr.trim())
       .filter((addr) => addr && addr !== replyTo);
 
-    originalToAddresses.forEach((addr) => ccSet.add(addr));
+    for (const addr of originalToAddresses) {
+      ccSet.add(addr);
+    }
   }
 
   return {

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -74,6 +74,7 @@ export interface EmailProvider {
   draftEmail(
     email: ParsedMessage,
     args: { to?: string; subject?: string; content: string },
+    userEmail: string,
     executedRule?: { id: string; threadId: string; emailAccountId: string },
   ): Promise<{ draftId: string }>;
   replyToEmail(email: ParsedMessage, content: string): Promise<void>;

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -244,13 +244,18 @@ export async function draftEmail(
     content: string;
     attachments?: Attachment[];
   },
+  userEmail: string,
 ) {
   const { text, html } = createReplyContent({
     textContent: args.content,
     message: originalEmail,
   });
 
-  const recipients = buildReplyAllRecipients(originalEmail.headers, args.to);
+  const recipients = buildReplyAllRecipients(
+    originalEmail.headers,
+    args.to,
+    userEmail,
+  );
 
   const raw = await createRawMailMessage({
     to: recipients.to,

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -17,6 +17,7 @@ import { createReplyContent } from "@/utils/gmail/reply";
 import type { EmailForAction } from "@/utils/ai/types";
 import { createScopedLogger } from "@/utils/logger";
 import { withGmailRetry } from "@/utils/gmail/retry";
+import { buildReplyAllRecipients, formatCcList } from "@/utils/email/reply-all";
 
 const logger = createScopedLogger("gmail/mail");
 
@@ -145,33 +146,13 @@ export async function replyToEmail(
     message,
   });
 
-  // Default to reply-all behavior: include original TO field recipients in CC
-  const replyToAddress = message.headers["reply-to"] || message.headers.from;
-  
-  // Build CC list for reply-all behavior
-  let ccList: string[] = [];
-  
-  // Add original CC recipients if they exist
-  if (message.headers.cc) {
-    const originalCcAddresses = message.headers.cc.split(',').map(addr => addr.trim());
-    ccList.push(...originalCcAddresses);
-  }
-  
-  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
-  if (message.headers.to && message.headers.to !== replyToAddress) {
-    // Split multiple TO addresses and filter out the reply-to address
-    const originalToAddresses = message.headers.to.split(',').map(addr => addr.trim());
-    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
-    ccList.push(...filteredToAddresses);
-  }
-  
-  // Remove duplicates and join CC list
-  const finalCcList = [...new Set(ccList)].join(', ');
+  // Use reply-all logic to build recipients
+  const recipients = buildReplyAllRecipients(message.headers);
 
   const raw = await createRawMailMessage(
     {
-      to: replyToAddress,
-      cc: finalCcList || undefined,
+      to: recipients.to,
+      cc: formatCcList(recipients.cc),
       subject: message.headers.subject,
       messageText: text,
       messageHtml: html,
@@ -272,32 +253,12 @@ export async function draftEmail(
     message: originalEmail,
   });
 
-  // Default to reply-all behavior: include original TO field recipients in CC
-  const replyToAddress = args.to || originalEmail.headers["reply-to"] || originalEmail.headers.from;
-  
-  // Build CC list for reply-all behavior
-  let ccList: string[] = [];
-  
-  // Add original CC recipients if they exist
-  if (originalEmail.headers.cc) {
-    const originalCcAddresses = originalEmail.headers.cc.split(',').map(addr => addr.trim());
-    ccList.push(...originalCcAddresses);
-  }
-  
-  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
-  if (originalEmail.headers.to && originalEmail.headers.to !== replyToAddress) {
-    // Split multiple TO addresses and filter out the reply-to address
-    const originalToAddresses = originalEmail.headers.to.split(',').map(addr => addr.trim());
-    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
-    ccList.push(...filteredToAddresses);
-  }
-  
-  // Remove duplicates and join CC list
-  const finalCcList = [...new Set(ccList)].join(', ');
+  // Use reply-all logic to build recipients
+  const recipients = buildReplyAllRecipients(originalEmail.headers, args.to);
 
   const raw = await createRawMailMessage({
-    to: replyToAddress,
-    cc: finalCcList || undefined,
+    to: recipients.to,
+    cc: formatCcList(recipients.cc),
     bcc: originalEmail.headers.bcc,
     subject: args.subject || originalEmail.headers.subject,
     messageHtml: html,

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -146,13 +146,10 @@ export async function replyToEmail(
     message,
   });
 
-  // Use reply-all logic to build recipients
-  const recipients = buildReplyAllRecipients(message.headers);
-
+  // Only replying to the original sender
   const raw = await createRawMailMessage(
     {
-      to: recipients.to,
-      cc: formatCcList(recipients.cc),
+      to: message.headers["reply-to"] || message.headers.from,
       subject: message.headers.subject,
       messageText: text,
       messageHtml: html,
@@ -253,13 +250,11 @@ export async function draftEmail(
     message: originalEmail,
   });
 
-  // Use reply-all logic to build recipients
   const recipients = buildReplyAllRecipients(originalEmail.headers, args.to);
 
   const raw = await createRawMailMessage({
     to: recipients.to,
     cc: formatCcList(recipients.cc),
-    bcc: originalEmail.headers.bcc,
     subject: args.subject || originalEmail.headers.subject,
     messageHtml: html,
     messageText: text,

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -145,9 +145,33 @@ export async function replyToEmail(
     message,
   });
 
+  // Default to reply-all behavior: include original TO field recipients in CC
+  const replyToAddress = message.headers["reply-to"] || message.headers.from;
+  
+  // Build CC list for reply-all behavior
+  let ccList: string[] = [];
+  
+  // Add original CC recipients if they exist
+  if (message.headers.cc) {
+    const originalCcAddresses = message.headers.cc.split(',').map(addr => addr.trim());
+    ccList.push(...originalCcAddresses);
+  }
+  
+  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
+  if (message.headers.to && message.headers.to !== replyToAddress) {
+    // Split multiple TO addresses and filter out the reply-to address
+    const originalToAddresses = message.headers.to.split(',').map(addr => addr.trim());
+    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
+    ccList.push(...filteredToAddresses);
+  }
+  
+  // Remove duplicates and join CC list
+  const finalCcList = [...new Set(ccList)].join(', ');
+
   const raw = await createRawMailMessage(
     {
-      to: message.headers["reply-to"] || message.headers.from,
+      to: replyToAddress,
+      cc: finalCcList || undefined,
       subject: message.headers.subject,
       messageText: text,
       messageHtml: html,
@@ -248,12 +272,32 @@ export async function draftEmail(
     message: originalEmail,
   });
 
+  // Default to reply-all behavior: include original TO field recipients in CC
+  const replyToAddress = args.to || originalEmail.headers["reply-to"] || originalEmail.headers.from;
+  
+  // Build CC list for reply-all behavior
+  let ccList: string[] = [];
+  
+  // Add original CC recipients if they exist
+  if (originalEmail.headers.cc) {
+    const originalCcAddresses = originalEmail.headers.cc.split(',').map(addr => addr.trim());
+    ccList.push(...originalCcAddresses);
+  }
+  
+  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
+  if (originalEmail.headers.to && originalEmail.headers.to !== replyToAddress) {
+    // Split multiple TO addresses and filter out the reply-to address
+    const originalToAddresses = originalEmail.headers.to.split(',').map(addr => addr.trim());
+    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
+    ccList.push(...filteredToAddresses);
+  }
+  
+  // Remove duplicates and join CC list
+  const finalCcList = [...new Set(ccList)].join(', ');
+
   const raw = await createRawMailMessage({
-    to:
-      args.to ||
-      originalEmail.headers["reply-to"] ||
-      originalEmail.headers.from,
-    cc: originalEmail.headers.cc,
+    to: replyToAddress,
+    cc: finalCcList || undefined,
     bcc: originalEmail.headers.bcc,
     subject: args.subject || originalEmail.headers.subject,
     messageHtml: html,

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -168,13 +168,18 @@ export async function draftEmail(
     content: string;
     attachments?: Attachment[];
   },
+  userEmail: string,
 ) {
   const { html } = createReplyContent({
     textContent: args.content,
     message: originalEmail,
   });
 
-  const recipients = buildReplyAllRecipients(originalEmail.headers, args.to);
+  const recipients = buildReplyAllRecipients(
+    originalEmail.headers,
+    args.to,
+    userEmail,
+  );
 
   // Convert CC addresses to Outlook format
   const ccRecipients = recipients.cc.map((addr) => ({

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -73,14 +73,7 @@ export async function replyToEmail(
     message,
   });
 
-  // Use reply-all logic to build recipients
-  const recipients = buildReplyAllRecipients(message.headers);
-
-  // Convert CC addresses to Outlook format
-  const ccRecipients = recipients.cc.map((addr) => ({
-    emailAddress: { address: addr },
-  }));
-
+  // Only replying to the original sender
   const replyMessage = {
     subject: `Re: ${message.headers.subject}`,
     body: {
@@ -90,11 +83,10 @@ export async function replyToEmail(
     toRecipients: [
       {
         emailAddress: {
-          address: recipients.to,
+          address: message.headers["reply-to"] || message.headers.from,
         },
       },
     ],
-    ...(ccRecipients.length > 0 ? { ccRecipients } : {}),
     conversationId: message.threadId,
   };
 
@@ -182,7 +174,6 @@ export async function draftEmail(
     message: originalEmail,
   });
 
-  // Use reply-all logic to build recipients
   const recipients = buildReplyAllRecipients(originalEmail.headers, args.to);
 
   // Convert CC addresses to Outlook format
@@ -204,13 +195,6 @@ export async function draftEmail(
       },
     ],
     ...(ccRecipients.length > 0 ? { ccRecipients } : {}),
-    ...(originalEmail.headers.bcc
-      ? {
-          bccRecipients: [
-            { emailAddress: { address: originalEmail.headers.bcc } },
-          ],
-        }
-      : {}),
     conversationId: originalEmail.threadId,
     isDraft: true,
   };

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -72,6 +72,35 @@ export async function replyToEmail(
     message,
   });
 
+  // Default to reply-all behavior: include original TO field recipients in CC
+  const replyToAddress = message.headers["reply-to"] || message.headers.from;
+  
+  // Build CC list for reply-all behavior
+  let ccRecipients: { emailAddress: { address: string } }[] = [];
+  
+  // Add original CC recipients if they exist
+  if (message.headers.cc) {
+    const originalCcAddresses = message.headers.cc.split(',').map(addr => addr.trim());
+    originalCcAddresses.forEach(addr => {
+      ccRecipients.push({ emailAddress: { address: addr } });
+    });
+  }
+  
+  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
+  if (message.headers.to && message.headers.to !== replyToAddress) {
+    // Split multiple TO addresses and filter out the reply-to address
+    const originalToAddresses = message.headers.to.split(',').map(addr => addr.trim());
+    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
+    filteredToAddresses.forEach(addr => {
+      ccRecipients.push({ emailAddress: { address: addr } });
+    });
+  }
+  
+  // Remove duplicate CC recipients
+  const uniqueCcRecipients = ccRecipients.filter((recipient, index, self) => 
+    index === self.findIndex(r => r.emailAddress.address === recipient.emailAddress.address)
+  );
+
   const replyMessage = {
     subject: `Re: ${message.headers.subject}`,
     body: {
@@ -81,10 +110,11 @@ export async function replyToEmail(
     toRecipients: [
       {
         emailAddress: {
-          address: message.headers["reply-to"] || message.headers.from,
+          address: replyToAddress,
         },
       },
     ],
+    ...(uniqueCcRecipients.length > 0 ? { ccRecipients: uniqueCcRecipients } : {}),
     conversationId: message.threadId,
   };
 
@@ -172,6 +202,35 @@ export async function draftEmail(
     message: originalEmail,
   });
 
+  // Default to reply-all behavior: include original TO field recipients in CC
+  const replyToAddress = args.to || originalEmail.headers["reply-to"] || originalEmail.headers.from;
+  
+  // Build CC list for reply-all behavior
+  let ccRecipients: { emailAddress: { address: string } }[] = [];
+  
+  // Add original CC recipients if they exist
+  if (originalEmail.headers.cc) {
+    const originalCcAddresses = originalEmail.headers.cc.split(',').map(addr => addr.trim());
+    originalCcAddresses.forEach(addr => {
+      ccRecipients.push({ emailAddress: { address: addr } });
+    });
+  }
+  
+  // Add original TO recipients to CC (excluding the reply-to address to avoid duplicates)
+  if (originalEmail.headers.to && originalEmail.headers.to !== replyToAddress) {
+    // Split multiple TO addresses and filter out the reply-to address
+    const originalToAddresses = originalEmail.headers.to.split(',').map(addr => addr.trim());
+    const filteredToAddresses = originalToAddresses.filter(addr => addr !== replyToAddress);
+    filteredToAddresses.forEach(addr => {
+      ccRecipients.push({ emailAddress: { address: addr } });
+    });
+  }
+  
+  // Remove duplicate CC recipients
+  const uniqueCcRecipients = ccRecipients.filter((recipient, index, self) => 
+    index === self.findIndex(r => r.emailAddress.address === recipient.emailAddress.address)
+  );
+
   const draft = {
     subject: args.subject || originalEmail.headers.subject,
     body: {
@@ -181,20 +240,11 @@ export async function draftEmail(
     toRecipients: [
       {
         emailAddress: {
-          address:
-            args.to ||
-            originalEmail.headers["reply-to"] ||
-            originalEmail.headers.from,
+          address: replyToAddress,
         },
       },
     ],
-    ...(originalEmail.headers.cc
-      ? {
-          ccRecipients: [
-            { emailAddress: { address: originalEmail.headers.cc } },
-          ],
-        }
-      : {}),
+    ...(uniqueCcRecipients.length > 0 ? { ccRecipients: uniqueCcRecipients } : {}),
     ...(originalEmail.headers.bcc
       ? {
           bccRecipients: [

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -51,7 +51,7 @@ export async function generateDraft({
   }
 
   // 2. Create draft
-  await client.draftEmail(message, { content: result });
+  await client.draftEmail(message, { content: result }, emailAccount.email);
 
   logger.info("Draft created");
 }


### PR DESCRIPTION
Implement default "reply all" behavior for AI draft replies by including original TO and CC recipients in the reply's CC field.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d6ec088-4563-4297-bafe-150cedf4f697">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d6ec088-4563-4297-bafe-150cedf4f697">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified "Reply All" recipient logic across Gmail and Outlook; reply-to preferred, supports overriding To when drafting.

* **Bug Fixes**
  * Removes duplicate recipients, trims spaces, excludes the sender from CC, and omits CC when no valid recipients remain.

* **Tests**
  * Added comprehensive tests validating reply-all recipient construction and CC formatting.

* **Chores**
  * Draft workflows updated to accept the user's email so replies correctly filter CC recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->