### PR TITLE
Admin: show nano-limit status in top spenders

### DIFF
--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import { useAdminTopSpenders } from "@/hooks/useAdminTopSpenders";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -30,11 +31,12 @@ export function AdminTopSpenders() {
   const topSpenders = data?.topSpenders ?? [];
 
   return (
-    <Card className="max-w-3xl">
+    <Card className="max-w-5xl">
       <CardHeader>
         <CardTitle>Top Spenders</CardTitle>
         <CardDescription>
-          Last 7 days (same window as spend limiter)
+          Last 7 days (same window as spend limiter). Nano-Limited shows who is
+          currently forced onto nano via the Redis spend guard.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -44,7 +46,9 @@ export function AdminTopSpenders() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-16">Rank</TableHead>
+                  <TableHead>Email Account ID</TableHead>
                   <TableHead>Email</TableHead>
+                  <TableHead>Nano-Limited</TableHead>
                   <TableHead className="text-right">Cost</TableHead>
                 </TableRow>
               </TableHeader>
@@ -52,8 +56,18 @@ export function AdminTopSpenders() {
                 {topSpenders.map((spender, index) => (
                   <TableRow key={spender.email}>
                     <TableCell>{index + 1}</TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {spender.emailAccountId ?? "-"}
+                    </TableCell>
                     <TableCell className="font-mono text-xs sm:text-sm">
                       {spender.email}
+                    </TableCell>
+                    <TableCell>
+                      {spender.nanoLimitedBySpendGuard ? (
+                        <Badge variant="red">Yes</Badge>
+                      ) : (
+                        <Badge variant="green">No</Badge>
+                      )}
                     </TableCell>
                     <TableCell className="text-right">
                       {currencyFormatter.format(spender.cost)}

--- a/apps/web/app/(app)/admin/page.tsx
+++ b/apps/web/app/(app)/admin/page.tsx
@@ -37,7 +37,6 @@ export default async function AdminPage() {
 
       <div className="space-y-8 mt-4 mb-20">
         <AdminUpgradeUserForm />
-        <AdminTopSpenders />
         <AdminUserControls />
         <AdminUserInfo />
         <AdminHashEmail />
@@ -49,6 +48,8 @@ export default async function AdminPage() {
           <AdminSyncStripe />
           <AdminSyncStripeCustomers />
         </div>
+
+        <AdminTopSpenders />
       </div>
     </PageWrapper>
   );

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { env } from "@/env";
+import prisma from "@/utils/prisma";
 import { withAdmin } from "@/utils/middleware";
 import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
 
@@ -11,5 +13,51 @@ export const GET = withAdmin("admin/top-spenders", async () => {
 
 async function getData() {
   const topSpenders = await getTopWeeklyUsageCosts({ limit: 25 });
-  return { topSpenders };
+  if (!topSpenders.length) return { topSpenders: [] };
+
+  const emails = topSpenders.map((spender) => spender.email);
+  const emailAccounts = await prisma.emailAccount.findMany({
+    where: { email: { in: emails } },
+    select: { id: true, email: true, userId: true },
+  });
+
+  const userIds = [...new Set(emailAccounts.map((account) => account.userId))];
+  const usersWithApiKey = userIds.length
+    ? await prisma.user.findMany({
+        where: {
+          id: { in: userIds },
+          AND: [{ aiApiKey: { not: null } }, { aiApiKey: { not: "" } }],
+        },
+        select: { id: true },
+      })
+    : [];
+
+  const emailAccountByEmail = new Map(
+    emailAccounts.map((account) => [account.email, account]),
+  );
+  const userIdsWithApiKey = new Set(usersWithApiKey.map((user) => user.id));
+
+  const nanoWeeklySpendLimitUsd = env.AI_NANO_WEEKLY_SPEND_LIMIT_USD ?? null;
+  const nanoModelConfigured = !!env.NANO_LLM_PROVIDER && !!env.NANO_LLM_MODEL;
+  const nanoLimiterEnabled =
+    nanoWeeklySpendLimitUsd !== null && nanoModelConfigured;
+
+  return {
+    topSpenders: topSpenders.map((spender) => {
+      const emailAccount = emailAccountByEmail.get(spender.email);
+      const hasUserApiKey = emailAccount
+        ? userIdsWithApiKey.has(emailAccount.userId)
+        : false;
+
+      return {
+        ...spender,
+        emailAccountId: emailAccount?.id ?? null,
+        nanoLimitedBySpendGuard:
+          nanoLimiterEnabled &&
+          nanoWeeklySpendLimitUsd !== null &&
+          !hasUserApiKey &&
+          spender.cost >= nanoWeeklySpendLimitUsd,
+      };
+    }),
+  };
 }


### PR DESCRIPTION
# User description
Improves admin visibility for weekly spend guard behavior.

- moves the Top Spenders card to the bottom of the admin page
- adds each row's email account ID
- adds a Nano-Limited indicator derived from spend guard configuration, weekly Redis spend, and API key usage

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
AdminPage_("AdminPage"):::modified
AdminTopSpenders_("AdminTopSpenders"):::modified
getData_("getData"):::modified
DATABASE_("DATABASE"):::added
ENV_("ENV"):::added
AdminPage_ -- "AdminTopSpenders moved into page; now rendered in layout." --> AdminTopSpenders_
AdminTopSpenders_ -- "Requests top spenders; expects account IDs and nano-limiter flags." --> getData_
getData_ -- "Responds with topSpenders including emailAccountId and nanoLimited flag." --> AdminTopSpenders_
getData_ -- "Fetches emailAccount rows for spender emails to attach IDs." --> DATABASE_
getData_ -- "Fetches users having aiApiKey to identify API-key holders." --> DATABASE_
getData_ -- "Reads env vars to decide nano limiter and weekly limit." --> ENV_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the admin dashboard by calculating and displaying the nano-limit status for top spenders based on weekly spend guard configurations. Updates the admin interface to include email account identifiers and relocates the spenders list for better page flow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1717?tool=ast&topic=Admin+UI+Updates>Admin UI Updates</a>
        </td><td>Updates the <code>AdminTopSpenders</code> component to display the <code>emailAccountId</code> and a <code>Badge</code> indicating nano-limit status, while moving the component to the bottom of the <code>AdminPage</code>.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/admin/AdminTopSpenders.tsx</li>
<li>apps/web/app/(app)/admin/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Admin-add-weekly-top-s...</td><td>February 25, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Move-sso-modal-to-admi...</td><td>September 04, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1717?tool=ast&topic=Spend+Guard+Logic>Spend Guard Logic</a>
        </td><td>Implements logic in the <code>top-spenders</code> API route to determine if a user is restricted by the nano-limit spend guard by checking Redis usage, environment configurations, and user API key status.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/admin/top-spenders/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Admin-add-weekly-top-s...</td><td>February 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1717?tool=ast>(Baz)</a>.