### PR TITLE
fix: Check for enabled rules in Reply Zero page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/onboarding/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/onboarding/page.tsx
@@ -13,6 +13,7 @@ export default async function OnboardingReplyTracker(props: {
     where: {
       emailAccountId,
       systemType: { in: CONVERSATION_STATUS_TYPES },
+      enabled: true,
     },
     select: { id: true },
   });

--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/page.tsx
@@ -47,6 +47,7 @@ export default async function ReplyTrackerPage(props: {
           systemType: {
             in: CONVERSATION_STATUS_TYPES,
           },
+          enabled: true,
         },
         select: { id: true },
       },


### PR DESCRIPTION
# User description
Reply Zero page now checks for enabled rules instead of just rule existence, redirecting users to onboarding when rules are disabled.

- Updated page.tsx to filter rules by enabled: true
- Updated onboarding/page.tsx to check for enabled rules consistently
- Users with disabled rules are now properly redirected to onboarding to re-enable

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>Reply Zero</code> feature to filter rules by their <code>enabled</code> status, ensuring only active rules are considered for display and processing. Redirect users with disabled rules to the onboarding flow, prompting them to re-enable necessary rules.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Clean-up-old-reply-tra...</td><td>October 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1184?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reply automation now correctly filters to apply only enabled rules during the onboarding process and in the main reply interface, ensuring disabled rules are properly excluded from operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->