### PR TITLE
threads: limit batch fetch concurrency

### DIFF
--- a/apps/web/utils/async.ts
+++ b/apps/web/utils/async.ts
@@ -1,0 +1,46 @@
+export type BoundedConcurrencyResult<TItem, TResult> = {
+  item: TItem;
+  result: PromiseSettledResult<TResult>;
+};
+
+export async function runWithBoundedConcurrency<TItem, TResult>({
+  items,
+  concurrency,
+  run,
+  onBatchComplete,
+}: {
+  items: TItem[];
+  concurrency: number;
+  run: (item: TItem, index: number) => Promise<TResult>;
+  onBatchComplete?: (
+    results: BoundedConcurrencyResult<TItem, TResult>[],
+  ) => Promise<void> | void;
+}) {
+  if (concurrency < 1) {
+    throw new Error("concurrency must be at least 1");
+  }
+
+  const results: BoundedConcurrencyResult<TItem, TResult>[] = [];
+
+  for (let i = 0; i < items.length; i += concurrency) {
+    const batch = items.slice(i, i + concurrency);
+    const settled = await Promise.allSettled(
+      batch.map((item, batchIndex) => run(item, i + batchIndex)),
+    );
+
+    const batchResults = settled.map((result, index) => {
+      const item = batch[index];
+      if (item === undefined) {
+        throw new Error("Batch result index out of bounds");
+      }
+
+      return { item, result };
+    });
+
+    if (onBatchComplete) await onBatchComplete(batchResults);
+
+    results.push(...batchResults);
+  }
+
+  return results;
+}


### PR DESCRIPTION
# User description
Reduce bursty provider calls in thread batch retrieval by replacing unbounded parallel fetches with bounded concurrency.

- Add a thread fetch concurrency limit constant.
- Process thread IDs in small chunks while preserving existing error handling and response shape.
- Keep API behavior the same while lowering rate-limit pressure during large requests.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
publishBulkActionToTinybird_("publishBulkActionToTinybird"):::modified
runWithBoundedConcurrency_("runWithBoundedConcurrency"):::added
TINYBIRD_("TINYBIRD"):::modified
runThreadActionsInParallel_("runThreadActionsInParallel"):::modified
publishBulkActionToTinybird_ -- "Replaces manual batching with bounded concurrency; publishes ownerEmail/threadId." --> runWithBoundedConcurrency_
publishBulkActionToTinybird_ -- "Now sends ownerEmail, threadId, actionSource and timestamp concurrently." --> TINYBIRD_
runThreadActionsInParallel_ -- "Replaces manual batching with bounded concurrency; returns per-thread success." --> runWithBoundedConcurrency_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implements a bounded concurrency utility to manage parallel execution and reduce rate-limit pressure on external providers. Replaces unbounded <code>Promise.all</code> and manual batching logic across the batch thread API, AI tools, and bulk action tracking.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1684?tool=ast&topic=Concurrency+Utility>Concurrency Utility</a>
        </td><td>Introduce <code>runWithBoundedConcurrency</code> in <code>apps/web/utils/async.ts</code> to provide a standardized way to process items in chunks with optional batch completion callbacks.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/async.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1684?tool=ast&topic=Batch+Processing>Batch Processing</a>
        </td><td>Refactor the batch thread retrieval API and bulk action tracking to use the new concurrency utility, ensuring a maximum of 5-100 concurrent requests depending on the context.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/api/threads/batch/route.ts</li>
<li>apps/web/utils/ai/assistant/chat-inbox-tools.ts</li>
<li>apps/web/utils/email/bulk-action-tracking.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Assistant-confirmation...</td><td>February 23, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-all-comments</td><td>July 11, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1684?tool=ast>(Baz)</a>.