### PR TITLE
Add title when showing Slack connect toast

### DIFF
--- a/apps/web/hooks/useSlackConnect.ts
+++ b/apps/web/hooks/useSlackConnect.ts
@@ -60,7 +60,10 @@ export function useSlackConnect({
             description: "Redirecting to Slack authorization...",
           });
         } else {
-          toastInfo({ description: "Redirecting to Slack authorization..." });
+          toastInfo({
+            title: "Continue in Slack",
+            description: "Redirecting to Slack authorization...",
+          });
         }
         // Always fall through to OAuth so the user isn't stuck.
       }


### PR DESCRIPTION
# User description
Summary:
- ensure the Slack connect toast includes the required title property so the build type-checks

Testing:
- Not run (not requested)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Slack connection hook to include a mandatory title in the notification toast, ensuring the build passes type-checks. Enhances the user experience by providing a clear 'Continue in Slack' heading during the OAuth redirection process.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-Slack-connecti...</td><td>February 18, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1635?tool=ast>(Baz)</a>.