### PR TITLE
Fix unique constraint violation in follow-up reminders

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -258,23 +258,26 @@ async function processFollowUpsForType({
         logger: threadLogger,
       });
 
-      if (!tracker) {
-        tracker = await prisma.threadTracker.create({
-          data: {
+      tracker = await prisma.threadTracker.upsert({
+        where: {
+          emailAccountId_threadId_messageId: {
             emailAccountId: emailAccount.id,
             threadId: thread.id,
             messageId: lastMessage.id,
-            type: trackerType,
-            sentAt: messageDate,
-            followUpAppliedAt: now,
           },
-        });
-      } else {
-        await prisma.threadTracker.update({
-          where: { id: tracker.id },
-          data: { followUpAppliedAt: now },
-        });
-      }
+        },
+        update: {
+          followUpAppliedAt: now,
+        },
+        create: {
+          emailAccountId: emailAccount.id,
+          threadId: thread.id,
+          messageId: lastMessage.id,
+          type: trackerType,
+          sentAt: messageDate,
+          followUpAppliedAt: now,
+        },
+      });
 
       if (generateDraft && tracker) {
         await generateFollowUpDraft({


### PR DESCRIPTION
# User description
Replace direct create() with upsert() when handling ThreadTracker records to avoid unique constraint violations. The issue occurs when a tracker exists (even if resolved) for the same thread/message combination and the code attempts to create a new record with identical unique keys. Uses the composite key approach already proven in handle-conversation-status.ts.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the follow-up reminder processing logic to use an atomic <code>upsert</code> operation for <code>ThreadTracker</code> records, preventing unique constraint violations. Ensures that existing trackers are correctly updated with the latest application timestamp instead of attempting to create duplicate entries.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-Outlook-follow-up-...</td><td>January 24, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Allow-follow-up-remind...</td><td>January 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1422?tool=ast>(Baz)</a>.