### PR TITLE
Remove obsolete assistant examples trigger

### DIFF
--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useChats } from "@/hooks/useChats";
 import { LoadingContent } from "@/components/LoadingContent";
-import { ExamplesDialog } from "@/components/assistant-chat/examples-dialog";
 import { Tooltip } from "@/components/Tooltip";
 import { useChat } from "@/providers/ChatProvider";
 import {
@@ -129,9 +128,7 @@ export function Chat({ open }: { open: boolean }) {
       }
     >
       <ChatTopBar
-        messages={messages}
         hasMessages={hasMessages}
-        setInput={setInput}
       />
       {hasMessages ? (
         <ChatMessagesView
@@ -258,13 +255,9 @@ function NewChatView({
 }
 
 function ChatTopBar({
-  messages,
   hasMessages,
-  setInput,
 }: {
-  messages: ChatMessage[];
   hasMessages: boolean;
-  setInput: (input: string) => void;
 }) {
   return (
     <div className="relative mx-auto w-full max-w-[calc(var(--chat-max-w)+var(--chat-px)*2)] px-[var(--chat-px)] pt-2">
@@ -272,7 +265,6 @@ function ChatTopBar({
         {hasMessages ? (
           <>
             <NewChatButton />
-            <ExamplesDialog setInput={setInput} />
             <ChatHistoryDropdown />
           </>
         ) : (

--- a/apps/web/components/assistant-chat/examples-dialog.tsx
+++ b/apps/web/components/assistant-chat/examples-dialog.tsx
@@ -11,7 +11,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
-  LightbulbIcon,
   ArrowLeftIcon,
   PlusIcon,
   CheckCircle2Icon,
@@ -21,7 +20,6 @@ import {
   convertLabelsToDisplay,
   convertMentionsToLabels,
 } from "@/utils/mention";
-import { Tooltip } from "@/components/Tooltip";
 import { ButtonList } from "@/components/ButtonList";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 import { cn } from "@/utils";
@@ -29,7 +27,7 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 
 interface ExamplesDialogProps {
   setInput: (input: string) => void;
-  children?: React.ReactNode;
+  children: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -92,18 +90,7 @@ export function ExamplesDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      {children ? (
-        <DialogTrigger asChild>{children}</DialogTrigger>
-      ) : (
-        <Tooltip content="Choose from examples">
-          <DialogTrigger asChild>
-            <Button variant="ghost" size="icon">
-              <LightbulbIcon className="size-5" />
-              <span className="sr-only">Show Examples</span>
-            </Button>
-          </DialogTrigger>
-        </Tooltip>
-      )}
+      <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="max-h-[80vh] max-w-2xl">
         <DialogHeader>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
# User description
## Summary
- remove the outdated top-bar examples icon entry point in assistant chat.
- simplify the examples dialog to always use an explicit child trigger and remove the dead fallback trigger path.

## Testing
- not run (not requested).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Chat_("Chat"):::modified
ChatTopBar_("ChatTopBar"):::modified
ExamplesDialog_("ExamplesDialog"):::modified
DIALOG_TRIGGER_("DIALOG_TRIGGER"):::added
Chat_ -- "Now passes only hasMessages; removed messages and setInput." --> ChatTopBar_
ExamplesDialog_ -- "Makes DialogTrigger wrapping children mandatory; removes tooltip fallback." --> DIALOG_TRIGGER_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Removes the obsolete top-bar examples icon from the assistant chat interface to streamline the user experience. Simplifies the <code>ExamplesDialog</code> component by enforcing an explicit child trigger and eliminating dead fallback logic.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Simplify-chat-examples...</td><td>February 15, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant-chat-UI-UX-i...</td><td>February 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1678?tool=ast>(Baz)</a>.