### PR TITLE
Add rewrite for /tools base path

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,8 +1,12 @@
 {
   "rewrites": [
     {
-      "source": "/tools/:path*",
-      "destination": "https://mini-apps-cyan.vercel.app/tools/:path*"
+      "source": "/tools",
+      "destination": "https://mini-apps-cyan.vercel.app/tools"
+    },
+    {
+      "source": "/tools/:path+",
+      "destination": "https://mini-apps-cyan.vercel.app/tools/:path+"
     }
   ]
 }


### PR DESCRIPTION
# User description
Ensure /tools redirects work in addition to /tools/* routes.

This adds a separate rewrite rule for the exact /tools path so it redirects correctly alongside the parameterized route.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Vercel configuration to include an explicit rewrite for the <code>/tools</code> base path and refines the wildcard routing for sub-paths. Ensures that both the root tools directory and its nested resources correctly proxy to the external mini-apps application.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Vercel-rewrites-to...</td><td>January 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1420?tool=ast>(Baz)</a>.