### PR TITLE
fix(google): extract nested gmail error message for label fallback

### DIFF
--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -55,6 +55,7 @@ import {
 } from "@/utils/gmail/thread";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { getDraft, deleteDraft } from "@/utils/gmail/draft";
+import { extractErrorInfo } from "@/utils/gmail/retry";
 import {
   getFiltersList,
   createFilter,
@@ -573,8 +574,7 @@ export class GmailProvider implements EmailProvider {
 
       return {};
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const { errorMessage } = extractErrorInfo(error);
 
       const isLabelNotFound =
         errorMessage.includes("Requested entity was not found") ||


### PR DESCRIPTION
# User description
google: fix "labelId not found" false positive in Sentry

Gmail API errors are nested (in `error.response.data.error.message`), so naive `error.message` was failing to detect the stale label ID error, preventing the fallback logic from running silently.

- Use `extractErrorInfo` to correctly parse nested Gmail error messages
- Preserves fallback logic and prevents unhandled re-throws that cause Sentry noise

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor error handling within the <code>GmailProvider</code> to correctly parse nested Gmail API error messages, ensuring the fallback logic for <code>labelId not found</code> errors is properly triggered and preventing Sentry noise from unhandled re-throws.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-fix-CC-BCC-r...</td><td>December 31, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1168?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for Gmail label operations by streamlining internal error extraction logic to enhance reliability of label management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->