### PR TITLE
fix: improve Outlook calendar invite detection and add attachment metadata

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -21,7 +21,7 @@ import type {
   MatchingRuleResult,
 } from "@/utils/ai/choose-rule/types";
 import { extractEmailAddress } from "@/utils/email";
-import { hasIcsAttachment } from "@/utils/parse/calender-event";
+import { isCalendarInvite } from "@/utils/parse/calender-event";
 import { checkSenderReplyHistory } from "@/utils/reply-tracker/check-sender-reply-history";
 import type { EmailProvider } from "@/utils/email/types";
 import type { ModelType } from "@/utils/llms/model";
@@ -155,9 +155,9 @@ async function findPotentialMatchingRules({
 
   // Go through all rules and collect matches and potential AI matches
   for (const rule of rules) {
-    // Special case for calendar rules
+    // Special case for calendar rules - only match with high-confidence signals
     const calendarMatch =
-      rule.systemType === SystemType.CALENDAR && hasIcsAttachment(message);
+      rule.systemType === SystemType.CALENDAR && isCalendarInvite(message);
 
     if (calendarMatch) {
       matches.push({

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -1,5 +1,8 @@
-import type { Message } from "@microsoft/microsoft-graph-types";
-import type { ParsedMessage } from "@/utils/types";
+import type {
+  Message,
+  Attachment as GraphAttachment,
+} from "@microsoft/microsoft-graph-types";
+import type { ParsedMessage, Attachment } from "@/utils/types";
 import type { OutlookClient } from "@/utils/outlook/client";
 import { OutlookLabel } from "./label";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
@@ -10,6 +13,10 @@ import type { Logger } from "@/utils/logger";
 // Standard fields to select when fetching messages from Microsoft Graph API
 export const MESSAGE_SELECT_FIELDS =
   "id,conversationId,conversationIndex,subject,bodyPreview,from,sender,toRecipients,ccRecipients,receivedDateTime,isDraft,isRead,body,categories,parentFolderId";
+
+// Expand attachments to get metadata (name, type, size) without fetching content
+export const MESSAGE_EXPAND_ATTACHMENTS =
+  "attachments($select=id,name,contentType,size)";
 
 // Well-known folder names in Outlook that are consistent across all languages
 export const WELL_KNOWN_FOLDERS = {
@@ -465,7 +472,11 @@ export async function getMessages(
  * Returns a typed request builder that can be chained with .filter(), .top(), etc.
  */
 export function createMessagesRequest(client: OutlookClient) {
-  return client.getClient().api("/me/messages").select(MESSAGE_SELECT_FIELDS);
+  return client
+    .getClient()
+    .api("/me/messages")
+    .select(MESSAGE_SELECT_FIELDS)
+    .expand(MESSAGE_EXPAND_ATTACHMENTS);
 }
 
 /**
@@ -475,7 +486,8 @@ export function createMessageRequest(client: OutlookClient, messageId: string) {
   return client
     .getClient()
     .api(`/me/messages/${messageId}`)
-    .select(MESSAGE_SELECT_FIELDS);
+    .select(MESSAGE_SELECT_FIELDS)
+    .expand(MESSAGE_EXPAND_ATTACHMENTS);
 }
 
 /**
@@ -539,6 +551,7 @@ export function convertMessage(
     internalDate: message.receivedDateTime || new Date().toISOString(),
     historyId: "",
     inline: [],
+    attachments: convertAttachments(message.attachments),
     conversationIndex: message.conversationIndex,
     rawRecipients: {
       from: message.from,
@@ -546,4 +559,25 @@ export function convertMessage(
       ccRecipients: message.ccRecipients,
     },
   };
+}
+
+function convertAttachments(
+  graphAttachments: GraphAttachment[] | undefined | null,
+): Attachment[] | undefined {
+  if (!graphAttachments || graphAttachments.length === 0) {
+    return undefined;
+  }
+
+  return graphAttachments.map((attachment) => ({
+    filename: attachment.name || "",
+    mimeType: attachment.contentType || "application/octet-stream",
+    size: attachment.size || 0,
+    attachmentId: attachment.id || "",
+    headers: {
+      "content-type": attachment.contentType || "",
+      "content-description": "",
+      "content-transfer-encoding": "",
+      "content-id": "",
+    },
+  }));
 }


### PR DESCRIPTION
# User description
Outlook calendar invites were inconsistently categorized because the preset calendar rule only checked for .ics attachments, which Outlook doesn't always include.

- Add `isCalendarInvite()` function with high-confidence detection (iCalendar content in body, text/calendar MIME type)
- Populate attachments field for Outlook messages using `$expand=attachments`
- Update calendar preset rule to use the new detection
- Add tests for Outlook calendar scenarios

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
findPotentialMatchingRules_("findPotentialMatchingRules"):::modified
isCalendarInvite_("isCalendarInvite"):::added
hasCalendarMimeType_("hasCalendarMimeType"):::added
hasICalendarContent_("hasICalendarContent"):::added
convertMessage_("convertMessage"):::modified
convertAttachments_("convertAttachments"):::added
createMessagesRequest_("createMessagesRequest"):::modified
MICROSOFT_GRAPH_API_("MICROSOFT_GRAPH_API"):::modified
findPotentialMatchingRules_ -- "Now uses isCalendarInvite to require high-confidence calendar signals." --> isCalendarInvite_
isCalendarInvite_ -- "Checks attachments' MIME types for text/calendar detection." --> hasCalendarMimeType_
isCalendarInvite_ -- "Scans body for VCALENDAR with DTSTART or METHOD markers." --> hasICalendarContent_
convertMessage_ -- "Adds attachments mapping from Graph metadata into local Attachment." --> convertAttachments_
createMessagesRequest_ -- "Requests messages with selected fields and expanded attachments metadata." --> MICROSOFT_GRAPH_API_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Improve calendar invite detection by implementing a new <code>isCalendarInvite</code> function that identifies invites based on iCalendar content in the body or <code>text/calendar</code> MIME types, and populate attachment metadata for Outlook messages to support this improved detection.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1227?tool=ast&topic=Populate+Outlook+Attachments>Populate Outlook Attachments</a>
        </td><td>Enhance Outlook message processing to fetch and convert attachment metadata, ensuring that <code>ParsedMessage</code> objects include detailed attachment information by expanding attachments in API requests and introducing a <code>convertAttachments</code> utility.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/message.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>remove-comment-and-logs</td><td>January 06, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-folder-functi...</td><td>August 13, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1227?tool=ast&topic=Improve+Calendar+Detection>Improve Calendar Detection</a>
        </td><td>Implement a robust <code>isCalendarInvite</code> function to accurately identify calendar invites by checking for <code>.ics</code> attachments, <code>text/calendar</code> MIME types, and iCalendar content within email bodies, and update the calendar preset rule to utilize this new detection logic.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/ai/choose-rule/match-rules.ts</li>
<li>apps/web/utils/parse/calender-event.test.ts</li>
<li>apps/web/utils/parse/calender-event.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>clean-up-resend-summar...</td><td>January 03, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Remove-metadata.-Test-...</td><td>July 28, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1227?tool=ast>(Baz)</a>.