### PR TITLE
Centralize UTC date string formatting

### DIFF
--- a/apps/web/__tests__/ai-detect-recurring-pattern.test.ts
+++ b/apps/web/__tests__/ai-detect-recurring-pattern.test.ts
@@ -6,6 +6,7 @@ import { getRuleName, getRuleConfig } from "@/utils/rule/consts";
 import { SystemType } from "@/generated/prisma/enums";
 import { getEmailAccount } from "@/__tests__/helpers";
 import { createScopedLogger } from "@/utils/logger";
+import { formatUtcDate } from "@/utils/date";
 
 // Run with: pnpm test-ai ai-detect-recurring-pattern
 
@@ -75,10 +76,10 @@ describe.runIf(isAiTest)(
         
         Order Details:
         Order #A${100_000 + i}
-        Date: ${new Date(Date.now() - i * 14 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]}
+        Date: ${formatUtcDate(new Date(Date.now() - i * 14 * 24 * 60 * 60 * 1000))}
         Total: $${(Math.random() * 100).toFixed(2)}
         
-        Your order will be delivered on ${new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]}.
+        Your order will be delivered on ${formatUtcDate(new Date(Date.now() + 3 * 24 * 60 * 60 * 1000))}.
         
         Thank you for shopping with us!`,
         date: new Date(Date.now() - i * 14 * 24 * 60 * 60 * 1000),
@@ -94,7 +95,7 @@ describe.runIf(isAiTest)(
         content: `You have a new calendar invitation:
         
         Event: Weekly Team Sync ${i + 1}
-        Date: ${new Date(Date.now() + (i + 1) * 7 * 24 * 60 * 60 * 1000).toISOString().split("T")[0]}
+        Date: ${formatUtcDate(new Date(Date.now() + (i + 1) * 7 * 24 * 60 * 60 * 1000))}
         Time: 10:00 AM - 11:00 AM
         Location: Conference Room A / Zoom
         

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/RuleImportExportSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/RuleImportExportSetting.tsx
@@ -14,6 +14,7 @@ import {
 import { toastError } from "@/components/Toast";
 import { useRules } from "@/hooks/useRules";
 import { importRulesAction } from "@/utils/actions/rule";
+import { formatUtcDate } from "@/utils/date";
 
 export function RuleImportExportSetting({
   emailAccountId,
@@ -59,7 +60,7 @@ export function RuleImportExportSetting({
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `inbox-zero-rules-${new Date().toISOString().split("T")[0]}.json`;
+    a.download = `inbox-zero-rules-${formatUtcDate(new Date())}.json`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/utils/ai/assistant/compact";
 import { getModel } from "@/utils/llms/model";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
+import { formatUtcDate } from "@/utils/date";
 
 export const maxDuration = 120;
 
@@ -193,7 +194,7 @@ export const POST = withEmailAccount("chat", async (request) => {
     });
     memories = recentMemories.map((m) => ({
       content: m.content,
-      date: m.createdAt.toISOString().split("T")[0],
+      date: formatUtcDate(m.createdAt),
     }));
   } catch (error) {
     request.logger.warn("Failed to load memories for chat", { error });

--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -1,6 +1,7 @@
 import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import prisma from "@/utils/prisma";
+import { formatUtcDate } from "@/utils/date";
 import type { Logger } from "@/utils/logger";
 
 export const searchMemoriesTool = ({
@@ -48,7 +49,7 @@ export const searchMemoriesTool = ({
       return {
         memories: memories.map((m) => ({
           content: m.content,
-          date: m.createdAt.toISOString().split("T")[0],
+          date: formatUtcDate(m.createdAt),
         })),
       };
     },

--- a/apps/web/utils/date.ts
+++ b/apps/web/utils/date.ts
@@ -77,6 +77,10 @@ export function formatDateForLLM(date: Date) {
   return format(date, "EEEE, yyyy-MM-dd HH:mm:ss 'UTC'");
 }
 
+export function formatUtcDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
 export function formatRelativeTimeForLLM(date: Date) {
   return formatDistanceToNow(date, { addSuffix: true });
 }

--- a/apps/web/utils/slack/process-slack-event.ts
+++ b/apps/web/utils/slack/process-slack-event.ts
@@ -10,6 +10,7 @@ import {
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
+import { formatUtcDate } from "@/utils/date";
 import type { Logger } from "@/utils/logger";
 import type { Prisma } from "@/generated/prisma/client";
 
@@ -236,7 +237,7 @@ async function getRecentChatMemories({
 
     return memories.map((memory) => ({
       content: memory.content,
-      date: memory.createdAt.toISOString().split("T")[0],
+      date: formatUtcDate(memory.createdAt),
     }));
   } catch (error) {
     logger.warn("Failed to load memories for Slack chat", { error });


### PR DESCRIPTION
# User description
This change centralizes UTC date-only formatting behind a single helper in the date utility file. It replaces repeated inline formatting in chat memory formatting, Slack memory formatting, rule export filenames, and related AI test fixtures. Behavior is unchanged and remains UTC date output. Verified with a targeted date utility test run in apps/web.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getRecentChatMemories_("getRecentChatMemories"):::modified
formatUtcDate_("formatUtcDate"):::added
searchMemoriesTool_("searchMemoriesTool"):::modified
RuleImportExportSetting_("RuleImportExportSetting"):::modified
getRecentChatMemories_ -- "Replaces ISO split with formatUtcDate for consistent UTC date." --> formatUtcDate_
searchMemoriesTool_ -- "Replaces ISO split with formatUtcDate for consistent UTC date." --> formatUtcDate_
RuleImportExportSetting_ -- "Uses UTC-formatted date in exported rules filename." --> formatUtcDate_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Centralizes UTC date-only string formatting by introducing a dedicated utility function in the date utility module. Replaces manual string manipulation across chat memory, Slack integration, rule exports, and AI test fixtures to ensure consistent date representation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1641?tool=ast&topic=Feature+Integration>Feature Integration</a>
        </td><td>Refactors various components including <code>searchMemoriesTool</code>, <code>RuleImportExportSetting</code>, and Slack event processing to use the new centralized date formatter.<details><summary>Modified files (5)</summary><ul><li>apps/web/__tests__/ai-detect-recurring-pattern.test.ts</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/settings/RuleImportExportSetting.tsx</li>
<li>apps/web/app/api/chat/route.ts</li>
<li>apps/web/utils/ai/assistant/chat-memory-tools.ts</li>
<li>apps/web/utils/slack/process-slack-event.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-proactive-automati...</td><td>February 19, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1641?tool=ast&topic=Date+Utility>Date Utility</a>
        </td><td>Introduces the <code>formatUtcDate</code> function to provide a standardized way to extract the ISO date string (YYYY-MM-DD) from a Date object.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/date.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>catch-invalid-tz</td><td>December 31, 2025</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Merge-branch-staging-o...</td><td>July 21, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1641?tool=ast>(Baz)</a>.