### PR TITLE
fix(docker): add required: false to remaining env_file directives

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - "${REDIS_HTTP_PORT:-8079}:80"
     image: hiett/serverless-redis-http:latest
     env_file:
-      - ./apps/web/.env
+      - path: ./apps/web/.env
+        required: false
     environment:
       SRH_MODE: env
       SRH_TOKEN: ${UPSTASH_REDIS_TOKEN}
@@ -60,7 +61,8 @@ services:
     image: ghcr.io/elie222/inbox-zero:latest
     pull_policy: always
     env_file:
-      - ./apps/web/.env
+      - path: ./apps/web/.env
+        required: false
     depends_on:
       db:
         condition: service_healthy
@@ -125,7 +127,8 @@ services:
         wait
       "
     env_file:
-      - ./apps/web/.env
+      - path: ./apps/web/.env
+        required: false
     depends_on:
       - web
     networks:


### PR DESCRIPTION
## Summary

Complete the `env_file` fix started in #411 by adding `required: false` to the three remaining services that were missed.

## Problem

After #411 fixed the `db` service, three other services still use the shorthand `env_file` syntax:

```yaml
# Before — fails if apps/web/.env doesn't exist
env_file:
  - ./apps/web/.env
```

On a fresh clone, `apps/web/.env` doesn't exist (only `.env.example` does). This causes `docker compose config` and `docker compose up` to fail:

```
env file /path/to/inbox-zero/apps/web/.env not found
```

As reported by @KarolKozlowski in #401.

## Fix

Apply the same long-form syntax that `db` already uses to all remaining services:

```yaml
# After — gracefully continues when .env is missing
env_file:
  - path: ./apps/web/.env
    required: false
```

### Services updated

| Service | Status |
|---------|--------|
| `db` | ✅ Already fixed (#411) |
| `serverless-redis-http` | ✅ **Fixed in this PR** |
| `web` | ✅ **Fixed in this PR** |
| `cron` | ✅ **Fixed in this PR** |

## Testing

```bash
# Fresh clone without .env — should succeed
git clone ... && cd inbox-zero
docker compose config  # ✅ No error

# With .env — should still load variables
cp apps/web/.env.example apps/web/.env
docker compose config  # ✅ Variables loaded
```

## Notes

- Requires Docker Compose v2.24+ (Dec 2023) for `required` field support
- Compose v1.x is EOL since July 2023 — this is consistent with the project's existing use of the `name` top-level key which also requires v2

Fixes #401