### PR TITLE
Fix digest scheduling timezone and cadence

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -23,6 +23,7 @@ import { createCanonicalTimeOfDay } from "@/utils/schedule";
 export function DigestSetting() {
   const [open, setOpen] = useState(false);
   const { data, isLoading, mutate } = useEmailAccountFull();
+  const timezone = data?.timezone ?? null;
 
   const enabled = data?.digestSchedule != null;
 
@@ -49,10 +50,12 @@ export function DigestSetting() {
       mutate(optimisticData as typeof data, false);
       executeToggle({
         enabled: enable,
-        timeOfDay: enable ? createCanonicalTimeOfDay(9, 0) : undefined,
+        timeOfDay: enable
+          ? createCanonicalTimeOfDay(9, 0, timezone)
+          : undefined,
       });
     },
-    [data, mutate, executeToggle],
+    [data, timezone, mutate, executeToggle],
   );
 
   return (

--- a/apps/web/app/api/user/email-accounts/route.ts
+++ b/apps/web/app/api/user/email-accounts/route.ts
@@ -26,6 +26,7 @@ async function getEmailAccounts({ userId }: { userId: string }) {
       accountId: true,
       name: true,
       image: true,
+      timezone: true,
       account: {
         select: {
           provider: true,

--- a/apps/web/utils/schedule.test.ts
+++ b/apps/web/utils/schedule.test.ts
@@ -748,6 +748,46 @@ describe("calculateNextScheduleDate", () => {
       expect(result!.getMinutes()).toBe(0);
     });
   });
+
+  describe("timezone-aware scheduling", () => {
+    it("should schedule daily digest in the specified timezone", () => {
+      const timezone = "America/Sao_Paulo";
+      const timeOfDay = createCanonicalTimeOfDay(9, 0, timezone);
+      const fromDate = new Date("2024-01-15T10:00:00Z"); // 7 AM in Sao Paulo
+
+      const result = calculateNextScheduleDate(
+        {
+          intervalDays: 1,
+          daysOfWeek: null,
+          timeOfDay,
+          occurrences: 1,
+          lastOccurrenceAt: fromDate,
+        },
+        timezone,
+      );
+
+      expect(result?.toISOString()).toBe("2024-01-15T12:00:00.000Z");
+    });
+
+    it("should respect DST shifts in the specified timezone", () => {
+      const timezone = "America/New_York";
+      const timeOfDay = createCanonicalTimeOfDay(9, 0, timezone);
+      const fromDate = new Date("2024-03-09T14:00:00Z"); // 9 AM EST
+
+      const result = calculateNextScheduleDate(
+        {
+          intervalDays: 1,
+          daysOfWeek: null,
+          timeOfDay,
+          occurrences: 1,
+          lastOccurrenceAt: fromDate,
+        },
+        timezone,
+      );
+
+      expect(result?.toISOString()).toBe("2024-03-10T13:00:00.000Z");
+    });
+  });
 });
 
 describe("calculateNextScheduleDate - Bug Fix Tests", () => {


### PR DESCRIPTION
Honor account timezones when storing digest times and computing next runs. Advance schedules even when no items are pending while recording actual run time. Surface last run in settings and add timezone-aware schedule coverage.