### PR TITLE
Skip Outlook Drafts folder lookup for reads

### DIFF
--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -201,7 +201,9 @@ export class OutlookProvider implements EmailProvider {
       return null;
     }
 
-    const folderIds = await getFolderIds(this.client, this.logger);
+    const folderIds = await getFolderIds(this.client, this.logger, {
+      includeDrafts: false,
+    });
     return convertMessage(message, folderIds);
   }
 
@@ -245,7 +247,9 @@ export class OutlookProvider implements EmailProvider {
   }
 
   async getSentMessages(maxResults = 20): Promise<ParsedMessage[]> {
-    const folderIds = await getFolderIds(this.client, this.logger);
+    const folderIds = await getFolderIds(this.client, this.logger, {
+      includeDrafts: false,
+    });
 
     const response: { value: Message[] } = await withOutlookRetry(
       () =>
@@ -265,7 +269,9 @@ export class OutlookProvider implements EmailProvider {
   }
 
   async getInboxMessages(maxResults = 20): Promise<ParsedMessage[]> {
-    const folderIds = await getFolderIds(this.client, this.logger);
+    const folderIds = await getFolderIds(this.client, this.logger, {
+      includeDrafts: false,
+    });
 
     const response: { value: Message[] } = await withOutlookRetry(
       () =>

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -213,7 +213,7 @@ export async function getThreadMessages(
 ): Promise<ParsedMessage[]> {
   const [messages, folderIds, categoryMap] = await Promise.all([
     getThread(threadId, client, logger),
-    getFolderIds(client, logger),
+    getFolderIds(client, logger, { includeDrafts: false }),
     getCategoryMap(client, logger),
   ]);
 


### PR DESCRIPTION
# User description
Avoids fetching Drafts folder IDs for non-draft Outlook reads. Reduces failures when Drafts lookup fails during stats and thread/message reads. Draft-specific flows still include Drafts.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getThreadMessages_("getThreadMessages"):::modified
getFolderIds_("getFolderIds"):::modified
queryBatchMessages_("queryBatchMessages"):::modified
getMessage_("getMessage"):::modified
getMessages_("getMessages"):::modified
OutlookProvider_getMessageByRfc822MessageId_("OutlookProvider.getMessageByRfc822MessageId"):::modified
OutlookProvider_getSentMessages_("OutlookProvider.getSentMessages"):::modified
OutlookProvider_getInboxMessages_("OutlookProvider.getInboxMessages"):::modified
getThreadMessages_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
queryBatchMessages_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
getMessage_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
getMessages_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
OutlookProvider_getMessageByRfc822MessageId_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
OutlookProvider_getSentMessages_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
OutlookProvider_getInboxMessages_ -- "Passes includeDrafts:false to exclude drafts when fetching folders." --> getFolderIds_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Optimizes Outlook email operations by making the Drafts folder lookup optional, thereby reducing potential failures during message and thread retrieval. Updates the <code>OutlookProvider</code> and associated utility functions to skip Drafts folder ID fetching for non-draft read flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1466?tool=ast&topic=Folder+Lookup+Logic>Folder Lookup Logic</a>
        </td><td>Enhances <code>getFolderIds</code> to support an <code>includeDrafts</code> option and improves caching logic to handle partial folder ID sets.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/message.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-Microsoft-email-pr...</td><td>February 03, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-folder-functi...</td><td>August 13, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1466?tool=ast&topic=Provider+Integration>Provider Integration</a>
        </td><td>Updates <code>OutlookProvider</code> methods and message query functions to set <code>includeDrafts</code> to false for standard read operations.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/email/microsoft.ts</li>
<li>apps/web/utils/outlook/message.ts</li>
<li>apps/web/utils/outlook/thread.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-Microsoft-email-pr...</td><td>February 03, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix-follow-up-reminder...</td><td>January 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1466?tool=ast>(Baz)</a>.