### PR TITLE
Add cron scheduled actions

### DIFF
--- a/apps/web/app/api/ai/digest/simple/route.ts
+++ b/apps/web/app/api/ai/digest/simple/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { env } from "@/env";
+import { withError } from "@/utils/middleware";
+import { isValidInternalApiKey } from "@/utils/internal-api";
+import { handleDigestRequest } from "@/app/api/ai/digest/route";
+
+export const POST = withError(
+  "ai/digest/simple",
+  async (request) => {
+    if (env.QSTASH_TOKEN) {
+      return NextResponse.json({
+        error: "Qstash is set. This endpoint is disabled.",
+      });
+    }
+
+    if (!isValidInternalApiKey(await headers(), request.logger)) {
+      return NextResponse.json({ error: "Invalid API key" });
+    }
+
+    return handleDigestRequest(request);
+  },
+);

--- a/apps/web/app/api/clean/gmail/route.ts
+++ b/apps/web/app/api/clean/gmail/route.ts
@@ -139,15 +139,19 @@ async function saveToDatabase({
 
 export const POST = withError(
   "clean/gmail",
-  verifySignatureAppRouter(async (request: Request) => {
-    const json = await request.json();
-    const body = cleanGmailSchema.parse(json);
-
-    await performGmailAction({
-      ...body,
-      logger: (request as RequestWithLogger).logger,
-    });
-
-    return NextResponse.json({ success: true });
-  }),
+  verifySignatureAppRouter(async (request: Request) =>
+    handleCleanGmailRequest(request as RequestWithLogger),
+  ),
 );
+
+export async function handleCleanGmailRequest(request: RequestWithLogger) {
+  const json = await request.json();
+  const body = cleanGmailSchema.parse(json);
+
+  await performGmailAction({
+    ...body,
+    logger: request.logger,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/clean/gmail/simple/route.ts
+++ b/apps/web/app/api/clean/gmail/simple/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { env } from "@/env";
+import { withError } from "@/utils/middleware";
+import { isValidInternalApiKey } from "@/utils/internal-api";
+import { handleCleanGmailRequest } from "@/app/api/clean/gmail/route";
+
+export const POST = withError(
+  "clean/gmail/simple",
+  async (request) => {
+    if (env.QSTASH_TOKEN) {
+      return NextResponse.json({
+        error: "Qstash is set. This endpoint is disabled.",
+      });
+    }
+
+    if (!isValidInternalApiKey(await headers(), request.logger)) {
+      return NextResponse.json({ error: "Invalid API key" });
+    }
+
+    return handleCleanGmailRequest(request);
+  },
+);

--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { withError } from "@/utils/middleware";
+import { hasCronSecret } from "@/utils/cron";
+import prisma from "@/utils/prisma";
+import { ScheduledActionStatus } from "@/generated/prisma/enums";
+import { markQStashActionAsExecuting } from "@/utils/scheduled-actions/scheduler";
+import { executeScheduledAction } from "@/utils/scheduled-actions/executor";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { Logger } from "@/utils/logger";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export const GET = withError(
+  "cron/scheduled-actions",
+  async (request) => {
+    if (!hasCronSecret(request)) {
+      request.logger.error("Unauthorized cron request");
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const result = await runScheduledActions(request.logger);
+    return NextResponse.json(result);
+  },
+);
+
+export const POST = withError(
+  "cron/scheduled-actions",
+  async (request) => {
+    if (!hasCronSecret(request)) {
+      request.logger.error("Unauthorized cron request");
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const result = await runScheduledActions(request.logger);
+    return NextResponse.json(result);
+  },
+);
+
+async function runScheduledActions(logger: Logger) {
+  const dueActions = await prisma.scheduledAction.findMany({
+    where: {
+      status: ScheduledActionStatus.PENDING,
+      scheduledFor: { lte: new Date() },
+    },
+    include: {
+      emailAccount: {
+        include: {
+          account: true,
+        },
+      },
+    },
+    orderBy: { scheduledFor: "asc" },
+    take: 100,
+  });
+
+  const summary = {
+    total: dueActions.length,
+    processed: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const scheduledAction of dueActions) {
+    if (!scheduledAction.emailAccount?.account?.provider) {
+      logger.error("Email account or provider missing", {
+        scheduledActionId: scheduledAction.id,
+      });
+      summary.skipped += 1;
+      continue;
+    }
+
+    const markedAction = await markQStashActionAsExecuting(
+      scheduledAction.id,
+    );
+    if (!markedAction) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    try {
+      const provider = await createEmailProvider({
+        emailAccountId: scheduledAction.emailAccountId,
+        provider: scheduledAction.emailAccount.account.provider,
+        logger,
+      });
+
+      const executionResult = await executeScheduledAction(
+        markedAction,
+        provider,
+        logger,
+      );
+
+      if (executionResult.success) {
+        summary.processed += 1;
+      } else {
+        summary.failed += 1;
+      }
+    } catch (error) {
+      logger.error("Failed to execute scheduled action", {
+        scheduledActionId: scheduledAction.id,
+        error,
+      });
+      summary.failed += 1;
+    }
+  }
+
+  return summary;
+}

--- a/apps/web/app/api/resend/digest/simple/route.ts
+++ b/apps/web/app/api/resend/digest/simple/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { env } from "@/env";
+import { withError } from "@/utils/middleware";
+import { isValidInternalApiKey } from "@/utils/internal-api";
+import { handleDigestSendRequest } from "@/app/api/resend/digest/route";
+
+export const POST = withError(
+  "resend/digest/simple",
+  async (request) => {
+    if (env.QSTASH_TOKEN) {
+      return NextResponse.json({
+        error: "Qstash is set. This endpoint is disabled.",
+      });
+    }
+
+    if (!isValidInternalApiKey(await headers(), request.logger)) {
+      return NextResponse.json({ error: "Invalid API key" });
+    }
+
+    return handleDigestSendRequest(request);
+  },
+);

--- a/apps/web/app/api/resend/summary/simple/route.ts
+++ b/apps/web/app/api/resend/summary/simple/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { env } from "@/env";
+import { withError } from "@/utils/middleware";
+import { isValidInternalApiKey } from "@/utils/internal-api";
+import { handleSummarySendRequest } from "@/app/api/resend/summary/route";
+
+export const POST = withError(
+  "resend/summary/simple",
+  async (request) => {
+    if (env.QSTASH_TOKEN) {
+      return NextResponse.json({
+        error: "Qstash is set. This endpoint is disabled.",
+      });
+    }
+
+    if (!isValidInternalApiKey(await headers(), request.logger)) {
+      return NextResponse.json({ error: "Invalid API key" });
+    }
+
+    return handleSummarySendRequest(request);
+  },
+);


### PR DESCRIPTION
Add a cron endpoint to process scheduled actions and keep them pending when QStash is unavailable. Introduce shared handlers and simple fallback routes for digest, summary, and clean workflows to avoid missing endpoints in self-hosted setups.