### PR TITLE
Update Slack setup docs with App Home configuration

### DIFF
--- a/docs/slack/setup.mdx
+++ b/docs/slack/setup.mdx
@@ -58,6 +58,15 @@ Under **Event Subscriptions**:
 
 Slack will send a verification challenge to the URL; the app handles this automatically.
 
+### Enable App Home
+
+Under **App Home**:
+
+1. Check **Allow users to send Slash commands and messages from the messages tab**
+2. Uncheck **Make the messages tab read-only** (if shown)
+
+This lets users DM the bot directly to chat with the AI assistant.
+
 </details>
 
 ## 2. Set Environment Variables


### PR DESCRIPTION
# User description
## Summary
- Add manual setup instructions for enabling the Messages tab under App Home
- Ensures self-hosters who don't use the manifest know to configure DM support

Companion to #1574 which updated the manifest itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Slack setup documentation to include manual configuration steps for enabling the App Home messages tab. This ensures self-hosted users can interact with the AI assistant via direct messages by correctly configuring their Slack application settings.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Slack-bot-processi...</td><td>February 13, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1577?tool=ast>(Baz)</a>.