### PR TITLE
fix(reply-zero): use raw SQL for correct distinct pagination

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/fetch-trackers.ts
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/fetch-trackers.ts
@@ -25,13 +25,16 @@ export async function getPaginatedThreadTrackers({
 
   const [trackers, total] = await Promise.all([
     prisma.$queryRaw<ThreadTracker[]>`
-      SELECT DISTINCT ON ("threadId") *
-      FROM "ThreadTracker"
-      WHERE "emailAccountId" = ${emailAccountId}
-        AND "resolved" = false
-        AND "type" = ${type}::text::"ThreadTrackerType"
-        ${dateClause}
-      ORDER BY "threadId", "createdAt" DESC
+      SELECT * FROM (
+        SELECT DISTINCT ON ("threadId") *
+        FROM "ThreadTracker"
+        WHERE "emailAccountId" = ${emailAccountId}
+          AND "resolved" = false
+          AND "type" = ${type}::text::"ThreadTrackerType"
+          ${dateClause}
+        ORDER BY "threadId", "createdAt" DESC
+      ) AS distinct_threads
+      ORDER BY "createdAt" DESC
       LIMIT ${PAGE_SIZE}
       OFFSET ${skip}
     `,


### PR DESCRIPTION
# User description
Fixes incorrect pagination in Reply Zero where Prisma's `distinct` clause applies AFTER `skip/take`.

- Replace Prisma `findMany` with raw SQL using `DISTINCT ON ("threadId")` 
- Ensures distinct filtering happens BEFORE pagination
- Each page now contains exactly 20 distinct threads (or fewer on last page)
- Consolidates date filter logic using `Prisma.sql`/`Prisma.empty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor the <code>getPaginatedThreadTrackers</code> function to correct pagination logic in Reply Zero, replacing Prisma's <code>findMany</code> with raw SQL to ensure <code>DISTINCT ON ("threadId")</code> filtering occurs before <code>skip/take</code> operations. Consolidate date filter logic using <code>Prisma.sql</code> and <code>Prisma.empty</code> for improved query construction.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1211?tool=ast&topic=Refactor+Date+Filter>Refactor Date Filter</a>
        </td><td>Consolidate date filter logic within the raw SQL query using <code>Prisma.sql</code> and <code>Prisma.empty</code> for dynamic query construction, improving readability and maintainability.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/reply-zero/fetch-trackers.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-up-imports-for</td><td>November 22, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1211?tool=ast&topic=Fix+Distinct+Pagination>Fix Distinct Pagination</a>
        </td><td>Correct distinct pagination for thread trackers by replacing Prisma's <code>findMany</code> with raw SQL, ensuring <code>DISTINCT ON ("threadId")</code> is applied before <code>LIMIT</code> and <code>OFFSET</code> clauses to return accurate paginated results.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/reply-zero/fetch-trackers.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-up-imports-for</td><td>November 22, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1211?tool=ast>(Baz)</a>.