### PR TITLE
google: handle expired history and log skipped items

### DIFF
--- a/apps/web/app/api/google/webhook/process-history.test.ts
+++ b/apps/web/app/api/google/webhook/process-history.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { processHistoryForUser } from "./process-history";
+import { getHistory } from "@/utils/gmail/history";
+import {
+  getWebhookEmailAccount,
+  validateWebhookAccount,
+} from "@/utils/webhook/validate-webhook-account";
+import { createScopedLogger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+const logger = createScopedLogger("test");
+// Mock logger.with to return the same logger instance so spies work
+vi.spyOn(logger, "with").mockReturnValue(logger);
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/gmail/client", () => ({
+  getGmailClientWithRefresh: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/utils/gmail/history", () => ({
+  getHistory: vi.fn(),
+}));
+
+vi.mock("@/utils/webhook/validate-webhook-account", () => ({
+  getWebhookEmailAccount: vi.fn(),
+  validateWebhookAccount: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("processHistoryForUser - 404 Handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should reset lastSyncedHistoryId when Gmail returns 404 (expired historyId)", async () => {
+    const email = "user@test.com";
+    const historyId = 2000;
+    const emailAccount = {
+      id: "account-123",
+      email,
+      lastSyncedHistoryId: "1000",
+    };
+
+    vi.mocked(getWebhookEmailAccount).mockResolvedValue(emailAccount as any);
+    vi.mocked(validateWebhookAccount).mockResolvedValue({
+      success: true,
+      data: {
+        emailAccount: {
+          ...emailAccount,
+          account: {
+            access_token: "token",
+            refresh_token: "refresh",
+            expires_at: new Date(Date.now() + 3_600_000),
+          },
+          rules: [],
+        },
+        hasAutomationRules: false,
+        hasAiAccess: false,
+      },
+    } as any);
+
+    // Simulate Gmail 404 error
+    const error404 = new Error("Requested entity was not found");
+    (error404 as any).status = 404;
+    vi.mocked(getHistory).mockRejectedValue(error404);
+
+    const result = await processHistoryForUser(
+      { emailAddress: email, historyId },
+      {},
+      logger,
+    );
+
+    const jsonResponse = await (result as any).json();
+    expect(jsonResponse).toEqual({ ok: true });
+
+    // Verify lastSyncedHistoryId was updated to the current historyId
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "account-123" },
+      data: { lastSyncedHistoryId: "2000" },
+    });
+  });
+
+  it("should log a warning when history items are skipped due to large gap", async () => {
+    const email = "user@test.com";
+    const historyId = 2000; // Gap of 1000 (2000 - 1000)
+    const emailAccount = {
+      id: "account-123",
+      email,
+      lastSyncedHistoryId: "1000",
+    };
+
+    vi.mocked(getWebhookEmailAccount).mockResolvedValue(emailAccount as any);
+    vi.mocked(validateWebhookAccount).mockResolvedValue({
+      success: true,
+      data: {
+        emailAccount: {
+          ...emailAccount,
+          account: {
+            access_token: "token",
+            refresh_token: "refresh",
+            expires_at: new Date(Date.now() + 3_600_000),
+          },
+          rules: [],
+        },
+        hasAutomationRules: false,
+        hasAiAccess: false,
+      },
+    } as any);
+
+    vi.mocked(getHistory).mockResolvedValue({ history: [] });
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    await processHistoryForUser({ emailAddress: email, historyId }, {}, logger);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Skipping history items due to large gap",
+      expect.objectContaining({
+        lastSyncedHistoryId: 1000,
+        webhookHistoryId: 2000,
+        skippedHistoryItems: 500, // (2000 - 500) - 1000 = 500
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# User description
google: handle expired history and log skipped items

Add logging when history items are skipped due to the 500-item cap and handle 404 errors gracefully when historyId expires.

- Refactor history fetching into `fetchGmailHistoryResilient` helper
- Add warning log for large history gaps (> 500 items)
- Catch 404 errors from Gmail API and reset `lastSyncedHistoryId` to current point
- Add unit tests for 404 handling and gap logging

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
processHistoryForUser_("processHistoryForUser"):::modified
fetchGmailHistoryResilient_("fetchGmailHistoryResilient"):::added
processHistory_("processHistory"):::modified
updateLastSyncedHistoryId_("updateLastSyncedHistoryId"):::modified
getHistory_("getHistory"):::modified
isHistoryIdExpiredError_("isHistoryIdExpiredError"):::added
GMAIL_("GMAIL"):::modified
processHistoryForUser_ -- "Now retrieves resilient historyResult handling expired IDs." --> fetchGmailHistoryResilient_
processHistoryForUser_ -- "Now passes resiliently fetched history to processHistory." --> processHistory_
processHistoryForUser_ -- "Persist current webhookHistoryId when history expired." --> updateLastSyncedHistoryId_
fetchGmailHistoryResilient_ -- "Calls getHistory with computed startHistoryId and filters." --> getHistory_
fetchGmailHistoryResilient_ -- "Detects 404 expired-history errors to reset sync." --> isHistoryIdExpiredError_
fetchGmailHistoryResilient_ -- "Uses Gmail API to list up to 500 history entries." --> GMAIL_
getHistory_ -- "Queries Gmail history:list endpoint for provided startHistoryId." --> GMAIL_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Refactor the Gmail history fetching logic into a new <code>fetchGmailHistoryResilient</code> helper function, enhancing the <code>processHistoryForUser</code> function to gracefully handle expired Gmail history IDs by resetting the sync point and to log warnings when history items are skipped due to large gaps.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-Sentry</td><td>December 19, 2025</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Separate-files-and-PR-...</td><td>August 15, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1174?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail history synchronization with resilient fetch logic to gracefully handle expired history data.
  * Enhanced error recovery mechanisms to prevent sync failures during large history gaps.
  * Better logging for troubleshooting sync-related issues.

* **Tests**
  * Added comprehensive test coverage for Gmail webhook history processing including edge cases and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->