### PR TITLE
Skip cancelled placeholder events in meeting briefs

### DIFF
--- a/apps/web/utils/meeting-briefs/fetch-upcoming-events.test.ts
+++ b/apps/web/utils/meeting-briefs/fetch-upcoming-events.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCalendarEventProviders } from "@/utils/calendar/event-provider";
+import { createScopedLogger } from "@/utils/logger";
+import type {
+  CalendarEvent,
+  CalendarEventProvider,
+} from "@/utils/calendar/event-types";
+import { fetchUpcomingEvents } from "./fetch-upcoming-events";
+
+vi.mock("@/utils/calendar/event-provider");
+
+const logger = createScopedLogger("test");
+
+describe("fetchUpcomingEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips cancelled event placeholder titles", async () => {
+    const provider = createProvider([
+      createEvent({
+        id: "skip-1",
+        title: "Cancelled event: Customer Sync",
+        startTime: new Date("2024-01-20T09:00:00Z"),
+      }),
+      createEvent({
+        id: "keep-1",
+        title: "Customer Sync",
+        startTime: new Date("2024-01-20T09:30:00Z"),
+      }),
+      createEvent({
+        id: "skip-2",
+        title: "Canceled: Product Demo",
+        startTime: new Date("2024-01-20T10:00:00Z"),
+      }),
+      createEvent({
+        id: "keep-2",
+        title: "Cancellation Policy Review",
+        startTime: new Date("2024-01-20T10:30:00Z"),
+      }),
+    ]);
+
+    vi.mocked(createCalendarEventProviders).mockResolvedValue([provider]);
+
+    const events = await fetchUpcomingEvents({
+      emailAccountId: "email-account-id",
+      minutesBefore: 240,
+      logger,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["keep-1", "keep-2"]);
+  });
+
+  it("keeps events sorted by start time after filtering", async () => {
+    const provider = createProvider([
+      createEvent({
+        id: "later",
+        title: "Design Review",
+        startTime: new Date("2024-01-20T11:00:00Z"),
+      }),
+      createEvent({
+        id: "skip",
+        title: "Cancelled: Standup",
+        startTime: new Date("2024-01-20T08:00:00Z"),
+      }),
+      createEvent({
+        id: "earlier",
+        title: "Sales Call",
+        startTime: new Date("2024-01-20T09:00:00Z"),
+      }),
+    ]);
+
+    vi.mocked(createCalendarEventProviders).mockResolvedValue([provider]);
+
+    const events = await fetchUpcomingEvents({
+      emailAccountId: "email-account-id",
+      minutesBefore: 240,
+      logger,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["earlier", "later"]);
+  });
+});
+
+function createProvider(events: CalendarEvent[]): CalendarEventProvider {
+  return {
+    fetchEvents: vi.fn().mockResolvedValue(events),
+    fetchEventsWithAttendee: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createEvent(overrides: Partial<CalendarEvent>): CalendarEvent {
+  const startTime = overrides.startTime ?? new Date("2024-01-20T09:00:00Z");
+
+  return {
+    id: overrides.id ?? "event-id",
+    title: overrides.title ?? "Meeting",
+    description: overrides.description,
+    location: overrides.location,
+    eventUrl: overrides.eventUrl,
+    videoConferenceLink: overrides.videoConferenceLink,
+    startTime,
+    endTime:
+      overrides.endTime ?? new Date(startTime.getTime() + 30 * 60 * 1000),
+    attendees: overrides.attendees ?? [{ email: "guest@example.com" }],
+  };
+}


### PR DESCRIPTION
# User description
## Summary
- filter out cancelled placeholder calendar titles before briefing generation
- log the count of skipped cancelled events
- add unit tests covering cancelled-title filtering and retained ordering

## Testing
- cd apps/web && pnpm test --run utils/meeting-briefs/fetch-upcoming-events.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
fetchUpcomingEvents_("fetchUpcomingEvents"):::modified
isCancelledEventTitle_("isCancelledEventTitle"):::added
LOGGER_("LOGGER"):::modified
fetchUpcomingEvents_ -- "Filters out events titled 'cancelled' or 'canceled'." --> isCancelledEventTitle_
fetchUpcomingEvents_ -- "Logs count of skipped cancelled calendar events." --> LOGGER_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Filters out cancelled placeholder events from meeting briefs by analyzing event titles and logs the count of skipped items. Ensures that the <code>fetchUpcomingEvents</code> utility maintains correct chronological ordering after the filtering process.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>logger</td><td>December 18, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1655?tool=ast>(Baz)</a>.