### PR TITLE
chore: sync Cursor rules to Codex prompts

### DIFF
--- a/scripts/sync-cursor-to-codex.sh
+++ b/scripts/sync-cursor-to-codex.sh
@@ -9,7 +9,6 @@ CODEX_PROMPTS="$HOME/.codex/prompts"
 
 # Create directories
 mkdir -p "$CODEX_PROMPTS/features"
-mkdir -p "$CODEX_PROMPTS/wireframes/assistant"
 
 count=0
 
@@ -28,15 +27,6 @@ for file in "$CURSOR_RULES"/features/*.mdc; do
   ln -sf "$file" "$CODEX_PROMPTS/features/${basename}.md"
   ((count++))
 done
-
-# Symlink wireframes/**/*.md files
-while IFS= read -r file; do
-  relpath=${file#$CURSOR_RULES/}
-  target_dir=$(dirname "$CODEX_PROMPTS/$relpath")
-  mkdir -p "$target_dir"
-  ln -sf "$file" "$CODEX_PROMPTS/$relpath"
-  ((count++))
-done < <(find "$CURSOR_RULES/wireframes" -name "*.md" -type f 2>/dev/null)
 
 echo "Synced $count Cursor rules to ~/.codex/prompts/"
 echo "Restart Codex to pick up changes."


### PR DESCRIPTION
# User description
Create symlinks from Cursor rules (.cursor/rules/) to Codex prompts (~/.codex/prompts/). This makes all project guidelines available as Codex slash commands. The sync script allows easy re-syncing when new Cursor rules are added to the project.

**Setup:** Run `./scripts/sync-cursor-to-codex.sh` to create symlinks.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces a synchronization script that creates symlinks from Cursor rules to Codex prompts, enabling project guidelines to be used as slash commands. Automates the mapping of <code>.mdc</code> files to <code>.md</code> format within the user's local Codex configuration directory.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1297?tool=ast>(Baz)</a>.