### PR TITLE
Restrict booking link suggestions to explicit meeting requests

### DIFF
--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -144,7 +144,7 @@ IMPORTANT: Use these available time slots when responding to meeting requests. M
 ${emailAccount.calendarBookingLink}
 </booking_link>
 
-You can suggest this booking link if it helps with scheduling (e.g., "Feel free to book a time: [link]"). Use your judgment on whether to include it.
+Only include this link if the sender explicitly requested a call or meeting. Do not proactively suggest calls.
 `
     : "";
 


### PR DESCRIPTION
# User description
Updated the drafting agent's calendar link prompt to only suggest booking links when a sender explicitly requests a call or meeting, rather than proactively offering them.

The previous instruction gave the AI too much discretion to suggest links whenever it judged them potentially helpful. This change makes the behavior more conservative and user-controlled.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refines the AI drafting logic to ensure calendar booking links are only included when a sender explicitly requests a meeting. Updates the <code>getUserPrompt</code> function to prevent proactive call suggestions and enforce a more conservative scheduling behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Reply-length-issue-1294</td><td>January 16, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Merge-branch-main-into...</td><td>January 15, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1397?tool=ast>(Baz)</a>.