### PR TITLE
Add setup script diagnostics and delay for shell initialization

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "sleep 1 && pnpm install\n\n# Copy .env file\ncp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local",
+        "setup": "echo 'Starting setup...' && sleep 3 && echo 'PATH:' $PATH && echo 'Running pnpm install...' && pnpm install && cp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local && echo 'Setup complete'",
         "run": "pnpm dev"
     }
 }


### PR DESCRIPTION
# User description
Adds logging and a delay to ensure the shell environment is fully initialized before running pnpm install.

This addresses timing issues where the setup script would exit immediately without running the install step.

The script now includes diagnostic output to help troubleshoot similar issues in the future.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the setup script in the conductor configuration to include diagnostic logging and an extended initialization delay. Ensures that the shell environment is fully ready before executing the package installation and environment file setup.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-setup-script-diagn...</td><td>January 19, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add-conductor-workspac...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1333?tool=ast>(Baz)</a>.