### PR TITLE
fix: require card validation at trial signup

### DIFF
--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -533,7 +533,7 @@ export const generateCheckoutSessionAction = actionClientUser
         subscription_data: { trial_period_days: 7 },
         line_items: [{ price: priceId, quantity }],
         allow_promotion_codes: true,
-        payment_method_collection: "if_required",
+        payment_method_collection: "always",
         metadata: {
           dubCustomerId: userId,
         },


### PR DESCRIPTION
# User description
Validate payment methods upfront during trial signup to catch invalid cards immediately.

**TLDR:** Changes `payment_method_collection` from `if_required` to `always` in Stripe Checkout, ensuring cards are validated at trial signup rather than 7 days later when the first charge fails.

- Prevents trial abuse with fake/expired/invalid cards
- Cards are validated via Stripe card check at checkout (no extra user friction)
- Users will only be rejected if their card is genuinely invalid

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Stripe Checkout session configuration to require immediate payment method validation during trial signup, preventing invalid cards from being accepted initially by changing <code>payment_method_collection</code> from <code>if_required</code> to <code>always</code>.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>remove-comments</td><td>December 29, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1240?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment method collection during premium checkout to ensure consistent processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->