### PR TITLE
Backport missing automation fixes after squash merge

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -1,5 +1,6 @@
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailForLLM } from "@/utils/types";
+import type { EmailProvider } from "@/utils/email/types";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import type { Action, Prisma } from "@/generated/prisma/client";
 import { isGoogleProvider } from "@/utils/email/provider-types";
@@ -84,6 +85,24 @@ export function getEmail({
     ...(cc && { cc }),
     ...(date && { date }),
   };
+}
+
+export function getMockEmailProvider({
+  unread = 0,
+  total = 0,
+  inboxMessages = [],
+}: {
+  unread?: number;
+  total?: number;
+  inboxMessages?: Awaited<ReturnType<EmailProvider["getInboxMessages"]>>;
+} = {}): EmailProvider {
+  return {
+    getInboxStats: async () => ({ unread, total }),
+    getInboxMessages: async () => inboxMessages,
+  } as Pick<
+    EmailProvider,
+    "getInboxStats" | "getInboxMessages"
+  > as EmailProvider;
 }
 
 export function getRule(

--- a/apps/web/utils/automation-jobs/message.ts
+++ b/apps/web/utils/automation-jobs/message.ts
@@ -23,11 +23,13 @@ export async function getAutomationJobMessage({
         prompt: trimmedPrompt,
         emailProvider,
         emailAccount,
+        logger,
       });
     } catch (error) {
       logger.warn("Failed to generate automation message from prompt", {
         error,
       });
+      return trimmedPrompt;
     }
   }
 


### PR DESCRIPTION
# User description
This backports the missing post-squash automation fixes from `automation-pr-pack` onto `main` without doing a history merge.

Included files:
- apps/web/app/api/automation-jobs/execute/route.ts
- apps/web/utils/automation-jobs/slack.ts
- apps/web/utils/automation-jobs/message.ts
- apps/web/utils/ai/automation-jobs/generate-check-in-message.ts
- apps/web/utils/automation-jobs/message.test.ts
- apps/web/__tests__/helpers.ts

Validation run locally (in `apps/web`):
- `pnpm exec biome check __tests__/helpers.ts app/api/automation-jobs/execute/route.ts utils/ai/automation-jobs/generate-check-in-message.ts utils/automation-jobs/message.ts utils/automation-jobs/message.test.ts utils/automation-jobs/slack.ts`
- `pnpm test --run utils/automation-jobs/message.test.ts utils/automation-jobs/cron.test.ts`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getAutomationJobMessage_("getAutomationJobMessage"):::modified
aiGenerateAutomationCheckInMessage_("aiGenerateAutomationCheckInMessage"):::modified
EMAIL_PROVIDER_("EMAIL_PROVIDER"):::modified
LLM_SERVICE_("LLM_SERVICE"):::modified
sendAutomationMessageToSlack_("sendAutomationMessageToSlack"):::modified
SLACK_API_("SLACK_API"):::modified
markAutomationJobRunSkipped_("markAutomationJobRunSkipped"):::added
PRISMA_DB_("PRISMA_DB"):::modified
getAutomationJobMessage_ -- "Passes logger; falls back to trimmed prompt on failure." --> aiGenerateAutomationCheckInMessage_
aiGenerateAutomationCheckInMessage_ -- "Adds validation and logging around inbox stats retrieval." --> EMAIL_PROVIDER_
aiGenerateAutomationCheckInMessage_ -- "Wraps generateObject with retry; includes account and schema." --> LLM_SERVICE_
sendAutomationMessageToSlack_ -- "Introduces specific config error and resolves destination channel." --> SLACK_API_
markAutomationJobRunSkipped_ -- "Adds skipped status update for configuration errors." --> PRISMA_DB_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the automation job execution flow by introducing premium status checks and specialized error handling for configuration issues. Refines the AI-driven message generation with retry logic and improved fallback mechanisms to ensure reliable Slack notifications.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1637?tool=ast&topic=AI+Generation>AI Generation</a>
        </td><td>Adds retry logic using <code>withRetry</code> for AI generations and updates <code>getAutomationJobMessage</code> to fallback to the original prompt if LLM generation fails, supported by updated test helpers.<details><summary>Modified files (4)</summary><ul><li>apps/web/__tests__/helpers.ts</li>
<li>apps/web/utils/ai/automation-jobs/generate-check-in-message.ts</li>
<li>apps/web/utils/automation-jobs/message.test.ts</li>
<li>apps/web/utils/automation-jobs/message.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-proactive-automati...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1637?tool=ast&topic=Job+Execution>Job Execution</a>
        </td><td>Implements premium user validation and introduces <code>AutomationJobConfigurationError</code> to distinguish between transient failures and misconfigurations in the execution route and Slack utility.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/automation-jobs/execute/route.ts</li>
<li>apps/web/utils/automation-jobs/slack.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-proactive-automati...</td><td>February 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1637?tool=ast>(Baz)</a>.