### PR TITLE
assistant: improve rule form labels for clarity

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
@@ -399,7 +399,7 @@ export function ConditionSteps({
                         <div className="mb-2">
                           <Label
                             name={`conditions.${index}.instructions`}
-                            label="Matching the prompt:"
+                            label="That matches:"
                           />
                         </div>
                       )}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -405,7 +405,7 @@ export function RuleForm({
         <RuleSectionCard
           icon={MailIcon}
           color="blue"
-          title="When a new email is received in your inbox"
+          title="When you get an email"
           errors={
             errors.conditions?.root?.message ? (
               <AlertError
@@ -433,7 +433,7 @@ export function RuleForm({
         <RuleSectionCard
           icon={BotIcon}
           color="green"
-          title="Then your assistant will perform these actions"
+          title="Then:"
           errors={
             actionErrors.length > 0 ? (
               <AlertError


### PR DESCRIPTION
# User description
Simplified and clarified labels in the rule form UI for better user experience.

- Changed "Matching the prompt:" to "That matches:" in condition steps
- Changed "When a new email is received in your inbox" to "When you get an email"
- Changed "Then your assistant will perform these actions" to "Then:"

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the user interface labels within the <code>RuleForm</code> component, which allows users to define email automation rules, and the <code>ConditionSteps</code> component, which guides users through setting rule conditions. Improves clarity and user experience by simplifying the language used for rule definitions.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>enable-learned-pattern...</td><td>January 04, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove-conditional-tit...</td><td>December 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1262?tool=ast>(Baz)</a>.