### PR TITLE
Fix E2E test isolation with unique message sequences

### DIFF
--- a/apps/web/__tests__/e2e/flows/config.ts
+++ b/apps/web/__tests__/e2e/flows/config.ts
@@ -18,11 +18,12 @@ export const E2E_RUN_ID =
   process.env.E2E_RUN_ID ||
   `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-// Message sequence counter for unique subjects within a run
-let messageSequence = 0;
-export function getNextMessageSequence(): number {
-  messageSequence += 1;
-  return messageSequence;
+// Generate unique message identifier using timestamp + random suffix
+// This ensures uniqueness across all test files (unlike a module-scoped counter)
+export function getNextMessageSequence(): string {
+  const timestamp = Date.now().toString(36); // Base36 for shorter string
+  const random = Math.random().toString(36).slice(2, 6); // 4 random chars
+  return `${timestamp}-${random}`;
 }
 
 // Webhook tunnel URL (set by tunnel startup script)

--- a/apps/web/__tests__/e2e/flows/helpers/polling.ts
+++ b/apps/web/__tests__/e2e/flows/helpers/polling.ts
@@ -84,11 +84,8 @@ export async function waitForExecutedRule(options: {
     labelId: string | null;
   }>;
 }> {
-  const {
-    threadId,
-    emailAccountId,
-    timeout = TIMEOUTS.WEBHOOK_PROCESSING,
-  } = options;
+  const { threadId, emailAccountId, timeout = TIMEOUTS.WEBHOOK_PROCESSING } =
+    options;
 
   logStep("Waiting for ExecutedRule", { threadId, emailAccountId });
 


### PR DESCRIPTION
# User description
## Summary
- Replace module-scoped sequence counter with timestamp-based unique IDs to prevent subject line collisions across test files

The root cause was that each test file got its own module scope with a counter starting at 0, so both `draft-cleanup.test.ts` and `full-reply-cycle.test.ts` generated the same sequence number for their first email. Outlook threaded them into the same conversation, causing later tests to find stale ExecutedRules.

## Test plan
- [ ] Run E2E flow tests in CI to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances E2E test isolation by replacing the module-scoped sequence counter with a unique timestamp-based identifier to prevent subject line collisions across concurrent test files. Ensures that the AI-driven email automation workflows correctly identify unique threads and executed rules during validation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1348?tool=ast&topic=Test+Isolation+Fix>Test Isolation Fix</a>
        </td><td>Implements <code>getNextMessageSequence</code> using a base36 timestamp and random suffix to guarantee unique email subjects across different test execution contexts.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/config.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-add-sequence-c...</td><td>January 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1348?tool=ast&topic=Polling+Refactor>Polling Refactor</a>
        </td><td>Refactors the parameter destructuring in <code>waitForExecutedRule</code> for better code consistency within the polling infrastructure.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/helpers/polling.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-E2E-test-polling-f...</td><td>January 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1348?tool=ast>(Baz)</a>.