### PR TITLE
Fix digest email timezone handling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -18,6 +18,7 @@ import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useAction } from "next-safe-action/hooks";
 import { toggleDigestAction } from "@/utils/actions/settings";
 import { toastError } from "@/components/Toast";
+import { createCanonicalTimeOfDay } from "@/utils/schedule";
 
 export function DigestSetting() {
   const [open, setOpen] = useState(false);
@@ -46,7 +47,10 @@ export function DigestSetting() {
         digestSchedule: enable ? {} : null,
       };
       mutate(optimisticData as typeof data, false);
-      executeToggle({ enabled: enable });
+      executeToggle({
+        enabled: enable,
+        timeOfDay: enable ? createCanonicalTimeOfDay(9, 0) : undefined,
+      });
     },
     [data, mutate, executeToggle],
   );

--- a/apps/web/utils/actions/settings.validation.ts
+++ b/apps/web/utils/actions/settings.validation.ts
@@ -54,5 +54,6 @@ export type UpdateDigestItemsBody = z.infer<typeof updateDigestItemsBody>;
 
 export const toggleDigestBody = z.object({
   enabled: z.boolean(),
+  timeOfDay: z.coerce.date().optional(),
 });
 export type ToggleDigestBody = z.infer<typeof toggleDigestBody>;


### PR DESCRIPTION
# User description
Pass digest delivery time from client browser instead of server to respect user timezone. When enabling digest via toggle, the default 9 AM schedule now uses the user's local time instead of UTC.

Changes:
- Add timeOfDay parameter to digest toggle schema
- Send canonical time from browser when enabling
- Use provided timeOfDay in action with fallback

Fixes digest emails being delivered at wrong time when user enables via toggle without configuring the schedule.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the digest email toggle flow to pass the user's local time from the browser to the server, ensuring scheduled deliveries respect the user's timezone. Modifies the <code>toggleDigestAction</code> and its validation schema to handle the optional <code>timeOfDay</code> parameter during activation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-address-PR-review-...</td><td>January 11, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Digest-email-fixes</td><td>July 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1375?tool=ast>(Baz)</a>.