### PR TITLE
fix: prevent duplicate API quota exceeded emails

### DIFF
--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -4,13 +4,13 @@ import { createReferral } from "@/utils/referral/referral-code";
 import { captureException } from "@/utils/error";
 import { handleReferralOnSignUp, saveTokens } from "@/utils/auth";
 import prisma from "@/utils/__mocks__/prisma";
-import { clearUserErrorMessages } from "@/utils/error-messages";
+import { clearSpecificErrorMessages } from "@/utils/error-messages";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/error-messages", () => ({
   addUserErrorMessage: vi.fn().mockResolvedValue(undefined),
-  clearUserErrorMessages: vi.fn().mockResolvedValue(undefined),
+  clearSpecificErrorMessages: vi.fn().mockResolvedValue(undefined),
   ErrorType: {
     ACCOUNT_DISCONNECTED: "Account disconnected",
   },
@@ -144,8 +144,11 @@ describe("saveTokens", () => {
         }),
       }),
     );
-    expect(clearUserErrorMessages).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "user_1" }),
+    expect(clearSpecificErrorMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        errorTypes: ["Account disconnected"],
+      }),
     );
   });
 
@@ -176,8 +179,11 @@ describe("saveTokens", () => {
         }),
       }),
     );
-    expect(clearUserErrorMessages).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "user_1" }),
+    expect(clearSpecificErrorMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        errorTypes: ["Account disconnected"],
+      }),
     );
   });
 });

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -25,7 +25,7 @@ import {
   claimPendingPremiumInvite,
   updateAccountSeats,
 } from "@/utils/premium/server";
-import { clearUserErrorMessages } from "@/utils/error-messages";
+import { clearSpecificErrorMessages, ErrorType } from "@/utils/error-messages";
 import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("auth");
@@ -436,7 +436,11 @@ async function handleLinkAccount(account: Account) {
       }),
     ]);
 
-    await clearUserErrorMessages({ userId: account.userId, logger });
+    await clearSpecificErrorMessages({
+      userId: account.userId,
+      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
+      logger,
+    });
 
     // Handle premium account seats
     await updateAccountSeats({ userId: account.userId }).catch((error) => {
@@ -520,7 +524,11 @@ export async function saveTokens({
       select: { userId: true },
     });
 
-    await clearUserErrorMessages({ userId: emailAccount.userId, logger });
+    await clearSpecificErrorMessages({
+      userId: emailAccount.userId,
+      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
+      logger,
+    });
   } else {
     if (!providerAccountId) {
       logger.error("No providerAccountId found in database", {
@@ -542,7 +550,11 @@ export async function saveTokens({
       data,
     });
 
-    await clearUserErrorMessages({ userId: account.userId, logger });
+    await clearSpecificErrorMessages({
+      userId: account.userId,
+      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
+      logger,
+    });
 
     return account;
   }


### PR DESCRIPTION
# User description
## Summary
- Token refresh operations were clearing ALL user error messages, including the `emailSentAt` flag that prevents duplicate notification emails
- This caused users to receive multiple "API Quota Exceeded" emails per hour (sometimes 5+ emails to the same user in a few hours)
- Now token refresh only clears `ACCOUNT_DISCONNECTED` errors, leaving AI API key errors untouched
- The existing deduplication logic (`emailSentAt` flag) now works correctly

## Test plan
- [ ] Verify users no longer receive duplicate quota exceeded emails
- [ ] Verify account disconnection errors are still cleared when tokens are refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor the error message clearing mechanism to prevent duplicate 'API Quota Exceeded' emails by ensuring token refresh operations only clear <code>ACCOUNT_DISCONNECTED</code> errors, preserving the <code>emailSentAt</code> flag for other error types. Update <code>saveTokens</code> and <code>handleLinkAccount</code> functions in <code>auth.ts</code> to utilize the new <code>clearSpecificErrorMessages</code> utility, which targets specific error types instead of clearing all user error messages.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-auth-prevent-email...</td><td>January 04, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-org-and-membe...</td><td>September 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1201?tool=ast>(Baz)</a>.