### PR TITLE
Restrict chat email tool parameters

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -774,6 +774,79 @@ describe("aiProcessAssistantChat", () => {
     expect(result.totalReturned).toBe(0);
   });
 
+  it("sends email with allowlisted chat params only", async () => {
+    const tools = await captureToolSet(true, "google");
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "message-1",
+      threadId: "thread-1",
+    });
+
+    mockCreateEmailProvider.mockResolvedValue({
+      sendEmailWithHtml,
+    });
+
+    const result = await tools.sendEmail.execute({
+      to: "recipient@example.test",
+      cc: "observer@example.test",
+      subject: "Subject line",
+      messageHtml: "<p>Hello</p>",
+    });
+
+    expect(result).toEqual({
+      success: true,
+      messageId: "message-1",
+      threadId: "thread-1",
+      to: "recipient@example.test",
+      subject: "Subject line",
+    });
+
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
+    expect(sendEmailWithHtml.mock.calls[0][0]).toEqual({
+      to: "recipient@example.test",
+      cc: "observer@example.test",
+      subject: "Subject line",
+      messageHtml: "<p>Hello</p>",
+    });
+  });
+
+  it("rejects unsupported from field in chat send params", async () => {
+    const tools = await captureToolSet(true, "google");
+    mockCreateEmailProvider.mockResolvedValue({
+      sendEmailWithHtml: vi.fn(),
+    });
+
+    const result = await tools.sendEmail.execute({
+      to: "recipient@example.test",
+      from: "sender.alias@example.test",
+      subject: "Subject line",
+      messageHtml: "<p>Hello</p>",
+    } as any);
+
+    expect(result).toEqual({
+      error: 'Invalid sendEmail input: unsupported field "from"',
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported bcc field in chat send params", async () => {
+    const tools = await captureToolSet(true, "google");
+    mockCreateEmailProvider.mockResolvedValue({
+      sendEmailWithHtml: vi.fn(),
+    });
+
+    const result = await tools.sendEmail.execute({
+      to: "recipient@example.test",
+      bcc: "hidden@example.test",
+      subject: "Subject line",
+      messageHtml: "<p>Done</p>",
+    } as any);
+
+    expect(result).toEqual({
+      error: 'Invalid sendEmail input: unsupported field "bcc"',
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+
   it("registers saveMemory tool", async () => {
     const tools = await captureToolSet();
     expect(tools.saveMemory).toBeDefined();


### PR DESCRIPTION
# User description
Restricts AI chat send-email inputs to an explicit allowlist and rejects unsupported fields before provider calls.\nAdds validation error handling for unsupported keys in chat send-email requests.\nAdds regression tests for allowed params and rejected unsupported params using generic test data.\nTests were not run in this workspace because dependencies are not installed (missing cross-env).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
sendEmailTool_("sendEmailTool"):::modified
EMAIL_PROVIDER_("EMAIL_PROVIDER"):::modified
getSendEmailValidationError_("getSendEmailValidationError"):::added
sendEmailTool_ -- "Validates input, sends parsedInput.data via provider, returns to/subject." --> EMAIL_PROVIDER_
sendEmailTool_ -- "Uses new formatter to produce clearer validation error messages." --> getSendEmailValidationError_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implements a strict allowlist for AI chat email tool parameters to prevent the use of unsupported fields like <code>from</code> or <code>bcc</code>. Enhances the <code>sendEmailTool</code> with Zod-based validation and custom error reporting to ensure only authorized inputs reach the email provider.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1620?tool=ast&topic=Input+Validation>Input Validation</a>
        </td><td>Define a strict <code>sendEmailToolInputSchema</code> and implement <code>getSendEmailValidationError</code> to handle and report invalid or unsupported tool inputs.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/assistant/chat-inbox-tools.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-assistant-manageIn...</td><td>February 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1620?tool=ast&topic=Regression+Testing>Regression Testing</a>
        </td><td>Add regression tests in <code>ai-assistant-chat.test.ts</code> to verify that valid email parameters are accepted while unsupported fields are correctly rejected.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-assistant-manageIn...</td><td>February 17, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1620?tool=ast>(Baz)</a>.