### PR TITLE
Fix Referral Modal Text Color In Dark Mode

### DIFF
--- a/apps/web/components/ReferralDialog.tsx
+++ b/apps/web/components/ReferralDialog.tsx
@@ -98,10 +98,10 @@ export function Referrals() {
   return (
     <div className="space-y-8">
       <div className="text-center">
-        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+        <h1 className="text-3xl font-bold tracking-tight text-primary dark:text-foreground">
           Refer Friends, Get Rewards
         </h1>
-        <p className="mt-4 text-lg text-gray-600">
+        <p className="mt-4 text-lg text-muted-foreground">
           Share Inbox Zero with friends and get a free month for each friend who
           completes their trial
         </p>


### PR DESCRIPTION
Fixes #940 

### 📋 Description
This PR fixes the text color in the **“Refer Friends, Get Rewards”** modal.  

Before :-
<img width="1911" height="970" alt="Screenshot 2025-11-10 174317" src="https://github.com/user-attachments/assets/43a391bc-8ee5-4e73-a1f5-211adb6a611d" />

After:- 
<img width="1917" height="873" alt="Screenshot 2025-11-10 180254" src="https://github.com/user-attachments/assets/14ed9966-d943-4819-936f-552c6e32a9dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling in the referral dialog to use primary and foreground colors, enhancing visual consistency with the design system and improving readability in both light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->