### PR TITLE
Hide Slack UI when integration is not configured

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
@@ -75,6 +75,8 @@ export function DeliveryChannelsSetting() {
     channelsData?.channels.filter((c) => c.isConnected) ?? [];
 
   const hasSlack = connectedChannels.some((c) => c.provider === "SLACK");
+  const slackAvailable =
+    channelsData?.availableProviders?.includes("SLACK") ?? false;
 
   return (
     <Card>
@@ -107,7 +109,7 @@ export function DeliveryChannelsSetting() {
             ))}
           </LoadingContent>
 
-          {!isLoadingChannels && !hasSlack && (
+          {!isLoadingChannels && !hasSlack && slackAvailable && (
             <MutedText className="text-xs">
               Want to receive briefs in Slack?{" "}
               <Link

--- a/apps/web/app/(app)/[emailAccountId]/drive/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/page.tsx
@@ -141,7 +141,10 @@ function IntegrationsPopover({ emailAccountId }: { emailAccountId: string }) {
   const allConnected = data?.channels.filter((c) => c.isConnected) ?? [];
   const withChannel = allConnected.filter((c) => c.channelId);
 
-  if (isLoading || allConnected.length === 0) return null;
+  const availableProviders = data?.availableProviders ?? [];
+
+  if (isLoading || (allConnected.length === 0 && availableProviders.length === 0))
+    return null;
 
   return (
     <Popover>

--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -46,6 +46,11 @@ export function ConnectedAppsSection({
   const hasSlack = connectedChannels.some(
     (channel) => channel.provider === "SLACK",
   );
+  const slackAvailable =
+    channelsData?.availableProviders?.includes("SLACK") ?? false;
+
+  if (!isLoading && !slackAvailable && connectedChannels.length === 0)
+    return null;
 
   const handleConnectSlack = async () => {
     setConnectingSlack(true);
@@ -79,7 +84,7 @@ export function ConnectedAppsSection({
       titleClassName="text-sm"
       descriptionClassName="text-xs sm:text-sm"
       actions={
-        !hasSlack ? (
+        !hasSlack && slackAvailable ? (
           <Button
             variant="outline"
             size="sm"

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
+import { env } from "@/env";
+import type { MessagingProvider } from "@/generated/prisma/enums";
 
 export type GetMessagingChannelsResponse = Awaited<ReturnType<typeof getData>>;
 
@@ -29,5 +31,11 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
     orderBy: { createdAt: "desc" },
   });
 
-  return { channels };
+  return { channels, availableProviders: getAvailableProviders() };
+}
+
+function getAvailableProviders(): MessagingProvider[] {
+  const providers: MessagingProvider[] = [];
+  if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) providers.push("SLACK");
+  return providers;
 }


### PR DESCRIPTION
# User description
## Summary
Self-hosted deployments can now disable Slack integration without UI artifacts. When `SLACK_CLIENT_ID`/`SLACK_CLIENT_SECRET` are not set, Slack-related UI is automatically hidden.

## Changes
- Add `availableProviders` to messaging-channels API response (computed from server env vars)
- Settings: Hide Connected Apps section when Slack unavailable
- Briefing: Hide "Connect Slack in Settings" link when Slack unavailable
- Drive: Hide Integrations popover when no providers available

## Approach
Generic solution for future integrations (e.g., WhatsApp). No extra env vars needed—uses existing Slack config.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getData_("getData"):::modified
PRISMA_DATABASE_("PRISMA_DATABASE"):::modified
getAvailableProviders_("getAvailableProviders"):::added
ENV_("ENV"):::added
ConnectedAppsSection_("ConnectedAppsSection"):::modified
DeliveryChannelsSetting_("DeliveryChannelsSetting"):::modified
IntegrationsPopover_("IntegrationsPopover"):::modified
getData_ -- "Still fetches channels ordered by createdAt; response augmented." --> PRISMA_DATABASE_
getData_ -- "Now calls new function to include availableProviders from env." --> getAvailableProviders_
getAvailableProviders_ -- "Reads SLACK_CLIENT_ID/SECRET from env to enable Slack." --> ENV_
ConnectedAppsSection_ -- "Uses availableProviders to conditionally render Slack connect and section." --> getData_
DeliveryChannelsSetting_ -- "Shows Slack promotion when Slack available but not connected." --> getData_
IntegrationsPopover_ -- "Hides integrations UI when no channels and no providers configured." --> getData_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the messaging channels API and frontend components to conditionally hide Slack integration features when the required environment variables are missing. Ensures that self-hosted deployments without Slack configured do not display broken or irrelevant UI elements in settings, briefs, and drive views.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1544?tool=ast&topic=Conditional+UI>Conditional UI</a>
        </td><td>Updates <code>DeliveryChannelsSetting</code>, <code>IntegrationsPopover</code>, and <code>ConnectedAppsSection</code> to check <code>availableProviders</code> before rendering Slack-related links, buttons, or sections.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/drive/page.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1544?tool=ast&topic=Provider+Detection>Provider Detection</a>
        </td><td>Enhances the <code>messaging-channels</code> API route to include an <code>availableProviders</code> list determined by the presence of <code>SLACK_CLIENT_ID</code> and <code>SLACK_CLIENT_SECRET</code> environment variables.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/user/messaging-channels/route.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1544?tool=ast>(Baz)</a>.