### PR TITLE
Add OAuth proxy support for Outlook

### DIFF
--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -123,6 +123,10 @@ export const betterAuthConfig = betterAuth({
       scope: [...OUTLOOK_SCOPES],
       tenantId: env.MICROSOFT_TENANT_ID,
       disableIdTokenSignIn: true,
+      // For preview deployments, redirect through staging (which proxies back to preview URL)
+      ...(env.OAUTH_PROXY_URL && {
+        redirectURI: `${env.OAUTH_PROXY_URL}/api/auth/callback/microsoft`,
+      }),
     },
   },
   databaseHooks: {


### PR DESCRIPTION
# User description
Enable Outlook OAuth callbacks to route through the staging proxy when OAUTH_PROXY_URL is set, matching the pattern already in place for Google. This allows preview deployments to properly handle OAuth redirects since Google doesn't allow wildcard redirect URIs.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Configures the Microsoft authentication provider to support an OAuth proxy URL, enabling proper redirect handling for preview deployments within the Inbox Zero AI authentication infrastructure. Updates the <code>socialProviders</code> configuration to dynamically set the <code>redirectURI</code> when the <code>OAUTH_PROXY_URL</code> environment variable is present.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-OAuth-proxy-suppor...</td><td>January 17, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-org-and-membe...</td><td>September 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1306?tool=ast>(Baz)</a>.