### PR TITLE
Fix unsubscribe detection for non-English emails

### DIFF
--- a/apps/web/utils/parse/parseHtml.client.ts
+++ b/apps/web/utils/parse/parseHtml.client.ts
@@ -1,5 +1,8 @@
 import { containsCtaKeyword } from "@/utils/parse/cta";
-import { containsUnsubscribeKeyword } from "@/utils/parse/unsubscribe";
+import {
+  containsUnsubscribeKeyword,
+  containsUnsubscribeUrlPattern,
+} from "@/utils/parse/unsubscribe";
 
 // very similar to apps/web/utils/parse/parseHtml.server.ts
 export function findUnsubscribeLink(html?: string | null): string | undefined {
@@ -15,7 +18,13 @@ export function findUnsubscribeLink(html?: string | null): string | undefined {
     const text = element.textContent?.toLowerCase() ?? "";
     if (containsUnsubscribeKeyword(text)) {
       unsubscribeLink = element.getAttribute("href") ?? undefined;
-      return;
+      break;
+    }
+
+    const href = element.getAttribute("href") ?? "";
+    if (containsUnsubscribeUrlPattern(href)) {
+      unsubscribeLink = href;
+      break;
     }
   }
 

--- a/apps/web/utils/parse/parseHtml.server.ts
+++ b/apps/web/utils/parse/parseHtml.server.ts
@@ -1,5 +1,8 @@
 import * as cheerio from "cheerio";
-import { containsUnsubscribeKeyword } from "@/utils/parse/unsubscribe";
+import {
+  containsUnsubscribeKeyword,
+  containsUnsubscribeUrlPattern,
+} from "@/utils/parse/unsubscribe";
 
 export function findUnsubscribeLink(html?: string | null) {
   if (!html) return;
@@ -17,9 +20,9 @@ export function findUnsubscribeLink(html?: string | null) {
       return false; // break the loop
     }
 
-    const href = $(element).attr("href")?.toLowerCase() || "";
-    if (href.includes("unsubscribe")) {
-      unsubscribeLink = $(element).attr("href");
+    const href = $(element).attr("href") || "";
+    if (containsUnsubscribeUrlPattern(href)) {
+      unsubscribeLink = href;
       // console.debug(
       //   `Found link with href '${href}' and a link: ${unsubscribeLink}`,
       // );

--- a/apps/web/utils/parse/unsubscribe.test.ts
+++ b/apps/web/utils/parse/unsubscribe.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { containsUnsubscribeKeyword } from "./unsubscribe";
+import {
+  containsUnsubscribeKeyword,
+  containsUnsubscribeUrlPattern,
+} from "./unsubscribe";
 
 describe("containsUnsubscribeKeyword", () => {
   describe("detects unsubscribe keywords", () => {
@@ -86,6 +89,104 @@ describe("containsUnsubscribeKeyword", () => {
 
     it("returns false for keywords with typos", () => {
       expect(containsUnsubscribeKeyword("unsubscibe")).toBe(false);
+    });
+  });
+});
+
+describe("containsUnsubscribeUrlPattern", () => {
+  describe("detects unsubscribe URL patterns", () => {
+    it("detects 'unsubscribe' in URL", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://example.com/unsubscribe?email=test",
+        ),
+      ).toBe(true);
+    });
+
+    it("detects 'unsub' in URL (short form)", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://click.example.com/campaign/unsub-email/123",
+        ),
+      ).toBe(true);
+    });
+
+    it("detects 'opt-out' in URL", () => {
+      expect(
+        containsUnsubscribeUrlPattern("https://example.com/opt-out/user123"),
+      ).toBe(true);
+    });
+
+    it("detects 'optout' in URL (no hyphen)", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://example.com/email/optout?id=abc",
+        ),
+      ).toBe(true);
+    });
+
+    it("detects 'list-manage' in URL (Mailchimp style)", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://list-manage.com/track/click?u=abc&id=123",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("URL pattern matching behavior", () => {
+    it("is case insensitive - matches UNSUB", () => {
+      expect(
+        containsUnsubscribeUrlPattern("https://example.com/UNSUB/email"),
+      ).toBe(true);
+    });
+
+    it("matches pattern in query string", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://example.com/email?action=unsubscribe",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches pattern in path", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://example.com/unsubscribe/confirm",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches Portuguese email example (unsub-email)", () => {
+      expect(
+        containsUnsubscribeUrlPattern(
+          "https://click.lindtbrasil.com/campaign/unsub-email/MTM",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("returns false for non-matching URLs", () => {
+    it("returns false for empty string", () => {
+      expect(containsUnsubscribeUrlPattern("")).toBe(false);
+    });
+
+    it("returns false for regular URLs", () => {
+      expect(containsUnsubscribeUrlPattern("https://example.com/about")).toBe(
+        false,
+      );
+    });
+
+    it("returns false for subscribe URLs (not unsubscribe)", () => {
+      expect(
+        containsUnsubscribeUrlPattern("https://example.com/subscribe"),
+      ).toBe(false);
+    });
+
+    it("returns false for URLs with 'sub' but not 'unsub'", () => {
+      expect(
+        containsUnsubscribeUrlPattern("https://example.com/submit-form"),
+      ).toBe(false);
     });
   });
 });

--- a/apps/web/utils/parse/unsubscribe.ts
+++ b/apps/web/utils/parse/unsubscribe.ts
@@ -10,3 +10,14 @@ export function containsUnsubscribeKeyword(text: string) {
   const lowerText = text.toLowerCase();
   return unsubscribeKeywords.some((keyword) => lowerText.includes(keyword));
 }
+
+// Patterns to detect unsubscribe URLs - checking for "unsub" catches:
+// - "unsubscribe", "unsub", "unsub-email", "unsubscribed", etc.
+// This helps with non-English emails where link text may not be in English
+// but the URL often contains these patterns
+const unsubscribeUrlPatterns = ["unsub", "opt-out", "optout", "list-manage"];
+
+export function containsUnsubscribeUrlPattern(url: string) {
+  const lowerUrl = url.toLowerCase();
+  return unsubscribeUrlPatterns.some((pattern) => lowerUrl.includes(pattern));
+}


### PR DESCRIPTION
# User description
## Summary
Adds URL pattern-based detection for unsubscribe links to support non-English emails. Previously, emails with unsubscribe links in non-English text (e.g., Portuguese "CLIQUE AQUI") but with standard URL patterns like "unsub-email" were incorrectly showing "Block" instead of "Unsubscribe".

## Changes
- Added `containsUnsubscribeUrlPattern()` function that detects patterns: "unsub", "opt-out", "optout", "list-manage"
- Updated both server and client-side HTML parsing to use URL pattern detection
- Added comprehensive test coverage for URL pattern matching

## Testing
All 30 unit tests pass, including a specific test for the Portuguese email example.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the email parsing logic to detect unsubscribe links based on URL patterns, improving support for non-English marketing emails. Introduces the <code>containsUnsubscribeUrlPattern</code> utility to identify common unsubscribe indicators within link destinations across both client-side and server-side environments.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1317?tool=ast&topic=URL+Pattern+Logic>URL Pattern Logic</a>
        </td><td>Implement <code>containsUnsubscribeUrlPattern</code> to detect common unsubscribe strings like <code>unsub</code>, <code>opt-out</code>, and <code>list-manage</code> within URLs.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/parse/unsubscribe.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-case-insensitive-u...</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1317?tool=ast&topic=Parser+Integration>Parser Integration</a>
        </td><td>Integrate URL-based detection into <code>findUnsubscribeLink</code> for both server and client parsers and add comprehensive unit tests for various URL formats.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/parse/parseHtml.client.ts</li>
<li>apps/web/utils/parse/parseHtml.server.ts</li>
<li>apps/web/utils/parse/unsubscribe.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-case-insensitive-u...</td><td>January 08, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1317?tool=ast>(Baz)</a>.