### PR TITLE
Add basic UI for agent onboarding and tools

### DIFF
--- a/apps/web/app/(landing)/components/AgentToolsDemo.tsx
+++ b/apps/web/app/(landing)/components/AgentToolsDemo.tsx
@@ -11,6 +11,8 @@ import {
   EnableSendingTool,
 } from "@/components/agent-tools";
 
+const noop = () => {};
+
 const mockSearchResults = {
   query: "newsletter unsubscribe",
   results: [
@@ -196,7 +198,7 @@ export function AgentToolsDemo() {
         <DraftReplyTool
           input={{ emailId: "1", instructions: "Write a brief acknowledgment" }}
           output={mockDraftReply}
-          onViewDraft={(id) => console.log("View draft:", id)}
+          onViewDraft={noop}
         />
       </section>
 
@@ -204,11 +206,7 @@ export function AgentToolsDemo() {
         <h3 className="mb-3 font-medium text-muted-foreground">
           Send Reply (Action Required)
         </h3>
-        <SendReplyTool
-          input={mockSendReply}
-          onApprove={() => console.log("Approved")}
-          onDeny={() => console.log("Denied")}
-        />
+        <SendReplyTool input={mockSendReply} onApprove={noop} onDeny={noop} />
       </section>
 
       <section>
@@ -217,8 +215,8 @@ export function AgentToolsDemo() {
         </h3>
         <UpdateSettingsTool
           input={mockSettingsUpdate}
-          onConfirm={() => console.log("Settings confirmed")}
-          onCancel={() => console.log("Settings cancelled")}
+          onConfirm={noop}
+          onCancel={noop}
         />
       </section>
 
@@ -226,10 +224,7 @@ export function AgentToolsDemo() {
         <h3 className="mb-3 font-medium text-muted-foreground">
           Enable Sending (Action Required)
         </h3>
-        <EnableSendingTool
-          onEnable={() => console.log("Sending enabled")}
-          onSkip={() => console.log("Skipped")}
-        />
+        <EnableSendingTool onEnable={noop} onSkip={noop} />
       </section>
     </div>
   );

--- a/apps/web/utils/ai/agent/execution.test.ts
+++ b/apps/web/utils/ai/agent/execution.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createEmailProvider } from "@/utils/email/provider";
+import { applySettingsUpdate } from "@/utils/ai/agent/settings";
+import { createScopedLogger } from "@/utils/logger";
+import { approveAgentAction, denyAgentAction } from "./execution";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+vi.mock("@/utils/ai/agent/settings", () => ({
+  applySettingsUpdate: vi.fn(),
+}));
+vi.mock("@/utils/mail", () => ({
+  ensureEmailSendingEnabled: vi.fn(),
+}));
+
+const logger = createScopedLogger("test");
+vi.spyOn(logger, "with").mockReturnValue(logger);
+
+describe("agent execution approvals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(logger, "with").mockReturnValue(logger);
+  });
+
+  it("rejects approval when action was already claimed", async () => {
+    vi.mocked(prisma.executedAgentAction.findUnique).mockResolvedValue({
+      id: "approval-1",
+      status: "PENDING_APPROVAL",
+      actionData: { type: "updateSettings", settings: {} },
+      emailAccountId: "ea-1",
+      resourceId: null,
+      threadId: null,
+      emailAccount: {
+        userId: "user-1",
+        email: "user@example.com",
+        account: { provider: "gmail" },
+      },
+    } as any);
+    vi.mocked(prisma.executedAgentAction.updateMany).mockResolvedValue({
+      count: 0,
+    } as any);
+
+    const result = await approveAgentAction({
+      approvalId: "approval-1",
+      userId: "user-1",
+      logger,
+    });
+
+    expect(result).toEqual({ error: "Action is not pending approval" });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+    expect(prisma.executedAgentAction.update).not.toHaveBeenCalled();
+  });
+
+  it("claims pending approval before executing action", async () => {
+    vi.mocked(prisma.executedAgentAction.findUnique).mockResolvedValue({
+      id: "approval-1",
+      status: "PENDING_APPROVAL",
+      actionData: {
+        type: "updateSettings",
+        settings: { allowedActions: [{ actionType: "archive" }] },
+      },
+      emailAccountId: "ea-1",
+      resourceId: null,
+      threadId: null,
+      emailAccount: {
+        userId: "user-1",
+        email: "user@example.com",
+        account: { provider: "gmail" },
+      },
+    } as any);
+    vi.mocked(prisma.executedAgentAction.updateMany).mockResolvedValue({
+      count: 1,
+    } as any);
+    vi.mocked(createEmailProvider).mockResolvedValue({} as any);
+    vi.mocked(applySettingsUpdate).mockResolvedValue(undefined);
+    vi.mocked(prisma.executedAgentAction.update).mockResolvedValue({} as any);
+
+    const result = await approveAgentAction({
+      approvalId: "approval-1",
+      userId: "user-1",
+      logger,
+    });
+
+    expect(result).toEqual({ success: true, logId: "approval-1" });
+    expect(prisma.executedAgentAction.updateMany).toHaveBeenCalledWith({
+      where: { id: "approval-1", status: "PENDING_APPROVAL" },
+      data: {
+        status: "PENDING",
+      },
+    });
+    expect(applySettingsUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects deny when action is no longer pending approval", async () => {
+    vi.mocked(prisma.executedAgentAction.findUnique).mockResolvedValue({
+      id: "approval-1",
+      status: "PENDING_APPROVAL",
+      emailAccount: { userId: "user-1" },
+    } as any);
+    vi.mocked(prisma.executedAgentAction.updateMany).mockResolvedValue({
+      count: 0,
+    } as any);
+
+    const result = await denyAgentAction({
+      approvalId: "approval-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ error: "Action is not pending approval" });
+  });
+
+  it("denies action atomically", async () => {
+    vi.mocked(prisma.executedAgentAction.findUnique).mockResolvedValue({
+      id: "approval-1",
+      status: "PENDING_APPROVAL",
+      emailAccount: { userId: "user-1" },
+    } as any);
+    vi.mocked(prisma.executedAgentAction.updateMany).mockResolvedValue({
+      count: 1,
+    } as any);
+
+    const result = await denyAgentAction({
+      approvalId: "approval-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.executedAgentAction.updateMany).toHaveBeenCalledWith({
+      where: { id: "approval-1", status: "PENDING_APPROVAL" },
+      data: {
+        status: "CANCELLED",
+        triggeredBy: "user:user-1:denied",
+      },
+    });
+  });
+});

--- a/apps/web/utils/ai/agent/process-email.test.ts
+++ b/apps/web/utils/ai/agent/process-email.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runAgentOnIncomingEmail } from "./process-email";
+import type { ParsedMessage } from "@/utils/types";
+import { buildAgentSystemPrompt } from "@/utils/ai/agent/context";
+import { createAgentTools } from "@/utils/ai/agent/agent";
+import { createExecuteAction } from "@/utils/ai/agent/execution";
+import { getAgentSystemData } from "@/utils/ai/agent/system-data";
+import { getModel } from "@/utils/llms/model";
+import { stringifyEmail } from "@/utils/stringify-email";
+import { getEmailForLLM } from "@/utils/get-email-from-message";
+import { createScopedLogger } from "@/utils/logger";
+
+vi.mock("ai", () => ({
+  ToolLoopAgent: class {
+    generate = vi.fn().mockResolvedValue(undefined);
+  },
+  stepCountIs: vi.fn(() => "stop"),
+}));
+
+vi.mock("@/utils/ai/agent/context", () => ({
+  buildAgentSystemPrompt: vi.fn(),
+}));
+vi.mock("@/utils/ai/agent/agent", () => ({
+  createAgentTools: vi.fn(),
+}));
+vi.mock("@/utils/ai/agent/execution", () => ({
+  createExecuteAction: vi.fn(),
+}));
+vi.mock("@/utils/ai/agent/system-data", () => ({
+  getAgentSystemData: vi.fn(),
+}));
+vi.mock("@/utils/llms/model", () => ({
+  getModel: vi.fn(),
+}));
+vi.mock("@/utils/usage", () => ({
+  saveAiUsage: vi.fn(),
+}));
+vi.mock("@/utils/stringify-email", () => ({
+  stringifyEmail: vi.fn(),
+}));
+vi.mock("@/utils/get-email-from-message", () => ({
+  getEmailForLLM: vi.fn(),
+}));
+
+const logger = createScopedLogger("test");
+vi.spyOn(logger, "with").mockReturnValue(logger);
+
+describe("runAgentOnIncomingEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(logger, "with").mockReturnValue(logger);
+    vi.mocked(getAgentSystemData).mockResolvedValue({
+      allowedActions: [],
+      allowedActionOptions: [],
+      skills: [],
+    });
+    vi.mocked(buildAgentSystemPrompt).mockResolvedValue("system");
+    vi.mocked(getModel).mockReturnValue({
+      model: {} as any,
+      modelName: "chat-model",
+      provider: "openai",
+      providerOptions: {},
+      backupModel: null,
+    });
+    vi.mocked(createExecuteAction).mockReturnValue(vi.fn() as any);
+    vi.mocked(createAgentTools).mockReturnValue({} as any);
+    vi.mocked(getEmailForLLM).mockReturnValue({} as any);
+    vi.mocked(stringifyEmail).mockReturnValue("email prompt");
+  });
+
+  it("passes email context to processing_email tools", async () => {
+    const message = {
+      id: "msg-1",
+      threadId: "thread-1",
+    } as ParsedMessage;
+
+    await runAgentOnIncomingEmail({
+      emailAccount: {
+        id: "ea-1",
+        email: "user@example.com",
+        user: {
+          aiProvider: null,
+          aiModel: null,
+          aiApiKey: null,
+        },
+        account: { provider: "gmail" },
+      } as any,
+      message,
+      logger,
+    });
+
+    expect(createAgentTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "processing_email",
+        emailId: "msg-1",
+        threadId: "thread-1",
+      }),
+    );
+  });
+});

--- a/apps/web/utils/ai/agent/process-email.ts
+++ b/apps/web/utils/ai/agent/process-email.ts
@@ -45,6 +45,8 @@ export async function runAgentOnIncomingEmail({
     logger,
     executeAction,
     mode: "processing_email",
+    emailId: message.id,
+    threadId: message.threadId,
   });
 
   const emailPrompt = stringifyEmail(

--- a/apps/web/utils/ai/agent/settings.test.ts
+++ b/apps/web/utils/ai/agent/settings.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { applySettingsUpdate } from "./settings";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+describe("applySettingsUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts allowed action deterministically for null resourceType", async () => {
+    vi.mocked(prisma.allowedAction.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.allowedAction.create).mockResolvedValue({
+      id: "action-1",
+    } as any);
+    vi.mocked(prisma.allowedAction.deleteMany).mockResolvedValue({
+      count: 0,
+    } as any);
+
+    await applySettingsUpdate({
+      emailAccountId: "ea-1",
+      payload: {
+        allowedActions: [
+          {
+            actionType: "archive",
+            resourceType: null,
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    expect(prisma.allowedAction.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "ea-1",
+        actionType: "archive",
+        resourceType: null,
+      },
+      select: { id: true },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+    });
+    expect(prisma.allowedAction.create).toHaveBeenCalledWith({
+      data: {
+        emailAccountId: "ea-1",
+        actionType: "archive",
+        resourceType: null,
+        enabled: true,
+        config: undefined,
+        conditions: undefined,
+      },
+    });
+    expect(prisma.allowedAction.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "ea-1",
+        actionType: "archive",
+        resourceType: null,
+        NOT: { id: "action-1" },
+      },
+    });
+  });
+
+  it("updates existing allowed action instead of creating duplicates", async () => {
+    vi.mocked(prisma.allowedAction.findFirst).mockResolvedValue({
+      id: "action-existing",
+    } as any);
+    vi.mocked(prisma.allowedAction.update).mockResolvedValue({
+      id: "action-existing",
+    } as any);
+    vi.mocked(prisma.allowedAction.deleteMany).mockResolvedValue({
+      count: 0,
+    } as any);
+
+    await applySettingsUpdate({
+      emailAccountId: "ea-1",
+      payload: {
+        allowedActions: [{ actionType: "archive", resourceType: null }],
+      },
+    });
+
+    expect(prisma.allowedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-existing" },
+      data: {
+        enabled: true,
+        config: undefined,
+        conditions: undefined,
+      },
+    });
+    expect(prisma.allowedAction.create).not.toHaveBeenCalled();
+  });
+
+  it("upserts allowed action options with null externalId deterministically", async () => {
+    vi.mocked(prisma.allowedActionOption.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.allowedActionOption.create).mockResolvedValue({
+      id: "opt-1",
+    } as any);
+    vi.mocked(prisma.allowedActionOption.deleteMany).mockResolvedValue({
+      count: 0,
+    } as any);
+
+    await applySettingsUpdate({
+      emailAccountId: "ea-1",
+      payload: {
+        allowedActionOptions: [
+          {
+            actionType: "classify",
+            resourceType: null,
+            provider: "gmail",
+            kind: "label",
+            name: "Newsletter",
+          },
+        ],
+      },
+    });
+
+    expect(prisma.allowedActionOption.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "ea-1",
+        actionType: "classify",
+        resourceType: null,
+        provider: "gmail",
+        kind: "label",
+        name: "Newsletter",
+        externalId: null,
+      },
+      select: { id: true },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+    });
+    expect(prisma.allowedActionOption.create).toHaveBeenCalledWith({
+      data: {
+        emailAccountId: "ea-1",
+        actionType: "classify",
+        resourceType: null,
+        provider: "gmail",
+        kind: "label",
+        name: "Newsletter",
+        externalId: null,
+        targetGroupId: null,
+      },
+    });
+    expect(prisma.allowedActionOption.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "ea-1",
+        actionType: "classify",
+        resourceType: null,
+        provider: "gmail",
+        kind: "label",
+        name: "Newsletter",
+        externalId: null,
+        NOT: { id: "opt-1" },
+      },
+    });
+  });
+});

--- a/apps/web/utils/ai/agent/tools/bulk.test.ts
+++ b/apps/web/utils/ai/agent/tools/bulk.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createEmailProvider } from "@/utils/email/provider";
+import { validateAction } from "@/utils/ai/agent/validation/allowed-actions";
+import { createScopedLogger } from "@/utils/logger";
+import { bulkArchiveTool } from "./bulk";
+
+vi.mock("server-only", () => ({}));
+vi.mock("ai", () => ({
+  tool: (definition: any) => definition,
+}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+vi.mock("@/utils/ai/agent/validation/allowed-actions", () => ({
+  validateAction: vi.fn(),
+}));
+
+const logger = createScopedLogger("test");
+vi.spyOn(logger, "with").mockReturnValue(logger);
+
+describe("bulkArchiveTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(logger, "with").mockReturnValue(logger);
+  });
+
+  it("blocks when archive action is not allowed", async () => {
+    vi.mocked(validateAction).mockResolvedValue({
+      allowed: false,
+      reason: 'Action type "archive" not enabled',
+      conditionsChecked: [],
+    });
+    vi.mocked(prisma.executedAgentAction.create).mockResolvedValue({
+      id: "log-blocked",
+    } as any);
+
+    const tool = bulkArchiveTool({
+      emailAccountId: "ea-1",
+      emailAccountEmail: "user@example.com",
+      provider: "gmail",
+      resourceType: "email",
+      logger,
+    } as any);
+    const result = await tool.execute({ senders: ["news@example.com"] });
+
+    expect(result).toEqual({
+      archived: 0,
+      senders: 1,
+      blocked: true,
+      reason: 'Action type "archive" not enabled',
+      logId: "log-blocked",
+    });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("logs and executes bulk archive when allowed", async () => {
+    vi.mocked(validateAction).mockResolvedValue({
+      allowed: true,
+      conditionsChecked: [],
+    } as any);
+    vi.mocked(prisma.executedAgentAction.create).mockResolvedValue({
+      id: "log-success",
+    } as any);
+    vi.mocked(prisma.executedAgentAction.update).mockResolvedValue({} as any);
+
+    const bulkArchiveFromSenders = vi.fn().mockResolvedValue({
+      totalArchived: 12,
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      bulkArchiveFromSenders,
+    } as any);
+
+    const tool = bulkArchiveTool({
+      emailAccountId: "ea-1",
+      emailAccountEmail: "user@example.com",
+      provider: "gmail",
+      resourceType: "email",
+      logger,
+    } as any);
+    const result = await tool.execute({
+      senders: ["a@example.com", "b@example.com"],
+    });
+
+    expect(result).toEqual({
+      archived: 12,
+      senders: 2,
+      logId: "log-success",
+    });
+    expect(prisma.executedAgentAction.update).toHaveBeenCalledWith({
+      where: { id: "log-success" },
+      data: { status: "SUCCESS" },
+    });
+  });
+});

--- a/apps/web/utils/ai/agent/tools/bulk.ts
+++ b/apps/web/utils/ai/agent/tools/bulk.ts
@@ -1,7 +1,12 @@
 import { tool, type InferUITool } from "ai";
 import { z } from "zod";
 import { createEmailProvider } from "@/utils/email/provider";
-import type { AgentToolContext } from "@/utils/ai/agent/types";
+import prisma from "@/utils/prisma";
+import { validateAction } from "@/utils/ai/agent/validation/allowed-actions";
+import type {
+  AgentToolContext,
+  StructuredAction,
+} from "@/utils/ai/agent/types";
 
 const bulkArchiveSchema = z.object({
   senders: z
@@ -16,6 +21,7 @@ export const bulkArchiveTool = ({
   emailAccountEmail,
   provider,
   logger,
+  dryRun,
 }: AgentToolContext) =>
   tool({
     description:
@@ -27,23 +33,113 @@ export const bulkArchiveTool = ({
         senderCount: senders.length,
       });
 
+      const action: StructuredAction = {
+        type: "archive",
+        resourceId: "bulk-archive",
+      };
+      const validation = await validateAction({
+        action,
+        context: {
+          emailAccountId,
+          provider,
+          resourceType: "email",
+          triggeredBy: "ai:decision:bulk-archive",
+          dryRun,
+        },
+        logger: log,
+      });
+
+      if (!validation.allowed) {
+        const blocked = await prisma.executedAgentAction.create({
+          data: {
+            actionType: "archive",
+            actionData: {
+              type: "archive",
+              mode: "bulkArchiveFromSenders",
+              senders,
+            },
+            status: "BLOCKED",
+            error: validation.reason ?? 'Action type "archive" not enabled',
+            triggeredBy: "ai:decision:bulk-archive",
+            matchMetadata: {
+              conditionsChecked: validation.conditionsChecked,
+              senderCount: senders.length,
+            },
+            emailAccountId,
+          },
+        });
+
+        return {
+          archived: 0,
+          senders: senders.length,
+          blocked: true,
+          reason: validation.reason,
+          logId: blocked.id,
+        };
+      }
+
+      if (dryRun) {
+        return {
+          archived: 0,
+          senders: senders.length,
+          dryRun: true,
+        };
+      }
+
+      const actionLog = await prisma.executedAgentAction.create({
+        data: {
+          actionType: "archive",
+          actionData: {
+            type: "archive",
+            mode: "bulkArchiveFromSenders",
+            senders,
+          },
+          status: "PENDING",
+          triggeredBy: "ai:decision:bulk-archive",
+          matchMetadata: {
+            conditionsChecked: validation.conditionsChecked,
+            senderCount: senders.length,
+          },
+          emailAccountId,
+        },
+      });
+
       const emailProvider = await createEmailProvider({
         emailAccountId,
         provider,
         logger,
       });
 
-      const result = await emailProvider.bulkArchiveFromSenders(
-        senders,
-        emailAccountEmail,
-      );
+      try {
+        const result = await emailProvider.bulkArchiveFromSenders(
+          senders,
+          emailAccountEmail,
+        );
 
-      log.info("Bulk archive complete", { result });
+        await prisma.executedAgentAction.update({
+          where: { id: actionLog.id },
+          data: { status: "SUCCESS" },
+        });
 
-      return {
-        archived: result.totalArchived,
-        senders: senders.length,
-      };
+        log.info("Bulk archive complete", { result });
+
+        return {
+          archived: result.totalArchived,
+          senders: senders.length,
+          logId: actionLog.id,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await prisma.executedAgentAction.update({
+          where: { id: actionLog.id },
+          data: {
+            status: "FAILED",
+            error: message,
+          },
+        });
+
+        throw error;
+      }
     },
   });
 

--- a/apps/web/utils/ai/agent/validation/allowed-actions.ts
+++ b/apps/web/utils/ai/agent/validation/allowed-actions.ts
@@ -118,6 +118,7 @@ export async function validateAction({
         ],
       },
       include: { targetGroup: true },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
     });
 
     if (!target) {
@@ -177,6 +178,7 @@ async function getAllowedAction({
       actionType,
       OR: [{ resourceType }, { resourceType: null }],
     },
+    orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
   });
 
   return (
@@ -198,6 +200,7 @@ async function getProviderTargetGroupValue({
 
   const options = await prisma.allowedActionOption.findMany({
     where: { emailAccountId, targetGroupId },
+    orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
   });
 
   const currentLabels = message.labelIds ?? [];


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
bulkArchiveTool_("bulkArchiveTool"):::modified
validateAction_("validateAction"):::modified
EXECUTED_AGENT_ACTION_("EXECUTED_AGENT_ACTION"):::modified
EMAIL_PROVIDER_("EMAIL_PROVIDER"):::modified
transitionPendingApproval_("transitionPendingApproval"):::added
approveAgentAction_("approveAgentAction"):::modified
denyAgentAction_("denyAgentAction"):::modified
bulkArchiveTool_ -- "Now validates bulk archive via validateAction with action context." --> validateAction_
bulkArchiveTool_ -- "Logs BLOCKED/PENDING and updates SUCCESS/FAILED with sender metadata." --> EXECUTED_AGENT_ACTION_
bulkArchiveTool_ -- "Invokes emailProvider.bulkArchiveFromSenders and records result status." --> EMAIL_PROVIDER_
transitionPendingApproval_ -- "Updates PENDING_APPROVAL rows to nextStatus, sets triggeredBy metadata." --> EXECUTED_AGENT_ACTION_
approveAgentAction_ -- "Claims pending approval by calling transitionPendingApproval before execution." --> transitionPendingApproval_
approveAgentAction_ -- "Updates approval log to SUCCESS/FAILED and annotates triggeredBy." --> EXECUTED_AGENT_ACTION_
denyAgentAction_ -- "Cancels pending approval via transitionPendingApproval, sets triggeredBy." --> transitionPendingApproval_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the agent's action execution and settings management by implementing atomic state transitions for approvals and denials, and refactoring upsert logic for allowed actions and options to ensure data consistency. Integrates robust validation and logging for agent-initiated bulk actions, while also improving the context provided to agent tools during email processing.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast&topic=Atomic+Action+Execution>Atomic Action Execution</a>
        </td><td>Refactor <code>approveAgentAction</code> and <code>denyAgentAction</code> to utilize a new <code>transitionPendingApproval</code> helper, ensuring atomic state transitions for agent actions from <code>PENDING_APPROVAL</code> to <code>PENDING</code> or <code>CANCELLED</code>. This prevents race conditions and ensures actions are processed only when in the correct state.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/agent/execution.test.ts</li>
<li>apps/web/utils/ai/agent/execution.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast&topic=Deterministic+Settings+Upsert>Deterministic Settings Upsert</a>
        </td><td>Implement a deterministic upsert pattern for <code>allowedAction</code> and <code>allowedActionOption</code> records in <code>applySettingsUpdate</code>, replacing Prisma's <code>upsert</code> to prevent duplicate entries and ensure consistent data management. This includes adding <code>orderBy</code> clauses for reliable <code>findFirst</code> operations and new unit tests to validate the deterministic behavior.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/ai/agent/settings.test.ts</li>
<li>apps/web/utils/ai/agent/settings.ts</li>
<li>apps/web/utils/ai/agent/validation/allowed-actions.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast&topic=Demo+UI+Cleanup>Demo UI Cleanup</a>
        </td><td>Clean up the <code>AgentToolsDemo</code> component by replacing <code>console.log</code> calls with a <code>noop</code> function for various tool callbacks. This removes side effects from the demo UI, making it purely presentational.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(landing)/components/AgentToolsDemo.tsx</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast&topic=Bulk+Action+Validation+%26+Logging>Bulk Action Validation & Logging</a>
        </td><td>Integrate <code>validateAction</code> into <code>bulkArchiveTool</code> to enforce permission checks before executing bulk archive operations, and enhance logging by persisting <code>BLOCKED</code>, <code>PENDING</code>, <code>SUCCESS</code>, and <code>FAILED</code> states of bulk actions in the database. This ensures that agent-initiated bulk actions are properly authorized and their lifecycle is fully auditable.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/agent/tools/bulk.test.ts</li>
<li>apps/web/utils/ai/agent/tools/bulk.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast&topic=Agent+Email+Context>Agent Email Context</a>
        </td><td>Pass <code>emailId</code> and <code>threadId</code> to <code>createAgentTools</code> when <code>runAgentOnIncomingEmail</code> is invoked, ensuring that agent tools have the necessary context for processing emails. This change is supported by new unit tests verifying the correct context propagation.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/agent/process-email.test.ts</li>
<li>apps/web/utils/ai/agent/process-email.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1482?tool=ast>(Baz)</a>.