### PR TITLE
chore(ci): align CLI releases with app releases

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -66,6 +66,10 @@ jobs:
       - name: Get version
         id: version
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "This workflow must be run from a tag ref (got: ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}')" >&2
+            exit 1
+          fi
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
@@ -99,8 +103,8 @@ jobs:
           # Update version
           content = re.sub(r'version "[^"]*"', 'version "${{ steps.version.outputs.version }}"', content)
           
-          # Update URLs from cli-v* to v* format
-          content = re.sub(r'releases/download/cli-v[^/]+/', 'releases/download/${{ steps.version.outputs.tag }}/', content)
+          # Update URLs to current version (handles both cli-v* and v* formats)
+          content = re.sub(r'releases/download/(?:cli-)?v[^/]+/', 'releases/download/${{ steps.version.outputs.tag }}/', content)
           
           # Update SHA256 for darwin-arm64 (first sha256 after "on_arm do")
           content = re.sub(


### PR DESCRIPTION
# User description
CLI binaries now build automatically on app release tags (v*) instead of separate cli-v* releases.

- Triggers on v* tags instead of manual workflow_dispatch only
- Gets version from git tag instead of deleted version.txt
- Attaches binaries to existing app release (no separate CLI release)
- Updates Homebrew formula URLs to use v* format

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Aligns CLI binary releases with application releases by triggering the build process on <code>v*</code> tags and attaching artifacts to the existing release. Updates the CI workflow to extract versioning from git tags and modifies the Homebrew formula update script to support the new URL format.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1290?tool=ast&topic=CI+Release+Flow>CI Release Flow</a>
        </td><td>Automate CLI releases by triggering on <code>v*</code> tags and uploading binaries directly to the corresponding application release instead of creating separate CLI-specific releases.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/cli-release.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fixes</td><td>November 30, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1290?tool=ast&topic=Homebrew+Updates>Homebrew Updates</a>
        </td><td>Update the Homebrew formula script to dynamically handle the new release tag format and ensure the <code>inbox-zero.rb</code> file points to the correct download URLs.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/cli-release.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fixes</td><td>November 30, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1290?tool=ast>(Baz)</a>.