### PR TITLE
Re-enable AI draft cleanup on outbound messages

### DIFF
--- a/apps/web/utils/reply-tracker/handle-outbound.ts
+++ b/apps/web/utils/reply-tracker/handle-outbound.ts
@@ -4,7 +4,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
 import { handleOutboundReply } from "./outbound";
-import { trackSentDraftStatus } from "./draft-tracking";
+import { trackSentDraftStatus, cleanupThreadAIDrafts } from "./draft-tracking";
 import { clearFollowUpLabel } from "@/utils/follow-up/labels";
 
 export async function handleOutboundMessage({
@@ -55,18 +55,17 @@ export async function handleOutboundMessage({
     }),
   ]);
 
-  // Draft cleanup temporarily disabled to investigate message deletion bug
-  // try {
-  //   await cleanupThreadAIDrafts({
-  //     threadId: message.threadId,
-  //     emailAccountId: emailAccount.id,
-  //     provider,
-  //     logger,
-  //   });
-  // } catch (error) {
-  //   logger.error("Error during thread draft cleanup", { error });
-  //   captureException(error, { emailAccountId: emailAccount.id });
-  // }
+  try {
+    await cleanupThreadAIDrafts({
+      threadId: message.threadId,
+      emailAccountId: emailAccount.id,
+      provider,
+      logger,
+    });
+  } catch (error) {
+    logger.error("Error during thread draft cleanup", { error });
+    captureException(error, { emailAccountId: emailAccount.id });
+  }
 
   // Remove follow-up label if present (user replied, so follow-up no longer needed)
   try {


### PR DESCRIPTION
# User description
Re-enables the cleanupThreadAIDrafts function that cleans up unmodified AI-generated drafts when users send replies. This targets AI rule drafts only and does not affect follow-up reminders.

The follow-up draft cleanup remains disabled as it has separate issues.

This restores functionality from commit #1361.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Restores the automatic cleanup of unmodified AI-generated drafts when an outbound message is sent. Re-integrates <code>cleanupThreadAIDrafts</code> into the <code>handleOutboundMessage</code> flow to ensure stale AI rule drafts are removed from the thread.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Disable-thread-AI-draf...</td><td>January 21, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Rename-function</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1380?tool=ast>(Baz)</a>.