### PR TITLE
fix(e2e): use fullSubject for unique message identification in tests

### DIFF
--- a/apps/web/__tests__/e2e/flows/auto-labeling.test.ts
+++ b/apps/web/__tests__/e2e/flows/auto-labeling.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterEach } from "vitest";
-import { shouldRunFlowTests, TIMEOUTS, getTestSubjectPrefix } from "./config";
+import { shouldRunFlowTests, TIMEOUTS } from "./config";
 import { initializeFlowTests, setupFlowTest } from "./setup";
 import { generateTestSummary } from "./teardown";
 import { sendTestEmail, TEST_EMAIL_SCENARIOS } from "./helpers/email";
@@ -48,17 +48,17 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
       // ========================================
       logStep("Sending email that needs reply");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
         body: scenario.body,
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match across tests
       const outlookMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -123,17 +123,17 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
       // ========================================
       logStep("Sending FYI email");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
         body: scenario.body,
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match across tests
       const outlookMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -192,17 +192,17 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
       // ========================================
       logStep("Sending thank you email");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
         body: scenario.body,
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match across tests
       const outlookMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -252,17 +252,17 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
       // ========================================
       logStep("Sending question email");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
         body: scenario.body,
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match across tests
       const outlookMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 

--- a/apps/web/__tests__/e2e/flows/draft-cleanup.test.ts
+++ b/apps/web/__tests__/e2e/flows/draft-cleanup.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterEach } from "vitest";
-import { shouldRunFlowTests, TIMEOUTS, getTestSubjectPrefix } from "./config";
+import { shouldRunFlowTests, TIMEOUTS } from "./config";
 import { initializeFlowTests, setupFlowTest } from "./setup";
 import { generateTestSummary } from "./teardown";
 import {
@@ -56,7 +56,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
       // ========================================
       logStep("Step 1: Sending email that needs reply");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
@@ -65,7 +65,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
 
       const receivedMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -161,7 +161,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
       // ========================================
       logStep("Setting up thread with multiple messages");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: "Multi-draft cleanup test",
@@ -170,7 +170,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
 
       const firstReceived = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -240,7 +240,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
       // ========================================
       logStep("Sending email and waiting for draft");
 
-      await sendTestEmail({
+      const sentEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: scenario.subject,
@@ -249,7 +249,7 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
 
       const receivedMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 

--- a/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
+++ b/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
-import { shouldRunFlowTests, TIMEOUTS, getTestSubjectPrefix } from "./config";
+import { shouldRunFlowTests, TIMEOUTS } from "./config";
 import { initializeFlowTests, setupFlowTest } from "./setup";
 import { generateTestSummary } from "./teardown";
 import {
@@ -84,10 +84,10 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
       // ========================================
       logStep("Step 2: Waiting for Outlook to receive email");
 
-      // Wait for message to appear in Outlook inbox
+      // Wait for message to appear in Outlook inbox - use fullSubject for unique match
       const outlookMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -190,9 +190,7 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
 
       const gmailReply = await waitForMessageInInbox({
         provider: gmail.emailProvider,
-        subjectContains: sentEmail.fullSubject
-          .replace(getTestSubjectPrefix(), "")
-          .trim(),
+        subjectContains: sentEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -263,10 +261,10 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
         body: "This is the first message in the thread.",
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match
       const outlookMsg1 = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: initialEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 

--- a/apps/web/__tests__/e2e/flows/outbound-tracking.test.ts
+++ b/apps/web/__tests__/e2e/flows/outbound-tracking.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, test, expect, beforeAll, afterEach } from "vitest";
 import prisma from "@/utils/prisma";
-import { shouldRunFlowTests, TIMEOUTS, getTestSubjectPrefix } from "./config";
+import { shouldRunFlowTests, TIMEOUTS } from "./config";
 import { initializeFlowTests, setupFlowTest } from "./setup";
 import { generateTestSummary } from "./teardown";
 import { sendTestEmail, sendTestReply } from "./helpers/email";
@@ -56,7 +56,7 @@ describe.skipIf(!shouldRunFlowTests())("Outbound Message Tracking", () => {
 
       const receivedMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: incomingEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -122,7 +122,7 @@ describe.skipIf(!shouldRunFlowTests())("Outbound Message Tracking", () => {
       // ========================================
       logStep("Setting up thread");
 
-      await sendTestEmail({
+      const incomingEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: "No duplicate test",
@@ -131,7 +131,7 @@ describe.skipIf(!shouldRunFlowTests())("Outbound Message Tracking", () => {
 
       const receivedMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: incomingEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -183,7 +183,7 @@ describe.skipIf(!shouldRunFlowTests())("Outbound Message Tracking", () => {
       // ========================================
       logStep("Setting up incoming email");
 
-      await sendTestEmail({
+      const incomingEmail = await sendTestEmail({
         from: gmail,
         to: outlook,
         subject: "Reply tracking update test",
@@ -192,7 +192,7 @@ describe.skipIf(!shouldRunFlowTests())("Outbound Message Tracking", () => {
 
       const receivedMessage = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: getTestSubjectPrefix(),
+        subjectContains: incomingEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 


### PR DESCRIPTION
# User description
Fix E2E test isolation issue where tests were finding messages from previous tests.

**TLDR:** Tests used only the run ID prefix to search for messages, but since all tests share the same run ID, later tests found earlier tests' messages. Now using fullSubject which includes both run ID and scenario-specific subject.

- Changed `waitForMessageInInbox` calls to use `sentEmail.fullSubject` instead of `getTestSubjectPrefix()`
- This ensures each test finds only its own message (e.g., "[E2E-abc123] FYI: Q4 report is attached" vs just "[E2E-abc123]")
- Fixed in all 4 flow test files: auto-labeling, draft-cleanup, full-reply-cycle, outbound-tracking

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolves an E2E test isolation issue within the <code>inbox-zero-ai</code> module by ensuring unique message identification. Updates the <code>waitForMessageInInbox</code> utility to use the <code>fullSubject</code> of sent emails, preventing tests from incorrectly matching messages from prior test runs.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-wait-for-Execu...</td><td>January 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1244?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability and reliability of end-to-end tests across multiple flows (auto-labeling, draft cleanup, full-reply cycle, outbound-tracking) by enhancing email subject matching logic for more accurate test assertions.

* **Refactor**
  * Updated internal test infrastructure to leverage actual email subject values for improved accuracy in test verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->