### PR TITLE
Fix Prisma module resolution in Docker containers

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -93,10 +93,6 @@ WORKDIR /app
 
 RUN apk add --no-cache openssl
 
-# Install Prisma CLI globally
-# Note: Prisma 7 requires config file for migrations
-RUN npm install -g prisma@7.2.0
-
 # Copy standalone build
 COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
@@ -106,6 +102,9 @@ COPY --from=builder /app/apps/web/prisma ./apps/web/prisma
 # Copy runtime scripts
 COPY docker/scripts /app/docker/scripts
 RUN chmod +x /app/docker/scripts/*.sh
+
+# Install Prisma locally for migrations (must be after COPY to merge with standalone node_modules)
+RUN npm install prisma@7.3.0 --no-save
 
 EXPOSE 3000
 

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -79,10 +79,6 @@ WORKDIR /app
 # Install openssl for Prisma
 RUN apk add --no-cache openssl
 
-# Install Prisma CLI globally
-# Note: Prisma 7 requires config file for migrations
-RUN npm install -g prisma@7.2.0
-
 # Copy the standalone server output (contains node_modules subset + server.js)
 COPY --from=builder /app/apps/web/.next/standalone ./
 # Static assets used by the server
@@ -93,6 +89,9 @@ COPY --from=builder /app/apps/web/prisma ./apps/web/prisma
 # Copy runtime scripts
 COPY docker/scripts /app/docker/scripts
 RUN chmod +x /app/docker/scripts/*.sh
+
+# Install Prisma locally for migrations (must be after COPY to merge with standalone node_modules)
+RUN npm install prisma@7.3.0 --no-save
 
 EXPOSE 3000
 

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -39,7 +39,7 @@ fi
 if [ -n "$DATABASE_URL" ] || [ -n "$PREVIEW_DATABASE_URL_UNPOOLED" ] || [ -n "$DIRECT_URL" ]; then
     echo "🔄 Running database migrations..."
     # Prisma 7 requires config file for migrations (schema no longer supports url)
-    if timeout 320 prisma migrate deploy --config=/app/docker/scripts/prisma.config.mjs --schema=./apps/web/prisma/schema.prisma; then
+    if timeout 320 npx prisma migrate deploy --config=/app/docker/scripts/prisma.config.mjs --schema=./apps/web/prisma/schema.prisma; then
         echo "✅ Database migrations completed successfully"
     else
         EXIT_CODE=$?


### PR DESCRIPTION
# User description
## Summary
Install Prisma locally instead of globally to enable proper module resolution for config imports in Docker. Update migration command to use npx for consistency.

## Changes
- Remove global Prisma CLI install from both Dockerfiles
- Add local install after COPY statements to merge with standalone node_modules
- Update start.sh to use `npx prisma` instead of `prisma`
- Align Prisma version with package.json (7.3.0)

## Verification
Build Docker image and verify migrations complete without module resolution errors.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Docker build process to install Prisma locally instead of globally, ensuring proper module resolution for configuration imports during container runtime. Modifies the migration script to execute via <code>npx</code> to maintain consistency with the local installation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-docker-update-Pris...</td><td>January 19, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix-docker-align-pnpm-...</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1398?tool=ast>(Baz)</a>.