### PR TITLE
WIP: Handle cold emails better across domains

### DIFF
--- a/apps/web/utils/cold-email/exclude-cold-emails.test.ts
+++ b/apps/web/utils/cold-email/exclude-cold-emails.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isColdEmail } from "@/utils/cold-email/is-cold-email";
+import { getEmailAccount } from "@/__tests__/helpers";
+import type { EmailProvider } from "@/utils/email/types";
+import { ActionType } from "@prisma/client";
+import prisma from "@/utils/__mocks__/prisma";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/llms", () => ({
+  createGenerateObject: vi.fn(() =>
+    vi.fn().mockResolvedValue({
+      object: { coldEmail: true, reason: "Test AI reason" },
+    }),
+  ),
+}));
+
+describe("Cold Email - Exclude from Search", () => {
+  const mockProvider: EmailProvider = {
+    hasPreviousCommunicationsWithSenderOrDomain: vi.fn(),
+  } as unknown as EmailProvider;
+
+  const mockEmailAccount = getEmailAccount();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock the database check for known cold email senders
+    prisma.coldEmail.findUnique.mockResolvedValue(null);
+  });
+
+  describe("Gmail - Label exclusion", () => {
+    it("should exclude emails with cold email label from search", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Cold Email",
+            labelId: "label-123",
+          },
+        ],
+      };
+
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          date: new Date(),
+          id: "msg-123",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalledWith({
+        from: "test@example.com",
+        date: expect.any(Date),
+        messageId: "msg-123",
+        excludeLabel: "Cold Email",
+        excludeFolder: null,
+      });
+    });
+
+    it("should use custom label name when configured", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Spam-ish",
+            labelId: "label-456",
+          },
+        ],
+      };
+
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          date: new Date(),
+          id: "msg-123",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeLabel: "Spam-ish",
+          excludeFolder: null,
+        }),
+      );
+    });
+  });
+
+  describe("Microsoft Outlook - Category vs Folder exclusion", () => {
+    it("should use category filter for LABEL action", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Cold Email",
+            labelId: "category-123",
+          },
+        ],
+      };
+
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          date: new Date(),
+          id: "msg-123",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalledWith({
+        from: "test@example.com",
+        date: expect.any(Date),
+        messageId: "msg-123",
+        excludeLabel: "Cold Email",
+        excludeFolder: null,
+      });
+    });
+
+    it("should use folder filter for MOVE_FOLDER action", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.MOVE_FOLDER,
+            label: "Cold Email",
+            labelId: null,
+          },
+        ],
+      };
+
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          date: new Date(),
+          id: "msg-123",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalledWith({
+        from: "test@example.com",
+        date: expect.any(Date),
+        messageId: "msg-123",
+        excludeLabel: null,
+        excludeFolder: "Cold Email",
+      });
+    });
+  });
+
+  describe("Fallback behavior", () => {
+    it("should use default Cold Email label when no rule is configured", async () => {
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          date: new Date(),
+          id: "msg-123",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule: null,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeLabel: "Cold Email",
+          excludeFolder: null,
+        }),
+      );
+    });
+
+    it("should not check previous emails when date or id is missing", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Cold Email",
+            labelId: "label-123",
+          },
+        ],
+      };
+
+      await isColdEmail({
+        email: {
+          from: "test@example.com",
+          to: "user@example.com",
+          subject: "Test",
+          content: "Test",
+          // Missing date and id
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Previous email detection with exclusion", () => {
+    it("should not mark as cold email when previous non-cold email exists", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Cold Email",
+            labelId: "label-123",
+          },
+        ],
+      };
+
+      // Simulate finding a previous email that's NOT marked as cold
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(true);
+
+      const result = await isColdEmail({
+        email: {
+          from: "colleague@company.com",
+          to: "user@example.com",
+          subject: "Follow up",
+          content: "Test",
+          date: new Date(),
+          id: "msg-456",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      expect(result.isColdEmail).toBe(false);
+      expect(result.reason).toBe("hasPreviousEmail");
+    });
+
+    it("should check AI when no previous non-cold email exists", async () => {
+      const coldEmailRule = {
+        id: "rule-1",
+        enabled: true,
+        instructions: "test",
+        actions: [
+          {
+            type: ActionType.LABEL,
+            label: "Cold Email",
+            labelId: "label-123",
+          },
+        ],
+      };
+
+      // Simulate NOT finding any previous email (all were cold emails and excluded)
+      vi.mocked(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).mockResolvedValue(false);
+
+      const result = await isColdEmail({
+        email: {
+          from: "spammer@company.com",
+          to: "user@example.com",
+          subject: "Buy our services",
+          content: "Test",
+          date: new Date(),
+          id: "msg-789",
+        },
+        emailAccount: mockEmailAccount,
+        provider: mockProvider,
+        coldEmailRule,
+      });
+
+      // Should proceed to AI check (we're not testing AI here, so it will use the real function)
+      expect(
+        mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/utils/cold-email/is-cold-email-label-exclusion.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email-label-exclusion.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isColdEmail } from "./is-cold-email";
+import { getEmailAccount } from "@/__tests__/helpers";
+import type { EmailForLLM } from "@/utils/types";
+import { ColdEmailStatus, ActionType } from "@prisma/client";
+import prisma from "@/utils/prisma";
+import type { ColdEmailRule } from "./cold-email-rule";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    coldEmail: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/llms", () => ({
+  createGenerateObject: vi.fn(() =>
+    vi.fn().mockResolvedValue({
+      object: {
+        coldEmail: false,
+        reason: "This is not a cold email",
+      },
+    }),
+  ),
+}));
+
+describe("isColdEmail - label exclusion in previous email check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should pass cold email label to provider when checking previous communications", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi
+        .fn()
+        .mockResolvedValue(false),
+    };
+
+    const coldEmailRule: ColdEmailRule = {
+      id: "rule-id",
+      enabled: true,
+      instructions: "Test instructions",
+      actions: [
+        {
+          type: ActionType.LABEL,
+          label: "Cold Email",
+          labelId: "label-123",
+        },
+      ],
+    };
+
+    // Mock that sender is not a known cold emailer
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue(null);
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule,
+    });
+
+    // Verify that the provider was called with the excludeLabel parameter
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).toHaveBeenCalledWith({
+      from: "sender@example.com",
+      date: email.date,
+      messageId: "msg1",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+  });
+
+  it("should use custom label name when configured", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi
+        .fn()
+        .mockResolvedValue(false),
+    };
+
+    const coldEmailRule: ColdEmailRule = {
+      id: "rule-id",
+      enabled: true,
+      instructions: "Test instructions",
+      actions: [
+        {
+          type: ActionType.LABEL,
+          label: "My Custom Cold Email Label",
+          labelId: "label-456",
+        },
+      ],
+    };
+
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue(null);
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule,
+    });
+
+    // Verify that the custom label name is used
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).toHaveBeenCalledWith({
+      from: "sender@example.com",
+      date: email.date,
+      messageId: "msg1",
+      excludeLabel: "My Custom Cold Email Label",
+      excludeFolder: null,
+    });
+  });
+
+  it("should fallback to 'Cold Email' when no label is configured", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi
+        .fn()
+        .mockResolvedValue(false),
+    };
+
+    const coldEmailRule: ColdEmailRule = {
+      id: "rule-id",
+      enabled: true,
+      instructions: "Test instructions",
+      actions: [],
+    };
+
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue(null);
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule,
+    });
+
+    // Verify that default label is used when no actions are configured
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).toHaveBeenCalledWith({
+      from: "sender@example.com",
+      date: email.date,
+      messageId: "msg1",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+  });
+
+  it("should fallback to 'Cold Email' when coldEmailRule is null", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi
+        .fn()
+        .mockResolvedValue(false),
+    };
+
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue(null);
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule: null,
+    });
+
+    // Verify that default label is used when coldEmailRule is null
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).toHaveBeenCalledWith({
+      from: "sender@example.com",
+      date: email.date,
+      messageId: "msg1",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+  });
+
+  it("should return false when hasPreviousEmail is true (excluding cold email label)", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi
+        .fn()
+        .mockResolvedValue(true), // Has previous non-cold email
+    };
+
+    const coldEmailRule: ColdEmailRule = {
+      id: "rule-id",
+      enabled: true,
+      instructions: "Test instructions",
+      actions: [
+        {
+          type: ActionType.LABEL,
+          label: "Cold Email",
+          labelId: "label-123",
+        },
+      ],
+    };
+
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue(null);
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    const result = await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule,
+    });
+
+    // Should not be marked as cold email because we have previous communication
+    // (excluding emails with the cold email label)
+    expect(result.isColdEmail).toBe(false);
+    expect(result.reason).toBe("hasPreviousEmail");
+  });
+
+  it("should not call provider if sender is already known cold emailer", async () => {
+    const emailAccount = getEmailAccount({ id: "test-account-id" });
+    const mockProvider = {
+      hasPreviousCommunicationsWithSenderOrDomain: vi.fn(),
+    };
+
+    const coldEmailRule: ColdEmailRule = {
+      id: "rule-id",
+      enabled: true,
+      instructions: "Test instructions",
+      actions: [
+        {
+          type: ActionType.LABEL,
+          label: "Cold Email",
+          labelId: "label-123",
+        },
+      ],
+    };
+
+    // Mock that sender is a known cold emailer
+    vi.mocked(prisma.coldEmail.findUnique).mockResolvedValue({
+      id: "cold-email-id",
+      emailAccountId: emailAccount.id,
+      fromEmail: "sender@example.com",
+      status: ColdEmailStatus.AI_LABELED_COLD,
+      reason: "Previous cold email",
+      messageId: "prev-msg",
+      threadId: "prev-thread",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const email: EmailForLLM = {
+      id: "msg1",
+      from: "sender@example.com",
+      to: emailAccount.email,
+      subject: "Test",
+      content: "Test content",
+      date: new Date(),
+    };
+
+    const result = await isColdEmail({
+      email,
+      emailAccount,
+      provider: mockProvider as never,
+      coldEmailRule,
+    });
+
+    // Should be marked as cold email due to database check
+    expect(result.isColdEmail).toBe(true);
+    expect(result.reason).toBe("ai-already-labeled");
+
+    // Provider should not be called since we already know it's a cold emailer
+    expect(
+      mockProvider.hasPreviousCommunicationsWithSenderOrDomain,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -217,6 +217,8 @@ export interface EmailProvider {
     from: string;
     date: Date;
     messageId: string;
+    excludeLabel: string | null; // Gmail: label name | Outlook: category name
+    excludeFolder: string | null; // Outlook only: folder name
   }): Promise<boolean>;
   getThreadsFromSenderWithSubject(
     sender: string,

--- a/apps/web/utils/gmail/message-label-exclusion.test.ts
+++ b/apps/web/utils/gmail/message-label-exclusion.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hasPreviousCommunicationsWithSenderOrDomain } from "./message";
+import type { EmailProvider } from "@/utils/email/types";
+
+vi.mock("server-only", () => ({}));
+
+describe("hasPreviousCommunicationsWithSenderOrDomain - label exclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should add label exclusion to Gmail search queries", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const testDate = new Date("2024-01-15T12:00:00Z");
+
+    // For company domains (non-public), searches by domain
+    await hasPreviousCommunicationsWithSenderOrDomain(mockProvider, {
+      from: "sender@example.com",
+      date: testDate,
+      messageId: "msg-123",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+
+    // Verify that both incoming and outgoing searches include label exclusion
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledTimes(2);
+
+    // Check incoming email search (from:) - searches by domain for company emails
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'from:example.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+
+    // Check outgoing email search (to:) - searches by domain for company emails
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'to:example.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+  });
+
+  it("should not add label exclusion when excludeLabel is null", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const testDate = new Date("2024-01-15T12:00:00Z");
+
+    await hasPreviousCommunicationsWithSenderOrDomain(mockProvider, {
+      from: "sender@example.com",
+      date: testDate,
+      messageId: "msg-123",
+      excludeLabel: null,
+      excludeFolder: null,
+    });
+
+    // Verify that queries don't include label exclusion
+    // For company domains (non-public), searches by domain
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: "from:example.com",
+      maxResults: 2,
+      before: testDate,
+    });
+
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: "to:example.com",
+      maxResults: 2,
+      before: testDate,
+    });
+  });
+
+  it("should search by domain for non-public domains with label exclusion", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const testDate = new Date("2024-01-15T12:00:00Z");
+
+    // Use a company domain (not a public one like gmail.com)
+    await hasPreviousCommunicationsWithSenderOrDomain(mockProvider, {
+      from: "person@company.com",
+      date: testDate,
+      messageId: "msg-123",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+
+    // For company domains, should search by domain, not full email
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'from:company.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'to:company.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+  });
+
+  it("should search by full email for public domains like gmail.com", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const testDate = new Date("2024-01-15T12:00:00Z");
+
+    await hasPreviousCommunicationsWithSenderOrDomain(mockProvider, {
+      from: "person@gmail.com",
+      date: testDate,
+      messageId: "msg-123",
+      excludeLabel: "Cold Email",
+      excludeFolder: null,
+    });
+
+    // For public domains like gmail.com, should search by full email
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'from:person@gmail.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'to:person@gmail.com -label:"Cold Email"',
+      maxResults: 2,
+      before: testDate,
+    });
+  });
+
+  it("should handle custom label names correctly", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const testDate = new Date("2024-01-15T12:00:00Z");
+
+    await hasPreviousCommunicationsWithSenderOrDomain(mockProvider, {
+      from: "sender@example.com",
+      date: testDate,
+      messageId: "msg-123",
+      excludeLabel: "My Custom Cold Email Label",
+      excludeFolder: null,
+    });
+
+    // Verify custom label name is used
+    // For company domains (non-public), searches by domain
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'from:example.com -label:"My Custom Cold Email Label"',
+      maxResults: 2,
+      before: testDate,
+    });
+
+    expect(mockGetMessagesWithPagination).toHaveBeenCalledWith({
+      query: 'to:example.com -label:"My Custom Cold Email Label"',
+      maxResults: 2,
+      before: testDate,
+    });
+  });
+
+  it("should return false when no previous emails exist (excluding cold emails)", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const result = await hasPreviousCommunicationsWithSenderOrDomain(
+      mockProvider,
+      {
+        from: "sender@example.com",
+        date: new Date(),
+        messageId: "msg-123",
+        excludeLabel: "Cold Email",
+        excludeFolder: null,
+      },
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true when previous emails exist (excluding cold emails)", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "prev-msg-1",
+          threadId: "thread-1",
+          from: "sender@example.com",
+          date: new Date("2024-01-10"),
+        },
+      ],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const result = await hasPreviousCommunicationsWithSenderOrDomain(
+      mockProvider,
+      {
+        from: "sender@example.com",
+        date: new Date("2024-01-15"),
+        messageId: "msg-123",
+        excludeLabel: "Cold Email",
+        excludeFolder: null,
+      },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("should exclude the current message from results", async () => {
+    const mockGetMessagesWithPagination = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "msg-123", // Same as current message
+          threadId: "thread-1",
+        },
+      ],
+    });
+
+    const mockProvider: EmailProvider = {
+      getMessagesWithPagination: mockGetMessagesWithPagination,
+    } as never;
+
+    const result = await hasPreviousCommunicationsWithSenderOrDomain(
+      mockProvider,
+      {
+        from: "sender@example.com",
+        date: new Date(),
+        messageId: "msg-123",
+        excludeLabel: "Cold Email",
+        excludeFolder: null,
+      },
+    );
+
+    // Should return false because the only message found is the current one
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
When someone emails us from the same domain, but under a different email, we skip the cold email check.

A better way to handle this is to only search for previous emails from the domain in question, that aren't labelled cold email. This PR does that.

Needs to be checked more before it can be merged in. And code may need clean up too.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cold email exclusion logic across multiple email providers and rule configurations, including edge cases and fallback scenarios.

* **Refactor**
  * Enhanced cold email detection to support label and folder-based exclusion when filtering previous communications.
  * Updated email provider interfaces to accept custom label and folder exclusion parameters for improved filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->