### PR TITLE
Simplify chat examples with quick-start prompts

### DIFF
--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import {
   ArrowUpIcon,
   HistoryIcon,
-  LightbulbIcon,
   Loader2,
   PlusIcon,
   SquareIcon,
@@ -149,7 +148,13 @@ export function Chat({ open }: { open: boolean }) {
         <NewChatView
           firstName={firstName}
           inputArea={inputArea}
-          setInput={setInput}
+          onSuggestionClick={(text) => {
+            chat.sendMessage({
+              role: "user",
+              parts: [{ type: "text", text }],
+            });
+            setLocalStorageInput("");
+          }}
         />
       )}
     </div>
@@ -212,14 +217,20 @@ function ChatMessagesView({
   );
 }
 
+const CHAT_EXAMPLES = [
+  "Help me handle my inbox today",
+  "Clean up my inbox",
+  "Auto-archive newsletters for me",
+];
+
 function NewChatView({
   firstName,
   inputArea,
-  setInput,
+  onSuggestionClick,
 }: {
   firstName: string | undefined;
   inputArea: React.ReactNode;
-  setInput: (input: string) => void;
+  onSuggestionClick: (text: string) => void;
 }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-[var(--chat-px)]">
@@ -228,13 +239,18 @@ function NewChatView({
           {getGreeting(firstName)}
         </h1>
         {inputArea}
-        <div className="mt-4 flex justify-center">
-          <ExamplesDialog setInput={setInput}>
-            <Button variant="outline" className="gap-2 rounded-full">
-              <LightbulbIcon className="size-4" />
-              Choose from examples
+        <div className="mt-3 flex flex-wrap justify-center gap-2">
+          {CHAT_EXAMPLES.map((example) => (
+            <Button
+              key={example}
+              variant="outline"
+              size="sm"
+              className="rounded-full"
+              onClick={() => onSuggestionClick(example)}
+            >
+              {example}
             </Button>
-          </ExamplesDialog>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# User description
## Summary
Replaced the multi-step persona/rules dialog with 3 clickable example prompts that submit immediately. Users now see action-oriented suggestions when starting a new chat.

## Changes
- Removed "Choose from examples" button and its underlying modal flow
- Added 3 direct example prompts: "Help me handle my inbox today", "Clean up my inbox", "Auto-archive newsletters for me"
- Examples submit immediately with a single click instead of requiring navigation through personas and rule selections
- ExamplesDialog remains available in the chat top bar for users in active conversations

## Testing
Examples should be clickable on the new chat screen and immediately send the prompt to the assistant.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Chat_("Chat"):::modified
CHAT_SERVICE_("CHAT_SERVICE"):::added
LOCAL_STORAGE_("LOCAL_STORAGE"):::added
NewChatView_("NewChatView"):::modified
CHAT_EXAMPLES_("CHAT_EXAMPLES"):::added
Chat_ -- "Sends example text as user message via chat.sendMessage" --> CHAT_SERVICE_
Chat_ -- "Clears stored draft input after suggestion acceptance" --> LOCAL_STORAGE_
NewChatView_ -- "Adds onSuggestionClick prop to send example text" --> Chat_
NewChatView_ -- "Adds CHAT_EXAMPLES list to render suggestion buttons" --> CHAT_EXAMPLES_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Simplifies the initial chat experience by replacing the multi-step example modal with direct, clickable suggestion buttons that immediately trigger a message. Updates the <code>NewChatView</code> and <code>Chat</code> components to handle immediate message submission upon selecting a prompt.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1601?tool=ast&topic=Chat+Interaction>Chat Interaction</a>
        </td><td>Refactors the <code>NewChatView</code> interface to use an <code>onSuggestionClick</code> callback, enabling the <code>Chat</code> component to directly invoke <code>chat.sendMessage</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/chat.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-Add-chat-compacti...</td><td>February 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1601?tool=ast&topic=Quick-Start+Prompts>Quick-Start Prompts</a>
        </td><td>Replaces the <code>ExamplesDialog</code> trigger with a set of <code>CHAT_EXAMPLES</code> buttons that allow users to start a conversation with a single click.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/chat.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-Add-chat-compacti...</td><td>February 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1601?tool=ast>(Baz)</a>.