### PR TITLE
Improve calendar OAuth error handling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/CalendarConnections.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/CalendarConnections.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import { useEffect } from "react";
 import { CalendarCheckIcon, FileTextIcon } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { LoadingContent } from "@/components/LoadingContent";
 import { useCalendars } from "@/hooks/useCalendars";
 import { CalendarConnectionCard } from "./CalendarConnectionCard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConnectCalendar } from "@/app/(app)/[emailAccountId]/calendars/ConnectCalendar";
 import { TypographyP } from "@/components/Typography";
+import { toastError } from "@/components/Toast";
 
 export function CalendarConnections() {
+  useCalendarNotifications();
   const { data, isLoading, error } = useCalendars();
   const connections = data?.connections || [];
 
@@ -62,4 +66,74 @@ export function CalendarConnections() {
       </div>
     </LoadingContent>
   );
+}
+
+function useCalendarNotifications() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const errorParam = searchParams.get("error");
+    if (!errorParam) return;
+
+    const errorDescription = searchParams.get("error_description");
+    const errorMessages: Record<string, { title: string; description: string }> =
+      {
+        consent_declined: {
+          title: "Calendar consent not granted",
+          description:
+            "Microsoft reported AADSTS65004, which means the consent screen was canceled or not completed. Please complete consent and try again.",
+        },
+        admin_consent_required: {
+          title: "Admin consent required",
+          description:
+            "Your Microsoft 365 tenant requires admin approval. Ask an admin to grant consent for this app in Entra ID, then retry.",
+        },
+        access_denied: {
+          title: "Calendar access denied",
+          description:
+            "Microsoft denied the request. Please try again or ask your admin to approve access.",
+        },
+        invalid_state: {
+          title: "Invalid calendar request",
+          description:
+            "This calendar authorization request was invalid. Please try again.",
+        },
+        invalid_state_format: {
+          title: "Invalid calendar request",
+          description:
+            "We couldn't validate the calendar authorization. Please try again.",
+        },
+        missing_code: {
+          title: "Calendar authorization canceled",
+          description:
+            "We didn't receive an authorization code from Microsoft. Please retry the connection.",
+        },
+        connection_failed: {
+          title: "Calendar connection failed",
+          description:
+            "We couldn't complete the calendar connection. Please try again.",
+        },
+        oauth_error: {
+          title: "Calendar connection failed",
+          description:
+            "Microsoft returned an OAuth error. Please try again or contact support.",
+        },
+      };
+
+    const errorMessage = errorMessages[errorParam] || {
+      title: "Calendar connection failed",
+      description:
+        errorDescription ||
+        "We couldn't complete the calendar connection. Please try again.",
+    };
+
+    toastError({
+      title: errorMessage.title,
+      description: errorMessage.description,
+    });
+
+    router.replace(pathname);
+  }, [pathname, router, searchParams]);
 }

--- a/apps/web/utils/calendar/oauth-callback-helpers.test.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractAadstsCode,
+  getSafeOAuthErrorDescription,
+  mapCalendarOAuthError,
+} from "./oauth-callback-helpers";
+
+describe("calendar OAuth callback helpers", () => {
+  describe("extractAadstsCode", () => {
+    it("extracts AADSTS code when present", () => {
+      expect(
+        extractAadstsCode(
+          "AADSTS65004: User declined to consent to access the app.",
+        ),
+      ).toBe("AADSTS65004");
+    });
+
+    it("extracts longer AADSTS codes", () => {
+      expect(extractAadstsCode("AADSTS7000215: Invalid client secret.")).toBe(
+        "AADSTS7000215",
+      );
+    });
+
+    it("returns null when no code present", () => {
+      expect(extractAadstsCode("Some other error")).toBeNull();
+    });
+
+    it("returns null for empty descriptions", () => {
+      expect(extractAadstsCode(null)).toBeNull();
+    });
+  });
+
+  describe("mapCalendarOAuthError", () => {
+    it("maps consent declined AADSTS", () => {
+      expect(
+        mapCalendarOAuthError({
+          oauthError: "access_denied",
+          errorSubcode: "cancel",
+          aadstsCode: "AADSTS65004",
+        }),
+      ).toBe("consent_declined");
+    });
+
+    it("maps admin consent required AADSTS", () => {
+      expect(
+        mapCalendarOAuthError({
+          oauthError: "access_denied",
+          errorSubcode: null,
+          aadstsCode: "AADSTS65001",
+        }),
+      ).toBe("admin_consent_required");
+    });
+
+    it("maps access_denied without subcode", () => {
+      expect(
+        mapCalendarOAuthError({
+          oauthError: "access_denied",
+          errorSubcode: null,
+          aadstsCode: null,
+        }),
+      ).toBe("access_denied");
+    });
+
+    it("falls back to oauth_error", () => {
+      expect(
+        mapCalendarOAuthError({
+          oauthError: "server_error",
+          errorSubcode: null,
+          aadstsCode: null,
+        }),
+      ).toBe("oauth_error");
+    });
+  });
+
+  describe("getSafeOAuthErrorDescription", () => {
+    it("returns a sanitized message with AADSTS code", () => {
+      expect(
+        getSafeOAuthErrorDescription(
+          "AADSTS65004: User declined to consent to access the app.",
+        ),
+      ).toBe("Microsoft error AADSTS65004.");
+    });
+
+    it("returns null when no AADSTS code is present", () => {
+      expect(getSafeOAuthErrorDescription("Something else")).toBeNull();
+    });
+  });
+});

--- a/apps/web/utils/calendar/oauth-callback-helpers.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.ts
@@ -29,13 +29,56 @@ export async function validateOAuthCallback(
 ): Promise<OAuthCallbackValidation> {
   const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get("code");
+  const oauthError = searchParams.get("error");
+  const errorDescription = searchParams.get("error_description");
+  const errorSubcode = searchParams.get("error_subcode");
   const receivedState = searchParams.get("state");
   const storedState = request.cookies.get(CALENDAR_STATE_COOKIE_NAME)?.value;
 
-  const redirectUrl = new URL("/calendars", env.NEXT_PUBLIC_BASE_URL);
-  const response = NextResponse.redirect(redirectUrl);
+  const baseRedirectUrl = new URL("/calendars", env.NEXT_PUBLIC_BASE_URL);
+  const response = NextResponse.redirect(baseRedirectUrl);
 
   response.cookies.delete(CALENDAR_STATE_COOKIE_NAME);
+
+  if (!storedState || !receivedState || storedState !== receivedState) {
+    logger.warn("Invalid state during calendar callback", {
+      receivedState,
+      hasStoredState: !!storedState,
+    });
+    baseRedirectUrl.searchParams.set("error", "invalid_state");
+    throw new RedirectError(baseRedirectUrl, response.headers);
+  }
+
+  const calendarState = parseAndValidateCalendarState(
+    receivedState,
+    logger,
+    baseRedirectUrl,
+    response.headers,
+  );
+
+  const redirectUrl = buildCalendarRedirectUrl(calendarState.emailAccountId);
+
+  if (oauthError) {
+    const aadstsCode = extractAadstsCode(errorDescription);
+    const mappedError = mapCalendarOAuthError({
+      oauthError,
+      errorSubcode,
+      aadstsCode,
+    });
+
+    logger.warn("OAuth error in calendar callback", {
+      oauthError,
+      errorSubcode,
+      aadstsCode,
+    });
+
+    redirectUrl.searchParams.set("error", mappedError);
+    const safeErrorDescription = getSafeOAuthErrorDescription(errorDescription);
+    if (safeErrorDescription) {
+      redirectUrl.searchParams.set("error_description", safeErrorDescription);
+    }
+    throw new RedirectError(redirectUrl, response.headers);
+  }
 
   if (!code || code.length < 10) {
     logger.warn("Missing or invalid code in calendar callback");
@@ -43,16 +86,7 @@ export async function validateOAuthCallback(
     throw new RedirectError(redirectUrl, response.headers);
   }
 
-  if (!storedState || !receivedState || storedState !== receivedState) {
-    logger.warn("Invalid state during calendar callback", {
-      receivedState,
-      hasStoredState: !!storedState,
-    });
-    redirectUrl.searchParams.set("error", "invalid_state");
-    throw new RedirectError(redirectUrl, response.headers);
-  }
-
-  return { code, redirectUrl, response };
+  return { code, redirectUrl, response, calendarState };
 }
 
 /**
@@ -134,4 +168,42 @@ export async function createCalendarConnection(params: {
       isConnected: true,
     },
   });
+}
+
+export function extractAadstsCode(errorDescription: string | null): string | null {
+  if (!errorDescription) return null;
+  const match = errorDescription.match(/AADSTS\d+/);
+  return match ? match[0] : null;
+}
+
+export function mapCalendarOAuthError(params: {
+  oauthError: string;
+  errorSubcode: string | null;
+  aadstsCode: string | null;
+}): string {
+  if (params.aadstsCode === "AADSTS65004") {
+    return "consent_declined";
+  }
+
+  if (params.aadstsCode === "AADSTS65001") {
+    return "admin_consent_required";
+  }
+
+  if (params.oauthError === "access_denied" && params.errorSubcode === "cancel") {
+    return "consent_declined";
+  }
+
+  if (params.oauthError === "access_denied") {
+    return "access_denied";
+  }
+
+  return "oauth_error";
+}
+
+export function getSafeOAuthErrorDescription(
+  errorDescription: string | null,
+): string | null {
+  const aadstsCode = extractAadstsCode(errorDescription);
+  if (!aadstsCode) return null;
+  return `Microsoft error ${aadstsCode}.`;
 }

--- a/apps/web/utils/calendar/oauth-types.ts
+++ b/apps/web/utils/calendar/oauth-types.ts
@@ -31,6 +31,7 @@ export interface OAuthCallbackValidation {
   code: string;
   redirectUrl: URL;
   response: NextResponse;
+  calendarState: CalendarOAuthState;
 }
 
 export interface CalendarOAuthState {


### PR DESCRIPTION
# User description
Improve calendar OAuth error handling and surfacing. Adds safer error parsing and user-facing messages, plus tests for the mapping helpers. Also avoids redundant state parsing in the callback flow.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
handleCalendarCallback_("handleCalendarCallback"):::modified
validateOAuthCallback_("validateOAuthCallback"):::modified
extractAadstsCode_("extractAadstsCode"):::added
mapCalendarOAuthError_("mapCalendarOAuthError"):::added
getSafeOAuthErrorDescription_("getSafeOAuthErrorDescription"):::added
CalendarConnections_("CalendarConnections"):::modified
useCalendarNotifications_("useCalendarNotifications"):::added
handleCalendarCallback_ -- "Returns calendarState; upstream uses it to build redirect." --> validateOAuthCallback_
validateOAuthCallback_ -- "Extracts AADSTS code from error_description for error mapping." --> extractAadstsCode_
validateOAuthCallback_ -- "Maps oauthError, subcode and AADSTS to user-facing key." --> mapCalendarOAuthError_
validateOAuthCallback_ -- "Produces safe AADSTS-based error_description to include in redirect." --> getSafeOAuthErrorDescription_
CalendarConnections_ -- "Reads OAuth error params, shows toast, then clears URL." --> useCalendarNotifications_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the calendar OAuth flow by implementing robust error parsing and user-facing notifications for various failure scenarios. Refines the callback logic to handle Microsoft-specific error codes and ensures consistent state validation across the connection process.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1462?tool=ast&topic=Error+UI+%26+Feedback>Error UI & Feedback</a>
        </td><td>Implements the <code>useCalendarNotifications</code> hook to display descriptive toast messages based on OAuth error parameters and clears the URL state after notification.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/calendars/CalendarConnections.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>sentence-case-cards</td><td>January 11, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Use-outlook-endpoint</td><td>October 09, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1462?tool=ast&topic=OAuth+Logic+%26+Tests>OAuth Logic & Tests</a>
        </td><td>Introduces helper functions like <code>mapCalendarOAuthError</code> and <code>extractAadstsCode</code> to safely parse Microsoft Entra ID errors and streamlines the <code>handleCalendarCallback</code> flow.<details><summary>Modified files (4)</summary><ul><li>apps/web/utils/calendar/handle-calendar-callback.ts</li>
<li>apps/web/utils/calendar/oauth-callback-helpers.test.ts</li>
<li>apps/web/utils/calendar/oauth-callback-helpers.ts</li>
<li>apps/web/utils/calendar/oauth-types.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1462?tool=ast>(Baz)</a>.