### PR TITLE
fix: persist setup completion state

### DIFF
--- a/apps/web/app/api/user/setup-progress/route.ts
+++ b/apps/web/app/api/user/setup-progress/route.ts
@@ -38,6 +38,7 @@ async function getSetupProgress({
         take: 1,
       },
       calendarConnections: { select: { id: true }, take: 1 },
+      user: { select: { dismissedHints: true } },
       members: {
         take: 1,
         select: {
@@ -68,7 +69,11 @@ async function getSetupProgress({
   const hasTeamMembers = (membership?.organization?._count.members ?? 0) > 1;
   const hasPendingInvitations =
     (membership?.organization?._count.invitations ?? 0) > 0;
-  const teamInviteCompleted = hasTeamMembers || hasPendingInvitations;
+  const teamInviteDismissed = emailAccount.user.dismissedHints.includes(
+    `setup:teamInvite:${emailAccountId}`,
+  );
+  const teamInviteCompleted =
+    hasTeamMembers || hasPendingInvitations || teamInviteDismissed;
 
   const showTeamInviteStep = hasNoOrg || isOwner;
 


### PR DESCRIPTION
# User description
This updates setup completion to use persisted hint state instead of local-only skip state.\n\nThe setup page now marks the team-invite step as skipped via the existing hint dismissal action and refreshes progress after mutation.\n\nThe setup-progress API now includes persisted dismissed hints when computing completion.\n\nThis keeps setup status consistent across sessions and surfaces.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
SetupContent_("SetupContent"):::modified
USE_SETUP_PROGRESS_("USE_SETUP_PROGRESS"):::modified
SetupPageContent_("SetupPageContent"):::modified
Checklist_("Checklist"):::modified
handleMarkTeamInviteDone_("handleMarkTeamInviteDone"):::modified
DISMISS_HINT_ACTION_("DISMISS_HINT_ACTION"):::added
getSetupProgress_("getSetupProgress"):::modified
PRISMA_DB_("PRISMA_DB"):::modified
SetupContent_ -- "now uses mutate from useSetupProgress to refresh" --> USE_SETUP_PROGRESS_
SetupContent_ -- "passes onSetupProgressChanged callback to enable refreshing" --> SetupPageContent_
SetupPageContent_ -- "forwards onSetupProgressChanged callback down to Checklist" --> Checklist_
Checklist_ -- "marking invite now triggers dismiss action and refresh" --> handleMarkTeamInviteDone_
handleMarkTeamInviteDone_ -- "calls dismissHintAction with setup:teamInvite hint id" --> DISMISS_HINT_ACTION_
handleMarkTeamInviteDone_ -- "invokes onSetupProgressChanged to refresh setup progress" --> USE_SETUP_PROGRESS_
USE_SETUP_PROGRESS_ -- "now returns user's dismissedHints enabling dismissal detection" --> getSetupProgress_
getSetupProgress_ -- "selects user's dismissedHints from DB to detect dismissals" --> PRISMA_DB_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the setup completion logic to persist the 'skipped' state of the team-invite step in the database rather than local storage. Ensures that setup progress remains consistent across different devices and sessions by integrating dismissed hints into the progress calculation API.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1712?tool=ast&topic=Setup+UI+Persistence>Setup UI Persistence</a>
        </td><td>Replace local storage state with <code>dismissHintAction</code> to persist step dismissal and refresh the setup progress data upon success.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-env-driven-white-l...</td><td>February 22, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Refresh-onboarding-flo...</td><td>February 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1712?tool=ast&topic=Setup+Progress+API>Setup Progress API</a>
        </td><td>Integrate <code>dismissedHints</code> from the user profile into the setup progress calculation to determine if the team-invite step is completed.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/user/setup-progress/route.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-request-visibility...</td><td>February 24, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Add-team-invite-step-t...</td><td>January 29, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1712?tool=ast>(Baz)</a>.