### PR TITLE
Remove private VPC import from AWS setup

### DIFF
--- a/docs/hosting/aws-copilot.md
+++ b/docs/hosting/aws-copilot.md
@@ -20,15 +20,6 @@ The CLI automates Copilot setup, addons (RDS + ElastiCache), secrets, and deploy
 pnpm setup-aws
 ```
 
-Useful flags (existing VPC import):
-```bash
-pnpm setup-aws -- \
-  --import-vpc-id vpc-1234567890abcdef \
-  --import-public-subnets subnet-aaa,subnet-bbb \
-  --import-private-subnets subnet-ccc,subnet-ddd \
-  --import-cert-arns arn:aws:acm:us-east-1:123456789012:certificate/abcd-efgh
-```
-
 Non-interactive mode:
 ```bash
 pnpm setup-aws -- --yes
@@ -86,29 +77,7 @@ copilot env init --name production
 
 This will prompt you for:
 - AWS profile/region (if not already configured)
-- Whether to create a new VPC or use an existing one
 - Other infrastructure options
-
-#### Using an Existing VPC
-
-Copilot can import an existing VPC during `env init`. You’ll need the VPC ID plus
-public/private subnet IDs:
-
-```bash
-copilot env init --name production \
-  --import-vpc-id vpc-1234567890abcdef \
-  --import-public-subnets subnet-aaa,subnet-bbb \
-  --import-private-subnets subnet-ccc,subnet-ddd
-```
-
-Requirements:
-- At least 2 public subnets and 2 private subnets across different AZs
-- Public subnets routed to an Internet Gateway
-- Private subnets routed through a NAT Gateway
-
-Notes:
-- Copilot will create its own ALB and security groups
-- Addons read `PrivateSubnets` from `copilot/environments/addons/addons.parameters.yml`
 
 ### 4. Initialize the Service
 
@@ -449,4 +418,3 @@ aws logs tail /aws/apigateway/inbox-zero-app-production-webhook-api --follow
 - [Copilot Manifest Reference](https://aws.github.io/copilot-cli/docs/manifest/overview/)
 - [Self-Hosting Guide](./self-hosting.md) - For local Docker setup
 - [Google Pub/Sub Push Authentication](https://cloud.google.com/pubsub/docs/authenticate-push-subscriptions)
-

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -125,16 +125,6 @@ async function main() {
     .option("--profile <profile>", "AWS CLI profile to use")
     .option("--region <region>", "AWS region")
     .option("--environment <env>", "Environment name (e.g., production)")
-    .option("--import-vpc-id <id>", "Use an existing VPC ID")
-    .option(
-      "--import-public-subnets <ids>",
-      "Comma-separated public subnet IDs",
-    )
-    .option(
-      "--import-private-subnets <ids>",
-      "Comma-separated private subnet IDs",
-    )
-    .option("--import-cert-arns <arns>", "Comma-separated ACM certificate ARNs")
     .option("-y, --yes", "Non-interactive mode with defaults")
     .action(runAwsSetup);
 


### PR DESCRIPTION
# User description
This change removes support for importing an existing private VPC in the AWS setup flow. It removes the related CLI flags and interactive prompts from setup-aws. Copilot environment initialization now always uses default configuration, and the AWS Copilot guide has been updated to match. Terraform setup remains unchanged.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
main_("main"):::modified
runAwsSetup_("runAwsSetup"):::modified
initCopilotEnv_("initCopilotEnv"):::modified
COPILOT_CLI_("COPILOT_CLI"):::modified
main_ -- "Removed VPC import flags; added non-interactive and basic options" --> runAwsSetup_
runAwsSetup_ -- "Always initializes environment with default config; drops VPC import" --> initCopilotEnv_
initCopilotEnv_ -- "Invokes 'copilot env init --default-config' without VPC args" --> COPILOT_CLI_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Removes support for importing existing private VPCs during the AWS setup flow to simplify environment initialization. Updates the CLI and internal logic to always use default Copilot-managed configurations.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1496?tool=ast&topic=CLI+and+Logic>CLI and Logic</a>
        </td><td>Remove VPC import flags, interactive prompts, and the <code>VpcImportConfig</code> interface from the AWS setup logic.<details><summary>Modified files (2)</summary><ul><li>packages/cli/src/main.ts</li>
<li>packages/cli/src/setup-aws.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>cli-harden-terraform-g...</td><td>January 31, 2026</td></tr>
<tr><td>mpetty@patternzones.com</td><td>fix-correct-Anthropic-...</td><td>December 16, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1496?tool=ast&topic=Documentation>Documentation</a>
        </td><td>Update the AWS Copilot hosting guide to remove instructions and examples related to existing VPC imports.<details><summary>Modified files (1)</summary><ul><li>docs/hosting/aws-copilot.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>cli-add-terraform-depl...</td><td>January 31, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Copilot-deployment-ins...</td><td>November 25, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1496?tool=ast>(Baz)</a>.