### PR TITLE
writing-style: Switch to Tiptap editor and preserve line breaks

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/WritingStyleSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/WritingStyleSetting.tsx
@@ -96,8 +96,7 @@ function WritingStyleDialog({
   );
 
   const onSubmit = (data: SaveWritingStyleBody) => {
-    const markdownContent = editorRef.current?.getMarkdown();
-    execute({ writingStyle: markdownContent ?? data.writingStyle });
+    execute(data);
   };
 
   return (
@@ -120,9 +119,21 @@ function WritingStyleDialog({
                 <Tiptap
                   ref={editorRef}
                   initialContent={field.value ?? ""}
-                  className="prose prose-sm dark:prose-invert max-w-none"
+                  onChange={field.onChange}
+                  output="markdown"
+                  className="prose prose-sm dark:prose-invert max-w-none [&_p.is-editor-empty:first-child::before]:pointer-events-none [&_p.is-editor-empty:first-child::before]:float-left [&_p.is-editor-empty:first-child::before]:h-0 [&_p.is-editor-empty:first-child::before]:text-muted-foreground [&_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]"
                   autofocus={false}
                   preservePastedLineBreaks
+                  placeholder={`Typical Length: 2-3 sentences
+
+Formality: Informal but professional
+
+Common Greeting: Hey,
+
+Notable Traits:
+- Uses contractions frequently
+- Concise and direct responses
+- Minimal closings`}
                 />
               </div>
             )}

--- a/apps/web/components/editor/Tiptap.tsx
+++ b/apps/web/components/editor/Tiptap.tsx
@@ -3,6 +3,7 @@
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "tiptap-markdown";
+import { Placeholder } from "@tiptap/extension-placeholder";
 import { useCallback, forwardRef, useImperativeHandle } from "react";
 import { cn } from "@/utils";
 import { EnterHandler } from "@/components/editor/extensions";
@@ -16,11 +17,13 @@ export const Tiptap = forwardRef<
   TiptapHandle,
   {
     initialContent?: string;
-    onChange?: (html: string) => void;
+    onChange?: (content: string) => void;
     className?: string;
     autofocus?: boolean;
     onMoreClick?: () => void;
     preservePastedLineBreaks?: boolean;
+    placeholder?: string;
+    output?: "html" | "markdown";
   }
 >(function Tiptap(
   {
@@ -30,6 +33,8 @@ export const Tiptap = forwardRef<
     autofocus = true,
     onMoreClick,
     preservePastedLineBreaks = false,
+    placeholder,
+    output = "html",
   },
   ref,
 ) {
@@ -57,14 +62,21 @@ export const Tiptap = forwardRef<
             bulletListMarker: "-",
           })
         : Markdown,
+      Placeholder.configure({
+        placeholder: placeholder || "",
+        showOnlyWhenEditable: true,
+      }),
     ],
     content: initialContent,
     onUpdate: useCallback(
       ({ editor }: { editor: Editor }) => {
-        const html = editor.getHTML();
-        onChange?.(html);
+        const content =
+          output === "markdown"
+            ? editor.storage.markdown.getMarkdown()
+            : editor.getHTML();
+        onChange?.(content);
       },
-      [onChange],
+      [onChange, output],
     ),
     autofocus,
     editorProps: {
@@ -73,6 +85,7 @@ export const Tiptap = forwardRef<
           "px-3 py-2 max-w-none focus:outline-none min-h-[120px]",
           className,
         ),
+        ...(placeholder && { "data-placeholder": placeholder }),
       },
     },
   });


### PR DESCRIPTION
# User description
Switches the writing style input from a plain textarea to a Tiptap rich text editor to allow better visual formatting. Also adds a prop to Tiptap to optionally preserve line breaks on paste to prevent paragraphs from collapsing.

- Switched WritingStyleSetting to use Tiptap via Controller
- Added preservePastedLineBreaks prop to Tiptap component
- Configured Markdown extension in Tiptap to handle line breaks and list markers when enabled

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
WritingStyleDialog_("WritingStyleDialog"):::modified
Tiptap_("Tiptap"):::modified
onSubmit_("onSubmit"):::added
SAVE_WRITING_STYLE_ACTION_("SAVE_WRITING_STYLE_ACTION"):::modified
TIPTAP_("TIPTAP"):::modified
MARKDOWN_("MARKDOWN"):::modified
WritingStyleDialog_ -- "Now provides markdown output, placeholder, and preserved pasted breaks." --> Tiptap_
Tiptap_ -- "Emits markdown or HTML via onChange depending on output prop." --> WritingStyleDialog_
WritingStyleDialog_ -- "Adds onSubmit to call execute with form data." --> onSubmit_
onSubmit_ -- "Sends markdown writingStyle payload to save action." --> SAVE_WRITING_STYLE_ACTION_
Tiptap_ -- "Adds placeholder extension and configurable markdown/html output." --> TIPTAP_
Tiptap_ -- "Conditionally configures Markdown to transform pasted text and output." --> MARKDOWN_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Integrate the <code>Tiptap</code> rich text editor component into the <code>WritingStyleSetting</code> to replace the previous plain text input. Enhance the <code>Tiptap</code> component to preserve line breaks when pasting content and to output markdown.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1182?tool=ast&topic=Tiptap+Editor+Integration>Tiptap Editor Integration</a>
        </td><td>Integrate the <code>Tiptap</code> rich text editor into the <code>WritingStyleSetting</code> component, replacing the standard <code>Input</code> field. This involves using <code>react-hook-form</code>'s <code>Controller</code> to manage the editor's state and outputting content as markdown.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/editor/Tiptap.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/settings/WritingStyleSetting.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>adjust-placeholder</td><td>January 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1182?tool=ast&topic=Preserve+Line+Breaks>Preserve Line Breaks</a>
        </td><td>Add a <code>preservePastedLineBreaks</code> prop to the <code>Tiptap</code> component, configuring the <code>Markdown</code> extension to handle line breaks and list markers correctly when enabled. This ensures that pasted content retains its original formatting.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/editor/Tiptap.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/settings/WritingStyleSetting.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>adjust-placeholder</td><td>January 03, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1182?tool=ast>(Baz)</a>.