### PR TITLE
fix: require webhook verification tokens to be configured

### DIFF
--- a/apps/web/app/api/google/webhook/route.ts
+++ b/apps/web/app/api/google/webhook/route.ts
@@ -15,15 +15,20 @@ export const POST = withError("google/webhook", async (request) => {
 
   let logger = request.logger;
 
-  if (
-    env.GOOGLE_PUBSUB_VERIFICATION_TOKEN &&
-    token !== env.GOOGLE_PUBSUB_VERIFICATION_TOKEN
-  ) {
-    logger.error("Invalid verification token", { token });
+  const verificationToken = env.GOOGLE_PUBSUB_VERIFICATION_TOKEN;
+
+  if (!verificationToken) {
+    logger.error("GOOGLE_PUBSUB_VERIFICATION_TOKEN not configured");
     return NextResponse.json(
-      {
-        message: "Invalid verification token",
-      },
+      { message: "Webhook not configured" },
+      { status: 500 },
+    );
+  }
+
+  if (token !== verificationToken) {
+    logger.error("Invalid verification token");
+    return NextResponse.json(
+      { message: "Invalid verification token" },
       { status: 403 },
     );
   }

--- a/apps/web/app/api/outlook/webhook/route.ts
+++ b/apps/web/app/api/outlook/webhook/route.ts
@@ -44,11 +44,19 @@ export const POST = withError("outlook/webhook", async (request) => {
   const body = parseResult.data;
 
   // Validate clientState for security (verify webhook is from Microsoft)
+  const expectedClientState = env.MICROSOFT_WEBHOOK_CLIENT_STATE;
+
+  if (!expectedClientState) {
+    logger.error("MICROSOFT_WEBHOOK_CLIENT_STATE not configured");
+    return NextResponse.json(
+      { error: "Webhook not configured" },
+      { status: 500 },
+    );
+  }
+
   for (const notification of body.value) {
-    if (notification.clientState !== env.MICROSOFT_WEBHOOK_CLIENT_STATE) {
+    if (notification.clientState !== expectedClientState) {
       logger.warn("Invalid or missing clientState", {
-        receivedClientState: notification.clientState,
-        hasExpectedClientState: !!env.MICROSOFT_WEBHOOK_CLIENT_STATE,
         subscriptionId: notification.subscriptionId,
       });
       return NextResponse.json(


### PR DESCRIPTION
# User description
## Summary
- Enforce that GOOGLE_PUBSUB_VERIFICATION_TOKEN must be set to authenticate Google Pub/Sub webhooks
- Enforce that MICROSOFT_WEBHOOK_CLIENT_STATE must be set to authenticate Outlook webhooks
- Previously, if these env vars were unset, webhook authentication was entirely bypassed

## Test Plan
- Existing e2e tests pass with tokens configured
- Webhook endpoints now reject requests with 500 if tokens are not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforces mandatory webhook authentication by requiring configuration of verification tokens for both Google and Outlook integrations. Ensures that the system rejects incoming notifications with a 500 error if security tokens are missing, preventing accidental bypass of authentication logic.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>improve-tests</td><td>December 20, 2025</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-webhook</td><td>June 19, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1293?tool=ast>(Baz)</a>.