### PR TITLE
Fix settings page layout issues

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -78,7 +78,6 @@ export function ConnectedAppsSection({
       description=""
       titleClassName="text-sm"
       descriptionClassName="text-xs sm:text-sm"
-      align="start"
       actions={
         !hasSlack ? (
           <Button

--- a/apps/web/app/(app)/[emailAccountId]/settings/OrgAnalyticsConsentSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/OrgAnalyticsConsentSection.tsx
@@ -5,6 +5,7 @@ import { useAction } from "next-safe-action/hooks";
 import { Switch } from "@/components/ui/switch";
 import { LoadingContent } from "@/components/LoadingContent";
 import { SettingsSection } from "@/components/SettingsSection";
+import { Separator } from "@/components/ui/separator";
 import { toastSuccess, toastError } from "@/components/Toast";
 import { getActionErrorMessage } from "@/utils/error";
 import { updateAnalyticsConsentAction } from "@/utils/actions/organization";
@@ -58,6 +59,8 @@ export function OrgAnalyticsConsentSection({
   return (
     <LoadingContent loading={isLoading} error={error}>
       {data?.organizationId && (
+        <>
+        <Separator />
         <SettingsSection
           title="Organization Analytics Access"
           description={`Allow organization admins${data.organizationName ? ` from ${data.organizationName}` : ""} to view your personal analytics and usage statistics.`}
@@ -71,6 +74,7 @@ export function OrgAnalyticsConsentSection({
             />
           }
         />
+        </>
       )}
     </LoadingContent>
   );

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -183,14 +183,11 @@ function EmailAccountSettingsCard({
           </Button>
         </div>
 
-        <div className="space-y-4">
-          <ConnectedAppsSection
-            emailAccountId={emailAccount.id}
-            showNotifications={showNotifications}
-          />
-          <Separator />
-          <OrgAnalyticsConsentSection emailAccountId={emailAccount.id} />
-        </div>
+        <ConnectedAppsSection
+          emailAccountId={emailAccount.id}
+          showNotifications={showNotifications}
+        />
+        <OrgAnalyticsConsentSection emailAccountId={emailAccount.id} />
 
         {showAdvanced && (
           <>


### PR DESCRIPTION
# User description
Fixes two layout issues on the settings page:

- Removes extra separator line when organization doesn't exist
- Vertically centers "Connected Apps" header with the "Connect Slack" button

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
EmailAccountSettingsCard_("EmailAccountSettingsCard"):::modified
ConnectedAppsSection_("ConnectedAppsSection"):::modified
OrgAnalyticsConsentSection_("OrgAnalyticsConsentSection"):::modified
SEPARATOR_("SEPARATOR"):::added
EmailAccountSettingsCard_ -- "Removed surrounding div/Separator; ConnectedAppsSection now rendered directly." --> ConnectedAppsSection_
EmailAccountSettingsCard_ -- "Inserted OrgAnalyticsConsentSection; now renders consent UI alongside connected apps." --> OrgAnalyticsConsentSection_
OrgAnalyticsConsentSection_ -- "Added visual Separator above analytics consent when organization present." --> SEPARATOR_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Refines the settings page layout by conditionally rendering separators and adjusting the vertical alignment of the connected apps header. Ensures that the <code>OrgAnalyticsConsentSection</code> and <code>ConnectedAppsSection</code> components present a cleaner interface based on the user's organization status.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1536?tool=ast&topic=Header+Alignment>Header Alignment</a>
        </td><td>Adjusts the <code>align</code> property in <code>ConnectedAppsSection</code> to vertically center the section header with the action buttons.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Refine-settings-page-c...</td><td>February 10, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1536?tool=ast&topic=Layout+Refinement>Layout Refinement</a>
        </td><td>Implements conditional rendering for the <code>Separator</code> within <code>OrgAnalyticsConsentSection</code> and removes the static separator from the main settings page to prevent empty lines when an organization is missing.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/settings/OrgAnalyticsConsentSection.tsx</li>
<li>apps/web/app/(app)/settings/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Refine-settings-page-c...</td><td>February 10, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1536?tool=ast>(Baz)</a>.