### PR TITLE
qa: Add follow-up flow specs and companion markdown summary

### DIFF
--- a/.claude/commands/qa-run.md
+++ b/.claude/commands/qa-run.md
@@ -23,12 +23,14 @@ Process:
 6. Record evidence. Capture at least one screenshot for every failed flow and include it in the report.
 7. Write the JSON report to `qa/browser-flows/results/<run-id>.json` and save screenshots under
    `qa/browser-flows/results/<run-id>/`.
-8. Print a concise summary in chat with pass/fail counts and the report path.
+8. Write a companion Markdown summary to `qa/browser-flows/results/<run-id>.md` following the template in the README.
+9. Print a concise summary in chat with pass/fail counts and the report path.
 
 Output rules:
 - Use the JSON schema described in `qa/browser-flows/README.md`.
 - Keep reports free of secrets. Use placeholders for sensitive values.
 - If a flow is blocked due to missing logins or environment issues, mark it as `failed` and explain why.
+- If a flow fails, specify which step failed and add the reason for failing.
 
 Behavior rules:
 - Do not invent steps. Follow each flow spec exactly.

--- a/qa/browser-flows/README.md
+++ b/qa/browser-flows/README.md
@@ -105,3 +105,41 @@ Claude Code should write a JSON report to `qa/browser-flows/results/<run-id>.jso
 ```
 
 Keep results free of secrets. Use placeholders for sensitive values.
+
+### Companion summary
+
+In addition to the JSON report, write a human-readable Markdown summary to
+`qa/browser-flows/results/<run-id>.md`.
+
+**Template:**
+
+````markdown
+# QA Run `<run-id>`
+
+**Mode:** `<mode>` | **Parallel:** `<yes/no>` | **Duration:** `<HH:MM:SS>`
+
+## <flow-title> — <STATUS>
+
+| Check | Result |
+|---|---|
+| <description of what was verified> | PASSED |
+| <description of what was verified> | FAILED — <short explanation> |
+
+**Failure reason:** <one-liner, only for failed flows>
+
+---
+
+## Summary
+
+| Passed | Failed | Skipped |
+|---|---|---|
+| N | N | N |
+
+**Report:** `qa/browser-flows/results/<run-id>.json`
+**Screenshots:** `qa/browser-flows/results/<run-id>/`
+````
+
+Rules for the checks table:
+- One row per verifiable assertion in the flow (settings saved, email sent, label applied, draft generated, etc.).
+- Use `PASSED` or `FAILED — <short reason>` in the Result column.
+- Keep descriptions concise (under ~80 chars).

--- a/qa/browser-flows/follow-up-gmail.md
+++ b/qa/browser-flows/follow-up-gmail.md
@@ -1,0 +1,62 @@
+---
+id: follow-up-gmail
+title: "Follow-ups in Gmail account"
+resources:
+  - conversation-rules
+  - gmail-account
+  - outlook-account
+---
+
+## Goal
+
+Verify that emails are correctly marked as follow-up and that follow-up drafts are generated for sent emails.
+
+## Preconditions
+
+- Signed into Inbox Zero as a test account.
+- Signed into Gmail test account in another tab.
+- Signed into Outlook test account in another tab.
+- Inbox Zero is connected to both Gmail and Outlook.
+
+## Steps
+
+1. In Inbox Zero, assign the Gmail test account in the upper-left user selector. 
+2. Open the Assistant page.
+3. Navigate to the Settings tab. 
+4. Find "Follow-up reminders" and verify if it's enabled. If not, toggle it on. 
+5. Click "Configure" next to "Follow up reminders". 
+6. Configure both options ("Remind me when they haven't replied after" and "Remind me when I haven't replied after") to "0.01 days"
+7. Find the "auto-generate drafts" option and verify if it's enabled. If not, toggle it on. 
+8. Click "Save." and confirm the settings are saved (a green confirmation toast appears at the bottom right)
+9. In Outlook (outlook.com), compose a new email to the Gmail test account (type the gmail address directly in the "To" field. Do not click the "TO" text).
+10. Use a subject/body that clearly needs a reply (for example: "Quick question" and "Movie preferences" - DO NOT use subject/body that request calendar availability).
+11. Send the email.
+12. In Gmail (mail.google.com), wait for the message to arrive in the inbox.
+13. In Gmail (mail.google.com), compose a new email to the Outlook test account.
+14. Use a subject/body that clearly needs a reply (for example: "Quick question" and "Movie preferences" - DO NOT use subject/body that request calendar availability).
+15. Send the email.
+16. Wait about 15 minutes.
+17. In Gmail, verify in the inbox that the email received from Outlook test account has the "Follow-up" label
+18. Verify that the received email does not have a follow-up draft.
+19. Switch to "Sent" folder and verify that the email sent to the Outlook test account has the "Follow-up" label
+20. Open the sent message (or inspect the conversation list) and confirm a follow-up draft exists for the thread.
+21. Verify that the draft email body talks about a follow-up to the previously sent email. 
+
+## Expected results
+
+- The "Follow Up" rule is enabled and configured in Inbox Zero.
+- The "Follow-up" rule is applied to both sent and received emails within the time frame configured in Inbox Zero.
+- A follow-up draft is generated for sent emails. 
+- A follow-up draft is not generated for received emails. 
+
+## Failure indicators
+
+- The Follow-up rule cannot be enabled or does not remain enabled after saving.
+- The follow-up rule is not applied to the emails after the configured time frame is up.
+- A follow-up draft is not generated for sent emails after the follow-up rule is applied.
+- A follow-up draft is generated for received emails after the follow-up rule is applied. 
+
+## Cleanup
+
+- Undo all changes made to the InboxZero account after the test is completed. 
+- close all tabs used for the test.

--- a/qa/browser-flows/follow-up-outlook.md
+++ b/qa/browser-flows/follow-up-outlook.md
@@ -1,0 +1,62 @@
+---
+id: follow-up-outlook
+title: "Follow-ups in Outlook account"
+resources:
+  - conversation-rules
+  - gmail-account
+  - outlook-account
+---
+
+## Goal
+
+Verify that emails are correctly marked as follow-up and that follow-up drafts are generated for sent emails.
+
+## Preconditions
+
+- Signed into Inbox Zero as a test account.
+- Signed into Gmail test account in another tab.
+- Signed into Outlook test account in another tab.
+- Inbox Zero is connected to both Gmail and Outlook.
+
+## Steps
+
+1. In Inbox Zero, assign the Outlook test account in the upper-left user selector.
+2. Open the Assistant page.
+3. Navigate to the Settings tab.
+4. Find "Follow-up reminders" and verify if it's enabled. If not, toggle it on.
+5. Click "Configure" next to "Follow up reminders".
+6. Configure both options ("Remind me when they haven't replied after" and "Remind me when I haven't replied after") to "0.01 days"
+7. Find the "auto-generate drafts" option and verify if it's enabled. If not, toggle it on.
+8. Click "Save." and confirm the settings are saved (a green confirmation toast appears at the bottom right)
+9. In Gmail (mail.google.com), compose a new email to the Outlook test account.
+10. Use a subject/body that clearly needs a reply (for example: "Quick question" and "Movie preferences" - DO NOT use subject/body that request calendar availability).
+11. Send the email.
+12. In Outlook (outlook.com), wait for the message to arrive in the inbox.
+13. In Outlook (outlook.com), compose a new email to the Gmail test account (type the gmail address directly in the "To" field. Do not click the "TO" text).
+14. Use a subject/body that clearly needs a reply (for example: "Quick question" and "Movie preferences" - DO NOT use subject/body that request calendar availability).
+15. Send the email.
+16. Wait about 15 minutes.
+17. In Outlook, verify in the inbox that the email received from Gmail test account has the "Follow-up" category.
+18. Verify that the received email does not have a follow-up draft.
+19. Switch to "Sent Items" folder and verify that the email sent to the Gmail test account has the "Follow-up" category.
+20. Open the sent message (or inspect the conversation list) and confirm a follow-up draft exists for the thread.
+21. Verify that the draft email body talks about a follow-up to the previously sent email.
+
+## Expected results
+
+- The "Follow Up" rule is enabled and configured in Inbox Zero.
+- The "Follow-up" rule is applied to both sent and received emails within the time frame configured in Inbox Zero.
+- A follow-up draft is generated for sent emails.
+- A follow-up draft is not generated for received emails.
+
+## Failure indicators
+
+- The Follow-up rule cannot be enabled or does not remain enabled after saving.
+- The follow-up rule is not applied to the emails after the configured time frame is up.
+- A follow-up draft is not generated for sent emails after the follow-up rule is applied.
+- A follow-up draft is generated for received emails after the follow-up rule is applied.
+
+## Cleanup
+
+- Undo all changes made to the InboxZero account after the test is completed.
+- close all tabs used for the test.


### PR DESCRIPTION
Add Gmail and Outlook follow-up QA flow specs that verify follow-up labels and auto-generated drafts. 
Update the qa-run command and README to produce a human-readable .md summary alongside the JSON report.