### PR TITLE
Update dialog and sheet overlay dimmer to black/50

### DIFF
--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -27,7 +27,7 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      overlay === "default" && "bg-background/80 backdrop-blur-sm",
+      overlay === "default" && "bg-black/50 backdrop-blur-sm",
       className,
     )}
     {...props}


### PR DESCRIPTION
Update the backdrop dimmer color for dialog and sheet overlays from bg-background/80 to bg-black/50 for better visual contrast and consistency.

Changes:
- dialog.tsx: Updated DialogOverlay dimmer color
- sheet.tsx: Updated SheetOverlay default overlay color