### PR TITLE
fix(e2e): use threadId for ExecutedRule matching and add detailed logging

### DIFF
--- a/apps/web/__tests__/e2e/flows/auto-labeling.test.ts
+++ b/apps/web/__tests__/e2e/flows/auto-labeling.test.ts
@@ -62,19 +62,35 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
+      logStep("Email received in Outlook", {
+        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
+      });
+
       // ========================================
       // Wait for rule execution
       // ========================================
-      logStep("Waiting for rule execution");
+      logStep("Waiting for rule execution", {
+        threadId: outlookMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
       });
 
       expect(executedRule).toBeDefined();
       expect(executedRule.status).toBe("APPLIED");
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: outlookMessage.messageId,
+        messageIdMatch: executedRule.messageId === outlookMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
+      });
 
       // ========================================
       // Verify draft was created (needs reply = should draft)
@@ -137,18 +153,34 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
+      logStep("Email received in Outlook", {
+        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
+      });
+
       // ========================================
       // Wait for rule execution
       // ========================================
-      logStep("Waiting for rule execution");
+      logStep("Waiting for rule execution", {
+        threadId: outlookMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
       });
 
       expect(executedRule).toBeDefined();
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: outlookMessage.messageId,
+        messageIdMatch: executedRule.messageId === outlookMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
+      });
 
       // ========================================
       // Verify NO draft was created for FYI email
@@ -206,18 +238,34 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
+      logStep("Email received in Outlook", {
+        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
+      });
+
       // ========================================
       // Wait for rule execution
       // ========================================
-      logStep("Waiting for rule execution");
+      logStep("Waiting for rule execution", {
+        threadId: outlookMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
       });
 
       expect(executedRule).toBeDefined();
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: outlookMessage.messageId,
+        messageIdMatch: executedRule.messageId === outlookMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
+      });
 
       // ========================================
       // Verify processing
@@ -266,18 +314,34 @@ describe.skipIf(!shouldRunFlowTests())("Auto-Labeling", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
+      logStep("Email received in Outlook", {
+        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
+      });
+
       // ========================================
       // Wait for rule execution
       // ========================================
-      logStep("Waiting for rule execution");
+      logStep("Waiting for rule execution", {
+        threadId: outlookMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
       });
 
       expect(executedRule).toBeDefined();
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: outlookMessage.messageId,
+        messageIdMatch: executedRule.messageId === outlookMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
+      });
 
       // ========================================
       // Verify draft created for question

--- a/apps/web/__tests__/e2e/flows/draft-cleanup.test.ts
+++ b/apps/web/__tests__/e2e/flows/draft-cleanup.test.ts
@@ -69,15 +69,31 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
+      logStep("Email received in Outlook", {
+        messageId: receivedMessage.messageId,
+        threadId: receivedMessage.threadId,
+      });
+
       // ========================================
       // Step 2: Wait for AI draft to be created
       // ========================================
-      logStep("Step 2: Waiting for AI draft creation");
+      logStep("Step 2: Waiting for AI draft creation", {
+        threadId: receivedMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: receivedMessage.messageId,
+        threadId: receivedMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
+      });
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: receivedMessage.messageId,
+        messageIdMatch: executedRule.messageId === receivedMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
       });
 
       const draftAction = executedRule.actionItems.find(
@@ -86,7 +102,6 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
 
       expect(draftAction).toBeDefined();
       expect(draftAction?.draftId).toBeTruthy();
-      // Safe to use ! after the assertions above
       const aiDraftId = draftAction!.draftId!;
 
       logStep("AI draft created", { draftId: aiDraftId });
@@ -174,18 +189,35 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
-      // Wait for first draft
-      const firstRule = await waitForExecutedRule({
+      logStep("Email received in Outlook", {
         messageId: firstReceived.messageId,
+        threadId: firstReceived.threadId,
+      });
+
+      // Wait for first draft
+      logStep("Waiting for rule execution", {
+        threadId: firstReceived.threadId,
+      });
+
+      const firstRule = await waitForExecutedRule({
+        threadId: firstReceived.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
+      });
+
+      logStep("ExecutedRule found", {
+        executedRuleId: firstRule.id,
+        executedRuleMessageId: firstRule.messageId,
+        inboxMessageId: firstReceived.messageId,
+        messageIdMatch: firstRule.messageId === firstReceived.messageId,
+        status: firstRule.status,
+        actionItems: firstRule.actionItems.length,
       });
 
       const firstDraftAction = firstRule.actionItems.find(
         (a) => a.type === "DRAFT_EMAIL" && a.draftId,
       );
 
-      // Assert draft was created - this test requires a draft
       expect(firstDraftAction?.draftId).toBeTruthy();
       const firstDraftId = firstDraftAction!.draftId!;
       logStep("First draft created", { draftId: firstDraftId });
@@ -253,17 +285,34 @@ describe.skipIf(!shouldRunFlowTests())("Draft Cleanup", () => {
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
-      const executedRule = await waitForExecutedRule({
+      logStep("Email received in Outlook", {
         messageId: receivedMessage.messageId,
+        threadId: receivedMessage.threadId,
+      });
+
+      logStep("Waiting for rule execution", {
+        threadId: receivedMessage.threadId,
+      });
+
+      const executedRule = await waitForExecutedRule({
+        threadId: receivedMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
+      });
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: receivedMessage.messageId,
+        messageIdMatch: executedRule.messageId === receivedMessage.messageId,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
       });
 
       const draftAction = executedRule.actionItems.find(
         (a) => a.type === "DRAFT_EMAIL" && a.draftId,
       );
 
-      // This test requires a draft to be created
       expect(draftAction?.draftId).toBeTruthy();
 
       const aiDraftId = draftAction!.draftId!;

--- a/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
+++ b/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
@@ -99,10 +99,12 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
       // ========================================
       // Step 3: Wait for rule execution
       // ========================================
-      logStep("Step 3: Waiting for rule execution");
+      logStep("Step 3: Waiting for rule execution", {
+        threadId: outlookMessage.threadId,
+      });
 
       const executedRule = await waitForExecutedRule({
-        messageId: outlookMessage.messageId,
+        threadId: outlookMessage.threadId,
         emailAccountId: outlook.id,
         timeout: TIMEOUTS.WEBHOOK_PROCESSING,
       });
@@ -110,7 +112,11 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
       expect(executedRule).toBeDefined();
       expect(executedRule.status).toBe("APPLIED");
 
-      logStep("Rule executed", {
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        executedRuleMessageId: executedRule.messageId,
+        inboxMessageId: outlookMessage.messageId,
+        messageIdMatch: executedRule.messageId === outlookMessage.messageId,
         ruleId: executedRule.ruleId,
         status: executedRule.status,
         actionItems: executedRule.actionItems.length,


### PR DESCRIPTION
# User description
## Summary

Fixes E2E test timeouts when waiting for ExecutedRule by using threadId instead of messageId.

## Changes

### 1. Query by threadId instead of messageId
- `waitForExecutedRule` now queries by `threadId` instead of `messageId`
- **Why**: Each test sends a new email which creates its own unique thread, so threadId uniquely identifies that message
- **Benefit**: More reliable matching since threadId is stable once the message arrives

### 2. Added comprehensive logging
Now logs after finding ExecutedRule:
- `executedRuleId` - the rule that was found
- `executedRuleMessageId` - messageId stored in the ExecutedRule
- `inboxMessageId` - messageId we found when polling the inbox
- `messageIdMatch` - boolean showing if they match
- `status` and `actionItems` count

This makes tests fully debuggable - we can see exactly what IDs are being matched.

## Testing
- Run E2E tests to verify the fix resolves the timeout issues

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>inbox-zero-ai</code> module's E2E testing infrastructure by modifying the <code>waitForExecutedRule</code> utility to query for <code>ExecutedRule</code> instances using <code>threadId</code> instead of <code>messageId</code>, resolving test timeouts. Enhances test observability by adding detailed logging of rule execution and message IDs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1245?tool=ast&topic=E2E+Rule+Matching>E2E Rule Matching</a>
        </td><td>Modifies the <code>waitForExecutedRule</code> utility to query for <code>ExecutedRule</code> instances using <code>threadId</code> instead of <code>messageId</code>, improving the reliability of E2E tests for AI-driven rule execution.<details><summary>Modified files (4)</summary><ul><li>apps/web/__tests__/e2e/flows/auto-labeling.test.ts</li>
<li>apps/web/__tests__/e2e/flows/draft-cleanup.test.ts</li>
<li>apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts</li>
<li>apps/web/__tests__/e2e/flows/helpers/polling.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-use-fullSubjec...</td><td>January 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1245?tool=ast&topic=E2E+Logging>E2E Logging</a>
        </td><td>Adds comprehensive logging within E2E tests to output <code>executedRuleId</code>, <code>executedRuleMessageId</code>, <code>inboxMessageId</code>, and <code>messageIdMatch</code> after an <code>ExecutedRule</code> is found, aiding in debugging test failures.<details><summary>Modified files (4)</summary><ul><li>apps/web/__tests__/e2e/flows/auto-labeling.test.ts</li>
<li>apps/web/__tests__/e2e/flows/draft-cleanup.test.ts</li>
<li>apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts</li>
<li>apps/web/__tests__/e2e/flows/helpers/polling.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-use-fullSubjec...</td><td>January 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1245?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive logging to email processing test flows including auto-labeling, draft cleanup, and reply scenarios to enhance observability of rule execution.
  * Improved test infrastructure stability by correlating rule execution verification with email threads instead of individual messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->