### PR TITLE
Fix follow-up dedup for repeated processing

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -239,7 +239,6 @@ async function processFollowUpsForType({
   const threadIds = threads.map((t) => t.id);
   const processedLedger = await getProcessedFollowUpLedger({
     emailAccountId: emailAccount.id,
-    trackerType,
     threadIds,
   });
 
@@ -429,11 +428,9 @@ function getThresholdWithWindow(threshold: Date, windowMinutes: number): Date {
 
 async function getProcessedFollowUpLedger({
   emailAccountId,
-  trackerType,
   threadIds,
 }: {
   emailAccountId: string;
-  trackerType: ThreadTrackerType;
   threadIds: string[];
 }): Promise<Map<string, Set<string>>> {
   if (threadIds.length === 0) return new Map();
@@ -442,7 +439,6 @@ async function getProcessedFollowUpLedger({
     where: {
       emailAccountId,
       threadId: { in: threadIds },
-      type: trackerType,
       OR: [
         { followUpAppliedAt: { not: null } },
         { followUpDraftId: { not: null } },


### PR DESCRIPTION
# User description
## Summary
This change updates follow-up deduplication to track processed work by thread and latest message id.
It reads processed tracker rows by type even when previously resolved and only for currently labeled threads.
It adds regression tests for repeated runs, replayed updates, stale tracker rows, and mixed old/new message handling.

## Testing
- cd apps/web && pnpm test --run app/api/follow-up-reminders/process.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the follow-up deduplication logic to track processed work by both thread and message ID, ensuring that repeated processing runs do not create duplicate drafts or labels. Refines the <code>threadTracker</code> lookup to include previously resolved rows and adds comprehensive regression tests for various edge cases like stale trackers and replayed updates.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1617?tool=ast&topic=Regression+Testing>Regression Testing</a>
        </td><td>Adds regression tests to verify the fix for repeated runs, stale tracker rows, and transitions between different follow-up types like 'Awaiting Reply' and 'To Reply'.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/follow-up-reminders/process.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-follow-up-dedup-fo...</td><td>February 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1617?tool=ast&topic=Deduplication+Logic>Deduplication Logic</a>
        </td><td>Implements a more granular deduplication mechanism using a ledger of processed thread and message IDs to prevent redundant follow-up actions.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/follow-up-reminders/process.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-follow-up-dedup-fo...</td><td>February 17, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Allow-follow-up-remind...</td><td>January 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1617?tool=ast>(Baz)</a>.