### PR TITLE
Add Vercel rewrites for /tools subpath proxy

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/tools/:path*",
+      "destination": "https://mini-apps-cyan.vercel.app/tools/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
# User description
Proxies all /tools/* requests to the mini-apps site. This enables displaying all free tools (email deliverability checker, subject line analyzer, and future tools) as a subpath on the main domain.

The rewrite configuration routes requests to the mini-apps deployment while maintaining a unified URL structure.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Configures Vercel rewrites to proxy all requests from the <code>/tools</code> subpath to the external mini-apps deployment. Enables a unified URL structure for free tools like the email deliverability checker and subject line analyzer.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1373?tool=ast>(Baz)</a>.