### PR TITLE
Add collapsible details to assistant chat tool results

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -10,6 +10,8 @@ import {
   AddToKnowledgeBase,
   BasicToolInfo,
   CreatedRuleToolCard,
+  ManageInboxResult,
+  SearchInboxResult,
   UpdateAbout,
   UpdatedLearnedPatterns,
   UpdatedRuleActions,
@@ -90,14 +92,7 @@ export function MessagePart({
       if (isOutputWithError(output)) {
         return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
       }
-      const totalReturned =
-        getOutputField<number>(output, "totalReturned") || 0;
-      return (
-        <BasicToolInfo
-          key={toolCallId}
-          text={`Searched inbox (${totalReturned} messages)`}
-        />
-      );
+      return <SearchInboxResult key={toolCallId} output={output} />;
     }
   }
 
@@ -111,16 +106,7 @@ export function MessagePart({
       if (isOutputWithError(output)) {
         return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
       }
-      const action = getOutputField<string>(output, "action");
-      const successCount = getOutputField<number>(output, "successCount");
-      const sendersCount = getOutputField<number>(output, "sendersCount");
-
-      const text =
-        action === "bulk_archive_senders"
-          ? `Bulk archived ${sendersCount || 0} sender${sendersCount === 1 ? "" : "s"}`
-          : `Completed inbox action${typeof successCount === "number" ? ` (${successCount} items)` : ""}`;
-
-      return <BasicToolInfo key={toolCallId} text={text} />;
+      return <ManageInboxResult key={toolCallId} output={output} />;
     }
   }
 


### PR DESCRIPTION
# User description
## Summary
Tool calls in the assistant chat now display expandable details. Users can click the chevron icon to reveal more information about search and inbox management operations.

**Search inbox**: Shows the query used, unread count, and a list of matching messages with from/subject/snippet/date.
**Manage inbox**: Shows the action performed, success/fail counts, and list of affected senders for bulk operations.

## Test plan
- In assistant chat, trigger a search action and verify the summary appears collapsed
- Click the chevron to expand and verify message details display correctly
- Collapse again and verify chevron rotates back
- Test with manage inbox actions to verify success/fail counts display properly

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
MessagePart_("MessagePart"):::modified
SearchInboxResult_("SearchInboxResult"):::added
ManageInboxResult_("ManageInboxResult"):::added
getOutputField_("getOutputField"):::added
CollapsibleToolCard_("CollapsibleToolCard"):::added
FORMAT_SHORT_DATE_("FORMAT_SHORT_DATE"):::added
UI_COLLAPSIBLE_("UI_COLLAPSIBLE"):::added
LUCIDE_REACT_("LUCIDE_REACT"):::modified
MessagePart_ -- "Replaces simple text with collapsible inbox search UI." --> SearchInboxResult_
MessagePart_ -- "Renders detailed action results instead of basic summary." --> ManageInboxResult_
SearchInboxResult_ -- "Extracts totalReturned, queryUsed, summary, messages." --> getOutputField_
ManageInboxResult_ -- "Parses action, successCount, sendersCount, failedCount, senders." --> getOutputField_
SearchInboxResult_ -- "Wraps search results in collapsible card with summary." --> CollapsibleToolCard_
ManageInboxResult_ -- "Displays management results inside collapsible card layout." --> CollapsibleToolCard_
SearchInboxResult_ -- "Formats message date using short lowercase representation." --> FORMAT_SHORT_DATE_
CollapsibleToolCard_ -- "Implements expand/collapse behavior with Collapsible components." --> UI_COLLAPSIBLE_
CollapsibleToolCard_ -- "Uses ChevronRightIcon to indicate open/closed state." --> LUCIDE_REACT_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the assistant chat interface by introducing collapsible detail views for tool execution results. Replaces static text summaries with interactive cards that reveal granular data for inbox search and management actions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1562?tool=ast&topic=Collapsible+UI>Collapsible UI</a>
        </td><td>Implements the <code>CollapsibleToolCard</code> component using Radix UI primitives to provide a consistent expandable interface with chevron animations.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-migrate-AI-SDK-f...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1562?tool=ast&topic=Tool+Result+Views>Tool Result Views</a>
        </td><td>Introduces <code>SearchInboxResult</code> and <code>ManageInboxResult</code> components to display detailed message lists, query parameters, and operation success/failure counts.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Expand-assistant-chat-...</td><td>February 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1562?tool=ast>(Baz)</a>.