### PR TITLE
Fix rule matching order to respect runOnThreads on learned patterns

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -169,6 +169,18 @@ async function findPotentialMatchingRules({
       // Don't continue - let it also be evaluated for AI matching below
     }
 
+    // Skip rules with runOnThreads=false, unless this rule was previously applied in the thread
+    // This ensures thread continuity (e.g., notifications continue to be labeled as notifications)
+    // Must be checked before learned patterns to prevent pattern matches from bypassing this guard
+    if (isThread && !rule.runOnThreads) {
+      const previousRuleIds = await previousRulesLoader.getRuleIds();
+      const wasPreviouslyApplied = previousRuleIds.has(rule.id);
+
+      if (!wasPreviouslyApplied) {
+        continue;
+      }
+    }
+
     // Learned patterns (groups)
     // Note: Groups are independent of the AND/OR operator (which only applies to AI/Static conditions)
     if (rule.groupId) {
@@ -197,17 +209,6 @@ async function findPotentialMatchingRules({
           });
           continue;
         }
-      }
-    }
-
-    // Skip rules with runOnThreads=false, unless this rule was previously applied in the thread
-    // This ensures thread continuity (e.g., notifications continue to be labeled as notifications)
-    if (isThread && !rule.runOnThreads) {
-      const previousRuleIds = await previousRulesLoader.getRuleIds();
-      const wasPreviouslyApplied = previousRuleIds.has(rule.id);
-
-      if (!wasPreviouslyApplied) {
-        continue;
       }
     }
 


### PR DESCRIPTION
# User description
## Summary
Fixed a rule matching order bug where learned patterns could bypass the `runOnThreads=false` restriction. Rules are now evaluated against thread restrictions before checking learned patterns, while preserving thread continuity logic.

## What Changed
- Moved `runOnThreads` check before learned pattern matching in `findPotentialMatchingRules`
- Rules with `runOnThreads=false` on new thread replies are now skipped
- Rules previously applied to a thread continue to match via patterns (thread continuity preserved)

## Test Coverage
Added comprehensive tests covering:
- Pattern matches blocked on new thread replies (runOnThreads=false)
- Pattern matches allowed when rule previously applied (thread continuity)
- First message exceptions (isReplyInThread=false)
- runOnThreads=true baseline (no restrictions)
- AI rules with runOnThreads constraints

All 97 tests pass.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensures that rule matching respects the <code>runOnThreads</code> restriction by evaluating thread constraints before checking learned patterns. This change prevents rules from being incorrectly applied to new thread replies while maintaining thread continuity for rules already active in a conversation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1560?tool=ast&topic=Validation+Tests>Validation Tests</a>
        </td><td>Add comprehensive test cases in <code>match-rules.test.ts</code> to verify that learned patterns are blocked on new threads when <code>runOnThreads</code> is false, but allowed when thread continuity is established.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/choose-rule/match-rules.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-tests</td><td>January 03, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-getMessage-to...</td><td>July 28, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1560?tool=ast&topic=Rule+Matching+Logic>Rule Matching Logic</a>
        </td><td>Reorder the matching logic in <code>findPotentialMatchingRules</code> to check <code>runOnThreads</code> and <code>wasPreviouslyApplied</code> status before evaluating learned patterns or AI conditions.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/choose-rule/match-rules.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-improve-Outlook-ca...</td><td>January 07, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Remove-metadata.-Test-...</td><td>July 28, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1560?tool=ast>(Baz)</a>.