### PR TITLE
Fix resolved thread count query pagination bug

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/Resolved.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/Resolved.tsx
@@ -33,12 +33,15 @@ export async function Resolved({
       OFFSET ${skip}
     `,
     prisma.$queryRaw<[{ count: bigint }]>`
-      SELECT COUNT(DISTINCT "threadId") as count
-      FROM "ThreadTracker"
-      WHERE "emailAccountId" = ${emailAccountId}
-      ${dateFilter ? Prisma.sql`AND "sentAt" <= (${dateFilter}->>'lte')::timestamp` : Prisma.empty}
-      GROUP BY "threadId"
-      HAVING bool_and(resolved) = true
+      SELECT COUNT(*) as count
+      FROM (
+        SELECT 1
+        FROM "ThreadTracker"
+        WHERE "emailAccountId" = ${emailAccountId}
+        ${dateFilter ? Prisma.sql`AND "sentAt" <= (${dateFilter}->>'lte')::timestamp` : Prisma.empty}
+        GROUP BY "threadId"
+        HAVING bool_and(resolved) = true
+      ) t
     `,
   ]);
 


### PR DESCRIPTION
# User description
## Summary
Fixed pagination miscounts in the Reply Zero resolved threads view. Users with multiple pages of resolved threads couldn't navigate beyond the first page.

## Problem
The count query used `COUNT(DISTINCT "threadId")` with `GROUP BY "threadId"`, returning one row per group with count=1. The code read only the first row, always reporting total=1 regardless of actual thread count.

## Solution
Wrapped the grouped result in a subquery to count the actual number of resolved threads correctly using `COUNT(*)`.

## Impact
Pagination controls now correctly report the total number of pages, allowing users to access all resolved threads.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes a pagination bug in the resolved threads view by correcting the SQL query used to calculate the total count of processed email threads. Ensures that the <code>Resolved</code> component accurately reports the total number of pages, enabling users to navigate through their entire history of addressed emails.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>wip-prisma-upgrade</td><td>November 21, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1288?tool=ast>(Baz)</a>.