### PR TITLE
Fix draft cleanup deleting sent replies

### DIFF
--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, type Mock } from "vitest";
+import { deleteDraft, getDraft } from "@/utils/gmail/draft";
+import { GmailLabel } from "@/utils/gmail/label";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/logger", () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    with: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock("@/utils/gmail/retry", () => ({
+  withGmailRetry: (fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/utils/gmail/message", () => ({
+  parseMessage: vi.fn(),
+}));
+
+describe("gmail/draft", () => {
+  it("getDraft returns null when embedded message is SENT or missing DRAFT label", async () => {
+    const gmail = {
+      users: {
+        drafts: {
+          get: vi.fn().mockResolvedValue({
+            data: { id: "r-1", message: { id: "m-1", threadId: "t-1" } },
+          }),
+        },
+      },
+    } as any;
+
+    const { parseMessage } = await import("@/utils/gmail/message");
+
+    (parseMessage as Mock).mockReturnValueOnce({
+      id: "m-1",
+      threadId: "t-1",
+      labelIds: [GmailLabel.SENT],
+    });
+    await expect(getDraft("r-1", gmail)).resolves.toBeNull();
+
+    (parseMessage as Mock).mockReturnValueOnce({
+      id: "m-1",
+      threadId: "t-1",
+      labelIds: [],
+    });
+    await expect(getDraft("r-1", gmail)).resolves.toBeNull();
+  });
+
+  it("getDraft returns message when embedded message has DRAFT and not SENT", async () => {
+    const gmail = {
+      users: {
+        drafts: {
+          get: vi.fn().mockResolvedValue({
+            data: { id: "r-1", message: { id: "m-1", threadId: "t-1" } },
+          }),
+        },
+      },
+    } as any;
+
+    const { parseMessage } = await import("@/utils/gmail/message");
+
+    (parseMessage as Mock).mockReturnValueOnce({
+      id: "m-1",
+      threadId: "t-1",
+      labelIds: [GmailLabel.DRAFT],
+      snippet: "",
+      historyId: "1",
+      inline: [],
+      headers: { from: "a@test.com", to: "b@test.com", subject: "s", date: "" },
+      subject: "s",
+      date: "",
+    });
+
+    const result = await getDraft("r-1", gmail);
+    expect(result).not.toBeNull();
+    expect(result?.labelIds).toEqual([GmailLabel.DRAFT]);
+  });
+
+  it("deleteDraft skips drafts.delete when getDraft returns null", async () => {
+    const draftsDelete = vi.fn().mockResolvedValue({ status: 204 });
+    const gmail = {
+      users: {
+        drafts: {
+          get: vi.fn().mockResolvedValue({
+            data: { id: "r-1", message: { id: "m-1", threadId: "t-1" } },
+          }),
+          delete: draftsDelete,
+        },
+      },
+    } as any;
+
+    const { parseMessage } = await import("@/utils/gmail/message");
+    (parseMessage as Mock).mockReturnValueOnce({
+      id: "m-1",
+      threadId: "t-1",
+      labelIds: [GmailLabel.SENT],
+    });
+
+    await deleteDraft(gmail, "r-1");
+    expect(draftsDelete).not.toHaveBeenCalled();
+  });
+
+  it("deleteDraft calls drafts.delete when getDraft returns a real draft", async () => {
+    const draftsDelete = vi.fn().mockResolvedValue({ status: 204 });
+    const gmail = {
+      users: {
+        drafts: {
+          get: vi.fn().mockResolvedValue({
+            data: { id: "r-1", message: { id: "m-1", threadId: "t-1" } },
+          }),
+          delete: draftsDelete,
+        },
+      },
+    } as any;
+
+    const { parseMessage } = await import("@/utils/gmail/message");
+    (parseMessage as Mock).mockReturnValueOnce({
+      id: "m-1",
+      threadId: "t-1",
+      labelIds: [GmailLabel.DRAFT],
+      snippet: "",
+      historyId: "1",
+      inline: [],
+      headers: { from: "a@test.com", to: "b@test.com", subject: "s", date: "" },
+      subject: "s",
+      date: "",
+    });
+
+    await deleteDraft(gmail, "r-1");
+    expect(draftsDelete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# User description
Summary
- prevent the draft cleanup routine from deleting replies that have already been sent so they stay available in Gmail
- adjust the draft-tracking helpers/tests to ensure outbound replies are only cleaned up when expected
- reinforce the Gmail draft utilities/tests to cover the tighter cleanup behavior

Testing
- Not run (not requested)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevents the draft cleanup routine from inadvertently deleting sent replies by verifying the message labels before execution. Ensures that only messages explicitly marked as drafts and not sent are eligible for deletion within the Gmail utility functions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1480?tool=ast&topic=Draft+Testing>Draft Testing</a>
        </td><td>Adds comprehensive unit tests to validate that <code>getDraft</code> returns null for sent messages and that <code>deleteDraft</code> skips the deletion process when a draft is no longer valid.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/gmail/draft.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1480?tool=ast&topic=Draft+Cleanup+Logic>Draft Cleanup Logic</a>
        </td><td>Implements safety checks in <code>getDraft</code> and <code>deleteDraft</code> to verify that a message retains the <code>DRAFT</code> label and has not been moved to <code>SENT</code> before proceeding with cleanup.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/gmail/draft.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1480?tool=ast>(Baz)</a>.