### PR TITLE
Replace rules toggle with disable all button

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/ToggleAllRulesSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ToggleAllRulesSection.tsx
@@ -68,7 +68,7 @@ export function ToggleAllRulesSection({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={() => execute({ enabled: false })}>
+              <AlertDialogAction type="button" onClick={() => execute({ enabled: false })}>
                 Disable All
               </AlertDialogAction>
             </AlertDialogFooter>


### PR DESCRIPTION
# User description
Replace the ambiguous Switch component with a destructive 'Disable All' button that only appears when at least one rule is enabled, requires confirmation before disabling, and clarifies that rules can be re-enabled individually.

**Changes:**
- Replace Switch toggle with confirmation button
- Only show button when at least one rule is enabled
- Add AlertDialog for confirmation
- Improve copy to clarify re-enabling rules per-rule

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replaces the global rules toggle with a 'Disable All' button and a confirmation dialog to prevent accidental bulk changes. Updates the <code>ToggleAllRulesSection</code> component to conditionally render based on the presence of enabled rules and provides clearer instructions for re-enabling them.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-disable-all-rules-...</td><td>February 13, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1584?tool=ast>(Baz)</a>.