### PR TITLE
messaging: fix Telegram chat routing to wrong email account

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -1493,18 +1493,11 @@ async function handleSwitchCommand({
     include: {
       emailAccount: { select: { email: true } },
     },
-    orderBy: { updatedAt: "desc" },
+    orderBy: { createdAt: "asc" },
   });
 
   if (channels.length === 0) {
     await sendLinkRequiredMessage({ provider, thread, logger });
-    return true;
-  }
-
-  if (channels.length === 1) {
-    await thread.post(
-      `Only one account connected: ${channels[0].emailAccount.email}`,
-    );
     return true;
   }
 
@@ -1515,6 +1508,19 @@ async function handleSwitchCommand({
     where: { id: chatId },
     select: { emailAccountId: true },
   });
+
+  if (channels.length === 1) {
+    const only = channels[0];
+    if (only.emailAccountId !== existingChat?.emailAccountId) {
+      await prisma.chat.upsert({
+        where: { id: chatId },
+        update: { emailAccountId: only.emailAccountId },
+        create: { id: chatId, emailAccountId: only.emailAccountId },
+      });
+    }
+    await thread.post(`Only one account connected: ${only.emailAccount.email}`);
+    return true;
+  }
 
   const arg = match[1];
 
@@ -1534,7 +1540,7 @@ async function handleSwitchCommand({
   }
 
   const index = Number.parseInt(arg, 10) - 1;
-  if (index < 0 || index >= channels.length) {
+  if (Number.isNaN(index) || index < 0 || index >= channels.length) {
     await thread.post("Invalid number. Use /switch to see your options.");
     return true;
   }


### PR DESCRIPTION
# User description
## Summary

- Fix Telegram/Teams chat history being permanently stuck on the wrong email account when a user connects multiple accounts to the same bot DM
- Add deterministic ordering (`orderBy: updatedAt desc`) to candidate queries so the most recently connected account wins by default
- Add `/switch` command for Telegram/Teams that lets users explicitly choose which connected email account is active

## How it works

The existing `selectCandidateFromExistingChat` uses the `Chat` row as a tiebreaker when multiple `MessagingChannel` candidates match. Previously, the `Chat` row was set on first message and never updated, so re-connecting to a new account had no effect.

`/switch` upserts the `Chat` row's `emailAccountId` to the selected account, which the existing tiebreaker then respects. `/switch` alone lists accounts with the active one marked; `/switch <n>` switches.

## Test plan

- [ ] Connect Telegram bot to email account A, send a message — verify it routes to A
- [ ] Connect same Telegram bot to email account B — verify new messages route to B (deterministic ordering fix)
- [ ] Send `/switch` — verify it lists both accounts with the active one marked
- [ ] Send `/switch 1` — verify it switches and confirms
- [ ] Send `/switch 1` again — verify "Already using" response (no unnecessary DB write)
- [ ] Send `/switch` in a non-DM context — verify DM-required message


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>/switch</code> via <code>handleSwitchCommand</code> so Telegram/Teams DMs can list and switch connected email accounts while updating the mapped <code>Chat</code> row when a different account is chosen. Force the candidate <code>MessagingChannel</code> queries in <code>resolveLinkedProviderMessagingContext</code> to order by <code>updatedAt</code> so the most recent connection routes messages by default.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1784?tool=ast&topic=Routing+order>Routing order</a>
        </td><td>Require deterministic candidate ordering by <code>updatedAt desc</code> when resolving messaging context so reconnecting accounts reroute to the latest connection. <details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-messaging-attachme...</td><td>March 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1784?tool=ast&topic=Switch+command>Switch command</a>
        </td><td>Add <code>/switch</code> handling to let Telegram/Teams DMs show and switch connected email accounts, covering identity checks, DM-only validation, list/switch UX, and chat record updates through <code>handleSwitchCommand</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-messaging-attachme...</td><td>March 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1784?tool=ast>(Baz)</a>.