### PR TITLE
docs: remove redundant migration steps from setup guides

### DIFF
--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -104,7 +104,7 @@ For external services, set the appropriate environment variables in `apps/web/.e
 
 ### 5. Check Logs
 
-Wait for the containers to start, then run the database migrations:
+Wait for the containers to start:
 
 ```bash
 # Check that containers are running (STATUS should show "Up")

--- a/docs/slack/setup.mdx
+++ b/docs/slack/setup.mdx
@@ -106,21 +106,7 @@ WEBHOOK_URL=https://your-domain.ngrok-free.app
 
 This is used for the OAuth callback and events webhook URLs. `NEXT_PUBLIC_BASE_URL` stays as `http://localhost:3000` so other auth flows aren't affected.
 
-## 3. Run the Database Migration
-
-The `MessagingChannel` model and `meetingBriefsSendEmail` column are created by the migration at:
-
-```
-apps/web/prisma/migrations/20260208000000_add_messaging_channels/
-```
-
-Apply with:
-
-```bash
-pnpm prisma migrate deploy
-```
-
-## 4. Connect from the UI
+## 3. Connect from the UI
 
 1. Navigate to **Settings** > **Email Account** tab
 2. Click **Connect Slack** under Connected Apps


### PR DESCRIPTION
# User description
## Summary

- Removed manual migration step from Slack setup guide (migrations run automatically)
- Fixed misleading comment in self-hosting guide that said "then run the database migrations" before log-checking commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the setup documentation by removing redundant manual database migration steps that are now handled automatically. Refines the self-hosting and Slack integration guides to ensure a more accurate and streamlined onboarding process.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1765?tool=ast&topic=Self-Hosting+Docs>Self-Hosting Docs</a>
        </td><td>Corrects a misleading instruction in the log-checking section by removing the reference to manual database migrations.<details><summary>Modified files (1)</summary><ul><li>docs/hosting/self-hosting.mdx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>docs-add-Vercel-deploy...</td><td>February 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1765?tool=ast&topic=Slack+Setup+Docs>Slack Setup Docs</a>
        </td><td>Removes the manual migration section and renumbers the subsequent steps to reflect that migrations are now automated.<details><summary>Modified files (1)</summary><ul><li>docs/slack/setup.mdx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Messaging-migrate-to-C...</td><td>March 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1765?tool=ast>(Baz)</a>.