### PR TITLE
fix: guard provider fallback in email URL utils

### DIFF
--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -58,14 +58,18 @@ describe("getEmailUrl", () => {
       );
     });
 
-    it("throws for unknown provider (bug: should fall back to default)", () => {
-      // NOTE: This documents a potential bug - unknown providers cause an error
-      // instead of falling back to the "default" config.
-      // The getProviderConfig function only falls back when provider is undefined,
-      // not when the provider key doesn't exist in PROVIDER_CONFIG.
-      expect(() =>
-        getEmailUrl("msg123", "user@gmail.com", "unknown"),
-      ).toThrow();
+    it("falls back to default for unknown provider", () => {
+      const result = getEmailUrl("msg123", "user@gmail.com", "unknown");
+      expect(result).toBe(
+        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+      );
+    });
+
+    it("falls back to default for empty provider", () => {
+      const result = getEmailUrl("msg123", "user@gmail.com", "");
+      expect(result).toBe(
+        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+      );
     });
   });
 });

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -53,7 +53,8 @@ const PROVIDER_CONFIG: Record<
 function getProviderConfig(
   provider?: string,
 ): (typeof PROVIDER_CONFIG)[keyof typeof PROVIDER_CONFIG] {
-  return PROVIDER_CONFIG[provider ?? "default"];
+  if (!provider) return PROVIDER_CONFIG.default;
+  return PROVIDER_CONFIG[provider] ?? PROVIDER_CONFIG.default;
 }
 
 export function getEmailUrl(


### PR DESCRIPTION
# User description
Harden email URL construction when provider data is missing or unrecognized.

- Fall back to the default URL config when provider is empty or unknown.
- Update URL utility tests to cover unknown and empty provider inputs.
- Prevent runtime errors caused by missing provider state during page refresh.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements a fallback mechanism in the email URL utility to ensure a default configuration is used when provider data is missing or unrecognized. Enhances the <code>getProviderConfig</code> function to prevent runtime errors during page refreshes or when encountering unknown provider states.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-bulk-archive-p...</td><td>February 18, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Bugfixes.-Update-readm...</td><td>August 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1725?tool=ast>(Baz)</a>.