### PR TITLE
Enable Slack direct messages for bot interaction

### DIFF
--- a/docs/slack/manifest.yaml
+++ b/docs/slack/manifest.yaml
@@ -9,9 +9,12 @@ display_information:
   background_color: "#1a1a2e"
 
 features:
+  app_home:
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Inbox Zero
-    always_online: false
+    always_online: true
 
 oauth_config:
   scopes:


### PR DESCRIPTION
# User description
Add app_home configuration to enable Messages tab on the bot profile, allowing users to DM the bot directly instead of seeing "turned off". Set bot to always_online since it processes async events.

This unblocks the conversational interface already implemented in the event handler, enabling users to chat with the AI assistant about their email—complementing the existing private channel delivery mode for automated briefs.

## Changes
- Enable Messages tab on bot App Home
- Set always_online to true

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enables the Slack Messages tab and sets the bot to always online to facilitate direct conversational interactions with the AI assistant. Updates the <code>manifest.yaml</code> configuration to unblock the existing event-driven messaging interface for users.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Slack-bot-processi...</td><td>February 13, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1574?tool=ast>(Baz)</a>.