### PR TITLE
Improve chat history dropdown with message preview and relative time

### DIFF
--- a/apps/web/app/api/chats/route.ts
+++ b/apps/web/app/api/chats/route.ts
@@ -14,7 +14,38 @@ async function getChats({ emailAccountId }: { emailAccountId: string }) {
   const chats = await prisma.chat.findMany({
     where: { emailAccountId },
     orderBy: { updatedAt: "desc" },
+    include: {
+      messages: {
+        where: { role: "user" },
+        orderBy: { createdAt: "asc" },
+        take: 1,
+      },
+    },
   });
 
-  return { chats };
+  return {
+    chats: chats.map((chat) => ({
+      id: chat.id,
+      createdAt: chat.createdAt,
+      updatedAt: chat.updatedAt,
+      preview: extractMessagePreview(chat.messages[0]?.parts),
+    })),
+  };
+}
+
+function extractMessagePreview(parts: unknown): string | null {
+  if (!Array.isArray(parts)) return null;
+  for (const part of parts) {
+    if (
+      part &&
+      typeof part === "object" &&
+      "type" in part &&
+      part.type === "text" &&
+      "text" in part &&
+      typeof part.text === "string"
+    ) {
+      return part.text.trim() || null;
+    }
+  }
+  return null;
 }

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
 import {
   ArrowUpIcon,
   HistoryIcon,
@@ -340,8 +341,20 @@ function ChatHistoryDropdown() {
                 onSelect={() => {
                   setChatId(chatItem.id);
                 }}
+                className="flex flex-col items-start gap-0.5 max-w-64"
               >
-                {`Chat from ${new Date(chatItem.createdAt).toLocaleString()}`}
+                <span className="truncate w-full text-sm">
+                  {chatItem.preview
+                    ? chatItem.preview.length > 50
+                      ? `${chatItem.preview.slice(0, 50)}…`
+                      : chatItem.preview
+                    : "New conversation"}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {formatDistanceToNow(new Date(chatItem.updatedAt), {
+                    addSuffix: true,
+                  })}
+                </span>
               </DropdownMenuItem>
             ))
           ) : (


### PR DESCRIPTION
# User description
- API: fetch first user message per chat and extract text preview
- UI: show first 50 chars of the opening message instead of a generic label
- UI: display relative timestamp (e.g. "2 hours ago") using date-fns

https://claude.ai/code/session_01AvrXj3tMPtGSGsSQx5qRK1

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the chat history interface by fetching and displaying message previews alongside relative timestamps. Updates the <code>getChats</code> API to extract the initial user message and modifies the <code>ChatHistoryDropdown</code> component to present this data clearly.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1658?tool=ast&topic=Chat+Preview+API>Chat Preview API</a>
        </td><td>Updates the <code>getChats</code> function to include the first user message and introduces <code>extractMessagePreview</code> to parse text content from message parts.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/chats/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Log-api-calls</td><td>November 14, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1658?tool=ast&topic=History+UI+Update>History UI Update</a>
        </td><td>Refactors the <code>ChatHistoryDropdown</code> to display a truncated 50-character preview and uses <code>formatDistanceToNow</code> for human-readable timestamps.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/chat.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Simplify-chat-examples...</td><td>February 15, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1658?tool=ast>(Baz)</a>.