### PR TITLE
Add warning log when follow-up reminders feature is disabled

### DIFF
--- a/apps/web/app/api/follow-up-reminders/route.ts
+++ b/apps/web/app/api/follow-up-reminders/route.ts
@@ -17,6 +17,7 @@ export const GET = withError("follow-up-reminders", async (request) => {
   }
 
   if (!env.NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED) {
+    request.logger.warn("Follow-up reminders feature is disabled");
     return NextResponse.json({ message: "Follow-up reminders disabled" });
   }
 
@@ -34,6 +35,7 @@ export const POST = withError("follow-up-reminders", async (request) => {
   }
 
   if (!env.NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED) {
+    request.logger.warn("Follow-up reminders feature is disabled");
     return NextResponse.json({ message: "Follow-up reminders disabled" });
   }
 


### PR DESCRIPTION
# User description
## Summary
Adds a warning log when the follow-up reminders cron endpoint is called but the feature flag is disabled.

## Problem
When `NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED=false`, the endpoint returns silently without any logging, making it impossible to debug via Axiom whether the cron is actually running.

## Solution
Log a warning before returning, so the cron invocations are visible in Axiom even when the feature is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the follow-up reminders API route by adding observability for disabled feature states within the inbox-zero-ai productivity system. Implements a warning log in the request handler to ensure cron job invocations are visible in monitoring tools even when the feature flag is inactive.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-warning-log-when-f...</td><td>January 20, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow-up-reminders</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1346?tool=ast>(Baz)</a>.