### PR TITLE
Use dropdown with feature list for admin plan selector

### DIFF
--- a/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
+++ b/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useState } from "react";
 import { useAction } from "next-safe-action/hooks";
 import { type SubmitHandler, useForm } from "react-hook-form";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Input";
@@ -15,18 +17,23 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toastError, toastSuccess } from "@/components/Toast";
 import type { PremiumTier } from "@/generated/prisma/enums";
 import { tiers } from "@/app/(app)/premium/config";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/utils";
 
 type TierKey = "STARTER" | "PLUS" | "PROFESSIONAL" | "LIFETIME";
 
-const tierOptions: { key: TierKey; name: string; description: string }[] = [
+const tierOptions: { key: TierKey; name: string; features: string }[] = [
   ...tiers.map((t) => ({
     key: t.tiers.annually.replace("_ANNUALLY", "") as TierKey,
     name: t.name,
-    description: t.description,
+    features: t.features.map((f) => f.text).join(", "),
   })),
-  { key: "LIFETIME", name: "Lifetime", description: "One-time purchase." },
+  { key: "LIFETIME", name: "Lifetime", features: "One-time purchase" },
 ];
 
 function buildPremiumTier(
@@ -110,31 +117,37 @@ export const AdminUpgradeUserForm = () => {
 
       <div>
         <Label name="plan" label="Plan" />
-        <RadioGroup
+        <Select
           value={selectedTier}
           onValueChange={(v) => setSelectedTier(v as TierKey)}
-          className="mt-1 gap-2"
         >
-          {tierOptions.map((tier) => (
-            <label
-              key={tier.key}
-              className={cn(
-                "flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors",
-                selectedTier === tier.key
-                  ? "border-primary bg-primary/5"
-                  : "border-input hover:bg-accent/50",
-              )}
-            >
-              <RadioGroupItem value={tier.key} className="mt-0.5" />
-              <div className="min-w-0">
-                <div className="text-sm font-medium">{tier.name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {tier.description}
+          <SelectTrigger className="mt-1">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {tierOptions.map((tier) => (
+              <SelectPrimitive.Item
+                key={tier.key}
+                value={tier.key}
+                className="relative flex w-full cursor-default select-none items-start rounded-sm py-2 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+              >
+                <span className="absolute left-2 top-2.5 flex h-3.5 w-3.5 items-center justify-center">
+                  <SelectPrimitive.ItemIndicator>
+                    <Check className="h-4 w-4" />
+                  </SelectPrimitive.ItemIndicator>
+                </span>
+                <div>
+                  <SelectPrimitive.ItemText>
+                    {tier.name}
+                  </SelectPrimitive.ItemText>
+                  <div className="text-xs text-muted-foreground">
+                    {tier.features}
+                  </div>
                 </div>
-              </div>
-            </label>
-          ))}
-        </RadioGroup>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {selectedTier !== "LIFETIME" && (


### PR DESCRIPTION
# User description
Replace radio group cards with a shadcn Select dropdown showing tier features. Trigger displays the selected tier name; each dropdown option shows the feature list below the tier name. Shows descriptions instead of raw enum values.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replaces the radio group selection in the <code>AdminUpgradeUserForm</code> with a more compact <code>Select</code> dropdown component. Enhances the plan selection UI by displaying detailed feature lists for each tier instead of generic descriptions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1598?tool=ast&topic=Plan+Metadata>Plan Metadata</a>
        </td><td>Modifies <code>tierOptions</code> to map and display specific feature strings from the premium configuration instead of raw enum descriptions.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-admin-plan-sel...</td><td>February 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1598?tool=ast&topic=Admin+UI+Refactor>Admin UI Refactor</a>
        </td><td>Updates the <code>AdminUpgradeUserForm</code> to use <code>@radix-ui/react-select</code> for plan selection, improving the layout and user experience for administrators.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-admin-plan-sel...</td><td>February 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1598?tool=ast>(Baz)</a>.