### PR TITLE
Fix Docker ARM64 build npm dependency conflict

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -91,7 +91,8 @@ COPY docker/scripts /app/docker/scripts
 RUN chmod +x /app/docker/scripts/*.sh
 
 # Install Prisma locally for migrations (must be after COPY to merge with standalone node_modules)
-RUN npm install prisma@7.3.0 --no-save
+# Use --legacy-peer-deps to avoid ERESOLVE conflicts with standalone package.json metadata
+RUN npm install prisma@7.3.0 --no-save --legacy-peer-deps
 
 EXPOSE 3000
 


### PR DESCRIPTION
# User description
## Summary
- Add `--legacy-peer-deps` to Prisma npm install in Dockerfile

Fixes the ARM64 Docker build that was failing with ERESOLVE errors after #1404 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the production Dockerfile to resolve npm dependency conflicts during the ARM64 build process. Ensures that the Prisma CLI installs correctly by using the <code>--legacy-peer-deps</code> flag to bypass peer dependency resolution errors.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-Prisma-module-reso...</td><td>January 25, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>feat-add-self-hosting-...</td><td>December 30, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1405?tool=ast>(Baz)</a>.