### PR TITLE
reply-tracker: decode HTML entities in similarity score comparison

### DIFF
--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -243,6 +243,16 @@ On Tue, 27 Jan 2026 at 2:59, Test User <test@example.com> wrote:
         expect(score).toBe(1.0);
       },
     );
+
+    it("should not throw on invalid code points and leave them unchanged", () => {
+      const storedContent = "Hello &#1114112; and &#xFFFFFFFF; world";
+      const gmailMessage = createParsedMessage(
+        "Hello &#1114112; and &#xFFFFFFFF; world",
+      );
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(1.0);
+    });
   });
 
   describe("Sent email tracking scenarios", () => {

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -18,15 +18,24 @@ function normalizeForOutlook(content: string): string {
 
 /**
  * Decodes HTML entities (e.g., &#x1F44B; -> 👋) without modifying other content.
+ * Invalid code points (> 0x10FFFF) are left unchanged to avoid RangeError.
  */
 function decodeHtmlEntities(text: string): string {
   return text
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
-      String.fromCodePoint(Number.parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/g, (_, dec) =>
-      String.fromCodePoint(Number.parseInt(dec, 10)),
-    );
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) => {
+      const codePoint = Number.parseInt(hex, 16);
+      if (!Number.isFinite(codePoint) || codePoint > 0x10_ff_ff) {
+        return match;
+      }
+      return String.fromCodePoint(codePoint);
+    })
+    .replace(/&#(\d+);/g, (match, dec) => {
+      const codePoint = Number.parseInt(dec, 10);
+      if (!Number.isFinite(codePoint) || codePoint > 0x10_ff_ff) {
+        return match;
+      }
+      return String.fromCodePoint(codePoint);
+    });
 }
 
 /**


### PR DESCRIPTION
# User description
Decodes HTML entities (hex and decimal) in email content before calculating similarity score to ensure emojis match correctly.

- Added `decodeHtmlEntities` helper to `similarity-score.ts`
- Updated Gmail normalization to decode entities
- Added comprehensive tests for 10 common emojis in both hex and decimal formats

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements HTML entity decoding within the email normalization process to ensure accurate similarity scoring for content containing emojis. Enhances the <code>normalizeForGmail</code> utility by integrating a new <code>decodeHtmlEntities</code> helper that handles both hex and decimal formats.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-use-consistent-nor...</td><td>January 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1425?tool=ast>(Baz)</a>.