### PR TITLE
Drive: auto-enable intermediate folders created during AI filing

### DIFF
--- a/apps/web/utils/drive/folder-utils.test.ts
+++ b/apps/web/utils/drive/folder-utils.test.ts
@@ -66,7 +66,9 @@ describe("createFolderPath", () => {
 
     const result = await createFolderPath(provider, "Receipts", logger);
 
-    expect(result.name).toBe("Receipts");
+    expect(result.folder.name).toBe("Receipts");
+    expect(result.allFolders).toHaveLength(1);
+    expect(result.allFolders[0].path).toBe("Receipts");
     expect(provider.createFolder).toHaveBeenCalledWith("Receipts", undefined);
   });
 
@@ -79,7 +81,11 @@ describe("createFolderPath", () => {
       logger,
     );
 
-    expect(result.name).toBe("December");
+    expect(result.folder.name).toBe("December");
+    expect(result.allFolders).toHaveLength(3);
+    expect(result.allFolders[0].path).toBe("Receipts");
+    expect(result.allFolders[1].path).toBe("Receipts/2024");
+    expect(result.allFolders[2].path).toBe("Receipts/2024/December");
     expect(provider.createFolder).toHaveBeenCalledTimes(3);
     expect(provider.createFolder).toHaveBeenNthCalledWith(
       1,
@@ -96,7 +102,11 @@ describe("createFolderPath", () => {
 
     const result = await createFolderPath(provider, "Receipts/2024", logger);
 
-    expect(result.name).toBe("2024");
+    expect(result.folder.name).toBe("2024");
+    expect(result.allFolders).toHaveLength(2);
+    expect(result.allFolders[0].folder.id).toBe("existing-1");
+    expect(result.allFolders[0].path).toBe("Receipts");
+    expect(result.allFolders[1].path).toBe("Receipts/2024");
     expect(provider.createFolder).toHaveBeenCalledTimes(1);
     expect(provider.createFolder).toHaveBeenCalledWith("2024", "existing-1");
   });
@@ -109,7 +119,7 @@ describe("createFolderPath", () => {
 
     const result = await createFolderPath(provider, "receipts/2024", logger);
 
-    expect(result.name).toBe("2024");
+    expect(result.folder.name).toBe("2024");
     expect(provider.createFolder).toHaveBeenCalledTimes(1);
     expect(provider.createFolder).toHaveBeenCalledWith("2024", "existing-1");
   });
@@ -119,7 +129,7 @@ describe("createFolderPath", () => {
 
     const result = await createFolderPath(provider, "/Receipts", logger);
 
-    expect(result.name).toBe("Receipts");
+    expect(result.folder.name).toBe("Receipts");
     expect(provider.createFolder).toHaveBeenCalledTimes(1);
   });
 
@@ -128,7 +138,7 @@ describe("createFolderPath", () => {
 
     const result = await createFolderPath(provider, "Receipts/", logger);
 
-    expect(result.name).toBe("Receipts");
+    expect(result.folder.name).toBe("Receipts");
     expect(provider.createFolder).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
# User description
When the AI creates a nested folder path during auto-filing, all intermediate folders along the path are now added to the allowed folders list.

- Modified `createFolderPath` to track all folders traversed along the path (both existing and newly created)
- Updated `createAndSaveFilingFolder` to upsert all intermediate folders into `FilingFolder`, not just the leaf
- Updated tests to verify the new `allFolders` return structure

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
createAndSaveFilingFolder_("createAndSaveFilingFolder"):::modified
createFolderPath_("createFolderPath"):::modified
DRIVE_PROVIDER_("DRIVE_PROVIDER"):::modified
FolderPathResult_("FolderPathResult"):::added
FILING_FOLDER_("FILING_FOLDER"):::modified
LOGGER_("LOGGER"):::modified
createAndSaveFilingFolder_ -- "Now persists all path folders instead of single folder." --> createFolderPath_
createFolderPath_ -- "Now collects and returns every traversed folder." --> DRIVE_PROVIDER_
createFolderPath_ -- "Introduces return type including final and all folders." --> FolderPathResult_
createAndSaveFilingFolder_ -- "Upserts all path folders into filing_folder, not just final." --> FILING_FOLDER_
createAndSaveFilingFolder_ -- "Logs folder path and saved folders count." --> LOGGER_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the folder creation logic to track and register all intermediate directories created during the AI filing process. Ensures that every folder in a nested path is persisted to the database as an allowed filing folder.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1534?tool=ast&topic=Utility+Testing>Utility Testing</a>
        </td><td>Updates the test suite to validate the new <code>FolderPathResult</code> structure and ensures that the full hierarchy of folders is correctly identified and returned.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/drive/folder-utils.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1534?tool=ast&topic=Folder+Persistence>Folder Persistence</a>
        </td><td>Enhances <code>createFolderPath</code> to return a collection of all folders in the path and updates <code>createAndSaveFilingFolder</code> to perform bulk upserts into the <code>FilingFolder</code> table.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/drive/folder-utils.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Auto-file-attachments-...</td><td>January 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1534?tool=ast>(Baz)</a>.