### PR TITLE
Add disable-model-invocation to command skills

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 Resolve all active PR comments (conversation + code review).
 Use GitHub MCP. If not available, use `gh` CLI.
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # Open a PR
 
 Important: Steps 2 and 3 require `required_permissions: ['all']` because:

--- a/.claude/skills/next-step/SKILL.md
+++ b/.claude/skills/next-step/SKILL.md
@@ -1,2 +1,6 @@
+---
+disable-model-invocation: true
+---
+
 Continue to the next step.
 

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # polish
 
 Remove AI slop and lint errors from branch. Autonomous, no confirmation.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # review
 
 Code review with craftsman's eye. Auto-fix obvious issues, surface real bugs.

--- a/.claude/skills/roast-my-code/SKILL.md
+++ b/.claude/skills/roast-my-code/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # roast-my-code
 
 Brutally honest code review with comedic flair. Mock the sins, then redeem the sinner.

--- a/.claude/skills/step-by-step/SKILL.md
+++ b/.claude/skills/step-by-step/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # Step-by-Step Execution
 
 Execute **one step at a time**. After each step, stop and wait for my approval before continuing.

--- a/.claude/skills/ux-writing/SKILL.md
+++ b/.claude/skills/ux-writing/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # UX Writing
 
 ## The Button Label Problem

--- a/.claude/skills/wait/SKILL.md
+++ b/.claude/skills/wait/SKILL.md
@@ -1,1 +1,5 @@
+---
+disable-model-invocation: true
+---
+
 wait X seconds/minutes (user will provide input). use `sleep` command. DONT do it in background

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,3 +1,7 @@
+---
+disable-model-invocation: true
+---
+
 # write-tests
 
 Write unit tests for utility functions and backend logic. Mock all external dependencies.


### PR DESCRIPTION
# User description
Add `disable-model-invocation: true` frontmatter to the remaining 10 command-based skills that were missing it.

- Ensures user-triggered workflow skills (review, create-pr, write-tests, etc.) cannot be auto-invoked by Claude
- Follows up on the previous skills consolidation PR

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the frontmatter of several command-based skills to include the <code>disable-model-invocation</code> flag. Prevents the automated invocation of user-triggered workflows like PR creation, code reviews, and test writing by the AI model.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Move-skill-documentati...</td><td>February 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1588?tool=ast>(Baz)</a>.