### PR TITLE
Add optional meeting briefs step to setup flow

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
   ChromeIcon,
   CalendarIcon,
+  FileTextIcon,
 } from "lucide-react";
 import { useLocalStorage } from "usehooks-ts";
 import {
@@ -24,6 +25,7 @@ import { LoadingContent } from "@/components/LoadingContent";
 import { EXTENSION_URL } from "@/utils/config";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { useMeetingBriefsEnabled } from "@/hooks/useFeatureFlags";
 import {
   STEP_KEYS,
   getStepNumber,
@@ -236,9 +238,18 @@ function Checklist({
     "inbox-zero-extension-installed",
     false,
   );
+  const [isMeetingBriefsViewed, setIsMeetingBriefsViewed] = useLocalStorage(
+    "inbox-zero-meeting-briefs-viewed",
+    false,
+  );
+  const isMeetingBriefsEnabled = useMeetingBriefsEnabled();
 
   const handleMarkExtensionDone = () => {
     setIsExtensionInstalled(true);
+  };
+
+  const handleMarkMeetingBriefsDone = () => {
+    setIsMeetingBriefsViewed(true);
   };
 
   return (
@@ -295,6 +306,21 @@ function Checklist({
         completed={isCalendarConnected}
         actionText="Connect"
       />
+
+      {isMeetingBriefsEnabled && (
+        <StepItem
+          href={prefixPath(emailAccountId, "/briefs")}
+          icon={<FileTextIcon size={20} />}
+          iconBg="bg-teal-100 dark:bg-teal-900/50"
+          iconColor="text-teal-500 dark:text-teal-400"
+          title="Optional: Set up Meeting Briefs"
+          timeEstimate="2 minutes"
+          completed={isMeetingBriefsViewed}
+          actionText="View"
+          onMarkDone={handleMarkMeetingBriefsDone}
+          showMarkDone={true}
+        />
+      )}
 
       {isGoogleProvider(provider) && (
         <StepItem


### PR DESCRIPTION
# User description
## Summary
- Adds meeting briefs as an optional step in the setup checklist
- Step only displays when NEXT_PUBLIC_MEETING_BRIEFS_ENABLED feature flag is enabled
- Users can navigate to the briefs page or mark the step done locally

## Test plan
- Verify step appears in setup when feature flag is enabled
- Verify step is hidden when feature flag is disabled
- Test "View" button navigates to /briefs
- Test "Mark Done" button shows checkmark and persists across page refresh

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Checklist_("Checklist"):::modified
FEATURE_FLAGS_SERVICE_("FEATURE_FLAGS_SERVICE"):::added
LOCAL_STORAGE_("LOCAL_STORAGE"):::added
handleMarkMeetingBriefsDone_("handleMarkMeetingBriefsDone"):::added
ROUTING_("ROUTING"):::modified
handleMarkExtensionDone_("handleMarkExtensionDone"):::modified
Checklist_ -- "Checks Meeting Briefs feature flag via hook." --> FEATURE_FLAGS_SERVICE_
Checklist_ -- "Reads 'inbox-zero-meeting-briefs-viewed' localStorage flag." --> LOCAL_STORAGE_
Checklist_ -- "Registers callback to mark Meeting Briefs viewed." --> handleMarkMeetingBriefsDone_
handleMarkMeetingBriefsDone_ -- "Sets 'inbox-zero-meeting-briefs-viewed' localStorage to true." --> LOCAL_STORAGE_
Checklist_ -- "Creates Meeting Briefs URL via prefixPath(emailAccountId, '/briefs')." --> ROUTING_
handleMarkExtensionDone_ -- "Sets 'inbox-zero-extension-installed' localStorage to true." --> LOCAL_STORAGE_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Integrates an optional meeting briefs step into the user onboarding checklist to enhance feature discovery. Utilizes the <code>useMeetingBriefsEnabled</code> hook to conditionally render the step and manages its completion status via local storage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1325?tool=ast&topic=Feature+Gating>Feature Gating</a>
        </td><td>Implements feature flag logic and local storage persistence using <code>useMeetingBriefsEnabled</code> and <code>useLocalStorage</code> to control the visibility and state of the new setup step.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Merge-branch-feat-ux-i...</td><td>December 07, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1325?tool=ast&topic=Setup+Flow+Update>Setup Flow Update</a>
        </td><td>Adds the 'Meeting Briefs' step to the setup checklist, including navigation to the briefs page and a manual completion toggle.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Merge-branch-feat-ux-i...</td><td>December 07, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1325?tool=ast>(Baz)</a>.