### PR TITLE
Reduce vertical spacing in chat tool displays

### DIFF
--- a/apps/web/components/ai-elements/message.tsx
+++ b/apps/web/components/ai-elements/message.tsx
@@ -11,7 +11,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full items-end justify-end gap-2 py-4",
+      "group flex w-full items-end justify-end gap-2 py-2",
       from === "user" ? "is-user" : "is-assistant flex-row-reverse justify-end",
       className,
     )}

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -41,7 +41,7 @@ export function Messages({
         className="mx-auto flex min-h-full flex-col max-w-[calc(var(--chat-max-w)+var(--chat-px)*2)] px-[var(--chat-px)] pt-0 pb-0"
         scrollClassName="![scrollbar-gutter:auto] scrollbar-thin"
       >
-        <div className="flex flex-1 flex-col gap-6">
+        <div className="flex flex-1 flex-col gap-4">
           {messages.length === 0 && <Overview setInput={setInput} />}
 
           {messages.map((message, index) => (

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -70,7 +70,7 @@ function CollapsibleToolCard({
   const [open, setOpen] = useState(initialOpen);
 
   return (
-    <Card className="mb-4 p-4">
+    <Card className="p-4">
       <Collapsible open={open} onOpenChange={setOpen}>
         <CollapsibleTrigger className="flex w-full items-center gap-2 text-sm">
           <ChevronRightIcon
@@ -654,7 +654,7 @@ function RuleActions({ ruleId }: { ruleId: string }) {
 }
 
 function ToolCard({ children }: { children: React.ReactNode }) {
-  return <Card className="mb-4 space-y-3 p-4">{children}</Card>;
+  return <Card className="space-y-3 p-4">{children}</Card>;
 }
 
 function ToolCardHeader({


### PR DESCRIPTION
# User description
## Summary
Reduces excess vertical spacing in the chat interface by removing redundant tool card margins and tightening message padding.

## Changes
- Removed `mb-4` bottom margins from `ToolCard` and `CollapsibleToolCard` components that were stacking with flexbox gaps
- Reduced message padding from `py-4` to `py-2`
- Reduced message gap from `gap-6` to `gap-4`

These changes tighten the layout without affecting readability or accessibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Messages_("Messages"):::modified
Message_("Message"):::modified
Messages_ -- "Reduced vertical spacing and message padding for tighter layout" --> Message_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Optimizes the chat interface layout by reducing vertical padding and gaps between messages and tool components. Adjusts the <code>Message</code> and <code>Messages</code> components to create a more compact visual flow while removing redundant margins from tool cards.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-bulk-archive-p...</td><td>February 18, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1654?tool=ast>(Baz)</a>.