### PR TITLE
Add CLI logs command to troubleshooting guide

### DIFF
--- a/docs/hosting/troubleshooting.mdx
+++ b/docs/hosting/troubleshooting.mdx
@@ -3,14 +3,25 @@ title: 'Troubleshooting'
 description: 'Solutions for common issues when running Inbox Zero'
 ---
 
-## Container Won't Start
+## Viewing Logs
 
-**Check logs for errors:**
+If you installed via the CLI, use the built-in logs command:
+```bash
+inbox-zero logs            # Show last 100 lines
+inbox-zero logs -f         # Follow logs in real-time
+inbox-zero logs -n 500     # Show last 500 lines
+```
+
+If you're running Docker directly, use:
 ```bash
 docker logs inbox-zero-services-web-1
 docker logs inbox-zero-services-db-1
 docker logs inbox-zero-services-redis-1
 ```
+
+## Container Won't Start
+
+Check logs for errors using the commands above.
 
 **Common issues:**
 - **Port conflicts**: Another service is using port 3000, 5432, or 6379


### PR DESCRIPTION
# User description
Added the CLI `logs` command to the troubleshooting guide so users installing via CLI know they can use `inbox-zero logs` instead of Docker commands.

Created a new "Viewing Logs" section that covers both CLI and direct Docker deployment approaches.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the troubleshooting guide by adding a dedicated section for viewing logs using the <code>inbox-zero</code> CLI and Docker commands. Enhances the documentation to provide clearer instructions for users diagnosing container startup issues.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Restructure-developer-...</td><td>February 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1523?tool=ast>(Baz)</a>.