### PR TITLE
Filter user's own accounts from team access settings

### DIFF
--- a/apps/web/app/api/user/settings/multi-account/route.ts
+++ b/apps/web/app/api/user/settings/multi-account/route.ts
@@ -14,6 +14,7 @@ async function getMultiAccountEmails({ userId }: { userId: string }) {
         select: {
           users: {
             select: {
+              id: true,
               emailAccounts: {
                 select: { email: true },
               },
@@ -25,8 +26,15 @@ async function getMultiAccountEmails({ userId }: { userId: string }) {
     },
   });
 
+  // Mark each email with whether it belongs to the current user
+  // Own accounts can't be removed from this form - users must go to /accounts
   const emailAccounts =
-    user?.premium?.users?.flatMap((u) => u.emailAccounts) || [];
+    user?.premium?.users?.flatMap((u) =>
+      u.emailAccounts.map((ea) => ({
+        email: ea.email,
+        isOwnAccount: u.id === userId,
+      })),
+    ) || [];
 
   return {
     emailAccounts,


### PR DESCRIPTION
# User description
## Summary

Fixes an issue where users saw their own email accounts in the Manage Team Access settings and couldn't remove them (they would reappear after saving). These accounts are now filtered from the form entirely, with guidance to use the Accounts page instead.

## Changes

- API route marks which accounts belong to the current user
- Form only displays team member accounts, not user's own accounts
- Simplifies UX by removing confusion about why removals didn't persist

## Testing

Verify that own accounts don't appear in Manage Team Access, and that adding/removing team members still works.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getMultiAccountEmails_("getMultiAccountEmails"):::modified
DATABASE_("DATABASE"):::modified
MultiAccountForm_("MultiAccountForm"):::modified
POSTHOG_("POSTHOG"):::modified
getMultiAccountEmails_ -- "Includes user IDs; marks emails with isOwnAccount flag." --> DATABASE_
MultiAccountForm_ -- "PostHog captures 'Clicked Remove User' on removal." --> POSTHOG_
MultiAccountForm_ -- "Filters out own accounts; seeds form with team emails." --> getMultiAccountEmails_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Filters the user's own email accounts from the team access management interface to prevent confusion and ensure only team member accounts are managed there. Updates the multi-account API and settings form to distinguish between personal and team-associated email addresses.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1344?tool=ast&topic=API+Account+Marking>API Account Marking</a>
        </td><td>Updates the <code>getMultiAccountEmails</code> function to include an <code>isOwnAccount</code> flag by comparing the user ID of the account owner with the current user's ID.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/user/settings/multi-account/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-add-optional-chain...</td><td>January 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1344?tool=ast&topic=Team+Access+UI>Team Access UI</a>
        </td><td>Modifies the <code>MultiAccountForm</code> to filter out accounts marked as <code>isOwnAccount</code>, ensuring the form only displays and manages team member seats and pending invites.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/settings/MultiAccountSection.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-add-getActionErro...</td><td>January 08, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Major-better-auth-refa...</td><td>August 06, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1344?tool=ast>(Baz)</a>.