### PR TITLE
fix: E2E test subject matching and Outlook JSON retry

### DIFF
--- a/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
+++ b/apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts
@@ -287,10 +287,10 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
         body: "This is the reply from Outlook.",
       });
 
-      // Wait for Gmail to receive
+      // Wait for Gmail to receive - use fullSubject for unique match
       const gmailReply = await waitForMessageInInbox({
         provider: gmail.emailProvider,
-        subjectContains: "Thread continuity test",
+        subjectContains: initialEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 
@@ -310,10 +310,10 @@ describe.skipIf(!shouldRunFlowTests())("Full Reply Cycle", () => {
         body: "This is the second reply from Gmail.",
       });
 
-      // Wait for Outlook to receive
+      // Wait for Outlook to receive - use fullSubject for unique match
       const outlookMsg2 = await waitForMessageInInbox({
         provider: outlook.emailProvider,
-        subjectContains: "Thread continuity test",
+        subjectContains: initialEmail.fullSubject,
         timeout: TIMEOUTS.EMAIL_DELIVERY,
       });
 

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -116,18 +116,20 @@ export async function clearFollowUpLabel({
   if (!threadId) return;
 
   try {
-    const { count } = await withPrismaRetry(() =>
-      prisma.threadTracker.updateMany({
-        where: {
-          emailAccountId,
-          threadId,
-          followUpAppliedAt: { not: null },
-          resolved: false,
-        },
-        data: {
-          followUpAppliedAt: null,
-        },
-      }),
+    const { count } = await withPrismaRetry(
+      () =>
+        prisma.threadTracker.updateMany({
+          where: {
+            emailAccountId,
+            threadId,
+            followUpAppliedAt: { not: null },
+            resolved: false,
+          },
+          data: {
+            followUpAppliedAt: null,
+          },
+        }),
+      { logger },
     );
 
     if (count === 0) {

--- a/apps/web/utils/prisma-retry.ts
+++ b/apps/web/utils/prisma-retry.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@/generated/prisma/client";
+import type { Logger } from "./logger";
 
 /**
  * Wraps a Prisma operation with retry logic for specific transient errors.
@@ -9,14 +10,15 @@ import { Prisma } from "@/generated/prisma/client";
  * @param options - Retry configuration.
  * @param options.maxRetries - Maximum number of retry attempts (default: 3).
  * @param options.delayMs - Initial delay in milliseconds for backoff (default: 100).
+ * @param options.logger - Optional logger for retry visibility.
  * @returns The result of the Prisma operation.
  * @throws The original error if retries are exhausted or if a non-retriable error occurs.
  */
 export async function withPrismaRetry<T>(
   operation: () => Promise<T>,
-  options: { maxRetries?: number; delayMs?: number } = {},
+  options: { maxRetries?: number; delayMs?: number; logger?: Logger } = {},
 ): Promise<T> {
-  const { maxRetries = 3, delayMs = 100 } = options;
+  const { maxRetries = 3, delayMs = 100, logger } = options;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -29,6 +31,11 @@ export async function withPrismaRetry<T>(
       ) {
         // Linear backoff: 100ms, 200ms, 300ms...
         const backoff = delayMs * attempt;
+        logger?.warn("Retrying Prisma operation due to P2028", {
+          attempt,
+          nextAttemptInMs: backoff,
+          error: error.message,
+        });
         await new Promise((resolve) => setTimeout(resolve, backoff));
         continue;
       }

--- a/apps/web/utils/reply-tracker/handle-conversation-status.ts
+++ b/apps/web/utils/reply-tracker/handle-conversation-status.ts
@@ -121,17 +121,19 @@ export async function updateThreadTrackers({
   status: SystemType;
 }) {
   // Resolve all existing trackers for this thread
-  await withPrismaRetry(() =>
-    prisma.threadTracker.updateMany({
-      where: {
-        emailAccountId,
-        threadId,
-        resolved: false,
-      },
-      data: {
-        resolved: true,
-      },
-    }),
+  await withPrismaRetry(
+    () =>
+      prisma.threadTracker.updateMany({
+        where: {
+          emailAccountId,
+          threadId,
+          resolved: false,
+        },
+        data: {
+          resolved: true,
+        },
+      }),
+    { logger },
   );
 
   const getTrackerType = (status: SystemType) => {

--- a/apps/web/utils/retry/is-fetch-error.ts
+++ b/apps/web/utils/retry/is-fetch-error.ts
@@ -1,3 +1,6 @@
 export function isFetchError(errorInfo: { errorMessage: string }): boolean {
-  return errorInfo.errorMessage === "fetch failed";
+  return (
+    errorInfo.errorMessage === "fetch failed" ||
+    errorInfo.errorMessage.includes("Unexpected end of JSON input")
+  );
 }


### PR DESCRIPTION
# User description
Fix E2E test flakiness and add retry for Microsoft Graph JSON errors.

- Fix thread continuity test to use unique `fullSubject` instead of generic string
- Add retry for 'Unexpected end of JSON input' errors from Microsoft Graph API
- Pass logger to `withPrismaRetry` for visibility into P2028 retries

**E2E Test Fix**: Thread continuity test was matching stale messages from previous runs due to generic subject string.

**Production Fix**: 1,274 JSON parse errors in 7 days from Outlook - now retried.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
updateThreadTrackers_("updateThreadTrackers"):::modified
withPrismaRetry_("withPrismaRetry"):::modified
trackSentDraftStatus_("trackSentDraftStatus"):::modified
cleanupThreadAIDrafts_("cleanupThreadAIDrafts"):::modified
clearFollowUpLabel_("clearFollowUpLabel"):::modified
runRules_("runRules"):::modified
executeMatchedRule_("executeMatchedRule"):::modified
PRISMA_DATABASE_("PRISMA_DATABASE"):::modified
updateThreadTrackers_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
trackSentDraftStatus_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
cleanupThreadAIDrafts_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
clearFollowUpLabel_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
runRules_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
executeMatchedRule_ -- "Passes logger; logs retries on P2028" --> withPrismaRetry_
withPrismaRetry_ -- "Logs retry attempts on P2028 with logger" --> PRISMA_DATABASE_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Resolves E2E test flakiness by ensuring unique subject matching in the <code>full-reply-cycle</code> test, and enhances system reliability by implementing retry logic for Microsoft Graph API JSON parsing errors and improving observability for <code>withPrismaRetry</code> operations.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1258?tool=ast&topic=System+Reliability>System Reliability</a>
        </td><td>Enhances system resilience by adding retry logic for <code>Unexpected end of JSON input</code> errors from external APIs and improves observability of Prisma operation retries by passing a logger to <code>withPrismaRetry</code>.<details><summary>Modified files (6)</summary><ul><li>apps/web/utils/ai/choose-rule/run-rules.ts</li>
<li>apps/web/utils/follow-up/labels.ts</li>
<li>apps/web/utils/prisma-retry.ts</li>
<li>apps/web/utils/reply-tracker/draft-tracking.ts</li>
<li>apps/web/utils/reply-tracker/handle-conversation-status.ts</li>
<li>apps/web/utils/retry/is-fetch-error.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-prisma-address-c...</td><td>January 11, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow-up-reminders</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1258?tool=ast&topic=E2E+Test+Stability>E2E Test Stability</a>
        </td><td>Ensures the <code>full-reply-cycle</code> E2E test reliably identifies messages by using unique subject lines, preventing flakiness from stale data.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/full-reply-cycle.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-use-threadId-f...</td><td>January 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1258?tool=ast>(Baz)</a>.