### PR TITLE
Fix preview deploy environment detection

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,8 @@
   "tasks": {
     "build": {
       "env": [
+        "VERCEL_ENV",
+        "VERCEL_URL",
         "NODE_ENV",
         "DATABASE_URL",
         "DIRECT_URL",


### PR DESCRIPTION
# User description
## Summary
Added Vercel system variables (`VERCEL_ENV` and `VERCEL_URL`) to turborepo's build environment list to ensure cache invalidation occurs when switching between deployment environments.

## Problem
Preview deployments were experiencing CORS errors because turborepo was reusing cached builds from production/staging, causing the environment detection to fail and default to the staging base URL.

## Solution
Include Vercel system variables in the turbo.json env list so preview deployments generate a fresh build with the correct base URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Turborepo configuration to include Vercel system environment variables in the build task's cache key. Ensures that preview deployments generate unique builds with correct environment-specific base URLs to prevent CORS errors caused by stale cache reuse.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-support-for-additi...</td><td>January 18, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Keep-NEXTAUTH_SECRET.-...</td><td>August 14, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1401?tool=ast>(Baz)</a>.