### PR TITLE
auth: Prevent email account ownership transfer

### DIFF
--- a/apps/web/app/(landing)/login/error/page.tsx
+++ b/apps/web/app/(landing)/login/error/page.tsx
@@ -20,6 +20,11 @@ const errorMessages: Record<string, { title: string; description: string }> = {
     description:
       "Your account is not authorized to access this application. This may be because your email is not part of the allowed organization. Please contact your administrator or try signing in with a different account.",
   },
+  email_already_linked: {
+    title: "Email Already Linked",
+    description:
+      "This email address is already linked to another Inbox Zero account. Please sign in with the original account, or use a different email address.",
+  },
 };
 
 function LoginErrorContent() {

--- a/apps/web/app/(landing)/login/page.tsx
+++ b/apps/web/app/(landing)/login/page.tsx
@@ -101,6 +101,16 @@ function ErrorAlert({ error }: { error: string }) {
     );
   }
 
+  if (error === "email_already_linked") {
+    return (
+      <AlertBasic
+        variant="destructive"
+        title="Email Already Linked"
+        description={`This email address is already linked to another Inbox Zero account. Please sign in with the original account, or use a different email address. If this error persists please contact support at ${env.NEXT_PUBLIC_SUPPORT_EMAIL}`}
+      />
+    );
+  }
+
   return (
     <>
       <AlertBasic


### PR DESCRIPTION
# User description
This PR fixes a critical bug where signing in with an email account already linked to another InboxZero user would transfer ownership of that email account to the new user.

- Added validation check in handleLinkAccount to prevent ownership transfer
- Added user-friendly error message for email_already_linked on the login error page
- Added fallback error handling on the login page for email_already_linked error code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Addresses a critical bug by preventing email account ownership transfer during sign-in, ensuring an email is not already linked to another user within the <code>handleLinkAccount</code> function. Updates the login pages to display a user-friendly error message when this scenario occurs, guiding users on how to resolve the issue.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1193?tool=ast&topic=Display+Login+Error>Display Login Error</a>
        </td><td>Update the login error pages to display a user-friendly message for the <code>email_already_linked</code> error, guiding users to sign in with the original account or use a different email address.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(landing)/login/page.tsx</li>
<li>apps/web/app/(landing)/login/error/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>security-fix-open-redi...</td><td>January 02, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Cleanup-unused-props.-...</td><td>August 07, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1193?tool=ast&topic=Prevent+Ownership+Transfer>Prevent Ownership Transfer</a>
        </td><td>Implement a validation check within <code>handleLinkAccount</code> to prevent an email account from being linked to a new user if it is already associated with another existing user.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/auth.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>pass-down-logger</td><td>January 04, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-org-and-membe...</td><td>September 18, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1193?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email validation when linking accounts to prevent using email addresses already linked to other accounts. Users will now receive a clear error message if they attempt to link an account with an email already in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->