### PR TITLE
fix(security): remove email-based fallback in Microsoft OAuth linking

### DIFF
--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -113,17 +113,18 @@ export const GET = withError("outlook/linking/callback", async (request) => {
     }
 
     const profile = await profileResponse.json();
+    const providerAccountId = profile.id;
     const providerEmail = profile.mail || profile.userPrincipalName;
 
-    if (!providerEmail) {
-      throw new Error("Profile missing required email");
+    if (!providerAccountId || !providerEmail) {
+      throw new Error("Profile missing required id or email");
     }
 
     const existingAccount = await prisma.account.findUnique({
       where: {
         provider_providerAccountId: {
           provider: "microsoft",
-          providerAccountId: profile.id || providerEmail,
+          providerAccountId,
         },
       },
       select: {
@@ -189,15 +190,13 @@ export const GET = withError("outlook/linking/callback", async (request) => {
         logger.warn("Failed to fetch profile picture", { error });
       }
 
-      const microsoftProviderAccountId = profile.id || providerEmail;
-
       try {
         const newAccount = await prisma.account.create({
           data: {
             userId: targetUserId,
             type: "oidc",
             provider: "microsoft",
-            providerAccountId: microsoftProviderAccountId,
+            providerAccountId,
             access_token: tokens.access_token,
             refresh_token: tokens.refresh_token,
             expires_at: expiresAt,
@@ -229,7 +228,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
             where: {
               provider_providerAccountId: {
                 provider: "microsoft",
-                providerAccountId: microsoftProviderAccountId,
+                providerAccountId,
               },
             },
             select: { userId: true },
@@ -240,7 +239,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
               "Account was created by concurrent request, continuing",
               {
                 targetUserId,
-                providerAccountId: microsoftProviderAccountId,
+                providerAccountId,
               },
             );
           } else {


### PR DESCRIPTION
# User description
Removes insecure email-based account matching in the Outlook OAuth linking callback.

- The email-based fallback could allow account hijacking when different Microsoft accounts share the same email address (e.g., shared mailboxes, mail delegation)
- Now matches solely by provider ID (`profile.id`), consistent with the Google OAuth implementation
- `handleAccountLinking` already handles email conflicts via `EmailAccount` lookups, so no additional logic is needed

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance the Microsoft OAuth linking callback by removing the insecure email-based account matching fallback, ensuring accounts are solely matched by <code>profile.id</code> to prevent potential hijacking. Update the <code>prisma.account</code> creation and lookup logic within the callback to consistently use the <code>providerAccountId</code> derived from <code>profile.id</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Don-t-force-user-to-lo...</td><td>December 04, 2025</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>PR-feedback</td><td>August 29, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1185?tool=ast>(Baz)</a>.