### PR TITLE
Fix auto-filer reply sender name

### DIFF
--- a/apps/web/utils/drive/handle-filing-reply.ts
+++ b/apps/web/utils/drive/handle-filing-reply.ts
@@ -9,7 +9,10 @@ import { emailToContent } from "@/utils/mail";
 import { createDriveProviderWithRefresh } from "@/utils/drive/provider";
 import { createAndSaveFilingFolder } from "@/utils/drive/folder-utils";
 import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
-import { getFilebotReplyTo } from "@/utils/filebot/is-filebot-email";
+import {
+  getFilebotFrom,
+  getFilebotReplyTo,
+} from "@/utils/filebot/is-filebot-email";
 
 interface ProcessFilingReplyArgs {
   emailAccountId: string;
@@ -86,8 +89,10 @@ export async function processFilingReply({
 
   if (parseResult.reply) {
     const filebotReplyTo = getFilebotReplyTo({ userEmail });
+    const filebotFrom = getFilebotFrom({ userEmail });
     await emailProvider.replyToEmail(message, parseResult.reply, {
       replyTo: filebotReplyTo,
+      from: filebotFrom,
     });
   }
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -795,9 +795,9 @@ export class GmailProvider implements EmailProvider {
   async replyToEmail(
     email: ParsedMessage,
     content: string,
-    options?: { replyTo?: string },
+    options?: { replyTo?: string; from?: string },
   ): Promise<void> {
-    await replyToEmail(this.client, email, content, undefined, options);
+    await replyToEmail(this.client, email, content, options?.from, options);
   }
 
   async sendEmail(args: {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -645,7 +645,7 @@ export class OutlookProvider implements EmailProvider {
   async replyToEmail(
     email: ParsedMessage,
     content: string,
-    options?: { replyTo?: string },
+    options?: { replyTo?: string; from?: string },
   ): Promise<void> {
     await replyToEmail(this.client, email, content, this.logger, options);
   }

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -117,7 +117,7 @@ export interface EmailProvider {
   replyToEmail(
     email: ParsedMessage,
     content: string,
-    options?: { replyTo?: string },
+    options?: { replyTo?: string; from?: string },
   ): Promise<void>;
   sendEmail(args: {
     to: string;

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -96,7 +96,7 @@ export async function replyToEmail(
   message: EmailForAction,
   reply: string,
   logger: Logger,
-  options?: { replyTo?: string },
+  options?: { replyTo?: string; from?: string },
 ) {
   ensureEmailSendingEnabled();
 
@@ -114,6 +114,21 @@ export async function replyToEmail(
     logger,
   );
 
+  // Build the from field if a display name is provided
+  const fromField = options?.from
+    ? {
+        from: {
+          emailAddress: {
+            name: extractNameFromEmail(options.from),
+            address:
+              extractEmailAddress(options.from) ||
+              replyDraft.from?.emailAddress?.address ||
+              "",
+          },
+        },
+      }
+    : {};
+
   // Update the draft with our content
   await withOutlookRetry(
     () =>
@@ -125,6 +140,7 @@ export async function replyToEmail(
             contentType: "html",
             content: html,
           },
+          ...fromField,
           ...(options?.replyTo
             ? {
                 replyTo: [{ emailAddress: { address: options.replyTo } }],


### PR DESCRIPTION
## Summary

Auto-filer conversational replies now display "Inbox Zero Assistant" as the sender name, matching the initial filing notifications.

Previously only the first notification showed the correct display name; subsequent replies (e.g., "Moving file to Tickets") showed the raw email address instead.

- Added `from` parameter support to `replyToEmail` interface
- Implemented sender name handling in Gmail and Outlook providers
- Pass formatted sender name when auto-filer replies to user messages

Fixes [INB-68](https://linear.app/inbox-zero-ai/issue/INB-68)