### PR TITLE
Add debug logging to Slack OAuth flow

### DIFF
--- a/apps/web/app/api/slack/auth-url/route.ts
+++ b/apps/web/app/api/slack/auth-url/route.ts
@@ -23,7 +23,14 @@ export const GET = withEmailAccount("slack/auth-url", async (request) => {
     );
   }
 
-  const { url, state } = getAuthUrl({ emailAccountId });
+  const { url, state, redirectUri } = getAuthUrl({ emailAccountId });
+
+  request.logger.info("Slack auth URL generated", {
+    redirectUri,
+    clientId: env.SLACK_CLIENT_ID,
+    baseUrl: env.NEXT_PUBLIC_BASE_URL,
+    webhookUrl: env.WEBHOOK_URL ?? null,
+  });
 
   const res: GetSlackAuthUrlResponse = { url };
   const response = NextResponse.json(res);
@@ -50,5 +57,5 @@ function getAuthUrl({ emailAccountId }: { emailAccountId: string }) {
 
   const url = `https://slack.com/oauth/v2/authorize?${params.toString()}`;
 
-  return { url, state };
+  return { url, state, redirectUri };
 }


### PR DESCRIPTION
# User description
Adds structured logging at both the authorization URL generation and token exchange stages to capture the exact redirect URI, client ID, and environment variables being used. This will help diagnose why Slack OAuth is consistently returning invalid_code errors.

Logs are emitted before the Slack API call and on failure, making it easy to spot mismatches between what we send and what Slack expects.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
handleSlackCallback_("handleSlackCallback"):::modified
exchangeCodeForTokens_("exchangeCodeForTokens"):::modified
SLACK_API_("SLACK_API"):::modified
getAuthUrl_("getAuthUrl"):::modified
handleSlackCallback_ -- "Now passes logger to exchangeCodeForTokens for contextual logging." --> exchangeCodeForTokens_
exchangeCodeForTokens_ -- "Adds redirect_uri param and logs exchange details before request." --> SLACK_API_
SLACK_API_ -- "Logs Slack error details on failed token exchange." --> exchangeCodeForTokens_
getAuthUrl_ -- "Returns redirectUri and logs auth URL generation metadata." --> SLACK_API_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the Slack OAuth flow by adding structured logging to capture critical environment variables and redirect URIs during authorization and token exchange. This change helps diagnose authentication failures by providing visibility into the parameters sent to Slack's API.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-Slack-bot-authoriz...</td><td>February 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1537?tool=ast>(Baz)</a>.