### PR TITLE
fix: re-enable thread draft cleanup in outbound handler

### DIFF
--- a/apps/web/utils/reply-tracker/handle-outbound.ts
+++ b/apps/web/utils/reply-tracker/handle-outbound.ts
@@ -4,7 +4,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
 import { handleOutboundReply } from "./outbound";
-import { trackSentDraftStatus } from "./draft-tracking";
+import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 import { clearFollowUpLabel } from "@/utils/follow-up/labels";
 
 export async function handleOutboundMessage({
@@ -55,18 +55,17 @@ export async function handleOutboundMessage({
     }),
   ]);
 
-  // Draft cleanup temporarily disabled to investigate message deletion bug
-  // try {
-  //   await cleanupThreadAIDrafts({
-  //     threadId: message.threadId,
-  //     emailAccountId: emailAccount.id,
-  //     provider,
-  //     logger,
-  //   });
-  // } catch (error) {
-  //   logger.error("Error during thread draft cleanup", { error });
-  //   captureException(error, { emailAccountId: emailAccount.id });
-  // }
+  try {
+    await cleanupThreadAIDrafts({
+      threadId: message.threadId,
+      emailAccountId: emailAccount.id,
+      provider,
+      logger,
+    });
+  } catch (error) {
+    logger.error("Error during thread draft cleanup", { error });
+    captureException(error, { emailAccountId: emailAccount.id });
+  }
 
   // Remove follow-up label if present (user replied, so follow-up no longer needed)
   try {


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Re-enables the automated cleanup of AI-generated thread drafts within the <code>handleOutboundMessage</code> function to ensure stale drafts are removed after a reply is sent. Utilizes the <code>cleanupThreadAIDrafts</code> utility to manage draft deletion across supported email providers.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Revert-Re-enable-AI-dr...</td><td>January 23, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Rename-function</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1424?tool=ast>(Baz)</a>.