### PR TITLE
Add Slack connection hint to chat screen

### DIFF
--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -18,6 +18,7 @@ async function getUser({ userId }: { userId: string }) {
       webhookSecret: true,
       referralCode: true,
       announcementDismissedAt: true,
+      dismissedHints: true,
       premium: {
         select: {
           lemonSqueezyCustomerId: true,

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -1,6 +1,7 @@
-import { useMemo, type ReactNode } from "react";
+import { Fragment, useMemo, type ReactNode } from "react";
 import { Overview } from "./overview";
 import { MessagePart } from "./message-part";
+import { MessagingChannelHint } from "./messaging-channel-hint";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
 import type { ThreadLookup } from "@/components/assistant-chat/tools";
@@ -29,6 +30,10 @@ export function Messages({
   footer,
 }: MessagesProps) {
   const threadLookup = useMemo(() => buildThreadLookup(messages), [messages]);
+  const firstAssistantIndex = useMemo(
+    () => messages.findIndex((m) => m.role === "assistant"),
+    [messages],
+  );
 
   return (
     <Conversation className="flex min-w-0 flex-1">
@@ -39,21 +44,24 @@ export function Messages({
         <div className="flex flex-1 flex-col gap-6">
           {messages.length === 0 && <Overview setInput={setInput} />}
 
-          {messages.map((message) => (
-            <Message from={message.role} key={message.id}>
-              <MessageContent variant="flat">
-                {message.parts?.map((part, index) => (
-                  <MessagePart
-                    key={`${message.id}-${index}`}
-                    part={part}
-                    isStreaming={status === "streaming"}
-                    messageId={message.id}
-                    partIndex={index}
-                    threadLookup={threadLookup}
-                  />
-                ))}
-              </MessageContent>
-            </Message>
+          {messages.map((message, index) => (
+            <Fragment key={message.id}>
+              <Message from={message.role}>
+                <MessageContent variant="flat">
+                  {message.parts?.map((part, partIndex) => (
+                    <MessagePart
+                      key={`${message.id}-${partIndex}`}
+                      part={part}
+                      isStreaming={status === "streaming"}
+                      messageId={message.id}
+                      partIndex={partIndex}
+                      threadLookup={threadLookup}
+                    />
+                  ))}
+                </MessageContent>
+              </Message>
+              {index === firstAssistantIndex && <MessagingChannelHint />}
+            </Fragment>
           ))}
 
           {status === "submitted" &&

--- a/apps/web/components/assistant-chat/messaging-channel-hint.tsx
+++ b/apps/web/components/assistant-chat/messaging-channel-hint.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { SlackIcon, XIcon } from "lucide-react";
+import Link from "next/link";
+import { useAction } from "next-safe-action/hooks";
+import { Button } from "@/components/ui/button";
+import { useUser } from "@/hooks/useUser";
+import { useMessagingChannels } from "@/hooks/useMessagingChannels";
+import { dismissHintAction } from "@/utils/actions/hints";
+
+const HINT_ID = "messaging-channel";
+
+export function MessagingChannelHint() {
+  const { data: user, mutate: mutateUser } = useUser();
+  const { data: channelsData, isLoading: channelsLoading } =
+    useMessagingChannels();
+
+  const { execute: dismiss } = useAction(dismissHintAction, {
+    onSuccess: () => mutateUser(),
+  });
+
+  if (!user || channelsLoading) return null;
+
+  const isDismissed = user.dismissedHints?.includes(HINT_ID);
+  if (isDismissed) return null;
+
+  const hasSlack = channelsData?.channels.some(
+    (channel) => channel.isConnected && channel.provider === "SLACK",
+  );
+  const slackAvailable =
+    channelsData?.availableProviders?.includes("SLACK") ?? false;
+
+  if (hasSlack || !slackAvailable) return null;
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-muted/50 px-4 py-3 text-sm">
+      <SlackIcon className="size-4 flex-shrink-0" />
+      <span className="flex-1 text-muted-foreground">
+        You can also chat with your assistant on Slack.
+      </span>
+      <Link href="/settings">
+        <Button variant="outline" size="sm" className="h-7 text-xs">
+          Connect
+        </Button>
+      </Link>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        className="rounded p-0.5 text-muted-foreground hover:bg-muted-foreground/10"
+        onClick={() => dismiss({ hintId: HINT_ID })}
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/prisma/migrations/20260217000000_add_dismissed_hints/migration.sql
+++ b/apps/web/prisma/migrations/20260217000000_add_dismissed_hints/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "dismissedHints" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -72,6 +72,7 @@ model User {
   utms                     Json?
   errorMessages            Json? // eg. user set incorrect AI API key
   announcementDismissedAt  DateTime?
+  dismissedHints           String[]  @default([])
 
   // survey answers (extracted from onboardingAnswers for easier querying)
   surveyFeatures     String[] // multiple choice: features user is interested in

--- a/apps/web/utils/actions/hints.ts
+++ b/apps/web/utils/actions/hints.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { dismissHintBody } from "@/utils/actions/hints.validation";
+import { actionClientUser } from "@/utils/actions/safe-action";
+import prisma from "@/utils/prisma";
+
+export const dismissHintAction = actionClientUser
+  .metadata({ name: "dismissHint" })
+  .schema(dismissHintBody)
+  .action(async ({ ctx: { userId }, parsedInput: { hintId } }) => {
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        dismissedHints: { push: hintId },
+      },
+    });
+
+    revalidatePath("/");
+
+    return { success: true };
+  });

--- a/apps/web/utils/actions/hints.validation.ts
+++ b/apps/web/utils/actions/hints.validation.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const dismissHintBody = z.object({
+  hintId: z.string(),
+});


### PR DESCRIPTION
Display a one-time, dismissible prompt after the first assistant reply encouraging users to connect Slack. Dismissal persists across devices via a new `dismissedHints` array field on the User model.

**Changes:**
- Add `dismissedHints` field to User model for generic hint tracking
- Create `dismissHintAction` server action for database-backed dismissals
- Add `MessagingChannelHint` component showing inline after first assistant message
- Integrate hint into chat messages view

The hint auto-hides if Slack is already connected or unavailable on the instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)