### PR TITLE
Improve admin plan selector UX

### DIFF
--- a/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
+++ b/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
@@ -1,27 +1,53 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useAction } from "next-safe-action/hooks";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
+import { Label } from "@/components/Input";
 import { adminChangePremiumStatusAction } from "@/utils/actions/premium";
-import { Select } from "@/components/Select";
 import {
   changePremiumStatusSchema,
   type ChangePremiumStatusOptions,
 } from "@/app/(app)/admin/validation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toastError, toastSuccess } from "@/components/Toast";
+import type { PremiumTier } from "@/generated/prisma/enums";
+import { tiers } from "@/app/(app)/premium/config";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/utils";
+
+type TierKey = "STARTER" | "PLUS" | "PROFESSIONAL" | "LIFETIME";
+
+const tierOptions: { key: TierKey; name: string; description: string }[] = [
+  ...tiers.map((t) => ({
+    key: t.tiers.annually.replace("_ANNUALLY", "") as TierKey,
+    name: t.name,
+    description: t.description,
+  })),
+  { key: "LIFETIME", name: "Lifetime", description: "One-time purchase." },
+];
+
+function buildPremiumTier(
+  tierKey: TierKey,
+  billingPeriod: "MONTHLY" | "ANNUALLY",
+): PremiumTier {
+  if (tierKey === "LIFETIME") return "LIFETIME";
+  return `${tierKey}_${billingPeriod}` as PremiumTier;
+}
 
 export const AdminUpgradeUserForm = () => {
+  const [selectedTier, setSelectedTier] = useState<TierKey>("STARTER");
+  const [billingPeriod, setBillingPeriod] = useState<"MONTHLY" | "ANNUALLY">(
+    "ANNUALLY",
+  );
+
   const { execute: changePremiumStatus, isExecuting } = useAction(
     adminChangePremiumStatusAction,
     {
       onSuccess: () => {
-        toastSuccess({
-          description: "Premium status changed",
-        });
+        toastSuccess({ description: "Premium status changed" });
       },
       onError: ({ error }) => {
         toastError({
@@ -54,6 +80,8 @@ export const AdminUpgradeUserForm = () => {
     [changePremiumStatus],
   );
 
+  const period = buildPremiumTier(selectedTier, billingPeriod);
+
   return (
     <form className="max-w-sm space-y-4">
       <Input
@@ -79,61 +107,59 @@ export const AdminUpgradeUserForm = () => {
         registerProps={register("emailAccountsAccess", { valueAsNumber: true })}
         error={errors.emailAccountsAccess}
       />
-      <Select
-        label="Plan"
-        options={[
-          {
-            label: "STARTER_ANNUALLY",
-            value: "STARTER_ANNUALLY",
-          },
-          {
-            label: "STARTER_MONTHLY",
-            value: "STARTER_MONTHLY",
-          },
-          {
-            label: "PLUS_ANNUALLY",
-            value: "PLUS_ANNUALLY",
-          },
-          {
-            label: "PLUS_MONTHLY",
-            value: "PLUS_MONTHLY",
-          },
-          {
-            label: "PROFESSIONAL_ANNUALLY",
-            value: "PROFESSIONAL_ANNUALLY",
-          },
-          {
-            label: "PROFESSIONAL_MONTHLY",
-            value: "PROFESSIONAL_MONTHLY",
-          },
-          {
-            label: "PRO_ANNUALLY",
-            value: "PRO_ANNUALLY",
-          },
-          {
-            label: "PRO_MONTHLY",
-            value: "PRO_MONTHLY",
-          },
-          {
-            label: "BASIC_ANNUALLY",
-            value: "BASIC_ANNUALLY",
-          },
-          {
-            label: "BASIC_MONTHLY",
-            value: "BASIC_MONTHLY",
-          },
-          {
-            label: "COPILOT_MONTHLY",
-            value: "COPILOT_MONTHLY",
-          },
-          {
-            label: "LIFETIME",
-            value: "LIFETIME",
-          },
-        ]}
-        {...register("period")}
-        error={errors.period}
-      />
+
+      <div>
+        <Label name="plan" label="Plan" />
+        <RadioGroup
+          value={selectedTier}
+          onValueChange={(v) => setSelectedTier(v as TierKey)}
+          className="mt-1 gap-2"
+        >
+          {tierOptions.map((tier) => (
+            <label
+              key={tier.key}
+              className={cn(
+                "flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors",
+                selectedTier === tier.key
+                  ? "border-primary bg-primary/5"
+                  : "border-input hover:bg-accent/50",
+              )}
+            >
+              <RadioGroupItem value={tier.key} className="mt-0.5" />
+              <div className="min-w-0">
+                <div className="text-sm font-medium">{tier.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {tier.description}
+                </div>
+              </div>
+            </label>
+          ))}
+        </RadioGroup>
+      </div>
+
+      {selectedTier !== "LIFETIME" && (
+        <div>
+          <Label name="billingPeriod" label="Billing period" />
+          <div className="mt-1 flex gap-1 rounded-md border border-input p-1">
+            {(["MONTHLY", "ANNUALLY"] as const).map((bp) => (
+              <button
+                key={bp}
+                type="button"
+                onClick={() => setBillingPeriod(bp)}
+                className={cn(
+                  "flex-1 rounded px-3 py-1.5 text-sm font-medium transition-colors",
+                  billingPeriod === bp
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {bp === "MONTHLY" ? "Monthly" : "Annual"}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       <Input
         type="number"
         name="count"
@@ -150,7 +176,7 @@ export const AdminUpgradeUserForm = () => {
               email: getValues("email"),
               lemonSqueezyCustomerId: getValues("lemonSqueezyCustomerId"),
               emailAccountsAccess: getValues("emailAccountsAccess"),
-              period: getValues("period"),
+              period,
               count: getValues("count"),
               upgrade: true,
             });
@@ -165,7 +191,7 @@ export const AdminUpgradeUserForm = () => {
           onClick={() => {
             onSubmit({
               email: getValues("email"),
-              period: getValues("period"),
+              period,
               count: getValues("count"),
               upgrade: false,
             });


### PR DESCRIPTION
# User description
Replaces confusing raw enum dropdown with radio cards showing tier names and descriptions. Adds separate billing period toggle. Removes legacy plans and fetches tier details from config to keep displays in sync.

🎨 UI improvements:
- Radio button cards with tier descriptions
- Separate monthly/annual toggle
- Only shows 3 active tiers + lifetime option

🧹 Code improvements:
- Descriptions pulled from config (eliminates redundancy)
- Smaller, more manageable component

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
AdminUpgradeUserForm_("AdminUpgradeUserForm"):::modified
buildPremiumTier_("buildPremiumTier"):::added
ADMIN_CHANGE_PREMIUM_STATUS_ACTION_("ADMIN_CHANGE_PREMIUM_STATUS_ACTION"):::modified
TIERS_CONFIG_("TIERS_CONFIG"):::added
PREMIUM_TIER_PRISMA_ENUM_("PREMIUM_TIER (PRISMA_ENUM)"):::added
AdminUpgradeUserForm_ -- "Introduces conversion to compute PremiumTier from selected options." --> buildPremiumTier_
AdminUpgradeUserForm_ -- "Replaces raw period value with computed PremiumTier period." --> ADMIN_CHANGE_PREMIUM_STATUS_ACTION_
AdminUpgradeUserForm_ -- "Adds tier config-driven radio options and descriptions." --> TIERS_CONFIG_
buildPremiumTier_ -- "Maps selected tier and billing to Prisma PremiumTier." --> PREMIUM_TIER_PRISMA_ENUM_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the <code>AdminUpgradeUserForm</code> by replacing the raw enum dropdown with interactive radio cards and a separate billing period toggle. Synchronizes available plans with the central configuration to eliminate legacy options and redundant descriptions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1596?tool=ast&topic=Data+Integration>Data Integration</a>
        </td><td>Integrate <code>tiers</code> from the premium configuration to dynamically generate plan options and remove hardcoded legacy enums.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Plus-tier-and-dedi...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1596?tool=ast&topic=UI%2FUX+Refactor>UI/UX Refactor</a>
        </td><td>Redesign the plan selection interface using <code>RadioGroup</code> cards and a custom billing period toggle for better usability.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Plus-tier-and-dedi...</td><td>February 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1596?tool=ast>(Baz)</a>.