### PR TITLE
Fix direct string error parsing

### DIFF
--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -36,6 +36,18 @@ describe("getUserFacingErrorMessage", () => {
     expect(result).toBe("Invalid arguments passed to the model.");
   });
 
+  it("reads direct string error from structured payloads", () => {
+    const result = getUserFacingErrorMessage(
+      new Error(
+        JSON.stringify({
+          error: "Too many requests",
+        }),
+      ),
+    );
+
+    expect(result).toBe("Too many requests");
+  });
+
   it("reads nested message from structured error payloads", () => {
     const result = getUserFacingErrorMessage(
       new Error(

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -368,7 +368,7 @@ export function getUserFacingErrorMessage(
   const parsed = parseJsonRecord(message);
   if (!parsed) return message;
 
-  return getErrorMessage(parsed) || message;
+  return getErrorMessage(parsed) || getStringProp(parsed, "error") || message;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {


### PR DESCRIPTION
# User description
This PR fixes user-facing error extraction for JSON payloads that include a direct string `error` field. It prevents those payloads from appearing as raw JSON in toasts and preserves existing behavior for nested and plain error messages. It also adds a focused unit test for the direct string case.

Testing: pnpm test --run utils/error.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the <code>getUserFacingErrorMessage</code> utility to correctly extract error messages from JSON payloads containing a direct string <code>error</code> field. Ensures that users see clean error messages instead of raw JSON strings in the UI.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-assistant-chat-toa...</td><td>February 26, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1738?tool=ast>(Baz)</a>.