### PR TITLE
fix: Add fallback env file locations for Conductor setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "echo 'Starting setup...' && sleep 3 && echo 'PATH:' $PATH && echo 'Running pnpm install...' && pnpm install && cp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local && echo 'Setup complete'",
+        "setup": "pnpm install && (cp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local 2>/dev/null || cp ~/.config/inbox-zero/.env.local apps/web/.env.local 2>/dev/null || echo 'WARNING: No .env.local found. Copy your env file to ~/.config/inbox-zero/.env.local')",
         "run": "pnpm dev"
     }
 }


### PR DESCRIPTION
# User description
Adds multiple fallback locations for .env.local in the Conductor setup script.

- Tries Conductor root path first, then ~/.config/inbox-zero/
- Shows warning message if neither location has the env file
- Ensures setup works across different machine configurations

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the Conductor setup process by implementing fallback logic for environment file configuration. Updates the <code>setup</code> script to attempt copying <code>.env.local</code> from multiple locations and provides a warning if no configuration is found.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Clean-up-setup-script-...</td><td>January 19, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add-conductor-workspac...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1335?tool=ast>(Baz)</a>.