### PR TITLE
fix(e2e): fix DraftSendLog creation and cross-provider threading

### DIFF
--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -57,40 +57,59 @@ export async function trackSentDraftStatus({
 
   const draftExists = await provider.getDraft(executedAction.draftId);
 
-  if (draftExists) {
-    logger.info("Original AI draft still exists, sent message was different.", {
-      executedActionId: executedAction.id,
-      draftId: executedAction.draftId,
-    });
-    // Mark the action to indicate its draft was not sent
-    await withPrismaRetry(
-      () =>
-        prisma.executedAction.update({
-          where: { id: executedAction.id },
-          data: { wasDraftSent: false },
-        }),
-      { logger },
-    );
-    return;
-  }
-
-  logger.info(
-    "Original AI draft not found (likely sent or deleted), proceeding to log similarity.",
-    {
-      executedActionId: executedAction.id,
-      draftId: executedAction.draftId,
-    },
-  );
-
   const executedActionId = executedAction.id;
 
+  // Calculate similarity between sent message and AI draft content
   // Pass full message to properly handle Outlook HTML content
   const similarityScore = calculateSimilarity(executedAction.content, message);
 
   logger.info("Calculated similarity score", {
     executedActionId,
     similarityScore,
+    draftExists: !!draftExists,
   });
+
+  if (draftExists) {
+    logger.info("Original AI draft still exists, sent message was different.", {
+      executedActionId: executedAction.id,
+      draftId: executedAction.draftId,
+      similarityScore,
+    });
+
+    // Create DraftSendLog to record the comparison, but mark wasDraftSent as false
+    await withPrismaRetry(
+      () =>
+        prisma.$transaction([
+          prisma.draftSendLog.create({
+            data: {
+              executedActionId: executedActionId,
+              sentMessageId: sentMessageId,
+              similarityScore: similarityScore,
+            },
+          }),
+          prisma.executedAction.update({
+            where: { id: executedActionId },
+            data: { wasDraftSent: false },
+          }),
+        ]),
+      { logger },
+    );
+
+    logger.info(
+      "Created draft send log and marked action as not sent (draft still exists)",
+      { executedActionId },
+    );
+    return;
+  }
+
+  logger.info(
+    "Original AI draft not found (likely sent or deleted), creating send log.",
+    {
+      executedActionId,
+      draftId: executedAction.draftId,
+      similarityScore,
+    },
+  );
 
   await withPrismaRetry(
     () =>
@@ -136,7 +155,9 @@ export async function cleanupThreadAIDrafts({
   logger.info("Starting cleanup of old AI drafts for thread");
 
   try {
-    // Find all draft actions for this thread that haven't resulted in a sent log
+    // Find all draft actions for this thread that:
+    // 1. Haven't been logged yet (draftSendLog is null), OR
+    // 2. Were logged but the user sent a different reply (wasDraftSent is false)
     const potentialDraftsToClean = await prisma.executedAction.findMany({
       where: {
         executedRule: {
@@ -145,7 +166,10 @@ export async function cleanupThreadAIDrafts({
         },
         type: ActionType.DRAFT_EMAIL,
         draftId: { not: null },
-        draftSendLog: null, // Only consider drafts not logged as sent
+        OR: [
+          { draftSendLog: null },
+          { wasDraftSent: false },
+        ],
       },
       select: {
         id: true,


### PR DESCRIPTION
# User description
## Summary
Fixes three E2E test failures related to draft tracking and cross-provider email threading:

1. **DraftSendLog not created when user sends different reply**
   - `trackSentDraftStatus()` now always creates a DraftSendLog when there's an AI draft
   - Previously only logged when draft was gone (presumed sent)

2. **Draft cleanup missing logged drafts**
   - `cleanupThreadAIDrafts()` now includes drafts where `wasDraftSent: false`
   - Previously only found drafts with `draftSendLog: null`

3. **Cross-provider threading broken (Outlook→Gmail)**
   - `sendReplyUsingCreateReply()` now sets `In-Reply-To` and `References` headers
   - Microsoft Graph's `createReply` doesn't set these correctly for non-Microsoft recipients

## Test plan
- [ ] Merge to main
- [ ] Sync e2e repo: `gh workflow run sync-upstream.yml --repo inbox-zero/inbox-zero-e2e`
- [ ] Run E2E tests: `gh workflow run e2e-flows.yml --repo inbox-zero/inbox-zero-e2e --ref main`
- [ ] Verify draft-cleanup tests pass (lines 137, 243, 346)
- [ ] Verify full-reply-cycle test passes (line 209 thread ID check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
trackSentDraftStatus_("trackSentDraftStatus"):::modified
PRISMA_("PRISMA"):::modified
cleanupThreadAIDrafts_("cleanupThreadAIDrafts"):::modified
sendReplyUsingCreateReply_("sendReplyUsingCreateReply"):::modified
OUTLOOK_API_("OUTLOOK_API"):::modified
trackSentDraftStatus_ -- "Creates DraftSendLog and sets wasDraftSent=false when draft exists" --> PRISMA_
cleanupThreadAIDrafts_ -- "Includes wasDraftSent=false drafts when selecting drafts to clean" --> PRISMA_
sendReplyUsingCreateReply_ -- "Adds In-Reply-To/References headers for cross-provider threading" --> OUTLOOK_API_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the reliability of the inbox-zero-ai automation by fixing cross-provider email threading and improving the accuracy of AI draft tracking. Updates the Outlook integration to support standard threading headers and refines the database logic for logging and cleaning up AI-generated drafts.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1303?tool=ast&topic=Email+Threading>Email Threading</a>
        </td><td>Implements standard <code>In-Reply-To</code> and <code>References</code> headers in <code>sendReplyUsingCreateReply</code> to ensure proper email threading when replying from Outlook to other providers like Gmail.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/mail.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-security-prevent-p...</td><td>January 14, 2026</td></tr>
<tr><td>cursoragent@cursor.com</td><td>Refactor-Extract-reply...</td><td>September 14, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1303?tool=ast&topic=Draft+Tracking>Draft Tracking</a>
        </td><td>Updates <code>trackSentDraftStatus</code> to always create a <code>DraftSendLog</code> and modifies <code>cleanupThreadAIDrafts</code> to include drafts where <code>wasDraftSent</code> is false, ensuring better audit trails and more thorough cleanup of unused AI drafts.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/reply-tracker/draft-tracking.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-E2E-test-subject-m...</td><td>January 12, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-webhook-email-proc...</td><td>July 04, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1303?tool=ast>(Baz)</a>.