### PR TITLE
Add debug logging for preview URL detection

### DIFF
--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -16,9 +16,24 @@ const llmProviderEnum = z.enum([
 
 /** For Vercel preview deployments, auto-detect from VERCEL_URL. */
 const getBaseUrl = (): string | undefined => {
+  // DEBUG: Log environment detection for preview deploys
+  console.log("[env.ts getBaseUrl] VERCEL_ENV:", process.env.VERCEL_ENV);
+  console.log("[env.ts getBaseUrl] VERCEL_URL:", process.env.VERCEL_URL);
+  console.log(
+    "[env.ts getBaseUrl] NEXT_PUBLIC_BASE_URL:",
+    process.env.NEXT_PUBLIC_BASE_URL,
+  );
+
   if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
+    const previewUrl = `https://${process.env.VERCEL_URL}`;
+    console.log("[env.ts getBaseUrl] Using preview URL:", previewUrl);
+    return previewUrl;
   }
+
+  console.log(
+    "[env.ts getBaseUrl] Using NEXT_PUBLIC_BASE_URL:",
+    process.env.NEXT_PUBLIC_BASE_URL,
+  );
   return process.env.NEXT_PUBLIC_BASE_URL;
 };
 


### PR DESCRIPTION
# User description
## Summary
Adds temporary debug logging to diagnose why preview deployments are using the wrong base URL.

## Context
Preview deploys are still making requests to staging instead of their own URL. This adds logging to identify whether `VERCEL_ENV` and `VERCEL_URL` are correctly set during the build.

## Next Steps
Once we identify the issue from build logs, we'll remove the debug logging and implement the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds temporary console logging to the <code>getBaseUrl</code> utility to diagnose environment variable resolution during Vercel preview deployments. Helps identify why preview builds might be defaulting to staging URLs instead of their unique deployment URLs.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-detect-base-URL-f...</td><td>January 20, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>feat-add-self-hosting-...</td><td>December 30, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1402?tool=ast>(Baz)</a>.