### PR TITLE
onboarding: fix unexpected redirect to onboarding-brief

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/page.tsx
@@ -31,7 +31,11 @@ export default async function OnboardingPage(props: {
     cookieStore,
   });
 
-  if (utmValues.utmSource === "briefmymeeting" && !searchParams.force) {
+  if (
+    utmValues.utmSource === "briefmymeeting" &&
+    !searchParams.force &&
+    !searchParams.step
+  ) {
     redirect(`/${emailAccountId}/onboarding-brief`);
   }
 


### PR DESCRIPTION
# User description
This PR fixes an issue where standard onboarding would redirect to the brief onboarding when navigating between steps.

- Added a check for the `step` search parameter in `onboarding/page.tsx`
- Bypassed the brief redirect if a specific step is already being viewed

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes an issue in the <code>OnboardingPage</code> component that caused an unexpected redirect to the brief onboarding flow when navigating between steps, by adding a check for the <code>step</code> search parameter. Prevents the brief onboarding redirect if a specific step is already being viewed.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1221?tool=ast>(Baz)</a>.