### PR TITLE
Consolidate footer columns by moving tools section

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -182,7 +182,7 @@ export function Footer() {
   return (
     <footer className="relative">
       <div className="mx-auto max-w-7xl overflow-hidden px-6 py-20 sm:py-24 lg:px-8">
-        <div className="mt-16 grid grid-cols-2 gap-8 lg:grid-cols-6 xl:col-span-2 xl:mt-0">
+        <div className="mt-16 grid grid-cols-2 gap-8 lg:grid-cols-5 xl:col-span-2 xl:mt-0">
           <div>
             <FooterList title="Product" items={footerNavigation.main} />
           </div>
@@ -194,10 +194,11 @@ export function Footer() {
             </div>
           </div>
           <div>
-            <FooterList title="Free Tools" items={footerNavigation.tools} />
-          </div>
-          <div>
             <FooterList title="Support" items={footerNavigation.support} />
+
+            <div className="mt-6">
+              <FooterList title="Free Tools" items={footerNavigation.tools} />
+            </div>
           </div>
           <div>
             <FooterList title="Company" items={footerNavigation.company} />

--- a/apps/web/components/new-landing/sections/Footer.tsx
+++ b/apps/web/components/new-landing/sections/Footer.tsx
@@ -81,7 +81,7 @@ export function Footer({ className, variant = "default" }: FooterProps) {
       <div
         className={cn("overflow-hidden px-6 py-20 sm:py-24 lg:px-8", className)}
       >
-        <div className="mt-16 grid grid-cols-2 gap-8 lg:grid-cols-6 xl:col-span-2 xl:mt-0">
+        <div className="mt-16 grid grid-cols-2 gap-8 lg:grid-cols-5 xl:col-span-2 xl:mt-0">
           <div>
             <FooterList title="Product" items={footerNavigation.main} />
           </div>
@@ -89,10 +89,10 @@ export function Footer({ className, variant = "default" }: FooterProps) {
             <FooterList title="Use Cases" items={footerNavigation.useCases} />
           </div>
           <div>
-            <FooterList title="Free Tools" items={footerNavigation.tools} />
-          </div>
-          <div>
             <FooterList title="Support" items={footerNavigation.support} />
+            <div className="mt-6">
+              <FooterList title="Free Tools" items={footerNavigation.tools} />
+            </div>
           </div>
           <div>
             <FooterList title="Company" items={footerNavigation.company} />


### PR DESCRIPTION
# User description
Reduce footer from 6 to 5 columns by placing free tools at the bottom of the support column instead of as a separate column.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Consolidates the footer layout by reducing the grid from 6 to 5 columns across landing page components. Relocates the 'Free Tools' section to reside within the 'Support' column to optimize space and visual hierarchy.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1391?tool=ast>(Baz)</a>.