### PR TITLE
Disable thread AI draft cleanup call

### DIFF
--- a/apps/web/utils/reply-tracker/handle-outbound.ts
+++ b/apps/web/utils/reply-tracker/handle-outbound.ts
@@ -4,7 +4,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
 import { handleOutboundReply } from "./outbound";
-import { trackSentDraftStatus, cleanupThreadAIDrafts } from "./draft-tracking";
+import { trackSentDraftStatus } from "./draft-tracking";
 import { clearFollowUpLabel } from "@/utils/follow-up/labels";
 
 export async function handleOutboundMessage({
@@ -55,17 +55,18 @@ export async function handleOutboundMessage({
     }),
   ]);
 
-  try {
-    await cleanupThreadAIDrafts({
-      threadId: message.threadId,
-      emailAccountId: emailAccount.id,
-      provider,
-      logger,
-    });
-  } catch (error) {
-    logger.error("Error during thread draft cleanup", { error });
-    captureException(error, { emailAccountId: emailAccount.id });
-  }
+  // Draft cleanup temporarily disabled to investigate message deletion bug
+  // try {
+  //   await cleanupThreadAIDrafts({
+  //     threadId: message.threadId,
+  //     emailAccountId: emailAccount.id,
+  //     provider,
+  //     logger,
+  //   });
+  // } catch (error) {
+  //   logger.error("Error during thread draft cleanup", { error });
+  //   captureException(error, { emailAccountId: emailAccount.id });
+  // }
 
   // Remove follow-up label if present (user replied, so follow-up no longer needed)
   try {


### PR DESCRIPTION
# User description
## Summary
- PR #1360 disabled `cleanupStaleDrafts` but `cleanupThreadAIDrafts` was still being called from `handle-outbound.ts`
- This explains why messages were still being deleted after PR #1360 was merged
- Disabling this second cleanup call should stop the message deletions

## Test plan
- [ ] Deploy and monitor that no more messages are being deleted
- [ ] Review logs from PR #1359's logging to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Disables the <code>cleanupThreadAIDrafts</code> function call within the outbound message processing flow to prevent unintended message deletions. Ensures that AI-generated drafts are preserved while investigating tracking issues within the <code>handleOutboundMessage</code> component.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1361?tool=ast>(Baz)</a>.