### PR TITLE
Fix filing feedback buttons (INB-71)

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/FilingActivity.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/FilingActivity.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { ExternalLinkIcon, InfoIcon } from "lucide-react";
+import { ExternalLinkIcon, FolderIcon, InfoIcon } from "lucide-react";
 import { LoadingContent } from "@/components/LoadingContent";
-import { toastError } from "@/components/Toast";
+import { toastError, toastSuccess } from "@/components/Toast";
 import { MutedText, SectionHeader } from "@/components/Typography";
 import {
   Table,
@@ -14,15 +14,26 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip } from "@/components/Tooltip";
 import { useFilingActivity } from "@/hooks/useFilingActivity";
+import { useDriveFolders } from "@/hooks/useDriveFolders";
 import { getDriveFileUrl } from "@/utils/drive/url";
 import type { GetFilingsResponse } from "@/app/api/user/drive/filings/route";
 import { useDriveConnections } from "@/hooks/useDriveConnections";
 import type { GetDriveConnectionsResponse } from "@/app/api/user/drive/connections/route";
 import { YesNoIndicator } from "@/components/drive/YesNoIndicator";
 import type { DriveProviderType } from "@/utils/drive/types";
-import { submitPreviewFeedbackAction } from "@/utils/actions/drive";
+import {
+  submitPreviewFeedbackAction,
+  moveFilingAction,
+} from "@/utils/actions/drive";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
 export function FilingActivity() {
@@ -32,6 +43,7 @@ export function FilingActivity() {
     offset: 0,
   });
   const { data: connectionsData } = useDriveConnections();
+  const { data: foldersData } = useDriveFolders();
   const refreshFilings = useCallback(() => {
     mutate();
   }, [mutate]);
@@ -63,6 +75,7 @@ export function FilingActivity() {
                     emailAccountId={emailAccountId}
                     filing={filing}
                     connections={connectionsData?.connections || []}
+                    savedFolders={foldersData?.savedFolders || []}
                     onFeedbackSaved={refreshFilings}
                   />
                 ))}
@@ -84,17 +97,21 @@ function FilingRow({
   emailAccountId,
   filing,
   connections,
+  savedFolders,
   onFeedbackSaved,
 }: {
   emailAccountId: string;
   filing: GetFilingsResponse["filings"][number];
   connections: GetDriveConnectionsResponse["connections"];
+  savedFolders: { folderId: string; folderName: string; folderPath: string }[];
   onFeedbackSaved: () => void;
 }) {
   const [vote, setVote] = useState<boolean | null>(
     filing.feedbackPositive ?? null,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const voteBeforeDropdownRef = useRef<boolean | null>(null);
 
   const connection = connections.find((c) => c.id === filing.driveConnectionId);
 
@@ -109,42 +126,119 @@ function FilingRow({
     setVote(filing.feedbackPositive ?? null);
   }, [filing.feedbackPositive]);
 
-  const handleFeedbackClick = useCallback(
-    async (value: boolean) => {
+  const handleCorrectClick = useCallback(async () => {
+    if (!canGiveFeedback || isSubmitting) return;
+
+    const previousValue = vote;
+    setVote(true);
+    setIsSubmitting(true);
+
+    try {
+      const result = await submitPreviewFeedbackAction(emailAccountId, {
+        filingId: filing.id,
+        feedbackPositive: true,
+      });
+
+      if (result?.serverError) {
+        setVote(previousValue);
+        toastError({ description: "Failed to submit feedback" });
+        return;
+      }
+
+      onFeedbackSaved();
+    } catch {
+      setVote(previousValue);
+      toastError({ description: "Failed to submit feedback" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    canGiveFeedback,
+    emailAccountId,
+    filing.id,
+    isSubmitting,
+    onFeedbackSaved,
+    vote,
+  ]);
+
+  const handleMoveToFolder = useCallback(
+    async (folderId: string, folderName: string, folderPath: string) => {
       if (!canGiveFeedback || isSubmitting) return;
 
-      const previousValue = vote;
-      setVote(value);
       setIsSubmitting(true);
 
       try {
-        const result = await submitPreviewFeedbackAction(emailAccountId, {
+        const result = await moveFilingAction(emailAccountId, {
           filingId: filing.id,
-          feedbackPositive: value,
+          targetFolderId: folderId,
+          targetFolderPath: folderPath,
         });
 
         if (result?.serverError) {
-          setVote(previousValue ?? null);
-          toastError({ description: "Failed to submit feedback" });
+          setVote(voteBeforeDropdownRef.current);
+          toastError({ description: "Failed to move file" });
           return;
         }
 
-        onFeedbackSaved();
+        toastSuccess({ description: `Moved to ${folderName}` });
       } catch {
-        setVote(previousValue ?? null);
-        toastError({ description: "Failed to submit feedback" });
+        setVote(voteBeforeDropdownRef.current);
+        toastError({ description: "Failed to move file" });
       } finally {
         setIsSubmitting(false);
       }
     },
-    [
-      canGiveFeedback,
-      emailAccountId,
-      filing.id,
-      isSubmitting,
-      onFeedbackSaved,
-      vote,
-    ],
+    [canGiveFeedback, emailAccountId, filing.id, isSubmitting],
+  );
+
+  const handleWrongClick = useCallback(async () => {
+    if (!canGiveFeedback || isSubmitting) return;
+
+    const previousValue = vote;
+    setVote(false);
+    setIsSubmitting(true);
+
+    try {
+      const result = await submitPreviewFeedbackAction(emailAccountId, {
+        filingId: filing.id,
+        feedbackPositive: false,
+      });
+
+      if (result?.serverError) {
+        setVote(previousValue);
+        toastError({ description: "Failed to submit feedback" });
+        return;
+      }
+
+      onFeedbackSaved();
+    } catch {
+      setVote(previousValue);
+      toastError({ description: "Failed to submit feedback" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    canGiveFeedback,
+    emailAccountId,
+    filing.id,
+    isSubmitting,
+    onFeedbackSaved,
+    vote,
+  ]);
+
+  const handleFeedbackClick = useCallback(
+    (value: boolean) => {
+      if (value) {
+        handleCorrectClick();
+      } else {
+        handleWrongClick();
+      }
+    },
+    [handleCorrectClick, handleWrongClick],
+  );
+
+  const otherFolders = savedFolders.filter(
+    (f) => f.folderPath !== filing.folderPath,
   );
 
   return (
@@ -164,12 +258,62 @@ function FilingRow({
       </TableCell>
       <TableCell>
         <div className="flex items-center justify-center">
-          <YesNoIndicator
-            value={vote}
-            onClick={
-              canGiveFeedback && !isSubmitting ? handleFeedbackClick : undefined
-            }
-          />
+          {canGiveFeedback && !isSubmitting && otherFolders.length > 0 ? (
+            <DropdownMenu
+              onOpenChange={(open) => {
+                setDropdownOpen(open);
+                if (open) {
+                  voteBeforeDropdownRef.current = vote;
+                  setVote(false);
+                }
+              }}
+            >
+              <DropdownMenuTrigger asChild>
+                <div>
+                  <YesNoIndicator
+                    value={vote}
+                    onClick={handleFeedbackClick}
+                    dropdownTrigger="wrong"
+                    wrongActive={dropdownOpen}
+                  />
+                </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>
+                  Which folder does this file belong in?
+                </DropdownMenuLabel>
+                {otherFolders.map((folder) => (
+                  <DropdownMenuItem
+                    key={folder.folderId}
+                    onClick={() =>
+                      handleMoveToFolder(
+                        folder.folderId,
+                        folder.folderName,
+                        folder.folderPath,
+                      )
+                    }
+                  >
+                    <FolderIcon className="size-4" />
+                    {folder.folderName}
+                  </DropdownMenuItem>
+                ))}
+                <DropdownMenuItem
+                  onClick={() => setVote(voteBeforeDropdownRef.current)}
+                >
+                  Cancel
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <YesNoIndicator
+              value={vote}
+              onClick={
+                canGiveFeedback && !isSubmitting
+                  ? handleFeedbackClick
+                  : undefined
+              }
+            />
+          )}
         </div>
       </TableCell>
       <TableCell>

--- a/apps/web/components/drive/YesNoIndicator.tsx
+++ b/apps/web/components/drive/YesNoIndicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { MouseEvent } from "react";
 import { CheckIcon, XIcon } from "lucide-react";
 import { cn } from "@/utils";
 
@@ -7,75 +8,86 @@ interface YesNoIndicatorProps {
   value: boolean | null | undefined;
   onClick?: (value: boolean) => void;
   size?: "sm" | "md";
+  /** When "wrong", the X button becomes a dropdown trigger (no onClick call, no stopPropagation) */
+  dropdownTrigger?: "wrong";
+  /** Force the X button to show as active (red) even when value !== false */
+  wrongActive?: boolean;
 }
 
 export function YesNoIndicator({
   value,
   onClick,
   size = "md",
+  dropdownTrigger,
+  wrongActive,
 }: YesNoIndicatorProps) {
   const iconSize = size === "sm" ? "size-3.5" : "size-4";
-  const isInteractive = !!onClick;
+  const isInteractive = !!onClick || !!dropdownTrigger;
 
-  if (value === true) {
-    return (
-      <button
-        type="button"
-        onClick={isInteractive ? () => onClick(true) : undefined}
-        disabled={!isInteractive}
-        className={cn(
-          "rounded-full p-1.5 transition-colors",
-          isInteractive
-            ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 hover:opacity-80"
-            : "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400",
-          !isInteractive && "cursor-default",
-        )}
-        aria-label="Correct"
-      >
-        <CheckIcon className={iconSize} />
-      </button>
-    );
-  }
-
-  if (value === false) {
-    return (
-      <button
-        type="button"
-        onClick={isInteractive ? () => onClick(false) : undefined}
-        disabled={!isInteractive}
-        className={cn(
-          "rounded-full p-1.5 transition-colors",
-          isInteractive
-            ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 hover:opacity-80"
-            : "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400",
-          !isInteractive && "cursor-default",
-        )}
-        aria-label="Wrong"
-      >
-        <XIcon className={iconSize} />
-      </button>
-    );
-  }
-
-  // value is null or undefined
   if (!isInteractive) {
-    return <span className="text-xs text-muted-foreground">—</span>;
+    if (value === true) {
+      return (
+        <span
+          className="rounded-full p-1.5 bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 inline-flex"
+          role="status"
+          aria-label="Correct"
+        >
+          <CheckIcon className={iconSize} />
+        </span>
+      );
+    }
+    if (value === false) {
+      return (
+        <span
+          className="rounded-full p-1.5 bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 inline-flex"
+          role="status"
+          aria-label="Wrong"
+        >
+          <XIcon className={iconSize} />
+        </span>
+      );
+    }
+    return <span className="text-xs text-muted-foreground">&mdash;</span>;
   }
+
+  const handleCheckClick = (e: MouseEvent) => {
+    if (dropdownTrigger) e.stopPropagation();
+    if (value !== true) onClick?.(true);
+  };
+
+  const handleXClick = (_e: MouseEvent) => {
+    if (dropdownTrigger === "wrong") {
+      // Let the click propagate to the DropdownMenuTrigger parent
+      return;
+    }
+    if (value !== false) onClick?.(false);
+  };
 
   return (
     <div className="flex items-center gap-1">
       <button
         type="button"
-        onClick={() => onClick(true)}
-        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        onClick={handleCheckClick}
+        onPointerDown={dropdownTrigger ? (e) => e.stopPropagation() : undefined}
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          value === true && !wrongActive
+            ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 hover:opacity-80"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
         aria-label="Correct"
       >
         <CheckIcon className={iconSize} />
       </button>
       <button
         type="button"
-        onClick={() => onClick(false)}
-        className="rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        onClick={handleXClick}
+        className={cn(
+          "rounded-full p-1.5 transition-colors",
+          value === false || wrongActive
+            ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400 hover:opacity-80"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
         aria-label="Wrong"
       >
         <XIcon className={iconSize} />


### PR DESCRIPTION
## Summary
Fixed two bugs where clicking the correct/incorrect feedback buttons did nothing or was confusing. Both buttons now always visible and interactive. Clicking check marks as correct. Clicking X either opens a dropdown to select the correct folder (if alternatives exist) or directly submits negative feedback (if only one folder). X turns red immediately on click with no flickering.

## Changes
- Both buttons always visible when interactive (not just the selected one)
- Check button highlights only when marked correct, unselecting itself when X is clicked
- X button opens folder selection dropdown only when there are alternative folders to choose from
- When only one folder is checked, clicking X directly submits negative feedback
- Optimistic UI updates with ref-based error rollback prevent flickering
- Added `wrongActive` prop to force X to show as active (red) when dropdown is open

## Testing
Manual testing in FilingActivity and DriveSetup verified:
- Toggle between check and X buttons works smoothly
- Dropdown opens only when needed with proper folder list (checked folders only)
- Cancel button in dropdown reverts vote state
- Single-folder case submits feedback directly on X click

🤖 Generated with [Claude Code](https://claude.com/claude-code)