### PR TITLE
assistant-settings: Clarify check-in instruction copy

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
@@ -291,12 +291,12 @@ export function ProactiveUpdatesSetting() {
                               setShowCustomPrompt((value) => !value)
                             }
                           >
-                            + Customize what's included
+                            + Add check-in instructions (optional)
                           </button>
                           {showCustomPrompt && (
                             <Textarea
                               id="scheduled-checkins-prompt"
-                              placeholder="Add custom instructions for what should be included."
+                              placeholder="Example: Only include emails that need a reply today or have a deadline in the next 2 days. Skip newsletters, receipts, and FYI updates."
                               value={prompt}
                               onChange={(event) =>
                                 setPrompt(event.target.value)


### PR DESCRIPTION
# User description
Clarifies the optional scheduled check-in instruction field so users know what to enter.

- Renames the toggle label to emphasize optional guidance
- Replaces placeholder text with a concrete include/exclude example

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the proactive updates configuration interface to clarify the purpose of the optional check-in instructions field. Modifies the <code>ProactiveUpdatesSetting</code> component to use more descriptive labels and provides a concrete example of instruction content to guide user input.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-add-draft-co...</td><td>February 28, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1760?tool=ast>(Baz)</a>.