### PR TITLE
Fix setup page progress counter when team invite step is skipped

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -271,6 +271,14 @@ function Checklist({
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const isMeetingBriefsEnabled = useMeetingBriefsEnabled();
 
+  const isTeamInviteSkipped =
+    teamInvite && isTeamInviteViewed && !teamInvite.completed;
+  const adjustedCompletedCount = isTeamInviteSkipped
+    ? completedCount + 1
+    : completedCount;
+  const adjustedProgressPercentage =
+    (adjustedCompletedCount / totalSteps) * 100;
+
   const handleMarkExtensionDone = () => {
     setIsExtensionInstalled(true);
   };
@@ -294,12 +302,12 @@ function Checklist({
           <h2 className="font-semibold text-foreground">Complete your setup</h2>
           <div className="flex items-center gap-3">
             <span className="text-sm text-muted-foreground hidden sm:block">
-              {completedCount} of {totalSteps} completed
+              {adjustedCompletedCount} of {totalSteps} completed
             </span>
             <div className="h-2 w-32 overflow-hidden rounded-full bg-muted">
               <div
                 className="h-2 rounded-full bg-primary"
-                style={{ width: `${progressPercentage}%` }}
+                style={{ width: `${adjustedProgressPercentage}%` }}
               />
             </div>
           </div>
@@ -405,6 +413,16 @@ function Checklist({
 export function SetupContent() {
   const { emailAccountId, provider } = useAccount();
   const { data, isLoading, error } = useSetupProgress();
+  const [isTeamInviteViewed] = useLocalStorage(
+    "inbox-zero-team-invite-viewed",
+    false,
+  );
+
+  const isTeamInviteSkipped =
+    data?.teamInvite && isTeamInviteViewed && !data.teamInvite.completed;
+  const allBaseStepsDone = data && data.completed === data.total - 1;
+  const adjustedIsComplete =
+    data?.isComplete || (isTeamInviteSkipped && allBaseStepsDone);
 
   return (
     <LoadingContent loading={isLoading} error={error}>
@@ -417,7 +435,7 @@ export function SetupContent() {
           isCalendarConnected={data.steps.calendarConnected}
           completedCount={data.completed}
           totalSteps={data.total}
-          isSetupComplete={data.isComplete}
+          isSetupComplete={adjustedIsComplete ?? false}
           teamInvite={data.teamInvite}
         />
       )}


### PR DESCRIPTION
# User description
## Summary
Fixed a bug where the setup page progress counter showed "3/4 completed" even when all steps were checked off. The issue occurred when users skipped the team invite step.

## Changes
- Progress count now properly reflects when the team invite step is skipped
- Setup page transitions to "complete" view when all steps are done (including skipped team invite)
- Both the progress text and completion status are now calculated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the setup progress logic to correctly account for skipped team invitations by calculating an adjusted completion count and status. Ensures the <code>SetupContent</code> component accurately reflects a finished state when all mandatory steps are fulfilled or skipped.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1448?tool=ast>(Baz)</a>.