### PR TITLE
web: skip preview builds for docs-only changes

### DIFF
--- a/apps/web/scripts/vercel-ignore-build.sh
+++ b/apps/web/scripts/vercel-ignore-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${VERCEL_ENV:-}" != "preview" ]]; then
+  echo "Non-preview environment; continue build."
+  exit 1
+fi
+
+current_sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+previous_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+if [[ -z "${previous_sha}" ]]; then
+  if git rev-parse --verify "${current_sha}^" >/dev/null 2>&1; then
+    previous_sha="${current_sha}^"
+  else
+    echo "No previous commit found; continue build."
+    exit 1
+  fi
+fi
+
+if ! git rev-parse --verify "${previous_sha}" >/dev/null 2>&1; then
+  echo "Previous commit ${previous_sha} is unavailable; continue build."
+  exit 1
+fi
+
+changed_files="$(git diff --name-only "${previous_sha}" "${current_sha}")"
+
+if [[ -z "${changed_files}" ]]; then
+  echo "No changed files detected; skip build."
+  exit 0
+fi
+
+non_docs_changes="$(printf '%s\n' "${changed_files}" | grep -Ev '(^docs/|\.md$|\.mdx$)' || true)"
+
+if [[ -n "${non_docs_changes}" ]]; then
+  echo "Non-doc changes detected; continue build."
+  printf '%s\n' "${non_docs_changes}"
+  exit 1
+fi
+
+echo "Only docs/markdown files changed; skip preview build."
+exit 0

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "buildCommand": "cd ../.. && if [ \"$VERCEL_ENV\" = preview ] && [ \"$IS_OAUTH_PROXY_SERVER\" != true ]; then NEXT_PUBLIC_BASE_URL=https://$VERCEL_URL turbo run build --force --filter={apps/web}...; else turbo run build --filter={apps/web}...; fi",
   "installCommand": "cd ../.. && corepack enable && bash clone-marketing.sh && pnpm install --no-frozen-lockfile",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "rewrites": [
     {
       "source": "/tools",


### PR DESCRIPTION
# User description
Adds a Vercel ignore command to prevent preview builds when a change set only touches documentation files.

- Adds a build-ignore script under apps/web/scripts to inspect changed files between commits
- Skips preview builds for docs-only changes (docs/**, *.md, *.mdx)
- Continues normal builds when non-doc files are changed and wires the command in vercel.json

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements a build-ignore mechanism for the web application to optimize CI resources by skipping Vercel preview builds for documentation-only changes. Integrates a custom shell script into the Vercel configuration to evaluate file diffs between commits.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-schedule-automat...</td><td>February 25, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1758?tool=ast>(Baz)</a>.