### PR TITLE
Meeting Briefs: Improve validation error message clarity

### DIFF
--- a/apps/web/utils/actions/meeting-briefs.validation.ts
+++ b/apps/web/utils/actions/meeting-briefs.validation.ts
@@ -9,7 +9,10 @@ export type UpdateMeetingBriefsEnabledBody = z.infer<
 >;
 
 export const updateMeetingBriefsMinutesBeforeBody = z.object({
-  minutesBefore: z.number().min(1).max(2880), // 1 minute to 48 hours
+  minutesBefore: z
+    .number()
+    .min(1, "Number must be at least 1 minute")
+    .max(2880, "Number must be at most 2880 minutes (48 hours)"),
 });
 
 export type UpdateMeetingBriefsMinutesBeforeBody = z.infer<


### PR DESCRIPTION
# User description
Clarify the max limit error message for the 'Send briefing before meeting' setting.

- Add custom error message specifying that 2880 is in minutes (48 hours)
- Also clarify the minimum validation message

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve the clarity of validation error messages for the <code>minutesBefore</code> field within the <code>updateMeetingBriefsMinutesBeforeBody</code> schema, specifically for the 'Send briefing before meeting' setting.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1153?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation error messages for meeting timing settings to provide clearer feedback when invalid duration values are entered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->