### PR TITLE
Keep onboarding select inline

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingCategories.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingCategories.tsx
@@ -219,12 +219,12 @@ function CategoryCard({
 }) {
   return (
     <Card>
-      <CardContent className="flex flex-col sm:flex-row sm:items-center gap-4 p-4">
-        <div className="flex items-center gap-2">
+      <CardContent className="flex items-center gap-4 p-4">
+        <div className="flex flex-1 min-w-0 items-center gap-2">
           <IconCircle size="sm" color={iconColor} Icon={Icon} />
           <div>
             {useTooltip ? (
-              <div className="flex flex-1 items-center gap-2 text-sm sm:text-base">
+              <div className="flex flex-1 min-w-0 items-center gap-2 text-sm sm:text-base">
                 {label}
                 {description && (
                   <TooltipExplanation
@@ -242,7 +242,7 @@ function CategoryCard({
           </div>
         </div>
 
-        <div className="sm:ml-auto flex items-center gap-4">
+        <div className="ml-auto flex shrink-0 items-center gap-4">
           <Select
             value={value || undefined}
             onValueChange={(value) => {


### PR DESCRIPTION
# User description
Keeps the onboarding category action select aligned inline on small screens. Adjusts layout flex behavior to match desktop.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>CategoryCard</code> layout in the onboarding flow to maintain an inline horizontal alignment for category actions across all screen sizes. Refines flexbox properties on the card content and action container to ensure proper spacing and prevent text truncation issues.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Refresh-onboarding-flo...</td><td>February 03, 2026</td></tr>
<tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1491?tool=ast>(Baz)</a>.