### PR TITLE
assistant history: guard optional pagination data

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -40,6 +40,7 @@ export function History() {
 
   const { data, isLoading, error } = useExecutedRules({ page, ruleId });
   const results = data?.results ?? [];
+  const totalPages = data?.totalPages ?? 1;
   const messageIds = useMemo(
     () => results.map((result) => result.messageId),
     [results],
@@ -60,7 +61,7 @@ export function History() {
           {results.length ? (
             <HistoryTable
               data={results}
-              totalPages={data.totalPages}
+              totalPages={totalPages}
               messagesById={messagesById}
               messagesLoading={isMessagesLoading}
             />


### PR DESCRIPTION
# User description
Prevents a strict null-check failure during production build by avoiding direct access to optional query data.

- derive a safe `totalPages` fallback from optional response data
- pass the derived value into `HistoryTable` instead of accessing optional object directly
- verify with `next build` using local placeholder env values

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensures the assistant history table handles optional pagination data safely by deriving a fallback value for total pages. Prevents build-time null-check failures when accessing the <code>useExecutedRules</code> response data.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-Stage-histor...</td><td>February 24, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1695?tool=ast>(Baz)</a>.