### PR TITLE
fix: use dynamic baseUrl for List-Unsubscribe header

### DIFF
--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -35,6 +35,7 @@ const sendEmail = async ({
   test,
   tags,
   unsubscribeToken,
+  baseUrl,
 }: {
   from: string;
   to: string;
@@ -44,6 +45,7 @@ const sendEmail = async ({
   entityRefId?: string;
   tags?: { name: string; value: string }[];
   unsubscribeToken: string;
+  baseUrl: string;
 }) => {
   if (!resend) {
     console.log(RESEND_NOT_CONFIGURED_MESSAGE);
@@ -59,7 +61,7 @@ const sendEmail = async ({
     react,
     text,
     headers: {
-      "List-Unsubscribe": `<https://www.getinboxzero.com/api/unsubscribe?token=${unsubscribeToken}>`,
+      "List-Unsubscribe": `<${baseUrl}/api/unsubscribe?token=${unsubscribeToken}>`,
       // From Feb 2024 Google requires this for bulk senders
       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
       // Prevent threading on Gmail
@@ -119,6 +121,7 @@ export const sendSummaryEmail = async ({
     react: <SummaryEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",
@@ -146,6 +149,7 @@ export const sendDigestEmail = async ({
     react: <DigestEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",
@@ -173,6 +177,7 @@ export const sendInvitationEmail = async ({
     react: <InvitationEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",
@@ -200,6 +205,7 @@ export const sendReconnectionEmail = async ({
     react: <ReconnectionEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",
@@ -227,6 +233,7 @@ export const sendActionRequiredEmail = async ({
     react: <ActionRequiredEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",
@@ -254,6 +261,7 @@ export const sendMeetingBriefingEmail = async ({
     react: <MeetingBriefingEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
     tags: [
       {
         name: "category",


### PR DESCRIPTION
# User description
## Summary

Fix hardcoded `getinboxzero.com` domain in `List-Unsubscribe` email header by using the deployment's actual base URL. This ensures one-click unsubscribe works correctly for self-hosted and custom-domain deployments.

## Changes

- Add `baseUrl` parameter to internal `sendEmail` function
- Update all 6 email functions to pass `baseUrl` from email props
- Replace hardcoded domain with dynamic `baseUrl` in List-Unsubscribe header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
sendSummaryEmail_("sendSummaryEmail"):::modified
sendEmail_("sendEmail"):::modified
sendDigestEmail_("sendDigestEmail"):::modified
sendInvitationEmail_("sendInvitationEmail"):::modified
sendReconnectionEmail_("sendReconnectionEmail"):::modified
sendActionRequiredEmail_("sendActionRequiredEmail"):::modified
RESEND_SERVICE_("RESEND_SERVICE"):::modified
UNSUBSCRIBE_API_("UNSUBSCRIBE_API"):::modified
sendSummaryEmail_ -- "Now passes baseUrl from emailProps to sendEmail." --> sendEmail_
sendDigestEmail_ -- "Now passes baseUrl from emailProps to sendEmail." --> sendEmail_
sendInvitationEmail_ -- "Now passes baseUrl from emailProps to sendEmail." --> sendEmail_
sendReconnectionEmail_ -- "Now passes baseUrl from emailProps to sendEmail." --> sendEmail_
sendActionRequiredEmail_ -- "Now passes baseUrl from emailProps to sendEmail." --> sendEmail_
sendEmail_ -- "Adds List-Unsubscribe header using baseUrl and token." --> RESEND_SERVICE_
sendEmail_ -- "Builds List-Unsubscribe header using baseUrl and token." --> UNSUBSCRIBE_API_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the email communication layer to use a dynamic <code>baseUrl</code> for the <code>List-Unsubscribe</code> header, replacing the hardcoded domain. This ensures that one-click unsubscribe functionality works correctly for self-hosted and custom-domain deployments across all transactional email types.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-add-unified-error-...</td><td>January 04, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>PR-feedback</td><td>September 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1291?tool=ast>(Baz)</a>.