### PR TITLE
fix(stripe): return error response on webhook signature validation failure

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -17,26 +17,21 @@ export const POST = withError("stripe/webhook", async (request) => {
 
   if (!signature) return NextResponse.json({}, { status: 400 });
 
-  async function doEventProcessing() {
-    if (typeof signature !== "string") throw new Error("Header isn't a string");
-
-    if (!env.STRIPE_WEBHOOK_SECRET)
-      throw new Error("STRIPE_WEBHOOK_SECRET is not set");
-
-    const event = getStripe().webhooks.constructEvent(
-      body,
-      signature,
-      env.STRIPE_WEBHOOK_SECRET,
-    );
-
-    after(() => processEvent(event, logger));
+  if (typeof signature !== "string") {
+    throw new Error("Header isn't a string");
   }
 
-  try {
-    await doEventProcessing();
-  } catch (error) {
-    logger.error("Error processing event", { error });
+  if (!env.STRIPE_WEBHOOK_SECRET) {
+    throw new Error("STRIPE_WEBHOOK_SECRET is not set");
   }
+
+  const event = getStripe().webhooks.constructEvent(
+    body,
+    signature,
+    env.STRIPE_WEBHOOK_SECRET,
+  );
+
+  after(() => processEvent(event, logger));
 
   return NextResponse.json({ received: true });
 });


### PR DESCRIPTION
# User description
Fixes Stripe webhook handler returning HTTP 200 on signature validation failure.

**TLDR:** The webhook handler was catching signature validation errors but still returning 200 success, causing Stripe to think invalid webhooks were successfully delivered.

- Removed try-catch that swallowed `StripeSignatureVerificationError` and other validation errors
- Flattened code by removing nested `doEventProcessing()` function
- Errors now propagate to `withError` middleware which returns appropriate HTTP error responses
- Valid webhooks still return 200; invalid signatures now return 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Corrects the Stripe webhook handler to properly return error responses for invalid signatures instead of a 200 OK, ensuring Stripe correctly identifies failed deliveries. Refactors the webhook processing logic by removing a nested function and allowing errors to propagate for appropriate HTTP error handling.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>logger</td><td>December 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1210?tool=ast>(Baz)</a>.