### PR TITLE
Remove redundant --env-file flag from docker compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ npm install
 npm run setup
 
 # Start Docker (Linux/Mac)
-NEXT_PUBLIC_BASE_URL=http://localhost:3000 docker compose --env-file apps/web/.env --profile all up -d
+NEXT_PUBLIC_BASE_URL=http://localhost:3000 docker compose --profile all up -d
 
 # Start Docker (Windows PowerShell)
-# $env:NEXT_PUBLIC_BASE_URL="http://localhost:3000"; docker compose --env-file apps/web/.env --profile all up -d
+# $env:NEXT_PUBLIC_BASE_URL="http://localhost:3000"; docker compose --profile all up -d
 
 # Verify startup (wait for "Ready" message, Ctrl+C to exit logs)
 docker logs inbox-zero-services-web-1 -f
@@ -112,8 +112,8 @@ Open http://localhost:3000
 **To update your configuration or pull the latest version:**
 
 ```bash
-docker compose --env-file apps/web/.env --profile all down
-NEXT_PUBLIC_BASE_URL=http://localhost:3000 docker compose --env-file apps/web/.env --profile all up -d
+docker compose --profile all down
+NEXT_PUBLIC_BASE_URL=http://localhost:3000 docker compose --profile all up -d
 ```
 
 See our **[Self-Hosting Guide](docs/hosting/self-hosting.md)** for complete instructions, production deployment, and configuration options.

--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -65,7 +65,7 @@ For detailed configuration instructions, see the [Environment Variables Referenc
 Pull and start the services with your domain:
 
 ```bash
-NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --env-file apps/web/.env --profile all up -d
+NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --profile all up -d
 ```
 
 The pre-built Docker image is hosted at `ghcr.io/elie222/inbox-zero:latest` and will be automatically pulled.
@@ -115,7 +115,7 @@ To update to the latest version:
 docker compose pull web
 
 # Restart with the new image
-NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --env-file apps/web/.env --profile all up -d
+NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --profile all up -d
 ```
 
 ## Monitoring
@@ -193,7 +193,7 @@ nano apps/web/.env
 
 # Build and start
 docker compose build
-NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --env-file apps/web/.env --profile all up -d
+NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --profile all up -d
 ```
 
 **Note**: Building from source requires significantly more resources (4GB+ RAM recommended) and takes longer than pulling the pre-built image.

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -707,7 +707,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
   if (runWebInDocker) {
     // Web app runs in Docker with database & Redis
     nextSteps = `# Start all services (web, database & Redis):
-NEXT_PUBLIC_BASE_URL=https://yourdomain.com ${composeCmd} --env-file ${envFile} --profile all up -d
+NEXT_PUBLIC_BASE_URL=https://yourdomain.com ${composeCmd} --profile all up -d
 
 # View logs:
 docker logs inbox-zero-services-web-1 -f


### PR DESCRIPTION
# User description
## Summary
- Simplifies docker compose commands by removing the `--env-file apps/web/.env` flag
- The docker-compose.yml services now have optional `env_file` directives with `required: false`, making the command-line flag redundant
- Users can now run simpler commands like `docker compose --profile all up -d`

## Test plan
- [ ] Verify docker compose commands work without the `--env-file` flag
- [ ] Verify the env file is still read correctly by services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplifies Docker Compose execution by removing the redundant <code>--env-file</code> flag from command-line instructions and setup scripts. Updates the documentation and the CLI tool to reflect that environment variables are now automatically loaded via the compose configuration.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Update-mission-stateme...</td><td>January 24, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Run-follow-up-reminder...</td><td>January 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1414?tool=ast>(Baz)</a>.