### PR TITLE
fix: correct Anthropic model IDs with valid release dates

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -49,9 +49,9 @@ LOG_ZOD_ERRORS=true
 
 # --- Anthropic ---
 # DEFAULT_LLM_PROVIDER=anthropic
-# DEFAULT_LLM_MODEL=claude-sonnet-4-5-20250514
+# DEFAULT_LLM_MODEL=claude-sonnet-4-5-20250929
 # ECONOMY_LLM_PROVIDER=anthropic
-# ECONOMY_LLM_MODEL=claude-haiku-4-5-20250514
+# ECONOMY_LLM_MODEL=claude-haiku-4-5-20251001
 # ANTHROPIC_API_KEY=
 
 # --- OpenAI ---

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -402,8 +402,8 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
 
   const defaultModels: Record<string, { default: string; economy: string }> = {
     anthropic: {
-      default: "claude-sonnet-4-5-20250514",
-      economy: "claude-haiku-4-5-20250514",
+      default: "claude-sonnet-4-5-20250929",
+      economy: "claude-haiku-4-5-20251001",
     },
     openai: { default: "gpt-4.1", economy: "gpt-4.1-mini" },
     google: { default: "gemini-2.5-pro", economy: "gemini-2.5-flash" },

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -47,9 +47,9 @@ ANTHROPIC_API_KEY=
     MICROSOFT_CLIENT_ID: "microsoft-id",
     MICROSOFT_CLIENT_SECRET: "microsoft-secret",
     DEFAULT_LLM_PROVIDER: "anthropic",
-    DEFAULT_LLM_MODEL: "claude-sonnet-4-5-20250514",
+    DEFAULT_LLM_MODEL: "claude-sonnet-4-5-20250929",
     ECONOMY_LLM_PROVIDER: "anthropic",
-    ECONOMY_LLM_MODEL: "claude-haiku-4-5-20250514",
+    ECONOMY_LLM_MODEL: "claude-haiku-4-5-20251001",
     ANTHROPIC_API_KEY: "sk-ant-xxx",
   };
 
@@ -316,9 +316,9 @@ UPSTASH_REDIS_TOKEN=
       MICROSOFT_WEBHOOK_CLIENT_STATE: "webhook-state-hex",
       // LLM
       DEFAULT_LLM_PROVIDER: "anthropic",
-      DEFAULT_LLM_MODEL: "claude-sonnet-4-5-20250514",
+      DEFAULT_LLM_MODEL: "claude-sonnet-4-5-20250929",
       ECONOMY_LLM_PROVIDER: "anthropic",
-      ECONOMY_LLM_MODEL: "claude-haiku-4-5-20250514",
+      ECONOMY_LLM_MODEL: "claude-haiku-4-5-20251001",
       ANTHROPIC_API_KEY: "sk-ant-api-key-value",
     };
 
@@ -374,9 +374,9 @@ MICROSOFT_WEBHOOK_CLIENT_STATE=webhook-state-hex
 # LLM Configuration
 # =============================================================================
 DEFAULT_LLM_PROVIDER=anthropic
-DEFAULT_LLM_MODEL=claude-sonnet-4-5-20250514
+DEFAULT_LLM_MODEL=claude-sonnet-4-5-20250929
 ECONOMY_LLM_PROVIDER=anthropic
-ECONOMY_LLM_MODEL=claude-haiku-4-5-20250514
+ECONOMY_LLM_MODEL=claude-haiku-4-5-20251001
 ANTHROPIC_API_KEY=sk-ant-api-key-value
 
 # =============================================================================


### PR DESCRIPTION
## Summary
While preparing a self-hosted deployment, we noticed our Anthropic API key showed no usage in the console. Docker logs revealed model name errors pointing to the invalid date suffix `20250514` in our auto-generated `.env`. After updating to the correct release dates (`20250929` for Sonnet, `20251001` for Haiku), we started seeing usage in our Anthropic console.

## Test plan
- [x] CLI tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated default Anthropic AI models to newer versions for improved performance and stability:
  * Claude Sonnet model reference updated
  * Claude Haiku economy model reference updated

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->