### PR TITLE
fix: align batch thread sender filtering

### DIFF
--- a/apps/web/app/api/threads/batch/route.ts
+++ b/apps/web/app/api/threads/batch/route.ts
@@ -49,6 +49,7 @@ export const GET = withEmailProvider("threads/batch", async (request) => {
           if (!message.headers?.from) return true;
           return !isIgnoredSender(message.headers.from);
         });
+        if (!filteredMessages.length) continue;
 
         validThreads.push({
           id: thread.id,


### PR DESCRIPTION
# User description
This updates the batch threads API to match ignored-sender handling used in other thread flows.

It now filters ignored-sender messages before returning each thread and skips threads that become empty after filtering.
This keeps batch thread data consistent and avoids empty-message thread entries for downstream consumers.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the batch threads API route to filter messages from ignored senders using <code>isIgnoredSender</code> and ensures that threads containing no valid messages are excluded from the response. This change maintains consistency across thread-related flows and prevents downstream consumers from processing empty thread entries.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-build-type-mismatc...</td><td>February 24, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-all-comments</td><td>July 11, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1687?tool=ast>(Baz)</a>.