### PR TITLE
api: simplify callback handler wiring

### DIFF
--- a/apps/web/app/api/slack/callback/route.ts
+++ b/apps/web/app/api/slack/callback/route.ts
@@ -1,6 +1,4 @@
 import { withError } from "@/utils/middleware";
 import { handleSlackCallback } from "@/utils/slack/handle-slack-callback";
 
-export const GET = withError("slack/callback", async (request) => {
-  return handleSlackCallback(request, request.logger);
-});
+export const GET = withError("slack/callback", handleSlackCallback);

--- a/apps/web/utils/slack/handle-slack-callback.ts
+++ b/apps/web/utils/slack/handle-slack-callback.ts
@@ -41,9 +41,9 @@ const slackOAuthResponseSchema = z.object({
 type SlackOAuthResponse = z.infer<typeof slackOAuthResponseSchema>;
 
 export async function handleSlackCallback(
-  request: NextRequest,
-  logger: Logger,
+  request: NextRequest & { logger: Logger },
 ): Promise<NextResponse> {
+  const logger = request.logger;
   let redirectHeaders = new Headers();
   let codeForCleanup: string | null = null;
   let callbackLogger = logger;


### PR DESCRIPTION
# User description
Simplifies callback route wiring by passing the handler directly into middleware and reading logger context from the request object.

- remove redundant async route wrapper
- keep callback behavior unchanged while reducing indirection

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplifies the Slack callback API route by removing redundant async wrappers and passing the handler directly to the error-handling middleware. Updates the <code>handleSlackCallback</code> function to extract the logger from the request object, reducing parameter indirection.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>settings-scope-slack-c...</td><td>February 24, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1722?tool=ast>(Baz)</a>.