### PR TITLE
fix prisma:migrate:local dotenv command

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "test-e2e": "cross-env RUN_E2E_TESTS=true vitest --run",
     "test-e2e:flows": "cross-env RUN_E2E_FLOW_TESTS=true vitest --run --dir __tests__/e2e/flows --no-file-parallelism",
     "prisma:migrate:e2e": "dotenv -e .env.e2e -- prisma migrate deploy",
-    "prisma:migrate:local": "dotenv-cli -e .env.local -- prisma migrate deploy",
+    "prisma:migrate:local": "dotenv -e .env.local -- prisma migrate deploy",
     "preinstall": "npx only-allow pnpm",
     "postinstall": "prisma generate"
   },


### PR DESCRIPTION
This updates the `prisma:migrate:local` script to use `dotenv` instead of `dotenv-cli`. In this repository the installed CLI binary is `dotenv`, so the previous command could fail with `command not found`. The PR scope is one line in `apps/web/package.json` and does not change runtime app behavior outside local migration command execution.