### PR TITLE
Improve assistant tool action state labels

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -102,7 +102,20 @@ export function MessagePart({
   if (part.type === "tool-manageInbox") {
     const { toolCallId, state } = part;
     if (state === "input-available") {
-      return <BasicToolInfo key={toolCallId} text="Applying inbox action..." />;
+      let actionText = "Updating emails...";
+      if (part.input.action === "bulk_archive_senders") {
+        actionText = "Bulk archiving by sender...";
+      } else if (part.input.action === "archive_threads") {
+        actionText = part.input.labelId
+          ? "Archiving and labeling emails..."
+          : "Archiving emails...";
+      } else if (part.input.action === "mark_read_threads") {
+        actionText = part.input.read === false
+          ? "Marking emails as unread..."
+          : "Marking emails as read...";
+      }
+
+      return <BasicToolInfo key={toolCallId} text={actionText} />;
     }
     if (state === "output-available") {
       const { output } = part;
@@ -112,6 +125,7 @@ export function MessagePart({
       return (
         <ManageInboxResult
           key={toolCallId}
+          input={part.input}
           output={output}
           threadIds={
             part.input.action !== "bulk_archive_senders"

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -9,6 +9,7 @@ import type {
   UpdateLearnedPatternsTool,
   AddToKnowledgeBaseTool,
   CreateRuleTool,
+  ManageInboxTool,
 } from "@/utils/ai/assistant/chat";
 import { isDefined } from "@/utils/types";
 import { Card } from "@/components/ui/card";
@@ -148,24 +149,42 @@ export function SearchInboxResult({ output }: { output: unknown }) {
 }
 
 export function ManageInboxResult({
+  input,
   output,
   threadIds,
   threadLookup,
 }: {
+  input?: ManageInboxTool["input"];
   output: unknown;
   threadIds?: string[];
   threadLookup: ThreadLookup;
 }) {
-  const action = getOutputField<string>(output, "action");
+  const outputAction = getOutputField<string>(output, "action");
+  const action = parseManageInboxAction(input?.action || outputAction);
   const successCount = getOutputField<number>(output, "successCount");
+  const requestedCount = getOutputField<number>(output, "requestedCount");
   const sendersCount = getOutputField<number>(output, "sendersCount");
   const failedCount = getOutputField<number>(output, "failedCount");
   const senders = getOutputField<string[]>(output, "senders");
+  const read =
+    input?.action === "mark_read_threads"
+      ? input.read !== false
+      : getOutputField<boolean>(output, "read");
+  const labelApplied =
+    input?.action === "archive_threads"
+      ? Boolean(input.labelId)
+      : Boolean(getOutputField<string>(output, "labelId"));
+  const actionLabel = getManageInboxActionLabel({ action, read, labelApplied });
+  const completedCount =
+    action === "bulk_archive_senders"
+      ? sendersCount ?? senders?.length
+      : successCount ?? requestedCount;
+  const countLabel = action === "bulk_archive_senders" ? "sender" : "item";
 
   const summaryText =
-    action === "bulk_archive_senders"
-      ? `Bulk archived ${sendersCount || 0} sender${sendersCount === 1 ? "" : "s"}`
-      : `Completed inbox action${typeof successCount === "number" ? ` (${successCount} items)` : ""}`;
+    typeof completedCount === "number"
+      ? `${actionLabel} (${completedCount} ${countLabel}${completedCount === 1 ? "" : "s"})`
+      : actionLabel;
 
   const resolvedThreads = threadIds
     ?.map((id) => threadLookup.get(id))
@@ -174,6 +193,8 @@ export function ManageInboxResult({
   return (
     <CollapsibleToolCard summary={summaryText}>
       <div className="space-y-1 text-sm">
+        <div className="text-xs text-muted-foreground">Action: {actionLabel}</div>
+
         {typeof failedCount === "number" && failedCount > 0 && (
           <div className="text-xs text-red-500">Failed: {failedCount}</div>
         )}
@@ -722,4 +743,42 @@ function renderActionFields(fields: {
       </ul>
     </div>
   );
+}
+
+type ManageInboxAction =
+  | "archive_threads"
+  | "mark_read_threads"
+  | "bulk_archive_senders";
+
+function parseManageInboxAction(
+  action: string | undefined,
+): ManageInboxAction | undefined {
+  if (
+    action === "archive_threads" ||
+    action === "mark_read_threads" ||
+    action === "bulk_archive_senders"
+  ) {
+    return action;
+  }
+
+  return undefined;
+}
+
+function getManageInboxActionLabel({
+  action,
+  read,
+  labelApplied,
+}: {
+  action: ManageInboxAction | undefined;
+  read?: boolean;
+  labelApplied: boolean;
+}) {
+  if (action === "bulk_archive_senders") return "Bulk archived senders";
+  if (action === "archive_threads") {
+    return labelApplied ? "Archived and labeled emails" : "Archived emails";
+  }
+  if (action === "mark_read_threads") {
+    return read === false ? "Marked emails as unread" : "Marked emails as read";
+  }
+  return "Updated emails";
 }

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -332,7 +332,7 @@ export const manageInboxTool = ({
         };
       } catch (error) {
         logger.error("Failed to run inbox action", { error });
-        return { error: "Failed to run inbox action" };
+        return { error: "Failed to update emails" };
       }
     },
   });


### PR DESCRIPTION
# User description
## Summary
- replace generic manage-email tool copy with explicit action labels and counts
- pass tool input into the result card so action type, read/unread, and label usage are shown
- add an Assistant Tools section to the components showcase with input and output states
- update manage-email error copy to use generic wording

## Testing
- lint was attempted in this workspace but dependencies are not installed

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
ManageInboxResult_("ManageInboxResult"):::modified
parseManageInboxAction_("parseManageInboxAction"):::added
getManageInboxActionLabel_("getManageInboxActionLabel"):::added
MessagePart_("MessagePart"):::modified
Components_("Components"):::modified
getAssistantToolThreadLookup_("getAssistantToolThreadLookup"):::added
getAssistantSearchInboxOutput_("getAssistantSearchInboxOutput"):::added
ManageInboxResult_ -- "Normalizes action from input/output to decide behavior" --> parseManageInboxAction_
ManageInboxResult_ -- "Computes human-readable label reflecting action, read, labelApplied" --> getManageInboxActionLabel_
MessagePart_ -- "Forwards tool input so result shows correct action summary" --> ManageInboxResult_
Components_ -- "Adds landing previews calling ManageInboxResult with mocked data" --> ManageInboxResult_
Components_ -- "Provides mocked thread metadata for ManageInboxResult previews" --> getAssistantToolThreadLookup_
Components_ -- "Generates canned search output displayed in preview" --> getAssistantSearchInboxOutput_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the assistant's inbox management feedback by replacing generic tool labels with specific action descriptions and item counts. It also introduces a dedicated section in the components showcase to visualize various assistant tool input and output states.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1591?tool=ast&topic=Tool+Action+Labels>Tool Action Labels</a>
        </td><td>Refine the <code>ManageInboxResult</code> and <code>MessagePart</code> components to display granular action labels such as 'Archiving and labeling emails' or 'Marking emails as unread' based on tool input.<details><summary>Modified files (3)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li>
<li>apps/web/utils/ai/assistant/chat-inbox-tools.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Split-assistant-chat-i...</td><td>February 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1591?tool=ast&topic=Component+Showcase>Component Showcase</a>
        </td><td>Expand the components showcase page with a new 'Assistant Tools' section, providing mock data and visual examples for various tool interaction states.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(landing)/components/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Plus-tier-and-dedi...</td><td>February 10, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Add-AnnouncementDialog...</td><td>February 03, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1591?tool=ast>(Baz)</a>.