### PR TITLE
fix(api): use scalar field for rule ownership check

### DIFF
--- a/apps/web/app/api/user/rules/[id]/route.ts
+++ b/apps/web/app/api/user/rules/[id]/route.ts
@@ -15,7 +15,7 @@ async function getRule({
   emailAccountId: string;
 }) {
   const rule = await prisma.rule.findUnique({
-    where: { id: ruleId, emailAccount: { id: emailAccountId } },
+    where: { id: ruleId, emailAccountId },
     include: {
       actions: true,
     },


### PR DESCRIPTION
# User description
Replace relation filter with scalar emailAccountId field in findUnique query for better security and performance.

- More efficient: avoids unnecessary join operation
- More explicit: directly filters on foreign key column
- Correct Prisma usage: findUnique should use scalar fields, not relation filters

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Optimizes the API's rule ownership check by directly filtering on the <code>emailAccountId</code> scalar field within the <code>prisma.rule.findUnique</code> query, enhancing both security and performance through correct Prisma usage.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Log-api-calls</td><td>November 14, 2025</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-folder-functi...</td><td>August 13, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1209?tool=ast>(Baz)</a>.