### PR TITLE
Fix type narrowing for optional thread lookup

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -10,6 +10,7 @@ import type {
   AddToKnowledgeBaseTool,
   CreateRuleTool,
 } from "@/utils/ai/assistant/chat";
+import { isDefined } from "@/utils/types";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -168,7 +169,7 @@ export function ManageInboxResult({
 
   const resolvedThreads = threadIds
     ?.map((id) => threadLookup.get(id))
-    .filter(Boolean);
+    .filter(isDefined);
 
   return (
     <CollapsibleToolCard summary={summaryText}>


### PR DESCRIPTION
# User description
## Summary
- Fixed TypeScript build error where `.filter(Boolean)` didn't narrow the type to exclude `undefined`
- Used a type predicate filter to properly narrow the array type

## Test plan
- [x] `tsc --noEmit` passes with no errors on the affected file
- [ ] Verify production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes TypeScript type narrowing for thread lookups in the <code>ManageInboxResult</code> component by replacing a boolean filter with a type predicate. Ensures that the <code>resolvedThreads</code> array is correctly typed as defined objects, preventing build-time errors.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-Slack-markdown...</td><td>February 13, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1569?tool=ast>(Baz)</a>.