### PR TITLE
Reduce E2E test timeouts and remove workflow timeout limit

### DIFF
--- a/.github/workflows/e2e-flows.yml
+++ b/.github/workflows/e2e-flows.yml
@@ -55,7 +55,6 @@ jobs:
     needs: check-enabled
     if: needs.check-enabled.outputs.enabled == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
       packages: read

--- a/apps/web/__tests__/e2e/flows/config.ts
+++ b/apps/web/__tests__/e2e/flows/config.ts
@@ -43,7 +43,7 @@ export const TIMEOUTS = {
   /** Default test timeout */
   TEST_DEFAULT: 120_000,
   /** Timeout for full reply cycle tests */
-  FULL_CYCLE: 300_000,
+  FULL_CYCLE: 180_000,
 } as const;
 
 // Test email subject prefix for identification


### PR DESCRIPTION
# User description
## Summary
- Reduce FULL_CYCLE timeout from 5 minutes to 3 minutes  
- Remove 30-minute timeout limit from E2E flow test workflow

This improves CI performance while keeping generous buffer for test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Optimizes E2E test execution by reducing the <code>FULL_CYCLE</code> timeout in the web application and removing the hardcoded 30-minute limit from the GitHub Actions workflow. These changes aim to improve CI performance while maintaining sufficient execution buffers.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1400?tool=ast&topic=CI+Workflow>CI Workflow</a>
        </td><td>Removes the <code>timeout-minutes</code> constraint from the E2E flow test workflow to allow for more flexible execution limits.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/e2e-flows.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Comprehensive-sync-of-...</td><td>January 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1400?tool=ast&topic=Test+Timeouts>Test Timeouts</a>
        </td><td>Reduces the <code>FULL_CYCLE</code> timeout constant from 300,000ms to 180,000ms to speed up failure detection in end-to-end tests.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/e2e/flows/config.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-E2E-test-diagn...</td><td>January 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1400?tool=ast>(Baz)</a>.