### PR TITLE
database: add index for ThreadTracker follow-up queries

### DIFF
--- a/apps/web/prisma/migrations/20260115091612_follow_up_index/migration.sql
+++ b/apps/web/prisma/migrations/20260115091612_follow_up_index/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX "ThreadTracker_emailAccountId_type_resolved_followUpAppliedAt_idx" ON "ThreadTracker"("emailAccountId", "type", "resolved", "followUpAppliedAt", "sentAt");
+CREATE INDEX IF NOT EXISTS "ThreadTracker_emailAccountId_type_resolved_followUpAppliedAt_idx" ON "ThreadTracker"("emailAccountId", "type", "resolved", "followUpAppliedAt", "sentAt");


### PR DESCRIPTION
# User description
Adds a composite index on ThreadTracker to optimize follow-up query performance.

- Creates index on (emailAccountId, type, resolved, followUpAppliedAt, sentAt)
- Improves query performance for follow-up tracking operations

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Optimizes follow-up query performance by adding a composite index to the <code>ThreadTracker</code> table. Enhances the efficiency of tracking operations by indexing key fields used in filtering and sorting follow-up threads.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1285?tool=ast>(Baz)</a>.