### PR TITLE
api: fix unsubscribe functionality by correcting prisma query

### DIFF
--- a/apps/web/app/api/unsubscribe/route.ts
+++ b/apps/web/app/api/unsubscribe/route.ts
@@ -48,7 +48,7 @@ async function unsubscribe(request: RequestWithLogger) {
 
   const [userUpdate, tokenDelete] = await Promise.allSettled([
     prisma.emailAccount.update({
-      where: { email: emailToken.emailAccountId },
+      where: { id: emailToken.emailAccountId },
       data: {
         summaryEmailFrequency: Frequency.NEVER,
         statsEmailFrequency: Frequency.NEVER,


### PR DESCRIPTION
# User description
Fixes the broken unsubscribe endpoint by correctly using the ID field in the Prisma update query.

The issue was that `emailAccountId` (an ID) was being used to query the `email` field in the `EmailAccount` table, leading to 500 errors.

- Changed `where: { email: emailToken.emailAccountId }` to `where: { id: emailToken.emailAccountId }` in `apps/web/app/api/unsubscribe/route.ts`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Corrects the unsubscribe endpoint's functionality by updating the <code>EmailAccount</code> record using its <code>id</code> field instead of the <code>email</code> field in the Prisma query, resolving 500 errors caused by incorrect query parameters.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>use-route-logger-in-mo...</td><td>December 17, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1172?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the unsubscribe process through more robust email account lookup, ensuring users can consistently remove themselves from mailing lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->