### PR TITLE
Add OpenRouter trace_name metadata defaults

### DIFF
--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -168,6 +168,9 @@ describe("createGenerateText fallback chain", () => {
     expect(providerOptions.openrouter.provider).toEqual({
       order: ["Anthropic"],
     });
+    expect(providerOptions.openrouter.extraBody.trace.trace_name).toBe(
+      "OpenRouter user metadata",
+    );
     expect(providerOptions.openrouter.extraBody.trace.generation_name).toBe(
       "OpenRouter user metadata",
     );
@@ -211,6 +214,7 @@ describe("createGenerateText fallback chain", () => {
           user: "explicit-user-id",
           extraBody: {
             trace: {
+              trace_name: "explicit-trace",
               generation_name: "explicit-generation",
               email_account_id: "explicit-email-account-id",
             },
@@ -223,6 +227,7 @@ describe("createGenerateText fallback chain", () => {
     const providerOptions = mockGenerateText.mock.calls[0][0].providerOptions;
     expect(providerOptions.openrouter.user).toBe("explicit-user-id");
     expect(providerOptions.openrouter.extraBody.trace).toEqual({
+      trace_name: "explicit-trace",
       generation_name: "explicit-generation",
       email_account_id: "explicit-email-account-id",
     });

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -760,6 +760,11 @@ function withOpenRouterMetadata({
   };
   let traceChanged = false;
 
+  if (label && typeof nextTrace.trace_name !== "string") {
+    nextTrace.trace_name = label;
+    traceChanged = true;
+  }
+
   if (label && typeof nextTrace.generation_name !== "string") {
     nextTrace.generation_name = label;
     traceChanged = true;


### PR DESCRIPTION
This updates OpenRouter provider metadata to set trace.trace_name from the existing AI request label when not already provided. It keeps existing behavior for generation_name and preserves explicit request-level trace values. Tests were updated to verify default trace_name injection and explicit override preservation in fallback generation coverage. Validation: pnpm test --run utils/llms/fallback.test.ts.