### PR TITLE
assistant: fix all rules disabled banner logic

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/AllRulesDisabledBanner.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/AllRulesDisabledBanner.tsx
@@ -18,8 +18,7 @@ export function AllRulesDisabledBanner() {
 
   if (isLoading || !rules) return null;
 
-  const allRulesDisabled =
-    rules.length > 0 && rules.every((rule) => !rule.enabled);
+  const allRulesDisabled = rules.every((rule) => !rule.enabled);
 
   if (!allRulesDisabled) return null;
 


### PR DESCRIPTION
# User description
This PR fixes the logic in AllRulesDisabledBanner to show the banner when there are no enabled rules, including the initial state where no rules exist yet.

- Update allRulesDisabled condition to handle empty rules array
- Remove unused console logs and variables

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>AllRulesDisabledBanner</code> component to correctly display when no rules are enabled, including the initial state where no rules have been created, by refining the <code>allRulesDisabled</code> condition.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-add-all-rules-dis...</td><td>January 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1220?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "All Rules Disabled" banner to display correctly when all rules are disabled, including scenarios with zero rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->