### PR TITLE
Simplify footer for self-hosted deployments

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -139,6 +139,7 @@ export function Footer() {
                 key={item.name}
                 href={item.href}
                 target={item.target}
+                rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
                 className="text-sm leading-6 text-gray-600 hover:text-gray-900"
               >
                 {item.name}
@@ -160,6 +161,7 @@ export function Footer() {
             <Link
               href="https://getinboxzero.com"
               target="_blank"
+              rel="noopener noreferrer"
               className="hover:text-gray-900"
             >
               Inbox Zero

--- a/apps/web/components/new-landing/sections/Footer.tsx
+++ b/apps/web/components/new-landing/sections/Footer.tsx
@@ -42,6 +42,7 @@ export function Footer({ className, variant = "default" }: FooterProps) {
                 key={item.name}
                 href={item.href}
                 target={item.target}
+                rel={item.target === "_blank" ? "noopener noreferrer" : undefined}
                 className="text-sm leading-6 text-gray-500 hover:text-gray-900"
               >
                 {item.name}
@@ -63,6 +64,7 @@ export function Footer({ className, variant = "default" }: FooterProps) {
             <Link
               href="https://getinboxzero.com"
               target="_blank"
+              rel="noopener noreferrer"
               className="hover:text-gray-900"
             >
               Inbox Zero


### PR DESCRIPTION
# User description
Show a minimal footer with only essential links (Documentation, GitHub, Discord, legal terms) when running self-hosted. Production deployments continue to display the full marketing footer with all sections.

The self-hosted footer uses the existing `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS` environment variable which is automatically set during the CLI setup process.

Both footer components (original and new-landing) have been updated with this logic.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements a simplified footer for self-hosted deployments to provide a cleaner interface with essential links only. Updates the <code>Footer</code> components in both the legacy and new landing page modules to conditionally render based on the <code>NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS</code> environment variable.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-add-Brief-My-Meet...</td><td>January 04, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Update-styling-of-blog...</td><td>November 16, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1353?tool=ast>(Baz)</a>.