### PR TITLE
fix(drive): remove invalid isDisabled prop causing build failure

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -786,7 +786,6 @@ function SetupFolderSelection({
                       isLast={index === rootFolders.length - 1}
                       selectedFolderIds={optimisticFolderIds}
                       onToggle={handleFolderToggle}
-                      isDisabled={false}
                       level={0}
                       parentPath=""
                       knownChildren={folderChildrenMap.get(folder.id)}


### PR DESCRIPTION
# User description
## Summary
- Removes the `isDisabled={false}` prop passed to `FolderNode` in `DriveSetup.tsx`, which doesn't accept that prop — introduced in #1755
- This was causing a TypeScript build error

## Test plan
- [x] Verified `pnpm --filter inbox-zero-ai exec next build` passes TypeScript (only pre-existing `sanity.config.ts` error remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Removes an invalid <code>isDisabled</code> prop from the <code>FolderNode</code> component within the <code>DriveSetup</code> view to resolve a TypeScript build error. Ensures the component correctly adheres to its defined prop interface while maintaining existing folder selection functionality.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>fix-drive-preserve-One...</td><td>March 01, 2026</td></tr>
<tr><td>elie222</td><td>Add-feedback-support-f...</td><td>January 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1756?tool=ast>(Baz)</a>.