### PR TITLE
Fix auto-filing UI blocking when all preview attachments are skipped

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -391,13 +391,9 @@ function PreviewResults({
         <Button
           onClick={onStartFiling}
           loading={isStarting}
-          disabled={anyFiling || filedCount === 0}
+          disabled={anyFiling}
         >
-          {anyFiling
-            ? "Processing..."
-            : filedCount === 0
-              ? "No attachments to file"
-              : "Looks good, start auto-filing"}
+          {anyFiling ? "Processing..." : "Looks good, start auto-filing"}
         </Button>
         <p className="text-xs text-muted-foreground">
           You'll get an email each time we file something. Reply to correct us.


### PR DESCRIPTION
# User description
## Summary
- Fixed the auto-filing setup UI incorrectly blocking progression when all preview attachments don't match filing preferences
- Removed the `filedCount === 0` condition that was disabling the "start auto-filing" button
- Users can now proceed with enabling auto-filing for future emails that will match their configured rules

## Testing
1. Set up auto-filing with preferences that won't match recent attachments
2. Click "Preview with my recent emails"
3. Wait for all attachments to be marked as skipped
4. Verify the button is clickable and says "Looks good, start auto-filing"
5. Enable auto-filing successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Google Drive integration setup to allow users to enable auto-filing even when no recent attachments match the current preview criteria. Modifies the <code>DriveSetup</code> component to ensure the action button remains enabled for future email processing regardless of the initial preview results.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1363?tool=ast>(Baz)</a>.