### PR TITLE
automation-jobs: add enqueue diagnostics

### DIFF
--- a/apps/web/app/api/cron/automation-jobs/route.ts
+++ b/apps/web/app/api/cron/automation-jobs/route.ts
@@ -68,6 +68,8 @@ async function enqueueDueAutomationJobs(logger: Logger) {
     take: BATCH_SIZE,
   });
 
+  logger.info("Found due automation jobs", { due: dueJobs.length });
+
   let claimed = 0;
   let queued = 0;
   let skipped = 0;
@@ -90,13 +92,14 @@ async function enqueueDueAutomationJobs(logger: Logger) {
       });
 
       if (!runId) {
+        jobLogger.info("Skipped automation job run claim");
         skipped += 1;
         continue;
       }
 
       claimed += 1;
 
-      await enqueueBackgroundJob({
+      const dispatchMode = await enqueueBackgroundJob({
         topic: AUTOMATION_JOBS_TOPIC,
         body: { automationJobRunId: runId },
         qstash: {
@@ -105,6 +108,11 @@ async function enqueueDueAutomationJobs(logger: Logger) {
           path: "/api/automation-jobs/execute",
         },
         logger: jobLogger,
+      });
+
+      jobLogger.info("Queued automation job run", {
+        automationJobRunId: runId,
+        dispatchMode,
       });
 
       queued += 1;
@@ -124,6 +132,14 @@ async function enqueueDueAutomationJobs(logger: Logger) {
       }
     }
   }
+
+  logger.info("Finished enqueueing due automation jobs", {
+    due: dueJobs.length,
+    claimed,
+    queued,
+    skipped,
+    failed,
+  });
 
   return {
     due: dueJobs.length,


### PR DESCRIPTION
# User description
Add targeted diagnostics for automation-job cron enqueue flow.

- log due job count before enqueue loop
- log skipped claim and successful queue dispatch mode
- log final due/claimed/queued/skipped/failed summary

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance diagnostics for the automation-job cron enqueue flow by recording due job counts before processing and summarizing outcomes when <code>enqueueDueAutomationJobs</code> finishes. Log claim skips and the <code>enqueueBackgroundJob</code> dispatch mode for each queued run to capture queue behavior.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>queue-add-dual-vercel-...</td><td>March 03, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1787?tool=ast>(Baz)</a>.