### PR TITLE
fix: close mobile sidebar when nav link is clicked

### DIFF
--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -308,8 +308,13 @@ export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <Link
             href="https://docs.getinboxzero.com"
             target="_blank"
+            rel="noopener noreferrer"
             onClick={() => {
-              if (isMobile) setOpenMobile([]);
+              if (isMobile) {
+                setOpenMobile((prev) =>
+                  prev.filter((name) => name !== "left-sidebar"),
+                );
+              }
             }}
           >
             <BookIcon className="size-4" />
@@ -321,7 +326,11 @@ export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <Link
             href="/settings"
             onClick={() => {
-              if (isMobile) setOpenMobile([]);
+              if (isMobile) {
+                setOpenMobile((prev) =>
+                  prev.filter((name) => name !== "left-sidebar"),
+                );
+              }
             }}
           >
             <SettingsIcon className="size-4" />

--- a/apps/web/components/SideNavMenu.tsx
+++ b/apps/web/components/SideNavMenu.tsx
@@ -45,7 +45,11 @@ export function SideNavMenu({
             <Link
               href={item.href}
               onClick={() => {
-                if (isMobile) setOpenMobile([]);
+                if (isMobile) {
+                  setOpenMobile((prev) =>
+                    prev.filter((name) => name !== "left-sidebar"),
+                  );
+                }
               }}
             >
               <item.icon />


### PR DESCRIPTION
# User description
On mobile, the sidebar renders as a Sheet (drawer) but clicking nav links
only navigated without closing it. Call setOpenMobile([]) on link click
when isMobile is true, covering all SideNavMenu items and the footer
Help Center and Settings links.

https://claude.ai/code/session_01FeY7fovZAmCxSkXxT9WwGo

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements automatic closing of the mobile sidebar drawer when navigation links are clicked to improve user experience on smaller screens. Updates the <code>SideNavMenu</code> and <code>SideNav</code> components to detect mobile state and trigger the sidebar visibility state change upon link interaction.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-Chat-navigation-it...</td><td>February 15, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1659?tool=ast>(Baz)</a>.