### PR TITLE
fix: preserve category capitalization in digest emails

### DIFF
--- a/packages/resend/emails/digest.tsx
+++ b/packages/resend/emails/digest.tsx
@@ -162,7 +162,7 @@ export default function DigestEmail(props: DigestEmailProps) {
                 <Text className="text-[16px] text-gray-700 mt-0 mb-0">
                   {categoryData.count}{" "}
                   <span className={`${colors.text} font-semibold`}>
-                    {(ruleNames?.[categoryKey] || categoryKey).toLowerCase()}
+                    {ruleNames?.[categoryKey] || categoryKey}
                   </span>
                   {" from "}
                   {categoryData.senders.map((sender, index) => {
@@ -218,7 +218,7 @@ export default function DigestEmail(props: DigestEmailProps) {
             <Text className="text-[16px] text-gray-700 mt-0 mb-0">
               {categoryData.count}{" "}
               <span className={`${colors.text} font-semibold`}>
-                {(ruleNames?.[categoryKey] || categoryKey).toLowerCase()}
+                {ruleNames?.[categoryKey] || categoryKey}
               </span>
               {" from "}
               {categoryData.senders.map((sender, index) => {
@@ -630,16 +630,16 @@ export const generateDigestSubject = (props: DigestEmailProps): string => {
 
   if (topCategories.length === 1) {
     const { name, count } = topCategories[0];
-    return `Summary of ${count} ${name.toLowerCase()} email${count === 1 ? "" : "s"}`;
+    return `Summary of ${count} ${name} email${count === 1 ? "" : "s"}`;
   }
 
   if (topCategories.length === 2) {
     const [first, second] = topCategories;
-    return `Summary of ${first.count} ${first.name.toLowerCase()} and ${second.count} ${second.name.toLowerCase()} emails`;
+    return `Summary of ${first.count} ${first.name} and ${second.count} ${second.name} emails`;
   }
 
   const [first, second, third] = topCategories;
-  return `Summary of ${first.count} ${first.name.toLowerCase()}, ${second.count} ${second.name.toLowerCase()} and ${third.count} ${third.name.toLowerCase()} emails`;
+  return `Summary of ${first.count} ${first.name}, ${second.count} ${second.name} and ${third.count} ${third.name} emails`;
 };
 
 const normalizeCategoryData = (


### PR DESCRIPTION
## Summary
Category names in digest emails are now displayed with proper capitalization. Previously, names like "FYI", "To Reply", and "Notification" were being lowercased to "fyi", "to reply", "notification". This fix removes five `.toLowerCase()` calls that were incorrectly transforming the original rule names both in the email body and subject line.

## Changes
- Removed `.toLowerCase()` from category name display in email body (2 locations)
- Removed `.toLowerCase()` from subject line generation (3 locations)
- Category names now preserve capitalization from the `ruleNames` map

## Fixes
Closes INB-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)