### PR TITLE
onboarding: hide persona custom category suggestions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingCategories.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingCategories.tsx
@@ -73,7 +73,7 @@ export function CategoriesSetup({
     })),
   );
 
-  const suggestedLabels = usersRolesInfo[data?.role || ""]?.suggestedLabels;
+  const suggestedLabels = usersRolesInfo.Other.suggestedLabels;
 
   // Initialize categories when persona data loads
   useEffect(() => {


### PR DESCRIPTION
# User description
This updates onboarding category setup to avoid persona-specific custom suggestions.

- Use the shared default suggestion set instead of role-based suggestions.
- Keep existing onboarding flow and category actions unchanged.
- Limit the change to a single line in onboarding category selection logic.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Use OnboardingCategories to apply the shared default suggestion set and prevent role-based custom suggestions during onboarding. Keep the category setup logic unchanged while always sourcing from <code>usersRolesInfo.Other</code> so persona data still initializes categories normally.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Improve-onboarding-rul...</td><td>February 11, 2026</td></tr>
<tr><td>elie222</td><td>Adjust-onboarding-layo...</td><td>February 07, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1781?tool=ast>(Baz)</a>.