### PR TITLE
Fix Anthropic System Message Usage

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -240,7 +240,7 @@ describe("aiProcessAssistantChat", () => {
       role: "assistant",
       content: "assistant response",
     });
-    expect(args.messages[3].role).toBe("system");
+    expect(args.messages[3].role).toBe("user");
     expect(args.messages[3].content).toContain(
       "Memories from previous conversations:",
     );
@@ -327,7 +327,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -385,7 +385,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -442,7 +442,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -504,7 +504,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -567,7 +567,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -627,7 +627,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -698,7 +698,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const hiddenContext = args.messages.find(
       (message: { role: string; content: string }) =>
-        message.role === "system" &&
+        message.role === "user" &&
         message.content.includes("Hidden context for the user's request"),
     );
 
@@ -1102,7 +1102,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const memoriesMessage = args.messages.find(
       (m: { role: string; content: string }) =>
-        m.role === "system" &&
+        m.role === "user" &&
         m.content.includes("Memories from previous conversations"),
     );
 
@@ -1135,7 +1135,7 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const memoriesMessage = args.messages.find(
       (m: { role: string; content: string }) =>
-        m.role === "system" &&
+        m.role === "user" &&
         m.content.includes("Memories from previous conversations"),
     );
 

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -249,7 +249,7 @@ Behavior anchors (minimal examples):
   const inboxContextMessage = inboxStats
     ? [
         {
-          role: "system" as const,
+          role: "user" as const,
           content: `Current inbox: ${inboxStats.total} emails total, ${inboxStats.unread} unread.`,
         },
       ]
@@ -259,7 +259,7 @@ Behavior anchors (minimal examples):
     context && context.type === "fix-rule"
       ? [
           {
-            role: "system" as const,
+            role: "user" as const,
             content:
               "Hidden context for the user's request (do not repeat this to the user):\n\n" +
               `<email>\n${stringifyEmail(
@@ -290,7 +290,7 @@ Behavior anchors (minimal examples):
     ...(memories && memories.length > 0
       ? [
           {
-            role: "system" as const,
+            role: "user" as const,
             content: `Memories from previous conversations:\n${memories.map((m) => `- [${m.date}] ${m.content}`).join("\n")}`,
           },
         ]


### PR DESCRIPTION
Anthropic models only allow system prompts to appear at the beginning of a conversation and the current approach fails for Anthropic models after the first message. One message can be sent to the agent, it responds and then an error occurs when attempting to send a second message. There are three ways this can be fixed:

1. Change the additional context to be a user message instead of a system prompt. This is simplest but could potentially affect performance for OpenAI or other models that don't have this restriction
2. Move these messages earlier - this would break the cache optimization
3. Check which model provider is being used and apply (1) conditionally for models with this restriction.

This PR implements (1) for simplicity, but I can go ahead and implement (3) if you prefer