### PR TITLE
Simplify AI chat email search to query-only

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -867,11 +867,11 @@ describe("aiProcessAssistantChat", () => {
     );
   });
 
-  it("keeps unlabeled Google messages as pass-through", async () => {
+  it("returns messages from searchMessages", async () => {
     const tools = await captureToolSet(true, "google");
 
     mockCreateEmailProvider.mockResolvedValue({
-      getMessagesWithPagination: vi.fn().mockResolvedValue({
+      searchMessages: vi.fn().mockResolvedValue({
         messages: [
           {
             id: "message-1",
@@ -901,62 +901,12 @@ describe("aiProcessAssistantChat", () => {
     });
 
     const result = await tools.searchInbox.execute({
-      query: "today",
-      after: undefined,
-      before: undefined,
+      query: "in:inbox today",
       limit: 20,
       pageToken: undefined,
-      inboxOnly: true,
-      unreadOnly: false,
     });
 
     expect(result.totalReturned).toBe(1);
-  });
-
-  it("excludes unlabeled messages in unread-only searches", async () => {
-    const tools = await captureToolSet(true, "google");
-
-    mockCreateEmailProvider.mockResolvedValue({
-      getMessagesWithPagination: vi.fn().mockResolvedValue({
-        messages: [
-          {
-            id: "message-1",
-            threadId: "thread-1",
-            labelIds: undefined,
-            snippet: "Message without labels",
-            historyId: "hist-1",
-            inline: [],
-            headers: {
-              from: "sender1@example.com",
-              to: "user@example.com",
-              subject: "No labels",
-              date: new Date().toISOString(),
-            },
-            subject: "No labels",
-            date: new Date().toISOString(),
-            attachments: [],
-          },
-        ],
-        nextPageToken: undefined,
-      }),
-      getLabels: vi.fn().mockResolvedValue([]),
-      archiveThreadWithLabel: vi.fn(),
-      markReadThread: vi.fn(),
-      bulkArchiveFromSenders: vi.fn(),
-      sendEmailWithHtml: vi.fn(),
-    });
-
-    const result = await tools.searchInbox.execute({
-      query: "today",
-      after: undefined,
-      before: undefined,
-      limit: 20,
-      pageToken: undefined,
-      inboxOnly: true,
-      unreadOnly: true,
-    });
-
-    expect(result.totalReturned).toBe(0);
   });
 
   it("sends email with allowlisted chat params only", async () => {
@@ -1509,7 +1459,7 @@ describe("aiProcessAssistantChat", () => {
         if (threadId === "thread-2") throw new Error("archive failed");
       });
 
-    const getMessagesWithPagination = vi.fn().mockResolvedValue({
+    const searchMessages = vi.fn().mockResolvedValue({
       messages: [
         {
           id: "message-1",
@@ -1550,7 +1500,7 @@ describe("aiProcessAssistantChat", () => {
     });
 
     mockCreateEmailProvider.mockResolvedValue({
-      getMessagesWithPagination,
+      searchMessages,
       getLabels: vi.fn().mockRejectedValue(new Error("labels unavailable")),
       archiveThreadWithLabel,
       markReadThread: vi.fn(),
@@ -1560,20 +1510,14 @@ describe("aiProcessAssistantChat", () => {
 
     const searchResult = await tools.searchInbox.execute({
       query: "today",
-      after: undefined,
-      before: undefined,
       limit: 20,
       pageToken: undefined,
-      inboxOnly: true,
-      unreadOnly: false,
     });
 
     expect(mockCreateEmailProvider).toHaveBeenCalled();
-    expect(getMessagesWithPagination).toHaveBeenCalledWith(
+    expect(searchMessages).toHaveBeenCalledWith(
       expect.objectContaining({
         query: "today",
-        inboxOnly: true,
-        unreadOnly: false,
       }),
     );
     expect(searchResult.totalReturned).toBe(2);

--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -80,6 +80,9 @@ export function createMockEmailProvider(
     getMessagesWithPagination: vi
       .fn()
       .mockResolvedValue({ messages: [], nextPageToken: undefined }),
+    searchMessages: vi
+      .fn()
+      .mockResolvedValue({ messages: [], nextPageToken: undefined }),
     getMessagesFromSender: vi
       .fn()
       .mockResolvedValue({ messages: [], nextPageToken: undefined }),

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -115,6 +115,9 @@ export const createMockEmailProvider = (
   getMessagesWithPagination: vi
     .fn()
     .mockResolvedValue({ messages: [], nextPageToken: undefined }),
+  searchMessages: vi
+    .fn()
+    .mockResolvedValue({ messages: [], nextPageToken: undefined }),
   getMessagesFromSender: vi
     .fn()
     .mockResolvedValue({ messages: [], nextPageToken: undefined }),

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -161,44 +161,34 @@ export type GetAccountOverviewTool = InferUITool<
   ReturnType<typeof getAccountOverviewTool>
 >;
 
-const searchInboxInputSchema = z.object({
-  query: z
-    .string()
-    .trim()
-    .min(1)
-    .max(300)
-    .optional()
-    .describe(
-      "Inbox search query. Use concise keywords by default. For Google accounts, Gmail syntax like from:, to:, subject:, and in: is supported.",
-    ),
-  after: z.coerce
-    .date()
-    .optional()
-    .describe("Only include messages after this datetime (ISO format)."),
-  before: z.coerce
-    .date()
-    .optional()
-    .describe("Only include messages before this datetime (ISO format)."),
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(50)
-    .default(20)
-    .describe("Maximum number of messages to return."),
-  pageToken: z
-    .string()
-    .optional()
-    .describe("Use the page token returned from a prior search to paginate."),
-  inboxOnly: z
-    .boolean()
-    .default(true)
-    .describe("If true, restrict results to inbox messages."),
-  unreadOnly: z
-    .boolean()
-    .default(false)
-    .describe("If true, only return unread messages."),
-});
+function getSearchQueryDescription(provider: string): string {
+  if (provider === "microsoft") {
+    return "Search query using KQL syntax. Supports: from:, to:, subject:, received>=YYYY-MM-DD, keyword search. Do not use Gmail-specific operators like in:, is:, label:, or after:/before:.";
+  }
+  return "Search query using Gmail syntax. Supports: from:, to:, subject:, in:inbox, is:unread, has:attachment, after:YYYY/MM/DD, before:YYYY/MM/DD, label:, newer_than:, older_than:.";
+}
+
+function searchInboxInputSchema(provider: string) {
+  return z.object({
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(500)
+      .describe(getSearchQueryDescription(provider)),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(20)
+      .describe("Maximum number of messages to return."),
+    pageToken: z
+      .string()
+      .optional()
+      .describe("Use the page token returned from a prior search to paginate."),
+  });
+}
 
 export const searchInboxTool = ({
   email,
@@ -214,16 +204,8 @@ export const searchInboxTool = ({
   tool({
     description:
       "Search inbox messages and return concise message metadata for triage and summarization.",
-    inputSchema: searchInboxInputSchema,
-    execute: async ({
-      query,
-      after,
-      before,
-      limit,
-      pageToken,
-      inboxOnly,
-      unreadOnly,
-    }) => {
+    inputSchema: searchInboxInputSchema(provider),
+    execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });
 
       try {
@@ -233,16 +215,11 @@ export const searchInboxTool = ({
           logger,
         });
 
-        const { messages, nextPageToken } =
-          await emailProvider.getMessagesWithPagination({
-            query: query?.trim(),
-            maxResults: limit,
-            pageToken,
-            after,
-            before,
-            inboxOnly,
-            unreadOnly,
-          });
+        const { messages, nextPageToken } = await emailProvider.searchMessages({
+          query,
+          maxResults: limit,
+          pageToken,
+        });
 
         let labels: Array<{ id: string; name: string }> = [];
         try {
@@ -253,22 +230,12 @@ export const searchInboxTool = ({
 
         const labelsById = createLabelLookupMap(labels);
 
-        const filteredMessages = messages
-          .filter((message) =>
-            shouldIncludeMessage({
-              message,
-              inboxOnly,
-              unreadOnly,
-            }),
-          )
-          .slice(0, limit);
-
-        const items = filteredMessages.map((message) =>
-          mapMessageForSearchResult(message, labelsById),
-        );
+        const items = messages
+          .slice(0, limit)
+          .map((message) => mapMessageForSearchResult(message, labelsById));
 
         return {
-          queryUsed: query?.trim() || null,
+          queryUsed: query,
           totalReturned: items.length,
           nextPageToken,
           summary: summarizeSearchResults(items),
@@ -918,28 +885,6 @@ function createPendingForwardEmailOutput(
       subject: message.subject || message.headers.subject,
     },
   };
-}
-
-function shouldIncludeMessage({
-  message,
-  inboxOnly,
-  unreadOnly,
-}: {
-  message: ParsedMessage;
-  inboxOnly: boolean;
-  unreadOnly: boolean;
-}) {
-  if (!message.labelIds?.length) return !unreadOnly;
-
-  const labelIds =
-    message.labelIds?.map((labelId) => labelId.toLowerCase()) || [];
-  const isInInbox = labelIds.includes("inbox");
-  const isUnread = labelIds.includes("unread");
-
-  if (inboxOnly && !isInInbox) return false;
-  if (unreadOnly && !isUnread) return false;
-
-  return true;
 }
 
 function mapMessageForSearchResult(

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -159,8 +159,7 @@ ${emailSendToolsEnabled ? '- For forwarding, always use a real messageId from se
 
 Provider context:
 - Current provider: ${user.account.provider}.
-- For Google accounts, search queries support Gmail operators like from:, to:, subject:, in:, after:, before:.
-- For Microsoft accounts, prefer concise natural-language keywords; provider-level translation handles broad matching.
+${user.account.provider === "microsoft" ? "- Use KQL syntax for search: from:, to:, subject:, received>=YYYY-MM-DD, keyword search. Do not use Gmail-specific operators like in:, is:, label:, or after:/before:." : "- Use Gmail search syntax: from:, to:, subject:, in:inbox, is:unread, has:attachment, after:YYYY/MM/DD, before:YYYY/MM/DD, label:, newer_than:, older_than:."}
 
 A rule is comprised of:
 1. A condition

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1072,6 +1072,28 @@ export class GmailProvider implements EmailProvider {
     };
   }
 
+  async searchMessages(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
+    const response = await getMessages(this.client, {
+      query: options.query,
+      maxResults: options.maxResults || 20,
+      pageToken: options.pageToken || undefined,
+    });
+
+    const messages = response.messages || [];
+    const messagePromises = messages.map((message) =>
+      this.getMessage(message.id!),
+    );
+
+    return {
+      messages: await Promise.all(messagePromises),
+      nextPageToken: response.nextPageToken || undefined,
+    };
+  }
+
   async getMessagesWithAttachments(options: {
     maxResults?: number;
     pageToken?: string;

--- a/apps/web/utils/email/local-bypass-provider.ts
+++ b/apps/web/utils/email/local-bypass-provider.ts
@@ -197,6 +197,12 @@ export function createLocalBypassEmailProvider(logger?: Logger): EmailProvider {
         options.maxResults,
         options.pageToken,
       ),
+    searchMessages: async (options) =>
+      paginateMessages(
+        filterMessages(messages, { query: options.query }),
+        options.maxResults,
+        options.pageToken,
+      ),
     getMessagesWithAttachments: async ({ maxResults, pageToken }) =>
       paginateMessages(sortMessagesByDateDesc(messages), maxResults, pageToken),
     getMessagesFromSender: async ({

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1078,6 +1078,27 @@ export class OutlookProvider implements EmailProvider {
     };
   }
 
+  async searchMessages(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
+    const response = await queryBatchMessages(
+      this.client,
+      {
+        searchQuery: options.query,
+        maxResults: options.maxResults || 20,
+        pageToken: options.pageToken,
+      },
+      this.logger,
+    );
+
+    return {
+      messages: response.messages || [],
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
   async getMessagesWithAttachments(options: {
     maxResults?: number;
     pageToken?: string;

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -203,6 +203,14 @@ export interface EmailProvider {
     messages: ParsedMessage[];
     nextPageToken?: string;
   }>;
+  searchMessages(options: {
+    query: string;
+    maxResults?: number;
+    pageToken?: string;
+  }): Promise<{
+    messages: ParsedMessage[];
+    nextPageToken?: string;
+  }>;
   getMessagesWithAttachments(options: {
     maxResults?: number;
     pageToken?: string;


### PR DESCRIPTION
# User description
## Summary
- Replace structured search params (`after`, `before`, `inboxOnly`, `unreadOnly`) with a single query string in the provider's native syntax
- Add `searchMessages()` to the `EmailProvider` interface — a direct passthrough to the underlying API (Gmail search / Outlook KQL)
- Make the tool schema description and system prompt dynamic per provider, so the AI only sees the relevant search syntax
- Remove client-side `shouldIncludeMessage` filtering — the provider handles this via the query itself

## Test plan
- [x] All 2057 tests pass (`pnpm test`)
- [x] Type-check passes (`tsc --noEmit`)
- [ ] Manual test: AI chat search with Google account
- [ ] Manual test: AI chat search with Microsoft account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Switch the inbox search flow to call <code>searchMessages</code> with a native provider query string and drop all client-side filtering so <code>searchInboxTool</code> simply maps the returned messages. Update the tool schema description and assistant system prompt to surface provider-specific search syntax and clarify the new behavior to the AI user.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1788?tool=ast&topic=Provider+prompts>Provider prompts</a>
        </td><td>Align the tool schema description and AI system prompt text with each provider so the assistant only sees the relevant native search syntax.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/assistant/chat-inbox-tools.ts</li>
<li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-clarify-pend...</td><td>March 03, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1788?tool=ast&topic=Query-driven+search>Query-driven search</a>
        </td><td>Replace the <code>searchInboxTool</code> flow with a query-only <code>searchMessages</code> passthrough, update the provider interfaces/implementations to support it, and keep the mocked/tested tools aligned with the new call pattern.<details><summary>Modified files (8)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li>
<li>apps/web/__tests__/mocks/email-provider.mock.ts</li>
<li>apps/web/utils/__mocks__/email-provider.ts</li>
<li>apps/web/utils/ai/assistant/chat-inbox-tools.ts</li>
<li>apps/web/utils/email/google.ts</li>
<li>apps/web/utils/email/local-bypass-provider.ts</li>
<li>apps/web/utils/email/microsoft.ts</li>
<li>apps/web/utils/email/types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-clarify-pend...</td><td>March 03, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1788?tool=ast>(Baz)</a>.