### PR TITLE
cli: Add calendar and drive OAuth redirect URIs to Google setup

### DIFF
--- a/packages/cli/src/setup-google.ts
+++ b/packages/cli/src/setup-google.ts
@@ -171,9 +171,13 @@ The console will open in your browser.`,
     const credentialsUrl = `https://console.cloud.google.com/apis/credentials/oauthclient?project=${projectId}`;
     const redirectUris = domain
       ? `   - https://${domain}/api/auth/callback/google
-   - https://${domain}/api/google/linking/callback`
+   - https://${domain}/api/google/linking/callback
+   - https://${domain}/api/google/calendar/callback
+   - https://${domain}/api/google/drive/callback`
       : `   - http://localhost:3000/api/auth/callback/google
-   - http://localhost:3000/api/google/linking/callback`;
+   - http://localhost:3000/api/google/linking/callback
+   - http://localhost:3000/api/google/calendar/callback
+   - http://localhost:3000/api/google/drive/callback`;
 
     p.note(
       `Now create OAuth 2.0 credentials:


### PR DESCRIPTION
# User description
Adds missing OAuth redirect URIs for Google Calendar and Drive callbacks to the Google Cloud setup script.

- Added calendar callback redirect URI
- Added drive callback redirect URI
- Updated both production and localhost redirect URI lists

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Google Cloud setup script to include additional OAuth redirect URIs for Calendar and Drive integrations. Ensures that the <code>runGoogleSetup</code> function provides users with the complete list of callback URLs for both production and local environments.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-programmatic-Googl...</td><td>January 16, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1309?tool=ast>(Baz)</a>.