### PR TITLE
feat: add calendar and drive OAuth redirect URIs to setup

### DIFF
--- a/packages/cli/src/setup-google.ts
+++ b/packages/cli/src/setup-google.ts
@@ -171,9 +171,13 @@ The console will open in your browser.`,
     const credentialsUrl = `https://console.cloud.google.com/apis/credentials/oauthclient?project=${projectId}`;
     const redirectUris = domain
       ? `   - https://${domain}/api/auth/callback/google
-   - https://${domain}/api/google/linking/callback`
+   - https://${domain}/api/google/linking/callback
+   - https://${domain}/api/google/calendar/callback
+   - https://${domain}/api/google/drive/callback`
       : `   - http://localhost:3000/api/auth/callback/google
-   - http://localhost:3000/api/google/linking/callback`;
+   - http://localhost:3000/api/google/linking/callback
+   - http://localhost:3000/api/google/calendar/callback
+   - http://localhost:3000/api/google/drive/callback`;
 
     p.note(
       `Now create OAuth 2.0 credentials:


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Google setup process by adding new OAuth redirect URIs for Calendar and Drive services to the CLI guidance. Ensures that the <code>runGoogleSetup</code> function provides developers with the correct callback URLs for both local and production environments.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-programmatic-Googl...</td><td>January 16, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1319?tool=ast>(Baz)</a>.