### PR TITLE
fix: allow non-premium users to dismiss SetupDialog

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -29,7 +29,13 @@ const features = [
   },
 ];
 
-export function AutoCategorizationSetup({ open }: { open: boolean }) {
+export function AutoCategorizationSetup({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
   const { emailAccountId } = useAccount();
   const { setIsBulkCategorizing } = useCategorizeProgress();
 
@@ -67,6 +73,7 @@ export function AutoCategorizationSetup({ open }: { open: boolean }) {
   return (
     <SetupDialog
       open={open}
+      onOpenChange={onOpenChange}
       imageSrc="/images/illustrations/working-vacation.svg"
       imageAlt="Bulk Archive"
       title="Bulk Archive"

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import useSWR from "swr";
 import { parseAsBoolean, useQueryState } from "nuqs";
 import { AutoCategorizationSetup } from "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup";
@@ -44,9 +44,12 @@ export function BulkArchive() {
     mutate();
   }, [mutate]);
 
+  const [setupDismissed, setSetupDismissed] = useState(false);
+
   // Show setup dialog for first-time setup only
   const shouldShowSetup =
-    onboarding || (!autoCategorizeSenders && !isBulkCategorizing);
+    !setupDismissed &&
+    (onboarding || (!autoCategorizeSenders && !isBulkCategorizing));
 
   return (
     <LoadingContent loading={isLoading} error={error}>
@@ -63,7 +66,12 @@ export function BulkArchive() {
         <BulkArchiveProgress onComplete={handleProgressComplete} />
         <BulkArchiveCards emailGroups={emailGroups} categories={categories} />
       </PageWrapper>
-      <AutoCategorizationSetup open={shouldShowSetup} />
+      <AutoCategorizationSetup
+        open={shouldShowSetup}
+        onOpenChange={(open) => {
+          if (!open) setSetupDismissed(true);
+        }}
+      />
     </LoadingContent>
   );
 }

--- a/apps/web/components/SetupCard.tsx
+++ b/apps/web/components/SetupCard.tsx
@@ -44,16 +44,15 @@ export function SetupCard(props: SetupContentProps) {
 
 export function SetupDialog({
   open,
+  onOpenChange,
   ...props
-}: SetupContentProps & { open: boolean }) {
+}: SetupContentProps & {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
   return (
-    <Dialog open={open}>
-      <DialogContent
-        className="max-w-lg"
-        onInteractOutside={(e) => e.preventDefault()}
-        onEscapeKeyDown={(e) => e.preventDefault()}
-        hideCloseButton
-      >
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
         <DialogHeader className="sr-only">
           <DialogTitle>{props.title}</DialogTitle>
           <DialogDescription>{props.description}</DialogDescription>


### PR DESCRIPTION
# User description
## Summary
Non-premium users were getting trapped in the AutoCategorizationSetup dialog on the bulk archive page with no way to escape.

- Remove dialog escape prevention props from SetupDialog
- Add `onOpenChange` callback to track when dialog is dismissed  
- Users can now close via X button, clicking outside, or pressing Escape

## Test plan
- [ ] Visit `/bulk-archive` as a non-premium user
- [ ] Verify dialog can be closed via X button, clicking outside, or Escape key
- [ ] Verify the "Categorize" button in top right is available after dismissing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
BulkArchive_("BulkArchive"):::modified
AutoCategorizationSetup_("AutoCategorizationSetup"):::modified
SetupDialog_("SetupDialog"):::modified
DIALOG_COMPONENT_("DIALOG_COMPONENT"):::modified
ACCOUNT_SERVICE_("ACCOUNT_SERVICE"):::modified
CATEGORIZE_PROGRESS_("CATEGORIZE_PROGRESS"):::modified
BulkArchive_ -- "Adds dismissal state; passes onOpenChange to dismiss." --> AutoCategorizationSetup_
AutoCategorizationSetup_ -- "Forwards parent's onOpenChange to SetupDialog." --> SetupDialog_
SetupDialog_ -- "Exposes onOpenChange to Dialog for external control." --> DIALOG_COMPONENT_
AutoCategorizationSetup_ -- "Gained onOpenChange param; account usage unchanged." --> ACCOUNT_SERVICE_
AutoCategorizationSetup_ -- "Categorize progress usage unchanged; dismiss logic added." --> CATEGORIZE_PROGRESS_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Resolves an issue where non-premium users were unable to close the <code>AutoCategorizationSetup</code> dialog within the <code>inbox-zero-ai</code> module, by modifying the <code>SetupDialog</code> component to allow standard dismissal actions and updating its integration in the <code>BulkArchive</code> flow.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-bulk-archive-allo...</td><td>January 09, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1251?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-categorization setup dialog to remain dismissed when closed by the user.
  * Improved dialog interaction behavior, allowing users better control over when setup screens appear during their session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->