### PR TITLE
messaging: handle unsupported chat attachments

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -4,6 +4,7 @@ import {
   buildPendingEmailCardFallbackText,
   buildPendingEmailSummary,
   ensureSlackTeamInstallation,
+  hasUnsupportedMessagingAttachment,
   normalizeMessagingAssistantText,
   stripLeadingSlackMention,
 } from "@/utils/messaging/chat-sdk/bot";
@@ -119,5 +120,56 @@ describe("buildPendingEmailCardFallbackText", () => {
     const input =
       "This draft is pending confirmation.\n\nI couldn't show the Send button right now. Ask me to prepare the draft again.";
     expect(buildPendingEmailCardFallbackText(input)).toBe(input);
+  });
+});
+
+describe("hasUnsupportedMessagingAttachment", () => {
+  it("returns true when Slack raw payload includes files", () => {
+    expect(
+      hasUnsupportedMessagingAttachment({
+        provider: "slack",
+        message: {
+          attachments: [],
+          raw: {
+            type: "message",
+            files: [{ id: "F123" }],
+          },
+        } as any,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when Telegram raw payload includes a document", () => {
+    expect(
+      hasUnsupportedMessagingAttachment({
+        provider: "telegram",
+        message: {
+          attachments: [],
+          raw: {
+            message_id: 1,
+            date: 1,
+            chat: { id: 1, type: "private", first_name: "Test" },
+            document: { file_id: "doc-1" },
+          },
+        } as any,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when no attachment metadata is present", () => {
+    expect(
+      hasUnsupportedMessagingAttachment({
+        provider: "telegram",
+        message: {
+          attachments: [],
+          raw: {
+            message_id: 1,
+            date: 1,
+            chat: { id: 1, type: "private", first_name: "Test" },
+            text: "hello",
+          },
+        } as any,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -57,6 +57,8 @@ const CONNECT_COMMAND_REGEX =
 const PENDING_EMAIL_CONFIRM_ACTION_ID = "acpe";
 const LEGACY_PENDING_EMAIL_CONFIRM_ACTION_ID =
   "assistant_confirm_pending_email";
+const UNSUPPORTED_MESSAGING_ATTACHMENT_MESSAGE =
+  "I can't access attachments sent in Slack or Telegram yet, so I can't send or forward files from here. I can still draft the email text if you share what to write.";
 
 const SLACK_ASSISTANT_SUGGESTED_PROMPTS = [
   { title: "Inbox summary", message: "Summarize what needs attention today." },
@@ -98,12 +100,14 @@ type LinkedProviderCandidate = {
 type ResolvedMessagingContext = {
   chatId: string;
   emailAccountId: string;
+  hasUnsupportedAttachments: boolean;
   messageText: string;
   provider: SupportedPlatform;
   threadLogContext: Record<string, unknown>;
 };
 
 type LinkedProviderIdentity = {
+  hasUnsupportedAttachments: boolean;
   messageText: string;
   providerUserId: string;
   teamId: string;
@@ -500,6 +504,24 @@ async function processMessagingAssistantMessage({
     });
 
     if (!context) return false;
+
+    if (context.hasUnsupportedAttachments) {
+      try {
+        await thread.post(
+          getMessagingAssistantPostPayload({
+            provider: context.provider,
+            text: UNSUPPORTED_MESSAGING_ATTACHMENT_MESSAGE,
+          }),
+        );
+      } catch (error) {
+        logger.warn("Failed to post unsupported attachment guidance", {
+          provider: context.provider,
+          error,
+        });
+      }
+
+      return true;
+    }
 
     const emailAccountUser = await getEmailAccountWithAi({
       emailAccountId: context.emailAccountId,
@@ -1516,11 +1538,16 @@ async function resolveSlackMessagingContext({
     messageText = stripLeadingSlackMention(messageText);
   }
 
-  if (!messageText) return null;
+  const hasUnsupportedAttachments = hasUnsupportedMessagingAttachment({
+    provider: "slack",
+    message,
+  });
+  if (!messageText && !hasUnsupportedAttachments) return null;
 
   return {
     provider: "slack",
     emailAccountId: messagingChannel.emailAccountId,
+    hasUnsupportedAttachments,
     messageText,
     chatId: getSlackChatId({ channel, threadTs: threadTs || undefined }),
     threadLogContext: { teamId, channel },
@@ -1539,6 +1566,7 @@ async function resolveLinkedProviderMessagingContext({
   logger: Logger;
 }): Promise<ResolvedMessagingContext | null> {
   if (!identity) return null;
+  if (!identity.messageText && !identity.hasUnsupportedAttachments) return null;
 
   if (!thread.isDM) {
     await sendDmRequiredMessage({ provider, thread, logger });
@@ -1590,6 +1618,7 @@ async function resolveLinkedProviderMessagingContext({
   return {
     provider,
     emailAccountId: linkedChannel.emailAccountId,
+    hasUnsupportedAttachments: identity.hasUnsupportedAttachments,
     messageText: identity.messageText,
     chatId,
     threadLogContext: {
@@ -1623,6 +1652,7 @@ function resolveTeamsIdentity({
   if (!teamId) return null;
 
   return {
+    hasUnsupportedAttachments: false,
     messageText,
     providerUserId,
     teamId,
@@ -1635,8 +1665,7 @@ function resolveTelegramIdentity({
 }: {
   message: Message;
 }): LinkedProviderIdentity | null {
-  const messageText = message.text.trim();
-  if (!messageText) return null;
+  const messageText = getTelegramMessageText(message);
 
   const providerUserId = message.author.userId.trim();
   if (!providerUserId) return null;
@@ -1646,11 +1675,48 @@ function resolveTelegramIdentity({
   const teamId = String(rawMessage.chat.id);
 
   return {
+    hasUnsupportedAttachments: hasUnsupportedMessagingAttachment({
+      provider: "telegram",
+      message,
+    }),
     messageText,
     providerUserId,
     teamId,
     teamName: getTelegramChatName(rawMessage),
   };
+}
+
+function getTelegramMessageText(message: Message): string {
+  const plainText = message.text.trim();
+  if (plainText) return plainText;
+
+  const rawMessage = message.raw as TelegramRawMessage;
+  return rawMessage.caption?.trim() || "";
+}
+
+export function hasUnsupportedMessagingAttachment({
+  provider,
+  message,
+}: {
+  provider: "slack" | "telegram";
+  message: Pick<Message, "attachments" | "raw">;
+}): boolean {
+  if (message.attachments.length > 0) return true;
+
+  if (provider === "slack") {
+    const rawEvent = message.raw as SlackEvent;
+    return Boolean(rawEvent.files?.length);
+  }
+
+  const rawMessage = message.raw as TelegramRawMessage;
+  return Boolean(
+    rawMessage.photo?.length ||
+      rawMessage.document ||
+      rawMessage.video ||
+      rawMessage.audio ||
+      rawMessage.voice ||
+      rawMessage.sticker,
+  );
 }
 
 function getTelegramChatName(rawMessage: TelegramRawMessage): string | null {


### PR DESCRIPTION
# User description
Adds explicit handling for unsupported file attachments in messaging chat flows.

- Detects Slack and Telegram attachment payloads before AI processing.
- Returns a clear assistant response that file attachments cannot be sent or forwarded from messaging.
- Handles attachment-only Telegram messages by reading caption text when present.
- Adds focused unit tests for attachment detection behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Detect unsupported Slack and Telegram attachments prior to AI processing and reply through <code>processMessagingAssistantMessage</code> with guidance while tracking the new <code>hasUnsupportedAttachments</code> context flag. Read Telegram captions when an attachment-only message arrives and reuse <code>hasUnsupportedMessagingAttachment</code> to gate both messaging context resolution and linked provider identity handling.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1782?tool=ast&topic=Attachment+tests>Attachment tests</a>
        </td><td>Validate the attachment detection helper against Slack and Telegram payloads to ensure the guidance flows trigger only when appropriate.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/chat-sdk/bot.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-messaging-pend...</td><td>March 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1782?tool=ast&topic=Attachment+handling>Attachment handling</a>
        </td><td>Handle unsupported attachments by flagging contexts, replying with the new guidance message, and stopping downstream AI processing when needed.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-messaging-pend...</td><td>March 03, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1782?tool=ast>(Baz)</a>.