### PR TITLE
Reduce redundant sender pattern analysis calls

### DIFF
--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -540,17 +540,18 @@ async function isSenderPatternAlreadyAnalyzed({
   const existingCheck = await prisma.newsletter.findFirst({
     where: {
       emailAccountId,
+      patternAnalyzed: true,
       email: {
         equals: from,
         mode: "insensitive",
       },
     },
     select: {
-      patternAnalyzed: true,
+      id: true,
     },
   });
 
-  return !!existingCheck?.patternAnalyzed;
+  return !!existingCheck;
 }
 
 /**


### PR DESCRIPTION
# User description
This PR reduces redundant internal sender-pattern analysis calls during rule execution.

It deduplicates analyze scheduling per sender within a single run and adds a pre-check to skip API calls when a sender is already marked as analyzed.

This keeps existing behavior for senders that still need future rechecks while lowering unnecessary background requests.

Validation: pnpm --filter inbox-zero-ai test utils/ai/choose-rule/run-rules.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Optimizes the rule execution process by deduplicating sender pattern analysis requests and introducing a pre-check to skip already analyzed senders. Enhances the <code>runRules</code> function and its helper <code>analyzeSenderPatternIfAiMatch</code> to manage a queue of pending analyses and verify existing analysis status via the database.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-add-draft-co...</td><td>February 28, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1768?tool=ast>(Baz)</a>.