### PR TITLE
chore: fix skill frontmatter metadata parsing

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: address-pr-comments
+description: Resolve active pull request comments and prepare replies
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: create-pr
+description: Commit changes and open a pull request with safe metadata
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/explain-changes/SKILL.md
+++ b/.claude/skills/explain-changes/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: explain-changes
 description: Explain recent changes and provide a structured summary with security checks
 ---
 

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: interview
 description: Interview me about the plan
-argument-hint: [plan]
+argument-hint: "[plan]"
 model: opus
 ---
 

--- a/.claude/skills/next-step/SKILL.md
+++ b/.claude/skills/next-step/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: next-step
+description: Continue execution with the next requested step
 disable-model-invocation: true
 ---
 
 Continue to the next step.
-

--- a/.claude/skills/polish/SKILL.md
+++ b/.claude/skills/polish/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: polish
+description: Remove lint and low-risk code quality issues from current branch changes
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/pr-loop/SKILL.md
+++ b/.claude/skills/pr-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-loop
 description: Review, commit, create PR, then auto-address review comments in a loop.
-argument-hint: [--wait 300] [--max 5]
+argument-hint: "[--wait 300] [--max 5]"
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/qa-new-flow/SKILL.md
+++ b/.claude/skills/qa-new-flow/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: qa-new-flow
 description: Create a new browser QA flow file from the template
 ---
 

--- a/.claude/skills/qa-run/SKILL.md
+++ b/.claude/skills/qa-run/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: qa-run
 description: Run browser QA flows and write a JSON report
 ---
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: review
+description: Review code changes, auto-fix safe issues, and report bugs
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/roast-my-code/SKILL.md
+++ b/.claude/skills/roast-my-code/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: roast-my-code
+description: Perform a blunt, humorous code review before proposing fixes
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/step-by-step/SKILL.md
+++ b/.claude/skills/step-by-step/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: step-by-step
+description: Execute tasks one step at a time with user confirmation
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/ux-writing/SKILL.md
+++ b/.claude/skills/ux-writing/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: ux-writing
+description: Improve UX copy for labels, actions, and error messages
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/wait/SKILL.md
+++ b/.claude/skills/wait/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: wait
+description: Pause execution for a user-specified duration
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: write-tests
+description: Write focused unit tests for backend and utility logic
 disable-model-invocation: true
 ---
 
@@ -139,4 +141,3 @@ If requested, run coverage to identify gaps:
 ```bash
 cd apps/web && pnpm test --run --coverage -- path/to/file.test.ts
 ```
-


### PR DESCRIPTION
# User description
This updates skill definitions so frontmatter metadata parses consistently and skill loading no longer fails.

- add missing `name` fields across skill files
- add concise descriptions where missing
- quote `argument-hint` values to keep YAML valid

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates skill definition files to ensure frontmatter metadata parses consistently and prevents loading failures. Standardizes the metadata structure by adding missing <code>name</code> and <code>description</code> fields and quoting <code>argument-hint</code> values to maintain valid YAML syntax.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-move-PR-review-h...</td><td>February 23, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1671?tool=ast>(Baz)</a>.