### PR TITLE
Add bulk archive link to sidebar

### DIFF
--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -100,6 +100,11 @@ export const useNavigation = () => {
         href: prefixPath(currentEmailAccountId, "/bulk-unsubscribe"),
         icon: MailsIcon,
       },
+      {
+        name: "Bulk Archive",
+        href: prefixPath(currentEmailAccountId, "/bulk-archive"),
+        icon: ArchiveIcon,
+      },
       ...(isGoogleProvider(provider) && showCleaner
         ? [
             {


### PR DESCRIPTION
Adds a new "Bulk Archive" navigation item to the sidebar positioned directly below the "Bulk Unsubscribe" link. Routes to the existing bulk archive feature for easier user access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)