### PR TITLE
Isolate follow-up reminders tests from AI rules

### DIFF
--- a/apps/web/__tests__/e2e/flows/follow-up-reminders.test.ts
+++ b/apps/web/__tests__/e2e/flows/follow-up-reminders.test.ts
@@ -11,7 +11,7 @@
  * RUN_E2E_FLOW_TESTS=true pnpm test-e2e follow-up-reminders
  */
 
-import { describe, test, expect, beforeAll, afterEach } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { subMinutes } from "date-fns/subMinutes";
 import prisma from "@/utils/prisma";
 import { shouldRunFlowTests, TIMEOUTS } from "./config";


### PR DESCRIPTION
# User description
## Summary

Add test isolation helpers to prevent AI rules from interfering with follow-up reminders test assertions.

## Changes

- Added `disableRulesForAccount()` and `enableRulesForAccount()` helpers
- Disable AI rules before follow-up reminders tests run
- Re-enable rules after tests complete to avoid affecting other test suites

## Test Plan

The follow-up reminders tests can now verify that drafts are created by the follow-up feature rather than by AI rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the reliability of the follow-up reminder system's end-to-end tests by introducing mechanisms to isolate them from AI-driven rules. Implements helper functions to temporarily disable and re-enable account rules, ensuring that test assertions for thread trackers and automated reminders are not affected by external AI actions.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-E2E-tests-for-foll...</td><td>January 20, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1358?tool=ast>(Baz)</a>.