### PR TITLE
Fix OpenAI structured output schema

### DIFF
--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -76,7 +76,7 @@ export const createRuleAction = actionClient
           result: {
             name,
             condition: {
-              aiInstructions: conditions.instructions,
+              aiInstructions: conditions.instructions ?? null,
               conditionalOperator: conditionalOperator || null,
               static: {
                 from: conditions.from || null,
@@ -129,7 +129,7 @@ export const updateRuleAction = actionClient
           result: {
             name: name || "",
             condition: {
-              aiInstructions: conditions.instructions,
+              aiInstructions: conditions.instructions ?? null,
               conditionalOperator: conditionalOperator || null,
               static: {
                 from: conditions.from || null,

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -256,6 +256,7 @@ const createRuleTool = ({
                     }),
                   }
                 : null,
+              delayInMinutes: null,
             })),
           },
           emailAccountId,

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -167,7 +167,7 @@ ${stringifyEmail(email, 500)}
         .describe("The reason you chose the rule. Keep it concise"),
       ruleName: z
         .string()
-        .nullish()
+        .nullable()
         .describe("The exact name of the rule you want to apply"),
       noMatchFound: z
         .boolean()

--- a/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
+++ b/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
@@ -13,7 +13,7 @@ import {
 // const braintrust = new Braintrust("recurring-pattern-detection");
 
 const schema = z.object({
-  matchedRule: z.string().nullish(),
+  matchedRule: z.string().nullable(),
   explanation: z.string(),
 });
 export type DetectPatternResult = z.infer<typeof schema>;

--- a/apps/web/utils/ai/clean/ai-clean-select-labels.ts
+++ b/apps/web/utils/ai/clean/ai-clean-select-labels.ts
@@ -3,7 +3,7 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getModel } from "@/utils/llms/model";
 import { createGenerateObject } from "@/utils/llms";
 
-const schema = z.object({ labels: z.array(z.string()).optional() });
+const schema = z.object({ labels: z.array(z.string()).nullable() });
 
 export async function aiCleanSelectLabels({
   emailAccount,

--- a/apps/web/utils/ai/document-filing/analyze-document.ts
+++ b/apps/web/utils/ai/document-filing/analyze-document.ts
@@ -13,13 +13,13 @@ const documentAnalysisSchema = z
       ),
     folderId: z
       .string()
-      .optional()
+      .nullable()
       .describe(
         "Required if action is 'use_existing'. The ID of the existing folder from the provided list.",
       ),
     folderPath: z
       .string()
-      .optional()
+      .nullable()
       .describe(
         "Required if action is 'create_new'. The path for the new folder to create.",
       ),

--- a/apps/web/utils/ai/document-filing/parse-filing-reply.ts
+++ b/apps/web/utils/ai/document-filing/parse-filing-reply.ts
@@ -17,7 +17,7 @@ Always write a helpful, concise reply.`;
 
 const schema = z.object({
   action: z.enum(["approve", "move", "undo", "none"]),
-  folderPath: z.string().optional(),
+  folderPath: z.string().nullable(),
   reply: z.string(),
 });
 
@@ -40,7 +40,7 @@ export async function aiParseFilingReply({
   emailAccount: EmailAccountWithAI;
 }): Promise<ParseFilingReplyResult> {
   if (!messages.length) {
-    return { action: "none", reply: "" };
+    return { action: "none", reply: "", folderPath: null };
   }
 
   const formattedMessages = messages

--- a/apps/web/utils/ai/rule/generate-rules-prompt.ts
+++ b/apps/web/utils/ai/rule/generate-rules-prompt.ts
@@ -18,7 +18,7 @@ const parametersSnippets = z.object({
         rule: z.string().describe("The rule to apply to the email"),
         snippet: z
           .string()
-          .optional()
+          .nullable()
           .describe(
             "Optional: Include ONLY if this is a snippet-based rule. The exact snippet text this rule is based on.",
           ),

--- a/apps/web/utils/ai/rule/prompt-to-rules-old.ts
+++ b/apps/web/utils/ai/rule/prompt-to-rules-old.ts
@@ -13,7 +13,7 @@ const logger = createScopedLogger("ai-prompt-to-rules");
 
 const updateRuleSchema = (provider: string) =>
   createRuleSchema(provider).extend({
-    ruleId: z.string().optional(),
+    ruleId: z.string().nullable(),
   });
 
 export async function aiPromptToRulesOld({

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -353,7 +353,11 @@ interface FolderTarget {
 }
 
 function resolveFolderTarget(
-  analysis: { action: string; folderId?: string; folderPath?: string },
+  analysis: {
+    action: string;
+    folderId?: string | null;
+    folderPath?: string | null;
+  },
   folders: FolderWithConnection[],
   connections: DriveConnection[],
   logger: Logger,

--- a/apps/web/utils/drive/handle-filing-reply.ts
+++ b/apps/web/utils/drive/handle-filing-reply.ts
@@ -208,7 +208,7 @@ async function handleMove({
   filingWasCorrected: boolean;
   filingOriginalPath: string | null;
   driveConnection: DriveConnection;
-  folderPath: string | undefined;
+  folderPath: string | null;
   emailAccountId: string;
   logger: Logger;
 }): Promise<void> {


### PR DESCRIPTION
# User description
## Summary
Fixed Zod schemas to be compatible with OpenAI's strict structured output mode. Changed `.nullish()` and `.optional()` to `.nullable()` across 12 files in AI utilities.

OpenAI requires all properties to be in the JSON Schema `required` array. Using `.nullable()` instead of `.nullish()` keeps fields required while allowing null values, making schemas compatible with all LLM providers.

## Files Changed
- AI rule/choice schemas (choose-rule, detect-recurring-pattern, create-rule-schema)
- Document filing schemas (analyze-document, parse-filing-reply)  
- Rules generation (generate-rules-prompt)
- Label selection (ai-clean-select-labels)
- Action handlers (rule.ts, chat.ts)
- File system utilities (filing-engine.ts, handle-filing-reply.ts)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
actionSchema_("actionSchema"):::modified
DATE_UTIL_("DATE_UTIL"):::added
handleMove_("handleMove"):::modified
DRIVE_SERVICE_("DRIVE_SERVICE"):::modified
actionSchema_ -- "Adds delayInMinutes capped 1–90 days via NINETY_DAYS_MINUTES." --> DATE_UTIL_
handleMove_ -- "Makes folderPath nullable, passed to DRIVE_SERVICE for moves." --> DRIVE_SERVICE_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates Zod schemas across the AI utility suite to ensure compatibility with OpenAI's strict structured output requirements. Replaces optional and nullish fields with nullable ones to maintain property presence in the generated JSON Schema while allowing null values.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1559?tool=ast&topic=Logic+%26+Utilities>Logic & Utilities</a>
        </td><td>Adjust action handlers and filing engine utilities to correctly handle <code>null</code> values instead of <code>undefined</code> for fields like <code>folderPath</code> and <code>aiInstructions</code>.<details><summary>Modified files (4)</summary><ul><li>apps/web/utils/actions/rule.ts</li>
<li>apps/web/utils/ai/assistant/chat.ts</li>
<li>apps/web/utils/drive/filing-engine.ts</li>
<li>apps/web/utils/drive/handle-filing-reply.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-migrate-AI-SDK-f...</td><td>February 10, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix-move-folder-add-te...</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1559?tool=ast&topic=AI+Schema+Alignment>AI Schema Alignment</a>
        </td><td>Transition Zod schemas from <code>.optional()</code> or <code>.nullish()</code> to <code>.nullable()</code> to satisfy OpenAI's requirement that all fields be present in the 'required' array.<details><summary>Modified files (8)</summary><ul><li>apps/web/utils/ai/choose-rule/ai-choose-rule.ts</li>
<li>apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts</li>
<li>apps/web/utils/ai/clean/ai-clean-select-labels.ts</li>
<li>apps/web/utils/ai/document-filing/analyze-document.ts</li>
<li>apps/web/utils/ai/document-filing/parse-filing-reply.ts</li>
<li>apps/web/utils/ai/rule/create-rule-schema.ts</li>
<li>apps/web/utils/ai/rule/generate-rules-prompt.ts</li>
<li>apps/web/utils/ai/rule/prompt-to-rules-old.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>security-add-prompt-ha...</td><td>January 14, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Add-provider-to-filter...</td><td>August 13, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1559?tool=ast>(Baz)</a>.