### PR TITLE
Fix mobile chat history control tap interception

### DIFF
--- a/apps/web/components/SideNavWithTopNav.tsx
+++ b/apps/web/components/SideNavWithTopNav.tsx
@@ -79,9 +79,12 @@ export function SideNavWithTopNav({
 
 function MobileHeader() {
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 h-9 md:hidden">
+    <header className="pointer-events-none fixed top-0 left-0 right-0 z-50 h-9 md:hidden">
       <div className="flex h-full items-center px-4">
-        <SidebarTrigger name="left-sidebar" className="size-6" />
+        <SidebarTrigger
+          name="left-sidebar"
+          className="pointer-events-auto size-6"
+        />
       </div>
     </header>
   );


### PR DESCRIPTION
# User description
## Summary
- Make the fixed mobile header ignore pointer events so chat controls remain tappable.
- Keep pointer events enabled on the sidebar trigger so opening the left sidebar still works.

## Testing
- Not run (UI layering change only).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the mobile header layout to prevent it from intercepting touch events, ensuring that underlying chat controls remain interactive. Modifies the <code>MobileHeader</code> component to disable pointer events globally while maintaining functionality for the <code>SidebarTrigger</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Remove-bottom-navigati...</td><td>February 15, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1677?tool=ast>(Baz)</a>.