### PR TITLE
fix(web): allow searching combobox items by label name

### DIFF
--- a/apps/web/components/Combobox.tsx
+++ b/apps/web/components/Combobox.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/popover";
 
 export function Combobox(props: {
-  options: { value: string; label: string }[];
+  options: { value: string; label: string; keywords?: string[] }[];
   placeholder: string;
   emptyText: React.ReactNode;
   value?: string;
@@ -75,6 +75,7 @@ export function Combobox(props: {
                   <CommandItem
                     key={options.value}
                     value={options.value}
+                    keywords={options.keywords ?? [options.label]}
                     onSelect={(currentValue) => {
                       onChangeValue(currentValue === value ? "" : currentValue);
                       setOpen(false);


### PR DESCRIPTION
# User description
assistant: Search for existing label doesn’t return any results

This PR fixes the issue where searching for labels in the rule action dropdown returned no results by allowing cmdk to search against the displayed label name instead of just the internal ID.

- Updated `Combobox` to pass displayed `label` as a `keyword` to `CommandItem`.
- This ensures search works even when the underlying `value` is an ID.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>Combobox</code> component to enable searching for items by their displayed label name, resolving an issue where searches failed when only internal IDs were used for matching. Configures the <code>CommandItem</code> to use the <code>label</code> as a keyword, ensuring search functionality works correctly for all combobox options.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>revert-changes-that-ar...</td><td>December 15, 2025</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Clean-up-label-rule-form</td><td>December 03, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1208?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combobox component now supports optional keywords for each option, enabling more flexible searching and allowing options to be discoverable through multiple search terms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->