### PR TITLE
fix: resume most recent chat on open instead of always creating new

### DIFF
--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -40,6 +40,7 @@ export function Chat({ open }: { open: boolean }) {
     setInput,
     handleSubmit,
     setNewChat,
+    loadOrCreateChat,
     context,
     setContext,
   } = useChat();
@@ -51,9 +52,9 @@ export function Chat({ open }: { open: boolean }) {
 
   useEffect(() => {
     if (open && !chatId) {
-      setNewChat();
+      loadOrCreateChat();
     }
-  }, [open, chatId, setNewChat]);
+  }, [open, chatId, loadOrCreateChat]);
 
   // Sync input with localStorage
   useEffect(() => {


### PR DESCRIPTION
# User description
When the chat panel opens without a chatId in the URL (e.g. on a new
device or fresh browser session), it previously called setNewChat()
which generated a random UUID — causing the user to always start with
an empty chat and never see their history automatically.

Now loadOrCreateChat() fetches /api/chats on open and sets the most
recent chat as active. Falls back to creating a new UUID only when
there are no existing chats.

The "New Chat" button still calls setNewChat() directly so users can
intentionally start a fresh conversation.

https://claude.ai/code/session_01PMGQP8oFbrkk2T2iYs6Us4

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Chat_("Chat"):::modified
ChatProvider_("ChatProvider"):::modified
CHATS_API_("CHATS_API"):::added
Chat_ -- "Now calls loadOrCreateChat to resume recent chat." --> ChatProvider_
ChatProvider_ -- "Sends GET /api/chats with EMAIL_ACCOUNT_HEADER (emailAccountId)." --> CHATS_API_
CHATS_API_ -- "Uses response.chats[0].id to set chatId, else creates new." --> ChatProvider_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implements a mechanism to resume the most recent chat session upon opening the assistant panel instead of defaulting to a new conversation. Updates the <code>Chat</code> component and <code>ChatProvider</code> to fetch existing chat history and set the active session ID accordingly.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Simplify-chat-examples...</td><td>February 15, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1657?tool=ast>(Baz)</a>.