### PR TITLE
fix: prevent follow-up cron from timing out

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -289,6 +289,7 @@ async function processFollowUpsForType({
         },
       });
 
+      let draftCreated = false;
       if (generateDraft) {
         try {
           await generateFollowUpDraft({
@@ -298,6 +299,7 @@ async function processFollowUpsForType({
             provider,
             logger: threadLogger,
           });
+          draftCreated = true;
         } catch (draftError) {
           threadLogger.error("Draft generation failed, label still applied", {
             error: draftError,
@@ -307,7 +309,7 @@ async function processFollowUpsForType({
       }
 
       threadLogger.info("Processed follow-up", {
-        draftGenerated: generateDraft,
+        draftCreated,
       });
       processedCount++;
     } catch (error) {


### PR DESCRIPTION
# User description
## Summary

The follow-up reminders cron was consistently timing out before completing, causing some accounts to never get their follow-ups processed automatically. The manual "Find Follow-ups" button worked because it processes a single account.

**Root cause (from Axiom logs):**
- Cron ran 1,332 times in 7 days but completed **0 times** (always timed out)
- For every thread (even already-processed ones), a Gmail API call (`getLatestMessageInThread`) was made *before* checking if the thread was already processed
- Draft generation errors (rate limits) bubbled up and marked the entire thread as "failed", even though the label and tracker were already saved

**Fix:**
- Batch-query thread trackers upfront to identify already-processed threads — replaces N individual DB queries and eliminates N unnecessary Gmail API calls
- Catch draft generation errors separately so label application + tracker update are still counted as successful
- Add `skipped` count to processing logs for better observability

## Test plan
- [ ] Verify cron completes within timeout by checking Axiom for "Completed processing follow-up reminders" logs
- [ ] Verify "Finished processing follow-ups" logs now appear with `skipped` counts
- [ ] Verify follow-up labels still applied correctly for new threads
- [ ] Verify draft generation errors no longer cause "Failed to process thread" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
processFollowUpsForType_("processFollowUpsForType"):::modified
DATABASE_("DATABASE"):::modified
GMAIL_API_("GMAIL_API"):::modified
SENTRY_("SENTRY"):::modified
processFollowUpsForType_ -- "Adds batch lookup to skip already-applied threads" --> DATABASE_
processFollowUpsForType_ -- "Upserts tracker and uses result instead of prior lookup" --> DATABASE_
processFollowUpsForType_ -- "Avoids Gmail calls for threads already labeled by skipping them" --> GMAIL_API_
processFollowUpsForType_ -- "Wraps draft creation in try/catch; captures failures to Sentry" --> GMAIL_API_
processFollowUpsForType_ -- "Now captures draft generation exceptions to Sentry" --> SENTRY_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Optimizes the follow-up reminders cron job by batch-checking thread statuses to prevent timeouts and redundant Gmail API calls. Enhances the reliability of the process by decoupling draft generation failures from the core label application logic.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1545?tool=ast&topic=Performance+Fix>Performance Fix</a>
        </td><td>Implements batch querying of <code>threadTracker</code> records to identify already-processed threads upfront, eliminating N individual database queries and N Gmail API calls per account.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/follow-up-reminders/process.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1545?tool=ast&topic=Reliability>Reliability</a>
        </td><td>Wraps <code>generateFollowUpDraft</code> in a try-catch block to ensure draft generation errors do not roll back label application, and adds <code>skippedCount</code> to logs for better observability.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/follow-up-reminders/process.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1545?tool=ast>(Baz)</a>.