### PR TITLE
analytics: Add AI span name to tracing

### DIFF
--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -292,6 +292,7 @@ describe("createGenerateText fallback chain", () => {
     const tracingOptions = mockWithTracing.mock.calls[0][2];
     expect(tracingOptions.posthogProperties).toEqual({
       label: "PostHog tracing",
+      $ai_span_name: "PostHog tracing",
       provider: "openai",
       model: "gpt-5-mini",
       emailAccountId: "email-account-1",

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -1080,6 +1080,7 @@ function withPosthogTracing({
     posthogPrivacyMode: true,
     posthogProperties: {
       label,
+      $ai_span_name: label,
       provider,
       model: modelName,
       emailAccountId,


### PR DESCRIPTION
# User description
Adds span-name metadata to AI tracing events so trace views show readable operation names.

- include `` in AI tracing properties
- update unit test expectations for tracing properties

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>$ai_span_name</code> metadata to <code>withPosthogTracing</code> so PostHog traces display readable AI operation names, and keep the fallback tracing test in sync with the new property.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-direct-PostHog-LLM...</td><td>March 03, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1780?tool=ast>(Baz)</a>.