### PR TITLE
Fix organization member removal unauthorized error

### DIFF
--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -90,12 +90,12 @@ export function Members({ organizationId }: { organizationId: string }) {
   const handleRemoveMember = useCallback(
     (memberId: string) =>
       handleAction(
-        () => removeMemberAction(emailAccountId, { memberId }),
+        () => removeMemberAction({ memberId }),
         "Error removing member",
         "Member removed successfully",
         "Failed to remove member",
       ),
-    [handleAction, emailAccountId],
+    [handleAction],
   );
 
   const handleCancelInvitation = useCallback(


### PR DESCRIPTION
# User description
## Summary
Fixed an issue where removing organization members resulted in an "Unauthorized" error. The removeMemberAction was using actionClient which requires a bound emailAccountId argument, but the organization page route doesn't include emailAccountId in the URL.

## Solution
Changed removeMemberAction to use actionClientUser instead, getting the user context from the session. This matches how cancelInvitationAction is implemented. Updated Members.tsx to remove the emailAccountId argument from the action call.

## Test Plan
1. Navigate to /organization/{organizationId} as an admin/owner
2. Click the dropdown menu on a member (not yourself)
3. Select "Remove"
4. Expected: Member is removed and success toast appears; member list refreshes

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes an unauthorized error in the organization member removal flow by transitioning <code>removeMemberAction</code> to use user session context instead of a specific email account ID. Updates the <code>Members</code> component to invoke the action without the redundant account parameter, ensuring consistency with the organization management routing.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fixes</td><td>December 09, 2025</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Partial-support-to-ema...</td><td>September 16, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1316?tool=ast>(Baz)</a>.