### PR TITLE
fix: normalize CRLF and preserve paragraph spacing in email drafts

### DIFF
--- a/apps/web/utils/gmail/mail.test.ts
+++ b/apps/web/utils/gmail/mail.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { convertTextToHtmlParagraphs } from "@/utils/gmail/mail";
+
+describe("convertTextToHtmlParagraphs", () => {
+  it("preserves paragraph spacing with double newlines", () => {
+    const input = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+    const result = convertTextToHtmlParagraphs(input);
+
+    // The output should have visual spacing between paragraphs using <br> tags
+    expect(result).toContain("<p>First paragraph.</p>");
+    expect(result).toContain("<p>Second paragraph.</p>");
+    expect(result).toContain("<p>Third paragraph.</p>");
+
+    // Should have <br> tags for spacing between paragraphs
+    expect(result).toContain("<br>");
+
+    // Verify the exact structure: paragraph, br (for empty line), paragraph
+    expect(result).toBe(
+      "<html><body><p>First paragraph.</p><br><p>Second paragraph.</p><br><p>Third paragraph.</p></body></html>",
+    );
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = "First line\r\nSecond line\r\nThird line";
+    const result = convertTextToHtmlParagraphs(input);
+
+    // Should NOT have \r characters in output
+    expect(result).not.toContain("\r");
+
+    // Should properly separate into paragraphs
+    expect(result).toContain("<p>First line</p>");
+    expect(result).toContain("<p>Second line</p>");
+    expect(result).toContain("<p>Third line</p>");
+  });
+
+  it("handles empty input", () => {
+    expect(convertTextToHtmlParagraphs("")).toBe("");
+    expect(convertTextToHtmlParagraphs(null)).toBe("");
+    expect(convertTextToHtmlParagraphs(undefined)).toBe("");
+  });
+
+  it("handles single line input", () => {
+    const input = "Just one line";
+    const result = convertTextToHtmlParagraphs(input);
+    expect(result).toBe("<html><body><p>Just one line</p></body></html>");
+  });
+});

--- a/apps/web/utils/gmail/reply.test.ts
+++ b/apps/web/utils/gmail/reply.test.ts
@@ -116,4 +116,54 @@ describe("email formatting", () => {
 </div>`.trim(),
     );
   });
+
+  it("handles CRLF line endings correctly", () => {
+    const textContent = "Line one\r\nLine two\r\nLine three";
+    const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {
+      headers: {
+        date: "Thu, 6 Feb 2025 23:23:47 +0200",
+        from: "John Doe <john@example.com>",
+        subject: "Test Email",
+        to: "jane@example.com",
+        "message-id": "<123@example.com>",
+      },
+      textPlain: "Original message content",
+      textHtml: "<div>Original message content</div>",
+    };
+
+    const { html } = createReplyContent({
+      textContent,
+      message,
+    });
+
+    // Should convert CRLF to <br> without leftover \r characters
+    expect(html).toContain("Line one<br>Line two<br>Line three");
+    expect(html).not.toContain("\r");
+  });
+
+  it("preserves paragraph spacing with multiple newlines", () => {
+    const textContent =
+      "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+    const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {
+      headers: {
+        date: "Thu, 6 Feb 2025 23:23:47 +0200",
+        from: "John Doe <john@example.com>",
+        subject: "Test Email",
+        to: "jane@example.com",
+        "message-id": "<123@example.com>",
+      },
+      textPlain: "Original message content",
+      textHtml: "<div>Original message content</div>",
+    };
+
+    const { html } = createReplyContent({
+      textContent,
+      message,
+    });
+
+    // Should preserve double newlines as <br><br> for paragraph spacing
+    expect(html).toContain(
+      "First paragraph.<br><br>Second paragraph.<br><br>Third paragraph.",
+    );
+  });
 });

--- a/apps/web/utils/gmail/reply.ts
+++ b/apps/web/utils/gmail/reply.ts
@@ -1,4 +1,5 @@
 import type { ParsedMessage } from "@/utils/types";
+import { convertNewlinesToBr } from "@/utils/string";
 
 export const createReplyContent = ({
   textContent,
@@ -26,12 +27,12 @@ export const createReplyContent = ({
     .join("\n");
   const plainText = `${textContent}\n\n${quotedHeader}\n\n${quotedContent}`;
 
-  // Get the message content, preserving any existing quotes
   const messageContent =
-    message.textHtml || message.textPlain?.replace(/\n/g, "<br>") || "";
+    message.textHtml ||
+    (message.textPlain ? convertNewlinesToBr(message.textPlain) : "");
 
-  // Use htmlContent if provided, otherwise convert textContent to HTML
-  const contentHtml = htmlContent || textContent?.replace(/\n/g, "<br>") || "";
+  const contentHtml =
+    htmlContent || (textContent ? convertNewlinesToBr(textContent) : "");
 
   // Format HTML version with Gmail-style quote formatting
   const html = `<div ${dirAttribute}>${contentHtml}</div>

--- a/apps/web/utils/outlook/reply.ts
+++ b/apps/web/utils/outlook/reply.ts
@@ -1,4 +1,5 @@
 import type { ParsedMessage } from "@/utils/types";
+import { convertNewlinesToBr } from "@/utils/string";
 
 export const createOutlookReplyContent = ({
   textContent,
@@ -26,12 +27,12 @@ export const createOutlookReplyContent = ({
     .join("\n");
   const plainText = `${textContent || ""}\n\n${quotedHeader}\n\n${quotedContent || ""}`;
 
-  // Get the message content, preserving any existing quotes
   const messageContent =
-    message.textHtml || message.textPlain?.replace(/\n/g, "<br>") || "";
+    message.textHtml ||
+    (message.textPlain ? convertNewlinesToBr(message.textPlain) : "");
 
-  // Use htmlContent if provided, otherwise convert textContent to HTML
-  const contentHtml = htmlContent || textContent?.replace(/\n/g, "<br>") || "";
+  const contentHtml =
+    htmlContent || (textContent ? convertNewlinesToBr(textContent) : "");
 
   // Outlook-specific font styling with Aptos as default
   const outlookFontStyle =

--- a/apps/web/utils/string.test.ts
+++ b/apps/web/utils/string.test.ts
@@ -3,6 +3,7 @@ import {
   removeExcessiveWhitespace,
   truncate,
   generalizeSubject,
+  convertNewlinesToBr,
 } from "./string";
 
 // Run with:
@@ -83,6 +84,40 @@ describe("string utils", () => {
       expect(generalizeSubject("Your account has been created")).toBe(
         "Your account has been created",
       );
+    });
+  });
+
+  describe("convertNewlinesToBr", () => {
+    it("should convert LF to <br>", () => {
+      expect(convertNewlinesToBr("line one\nline two")).toBe(
+        "line one<br>line two",
+      );
+    });
+
+    it("should convert CRLF to <br>", () => {
+      expect(convertNewlinesToBr("line one\r\nline two")).toBe(
+        "line one<br>line two",
+      );
+    });
+
+    it("should handle mixed line endings", () => {
+      expect(convertNewlinesToBr("line one\r\nline two\nline three")).toBe(
+        "line one<br>line two<br>line three",
+      );
+    });
+
+    it("should preserve multiple newlines for paragraph spacing", () => {
+      expect(convertNewlinesToBr("para one\n\npara two")).toBe(
+        "para one<br><br>para two",
+      );
+    });
+
+    it("should handle empty string", () => {
+      expect(convertNewlinesToBr("")).toBe("");
+    });
+
+    it("should handle text without newlines", () => {
+      expect(convertNewlinesToBr("no newlines here")).toBe("no newlines here");
     });
   });
 });

--- a/apps/web/utils/string.ts
+++ b/apps/web/utils/string.ts
@@ -57,3 +57,7 @@ export function slugify(text: string): string {
     .replace(/[\s_-]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
+
+export function convertNewlinesToBr(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\n/g, "<br>");
+}


### PR DESCRIPTION
# User description
Fix drafts appearing as single line instead of multiline.

- Normalize CRLF (\r\n) to LF (\n) before converting to `<br>` tags in Gmail and Outlook reply content
- Preserve paragraph spacing in `convertTextToHtmlParagraphs` by using `<br>` for empty lines instead of filtering them out
- Fix HTML-to-text fallback to convert `<br>` and `</p>` to newlines before stripping tags
- Extract `convertNewlinesToBr` utility to `utils/string.ts` for DRY code
- Add comprehensive tests for all changes

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
createOutlookReplyContent_("createOutlookReplyContent"):::modified
convertNewlinesToBr_("convertNewlinesToBr"):::added
createReplyContent_("createReplyContent"):::modified
createOutlookReplyContent_ -- "Preserves line breaks by converting plaintext to <br>." --> convertNewlinesToBr_
createReplyContent_ -- "Converts plaintext replies to HTML using <br> for newlines." --> convertNewlinesToBr_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Fixes email draft formatting by normalizing line endings and preserving paragraph spacing in <code>convertTextToHtmlParagraphs</code> and reply content generation functions for Gmail and Outlook. Improves the HTML-to-text fallback to correctly convert <code><br></code> and <code></p></code> tags to newlines, ensuring accurate representation of email content.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1264?tool=ast>(Baz)</a>.