### PR TITLE
fix: Clean up setup script and restore pnpm install

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "echo 'Step 1: Starting setup' && echo 'Step 2: Copying env file' && (cp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local 2>/dev/null && echo 'Copied from CONDUCTOR_ROOT_PATH' || cp ~/.config/inbox-zero/.env.local apps/web/.env.local 2>/dev/null && echo 'Copied from ~/.config' || echo 'WARNING: No .env.local found') && echo 'Step 3: Setup complete'",
+        "setup": "pnpm install && (cp $CONDUCTOR_ROOT_PATH/apps/web/.env.local apps/web/.env.local 2>/dev/null || cp ~/.config/inbox-zero/.env.local apps/web/.env.local 2>/dev/null || echo 'WARNING: No .env.local found. Copy your env file to ~/.config/inbox-zero/.env.local')",
         "run": "pnpm dev"
     }
 }


### PR DESCRIPTION
# User description
Restores the setup script to working state with pnpm install and removes debug logging.

- Restores `pnpm install` step that was removed during debugging
- Removes temporary echo statements
- Keeps fallback env file locations (tries CONDUCTOR_ROOT_PATH first, then ~/.config/inbox-zero/)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Restores the <code>pnpm install</code> command to the <code>setup</code> script and removes verbose debug logging to streamline the initialization process. Ensures environment configuration is handled via a fallback mechanism that checks multiple directory paths.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Clean-up-setup-script-...</td><td>January 19, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add-conductor-workspac...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1337?tool=ast>(Baz)</a>.