### PR TITLE
Persist cold-email notification failures

### DIFF
--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
+import { executeAct } from "@/utils/ai/choose-rule/execute";
+import { runActionFunction } from "@/utils/ai/actions";
+import prisma from "@/utils/prisma";
+import type { EmailProvider } from "@/utils/email/types";
+import { createScopedLogger } from "@/utils/logger";
+import type { ParsedMessage } from "@/utils/types";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/ai/actions", () => ({
+  runActionFunction: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    executedRule: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+describe("executeAct", () => {
+  const logger = createScopedLogger("test");
+  const mockClient = {} as EmailProvider;
+  const message: ParsedMessage = {
+    id: "message-id-1",
+    threadId: "thread-id-1",
+    snippet: "",
+    historyId: "history-id-1",
+    inline: [],
+    headers: {
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "Subject",
+      date: "Mon, 1 Jan 2026 12:00:00 +0000",
+      "message-id": "<message-id-1>",
+    },
+    subject: "Subject",
+    date: "2026-01-01T12:00:00.000Z",
+    internalDate: "1700000000000",
+  };
+
+  const baseExecutedRule = {
+    id: "executed-rule-1",
+    ruleId: "rule-1",
+    threadId: "thread-id-1",
+    messageId: "message-id-1",
+    emailAccountId: "email-account-1",
+    automated: true,
+    reason: "Rule matched",
+    createdAt: new Date("2026-01-01T12:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T12:00:00.000Z"),
+    status: ExecutedRuleStatus.APPLYING,
+  };
+
+  const mockRunActionFunction = runActionFunction as Mock;
+  const mockExecutedRuleUpdate = prisma.executedRule.update as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecutedRuleUpdate.mockResolvedValue({});
+  });
+
+  it("marks executed rule as ERROR when notify sender reports a failure", async () => {
+    mockRunActionFunction.mockResolvedValueOnce({
+      success: false,
+      errorCode: "RESEND_NOT_CONFIGURED",
+    });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [{ id: "action-1", type: ActionType.NOTIFY_SENDER }],
+    } as any;
+
+    await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      userEmail: "recipient@example.com",
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      logger,
+    });
+
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: {
+        status: ExecutedRuleStatus.ERROR,
+        reason:
+          "Rule matched\nAction failures: NOTIFY_SENDER:RESEND_NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("marks executed rule as APPLIED when actions succeed", async () => {
+    mockRunActionFunction.mockResolvedValueOnce({ success: true });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [{ id: "action-1", type: ActionType.NOTIFY_SENDER }],
+    } as any;
+
+    await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      userEmail: "recipient@example.com",
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      logger,
+    });
+
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: { status: ExecutedRuleStatus.APPLIED },
+    });
+  });
+
+  it("keeps throwing for unexpected action exceptions", async () => {
+    mockRunActionFunction.mockRejectedValueOnce(new Error("boom"));
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [{ id: "action-1", type: ActionType.LABEL }],
+    } as any;
+
+    await expect(
+      executeAct({
+        client: mockClient,
+        executedRule,
+        message,
+        userEmail: "recipient@example.com",
+        userId: "user-1",
+        emailAccountId: "email-account-1",
+        logger,
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: { status: ExecutedRuleStatus.ERROR },
+    });
+  });
+});


### PR DESCRIPTION
# User description
## Summary
This PR records cold-email notification action failures so they are queryable from executed rule records.
It updates notify-sender action handling to return structured success or failure codes and keeps sender details in trace-level logs.
It updates rule execution to set executed rules to ERROR when notify-sender failures occur and append a normalized failure summary to the reason field.
It adds focused tests covering failure persistence, success behavior, and exception handling.

## Validation
- 
> inbox-zero-ai@1.0.0 test /Users/elie/conductor/workspaces/inbox-zero/sarajevo/apps/web
> cross-env RUN_AI_TESTS=false vitest --run utils/ai/choose-rule/execute.test.ts

[dotenv@17.2.4] injecting env (0) from .env.test -- tip: 🗂️ backup and recover secrets: https://dotenvx.com/ops

 RUN  v4.0.18 /Users/elie/conductor/workspaces/inbox-zero/sarajevo/apps/web

stdout | utils/ai/choose-rule/execute.test.ts > executeAct > marks executed rule as APPLIED when actions succeed
[test]: ExecutedRule status updated to APPLIED {
  "executedRuleId": "executed-rule-1"
} {
  "module": "ai-execute-act",
  "executedRuleId": "executed-rule-1",
  "ruleId": "rule-1",
  "threadId": "thread-id-1",
  "messageId": "message-id-1"
}

 ✓ utils/ai/choose-rule/execute.test.ts (3 tests) 4ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  12:17:01
   Duration  904ms (transform 135ms, setup 33ms, import 728ms, tests 4ms, environment 0ms)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
executeAct_("executeAct"):::modified
getActionFailure_("getActionFailure"):::added
buildFailureReason_("buildFailureReason"):::added
PRISMA_("PRISMA"):::modified
notify_sender_("notify_sender"):::modified
SEND_COLD_EMAIL_NOTIFICATION_("SEND_COLD_EMAIL_NOTIFICATION"):::modified
SENTRY_("SENTRY"):::modified
executeAct_ -- "Collects notify failures into ActionFailure objects with error codes." --> getActionFailure_
executeAct_ -- "Merges existing reason with action failure summary before persisting." --> buildFailureReason_
executeAct_ -- "Updates executedRule status to ERROR including failure reason." --> PRISMA_
notify_sender_ -- "Returns structured success and errorCode on send failure." --> SEND_COLD_EMAIL_NOTIFICATION_
notify_sender_ -- "Reports send failures to Sentry, capturing error and context." --> SENTRY_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the cold-email notification flow by introducing structured error codes and persisting failure reasons to the database. Updates the rule execution logic to mark rules as failed when notification actions encounter errors, ensuring better observability of automated actions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1662?tool=ast&topic=Execution+Testing>Execution Testing</a>
        </td><td>Adds comprehensive unit tests for <code>executeAct</code> to verify correct status transitions and reason string formatting during both success and failure scenarios.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/choose-rule/execute.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1662?tool=ast&topic=Error+Persistence>Error Persistence</a>
        </td><td>Implements structured return types for <code>notify_sender</code> and updates <code>executeAct</code> to capture and persist these failures in the <code>ExecutedRule</code> record.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/actions.ts</li>
<li>apps/web/utils/ai/choose-rule/execute.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Make-email-send-action...</td><td>January 21, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix-move-folder-add-te...</td><td>January 08, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1662?tool=ast>(Baz)</a>.