### PR TITLE
chore: move PR review script into skills directory

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -27,7 +27,7 @@ gh pr view --json comments --jq '.comments[] | {id, body, author: .author.login}
 
 # Code review comments (inline on specific lines) - usually the main ones
 # Script runs: gh api repos/$REPO/pulls/$PR_NUM/comments --jq '.[] | {id, body, author, path, line, in_reply_to_id}'
-.claude/scripts/get-pr-review-comments.sh
+.claude/skills/scripts/get-pr-review-comments.sh
 ```
 
 ──────────

--- a/.claude/skills/pr-loop/SKILL.md
+++ b/.claude/skills/pr-loop/SKILL.md
@@ -138,7 +138,7 @@ Note: Conversation comments (from bots like Vercel, or general discussion) do NO
 
 Fetch code review comments:
 ```bash
-.claude/scripts/get-pr-review-comments.sh
+.claude/skills/scripts/get-pr-review-comments.sh
 ```
 
 Fetch conversation comments:

--- a/.claude/skills/scripts/get-pr-review-comments.sh
+++ b/.claude/skills/scripts/get-pr-review-comments.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Fetch PR code review comments (review comments made on specific lines of code)
-# Usage: .claude/scripts/get-pr-review-comments.sh [pr_number] [limit]
+# Usage: .claude/skills/scripts/get-pr-review-comments.sh [pr_number] [limit]
 #
 # If pr_number is omitted, auto-detects from current branch's PR
 #
-# Example: .claude/scripts/get-pr-review-comments.sh
-# Example: .claude/scripts/get-pr-review-comments.sh 1239
-# Example: .claude/scripts/get-pr-review-comments.sh 1239 50
+# Example: .claude/skills/scripts/get-pr-review-comments.sh
+# Example: .claude/skills/scripts/get-pr-review-comments.sh 1239
+# Example: .claude/skills/scripts/get-pr-review-comments.sh 1239 50
 
 set -e
 


### PR DESCRIPTION
# User description
Moves the PR review comment helper into the shared skills scripts directory.

- Relocates get-pr-review-comments.sh under .claude/skills/scripts/
- Updates address-pr-comments and pr-loop skill instructions to the new path
- Updates script usage examples to match the new location

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Relocates the PR review comment helper script to a centralized skills directory to improve project organization. Updates the skill instructions and script documentation to reflect the new file path.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-Add-disable-mode...</td><td>February 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1664?tool=ast>(Baz)</a>.