### PR TITLE
Ensure reconnect resets watch state

### DIFF
--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -376,6 +376,16 @@ async function updateMicrosoftAccountTokens(
       expires_at: parseMicrosoftExpiresAt(tokens),
       scope: tokens.scope,
       token_type: tokens.token_type,
+      disconnectedAt: null,
+    },
+  });
+
+  // Force subscription renewal on next watch cycle after reconnect.
+  // This avoids reusing stale subscription state that can survive token issues.
+  await prisma.emailAccount.updateMany({
+    where: { accountId },
+    data: {
+      watchEmailsExpirationDate: new Date(0),
     },
   });
 }


### PR DESCRIPTION
# User description
This change updates the Outlook linking callback to fully restore account connectivity after token updates. It clears the disconnected flag and marks the stored watch expiration as expired so the next watch cycle renews the subscription instead of reusing stale state. The update is scoped to the account being reconnected.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Outlook account reconnection logic to clear disconnection flags and force a renewal of email watch subscriptions. Ensures that the <code>updateMicrosoftAccountTokens</code> process resets the <code>disconnectedAt</code> field and expires the <code>watchEmailsExpirationDate</code> to prevent stale state reuse.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-only-update-refres...</td><td>January 06, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>PR-feedback</td><td>August 29, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1552?tool=ast>(Baz)</a>.