### PR TITLE
Document pnpm install prerequisite for local e2e testing

### DIFF
--- a/.cursor/rules/e2e-testing.mdc
+++ b/.cursor/rules/e2e-testing.mdc
@@ -104,6 +104,8 @@ gh run download <run-id> --repo inbox-zero/inbox-zero-e2e
 
 ## Local Development
 
+**Prerequisites:** Run `pnpm install` first to install dependencies.
+
 Run E2E tests locally with `./scripts/run-e2e-local.sh`. Config lives at `~/.config/inbox-zero/.env.e2e`.
 
 See `apps/web/__tests__/e2e/flows/README.md` for full setup instructions.


### PR DESCRIPTION
# User description
## Summary
- Add note to e2e testing rules clarifying dependencies must be installed first
- Prevents dependency-related errors when running the local test script

## Testing
Documentation update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the E2E testing documentation to include a mandatory dependency installation step. Ensures that developers run <code>pnpm install</code> before executing the local test script to prevent environment errors.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>docs-Add-local-E2E-set...</td><td>January 18, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1362?tool=ast>(Baz)</a>.