### PR TITLE
chore: run watch and digest crons hourly

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -30,7 +30,11 @@
     },
     {
       "path": "/api/watch/all",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/resend/digest/all",
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/meeting-briefs",


### PR DESCRIPTION
Updates Vercel cron schedules so key background email jobs run every hour.

- Change /api/watch/all from every 6 hours to hourly.
- Add a new hourly cron for /api/resend/digest/all.
- Leave all other cron schedules unchanged.