### PR TITLE
Make Google Pub/Sub verification token optional

### DIFF
--- a/apps/web/app/api/google/webhook/route.ts
+++ b/apps/web/app/api/google/webhook/route.ts
@@ -17,15 +17,7 @@ export const POST = withError("google/webhook", async (request) => {
 
   const verificationToken = env.GOOGLE_PUBSUB_VERIFICATION_TOKEN;
 
-  if (!verificationToken) {
-    logger.error("GOOGLE_PUBSUB_VERIFICATION_TOKEN not configured");
-    return NextResponse.json(
-      { message: "Webhook not configured" },
-      { status: 500 },
-    );
-  }
-
-  if (token !== verificationToken) {
+  if (verificationToken && token !== verificationToken) {
     logger.error("Invalid verification token");
     return NextResponse.json(
       { message: "Invalid verification token" },


### PR DESCRIPTION
# User description
## Summary
Allow webhook endpoint to function without GOOGLE_PUBSUB_VERIFICATION_TOKEN when using OIDC JWT authentication. The token is now only validated if explicitly configured.

## Details
- Removes hard requirement for verification token
- Token is validated only if configured in environment variables
- Supports deployments using OIDC JWT authentication exclusively

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Google Pub/Sub webhook route to make the verification token optional, allowing the endpoint to function when using OIDC JWT authentication. Modifies the <code>route.ts</code> logic to skip token validation unless the <code>GOOGLE_PUBSUB_VERIFICATION_TOKEN</code> environment variable is explicitly configured.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-require-webhook-ve...</td><td>January 16, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1512?tool=ast>(Baz)</a>.