### PR TITLE
Remove tab=email query param from Slack OAuth redirects

### DIFF
--- a/apps/web/utils/slack/handle-slack-callback.ts
+++ b/apps/web/utils/slack/handle-slack-callback.ts
@@ -160,7 +160,6 @@ export async function handleSlackCallback(
     }
 
     const errorRedirectUrl = new URL(errorPath, env.NEXT_PUBLIC_BASE_URL);
-    errorRedirectUrl.searchParams.set("tab", "email");
     errorRedirectUrl.searchParams.set("error", "connection_failed");
     errorRedirectUrl.searchParams.set("error_reason", reason);
     errorRedirectUrl.searchParams.set("error_detail", errorDetail);
@@ -187,7 +186,6 @@ function validateOAuthCallback(
   const storedState = request.cookies.get(SLACK_STATE_COOKIE_NAME)?.value;
 
   const redirectUrl = new URL("/settings", env.NEXT_PUBLIC_BASE_URL);
-  redirectUrl.searchParams.set("tab", "email");
   const response = NextResponse.redirect(redirectUrl);
 
   response.cookies.delete(SLACK_STATE_COOKIE_NAME);
@@ -281,7 +279,6 @@ function buildSettingsRedirectUrl(emailAccountId: string): URL {
     prefixPath(emailAccountId, "/settings"),
     env.NEXT_PUBLIC_BASE_URL,
   );
-  url.searchParams.set("tab", "email");
   return url;
 }
 


### PR DESCRIPTION
# User description
Removes the unnecessary tab=email query parameter from Slack OAuth callback redirects. The settings page no longer requires this parameter.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Removes the obsolete <code>tab=email</code> query parameter from Slack OAuth callback and error redirection logic within the <code>handleSlackCallback</code> utility. Ensures that users are redirected to the settings page without unnecessary state parameters after completing or failing the Slack integration flow.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-Slack-OAuth-ca...</td><td>February 11, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1565?tool=ast>(Baz)</a>.