### PR TITLE
docs: remove broken Vercel integration params

### DIFF
--- a/docs/hosting/vercel.mdx
+++ b/docs/hosting/vercel.mdx
@@ -10,7 +10,7 @@ To use other databases, see [Environment Variables](/hosting/environment-variabl
 
 Click here to deploy on Vercel:
 
-[![Deploy on Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Felie222%2Finbox-zero&root-directory=apps%2Fweb&env=AUTH_SECRET%2CINTERNAL_API_KEY%2CEMAIL_ENCRYPT_SECRET%2CEMAIL_ENCRYPT_SALT%2CDEFAULT_LLM_PROVIDER%2CLLM_API_KEY&integration-ids=icfg_7PxtVfUypEklb2DtJhjRRMEY%2Cicfg_grUsNAwBAqMdv3Hx2DeIdDL5)
+[![Deploy on Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Felie222%2Finbox-zero&root-directory=apps%2Fweb&env=AUTH_SECRET%2CINTERNAL_API_KEY%2CEMAIL_ENCRYPT_SECRET%2CEMAIL_ENCRYPT_SALT%2CDEFAULT_LLM_PROVIDER%2CLLM_API_KEY)
 
 Set the following environment variables:
 


### PR DESCRIPTION
# User description
Removes broken integration parameters from the Deploy on Vercel button in hosting docs.

- updates the deploy button URL in docs/hosting/vercel.mdx
- keeps the environment variable setup flow unchanged

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the Vercel deployment documentation by removing broken integration identifiers from the deployment button URL. Ensures the one-click deployment flow remains functional while preserving the necessary environment variable configuration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>docs-add-Vercel-deploy...</td><td>February 25, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1727?tool=ast>(Baz)</a>.