### PR TITLE
docs: Add local E2E setup and debugging guides

### DIFF
--- a/.cursor/rules/e2e-testing.mdc
+++ b/.cursor/rules/e2e-testing.mdc
@@ -101,3 +101,11 @@ gh run view <run-id> --repo inbox-zero/inbox-zero-e2e --log
 # Download artifacts (includes server.log on failure)
 gh run download <run-id> --repo inbox-zero/inbox-zero-e2e
 ```
+
+## Local Development
+
+Run E2E tests locally with `./scripts/run-e2e-local.sh`. Config lives at `~/.config/inbox-zero/.env.e2e`.
+
+See `apps/web/__tests__/e2e/flows/README.md` for full setup instructions.
+
+**Debug logs:** `/tmp/ngrok-e2e.log` (tunnel) and `/tmp/nextjs-e2e.log` (app)


### PR DESCRIPTION
# User description
Add comprehensive documentation for running E2E tests locally with ngrok tunnel support.

- Updates `.cursor/rules/e2e-testing.mdc` with quick reference for local development
- Expands `apps/web/__tests__/e2e/flows/README.md` with detailed setup, config, and troubleshooting
- Documents the `./scripts/run-e2e-local.sh` convenience script and `~/.config/inbox-zero/.env.e2e` config location
- Adds ngrok and webhook troubleshooting steps

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the E2E testing documentation by providing detailed guides for local development and debugging using ngrok tunnels. Updates the project's testing rules and README to include setup instructions for the <code>./scripts/run-e2e-local.sh</code> script and environment configuration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rule</td><td>January 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1308?tool=ast>(Baz)</a>.