### PR TITLE
llms: enable structured output mode for compatible provider

### DIFF
--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -6,6 +6,7 @@ import type { UserAIFields } from "./types";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createVertex } from "@ai-sdk/google-vertex";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
 // Mock AI provider imports
 vi.mock("@ai-sdk/openai", () => ({
@@ -841,6 +842,13 @@ describe("Models", () => {
       expect(result.provider).toBe(Provider.OPENAI_COMPATIBLE);
       expect(result.modelName).toBe("llama-3.2-3b-instruct");
       expect(result.model).toBeDefined();
+      expect(createOpenAICompatible).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "openai-compatible",
+          baseURL: "http://localhost:1234/v1",
+          supportsStructuredOutputs: true,
+        }),
+      );
     });
 
     it("should configure OpenAI-compatible provider without an API key", () => {

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -236,6 +236,7 @@ function selectModel(
       const openaiCompatible = createOpenAICompatible({
         name: "openai-compatible",
         baseURL,
+        supportsStructuredOutputs: true,
         ...(openAiCompatibleApiKey ? { apiKey: openAiCompatibleApiKey } : {}),
       });
       return {


### PR DESCRIPTION
# User description
Enable structured output mode for OpenAI-compatible model configuration so object generation uses schema-based response formatting.

- set OpenAI-compatible provider to support structured outputs
- add a regression assertion covering provider initialization options
- verify with targeted model test suite

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enables structured output mode for OpenAI-compatible model configurations to ensure object generation utilizes schema-based response formatting. Updates the <code>selectModel</code> utility to initialize the provider with the <code>supportsStructuredOutputs</code> flag and includes a corresponding assertion in the test suite.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-chat-fix-Gro...</td><td>February 27, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add-OpenAI-compatible-...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1749?tool=ast>(Baz)</a>.