### PR TITLE
Use shared deterministic sorting for automation rules

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -56,6 +56,7 @@ import {
   SYSTEM_RULE_ORDER,
   getDefaultActions,
 } from "@/utils/rule/consts";
+import { sortRulesForAutomation } from "@/utils/rule/sort";
 import {
   STEP_KEYS,
   getStepNumber,
@@ -126,9 +127,7 @@ export function Rules({
 
     const userRules = existingRules.filter((rule) => !rule.systemType);
 
-    return [...systemRulePlaceholders, ...userRules].sort(
-      (a, b) => (b.enabled ? 1 : 0) - (a.enabled ? 1 : 0),
-    );
+    return sortRulesForAutomation([...systemRulePlaceholders, ...userRules]);
   }, [data, emailAccountId, provider]);
 
   const hasRules = !!rules?.length;

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -6,6 +6,7 @@ import { getModel, type ModelType } from "@/utils/llms/model";
 import { createGenerateObject } from "@/utils/llms";
 import { getUserInfoPrompt, getUserRulesPrompt } from "@/utils/ai/helpers";
 import { PROMPT_SECURITY_INSTRUCTIONS } from "@/utils/ai/security";
+import { sortRulesForAutomation } from "@/utils/rule/sort";
 
 type GetAiResponseOptions = {
   email: EmailForLLM;
@@ -32,9 +33,11 @@ export async function aiChooseRule<
 }> {
   if (!rules.length) return { rules: [], reason: "No rules to evaluate" };
 
+  const orderedRules = sortRulesForAutomation(rules);
+
   const { result: aiResponse } = await getAiResponse({
     email,
-    rules,
+    rules: orderedRules,
     emailAccount,
     modelType,
   });
@@ -49,7 +52,7 @@ export async function aiChooseRule<
   const rulesWithMetadata = aiResponse.matchedRules
     .map((match) => {
       if (!match.ruleName) return undefined;
-      const rule = rules.find(
+      const rule = orderedRules.find(
         (r) => r.name.toLowerCase() === match.ruleName.toLowerCase(),
       );
       return rule ? { rule, isPrimary: match.isPrimary } : undefined;

--- a/apps/web/utils/rule/sort.ts
+++ b/apps/web/utils/rule/sort.ts
@@ -1,0 +1,36 @@
+import { SYSTEM_RULE_ORDER } from "@/utils/rule/consts";
+
+type SortableRule = {
+  enabled?: boolean | null;
+  systemType?: string | null;
+  name: string;
+  instructions?: string | null;
+};
+
+export function sortRulesForAutomation<T extends SortableRule>(rules: T[]): T[] {
+  return [...rules].sort((a, b) => {
+    const enabledCompare = Number(Boolean(b.enabled)) - Number(Boolean(a.enabled));
+    if (enabledCompare !== 0) return enabledCompare;
+
+    const systemOrderCompare =
+      getSystemRuleOrderIndex(a.systemType) - getSystemRuleOrderIndex(b.systemType);
+    if (systemOrderCompare !== 0) return systemOrderCompare;
+
+    const nameCompare = a.name.localeCompare(b.name, undefined, {
+      sensitivity: "base",
+    });
+    if (nameCompare !== 0) return nameCompare;
+
+    return (a.instructions ?? "").localeCompare(b.instructions ?? "", undefined, {
+      sensitivity: "base",
+    });
+  });
+}
+
+function getSystemRuleOrderIndex(systemType?: string | null) {
+  if (!systemType) return SYSTEM_RULE_ORDER.length;
+  const index = SYSTEM_RULE_ORDER.indexOf(
+    systemType as (typeof SYSTEM_RULE_ORDER)[number],
+  );
+  return index === -1 ? SYSTEM_RULE_ORDER.length : index;
+}


### PR DESCRIPTION
# User description
Introduces one shared helper to keep automation rule ordering deterministic across the app and AI prompts.

- Add `sortRulesForAutomation` with stable tie-breakers and system-rule ordering.
- Reuse the helper in the assistant rules page instead of inline sort logic.
- Reuse the helper in choose-rule prompt building and matched-rule lookup.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
sortRulesForAutomation_("sortRulesForAutomation"):::added
getSystemRuleOrderIndex_("getSystemRuleOrderIndex"):::added
SYSTEM_RULE_ORDER_("SYSTEM_RULE_ORDER"):::modified
aiChooseRule_("aiChooseRule"):::modified
Rules_("Rules"):::modified
GET_AI_RESPONSE_("GET_AI_RESPONSE"):::modified
sortRulesForAutomation_ -- "Uses helper to map systemType to ordering index." --> getSystemRuleOrderIndex_
sortRulesForAutomation_ -- "References SYSTEM_RULE_ORDER to determine canonical system type priority." --> SYSTEM_RULE_ORDER_
aiChooseRule_ -- "Pre-sorts rules before AI evaluation, preserving enabled/system ordering." --> sortRulesForAutomation_
Rules_ -- "Sorts combined system placeholders and user rules for display." --> sortRulesForAutomation_
aiChooseRule_ -- "Sends ordered rules, email, and modelType to AI endpoint." --> GET_AI_RESPONSE_
GET_AI_RESPONSE_ -- "Returns matched rule metadata for mapping back onto ordered rules." --> aiChooseRule_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Introduces a centralized <code>sortRulesForAutomation</code> utility to ensure deterministic rule ordering across the application. Replaces fragmented sorting logic in the UI and AI prompt generation to maintain consistency in rule evaluation and display.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1693?tool=ast&topic=Feature+Integration>Feature Integration</a>
        </td><td>Integrates the new sorting utility into the assistant rules page and the AI rule selection logic to ensure the LLM receives rules in a predictable order.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx</li>
<li>apps/web/utils/ai/choose-rule/ai-choose-rule.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-OpenAI-structured-...</td><td>February 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Align-action-columns-t...</td><td>December 07, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1693?tool=ast&topic=Core+Sorting+Logic>Core Sorting Logic</a>
        </td><td>Implements the <code>sortRulesForAutomation</code> helper in a new utility file to provide stable sorting based on status, system type, name, and instructions.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/rule/sort.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1693?tool=ast>(Baz)</a>.