### PR TITLE
Fix Google Calendar auth redirect for self-hosted deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     networks:
       - inbox-zero-network
     environment:
-      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:3000}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-https://apse1.pa.email.useprivate.ai}
       NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: ${NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS:-true}
       NEXT_PUBLIC_EMAIL_SEND_ENABLED: ${NEXT_PUBLIC_EMAIL_SEND_ENABLED:-true}
       DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-inboxzero}?schema=public}


### PR DESCRIPTION
### Closes #873 — Google Calendar auth redirect incorrectly goes to localhost on self-hosted instances.

Steps to Test

1. Self-host a Dokploy deployment of inbox-zero.
2. Configure Google Calendar integration with proper OAuth keys and callback URL.
3. Ensure environment variables are set to the public URL.
4. Go through the Google OAuth flow.
5. Confirm the redirect sends you back to the correct domain (e.g., https://your-domain.com/calendars) instead of localhost:3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default service endpoint configuration from a local development environment to a remote HTTPS domain for improved consistency with standard deployment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->