### PR TITLE
Revert AI draft cleanup on outbound messages

### DIFF
--- a/apps/web/utils/reply-tracker/handle-outbound.ts
+++ b/apps/web/utils/reply-tracker/handle-outbound.ts
@@ -4,7 +4,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
 import { handleOutboundReply } from "./outbound";
-import { trackSentDraftStatus, cleanupThreadAIDrafts } from "./draft-tracking";
+import { trackSentDraftStatus } from "./draft-tracking";
 import { clearFollowUpLabel } from "@/utils/follow-up/labels";
 
 export async function handleOutboundMessage({
@@ -55,17 +55,18 @@ export async function handleOutboundMessage({
     }),
   ]);
 
-  try {
-    await cleanupThreadAIDrafts({
-      threadId: message.threadId,
-      emailAccountId: emailAccount.id,
-      provider,
-      logger,
-    });
-  } catch (error) {
-    logger.error("Error during thread draft cleanup", { error });
-    captureException(error, { emailAccountId: emailAccount.id });
-  }
+  // Draft cleanup temporarily disabled to investigate message deletion bug
+  // try {
+  //   await cleanupThreadAIDrafts({
+  //     threadId: message.threadId,
+  //     emailAccountId: emailAccount.id,
+  //     provider,
+  //     logger,
+  //   });
+  // } catch (error) {
+  //   logger.error("Error during thread draft cleanup", { error });
+  //   captureException(error, { emailAccountId: emailAccount.id });
+  // }
 
   // Remove follow-up label if present (user replied, so follow-up no longer needed)
   try {


### PR DESCRIPTION
# User description
## Summary
- Reverts the automatic cleanup of AI-generated drafts when users send replies
- Disables the `cleanupThreadAIDrafts` functionality in the outbound message handler

## Test plan
- [ ] Verify AI-generated drafts are no longer automatically deleted when sending a reply
- [ ] Confirm the webhook handler processes outbound messages without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Disables the automatic cleanup of AI-generated drafts within the outbound message handler to prevent unintended message deletions. Modifies <code>handleOutboundMessage</code> to bypass the <code>cleanupThreadAIDrafts</code> logic while maintaining existing reply tracking and label management.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Re-enable-AI-draft-cle...</td><td>January 22, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Rename-function</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1386?tool=ast>(Baz)</a>.