### PR TITLE
Simplify draft cleanup result messaging

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/CleanupDraftsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/CleanupDraftsSection.tsx
@@ -22,8 +22,13 @@ export function CleanupDraftsSection() {
       onSuccess: (res) => {
         if (res.data) {
           setResult(res.data);
-          if (res.data.deleted === 0) {
+          if (res.data.deleted === 0 && res.data.skippedModified === 0) {
             toastSuccess({ description: "No stale drafts found." });
+          } else if (res.data.deleted === 0) {
+            toastSuccess({
+              description:
+                "All stale drafts were edited by you, so none were removed.",
+            });
           } else {
             toastSuccess({
               description: `Cleaned up ${res.data.deleted} draft${res.data.deleted === 1 ? "" : "s"}.`,
@@ -57,8 +62,8 @@ export function CleanupDraftsSection() {
           {result && result.deleted > 0 && result.skippedModified > 0 && (
             <p className="text-muted-foreground text-xs">
               {result.skippedModified} draft
-              {result.skippedModified === 1 ? " was" : "s were"} kept because you
-              edited {result.skippedModified === 1 ? "it" : "them"}
+              {result.skippedModified === 1 ? " was" : "s were"} kept because
+              you edited {result.skippedModified === 1 ? "it" : "them"}
             </p>
           )}
         </div>


### PR DESCRIPTION
# User description
## Summary

- Only show toast with number of deleted drafts (or "No stale drafts found")
- Only mention user-edited drafts when relevant (some were deleted AND some were skipped)
- Remove internal details (already-gone counts, error counts) from the UI

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refines the draft cleanup feedback logic in the <code>CleanupDraftsSection</code> component to provide clearer, more user-centric messaging. Simplifies the displayed results by focusing on deleted and skipped drafts while hiding internal counters like errors and already-gone items.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-self-service-draft...</td><td>February 06, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1490?tool=ast>(Baz)</a>.