### PR TITLE
follow-up: remove provider label after thread activity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Reusable components shared across pages go in `apps/web/components/`
 - One resource per API route file
 - Env vars: add to `.env.example`, `env.ts`, and `turbo.json`. Prefix client-side with `NEXT_PUBLIC_`.
+- Prisma retries: default to no retry logic. Use `withPrismaRetry` only for clearly idempotent operations where transient DB failures are expected, and keep the reason explicit in code.
 
 ## Change Philosophy
 - Prefer the simplest, most readable change; only keep backwards compatibility when explicitly requested.

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -278,6 +278,7 @@ describe("clearFollowUpLabel", () => {
     });
 
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+    prisma.threadTracker.findFirst.mockResolvedValue({ id: "tracker-1" });
 
     await clearFollowUpLabel({
       emailAccountId: "account-1",
@@ -297,7 +298,14 @@ describe("clearFollowUpLabel", () => {
         followUpAppliedAt: null,
       },
     });
-    expect(prisma.threadTracker.findFirst).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        followUpAppliedAt: { not: null },
+      },
+      select: { id: true },
+    });
     expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
       "thread-1",
       "label-123",
@@ -325,7 +333,6 @@ describe("clearFollowUpLabel", () => {
         emailAccountId: "account-1",
         threadId: "thread-1",
         followUpAppliedAt: { not: null },
-        resolved: false,
       },
       select: { id: true },
     });
@@ -357,6 +364,7 @@ describe("clearFollowUpLabel", () => {
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+    prisma.threadTracker.findFirst.mockResolvedValue({ id: "tracker-1" });
 
     await clearFollowUpLabel({
       emailAccountId: "account-1",
@@ -384,6 +392,7 @@ describe("clearFollowUpLabel", () => {
         .fn()
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
+    prisma.threadTracker.findFirst.mockResolvedValue({ id: "tracker-1" });
     prisma.threadTracker.updateMany.mockRejectedValue(new Error("db failed"));
 
     await expect(


### PR DESCRIPTION
# User description
Ensure follow-up labels are removed from the email provider when a thread no longer needs follow-up, even if no tracker rows are updated. This keeps provider label state in sync during outbound and inbound activity.

- Always attempt provider label removal in clearFollowUpLabel while keeping DB tracker updates scoped to unresolved trackers.
- Add and update unit tests for the zero-updated-tracker path and unresolved tracker filter behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensures email provider follow-up labels are removed even when no database tracker rows are updated, maintaining synchronization between the provider and the application state. Refactors <code>clearFollowUpLabel</code> to verify the existence of a <code>threadTracker</code> before proceeding with label removal and database updates.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1724?tool=ast&topic=Tests+%26+Docs>Tests & Docs</a>
        </td><td>Update unit tests to cover scenarios with zero updated trackers and add guidance on Prisma retry usage in documentation.<details><summary>Modified files (2)</summary><ul><li>AGENTS.md</li>
<li>apps/web/utils/follow-up/labels.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>gmail-Add-serverless-s...</td><td>February 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1724?tool=ast&topic=Follow-up+Logic>Follow-up Logic</a>
        </td><td>Refactor <code>clearFollowUpLabel</code> to decouple provider label removal from the database update count and improve error handling.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/follow-up/labels.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>follow-up-reduce-polli...</td><td>February 25, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow-up-reminders</td><td>January 08, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1724?tool=ast>(Baz)</a>.