### PR TITLE
fix: Follow up reminders in Outlook

### DIFF
--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -446,11 +446,15 @@ export class OutlookProvider implements EmailProvider {
     }
 
     // Get current message categories to avoid replacing them
-    const message = await this.client
-      .getClient()
-      .api(`/me/messages/${messageId}`)
-      .select("categories")
-      .get();
+    const message = await withOutlookRetry(
+      () =>
+        this.client
+          .getClient()
+          .api(`/me/messages/${messageId}`)
+          .select("categories")
+          .get(),
+      this.logger,
+    );
 
     const currentCategories = message.categories || [];
 

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -3,7 +3,12 @@ import type { Message } from "@microsoft/microsoft-graph-types";
 import type { ParsedMessage } from "@/utils/types";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
 import type { Logger } from "@/utils/logger";
-import { convertMessage, createMessagesRequest } from "@/utils/outlook/message";
+import {
+  convertMessage,
+  createMessagesRequest,
+  getCategoryMap,
+  getFolderIds,
+} from "@/utils/outlook/message";
 import { withOutlookRetry } from "@/utils/outlook/retry";
 
 export async function getThread(
@@ -206,9 +211,13 @@ export async function getThreadMessages(
   client: OutlookClient,
   logger: Logger,
 ): Promise<ParsedMessage[]> {
-  const messages: Message[] = await getThread(threadId, client, logger);
+  const [messages, folderIds, categoryMap] = await Promise.all([
+    getThread(threadId, client, logger),
+    getFolderIds(client, logger),
+    getCategoryMap(client, logger),
+  ]);
 
   return messages
     .filter((msg) => !msg.isDraft)
-    .map((msg) => convertMessage(msg));
+    .map((msg) => convertMessage(msg, folderIds, categoryMap));
 }


### PR DESCRIPTION
Fixes follow up reminders for Outlook by properly converting messages with folder IDs and category maps.

- Wrap message category fetch in `withOutlookRetry` for resilience
- Pass `folderIds` and `categoryMap` to `convertMessage` in draft and thread utils
- Use `Promise.all` to fetch message data, folder IDs, and category maps in parallel