### PR TITLE
Add Chat navigation item to sidebar

### DIFF
--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -20,6 +20,7 @@ import {
   InboxIcon,
   type LucideIcon,
   MailsIcon,
+  MessageSquareIcon,
   MessagesSquareIcon,
   PenIcon,
   PersonStandingIcon,
@@ -88,6 +89,11 @@ export const useNavigation = () => {
 
   const manageItems: NavItem[] = useMemo(
     () => [
+      {
+        name: "Chat",
+        href: prefixPath(currentEmailAccountId, "/assistant"),
+        icon: MessageSquareIcon,
+      },
       {
         name: "Assistant",
         href: prefixPath(currentEmailAccountId, "/automation"),


### PR DESCRIPTION
# User description
Re-enable the Chat interface in the sidebar navigation menu under the Manage section.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the sidebar navigation to include a 'Chat' entry within the management section. Links the new navigation item to the assistant path using the <code>MessageSquareIcon</code> for visual representation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr>
<tr><td>elie222</td><td>chore-reorganize-sideb...</td><td>February 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1604?tool=ast>(Baz)</a>.