### PR TITLE
Improve conversation status guidance in assistant

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -126,6 +126,9 @@ describe("aiProcessAssistantChat", () => {
     );
     expect(args.messages[0].content).toContain("Provider context:");
     expect(args.messages[0].content).toContain("Inbox triage guidance:");
+    expect(args.messages[0].content).toContain(
+      "Conversation status behavior should be customized by updating conversation rules directly",
+    );
 
     expect(args.tools.getAccountOverview).toBeDefined();
     expect(args.tools.searchInbox).toBeDefined();


### PR DESCRIPTION
# User description
## Summary
This updates assistant chat guidance to prefer conversation rule updates for conversation status behavior. It replaces outdated guidance that suggested using personal instructions for status routing changes. It also adds context-specific fix guidance for conversation-status corrections and a test assertion to prevent prompt regressions.

## Testing
Not run in this workspace (dependencies are not installed).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
aiProcessAssistantChat_("aiProcessAssistantChat"):::modified
isConversationStatusFixContext_("isConversationStatusFixContext"):::added
UPDATE_RULE_CONDITIONS_("UPDATE_RULE_CONDITIONS"):::modified
UPDATE_ABOUT_("UPDATE_ABOUT"):::modified
UPDATE_INBOX_FEATURES_("UPDATE_INBOX_FEATURES"):::modified
SEARCH_INBOX_("SEARCH_INBOX"):::modified
aiProcessAssistantChat_ -- "Detects conversation-status fixes to surface rule-update guidance." --> isConversationStatusFixContext_
aiProcessAssistantChat_ -- "Recommends updateRuleConditions to revise conversation-status rule instructions." --> UPDATE_RULE_CONDITIONS_
aiProcessAssistantChat_ -- "Persists Personal Instructions to influence conversation-status categorization." --> UPDATE_ABOUT_
aiProcessAssistantChat_ -- "Enables toggling meeting briefs and auto-file attachment settings." --> UPDATE_INBOX_FEATURES_
aiProcessAssistantChat_ -- "Ensures searchInbox fetches IDs before executing write actions." --> SEARCH_INBOX_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the AI assistant's guidance to prioritize direct conversation rule modifications over personal instructions for managing email status behavior. Enhances the <code>aiProcessAssistantChat</code> component to provide context-specific instructions when users attempt to fix conversation status classifications.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1572?tool=ast&topic=Status+Fix+Logic>Status Fix Logic</a>
        </td><td>Implement <code>isConversationStatusFixContext</code> to detect status-related corrections and add a regression test to ensure the assistant receives the updated guidance.<details><summary>Modified files (2)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li>
<li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Refine-AI-prompt-guida...</td><td>February 13, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-and-PR-feedback</td><td>August 14, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1572?tool=ast&topic=Assistant+Guidance>Assistant Guidance</a>
        </td><td>Refactor the system prompt to instruct the AI to use <code>updateRuleConditions</code> for conversation statuses like 'To Reply' or 'FYI' instead of <code>updateAbout</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Refine-AI-prompt-guida...</td><td>February 13, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-and-PR-feedback</td><td>August 14, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1572?tool=ast>(Baz)</a>.