### PR TITLE
Fix components page prerender error

### DIFF
--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -836,13 +836,15 @@ export default function Components() {
                     "I prefer concise responses and want newsletters archived by default.",
                 }}
               />
-              <AddToKnowledgeBase
-                args={{
-                  title: "Escalation preference",
-                  content:
-                    "Escalate billing emails quickly and keep status updates short.",
-                }}
-              />
+              <Suspense>
+                <AddToKnowledgeBase
+                  args={{
+                    title: "Escalation preference",
+                    content:
+                      "Escalate billing emails quickly and keep status updates short.",
+                  }}
+                />
+              </Suspense>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# User description
Wrap AddToKnowledgeBase in a Suspense boundary to prevent nuqs useQueryState from throwing during static prerendering.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Wraps the <code>AddToKnowledgeBase</code> component within a <code>Suspense</code> boundary on the components landing page. This prevents <code>useQueryState</code> from causing errors during the static prerendering process.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-assistant-tool...</td><td>February 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Add-AnnouncementDialog...</td><td>February 03, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1595?tool=ast>(Baz)</a>.