### PR TITLE
Add logging for draft deletion bug investigation

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -21,6 +21,7 @@
 - Format code with Prettier
 - Consult .cursor/rules for environment variable management
 - Prefer self-documenting code over comments; use descriptive variable and function names instead of explaining intent with comments. Never add comments that just describe what the code does - code should explain itself. Only add comments for "why" not "what".
+- Logging: Avoid duplicating logger context fields already passed from higher up in the call chain. Use `logger.trace()` for PII fields (from, to, subject, etc.).
 - Add helper functions to the bottom of files, not the top!
 - All imports go at the top of files, no mid-file dynamic imports.
 - Co-locate test files next to source files (e.g., `utils/example.test.ts`). Only E2E and AI tests go in `__tests__/`.

--- a/apps/web/__tests__/e2e/flows/message-preservation.test.ts
+++ b/apps/web/__tests__/e2e/flows/message-preservation.test.ts
@@ -1,0 +1,345 @@
+/**
+ * E2E Flow Test: Message Preservation During Draft Cleanup
+ *
+ * Tests that real messages are NOT deleted during AI draft cleanup operations.
+ * This test was created to reproduce a bug where a follow-up message in a thread
+ * was accidentally deleted when draft cleanup ran.
+ *
+ * Scenario being tested:
+ * 1. External sender sends first message to user
+ * 2. AI creates draft reply
+ * 3. External sender sends SECOND message (follow-up) to the same thread
+ * 4. Verify: The second message is preserved (NOT deleted)
+ *
+ * Usage:
+ * RUN_E2E_FLOW_TESTS=true pnpm test-e2e message-preservation
+ */
+
+import { describe, test, expect, beforeAll, afterEach } from "vitest";
+import { shouldRunFlowTests, TIMEOUTS } from "./config";
+import { initializeFlowTests, setupFlowTest } from "./setup";
+import { generateTestSummary } from "./teardown";
+import {
+  sendTestEmail,
+  sendTestReply,
+  TEST_EMAIL_SCENARIOS,
+} from "./helpers/email";
+import {
+  waitForExecutedRule,
+  waitForMessageInInbox,
+  waitForReplyInInbox,
+} from "./helpers/polling";
+import { logStep, clearLogs } from "./helpers/logging";
+import type { TestAccount } from "./helpers/accounts";
+
+describe.skipIf(!shouldRunFlowTests())("Message Preservation", () => {
+  let gmail: TestAccount;
+  let outlook: TestAccount;
+  let testStartTime: number;
+
+  beforeAll(async () => {
+    await initializeFlowTests();
+    const accounts = await setupFlowTest();
+    gmail = accounts.gmail;
+    outlook = accounts.outlook;
+  }, TIMEOUTS.TEST_DEFAULT);
+
+  afterEach(async () => {
+    generateTestSummary("Message Preservation", testStartTime);
+    clearLogs();
+  });
+
+  test(
+    "should NOT delete follow-up message when sender sends second message to thread",
+    async () => {
+      testStartTime = Date.now();
+      const scenario = TEST_EMAIL_SCENARIOS.NEEDS_REPLY;
+
+      // ========================================
+      // Step 1: External sender (Outlook) sends first message to user (Gmail)
+      // Using Gmail as receiver since Gmail pub/sub webhooks work better locally
+      // ========================================
+      logStep("Step 1: External sender sends first message");
+
+      const firstEmail = await sendTestEmail({
+        from: outlook,
+        to: gmail,
+        subject: `Preservation test - ${scenario.subject}`,
+        body: scenario.body,
+      });
+
+      const firstReceived = await waitForMessageInInbox({
+        provider: gmail.emailProvider,
+        subjectContains: firstEmail.fullSubject,
+        timeout: TIMEOUTS.EMAIL_DELIVERY,
+      });
+
+      logStep("First message received", {
+        messageId: firstReceived.messageId,
+        threadId: firstReceived.threadId,
+      });
+
+      // ========================================
+      // Step 2: Wait for AI draft to be created
+      // ========================================
+      logStep("Step 2: Waiting for AI draft creation");
+
+      const executedRule = await waitForExecutedRule({
+        threadId: firstReceived.threadId,
+        emailAccountId: gmail.id,
+        timeout: TIMEOUTS.WEBHOOK_PROCESSING,
+      });
+
+      logStep("ExecutedRule found", {
+        executedRuleId: executedRule.id,
+        status: executedRule.status,
+        actionItems: executedRule.actionItems.length,
+      });
+
+      const draftAction = executedRule.actionItems.find(
+        (a) => a.type === "DRAFT_EMAIL" && a.draftId,
+      );
+
+      expect(draftAction).toBeDefined();
+      expect(draftAction?.draftId).toBeTruthy();
+      const aiDraftId = draftAction!.draftId!;
+
+      logStep("AI draft created", { draftId: aiDraftId });
+
+      // Verify draft exists
+      const aiDraft = await gmail.emailProvider.getDraft(aiDraftId);
+      expect(aiDraft).toBeDefined();
+      logStep("Verified AI draft exists", {
+        draftId: aiDraftId,
+        draftMessageId: aiDraft?.id,
+      });
+
+      // ========================================
+      // Step 3: External sender sends SECOND message (follow-up)
+      // This is the message that was getting deleted in the bug
+      // ========================================
+      logStep("Step 3: External sender sends follow-up message");
+
+      // Important: Send from Outlook to Gmail (same as first message)
+      // This simulates the sender following up before user responds
+      const followUpEmail = await sendTestReply({
+        from: outlook,
+        to: gmail,
+        threadId: firstReceived.threadId,
+        originalMessageId: firstReceived.messageId,
+        body: "I wanted to add some more context to my previous message. Please let me know your thoughts on this.",
+      });
+
+      logStep("Follow-up sent from external sender", {
+        messageId: followUpEmail.messageId,
+        threadId: followUpEmail.threadId,
+      });
+
+      // Wait for the follow-up to be received and processed
+      // Use a slightly longer timeout to ensure webhook processing completes
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      // ========================================
+      // Step 4: CRITICAL - Verify the follow-up message still exists
+      // This is the bug we're testing for - the message should NOT be deleted
+      // ========================================
+      logStep("Step 4: Verifying follow-up message was NOT deleted");
+
+      // Get all messages in the thread
+      const threadMessages = await gmail.emailProvider.getThreadMessages(
+        firstReceived.threadId,
+      );
+
+      logStep("Thread messages retrieved", {
+        messageCount: threadMessages.length,
+        messageIds: threadMessages.map((m) => m.id),
+      });
+
+      // Should have at least 2 messages (first + follow-up)
+      // Note: May have 3 if the AI draft message is counted
+      expect(threadMessages.length).toBeGreaterThanOrEqual(2);
+
+      // Verify both the first message and follow-up still exist
+      const firstMessageStillExists = threadMessages.some(
+        (m) => m.id === firstReceived.messageId,
+      );
+      const followUpStillExists = threadMessages.some(
+        (m) => m.id === followUpEmail.messageId,
+      );
+
+      logStep("Message existence check", {
+        firstMessageId: firstReceived.messageId,
+        firstMessageExists: firstMessageStillExists,
+        followUpMessageId: followUpEmail.messageId,
+        followUpExists: followUpStillExists,
+      });
+
+      expect(firstMessageStillExists).toBe(true);
+      expect(followUpStillExists).toBe(true);
+
+      // ========================================
+      // Step 5: Verify by directly getting the follow-up message
+      // ========================================
+      logStep("Step 5: Directly verifying follow-up message");
+
+      try {
+        const followUpMessage = await gmail.emailProvider.getMessage(
+          followUpEmail.messageId,
+        );
+        expect(followUpMessage).toBeDefined();
+        expect(followUpMessage.id).toBe(followUpEmail.messageId);
+        logStep("Follow-up message verified - NOT deleted", {
+          messageId: followUpMessage.id,
+          subject: followUpMessage.headers.subject,
+        });
+      } catch (error) {
+        // If we get a "not found" error, that's the bug!
+        logStep("ERROR: Follow-up message was deleted!", {
+          error: String(error),
+        });
+        throw new Error(
+          `BUG REPRODUCED: Follow-up message ${followUpEmail.messageId} was deleted during draft cleanup. This should NOT happen.`,
+        );
+      }
+
+      // ========================================
+      // Step 6: Additional check - verify draft still exists (it should, since user hasn't replied)
+      // ========================================
+      logStep("Step 6: Checking if AI draft still exists");
+
+      const draftAfterFollowUp = await gmail.emailProvider.getDraft(aiDraftId);
+      logStep("AI draft status after follow-up", {
+        draftId: aiDraftId,
+        stillExists: !!draftAfterFollowUp,
+      });
+      // Note: Draft may or may not exist depending on implementation
+      // The key thing is that the follow-up message was NOT deleted
+    },
+    TIMEOUTS.FULL_CYCLE,
+  );
+
+  test(
+    "should preserve all thread messages when user sends reply after receiving multiple messages",
+    async () => {
+      testStartTime = Date.now();
+
+      // ========================================
+      // Setup: External sender sends multiple messages, then user replies
+      // Using Gmail as receiver since Gmail pub/sub webhooks work better locally
+      // ========================================
+      logStep("Setup: Creating thread with multiple messages from sender");
+
+      // First message
+      const firstEmail = await sendTestEmail({
+        from: outlook,
+        to: gmail,
+        subject: "Multi-message preservation test",
+        body: "This is my first question about the project.",
+      });
+
+      const firstReceived = await waitForMessageInInbox({
+        provider: gmail.emailProvider,
+        subjectContains: firstEmail.fullSubject,
+        timeout: TIMEOUTS.EMAIL_DELIVERY,
+      });
+
+      logStep("First message received", {
+        messageId: firstReceived.messageId,
+        threadId: firstReceived.threadId,
+      });
+
+      // Wait for AI to process first message
+      const executedRule = await waitForExecutedRule({
+        threadId: firstReceived.threadId,
+        emailAccountId: gmail.id,
+        timeout: TIMEOUTS.WEBHOOK_PROCESSING,
+      });
+
+      const draftAction = executedRule.actionItems.find(
+        (a) => a.type === "DRAFT_EMAIL" && a.draftId,
+      );
+      const aiDraftId = draftAction?.draftId;
+      logStep("AI draft created", { draftId: aiDraftId });
+
+      // Second message from sender (follow-up)
+      const secondEmail = await sendTestReply({
+        from: outlook,
+        to: gmail,
+        threadId: firstReceived.threadId,
+        originalMessageId: firstReceived.messageId,
+        body: "Actually, I have one more question I forgot to ask.",
+      });
+
+      logStep("Second message sent from external sender", {
+        messageId: secondEmail.messageId,
+      });
+
+      // Wait for second message to be received and processed
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      // ========================================
+      // Now user sends a reply (triggers outbound handling and cleanup)
+      // ========================================
+      logStep("User sends reply to the thread");
+
+      const userReply = await sendTestReply({
+        from: gmail,
+        to: outlook,
+        threadId: firstReceived.threadId,
+        originalMessageId: firstReceived.messageId,
+        body: "Thanks for reaching out. Here is my response to your questions.",
+      });
+
+      logStep("User reply sent", { messageId: userReply.messageId });
+
+      // Wait for webhook processing (cleanup runs here)
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+
+      // ========================================
+      // CRITICAL: Verify all messages still exist
+      // ========================================
+      logStep("Verifying all messages preserved after user reply");
+
+      const threadMessages = await gmail.emailProvider.getThreadMessages(
+        firstReceived.threadId,
+      );
+
+      logStep("Thread messages after user reply", {
+        messageCount: threadMessages.length,
+        messageIds: threadMessages.map((m) => m.id),
+      });
+
+      // Verify all 3 messages exist (first, second from sender, user reply)
+      // The outbound user reply triggers cleanup, but should NOT delete sender messages
+      expect(threadMessages.length).toBeGreaterThanOrEqual(3);
+
+      // Verify each message
+      const messages = [
+        { id: firstReceived.messageId, name: "First message" },
+        {
+          id: secondEmail.messageId,
+          name: "Second message (sender follow-up)",
+        },
+        { id: userReply.messageId, name: "User reply" },
+      ];
+
+      for (const msg of messages) {
+        const exists = threadMessages.some((m) => m.id === msg.id);
+        logStep(`Checking ${msg.name}`, {
+          messageId: msg.id,
+          exists,
+        });
+
+        if (!exists) {
+          throw new Error(
+            `BUG: ${msg.name} (${msg.id}) was deleted! This should NOT happen.`,
+          );
+        }
+        expect(exists).toBe(true);
+      }
+
+      logStep("All messages preserved successfully");
+    },
+    TIMEOUTS.FULL_CYCLE,
+  );
+});

--- a/apps/web/utils/gmail/draft.ts
+++ b/apps/web/utils/gmail/draft.ts
@@ -9,6 +9,7 @@ const logger = createScopedLogger("gmail/draft");
 
 export async function getDraft(draftId: string, gmail: gmail_v1.Gmail) {
   try {
+    logger.info("Fetching draft", { draftId });
     const response = await withGmailRetry(() =>
       gmail.users.drafts.get({
         userId: "me",
@@ -16,6 +17,14 @@ export async function getDraft(draftId: string, gmail: gmail_v1.Gmail) {
         format: "full",
       }),
     );
+
+    logger.info("Draft API response received", {
+      draftId,
+      responseDraftId: response.data.id,
+      embeddedMessageId: response.data.message?.id,
+      embeddedThreadId: response.data.message?.threadId,
+    });
+
     const message = parseMessage(response.data.message as MessageWithPayload);
     return message;
   } catch (error) {
@@ -46,9 +55,34 @@ function isNotFoundError(error: unknown): boolean {
   return statusCode === 404;
 }
 
+/**
+ * Validates that a draft ID has the expected format.
+ * Gmail draft IDs start with 'r-' followed by numbers (e.g., 'r-2497042748957023124').
+ * This helps prevent accidentally passing a message ID to the draft delete API.
+ */
+function isValidGmailDraftId(draftId: string): boolean {
+  return /^r-\d+$/.test(draftId);
+}
+
 export async function deleteDraft(gmail: gmail_v1.Gmail, draftId: string) {
+  // Log detailed info about the draft ID format for debugging
+  logger.info("Attempting to delete draft", {
+    draftId,
+    draftIdLength: draftId.length,
+    startsWithR: draftId.startsWith("r-"),
+    isValidFormat: isValidGmailDraftId(draftId),
+  });
+
+  // Warn but don't block if draft ID format is unexpected
+  // This helps us identify potential issues without breaking functionality
+  if (!isValidGmailDraftId(draftId)) {
+    logger.warn(
+      "Draft ID does not match expected Gmail format (r-NNNNN). This may indicate an issue.",
+      { draftId },
+    );
+  }
+
   try {
-    logger.info("Deleting draft", { draftId });
     const response = await withGmailRetry(() =>
       gmail.users.drafts.delete({
         userId: "me",
@@ -56,7 +90,10 @@ export async function deleteDraft(gmail: gmail_v1.Gmail, draftId: string) {
       }),
     );
     if (response.status !== 200 && response.status !== 204) {
-      logger.error("Failed to delete draft", { draftId, response });
+      logger.error("Unexpected response status from draft deletion", {
+        draftId,
+        status: response.status,
+      });
     }
     logger.info("Successfully deleted draft", { draftId });
   } catch (error) {

--- a/apps/web/utils/reply-tracker/handle-outbound.ts
+++ b/apps/web/utils/reply-tracker/handle-outbound.ts
@@ -24,7 +24,15 @@ export async function handleOutboundMessage({
     threadId: message.threadId,
   });
 
-  logger.info("Handling outbound message");
+  logger.info("Handling outbound message", {
+    messageLabelIds: message.labelIds,
+    messageInternalDate: message.internalDate,
+  });
+  logger.trace("Outbound message details", {
+    messageFrom: message.headers.from,
+    messageTo: message.headers.to,
+    messageSubject: message.headers.subject,
+  });
 
   await Promise.allSettled([
     trackSentDraftStatus({

--- a/apps/web/utils/webhook/process-history-item.ts
+++ b/apps/web/utils/webhook/process-history-item.ts
@@ -134,7 +134,14 @@ export async function processHistoryItem(
 
     const isOutbound = provider.isSentMessage(parsedMessage);
 
-    logger.info("Message direction check", { isOutbound });
+    logger.info("Message direction check", {
+      isOutbound,
+      labelIds: parsedMessage.labelIds,
+    });
+    logger.trace("Message direction details", {
+      from: parsedMessage.headers.from,
+      to: parsedMessage.headers.to,
+    });
 
     if (isOutbound) {
       await handleOutboundMessage({


### PR DESCRIPTION
# User description
## Summary
Added comprehensive diagnostic logging across the draft cleanup flow to help identify why real messages are being deleted during AI draft cleanup operations.

## Changes
- Draft ID format validation to detect invalid IDs passed to delete API
- Enhanced logging in draft operations (getDraft, deleteDraft) capturing embedded message and thread IDs
- Detailed logging in draft cleanup operations before deletion
- E2E test reproducing the exact bug scenario
- Updated development guidelines for logging and code style

## Test Plan
- E2E test verifies follow-up messages are not deleted during draft cleanup
- When bug recurs, logs will capture draft IDs and message IDs for root cause analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
processHistoryItem_("processHistoryItem"):::modified
handleOutboundMessage_("handleOutboundMessage"):::modified
cleanupThreadAIDrafts_("cleanupThreadAIDrafts"):::modified
PROVIDER_("PROVIDER"):::modified
getDraft_("getDraft"):::modified
GMAIL_API_("GMAIL_API"):::modified
deleteDraft_("deleteDraft"):::modified
isValidGmailDraftId_("isValidGmailDraftId"):::added
processHistoryItem_ -- "Adds detailed logging of outbound determination and labels" --> handleOutboundMessage_
cleanupThreadAIDrafts_ -- "Logs draft fetch/delete details and content previews" --> PROVIDER_
getDraft_ -- "Logs draft fetch request and response identifiers" --> GMAIL_API_
GMAIL_API_ -- "Includes response message/thread identifiers in logs" --> getDraft_
deleteDraft_ -- "Validates and logs draft ID before deletion request" --> GMAIL_API_
GMAIL_API_ -- "Logs unexpected deletion statuses and success" --> deleteDraft_
deleteDraft_ -- "Adds Gmail draft ID format validation utility" --> isValidGmailDraftId_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the AI draft management system with comprehensive diagnostic logging and validation to investigate reports of accidental message deletion during cleanup. Introduces a robust E2E test suite to ensure that follow-up messages from external senders are preserved when the AI processes or cleans up drafts.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1359?tool=ast&topic=Diagnostic+Logging>Diagnostic Logging</a>
        </td><td>Implement detailed logging and ID validation across <code>getDraft</code>, <code>deleteDraft</code>, and <code>cleanupThreadAIDrafts</code> to track draft lifecycles and prevent accidental deletion of non-draft messages.<details><summary>Modified files (5)</summary><ul><li>apps/web/CLAUDE.md</li>
<li>apps/web/utils/gmail/draft.ts</li>
<li>apps/web/utils/reply-tracker/draft-tracking.ts</li>
<li>apps/web/utils/reply-tracker/handle-outbound.ts</li>
<li>apps/web/utils/webhook/process-history-item.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Run-e2e-locally-1313</td><td>January 18, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add-line-to-CLAUDE.md-...</td><td>January 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1359?tool=ast&topic=Preservation+Tests>Preservation Tests</a>
        </td><td>Add a new E2E test flow in <code>message-preservation.test.ts</code> that simulates multi-message threads to verify that AI draft cleanup operations do not impact legitimate user or sender messages.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/message-preservation.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1359?tool=ast>(Baz)</a>.