### PR TITLE
Clarify Slack channel purpose in UI

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
@@ -238,7 +238,8 @@ function ChannelRow({
             </div>
             {!isLoadingTargets && (
               <MutedText className="text-xs">
-                Create a private Slack channel, then type{" "}
+                Pick a channel to receive meeting briefs. Create a private Slack
+                channel, then type{" "}
                 <code className="bg-muted px-1 rounded">
                   /invite @InboxZero
                 </code>{" "}

--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -298,13 +298,19 @@ function ConnectedChannelRow({
           {channel.provider === "SLACK" && (
             <div className="space-y-1">
               {selectionState.showCurrentChannel ? (
-                <button
-                  type="button"
-                  className="text-xs text-muted-foreground underline underline-offset-4"
-                  onClick={() => setSelectingTarget(true)}
-                >
-                  #{channel.channelName || channel.channelId}
-                </button>
+                <div className="space-y-0.5">
+                  <button
+                    type="button"
+                    className="text-xs text-muted-foreground underline underline-offset-4"
+                    onClick={() => setSelectingTarget(true)}
+                  >
+                    #{channel.channelName || channel.channelId}
+                  </button>
+                  <p className="text-xs text-muted-foreground">
+                    Inbox Zero sends notifications here (meeting briefs, filed
+                    documents) and responds to @mentions in this channel.
+                  </p>
+                </div>
               ) : (
                 <Select
                   onValueChange={(value) => {
@@ -352,11 +358,12 @@ function ConnectedChannelRow({
 
               {selectionState.showInviteHint && (
                 <div className="text-xs text-muted-foreground">
-                  Invite the bot with{" "}
+                  Pick a private channel for notifications and @mentions. Invite
+                  the bot with{" "}
                   <code className="rounded bg-muted px-1">
                     /invite @InboxZero
                   </code>{" "}
-                  in a private channel.
+                  first.
                 </div>
               )}
 


### PR DESCRIPTION
# User description
Add explanatory text to help users understand that the selected Slack channel is for receiving notifications (meeting briefs, filed documents) and responding to @mentions. Updated both the Connected Apps settings and Delivery Channels sections to make the channel's purpose immediately clear.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the user interface by adding descriptive text to clarify the purpose of Slack channel integrations for notifications and @mentions. Updates the <code>DeliveryChannelsSetting</code> and <code>ConnectedAppsSection</code> components to provide better guidance on bot invitation and channel usage.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>settings-scope-slack-c...</td><td>February 24, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1750?tool=ast>(Baz)</a>.