### PR TITLE
Security: bind docker ports to localhost only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - database-data:/var/lib/postgresql/data/
     ports:
-      - ${POSTGRES_PORT:-5432}:5432
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     networks:
       - inbox-zero-network
     profiles:
@@ -29,7 +29,7 @@ services:
   redis:
     image: redis:7
     ports:
-      - ${REDIS_PORT:-6380}:6379
+      - "127.0.0.1:${REDIS_PORT:-6380}:6379"
     volumes:
       - database-data:/data
     networks:
@@ -41,7 +41,7 @@ services:
 
   serverless-redis-http:
     ports:
-      - "${REDIS_HTTP_PORT:-8079}:80"
+      - "127.0.0.1:${REDIS_HTTP_PORT:-8079}:80"
     image: hiett/serverless-redis-http:latest
     env_file:
       - ./apps/web/.env


### PR DESCRIPTION
### Problem

In `docker-compose.yml`, all ports are currently bound to `0.0.0.0`, meaning they are exposed on all network interfaces, including public ones.

This is particularly critical for:
- **PostgreSQL** (`5432`) - database directly accessible from the internet
- **Redis** (`6379`) - cache/queue directly accessible from the internet
- **Serverless Redis HTTP** (`8079`) - same issue

This is a well-known attack vector bots continuously scan the internet for exposed Redis and PostgreSQL instances. This affects anyone self-hosting this project on a VPS, even if they have a firewall configured, because Docker bypasses UFW/iptables rules by default.

### Fix

Bind all ports to `127.0.0.1` in `docker-compose.yml` so they are only accessible locally. Services still communicate with each other through the internal Docker network (`inbox-zero-network`), so nothing breaks.

`docker-compose.dev.yml` is left unchanged open ports make sense in a local development context.

### Impact

Anyone self-hosting inbox-zero on a VPS with the default configuration has their database and Redis exposed to the internet.