### PR TITLE
assistant-chat: improve email action display

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -494,7 +494,7 @@ function EmailActionResult({
               Message
             </div>
             <div className="rounded-md bg-muted p-2 text-xs">
-              <ExpandableText text={body} />
+              <div className="break-words whitespace-pre-wrap">{body}</div>
             </div>
           </div>
         )}
@@ -506,70 +506,74 @@ function EmailActionResult({
           </div>
         )}
 
-        {externalUrl && (
-          <ToolExternalLink href={externalUrl}>
-            Open in {provider === "microsoft" ? "Outlook" : "Gmail"}
-          </ToolExternalLink>
-        )}
-
-        {requiresConfirmation && !isConfirmed && (
-          <Button
-            size="sm"
-            className="w-fit"
-            disabled={isConfirming || isProcessing || isChatBusy}
-            onClick={async () => {
-              setIsConfirming(true);
-              try {
-                const result = await confirmAssistantEmailAction(
-                  emailAccountId,
-                  {
-                    chatMessageId,
-                    toolCallId,
-                    actionType,
-                  },
-                );
-
-                if (result?.serverError) {
-                  toastError({ description: result.serverError });
-                  return;
-                }
-
-                const confirmationResult = parseConfirmationResult(
-                  result?.data?.confirmationResult,
-                );
-                if (!confirmationResult) {
-                  toastError({
-                    description: "Could not confirm this email action.",
-                  });
-                  return;
-                }
-
-                setConfirmationResultOverride(confirmationResult);
-                toastSuccess({
-                  description: getAssistantEmailSuccessMessage(actionType),
-                });
-              } catch {
-                toastError({
-                  description: "Could not confirm this email action.",
-                });
-              } finally {
-                setIsConfirming(false);
-              }
-            }}
-          >
-            {isProcessing ? (
-              "Sending..."
-            ) : isConfirming ? (
-              <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
-                Sending...
-              </>
-            ) : isChatBusy ? (
-              "Wait for response..."
-            ) : (
-              "Confirm and send"
+        {(externalUrl || (requiresConfirmation && !isConfirmed)) && (
+          <div className="flex flex-wrap items-center gap-2">
+            {externalUrl && (
+              <ToolExternalLink href={externalUrl}>
+                Open in {provider === "microsoft" ? "Outlook" : "Gmail"}
+              </ToolExternalLink>
             )}
-          </Button>
+
+            {requiresConfirmation && !isConfirmed && (
+              <Button
+                size="sm"
+                className="w-fit"
+                disabled={isConfirming || isProcessing || isChatBusy}
+                onClick={async () => {
+                  setIsConfirming(true);
+                  try {
+                    const result = await confirmAssistantEmailAction(
+                      emailAccountId,
+                      {
+                        chatMessageId,
+                        toolCallId,
+                        actionType,
+                      },
+                    );
+
+                    if (result?.serverError) {
+                      toastError({ description: result.serverError });
+                      return;
+                    }
+
+                    const confirmationResult = parseConfirmationResult(
+                      result?.data?.confirmationResult,
+                    );
+                    if (!confirmationResult) {
+                      toastError({
+                        description: "Could not confirm this email action.",
+                      });
+                      return;
+                    }
+
+                    setConfirmationResultOverride(confirmationResult);
+                    toastSuccess({
+                      description: getAssistantEmailSuccessMessage(actionType),
+                    });
+                  } catch {
+                    toastError({
+                      description: "Could not confirm this email action.",
+                    });
+                  } finally {
+                    setIsConfirming(false);
+                  }
+                }}
+              >
+                {isProcessing ? (
+                  "Sending..."
+                ) : isConfirming ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Sending...
+                  </>
+                ) : isChatBusy ? (
+                  "Wait for response..."
+                ) : (
+                  "Confirm and send"
+                )}
+              </Button>
+            )}
+          </div>
         )}
       </div>
     </CollapsibleToolCard>


### PR DESCRIPTION
# User description
Improves assistant email action cards for clearer review and confirmation workflows.

- Add consistent spacing between external-link and confirm actions.
- Show full generated message text for send/reply/forward actions instead of truncating with expansion controls.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the email action card UI within the assistant chat by ensuring full visibility of generated message content and improving the layout of action buttons. Updates <code>EmailActionResult</code> to provide a clearer review experience and consistent spacing for confirmation workflows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1723?tool=ast&topic=Email+Content+UI>Email Content UI</a>
        </td><td>Displays the full email body using <code>break-words</code> and <code>whitespace-pre-wrap</code> instead of the <code>ExpandableText</code> component to facilitate easier review of generated content.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-chat-message-persi...</td><td>February 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1723?tool=ast&topic=Action+Layout>Action Layout</a>
        </td><td>Wraps action buttons in a flex container with a gap to ensure consistent spacing between external links and confirmation buttons.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-chat-message-persi...</td><td>February 24, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1723?tool=ast>(Baz)</a>.