### PR TITLE
fix(outlook): properly sanitize KQL field queries for Microsoft Graph search

### DIFF
--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeOutlookSearchQuery,
+  sanitizeKqlValue,
+  sanitizeKqlFieldQuery,
+  sanitizeKqlTextQuery,
+} from "@/utils/outlook/message";
+
+describe("sanitizeKqlValue", () => {
+  it("should return empty string for empty input", () => {
+    expect(sanitizeKqlValue("")).toBe("");
+    expect(sanitizeKqlValue("   ")).toBe("");
+  });
+
+  it("should replace ? with space", () => {
+    expect(sanitizeKqlValue("hello?world")).toBe("hello world");
+  });
+
+  it("should escape backslashes", () => {
+    expect(sanitizeKqlValue("path\\to\\file")).toBe("path\\\\to\\\\file");
+  });
+
+  it("should escape double quotes", () => {
+    expect(sanitizeKqlValue('say "hello"')).toBe('say \\"hello\\"');
+  });
+
+  it("should normalize multiple spaces", () => {
+    expect(sanitizeKqlValue("hello   world")).toBe("hello world");
+  });
+
+  it("should handle email addresses", () => {
+    expect(sanitizeKqlValue("user@example.com")).toBe("user@example.com");
+  });
+});
+
+describe("sanitizeKqlFieldQuery", () => {
+  it("should return field:value without outer quotes", () => {
+    expect(sanitizeKqlFieldQuery("participants:user@example.com")).toBe(
+      "participants:user@example.com",
+    );
+  });
+
+  it("should quote value with spaces", () => {
+    expect(sanitizeKqlFieldQuery("subject:meeting notes")).toBe(
+      'subject:"meeting notes"',
+    );
+  });
+
+  it("should replace ? and quote if result has spaces", () => {
+    expect(sanitizeKqlFieldQuery("from:user?name")).toBe('from:"user name"');
+  });
+
+  it("should escape backslashes in value", () => {
+    expect(sanitizeKqlFieldQuery("subject:path\\file")).toBe(
+      "subject:path\\\\file",
+    );
+  });
+
+  it("should escape quotes in value", () => {
+    expect(sanitizeKqlFieldQuery('subject:say "hi"')).toBe(
+      'subject:"say \\"hi\\""',
+    );
+  });
+
+  it("should handle empty value", () => {
+    expect(sanitizeKqlFieldQuery("field:")).toBe("field:");
+  });
+
+  it("should handle query without colon", () => {
+    expect(sanitizeKqlFieldQuery("nofield")).toBe("nofield");
+  });
+});
+
+describe("sanitizeKqlTextQuery", () => {
+  it("should wrap text in quotes", () => {
+    expect(sanitizeKqlTextQuery("hello world")).toBe('"hello world"');
+  });
+
+  it("should remove internal quotes", () => {
+    expect(sanitizeKqlTextQuery('say "hello"')).toBe('"say hello"');
+  });
+
+  it("should replace ? with space", () => {
+    expect(sanitizeKqlTextQuery("hello?world")).toBe('"hello world"');
+  });
+
+  it("should escape backslashes", () => {
+    expect(sanitizeKqlTextQuery("path\\to")).toBe('"path\\\\to"');
+  });
+
+  it("should normalize multiple spaces", () => {
+    expect(sanitizeKqlTextQuery("hello    world")).toBe('"hello world"');
+  });
+});
+
+describe("sanitizeOutlookSearchQuery", () => {
+  describe("empty and whitespace inputs", () => {
+    it("should return empty string for empty input", () => {
+      const result = sanitizeOutlookSearchQuery("");
+      expect(result.sanitized).toBe("");
+      expect(result.wasSanitized).toBe(false);
+    });
+
+    it("should return empty string for whitespace-only input", () => {
+      const result = sanitizeOutlookSearchQuery("   ");
+      expect(result.sanitized).toBe("");
+      expect(result.wasSanitized).toBe(false);
+    });
+  });
+
+  describe("KQL field queries (field:value syntax)", () => {
+    it("should NOT wrap participants:email in outer quotes", () => {
+      const result = sanitizeOutlookSearchQuery(
+        "participants:user@example.com",
+      );
+      expect(result.sanitized).toBe("participants:user@example.com");
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should handle subject field query without outer quotes", () => {
+      const result = sanitizeOutlookSearchQuery("subject:meeting");
+      expect(result.sanitized).toBe("subject:meeting");
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should quote value with spaces in field query", () => {
+      const result = sanitizeOutlookSearchQuery("subject:meeting notes");
+      expect(result.sanitized).toBe('subject:"meeting notes"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should handle ? in field query value by replacing with space", () => {
+      const result = sanitizeOutlookSearchQuery("participants:user?name");
+      expect(result.sanitized).toBe('participants:"user name"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should treat empty value after colon as text query", () => {
+      const result = sanitizeOutlookSearchQuery("field:");
+      expect(result.sanitized).toBe('"field:"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should escape backslashes in field value", () => {
+      const result = sanitizeOutlookSearchQuery("subject:path\\file");
+      expect(result.sanitized).toBe("subject:path\\\\file");
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should escape quotes in field value and wrap if needed", () => {
+      const result = sanitizeOutlookSearchQuery('subject:say "hello"');
+      expect(result.sanitized).toBe('subject:"say \\"hello\\""');
+      expect(result.wasSanitized).toBe(true);
+    });
+  });
+
+  describe("regular text queries (no field:value syntax)", () => {
+    it("should wrap simple query in quotes", () => {
+      const result = sanitizeOutlookSearchQuery("simple query");
+      expect(result.sanitized).toBe('"simple query"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should remove internal double quotes and wrap in outer quotes", () => {
+      const result = sanitizeOutlookSearchQuery(
+        'Reinstatement of "Universal policy" for "5161 Collins Ave"',
+      );
+      expect(result.sanitized).toBe(
+        '"Reinstatement of Universal policy for 5161 Collins Ave"',
+      );
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should replace ? with space in text query", () => {
+      const result = sanitizeOutlookSearchQuery("hello? world");
+      expect(result.sanitized).toBe('"hello world"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should escape backslashes in text query", () => {
+      const result = sanitizeOutlookSearchQuery("test\\path");
+      expect(result.sanitized).toBe('"test\\\\path"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should normalize multiple spaces", () => {
+      const result = sanitizeOutlookSearchQuery("hello    world");
+      expect(result.sanitized).toBe('"hello world"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should handle single word queries", () => {
+      const result = sanitizeOutlookSearchQuery("hello");
+      expect(result.sanitized).toBe('"hello"');
+      expect(result.wasSanitized).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle colon in middle of text (not at start)", () => {
+      const result = sanitizeOutlookSearchQuery("meeting at 10:30am");
+      expect(result.sanitized).toBe('"meeting at 10:30am"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should not treat URL-like strings as KQL fields", () => {
+      const result = sanitizeOutlookSearchQuery("https://example.com");
+      expect(result.sanitized).toBe('"https://example.com"');
+      expect(result.wasSanitized).toBe(true);
+    });
+
+    it("should treat http: as text query, not KQL field", () => {
+      const result = sanitizeOutlookSearchQuery("http://test.com");
+      expect(result.sanitized).toBe('"http://test.com"');
+      expect(result.wasSanitized).toBe(true);
+    });
+  });
+
+  describe("real-world error cases", () => {
+    it("should handle queries with internal quotes that caused unterminated string literal error", () => {
+      const query =
+        'Reinstatement of "Universal policy" for "123 Main St Apt #100"';
+      const result = sanitizeOutlookSearchQuery(query);
+      expect(result.sanitized).not.toContain('\\"');
+      expect(result.sanitized).toBe(
+        '"Reinstatement of Universal policy for 123 Main St Apt #100"',
+      );
+    });
+
+    it("should handle the participants query that caused colon error", () => {
+      const query = "participants:john.doe@company.example.com";
+      const result = sanitizeOutlookSearchQuery(query);
+      expect(result.sanitized).not.toMatch(/^"participants:/);
+      expect(result.sanitized).toBe(
+        "participants:john.doe@company.example.com",
+      );
+    });
+  });
+});

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -118,7 +118,9 @@ function getOutlookLabels(
 const OUTLOOK_SEARCH_DISALLOWED_CHARS = /[?]/g;
 
 // Pattern to detect KQL field syntax: fieldname:value (e.g., participants:email@example.com)
+// Excludes URL schemes (http, https, ftp, mailto, file) which should be treated as text
 const KQL_FIELD_PATTERN = /^(\w+):.+$/;
+const URL_SCHEME_PATTERN = /^(https?|ftp|mailto|file):/i;
 
 /**
  * Sanitizes a value for use in KQL queries.
@@ -136,7 +138,54 @@ export function sanitizeKqlValue(value: string): string {
     .replace(/"/g, '\\"');
 }
 
-function sanitizeOutlookSearchQuery(query: string): {
+/**
+ * Sanitizes a KQL field query (e.g., participants:email@example.com).
+ * Does NOT wrap the entire query in outer quotes - only quotes the value if it contains spaces.
+ */
+export function sanitizeKqlFieldQuery(query: string): string {
+  const colonIndex = query.indexOf(":");
+  if (colonIndex === -1) return query;
+
+  const field = query.substring(0, colonIndex);
+  const value = query.substring(colonIndex + 1);
+
+  if (!value) {
+    return `${field}:`;
+  }
+
+  let sanitizedValue = value
+    .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const hasSpaces = sanitizedValue.includes(" ");
+
+  sanitizedValue = sanitizedValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  if (hasSpaces) {
+    return `${field}:"${sanitizedValue}"`;
+  }
+
+  return `${field}:${sanitizedValue}`;
+}
+
+/**
+ * Sanitizes a regular text query for KQL.
+ * Removes internal double quotes and wraps the entire query in outer quotes.
+ */
+export function sanitizeKqlTextQuery(query: string): string {
+  let sanitized = query
+    .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
+    .replace(/"/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  sanitized = sanitized.replace(/\\/g, "\\\\");
+
+  return `"${sanitized}"`;
+}
+
+export function sanitizeOutlookSearchQuery(query: string): {
   sanitized: string;
   wasSanitized: boolean;
 } {
@@ -146,37 +195,19 @@ function sanitizeOutlookSearchQuery(query: string): {
   }
 
   // Check if this is a KQL field syntax query (e.g., participants:email@example.com)
-  // KQL field queries still need to be wrapped in quotes for MS Graph $search parameter
-  if (KQL_FIELD_PATTERN.test(normalized)) {
-    const sanitized = normalized
-      .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
-      .replace(/\s+/g, " ")
-      .trim()
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"');
-
+  // but exclude URL schemes which should be treated as text
+  if (
+    KQL_FIELD_PATTERN.test(normalized) &&
+    !URL_SCHEME_PATTERN.test(normalized)
+  ) {
     return {
-      sanitized: `"${sanitized}"`,
+      sanitized: sanitizeKqlFieldQuery(normalized),
       wasSanitized: true,
     };
   }
 
-  // Remove disallowed characters (including double quotes which cause "unterminated string literal" errors)
-  let sanitized = normalized
-    .replace(OUTLOOK_SEARCH_DISALLOWED_CHARS, " ")
-    .replace(/"/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-
-  // Escape backslashes for KQL
-  sanitized = sanitized.replace(/\\/g, "\\\\");
-
-  // Wrap in double quotes to treat as literal phrase search
-  // This prevents KQL from interpreting special characters like - . and numbers
-  sanitized = `"${sanitized}"`;
-
   return {
-    sanitized,
+    sanitized: sanitizeKqlTextQuery(normalized),
     wasSanitized: true,
   };
 }


### PR DESCRIPTION
# User description
Fix KQL field query sanitization that was causing Microsoft Graph API errors for Outlook search.

**TLDR:** KQL field queries like `participants:email` were incorrectly wrapped in outer quotes, causing the API to treat them as literal phrase searches instead of field filters.

## Changes

- Extract `sanitizeKqlFieldQuery` helper that preserves `field:value` format without outer quotes
- Extract `sanitizeKqlTextQuery` helper for regular text searches (wrapped in quotes)
- Add URL scheme detection (`http`, `https`, etc.) to treat URLs as text, not KQL fields
- Add comprehensive test suite with 38 tests covering all sanitization scenarios

## Fixed Issues

| Error Type | Query Example | Before (broken) | After (fixed) |
|------------|---------------|-----------------|---------------|
| Colon syntax error | `participants:user@example.com` | `"participants:user@example.com"` | `participants:user@example.com` |
| Unterminated string | Text with internal quotes | Already working | Still working |

## Test Plan

- [x] All 38 new tests pass
- [x] No lint errors
- [ ] Test with real Outlook account to verify API accepts the new format

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
sanitizeOutlookSearchQuery_("sanitizeOutlookSearchQuery"):::modified
sanitizeKqlFieldQuery_("sanitizeKqlFieldQuery"):::added
sanitizeKqlTextQuery_("sanitizeKqlTextQuery"):::added
URL_SCHEME_PATTERN_("URL_SCHEME_PATTERN"):::added
sanitizeOutlookSearchQuery_ -- "Routes field:value queries to field-specific sanitizer, preserving format." --> sanitizeKqlFieldQuery_
sanitizeOutlookSearchQuery_ -- "Quotes and escapes plain text queries for literal KQL search." --> sanitizeKqlTextQuery_
sanitizeOutlookSearchQuery_ -- "Excludes URL schemes so URLs are treated as plain text." --> URL_SCHEME_PATTERN_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Refactors the <code>sanitizeOutlookSearchQuery</code> function within the <code>inbox-zero-ai</code> module to accurately format KQL search queries for the Microsoft Graph API. This prevents errors by distinguishing between field-based queries and general text, ensuring correct quoting and URL scheme handling.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-wrap-KQL-field-que...</td><td>January 13, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-folder-functi...</td><td>August 13, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1271?tool=ast>(Baz)</a>.