### PR TITLE
Remove Meeting Briefs from setup page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -11,7 +11,6 @@ import {
   type LucideIcon,
   ChromeIcon,
   CalendarIcon,
-  FileTextIcon,
   UsersIcon,
 } from "lucide-react";
 import { useLocalStorage } from "usehooks-ts";
@@ -27,7 +26,6 @@ import { LoadingContent } from "@/components/LoadingContent";
 import { EXTENSION_URL } from "@/utils/config";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { useMeetingBriefsEnabled } from "@/hooks/useFeatureFlags";
 import {
   STEP_KEYS,
   getStepNumber,
@@ -258,17 +256,11 @@ function Checklist({
     "inbox-zero-extension-installed",
     false,
   );
-  const [isMeetingBriefsViewed, setIsMeetingBriefsViewed] = useLocalStorage(
-    "inbox-zero-meeting-briefs-viewed",
-    false,
-  );
   const [isTeamInviteViewed, setIsTeamInviteViewed] = useLocalStorage(
     "inbox-zero-team-invite-viewed",
     false,
   );
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
-  const isMeetingBriefsEnabled = useMeetingBriefsEnabled();
-
   const isTeamInviteSkipped =
     teamInvite && isTeamInviteViewed && !teamInvite.completed;
   const adjustedCompletedCount = isTeamInviteSkipped
@@ -279,10 +271,6 @@ function Checklist({
 
   const handleMarkExtensionDone = () => {
     setIsExtensionInstalled(true);
-  };
-
-  const handleMarkMeetingBriefsDone = () => {
-    setIsMeetingBriefsViewed(true);
   };
 
   const handleMarkTeamInviteDone = () => {
@@ -371,21 +359,6 @@ function Checklist({
           open={isInviteModalOpen}
           onOpenChange={setIsInviteModalOpen}
           trigger={null}
-        />
-      )}
-
-      {isMeetingBriefsEnabled && (
-        <StepItem
-          href={prefixPath(emailAccountId, "/briefs")}
-          icon={<FileTextIcon size={20} />}
-          iconBg="bg-pink-100 dark:bg-pink-900/50"
-          iconColor="text-pink-500 dark:text-pink-400"
-          title="Optional: Set up Meeting Briefs"
-          timeEstimate="2 minutes"
-          completed={isMeetingBriefsViewed}
-          actionText="View"
-          onMarkDone={handleMarkMeetingBriefsDone}
-          showMarkDone={true}
         />
       )}
 


### PR DESCRIPTION
# User description
Removed the Meeting Briefs step from the setup checklist as requested.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Checklist_("Checklist"):::modified
handleMarkExtensionDone_("handleMarkExtensionDone"):::modified
handleMarkTeamInviteDone_("handleMarkTeamInviteDone"):::modified
LOCAL_STORAGE_("LOCAL_STORAGE"):::modified
Checklist_ -- "Now persists extension-installed flag to localStorage via useLocalStorage" --> handleMarkExtensionDone_
Checklist_ -- "Marks team-invite viewed persisted to localStorage via useLocalStorage" --> handleMarkTeamInviteDone_
handleMarkExtensionDone_ -- "Saves 'inbox-zero-extension-installed' flag to localStorage" --> LOCAL_STORAGE_
handleMarkTeamInviteDone_ -- "Saves 'inbox-zero-team-invite-viewed' flag to localStorage" --> LOCAL_STORAGE_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Removes the Meeting Briefs step from the setup checklist within the <code>SetupContent</code> component to streamline the onboarding process. Cleans up associated state management and feature flag hooks that were previously used to display this optional configuration step.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1529?tool=ast>(Baz)</a>.