### PR TITLE
fix(webhook): add observability for Gmail history pagination

### DIFF
--- a/apps/web/app/api/google/webhook/process-history.ts
+++ b/apps/web/app/api/google/webhook/process-history.ts
@@ -326,6 +326,14 @@ async function fetchGmailHistoryResilient({
       historyTypes: ["messageAdded", "labelAdded", "labelRemoved"],
       maxResults: 500,
     });
+
+    if (data.nextPageToken) {
+      logger.warn("Gmail history has more pages that were not fetched", {
+        historyItemCount: data.history?.length ?? 0,
+        startHistoryId,
+      });
+    }
+
     return { status: "success", data, startHistoryId };
   } catch (error) {
     // Gmail history IDs are typically valid for ~1 week. If older, Gmail returns a 404.


### PR DESCRIPTION
# User description
## Summary

Add warning log when Gmail API returns `nextPageToken`, indicating more history items exist beyond the 500 fetched per request.

- Logs `historyItemCount` and `startHistoryId` when pagination token is present
- Provides visibility into potential data loss without changing behavior
- Keeps existing 500-item safety cap due to Vercel's 5-minute timeout constraint

## Test plan

- [ ] Deploy to staging and monitor logs for "Gmail history has more pages" warnings
- [ ] Verify warning appears when more than 500 history items exist between syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds a warning log within the <code>process-history.ts</code> webhook handler to indicate when the Gmail API returns a <code>nextPageToken</code>, signifying that more history items exist beyond the 500 fetched per request without changing the existing behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-google-add-observa...</td><td>January 02, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Separate-files-and-PR-...</td><td>August 15, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1212?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for Gmail history synchronization to improve monitoring and visibility into data fetching operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->