### PR TITLE
fix(web): ensure label is always included in search keywords

### DIFF
--- a/apps/web/components/Combobox.tsx
+++ b/apps/web/components/Combobox.tsx
@@ -75,7 +75,11 @@ export function Combobox(props: {
                   <CommandItem
                     key={options.value}
                     value={options.value}
-                    keywords={options.keywords ?? [options.label]}
+                    keywords={
+                      options.keywords
+                        ? [...options.keywords, options.label]
+                        : [options.label]
+                    }
                     onSelect={(currentValue) => {
                       onChangeValue(currentValue === value ? "" : currentValue);
                       setOpen(false);


### PR DESCRIPTION
# User description
assistant: Address PR review comment

This PR ensures that the visible label name is always included in the search keywords for the `Combobox` component, even if custom keywords are provided.

- Appends `options.label` to `keywords` if they exist.
- Uses `[options.label]` as fallback.
- Fixes potential search regression identified in review.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>Combobox</code> component to ensure its visible label is consistently included in search keywords, either by appending it to custom keywords or using it as the primary keyword. This guarantees discoverability and prevents search regressions.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-web-allow-searchin...</td><td>January 05, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Clean-up-label-rule-form</td><td>December 03, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1213?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combobox search functionality to better match items by including both custom keywords and labels when searching, making items easier to find and select.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->