### PR TITLE
Fix Outlook sendEmailWithHtml to return conversationId

### DIFF
--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -43,38 +43,42 @@ export async function sendEmailWithHtml(
     return sendReplyUsingCreateReply(client, body, logger);
   }
 
-  // For new emails (no reply context), use sendMail
-  const message: OutlookMessageRequest = {
-    subject: body.subject,
-    body: {
-      contentType: "html",
-      content: body.messageHtml,
-    },
-    toRecipients: [{ emailAddress: { address: body.to } }],
-    ...(body.cc
-      ? { ccRecipients: [{ emailAddress: { address: body.cc } }] }
-      : {}),
-    ...(body.bcc
-      ? { bccRecipients: [{ emailAddress: { address: body.bcc } }] }
-      : {}),
-    ...(body.replyTo
-      ? { replyTo: [{ emailAddress: { address: body.replyTo } }] }
-      : {}),
-  };
-
-  await withOutlookRetry(
+  // For new emails, create draft then send to get the conversationId.
+  // sendMail returns 202 with no body, so we use the draft approach instead.
+  const draft: Message = await withOutlookRetry(
     () =>
-      client.getClient().api("/me/sendMail").post({
-        message,
-        saveToSentItems: true,
-      }),
+      client
+        .getClient()
+        .api("/me/messages")
+        .post({
+          subject: body.subject,
+          body: {
+            contentType: "html",
+            content: body.messageHtml,
+          },
+          toRecipients: [{ emailAddress: { address: body.to } }],
+          ...(body.cc
+            ? { ccRecipients: [{ emailAddress: { address: body.cc } }] }
+            : {}),
+          ...(body.bcc
+            ? { bccRecipients: [{ emailAddress: { address: body.bcc } }] }
+            : {}),
+          ...(body.replyTo
+            ? { replyTo: [{ emailAddress: { address: body.replyTo } }] }
+            : {}),
+        }),
     logger,
   );
 
-  // sendMail returns 202 with no body, so we can't get the sent message ID
+  await withOutlookRetry(
+    () => client.getClient().api(`/me/messages/${draft.id}/send`).post({}),
+    logger,
+  );
+
+  // Draft id is no longer valid after sending; Graph doesn't return sent message id
   return {
     id: "",
-    conversationId: body.replyToEmail?.threadId,
+    conversationId: draft.conversationId,
   };
 }
 


### PR DESCRIPTION
# User description
## Summary
- Fixed E2E test failures caused by Outlook's `/me/sendMail` returning 202 with no response body
- Changed `sendEmailWithHtml` to use draft-then-send approach: create message draft, then send it
- This returns the full message object including `conversationId`, consistent with how replies already work

## Test plan
- [x] Verified locally that "should track outbound message when user sends email (Gmail receiver)" test passes
- [ ] E2E tests in inbox-zero-e2e repo should pass after syncing this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
sendEmailWithHtml_("sendEmailWithHtml"):::modified
OUTLOOK_CLIENT_("OUTLOOK_CLIENT"):::modified
ME_MESSAGES_ENDPOINT_("ME_MESSAGES_ENDPOINT"):::added
ME_MESSAGES_SEND_ENDPOINT_("ME_MESSAGES_SEND_ENDPOINT"):::added
MICROSOFT_GRAPH_("MICROSOFT_GRAPH"):::modified
sendEmailWithHtml_ -- "Now creates draft via client before sending." --> OUTLOOK_CLIENT_
sendEmailWithHtml_ -- "Creates draft (/me/messages) with subject, HTML body, replyTo." --> ME_MESSAGES_ENDPOINT_
ME_MESSAGES_ENDPOINT_ -- "Returns draft containing conversationId used for sending." --> sendEmailWithHtml_
sendEmailWithHtml_ -- "Sends draft via POST to /me/messages/{draft.id}/send." --> ME_MESSAGES_SEND_ENDPOINT_
OUTLOOK_CLIENT_ -- "Now uses Graph draft+send endpoints via client wrapper." --> MICROSOFT_GRAPH_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the Outlook email sending flow to use a draft-then-send approach, ensuring the <code>conversationId</code> is captured before the message is dispatched. Enhances E2E test reliability by implementing a verification mechanism to locate sent messages in the Outlook 'Sent Items' folder.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1382?tool=ast&topic=Outlook+Send+Logic>Outlook Send Logic</a>
        </td><td>Modify <code>sendEmailWithHtml</code> to create a draft before sending, allowing the retrieval of a valid <code>conversationId</code> which is otherwise unavailable in the standard send response.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/mail.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-fix-DraftSendL...</td><td>January 17, 2026</td></tr>
<tr><td>cursoragent@cursor.com</td><td>Refactor-Extract-reply...</td><td>September 14, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1382?tool=ast&topic=E2E+Test+Helpers>E2E Test Helpers</a>
        </td><td>Introduce <code>findVerifiedSentMessage</code> and update <code>sendTestEmail</code> and <code>sendTestReply</code> to poll for sent messages in Microsoft accounts, ensuring test stability despite API limitations.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/helpers/email.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-E2E-test-polling-f...</td><td>January 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1382?tool=ast>(Baz)</a>.