### PR TITLE
Improve scheduled check-ins copy

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
@@ -195,7 +195,7 @@ export function ProactiveUpdatesSetting() {
   return (
     <SettingCard
       title="Scheduled check-ins"
-      description="Get inbox briefings on a schedule. Reply to take action."
+      description="Your AI checks in on Slack with updates you can act on."
       right={
         showLoading ? (
           <Skeleton className="h-5 w-24" />


### PR DESCRIPTION
# User description
Updated the description for scheduled check-ins to better communicate that the AI proactively checks in on Slack with actionable updates, rather than passive briefings.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the user-facing copy for scheduled check-ins within the <code>ProactiveUpdatesSetting</code> component to emphasize proactive AI engagement on Slack. Clarifies that these updates are actionable rather than just passive briefings.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-proactive-automati...</td><td>February 19, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1640?tool=ast>(Baz)</a>.