### PR TITLE
Remove redundant text from drive folder settings UI

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
@@ -218,9 +218,6 @@ function AllowedFoldersContent({
                 triggerClassName="text-muted-foreground hover:text-foreground"
               />
             </div>
-            <p className="mt-2 text-xs text-muted-foreground">
-              We'll only ever put files in folders you select
-            </p>
           </>
         ) : (
           <NoFoldersFound


### PR DESCRIPTION
# User description
The card header already communicates that only selected folders can be used. Removed the duplicate reassurance text that appeared below the add folder button.

This simplifies the UI by eliminating the redundant message.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplifies the drive folder settings UI by removing redundant reassurance text from the <code>AllowedFolders</code> component. Ensures a cleaner interface by relying on the existing card header to communicate folder selection constraints.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Auto-filing-fixes-1461</td><td>February 04, 2026</td></tr>
<tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1503?tool=ast>(Baz)</a>.