### PR TITLE
Simplify inbox action notifications

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -18,14 +18,11 @@ import {
   UpdatedRuleConditions,
 } from "@/components/assistant-chat/tools";
 import type { ChatMessage } from "@/components/assistant-chat/types";
-import type { ThreadLookup } from "@/components/assistant-chat/tools";
-
 interface MessagePartProps {
   part: ChatMessage["parts"][0];
   isStreaming: boolean;
   messageId: string;
   partIndex: number;
-  threadLookup: ThreadLookup;
 }
 
 function ErrorToolCard({ error }: { error: string }) {
@@ -48,7 +45,6 @@ export function MessagePart({
   isStreaming,
   messageId,
   partIndex,
-  threadLookup,
 }: MessagePartProps) {
   const key = `${messageId}-${partIndex}`;
 
@@ -109,18 +105,7 @@ export function MessagePart({
       if (isOutputWithError(output)) {
         return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
       }
-      return (
-        <ManageInboxResult
-          key={toolCallId}
-          output={output}
-          threadIds={
-            part.input.action !== "bulk_archive_senders"
-              ? part.input.threadIds
-              : undefined
-          }
-          threadLookup={threadLookup}
-        />
-      );
+      return <ManageInboxResult key={toolCallId} output={output} />;
     }
   }
 

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -1,9 +1,8 @@
-import { useMemo, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Overview } from "./overview";
 import { MessagePart } from "./message-part";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
-import type { ThreadLookup } from "@/components/assistant-chat/tools";
 import {
   Conversation,
   ConversationContent,
@@ -28,8 +27,6 @@ export function Messages({
   setInput,
   footer,
 }: MessagesProps) {
-  const threadLookup = useMemo(() => buildThreadLookup(messages), [messages]);
-
   return (
     <Conversation className="flex min-w-0 flex-1">
       <ConversationContent
@@ -49,7 +46,6 @@ export function Messages({
                     isStreaming={status === "streaming"}
                     messageId={message.id}
                     partIndex={index}
-                    threadLookup={threadLookup}
                   />
                 ))}
               </MessageContent>
@@ -79,37 +75,4 @@ export function Messages({
       </ConversationContent>
     </Conversation>
   );
-}
-
-function buildThreadLookup(messages: Array<ChatMessage>): ThreadLookup {
-  const lookup: ThreadLookup = new Map();
-  for (const message of messages) {
-    for (const part of message.parts ?? []) {
-      if (
-        part.type === "tool-searchInbox" &&
-        part.state === "output-available"
-      ) {
-        const output = part.output as Record<string, unknown> | undefined;
-        const items = output?.messages as
-          | Array<{
-              threadId: string;
-              subject: string;
-              from: string;
-              snippet: string;
-            }>
-          | undefined;
-        if (!items) continue;
-        for (const item of items) {
-          if (!lookup.has(item.threadId)) {
-            lookup.set(item.threadId, {
-              subject: item.subject,
-              from: item.from,
-              snippet: item.snippet,
-            });
-          }
-        }
-      }
-    }
-  }
-  return lookup;
 }


### PR DESCRIPTION
# User description
Show specific action taken (archived, marked read) instead of generic message. Remove per-email detail list from notification since it's not helpful.

**Changes:**
- Display "Archived X items", "Marked X items as read", etc. instead of generic "Completed inbox action"
- Remove per-thread email sender and subject display from notification
- Clean up unused thread lookup infrastructure

The bulk sender list and failure count are still shown when relevant.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
ManageInboxResult_("ManageInboxResult"):::modified
getOutputField_("getOutputField"):::modified
MessagePart_("MessagePart"):::modified
Messages_("Messages"):::modified
ManageInboxResult_ -- "Uses getOutputField to compute summaryText, added itemCount-based summaries" --> getOutputField_
MessagePart_ -- "Now passes only output; removed threadIds and threadLookup props" --> ManageInboxResult_
Messages_ -- "Stopped building threadLookup; no longer passes threadLookup prop" --> MessagePart_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances inbox action notifications by displaying specific outcomes like 'Archived X items' and removes redundant per-email detail lists. Simplifies the <code>ManageInboxResult</code> component and removes the <code>ThreadLookup</code> infrastructure to streamline the assistant chat interface.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1590?tool=ast&topic=Code+Cleanup>Code Cleanup</a>
        </td><td>Remove the <code>ThreadLookup</code> type and <code>buildThreadLookup</code> logic from <code>Messages</code> and <code>MessagePart</code> components as thread metadata is no longer required for notifications.<details><summary>Modified files (3)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/messages.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-type-narrowing-for...</td><td>February 13, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1590?tool=ast&topic=Notification+UI>Notification UI</a>
        </td><td>Update <code>ManageInboxResult</code> to show specific action summaries (e.g., 'Archived', 'Marked as read') and remove the detailed list of email senders and subjects from the notification card.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-type-narrowing-for...</td><td>February 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1590?tool=ast>(Baz)</a>.