### PR TITLE
Show thread details in manage inbox tool results

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -18,12 +18,14 @@ import {
   UpdatedRuleConditions,
 } from "@/components/assistant-chat/tools";
 import type { ChatMessage } from "@/components/assistant-chat/types";
+import type { ThreadLookup } from "@/components/assistant-chat/tools";
 
 interface MessagePartProps {
   part: ChatMessage["parts"][0];
   isStreaming: boolean;
   messageId: string;
   partIndex: number;
+  threadLookup: ThreadLookup;
 }
 
 function ErrorToolCard({ error }: { error: string }) {
@@ -46,6 +48,7 @@ export function MessagePart({
   isStreaming,
   messageId,
   partIndex,
+  threadLookup,
 }: MessagePartProps) {
   const key = `${messageId}-${partIndex}`;
 
@@ -106,7 +109,14 @@ export function MessagePart({
       if (isOutputWithError(output)) {
         return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
       }
-      return <ManageInboxResult key={toolCallId} output={output} />;
+      return (
+        <ManageInboxResult
+          key={toolCallId}
+          output={output}
+          threadIds={part.input.action !== "bulk_archive_senders" ? part.input.threadIds : undefined}
+          threadLookup={threadLookup}
+        />
+      );
     }
   }
 

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { Overview } from "./overview";
 import { MessagePart } from "./message-part";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
+import type { ThreadLookup } from "@/components/assistant-chat/tools";
 import {
   Conversation,
   ConversationContent,
@@ -27,6 +28,8 @@ export function Messages({
   setInput,
   footer,
 }: MessagesProps) {
+  const threadLookup = useMemo(() => buildThreadLookup(messages), [messages]);
+
   return (
     <Conversation className="flex min-w-0 flex-1">
       <ConversationContent
@@ -46,6 +49,7 @@ export function Messages({
                     isStreaming={status === "streaming"}
                     messageId={message.id}
                     partIndex={index}
+                    threadLookup={threadLookup}
                   />
                 ))}
               </MessageContent>
@@ -75,4 +79,37 @@ export function Messages({
       </ConversationContent>
     </Conversation>
   );
+}
+
+function buildThreadLookup(messages: Array<ChatMessage>): ThreadLookup {
+  const lookup: ThreadLookup = new Map();
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (
+        part.type === "tool-searchInbox" &&
+        part.state === "output-available"
+      ) {
+        const output = part.output as Record<string, unknown> | undefined;
+        const items = output?.messages as
+          | Array<{
+              threadId: string;
+              subject: string;
+              from: string;
+              snippet: string;
+            }>
+          | undefined;
+        if (!items) continue;
+        for (const item of items) {
+          if (!lookup.has(item.threadId)) {
+            lookup.set(item.threadId, {
+              subject: item.subject,
+              from: item.from,
+              snippet: item.snippet,
+            });
+          }
+        }
+      }
+    }
+  }
+  return lookup;
 }

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -34,6 +34,11 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 
+export type ThreadLookup = Map<
+  string,
+  { subject: string; from: string; snippet: string }
+>;
+
 function getOutputField<T>(output: unknown, field: string): T | undefined {
   if (typeof output === "object" && output !== null && field in output) {
     return (output as Record<string, unknown>)[field] as T;
@@ -146,8 +151,12 @@ export function SearchInboxResult({ output }: { output: unknown }) {
 
 export function ManageInboxResult({
   output,
+  threadIds,
+  threadLookup,
 }: {
   output: unknown;
+  threadIds?: string[];
+  threadLookup: ThreadLookup;
 }) {
   const action = getOutputField<string>(output, "action");
   const successCount = getOutputField<number>(output, "successCount");
@@ -160,23 +169,31 @@ export function ManageInboxResult({
       ? `Bulk archived ${sendersCount || 0} sender${sendersCount === 1 ? "" : "s"}`
       : `Completed inbox action${typeof successCount === "number" ? ` (${successCount} items)` : ""}`;
 
+  const resolvedThreads = threadIds
+    ?.map((id) => threadLookup.get(id))
+    .filter(Boolean);
+
   return (
     <CollapsibleToolCard summary={summaryText}>
       <div className="space-y-1 text-sm">
-        {action && (
-          <div className="text-xs text-muted-foreground">
-            Action: {action.replace(/_/g, " ")}
-          </div>
-        )}
-
-        {typeof successCount === "number" && (
-          <div className="text-xs text-muted-foreground">
-            Succeeded: {successCount}
-          </div>
-        )}
-
         {typeof failedCount === "number" && failedCount > 0 && (
           <div className="text-xs text-red-500">Failed: {failedCount}</div>
+        )}
+
+        {resolvedThreads && resolvedThreads.length > 0 && (
+          <div className="space-y-1">
+            {resolvedThreads.map((thread, i) => (
+              <div
+                key={i}
+                className="rounded-md bg-muted px-3 py-2 text-sm"
+              >
+                <div className="truncate">{thread.from}</div>
+                <div className="truncate text-muted-foreground">
+                  {thread.subject}
+                </div>
+              </div>
+            ))}
+          </div>
         )}
 
         {senders && senders.length > 0 && (


### PR DESCRIPTION
# User description
## Summary
When expanding the "Completed inbox action (4 items)" collapsible in assistant chat, users can now see which emails were acted on (subject + sender for each thread).

Builds a thread lookup map from previous search results in the conversation and cross-references thread IDs from the manage inbox input. No extra API calls needed.

## Test plan
- In assistant chat, search inbox then archive/mark-read threads
- Expand the manage inbox result card
- Verify archived thread subjects and senders are displayed
- Verify bulk archive senders still shows sender list as before

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Messages_("Messages"):::modified
buildThreadLookup_("buildThreadLookup"):::added
TOOL_SEARCHINBOX_("TOOL_SEARCHINBOX"):::added
ThreadLookup_("ThreadLookup"):::added
MessagePart_("MessagePart"):::modified
ManageInboxResult_("ManageInboxResult"):::modified
Messages_ -- "Now memoizes thread lookup from messages for reuse." --> buildThreadLookup_
buildThreadLookup_ -- "Extracts messages (threadId, subject, from, snippet) from responses." --> TOOL_SEARCHINBOX_
buildThreadLookup_ -- "Populates ThreadLookup map storing subject, from, snippet keyed by id." --> ThreadLookup_
MessagePart_ -- "Passes threadIds and threadLookup to render resolved threads." --> ManageInboxResult_
MessagePart_ -- "Adds threadLookup prop to pass resolved thread metadata." --> ThreadLookup_
ManageInboxResult_ -- "Resolves threadIds via ThreadLookup to display sender/subject." --> ThreadLookup_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the assistant chat by displaying thread subjects and senders within the 'Manage Inbox' tool result cards. Implements a client-side lookup mechanism that cross-references thread IDs with previous search results to provide detailed context without additional API overhead.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1563?tool=ast&topic=Thread+Data+Lookup>Thread Data Lookup</a>
        </td><td>Implements <code>buildThreadLookup</code> to extract and cache thread metadata from previous <code>tool-searchInbox</code> message parts in the conversation history.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/assistant-chat/messages.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-collapsible-detail...</td><td>February 13, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1563?tool=ast&topic=Inbox+Result+UI>Inbox Result UI</a>
        </td><td>Updates <code>ManageInboxResult</code> and <code>MessagePart</code> to resolve and render thread details like sender and subject within a collapsible UI component.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-collapsible-detail...</td><td>February 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1563?tool=ast>(Baz)</a>.