### PR TITLE
assistant: Stage history loading for faster render

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -39,28 +39,27 @@ export function History() {
   const [ruleId] = useQueryState("ruleId", parseAsString.withDefault("all"));
 
   const { data, isLoading, error } = useExecutedRules({ page, ruleId });
+  const results = data?.results ?? [];
   const messageIds = useMemo(
-    () => data?.results.map((result) => result.messageId) || [],
-    [data?.results],
+    () => results.map((result) => result.messageId),
+    [results],
   );
   const { data: messagesData, isLoading: isMessagesLoading } = useMessagesBatch(
     {
       ids: messageIds,
     },
   );
-  const messagesById = useMemo(
-    () => mapMessagesById(messagesData?.messages || []),
-    [messagesData?.messages],
-  );
+  const messages = messagesData?.messages ?? [];
+  const messagesById = useMemo(() => mapMessagesById(messages), [messages]);
 
   return (
     <>
       <RulesSelect />
       <Card className="mt-2">
         <LoadingContent loading={isLoading} error={error}>
-          {data?.results.length ? (
+          {results.length ? (
             <HistoryTable
-              data={data.results}
+              data={results}
               totalPages={data.totalPages}
               messagesById={messagesById}
               messagesLoading={isMessagesLoading}

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -88,20 +88,13 @@ async function getExecutedRules({
 
   const executedRulesByMessageId = groupBy(executedRules, (er) => er.messageId);
 
-  const results = Object.entries(executedRulesByMessageId).flatMap(
-    ([messageId, groupedExecutedRules]) => {
-      const firstExecutedRule = groupedExecutedRules[0];
-      if (!firstExecutedRule) return [];
-
-      return [
-        {
-          messageId,
-          threadId: firstExecutedRule.threadId,
-          executedRules: groupedExecutedRules,
-        },
-      ];
-    },
-  );
+  const results = Object.entries(executedRulesByMessageId)
+    .filter(([, groupedExecutedRules]) => groupedExecutedRules.length > 0)
+    .map(([messageId, groupedExecutedRules]) => ({
+      messageId,
+      threadId: groupedExecutedRules[0].threadId,
+      executedRules: groupedExecutedRules,
+    }));
 
   return {
     results,


### PR DESCRIPTION
# User description
Load the History tab in two phases to reduce initial wait time.

- Return executed-rule history rows from the database without waiting on provider message fetches.
- Hydrate message details in a follow-up batch request and map them client-side by message ID.
- Show skeleton placeholders and safe fallbacks for message-dependent UI while hydration completes.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
WITH_EMAIL_ACCOUNT_("WITH_EMAIL_ACCOUNT"):::added
getExecutedRules_("getExecutedRules"):::modified
PRISMA_("PRISMA"):::modified
History_("History"):::modified
HistoryTable_("HistoryTable"):::modified
USE_MESSAGES_BATCH_MESSAGES_BATCH_API_("USE_MESSAGES_BATCH / MESSAGES_BATCH_API"):::added
EmailCell_("EmailCell"):::modified
RuleCell_("RuleCell"):::modified
WITH_EMAIL_ACCOUNT_ -- "Replaces provider middleware, supplies emailAccountId authentication." --> getExecutedRules_
getExecutedRules_ -- "Still queries by emailAccountId; returns grouped results by messageId." --> PRISMA_
History_ -- "Now passes messagesById and messagesLoading for message merging." --> HistoryTable_
History_ -- "Sends list of message IDs to fetch batched message metadata." --> USE_MESSAGES_BATCH_MESSAGES_BATCH_API_
USE_MESSAGES_BATCH_MESSAGES_BATCH_API_ -- "Returns ParsedMessage objects to enrich executed-rule rows." --> History_
HistoryTable_ -- "EmailCell now accepts message and shows skeletons while loading." --> EmailCell_
HistoryTable_ -- "RuleCell now uses message state to enable or disable FixWithChat." --> RuleCell_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Optimizes the history loading flow by decoupling database record retrieval from external provider message fetching. Implements a client-side hydration strategy using batch requests and skeleton states to improve perceived performance.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1692?tool=ast&topic=API+Optimization>API Optimization</a>
        </td><td>Refactor the <code>GET</code> handler and <code>getExecutedRules</code> to return database records immediately without waiting for external email provider data.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/user/executed-rules/history/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Use-system-types-for-f...</td><td>February 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1692?tool=ast&topic=UI+Hydration>UI Hydration</a>
        </td><td>Update the <code>History</code> component to use <code>useMessagesBatch</code> for secondary hydration and introduce <code>Skeleton</code> components for loading states.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/History.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Use-the-same-component...</td><td>November 01, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1692?tool=ast>(Baz)</a>.