### PR TITLE
refactor: reorganize assistant settings with new updates section

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
@@ -19,6 +19,10 @@ export function SettingsTab() {
       <div className="space-y-2">
         <DraftReplies />
         <DraftConfidenceSetting />
+      </div>
+
+      <div className="space-y-2">
+        <SectionHeader>Updates</SectionHeader>
         <FollowUpRemindersSetting />
         <ProactiveUpdatesSetting />
         {env.NEXT_PUBLIC_DIGEST_ENABLED && <DigestSetting />}


### PR DESCRIPTION
# User description
Reorganized the settings tab to group update-related settings under a new 'Updates' section.

## Changes
- Created new 'Updates' section grouping:
  - Follow-up reminders
  - Scheduled check-ins  
  - Digest
- Moved these settings from the initial unnamed section for better organization

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reorganizes the assistant settings interface by grouping update-related configurations into a dedicated section. Enhances the layout of the <code>SettingsTab</code> component to improve the categorization of follow-up, proactive, and digest settings.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>refactor-reorganize-as...</td><td>March 01, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow-up-reminders</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1757?tool=ast>(Baz)</a>.