### PR TITLE
Fix: Error message not displaying when no actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -338,7 +338,7 @@ export function RuleForm({
     }
   }, [alwaysEditMode]);
   
-  function getErrorMessages(errors: any): string[] {
+  function getErrorMessages(errors: FieldErrors<CreateRuleBody>): string[] {
     const messages: string[] = [];
   
     if (!errors) {


### PR DESCRIPTION
Fixes #912

## 📝 Description
This pull request adds a clear, top-level error message to the Rule Dialog to improve form validation feedback and user experience.

### What’s New

* A general error message now appears at the top of the dialog when:
    * No condition is defined
    * No action is added
    * The rule name is missing

## 🎥 Demo
A short video of the change is attached below, showing how the error message appears dynamically when required fields are missing.

https://github.com/user-attachments/assets/bac61977-f443-4714-b14e-e6bb1af4950b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined form validation in the rules editor for clearer, more consistent error feedback.
  * Consolidated error messages into a single, user-facing list to reduce duplication and make issues easier to scan and act on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->