### PR TITLE
fix: handle unsupported message types in Outlook follow-up draft generation

### DIFF
--- a/apps/web/utils/follow-up/generate-draft.ts
+++ b/apps/web/utils/follow-up/generate-draft.ts
@@ -141,6 +141,18 @@ export async function generateFollowUpDraft({
 
     logger.info("Follow-up draft created", { threadId, draftId });
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Skip draft generation for messages that don't support replies
+    // (e.g., calendar invites, meeting requests, delivery reports)
+    if (errorMessage.includes("Item type is invalid for creating a Reply")) {
+      logger.info(
+        "Skipping draft generation - message type doesn't support replies",
+        { threadId },
+      );
+      return;
+    }
+
     logger.error("Failed to generate follow-up draft", { threadId, error });
     throw error;
   }


### PR DESCRIPTION
# User description
## Summary

Skip draft generation gracefully for Outlook messages that don't support replies instead of failing the entire follow-up scan.

**Root Cause:** The error "Item type is invalid for creating a ReplyAll" occurs when follow-up draft generation tries to create a reply on messages that don't support it (calendar invites, meeting requests, delivery reports, etc.).

## Changes

- Catch the specific "Item type is invalid for creating a Reply" error in `generate-draft.ts`
- Log an info message instead of an error for unsupported message types
- Skip draft generation for those messages (instead of failing the whole process)

## Test Plan

- [ ] Deploy and verify follow-up scanning completes for Outlook users with calendar invites in their mailbox
- [ ] Verify other threads still get processed correctly

Fixes INB-43

🤖 Generated with [Claude Code](https://claude.ai/code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements graceful handling for unsupported Outlook message types during follow-up draft generation to prevent process failures. Updates the draft generation logic to identify specific API errors and skip processing for items like calendar invites or delivery reports.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Refactor-follow-up-rem...</td><td>January 22, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix-draft-generation-f...</td><td>January 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1432?tool=ast>(Baz)</a>.