### PR TITLE
Add docs route redirects to docs subdomain

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -144,6 +144,16 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: "/docs",
+        destination: "https://docs.getinboxzero.com",
+        permanent: true,
+      },
+      {
+        source: "/docs/:path*",
+        destination: "https://docs.getinboxzero.com/:path*",
+        permanent: true,
+      },
+      {
         source: "/request-access",
         destination: "/early-access",
         permanent: true,


### PR DESCRIPTION
## Summary
- Add permanent redirects for `/docs` and `/docs/:path*` to `https://docs.getinboxzero.com`.
- Preserve deep links to docs pages while avoiding 404s on docs paths.

## Testing
- Not run (Next.js redirect config change only).