### PR TITLE
Improve Slack OAuth callback reliability

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -7,7 +7,7 @@ import { useAction } from "next-safe-action/hooks";
 import { Button } from "@/components/ui/button";
 import { LoadingContent } from "@/components/LoadingContent";
 import { SettingsSection } from "@/components/SettingsSection";
-import { toastSuccess, toastError } from "@/components/Toast";
+import { toastSuccess, toastError, toastInfo } from "@/components/Toast";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
 import { disconnectChannelAction } from "@/utils/actions/messaging-channels";
 import { fetchWithAccount } from "@/utils/fetch";
@@ -190,12 +190,19 @@ function useSlackNotifications(enabled: boolean) {
     const errorDetail = searchParams.get("error_detail");
     const resolvedReason = resolveSlackErrorReason(errorReason, errorDetail);
 
-    if (!message && !error && !errorDetail) return;
+    if (!message && !error && !errorReason && !errorDetail) return;
 
     handled.current = true;
 
     if (message === "slack_connected") {
       toastSuccess({ description: "Slack connected" });
+    }
+    if (message === "processing") {
+      toastInfo({
+        title: "Slack connection in progress",
+        description:
+          "Slack is still finalizing your connection. Please refresh in a moment.",
+      });
     }
 
     if (error === "connection_failed" || errorDetail) {

--- a/apps/web/utils/slack/handle-slack-callback.ts
+++ b/apps/web/utils/slack/handle-slack-callback.ts
@@ -86,6 +86,8 @@ export async function handleSlackCallback(
       const inFlightResult = await getOAuthCodeResult(code);
       if (inFlightResult) {
         applyRedirectParams(finalRedirectUrl, inFlightResult.params);
+      } else {
+        applyRedirectParams(finalRedirectUrl, { message: "processing" });
       }
       await flushLogger(callbackLogger);
       return NextResponse.redirect(finalRedirectUrl, {


### PR DESCRIPTION
# User description
## Summary
- Make OAuth callback handling idempotent to avoid duplicate callback failures.
- Add explicit callback log flushes and structured redirect error reasons.
- Update settings notifications to handle both legacy and current error query parameters.

## Validation
- Ran biome check on the two changed files.
- Ran pnpm lint (fails due to pre-existing repo-wide lint diagnostics unrelated to this change).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
handleSlackCallback_("handleSlackCallback"):::modified
REDIS_("REDIS"):::modified
SLACK_API_("SLACK_API"):::modified
getRedirectReason_("getRedirectReason"):::added
mapSlackCallbackErrorReason_("mapSlackCallbackErrorReason"):::added
useSlackNotifications_("useSlackNotifications"):::modified
resolveSlackErrorReason_("resolveSlackErrorReason"):::added
getSlackConnectionFailedDescription_("getSlackConnectionFailedDescription"):::added
handleSlackCallback_ -- "Adds Redis locks/caching for OAuth codes to prevent duplicates." --> REDIS_
handleSlackCallback_ -- "Exchanges OAuth code for team tokens after acquiring lock." --> SLACK_API_
handleSlackCallback_ -- "Adds sanitized error reason extraction for redirect URLs." --> getRedirectReason_
handleSlackCallback_ -- "Adds error-to-reason mapping for structured logging/redirects." --> mapSlackCallbackErrorReason_
useSlackNotifications_ -- "Normalizes error_reason/detail into canonical reason client-side." --> resolveSlackErrorReason_
useSlackNotifications_ -- "Maps normalized error reasons to user-facing descriptions." --> getSlackConnectionFailedDescription_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the Slack OAuth flow by implementing idempotent callback handling and structured error reporting. Ensures that duplicate callback requests are handled gracefully while providing users with more specific feedback during connection failures or delays.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1549?tool=ast&topic=UI+Notifications>UI Notifications</a>
        </td><td>Update <code>useSlackNotifications</code> and <code>ConnectedAppsSection</code> to support new error reasons and a 'processing' state for better user feedback.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Hide-Slack-UI-when-int...</td><td>February 11, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1549?tool=ast&topic=OAuth+Reliability>OAuth Reliability</a>
        </td><td>Implement idempotency and locking in <code>handleSlackCallback</code> using Redis to prevent duplicate processing of OAuth codes and ensure reliable logging.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/slack/handle-slack-callback.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-error-detail-to-Sl...</td><td>February 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1549?tool=ast>(Baz)</a>.