### PR TITLE
Add local skills directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ copilot/environments/**/manifest.yml
 # browser QA flow results
 qa/browser-flows/results/*
 !qa/browser-flows/results/README.md
+
+# local skills
+.claude/skills/local/
+.agents/skills/local/


### PR DESCRIPTION
# User description
Exclude .claude/skills/local/ and .agents/skills/local/ from version control to prevent local skill configurations from being committed to the repository.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the repository configuration to exclude local skill directories from version control. Prevents environment-specific configurations in <code>.claude/skills/local/</code> and <code>.agents/skills/local/</code> from being accidentally committed.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-add-project-spec...</td><td>February 05, 2026</td></tr>
<tr><td>jamesc@berkeley.edu</td><td>Update-.gitignore-to-a...</td><td>May 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1648?tool=ast>(Baz)</a>.