### PR TITLE
Disable AI thinking for cost optimization

### DIFF
--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -70,6 +70,11 @@ export function createGenerateText({
         {
           ...options,
           ...commonOptions,
+          providerOptions: {
+            ...commonOptions.providerOptions,
+            ...modelOptions.providerOptions,
+            ...options.providerOptions,
+          },
           model,
         },
         ...restArgs,
@@ -182,6 +187,11 @@ export function createGenerateObject({
           },
           ...options,
           ...commonOptions,
+          providerOptions: {
+            ...commonOptions.providerOptions,
+            ...modelOptions.providerOptions,
+            ...options.providerOptions,
+          },
           model: modelOptions.model,
         },
         ...restArgs,
@@ -261,8 +271,11 @@ export async function chatCompletionStream({
     messages,
     tools,
     stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
-    providerOptions,
     ...commonOptions,
+    providerOptions: {
+      ...commonOptions.providerOptions,
+      ...providerOptions,
+    },
     experimental_transform: smoothStream({ chunking: "word" }),
     onStepFinish,
     onFinish: async (result) => {

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV2 } from "@ai-sdk/provider";
+import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
@@ -11,6 +12,9 @@ import { env } from "@/env";
 import { Provider } from "@/utils/llms/config";
 import type { UserAIFields } from "@/utils/llms/types";
 import { createScopedLogger } from "@/utils/logger";
+
+// Thinking budget for Google models (set low to minimize cost)
+const GOOGLE_THINKING_BUDGET = 0;
 
 const logger = createScopedLogger("llms/model");
 
@@ -102,6 +106,13 @@ function selectModel(
         model: createGoogleGenerativeAI({
           apiKey: aiApiKey || env.GOOGLE_API_KEY,
         })(mod),
+        providerOptions: {
+          google: {
+            thinkingConfig: {
+              thinkingBudget: GOOGLE_THINKING_BUDGET,
+            },
+          } satisfies GoogleGenerativeAIProviderOptions,
+        },
         backupModel: getBackupModel(aiApiKey),
       };
     }
@@ -143,6 +154,15 @@ function selectModel(
         provider: Provider.AI_GATEWAY,
         modelName,
         model: gateway(modelName),
+        providerOptions: {
+          // Disable/cap thinking for Google models (Gemini)
+          google: {
+            thinkingConfig: {
+              thinkingBudget: GOOGLE_THINKING_BUDGET,
+            },
+          } satisfies GoogleGenerativeAIProviderOptions,
+          // Note: Anthropic thinking is disabled by default (not including the config)
+        },
         backupModel: getBackupModel(aiApiKey),
       };
     }
@@ -173,6 +193,7 @@ function selectModel(
             sessionToken: undefined,
           }),
         })(modelName),
+        // Note: Anthropic thinking is disabled by default (not including the config)
         backupModel: getBackupModel(aiApiKey),
       };
     }
@@ -184,6 +205,7 @@ function selectModel(
         model: createAnthropic({
           apiKey: aiApiKey || env.ANTHROPIC_API_KEY,
         })(modelName),
+        // Note: Anthropic thinking is disabled by default (not including the config)
         backupModel: getBackupModel(aiApiKey),
       };
     }


### PR DESCRIPTION
## Summary
- Disable Google Gemini thinking by setting budget to 0
- Ensure Anthropic thinking stays disabled (no config)
- Pass provider options through LLM wrapper functions
- OpenRouter reasoning cap unchanged at 20 tokens

Fixes cost issue where Gemini was using dynamic default budget (up to 8,192 tokens).

## Test Plan
- Verify Google models don't use extended thinking
- Check Anthropic models work without thinking enabled
- Confirm existing OpenRouter behavior unchanged