### PR TITLE
Note single drive connection assumption

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -619,6 +619,7 @@ function SetupFolderSelection({
   const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
     () => new Set(savedFolders.map((f) => f.folderId)),
   );
+  // TODO: This assumes a single drive connection; swap to a selected connection ID when multi-connection UX exists.
   const driveConnectionId = connections[0]?.id ?? null;
 
   // Sync optimistic state when server data changes


### PR DESCRIPTION
Adds a TODO documenting the single-connection assumption for drive connection selection. This flags the need to switch to an explicit selected connection when multi-connection support lands.