### PR TITLE
fix: case-insensitive pattern matching for email rules

### DIFF
--- a/apps/web/utils/group/find-matching-group.test.ts
+++ b/apps/web/utils/group/find-matching-group.test.ts
@@ -8,8 +8,12 @@ import { GroupItemType } from "@/generated/prisma/enums";
 describe("findMatchingGroupItem", () => {
   it("should match FROM rules", () => {
     const groupItems = [
-      { type: GroupItemType.FROM, value: "newsletter@company.com" },
-      { type: GroupItemType.FROM, value: "@company.com" },
+      {
+        type: GroupItemType.FROM,
+        value: "newsletter@company.com",
+        exclude: false,
+      },
+      { type: GroupItemType.FROM, value: "@company.com", exclude: false },
     ];
 
     // Full email match
@@ -39,8 +43,8 @@ describe("findMatchingGroupItem", () => {
 
   it("should match SUBJECT rules", () => {
     const groupItems = [
-      { type: GroupItemType.SUBJECT, value: "Invoice" },
-      { type: GroupItemType.SUBJECT, value: "[GitHub]" },
+      { type: GroupItemType.SUBJECT, value: "Invoice", exclude: false },
+      { type: GroupItemType.SUBJECT, value: "[GitHub]", exclude: false },
     ];
 
     // Exact subject match
@@ -75,8 +79,8 @@ describe("findMatchingGroupItem", () => {
 
   it("should handle empty inputs", () => {
     const groupItems = [
-      { type: GroupItemType.FROM, value: "test@example.com" },
-      { type: GroupItemType.SUBJECT, value: "Test" },
+      { type: GroupItemType.FROM, value: "test@example.com", exclude: false },
+      { type: GroupItemType.SUBJECT, value: "Test", exclude: false },
     ];
 
     expect(
@@ -93,14 +97,58 @@ describe("findMatchingGroupItem", () => {
 
   it("should prioritize first matching rule", () => {
     const groupItems = [
-      { type: GroupItemType.SUBJECT, value: "Invoice" },
-      { type: GroupItemType.SUBJECT, value: "Company" },
+      { type: GroupItemType.SUBJECT, value: "Invoice", exclude: false },
+      { type: GroupItemType.SUBJECT, value: "Company", exclude: false },
     ];
 
     // Should return first matching rule even though both would match
     expect(
       findMatchingGroupItem(
         { from: "", subject: "Invoice from Company" },
+        groupItems,
+      ),
+    ).toBe(groupItems[0]);
+  });
+
+  it("should match FROM rules case-insensitively", () => {
+    const groupItems = [
+      { type: GroupItemType.FROM, value: "@Acme-Corp.com", exclude: false },
+    ];
+
+    // Lowercase email should match mixed-case pattern
+    expect(
+      findMatchingGroupItem(
+        { from: "billing@acme-corp.com", subject: "" },
+        groupItems,
+      ),
+    ).toBe(groupItems[0]);
+
+    // Uppercase email should match mixed-case pattern
+    expect(
+      findMatchingGroupItem(
+        { from: "BILLING@ACME-CORP.COM", subject: "" },
+        groupItems,
+      ),
+    ).toBe(groupItems[0]);
+  });
+
+  it("should match SUBJECT rules case-insensitively", () => {
+    const groupItems = [
+      { type: GroupItemType.SUBJECT, value: "Invoice", exclude: false },
+    ];
+
+    // Lowercase subject should match capitalized pattern
+    expect(
+      findMatchingGroupItem(
+        { from: "", subject: "invoice #12345" },
+        groupItems,
+      ),
+    ).toBe(groupItems[0]);
+
+    // Uppercase subject should match capitalized pattern
+    expect(
+      findMatchingGroupItem(
+        { from: "", subject: "INVOICE #12345" },
         groupItems,
       ),
     ).toBe(groupItems[0]);

--- a/apps/web/utils/group/find-matching-group.ts
+++ b/apps/web/utils/group/find-matching-group.ts
@@ -49,16 +49,21 @@ function matchesPattern<T extends Pick<GroupItem, "type" | "value">>(
 
   // from check
   if (item.type === GroupItemType.FROM && from) {
-    return item.value.includes(from) || from.includes(item.value);
+    const lowerValue = item.value.toLowerCase();
+    const lowerFrom = from.toLowerCase();
+    return lowerValue.includes(lowerFrom) || lowerFrom.includes(lowerValue);
   }
 
   // subject check
   if (item.type === GroupItemType.SUBJECT && subject) {
-    const subjectWithoutNumbers = generalizeSubject(subject);
-    const valueWithoutNumbers = generalizeSubject(item.value);
+    const lowerSubject = subject.toLowerCase();
+    const lowerItemValue = item.value.toLowerCase();
+
+    const subjectWithoutNumbers = generalizeSubject(lowerSubject);
+    const valueWithoutNumbers = generalizeSubject(lowerItemValue);
 
     return (
-      subject.includes(item.value) ||
+      lowerSubject.includes(lowerItemValue) ||
       subjectWithoutNumbers.includes(valueWithoutNumbers)
     );
   }


### PR DESCRIPTION
# User description
Filtering: Fix case-sensitivity in email rule matching

Email addresses and subject lines are now matched case-insensitively, ensuring rules work as expected regardless of how the incoming email is cased.

- Added case-insensitive matching for FROM and SUBJECT rule types
- Updated generalization logic to handle lowercased strings
- Fixed missing exclude property in tests to satisfy type constraints

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implement case-insensitive pattern matching for email filtering rules, specifically for <code>FROM</code> and <code>SUBJECT</code> fields, by converting input values to lowercase during comparison within the <code>findMatchingGroupItem</code> utility. Update the <code>matchesPattern</code> function to handle lowercased strings for both rule values and incoming email parts, ensuring consistent matching regardless of casing.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-up-imports-for</td><td>November 22, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1187?tool=ast>(Baz)</a>.