### PR TITLE
Show fallback when integrations is disabled

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import Link from "next/link";
+import { ZapIcon } from "lucide-react";
 import { PageWrapper } from "@/components/PageWrapper";
 import { PageHeader } from "@/components/PageHeader";
 import { Integrations } from "@/app/(app)/[emailAccountId]/integrations/Integrations";
 import { Button } from "@/components/ui/button";
+import { ActionCard } from "@/components/ui/card";
 import { RequestAccessDialog } from "./RequestAccessDialog";
 import { usePremium } from "@/components/PremiumAlert";
 import { hasTierAccess } from "@/utils/premium";
@@ -19,9 +22,31 @@ export default function IntegrationsPage() {
     minimumTier: "PLUS_MONTHLY",
   });
 
-  // Feature flag check - return null for client-side (notFound() is server-only)
   if (!integrationsEnabled) {
-    return null;
+    return (
+      <PageWrapper>
+        <div className="flex items-center justify-between gap-2">
+          <PageHeader
+            title="Integrations"
+            description="Connect to external services to help the AI assistant draft better replies by accessing relevant data from your tools."
+          />
+        </div>
+
+        <div className="mt-8">
+          <ActionCard
+            variant="blue"
+            icon={<ZapIcon className="h-5 w-5" />}
+            title="Integrations are not enabled"
+            description="This feature is in limited rollout. Join early access to enable integrations for your account."
+            action={
+              <Button asChild variant="outline">
+                <Link href="/early-access">Join Early Access</Link>
+              </Button>
+            }
+          />
+        </div>
+      </PageWrapper>
+    );
   }
 
   return (


### PR DESCRIPTION
# User description
## Summary
- replace the blank render path on the integrations page when the feature flag is off
- show a clear in-app fallback card with a link to early access
- keep the existing integrations and premium behavior unchanged when enabled

## Testing
- not run (not requested)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the integrations page by replacing a null render with a descriptive fallback UI when the feature flag is disabled. Utilizes <code>ActionCard</code> and <code>PageWrapper</code> to provide users with a clear path to request early access for the integrations feature.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-mobile-layout-issu...</td><td>February 15, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1673?tool=ast>(Baz)</a>.