### PR TITLE
OAuth proxy for previews

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -25,6 +25,9 @@ MICROSOFT_WEBHOOK_CLIENT_STATE= # openssl rand -hex 32
 MICROSOFT_TENANT_ID= # leave empty for "common"
 
 AUTH_SECRET= # openssl rand -hex 32
+# OAuth Proxy - for preview deployments that can't have their own OAuth redirect URIs
+# Set this to a stable deployment URL (e.g., staging) that has registered OAuth callbacks
+# OAUTH_PROXY_URL=https://staging.example.com
 EMAIL_ENCRYPT_SECRET= # openssl rand -hex 32
 EMAIL_ENCRYPT_SALT= # openssl rand -hex 16
 INTERNAL_API_KEY= # openssl rand -hex 32

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
 
     AUTH_SECRET: z.string().optional(),
     NEXTAUTH_SECRET: z.string().optional(),
+    OAUTH_PROXY_URL: z.string().url().optional(),
     GOOGLE_CLIENT_ID: z.string().min(1),
     GOOGLE_CLIENT_SECRET: z.string().min(1),
     MICROSOFT_CLIENT_ID: z.string().optional(),

--- a/apps/web/utils/auth-client.ts
+++ b/apps/web/utils/auth-client.ts
@@ -1,10 +1,10 @@
 import { createAuthClient } from "better-auth/react";
 import { env } from "@/env";
 import { ssoClient } from "@better-auth/sso/client";
-import { organizationClient } from "better-auth/client/plugins";
+import { oAuthProxyClient, organizationClient } from "better-auth/client/plugins";
 
 export const { signIn, signOut, signUp, useSession, getSession, sso } =
   createAuthClient({
     baseURL: env.NEXT_PUBLIC_BASE_URL,
-    plugins: [ssoClient(), organizationClient()],
+    plugins: [ssoClient(), organizationClient(), oAuthProxyClient()],
   });

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -7,6 +7,7 @@ import type { Account, AuthContext } from "better-auth";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
+import { oAuthProxy } from "better-auth/plugins";
 import { cookies, headers } from "next/headers";
 import { env } from "@/env";
 import { trackDubSignUp } from "@/utils/dub";
@@ -64,6 +65,7 @@ export const betterAuthConfig = betterAuth({
       disableImplicitSignUp: false,
       organizationProvisioning: { disabled: true },
     }),
+    ...(env.OAUTH_PROXY_URL ? [oAuthProxy()] : []),
   ],
   session: {
     modelName: "Session",
@@ -105,6 +107,9 @@ export const betterAuthConfig = betterAuth({
       accessType: "offline",
       prompt: "select_account consent",
       disableIdTokenSignIn: true,
+      ...(env.OAUTH_PROXY_URL && {
+        redirectURI: `${env.OAUTH_PROXY_URL}/api/auth/callback/google`,
+      }),
     },
     microsoft: {
       clientId: env.MICROSOFT_CLIENT_ID || "",
@@ -112,6 +117,9 @@ export const betterAuthConfig = betterAuth({
       scope: [...OUTLOOK_SCOPES],
       tenantId: env.MICROSOFT_TENANT_ID,
       disableIdTokenSignIn: true,
+      ...(env.OAUTH_PROXY_URL && {
+        redirectURI: `${env.OAUTH_PROXY_URL}/api/auth/callback/microsoft`,
+      }),
     },
   },
   databaseHooks: {

--- a/docs/hosting/environment-variables.md
+++ b/docs/hosting/environment-variables.md
@@ -17,6 +17,7 @@ cp apps/web/.env.example apps/web/.env
 | `NEXT_PUBLIC_BASE_URL` | Yes | Public URL where app is hosted (e.g., `https://yourdomain.com`) | — |
 | `INTERNAL_API_KEY` | Yes | Secret key for internal API calls. Generate with `openssl rand -hex 32` | — |
 | `AUTH_SECRET` | Yes | better-auth secret. Generate with `openssl rand -hex 32` | — |
+| `OAUTH_PROXY_URL` | No | OAuth proxy URL for preview deployments. Set to staging URL (e.g., `https://staging.getinboxzero.com`) to enable OAuth for preview environments | — |
 | `NODE_ENV` | No | Environment mode | `development` |
 | **Encryption** ||||
 | `EMAIL_ENCRYPT_SECRET` | Yes | Secret for encrypting OAuth tokens. Generate with `openssl rand -hex 32` | — |


### PR DESCRIPTION
# User description
Implement Better Auth's OAuth Proxy to enable Google and Microsoft OAuth flows for Vercel preview deployments.

Google OAuth does not support wildcard redirect URIs, which prevents Vercel preview deployments from completing OAuth flows. This PR configures the Better Auth OAuth Proxy plugin to route preview OAuth callbacks through a stable staging environment, allowing users to sign in via Google/Microsoft on preview deployments.

---
Linear Issue: [INB-9](https://linear.app/inbox-zero-ai/issue/INB-9/oauth-proxy-for-preview-deployments)

<a href="https://cursor.com/background-agent?bcId=bc-4e4aae54-ee52-4ff3-a67c-ed0865dc1d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e4aae54-ee52-4ff3-a67c-ed0865dc1d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Integrates the Better Auth OAuth Proxy plugin to enable social authentication flows for Vercel preview deployments by routing callbacks through a stable staging environment. Configures the <code>oAuthProxy</code> and <code>oAuthProxyClient</code> components while updating the Google and Microsoft social providers to utilize a proxy redirect URI when <code>OAUTH_PROXY_URL</code> is defined.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1302?tool=ast&topic=Environment+Config>Environment Config</a>
        </td><td>Defines and documents the <code>OAUTH_PROXY_URL</code> environment variable used to specify the stable deployment URL for OAuth callbacks.<details><summary>Modified files (3)</summary><ul><li>apps/web/.env.example</li>
<li>apps/web/env.ts</li>
<li>docs/hosting/environment-variables.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>refactor-remove-NEXT_P...</td><td>January 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1302?tool=ast&topic=OAuth+Proxy+Setup>OAuth Proxy Setup</a>
        </td><td>Configures the <code>betterAuth</code> server and client instances with the <code>oAuthProxy</code> plugin and updates social provider redirect logic.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/auth-client.ts</li>
<li>apps/web/utils/auth.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>security-encode-UTM-co...</td><td>January 06, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-org-and-membe...</td><td>September 18, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1302?tool=ast>(Baz)</a>.