### PR TITLE
feat: Pre-Draft All Replies - Automatic draft generation

### DIFF
--- a/apps/web/app/api/pre-drafts/generate/route.ts
+++ b/apps/web/app/api/pre-drafts/generate/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import { generatePreDraftsForAccount } from "@/utils/pre-drafts/generate-pre-drafts";
+
+/**
+ * POST /api/pre-drafts/generate
+ * Triggers pre-draft generation for an email account.
+ * Can be called manually or via QStash scheduled job.
+ */
+export const POST = withEmailAccount(async (request) => {
+  const { emailAccountId } = request.auth;
+
+  const results = await generatePreDraftsForAccount(emailAccountId);
+
+  return NextResponse.json({
+    success: true,
+    results,
+    summary: {
+      total: results.length,
+      successful: results.filter((r) => r.success).length,
+      failed: results.filter((r) => !r.success).length,
+    },
+  });
+});

--- a/apps/web/prisma/migrations/20251231000001_add_pre_draft/migration.sql
+++ b/apps/web/prisma/migrations/20251231000001_add_pre_draft/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "PreDraftStatus" AS ENUM ('PENDING', 'CREATED', 'SENT', 'DELETED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN "preDraftsEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "EmailAccount" ADD COLUMN "preDraftsMaxPerDay" INTEGER NOT NULL DEFAULT 10;
+
+-- CreateTable
+CREATE TABLE "PreDraft" (
+    "id" TEXT NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "draftId" TEXT,
+    "status" "PreDraftStatus" NOT NULL DEFAULT 'PENDING',
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PreDraft_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PreDraft_emailAccountId_threadId_key" ON "PreDraft"("emailAccountId", "threadId");
+
+-- CreateIndex
+CREATE INDEX "PreDraft_emailAccountId_status_idx" ON "PreDraft"("emailAccountId", "status");
+
+-- AddForeignKey
+ALTER TABLE "PreDraft" ADD CONSTRAINT "PreDraft_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -175,6 +175,11 @@ model EmailAccount {
   calendarConnections CalendarConnection[]
   mcpConnections      McpConnection[]
   meetingBriefings    MeetingBriefing[]
+  preDrafts           PreDraft[]
+
+  // pre-draft settings
+  preDraftsEnabled    Boolean @default(false)
+  preDraftsMaxPerDay  Int     @default(10) // cost control
 
   @@index([userId])
   @@index([lastSummaryEmailAt])
@@ -744,6 +749,31 @@ model ThreadTracker {
   @@index([emailAccountId, resolved])
   @@index([emailAccountId, resolved, sentAt, type])
   @@index([emailAccountId, type, resolved, sentAt])
+}
+
+// Tracks pre-generated drafts created for threads needing reply
+model PreDraft {
+  id             String          @id @default(cuid())
+  emailAccountId String
+  emailAccount   EmailAccount    @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  threadId       String
+  messageId      String // The message this draft is replying to
+  draftId        String? // Gmail/Outlook draft ID (null if generation failed)
+  status         PreDraftStatus  @default(PENDING)
+  errorMessage   String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  @@unique([emailAccountId, threadId])
+  @@index([emailAccountId, status])
+}
+
+enum PreDraftStatus {
+  PENDING // Draft generation queued
+  CREATED // Draft successfully created in email provider
+  SENT // User sent the draft
+  DELETED // User deleted the draft or we cleaned it up
+  FAILED // Draft generation failed
 }
 
 model CleanupJob {

--- a/apps/web/utils/pre-drafts/generate-pre-drafts.ts
+++ b/apps/web/utils/pre-drafts/generate-pre-drafts.ts
@@ -1,0 +1,265 @@
+import prisma from "@/utils/prisma";
+import { createScopedLogger } from "@/utils/logger";
+import { fetchMessagesAndGenerateDraft } from "@/utils/reply-tracker/generate-draft";
+import { getEmailAccountWithAI } from "@/utils/llms/get-email-account-with-ai";
+import { GmailProvider } from "@/utils/email/google";
+import { getGmailClient } from "@/utils/gmail/client";
+import { draftEmail } from "@/utils/gmail/mail";
+import type { ParsedMessage } from "@/utils/types";
+
+const logger = createScopedLogger("pre-drafts");
+
+const DEFAULT_MAX_PER_DAY = 10;
+
+interface PreDraftResult {
+  threadId: string;
+  success: boolean;
+  draftId?: string;
+  error?: string;
+}
+
+/**
+ * Generates pre-drafts for threads that need a reply.
+ * Creates drafts in the user's Gmail/Outlook drafts folder.
+ */
+export async function generatePreDraftsForAccount(
+  emailAccountId: string,
+): Promise<PreDraftResult[]> {
+  const results: PreDraftResult[] = [];
+
+  try {
+    // get email account with settings
+    const emailAccountWithSettings = await prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: {
+        id: true,
+        preDraftsEnabled: true,
+        preDraftsMaxPerDay: true,
+        account: {
+          select: {
+            providerId: true,
+          },
+        },
+      },
+    });
+
+    if (!emailAccountWithSettings) {
+      logger.warn("Email account not found", { emailAccountId });
+      return results;
+    }
+
+    if (!emailAccountWithSettings.preDraftsEnabled) {
+      logger.debug("Pre-drafts not enabled for account", { emailAccountId });
+      return results;
+    }
+
+    // check how many drafts we've created today
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const todayDraftCount = await prisma.preDraft.count({
+      where: {
+        emailAccountId,
+        createdAt: { gte: todayStart },
+        status: { in: ["CREATED", "PENDING"] },
+      },
+    });
+
+    const maxPerDay =
+      emailAccountWithSettings.preDraftsMaxPerDay || DEFAULT_MAX_PER_DAY;
+    const remainingQuota = maxPerDay - todayDraftCount;
+
+    if (remainingQuota <= 0) {
+      logger.info("Daily pre-draft limit reached", {
+        emailAccountId,
+        maxPerDay,
+        todayDraftCount,
+      });
+      return results;
+    }
+
+    // get threads needing reply that don't have pre-drafts yet
+    const threadsNeedingReply = await prisma.threadTracker.findMany({
+      where: {
+        emailAccountId,
+        type: "NEEDS_REPLY",
+        resolved: false,
+      },
+      orderBy: { sentAt: "desc" },
+      take: remainingQuota,
+      distinct: ["threadId"],
+    });
+
+    // filter out threads that already have pre-drafts
+    const existingPreDrafts = await prisma.preDraft.findMany({
+      where: {
+        emailAccountId,
+        threadId: { in: threadsNeedingReply.map((t) => t.threadId) },
+        status: { in: ["CREATED", "PENDING"] },
+      },
+      select: { threadId: true },
+    });
+
+    const existingThreadIds = new Set(existingPreDrafts.map((p) => p.threadId));
+    const threadsToProcess = threadsNeedingReply.filter(
+      (t) => !existingThreadIds.has(t.threadId),
+    );
+
+    if (threadsToProcess.length === 0) {
+      logger.debug("No new threads to pre-draft", { emailAccountId });
+      return results;
+    }
+
+    logger.info("Processing pre-drafts", {
+      emailAccountId,
+      threadCount: threadsToProcess.length,
+    });
+
+    // get the email account with AI config
+    const emailAccount = await getEmailAccountWithAI({ emailAccountId });
+    if (!emailAccount) {
+      logger.error("Failed to get email account with AI", { emailAccountId });
+      return results;
+    }
+
+    // only supporting Gmail for now
+    const isGmail =
+      emailAccountWithSettings.account.providerId === "google" ||
+      emailAccountWithSettings.account.providerId === "google-workspace";
+
+    if (!isGmail) {
+      logger.info("Pre-drafts only supported for Gmail accounts currently", {
+        emailAccountId,
+        provider: emailAccountWithSettings.account.providerId,
+      });
+      return results;
+    }
+
+    // get Gmail client
+    const gmail = await getGmailClient({ emailAccountId });
+    const provider = new GmailProvider(gmail, logger);
+
+    // process each thread
+    for (const tracker of threadsToProcess) {
+      const result = await generatePreDraftForThread({
+        emailAccountId,
+        emailAccount,
+        threadId: tracker.threadId,
+        messageId: tracker.messageId,
+        provider,
+        gmail,
+      });
+      results.push(result);
+    }
+
+    return results;
+  } catch (error) {
+    logger.error("Failed to generate pre-drafts", { error, emailAccountId });
+    return results;
+  }
+}
+
+async function generatePreDraftForThread({
+  emailAccountId,
+  emailAccount,
+  threadId,
+  messageId,
+  provider,
+  gmail,
+}: {
+  emailAccountId: string;
+  emailAccount: Awaited<ReturnType<typeof getEmailAccountWithAI>>;
+  threadId: string;
+  messageId: string;
+  provider: GmailProvider;
+  gmail: Awaited<ReturnType<typeof getGmailClient>>;
+}): Promise<PreDraftResult> {
+  try {
+    // create pending record first
+    await prisma.preDraft.upsert({
+      where: { emailAccountId_threadId: { emailAccountId, threadId } },
+      create: {
+        emailAccountId,
+        threadId,
+        messageId,
+        status: "PENDING",
+      },
+      update: {
+        messageId,
+        status: "PENDING",
+        errorMessage: null,
+      },
+    });
+
+    if (!emailAccount) {
+      throw new Error("Email account not found");
+    }
+
+    // generate the draft content
+    const draftContent = await fetchMessagesAndGenerateDraft(
+      emailAccount,
+      threadId,
+      provider,
+      undefined,
+      logger,
+    );
+
+    // get the thread to find the message we're replying to
+    const threadMessages = await provider.getThreadMessages(threadId);
+    const lastMessage = threadMessages.at(-1) as ParsedMessage | undefined;
+
+    if (!lastMessage) {
+      throw new Error("No messages in thread");
+    }
+
+    // create the draft in Gmail
+    const draftResult = await draftEmail({
+      gmail,
+      draftText: draftContent,
+      originalEmail: lastMessage,
+    });
+
+    const draftId = draftResult?.data?.id;
+
+    // update the pre-draft record
+    await prisma.preDraft.update({
+      where: { emailAccountId_threadId: { emailAccountId, threadId } },
+      data: {
+        draftId,
+        status: "CREATED",
+      },
+    });
+
+    logger.info("Pre-draft created successfully", {
+      emailAccountId,
+      threadId,
+      draftId,
+    });
+
+    return { threadId, success: true, draftId: draftId || undefined };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+
+    logger.error("Failed to generate pre-draft for thread", {
+      error,
+      emailAccountId,
+      threadId,
+    });
+
+    // update the record with error status
+    await prisma.preDraft
+      .update({
+        where: { emailAccountId_threadId: { emailAccountId, threadId } },
+        data: {
+          status: "FAILED",
+          errorMessage,
+        },
+      })
+      .catch((e) => {
+        logger.error("Failed to update pre-draft error status", { error: e });
+      });
+
+    return { threadId, success: false, error: errorMessage };
+  }
+}


### PR DESCRIPTION
## Summary

@elie222 This is a feature suggestion, feel free to delete or incorporate.

Automatically generates draft replies for ALL emails detected as needing a reply. Drafts are created directly in the user's Gmail drafts folder - they see them in their normal email client, not in Inbox Zero.

## Changes

- **New model**: `PreDraft` in Prisma schema
  - Tracks generated drafts with status (PENDING, CREATED, SENT, DELETED, FAILED)
  - Stores Gmail draft ID for lifecycle management

- **New settings**: Added to `EmailAccount`
  - `preDraftsEnabled` - Toggle feature on/off (default: false)
  - `preDraftsMaxPerDay` - Daily limit for cost control (default: 10)

- **New file**: `apps/web/utils/pre-drafts/generate-pre-drafts.ts`
  - `generatePreDraftsForAccount()` - Main function to generate drafts
  - Queries ThreadTracker for NEEDS_REPLY threads
  - Respects daily limits and skips already-drafted threads

- **New endpoint**: `POST /api/pre-drafts/generate`
  - Triggers pre-draft generation for an email account
  - Can be called manually or via QStash scheduled job

## How it works

1. User enables pre-drafts in settings (not implemented in this PR)
2. Background job or API call triggers `generatePreDraftsForAccount`
3. System queries ThreadTracker for threads with `type = NEEDS_REPLY`
4. For each thread without a pre-draft:
   - Generates draft content using existing `aiDraftWithKnowledge`
   - Creates draft in Gmail via `draftEmail` API
   - Records draft in `PreDraft` table
5. User opens Gmail, sees drafts ready to send/edit

## Limitations

- Currently Gmail-only (Outlook support can be added later)
- No UI for settings (can be added in follow-up)
- No QStash scheduling configured (needs webhook trigger)

## Test plan

- [ ] Verify PreDraft model works correctly
- [ ] Test with account that has NEEDS_REPLY threads
- [ ] Confirm daily limit is respected
- [ ] Verify drafts appear in Gmail drafts folder