### PR TITLE
Common Topics

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/stats/BarListCard.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/BarListCard.tsx
@@ -16,11 +16,19 @@ import { cn } from "@/utils";
 
 interface BarListCardProps {
   tabs: { id: string; label: string; data: any }[]; // TODO: add type
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   title: string;
+  onItemClick?: (item: any) => void;
+  hideIcons?: boolean;
 }
 
-export function BarListCard({ tabs, icon, title }: BarListCardProps) {
+export function BarListCard({
+  tabs,
+  icon,
+  title,
+  onItemClick,
+  hideIcons,
+}: BarListCardProps) {
   const [selected, setSelected] = useState<string | null>(
     tabs?.length > 0 ? tabs[0]?.id : null,
   );
@@ -35,7 +43,7 @@ export function BarListCard({ tabs, icon, title }: BarListCardProps) {
             selected={selected}
           />
           <div className="flex items-center gap-2">
-            {icon}
+            {icon && icon}
             <p className="text-xs text-neutral-500">{title.toUpperCase()}</p>
           </div>
         </div>
@@ -49,6 +57,8 @@ export function BarListCard({ tabs, icon, title }: BarListCardProps) {
         />
         <HorizontalBarChart
           data={tabs.find((d) => d.id === selected)?.data || []}
+          onItemClick={onItemClick}
+          hideIcon={hideIcons}
         />
         <div className="absolute w-full left-0 bottom-0 pb-6 z-30">
           {tabs.find((d) => d.id === selected)?.data.length > 0 && (
@@ -71,6 +81,8 @@ export function BarListCard({ tabs, icon, title }: BarListCardProps) {
                   <div className="max-h-[60vh] overflow-y-auto p-6">
                     <HorizontalBarChart
                       data={tabs.find((d) => d.id === selected)?.data || []}
+                      onItemClick={onItemClick}
+                      hideIcon={hideIcons}
                     />
                   </div>
                 </DialogContent>

--- a/apps/web/app/(app)/[emailAccountId]/stats/Stats.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/Stats.tsx
@@ -17,6 +17,7 @@ import { ActionBar } from "@/app/(app)/[emailAccountId]/stats/ActionBar";
 import { DetailedStatsFilter } from "@/app/(app)/[emailAccountId]/stats/DetailedStatsFilter";
 import { LayoutGrid } from "lucide-react";
 import { DatePickerWithRange } from "@/components/DatePickerWithRange";
+import { TopicDistribution } from "@/app/(app)/[emailAccountId]/stats/TopicDistribution";
 
 const selectOptions = [
   { label: "Last week", value: "7" },
@@ -122,6 +123,9 @@ export function Stats() {
           dateRange={dateRange}
           refreshInterval={refreshInterval}
         />
+        <div className="grid grid-cols-2 gap-4">
+          <TopicDistribution />
+        </div>
         <RuleStatsChart
           dateRange={dateRange}
           title="Assistant processed emails"

--- a/apps/web/app/(app)/[emailAccountId]/stats/TopicDistribution.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/TopicDistribution.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { NewBarChart } from "@/app/(app)/[emailAccountId]/stats/NewBarChart";
+import { format, subDays } from "date-fns";
+import { COLORS } from "@/utils/colors";
+import { BarListCard } from "@/app/(app)/[emailAccountId]/stats/BarListCard";
+
+// Mock data for demo
+const MOCK_TOPICS = [
+  {
+    topic: "Customer Support",
+    count: 342,
+    chartColor: COLORS.analytics.blue,
+    emoji: "💬",
+  },
+  {
+    topic: "Product Updates",
+    count: 256,
+    chartColor: COLORS.analytics.purple,
+    emoji: "🚀",
+  },
+  {
+    topic: "Billing & Payments",
+    count: 189,
+    chartColor: COLORS.analytics.green,
+    emoji: "💰",
+  },
+  {
+    topic: "Feature Requests",
+    count: 167,
+    chartColor: COLORS.analytics.lightGreen,
+    emoji: "✨",
+  },
+  {
+    topic: "Bug Reports",
+    count: 134,
+    chartColor: COLORS.analytics.pink,
+    emoji: "🐛",
+  },
+  {
+    topic: "Sales Inquiries",
+    count: 89,
+    chartColor: COLORS.analytics.lightPink,
+    emoji: "📈",
+  },
+  { topic: "General Questions", count: 45, chartColor: "#94A3B8", emoji: "❓" },
+];
+
+// Generate mock daily data for past 30 days
+function generateDailyData(topicCount: number) {
+  const data = [];
+  const now = new Date();
+
+  for (let i = 29; i >= 0; i--) {
+    const date = subDays(now, i);
+    // Generate semi-realistic data with some variance
+    const baseCount = topicCount / 30;
+    const variance = Math.random() * baseCount * 0.8;
+    const count = Math.max(
+      0,
+      Math.round(baseCount + variance - baseCount * 0.4),
+    );
+
+    data.push({
+      date: format(date, "yyyy-MM-dd"),
+      count: count,
+    });
+  }
+
+  return data;
+}
+
+export function TopicDistribution() {
+  const [selectedTopic, setSelectedTopic] = useState<
+    (typeof MOCK_TOPICS)[0] | null
+  >(null);
+
+  const handleTopicClick = (item: { name: string; value: number }) => {
+    const topic = MOCK_TOPICS.find((t) => t.topic === item.name);
+    if (topic) {
+      setSelectedTopic(topic);
+    }
+  };
+
+  const tabs = [
+    {
+      id: "common-topics",
+      label: "Common Topics",
+      data: MOCK_TOPICS.map((topic) => ({
+        name: topic.topic,
+        value: topic.count,
+        icon: topic.emoji,
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <BarListCard
+        tabs={tabs}
+        icon={<MessageSquare className="h-4 w-4 text-neutral-500" />}
+        title="Topics"
+        onItemClick={handleTopicClick}
+      />
+
+      <Dialog
+        open={!!selectedTopic}
+        onOpenChange={() => setSelectedTopic(null)}
+      >
+        <DialogContent className="max-w-3xl">
+          {selectedTopic && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{selectedTopic.topic}</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="flex items-center gap-6">
+                  <div>
+                    <p className="text-sm text-gray-500">Total (30 days)</p>
+                    <p className="text-2xl font-bold">
+                      {selectedTopic.count.toLocaleString()}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-500">Average per day</p>
+                    <p className="text-2xl font-bold">
+                      {Math.round(selectedTopic.count / 30).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+                <NewBarChart
+                  data={generateDailyData(selectedTopic.count)}
+                  config={{
+                    count: { label: "Emails", color: selectedTopic.chartColor },
+                  }}
+                  xAxisKey="date"
+                  period="day"
+                />
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/components/charts/HorizontalBarChart.tsx
+++ b/apps/web/components/charts/HorizontalBarChart.tsx
@@ -3,19 +3,26 @@
 import { DomainIcon } from "@/components/charts/DomainIcon";
 import { cn } from "@/utils";
 
+export interface HorizontalBarChartItem {
+  name: string;
+  value: number;
+  href?: string;
+  target?: string;
+  icon?: string;
+}
+
 interface HorizontalBarChartProps {
-  data: Array<{
-    name: string;
-    value: number;
-    href?: string;
-    target?: string;
-  }>;
+  data: Array<HorizontalBarChartItem>;
   className?: string;
+  onItemClick?: (item: HorizontalBarChartItem) => void;
+  hideIcon?: boolean;
 }
 
 export function HorizontalBarChart({
   data,
   className,
+  onItemClick,
+  hideIcon,
 }: HorizontalBarChartProps) {
   const maxValue = Math.max(...data.map((item) => item.value), 1);
 
@@ -27,26 +34,39 @@ export function HorizontalBarChart({
           ? item.name.split("@")[1]
           : item.name;
 
-        return (
-          <div
-            key={item.name}
-            className="flex items-center justify-between gap-4"
-          >
+        const content = (
+          <>
             <div className="flex-1 min-w-0">
               <div className="px-3 py-2 relative">
                 <div
                   className="absolute top-0 left-0 bg-gradient-to-r from-blue-100 to-blue-50 h-full rounded-md"
                   style={{ width: `${widthPercentage}%` }}
                 />
-                <div className="flex items-center gap-2">
-                  <DomainIcon domain={domain} />
-                  <a
-                    href={item.href}
-                    target={item.target}
-                    className="text-sm text-gray-900 truncate block z-10 relative hover:underline"
-                  >
-                    {item.name}
-                  </a>
+                <div className="flex items-center gap-2 relative z-10">
+                  {!hideIcon &&
+                    (item.icon ? (
+                      <span className="text-base">{item.icon}</span>
+                    ) : (
+                      <DomainIcon domain={domain} />
+                    ))}
+                  {item.href ? (
+                    <a
+                      href={item.href}
+                      target={item.target}
+                      className="text-sm text-gray-900 truncate block z-10 relative hover:underline"
+                    >
+                      {item.name}
+                    </a>
+                  ) : (
+                    <span
+                      className={cn(
+                        "text-sm text-gray-900 truncate block z-10 relative",
+                        onItemClick && "group-hover:underline",
+                      )}
+                    >
+                      {item.name}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>
@@ -55,6 +75,28 @@ export function HorizontalBarChart({
                 {item.value.toLocaleString()}
               </span>
             </div>
+          </>
+        );
+
+        if (onItemClick) {
+          return (
+            <button
+              key={item.name}
+              type="button"
+              className="w-full flex items-center justify-between gap-4 group"
+              onClick={() => onItemClick(item)}
+            >
+              {content}
+            </button>
+          );
+        }
+
+        return (
+          <div
+            key={item.name}
+            className="flex items-center justify-between gap-4"
+          >
+            {content}
           </div>
         );
       })}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Replace Tremor charts with `NewBarChart`, restructure stats pages with `MainStatChart`, `BarListCard`, and preset `DatePickerWithRange`, and update Tailwind to remove Tremor tokens to support Common Topics work
Switch charting to `NewBarChart` across analytics, introduce `MainStatChart` and `BarListCard`, refactor `ActionBar` to layout-only, add preset-driven `DatePickerWithRange`, remove Tremor dependencies and tokens, and add favicon support via `t1.gstatic.com`. Key entry points: [file:apps/web/app/(app)/[emailAccountId]/stats/Stats.tsx], [file:apps/web/app/(app)/[emailAccountId]/stats/MainStatChart.tsx], [file:apps/web/app/(app)/[emailAccountId]/stats/NewBarChart.tsx], and [file:apps/web/tailwind.config.js].

#### 📍Where to Start
Start with `Stats` page composition in [Stats.tsx](https://github.com/elie222/inbox-zero/pull/1004/files#diff-f1a518696510d77047fd4f413d92447b6bc415ac8216b94de2b66b7e773df45b), then review chart foundations in `NewBarChart` ([file:apps/web/app/(app)/[emailAccountId]/stats/NewBarChart.tsx]) and summary logic in `MainStatChart` ([file:apps/web/app/(app)/[emailAccountId]/stats/MainStatChart.tsx]); validate theme changes in [file:apps/web/tailwind.config.js].

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 480449f. 46 files reviewed, 41 issues evaluated, 30 issues filtered, 4 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 171](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx#L171): `readPercentage` and `archivedPercentage` are computed by dividing by `item.value` without guarding against `0`. If `item.value` is `0`, both `(item.readEmails / item.value) * 100` and `((item.value - item.inboxEmails) / item.value) * 100` will yield `Infinity` or `NaN`, which then propagates to UI components (e.g., progress bars and percentage text), causing broken rendering and potentially invalid `value` props. Add a zero-check and fall back to `0` or skip rendering when `item.value === 0`. <b>[ Out of scope ]</b>
- [line 201](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx#L201): When `sortColumn === "emails"`, the sorting iteratee returns `undefined`, so `sortBy` doesn’t sort by the intended emails count. This yields an unsorted or implementation-defined order rather than sorting by `item.value`. Use `item.value` (the emails count) as the iteratee for the `"emails"` case. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/app/(app)/[emailAccountId]/stats/DetailedStatsFilter.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 36](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/DetailedStatsFilter.tsx#L36): `DetailedStatsFilter` sets `DropdownMenu` to a controlled open state when `keepOpenOnSelect` is true, but its `onOpenChange` handler ignores the `open` argument and only ever sets `isOpen` to `true` if it was previously `false`. This prevents normal close actions (e.g., pressing Escape or clicking the trigger again) from closing the menu; the menu can remain stuck open unless `onInteractOutside` fires. Use the `open` parameter to set state (`setIsOpen(open)`) or otherwise allow close events when appropriate. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/app/(app)/[emailAccountId]/stats/MainStatChart.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 38](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/MainStatChart.tsx#L38): `format(date, "yyyy-MM-dd")` is called on `date` parsed from `item.startOfPeriod` without validating the parse result. If `item.startOfPeriod` does not match `"MMM dd, yyyy"`, `parse(...)` yields an Invalid Date and `date-fns` `format(...)` will throw a `RangeError: Invalid time value`. Add validation (e.g., `isValid(date)`) or a fallback before formatting. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/app/(app)/[emailAccountId]/stats/NewBarChart.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 50](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/NewBarChart.tsx#L50): Date formatting in `NewBarChart` assumes `xAxisKey` values are valid dates. `new Date(value)` followed by `toLocaleDateString(...)` will throw `RangeError: Invalid time value` if `value` is missing or unparsable. This occurs in the default tick formatter and in the tooltip (`new Date(data.payload[xAxisKey])`). Add validation and fallback formatting, or guard against missing/invalid `xAxisKey` values. <b>[ Low confidence ]</b>
- [line 74](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/NewBarChart.tsx#L74): `config[key].color` is accessed without existence checks while iterating `keys` derived from `dataKeys || Object.keys(config)`. If `dataKeys` includes a key not present in `config`, accessing `config[key].color` will throw at runtime. Guard with `config[key] ? config[key].color : fallback`, validate `dataKeys` against `config`, or derive `keys` solely from `config`. Occurs in gradient `stopColor` and in `<Bar color={...}>`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/app/(app)/[emailAccountId]/stats/NewsletterModal.tsx — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 59](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/NewsletterModal.tsx#L59): Interactive element nesting: a `Button` (renders as a native `<button>` when `asChild` is false) contains an `<a>` anchor inside it (lines `59-67`). Nesting interactive controls is invalid HTML and can cause broken keyboard/focus behavior and inconsistent click handling. Use `Button` with `asChild` and render the anchor as the root (e.g., `<Button asChild><Link ... /></Button>`) or make the anchor the primary element without wrapping it in a button. <b>[ Out of scope ]</b>
- [line 82](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/(app)/[emailAccountId]/stats/NewsletterModal.tsx#L82): Provider-specific link mismatch: When `newsletter.autoArchived` is truthy, the UI always shows a `View Skip Inbox Filter` link built with `getGmailFilterSettingsUrl(userEmail)` (lines `82-91`). For non-Gmail providers (e.g., Outlook), this link is incorrect and misleading. Gate this by provider (show Gmail link only for Google accounts) or render the appropriate settings destination per provider. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/app/api/user/stats/by-period/route.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 25](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/app/api/user/stats/by-period/route.ts#L25): `getEmailStatsByPeriod` uses truthy checks for `fromDate` and `toDate` (`if (fromDate)`, `if (toDate)`), which will skip valid timestamp values of `0` (Unix epoch). Since `statsByWeekParams` allows any number via `z.coerce.number().nullish()`, `0` is an explicitly valid input and should be included. Use explicit null/undefined checks (e.g., `if (fromDate != null)`) to avoid dropping epoch filters. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/components/DatePickerWithRange.tsx — 1 comment posted, 3 evaluated, 2 filtered</summary>

- [line 99](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/DatePickerWithRange.tsx#L99): Selecting the "All" option (commonly represented with a `value` of `"0"`) now sets `dateRange` to `{ from: subDays(now, 0), to: now }` (i.e., a single day) instead of clearing the range. Previously, "All" cleared the date range (`undefined`). This breaks contract parity and produces inconsistent semantics: the label shows `"All"` while the selection is actually a one-day range. <b>[ Low confidence ]</b>
- [line 100](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/DatePickerWithRange.tsx#L100): Selecting a non-numeric or malformed `value` in `selectOptions` will pass `NaN` to `Number.parseInt(value)`, resulting in `subDays(now, NaN)` which yields an invalid `Date`. That invalid `Date` is set into `dateRange` (`{ from: Invalid Date, to: now }`), and then passed to `<Calendar selected={dateRange}>`, risking runtime errors or inconsistent rendering in the date picker. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/PageHeader.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 28](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/PageHeader.tsx#L28): The conditional `video && (video.youtubeVideoId || video.muxPlaybackId)` relies on JavaScript truthiness to decide whether to render `<WatchVideo />`. This will render the button when either `youtubeVideoId` or `muxPlaybackId` is a non-empty string, including whitespace-only values (e.g., `" "`), which are truthy but invalid IDs. That can cause downstream runtime errors or a broken player when `<OnboardingDialogContent>` receives an invalid ID. Use explicit validation (e.g., trim and non-empty checks) before rendering: `const hasValidId = !!(video.youtubeVideoId?.trim() || video.muxPlaybackId?.trim());` and guard on `hasValidId`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/ProgressPanel.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 22](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/ProgressPanel.tsx#L22): `progress` is not clamped to the [0, 100] range. If `remainingItems` is greater than `totalItems`, `totalProcessed` becomes negative and `progress` becomes negative; if `remainingItems` is negative or `totalItems` is smaller than `totalProcessed`, `progress` can exceed 100. This yields incorrect UI and out-of-bounds indicator motion when passed to `<Progress value={progress} />`. Clamp `progress` to `[0, 100]` before rendering. <b>[ Low confidence ]</b>
- [line 50](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/ProgressPanel.tsx#L50): Invalid HTML structure: a block-level `<div>` is rendered inside an inline `<span>` (`<span> ... <div className="flex items-center gap-1"> ... </div> ... </span>`). This produces malformed markup and may lead to inconsistent layout/semantics across browsers and screen readers. Replace the outer `<span>` with a `<div>` or change the inner container to a `<span>`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/components/TabSelect.tsx — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 65](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/TabSelect.tsx#L65): When `href` is provided, `As` is `Link` which renders an `<a>` element, and a `<button>` is rendered inside it. Nesting interactive elements (`<button>` inside `<a>`) violates accessibility and can cause unexpected click/keyboard behavior. Consider making the clickable element a single `<a>` styled as a button, or handling selection/navigation on one element only. <b>[ Out of scope ]</b>
- [line 68](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/TabSelect.tsx#L68): When `href` is falsy, `As` becomes a `div`, but `href` and `target` props are still applied (`href={href ?? "#"}` and `target={target ?? undefined}`), resulting in invalid DOM attributes on a `<div>`. This can produce console warnings and malformed semantics (a non-interactive element with link attributes). Guard these props so they are only passed when `As` is `Link`, or conditionally render attributes based on `href` presence. <b>[ Out of scope ]</b>
- [line 69](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/TabSelect.tsx#L69): Opening links in a new tab (`target="_blank"`) without `rel="noopener noreferrer"` is a security/performance issue (tabnabbing). Add `rel="noopener noreferrer"` when `target="_blank"`. <b>[ Out of scope ]</b>
- [line 82](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/TabSelect.tsx#L82): UI contract inconsistency: the external link icon (`ArrowUpRight`) renders when `target === "_blank"` even if `href` is absent (so `As` is a `div`). This suggests an external link but results in a non-link element with `target` attr incorrectly applied, confusing users and a11y. Gate the icon and `target` by the presence of `href`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/components/charts/DomainIcon.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 6](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/charts/DomainIcon.tsx#L6): `getFavicon` attempts to derive the apex domain by removing only the first label when it detects a subdomain (lines `6-10` in code object `0`). For multi-level subdomains (e.g., `a.b.example.com`), it returns `b.example.com` rather than `example.com`. For special public suffixes (e.g., `example.co.uk` with `www`), this heuristic can produce incorrect hosts. This yields incorrect favicon URLs and avoidable `onError` fallbacks. Consider using a proper public suffix list or leave the domain unchanged. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/charts/HorizontalBarChart.tsx — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 33](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/charts/HorizontalBarChart.tsx#L33): When `item.name` is an email missing the domain part (e.g., `"user@"`) or contains multiple `@`, `domain` computed in `HorizontalBarChart` (lines `33-35` in code object `8`) can be empty or invalid, leading `DomainIcon` to build a favicon URL with `url=http://` (no host). This reliably triggers an error and `onError` fallback on each render. Add a guard to skip favicon fetch when the extracted domain is empty or invalid. <b>[ Low confidence ]</b>
- [line 56](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/charts/HorizontalBarChart.tsx#L56): Anchor tags opened in a new tab (`target="_blank"`) are rendered without `rel="noopener noreferrer"` (lines `53-59` in code object `8`). This exposes users to reverse tabnabbing and leaves the opener reference accessible to the new page. Add `rel="noopener noreferrer"` when `target==="_blank"`. <b>[ Low confidence ]</b>
- [line 83](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/charts/HorizontalBarChart.tsx#L83): `HorizontalBarChart` renders a `<button>` container when `onItemClick` is provided (lines `83-91` in code object `8`), but `content` may contain an interactive `<a>` element when `item.href` is set (lines `53-59` in code object `8`). This nests an interactive control inside another interactive control, which is invalid HTML, can cause conflicting click/keyboard behaviors, and may lead to double-handling (both navigation and `onItemClick` firing). Use either a single interactive element per item or conditionally avoid wrapping link content inside a button. <b>[ Low confidence ]</b>
- [line 84](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/charts/HorizontalBarChart.tsx#L84): React keys use `item.name` (lines `84` and `96` in code object `8`). If `data` contains duplicate names, keys collide, causing incorrect reconciliation, stale UI state, or event handler mix-ups. Use a stable unique key (e.g., an ID or index combined with name) or validate uniqueness. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/new-landing/BrandScroller.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 23](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/new-landing/BrandScroller.tsx#L23): The `className` on line 23 contains an invalid Tailwind arbitrary style token: `[gap:var(--gap))]` has an extra `)` which prevents Tailwind from generating the rule. As a result, the intended `gap: var(--gap)` will not apply, breaking spacing between items in the scroller. It should be `[gap:var(--gap)]`. <b>[ Out of scope ]</b>
- [line 33](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/new-landing/BrandScroller.tsx#L33): Using `alt` as the React `key` for brand items (line 33) is unsafe because `alt` values are not guaranteed unique across a customizable `brandList`. Duplicate keys cause React reconciliation issues (items may be merged or updated incorrectly), leading to visual glitches during animation. Use a guaranteed-unique identifier (e.g., an index scoped to the list or a stable unique `id`) or enforce uniqueness of `alt` upstream. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/new-landing/UnicornScene.tsx — 0 comments posted, 3 evaluated, 1 filtered</summary>

- [line 38](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/new-landing/UnicornScene.tsx#L38): Potential TypeError on `UnicornStudio.init()` if the CDN script respects an existing global and does not overwrite `window.UnicornStudio` because it was set to the flag object earlier. In that case, `UnicornStudio` would still refer to the flag object without an `init` method, and `script.onload` will attempt `UnicornStudio.init()` leading to a runtime error. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/components/new-landing/common/Badge.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 94](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/new-landing/common/Badge.tsx#L94): Using `icon || null` can silently drop valid `React.ReactNode` values like the number `0`. React supports rendering numbers, but because `0` is falsy, `icon || null` will render `null` instead of `0`. This causes unexpected loss of output when a numeric icon or count of `0` is passed. Prefer `{icon}` (React ignores `undefined`/`null` automatically) or an explicit check for `icon !== undefined && icon !== null` to avoid dropping `0`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/components/new-landing/sections/Pricing.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 106](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/new-landing/sections/Pricing.tsx#L106): In `Pricing`, the `RadioGroup`’s `className` contains an invalid RGBA alpha value `rgba(0,0,0,0.0.07)` within the arbitrary shadow class: `shadow-[0_0_7px_0_rgba(0,0,0,0.0.07)]`. CSS numbers cannot have multiple decimal points, so this likely results in the entire `box-shadow` being ignored by the browser. Use a valid value like `rgba(0,0,0,0.07)`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/components/ui/progress.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 23](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/components/ui/progress.tsx#L23): `Progress` does not defensively clamp `value` to `[0, 100]`. When given out-of-range values (e.g., negative or >100), the computed transform `translateX(-${100 - (value || 0)}%)` can produce unexpected motion beyond the track. Clamp `value` to `[0, 100]` before computing the transform to ensure consistent visuals. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/web/next.config.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 237](https://github.com/elie222/inbox-zero/blob/480449f3cc6cc606f385d39d9c3b3ae027ae9cd2/apps/web/next.config.ts#L237): Setting the `Access-Control-Allow-Origin` header globally to a fixed value `env.NEXT_PUBLIC_BASE_URL` on all routes (`source: '/(.*)'`) can cause CORS failures for requests originating from any other valid deployment domain (e.g., preview/staging URLs). When the browser origin doesn’t exactly match `env.NEXT_PUBLIC_BASE_URL`, cross-origin requests to Next.js API routes or assets will be blocked by CORS, breaking functionality in those environments. Consider reflecting the request’s `Origin` when appropriate or scoping CORS headers only to API endpoints that require them. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rule selection now uses dropdown menu for streamlined navigation.
  * Enhanced date range picker with quick-select options (e.g., "Last week").
  * Topic distribution analytics view for trend insights.

* **Improvements**
  * Reorganized dashboard layout with consolidated statistics and controls.
  * Email analytics now presented in tabbed card format for better organization.
  * Enhanced progress indicators with improved visual feedback.
  * Refined color system and design consistency across stats interfaces.

* **Removals**
  * Simplified summary stats display by consolidating legacy components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->