### PR TITLE
Draft cleanup disable

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -7,7 +7,6 @@ import {
   getOrCreateFollowUpLabel,
 } from "@/utils/follow-up/labels";
 import { generateFollowUpDraft } from "@/utils/follow-up/generate-draft";
-import { cleanupStaleDrafts } from "@/utils/follow-up/cleanup";
 import { ThreadTrackerType } from "@/generated/prisma/enums";
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
@@ -183,17 +182,18 @@ export async function processAccountFollowUps({
     });
   }
 
+  // Draft cleanup temporarily disabled to avoid deleting old drafts.
   // Wrapped in try/catch since it's non-critical
-  try {
-    await cleanupStaleDrafts({
-      emailAccountId,
-      provider,
-      logger,
-    });
-  } catch (error) {
-    logger.error("Failed to cleanup stale drafts", { error });
-    captureException(error);
-  }
+  // try {
+  //   await cleanupStaleDrafts({
+  //     emailAccountId,
+  //     provider,
+  //     logger,
+  //   });
+  // } catch (error) {
+  //   logger.error("Failed to cleanup stale drafts", { error });
+  //   captureException(error);
+  // }
 
   logger.info("Finished processing follow-ups for account");
 }


### PR DESCRIPTION
# User description
Temporarily disable stale draft cleanup to prevent the deletion of old drafts.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3b34ba8-47fe-4c63-a530-d8149109b04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3b34ba8-47fe-4c63-a530-d8149109b04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Disables the automated cleanup of stale email drafts within the follow-up reminder flow to prevent the unintended deletion of older messages. Modifies the <code>processAccountFollowUps</code> function to comment out the cleanup logic while maintaining the rest of the account processing sequence.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1360?tool=ast>(Baz)</a>.