### PR TITLE
Protect token from xtrace in clone-marketing.sh

### DIFF
--- a/clone-marketing.sh
+++ b/clone-marketing.sh
@@ -18,6 +18,7 @@ if [ -d "$MARKETING_DIR/(landing)" ]; then
 fi
 
 echo "🚀 Cloning private marketing repository..."
-git clone --depth 1 "https://${GITHUB_MARKETING_TOKEN}@${REPO_URL}" "$MARKETING_DIR"
+# Disable xtrace to prevent token from leaking to logs
+(set +x; git clone --depth 1 "https://${GITHUB_MARKETING_TOKEN}@${REPO_URL}" "$MARKETING_DIR")
 
 echo "✅ Private marketing repository cloned to $MARKETING_DIR"


### PR DESCRIPTION
# User description
## Summary
Re-adds xtrace protection around the git clone command to prevent `GITHUB_MARKETING_TOKEN` from leaking to build logs if shell tracing is enabled.

## Changes
Wraps the git clone in `(set +x; ...)` subshell to temporarily disable tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances security in the marketing repository cloning process by preventing sensitive credentials from being exposed in build logs. Wraps the <code>git clone</code> command in a subshell that temporarily disables shell tracing to protect the <code>GITHUB_MARKETING_TOKEN</code>.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1413?tool=ast>(Baz)</a>.