### PR TITLE
Improve Outlook retry handling

### DIFF
--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -36,21 +36,20 @@ export async function getFolderIds(client: OutlookClient, logger: Logger) {
 
   const wellKnownFolders = await Promise.all(
     Object.entries(WELL_KNOWN_FOLDERS).map(async ([key, folderName]) => {
-      try {
-        const response: { id?: string } = await withOutlookRetry(
-          () =>
-            client
-              .getClient()
-              .api(`/me/mailFolders/${folderName}`)
-              .select("id")
-              .get(),
-          logger,
-        );
-        return [key, response.id ?? null] as [string, string | null];
-      } catch (error) {
+      const response: { id?: string | null } = await withOutlookRetry(
+        () =>
+          client
+            .getClient()
+            .api(`/me/mailFolders/${folderName}`)
+            .select("id")
+            .get(),
+        logger,
+      ).catch((error) => {
         logWellKnownFolderFetchError(logger, folderName, error);
-        return [key, null] as [string, string | null];
-      }
+        return { id: null };
+      });
+
+      return [key, response.id ?? null] as [string, string | null];
     }),
   );
 


### PR DESCRIPTION
# User description
Adds retry handling for Outlook folder and category lookups. Lowers throttling log noise while keeping existing behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the reliability of Outlook integrations by wrapping folder and category lookups with a retry mechanism. Implements conditional logging to reduce noise from throttling errors while maintaining visibility for other failure types.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-e2e-handle-deleted...</td><td>January 16, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-folder-functi...</td><td>August 13, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1449?tool=ast>(Baz)</a>.