### PR TITLE
fix internal date type

### DIFF
--- a/apps/web/utils/gmail/message.ts
+++ b/apps/web/utils/gmail/message.ts
@@ -27,6 +27,9 @@ export function parseMessage(
     ...parsed,
     subject: parsed.headers?.subject || "",
     date: parsed.headers?.date || "",
+    // gmail-api-parse-message converts internalDate to a number, but our type expects string
+    internalDate:
+      parsed.internalDate != null ? String(parsed.internalDate) : null,
   };
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Coerce `apps/web/utils/gmail/message.ts` `parseMessage` return `internalDate` to a string or null to fix internal date type
Force `internalDate` in `parseMessage` to `String(parsed.internalDate)` when present, else `null`, with an inline comment documenting the upstream numeric type in [message.ts](https://github.com/elie222/inbox-zero/pull/1132/files#diff-c848c5b34b43ebcf65dcd9f18fba37adfceedada15a57a1173ec953c09927983).

#### 📍Where to Start
Start with the `parseMessage` function in [message.ts](https://github.com/elie222/inbox-zero/pull/1132/files#diff-c848c5b34b43ebcf65dcd9f18fba37adfceedada15a57a1173ec953c09927983).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized df1f1a8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date handling for email messages to ensure proper formatting and consistency across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->