### PR TITLE
show outlook sign in again message

### DIFF
--- a/apps/web/utils/middleware.ts
+++ b/apps/web/utils/middleware.ts
@@ -305,6 +305,12 @@ async function emailProviderMiddleware(
       emailAccountId,
       userId,
     });
+
+    // Re-throw SafeError so it gets handled with the user-friendly message
+    if (error instanceof SafeError) {
+      throw error;
+    }
+
     return NextResponse.json(
       { error: "Failed to initialize email provider" },
       { status: 500 },


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Show Outlook sign-in again by throwing `SafeError` in `apps/web/utils/outlook/client.ts:getOutlookClientWithRefresh` when Microsoft identity errors (e.g., AADSTS70000, AADSTS70008, AADSTS70011, AADSTS700082, AADSTS50173, AADSTS65001, AADSTS500011, AADSTS54005, invalid_grant) require re-authentication
Propagate `SafeError` from `emailProviderMiddleware` instead of returning 500, and emit a `SafeError` with a reconnect message from `getOutlookClientWithRefresh` on specific Microsoft identity errors.

#### 📍Where to Start
Start with the error handling branch in `getOutlookClientWithRefresh` in [client.ts](https://github.com/elie222/inbox-zero/pull/1007/files#diff-17123ab3214345e3613027867e8af43d3fd60e64d6d484b8df118b293b27fa87), then review the `SafeError` guard in [middleware.ts](https://github.com/elie222/inbox-zero/pull/1007/files#diff-e5c16f83f3b372c14918c0991770cf7ec24b5be98d8a15a831c8aed102bd7062).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 977a164. 2 files reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/web/utils/middleware.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 292](https://github.com/elie222/inbox-zero/blob/977a1644855a4dfc92c345758da0178d95c544b5/apps/web/utils/middleware.ts#L292): Potential null/undefined dereference of `emailAccount.account` when reading `emailAccount.account.provider`. The Prisma query includes `account` with only `provider` selected, but the relation may be `null` (e.g., missing linked account). In that case `emailAccount.account.provider` will throw at runtime with "Cannot read properties of null (reading 'provider')" before `createEmailProvider` is called, leading to a 500 response from the catch block. Add a guard to verify `emailAccount.account` and `emailAccount.account.provider` exist, and return a defined error (e.g., 404/400) rather than crashing. <b>[ Out of scope ]</b>
</details>

<details>
<summary>apps/web/utils/outlook/client.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 100](https://github.com/elie222/inbox-zero/blob/977a1644855a4dfc92c345758da0178d95c544b5/apps/web/utils/outlook/client.ts#L100): Token expiry units mismatch: `expiresAt` is compared against `Date.now()` (milliseconds) on line 100, but the function later persists `expires_at` as seconds via `Math.floor(Date.now() / 1000 + tokens.expires_in)` (line 187). On subsequent calls, a seconds-based `expiresAt` will be compared to milliseconds, causing premature refresh attempts (or always-refresh). Fix by normalizing units (either store/read milliseconds or divide `Date.now()` by 1000). <b>[ Out of scope ]</b>
- [line 184](https://github.com/elie222/inbox-zero/blob/977a1644855a4dfc92c345758da0178d95c544b5/apps/web/utils/outlook/client.ts#L184): Refresh token rotation is ignored. Microsoft may return a new `refresh_token` on refresh. The code persists only `access_token` and `expires_at` (lines 184–192) and continues using the old `refreshToken`. This can lead to future refresh failures once the old refresh token is invalidated. Capture and persist `tokens.refresh_token` when present. <b>[ Low confidence ]</b>
- [line 186](https://github.com/elie222/inbox-zero/blob/977a1644855a4dfc92c345758da0178d95c544b5/apps/web/utils/outlook/client.ts#L186): Missing validation of token response fields. The code uses `tokens.access_token` (line 194) and `tokens.expires_in` (line 187) without checking presence or type. If either is missing or malformed, `Math.floor(Date.now() / 1000 + tokens.expires_in)` yields `NaN` and persists an invalid `expires_at`, and `createOutlookClient(tokens.access_token)` will throw due to an undefined token after already saving broken state. Add explicit checks for `access_token` and `expires_in` before saving/returning, and fail atomically. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for email provider authentication with enhanced user-facing messages that prompt account reconnection when Microsoft account re-authentication is required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->