### PR TITLE
fix: organization redirect 404

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/organization/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/organization/page.tsx
@@ -23,7 +23,5 @@ export default async function OrganizationPage({
     redirect(prefixPath(emailAccountId, "/organization/create"));
   }
 
-  redirect(
-    prefixPath(emailAccountId, `/organization/${member.organizationId}`),
-  );
+  redirect(`/organization/${member.organizationId}`);
 }


### PR DESCRIPTION
# User description
The 'My Organization' link was incorrectly including the email account ID prefix for global organization routes, leading to a 404 error.

- Remove prefixPath from organization redirect in [emailAccountId]/organization/page.tsx

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Corrects the organization page redirect by removing the <code>prefixPath</code> utility, which was incorrectly prepending an <code>emailAccountId</code> to global organization routes. Resolves a 404 error when accessing 'My Organization' links.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>rsnodgrass@gmail.com</td><td>fix-preserve-emailAcco...</td><td>January 04, 2026</td></tr>
<tr><td>elie222</td><td>fixes</td><td>September 25, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1202?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected organization page navigation to reliably redirect users to their organization dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->