### PR TITLE
chore: update openrouter example defaults

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -48,9 +48,9 @@ NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
 
 # --- OpenRouter ---
 # DEFAULT_LLM_PROVIDER=openrouter
-# DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4.5
+# DEFAULT_LLM_MODEL=google/gemini-3-flash
 # ECONOMY_LLM_PROVIDER=openrouter
-# ECONOMY_LLM_MODEL=anthropic/claude-haiku-4.5
+# ECONOMY_LLM_MODEL=google/gemini-2.5-flash
 # OPENROUTER_API_KEY=
 
 # --- Anthropic ---


### PR DESCRIPTION
# User description
Updates OpenRouter sample settings in the example env configuration to Gemini defaults.

- Set DEFAULT_LLM_MODEL example to google/gemini-3-flash
- Set ECONOMY_LLM_MODEL example to google/gemini-2.5-flash

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the example environment configuration for OpenRouter by replacing Anthropic model placeholders with Google Gemini defaults. Ensures that the <code>.env.example</code> file reflects current recommended model selections for both standard and economy tiers.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>llm-add-nano-routing-f...</td><td>February 24, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add-OpenAI-compatible-...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1714?tool=ast>(Baz)</a>.