### PR TITLE
queue: accept internal auth when qstash is enabled

### DIFF
--- a/apps/web/utils/qstash.test.ts
+++ b/apps/web/utils/qstash.test.ts
@@ -56,7 +56,7 @@ describe("withQstashOrInternal", () => {
     vi.clearAllMocks();
   });
 
-  it("uses QStash verification when configured even if internal key is present", async () => {
+  it("uses internal API key when provided even if QStash is configured", async () => {
     const {
       withQstashOrInternal,
       isValidInternalApiKey,
@@ -64,7 +64,6 @@ describe("withQstashOrInternal", () => {
     } = await loadMiddleware({
       qstashToken: "qstash-token",
       internalApiKeyValid: true,
-      verifyResponse: new Response("verified"),
     });
 
     const handler = vi.fn(() => new Response("ok"));
@@ -75,9 +74,9 @@ describe("withQstashOrInternal", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(handler).not.toHaveBeenCalled();
-    expect(isValidInternalApiKey).not.toHaveBeenCalled();
-    expect(verifySignatureAppRouter).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(isValidInternalApiKey).toHaveBeenCalledTimes(1);
+    expect(verifySignatureAppRouter).not.toHaveBeenCalled();
   });
 
   it("uses QStash signature verification when no internal key is provided", async () => {

--- a/apps/web/utils/qstash.ts
+++ b/apps/web/utils/qstash.ts
@@ -1,12 +1,22 @@
 import { verifySignatureAppRouter } from "@upstash/qstash/nextjs";
 import { env } from "@/env";
-import { isValidInternalApiKey } from "@/utils/internal-api";
+import {
+  INTERNAL_API_KEY_HEADER,
+  isValidInternalApiKey,
+} from "@/utils/internal-api";
 import type { NextHandler, RequestWithLogger } from "@/utils/middleware";
 
 export function withQstashOrInternal(
   handler: NextHandler<RequestWithLogger>,
 ): NextHandler<RequestWithLogger> {
   return async (request, context) => {
+    if (
+      request.headers.has(INTERNAL_API_KEY_HEADER) &&
+      isValidInternalApiKey(request.headers, request.logger)
+    ) {
+      return handler(request, context);
+    }
+
     if (env.QSTASH_TOKEN) {
       const verified = verifySignatureAppRouter(
         (req: Request, params?: { params?: Record<string, string> }) =>


### PR DESCRIPTION
# User description
Allow queue-forwarded internal requests to execute even when QStash is configured.

- prioritize valid internal API key in mixed queue environments
- retain QStash signature verification when no internal key is present
- update middleware tests to cover the new precedence

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prioritize internal auth in the <code>withQstashOrInternal</code> middleware by checking for <code>INTERNAL_API_KEY_HEADER</code> and invoking the handler before running QStash signature verification so queue-forwarded internal requests succeed in mixed environments. Retest the middleware to confirm <code>verifySignatureAppRouter</code> still runs when no internal key is present, preserving QStash validation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1789?tool=ast&topic=Internal+Auth+Priority>Internal Auth Priority</a>
        </td><td>Prioritize <code>INTERNAL_API_KEY_HEADER</code> authentication so <code>withQstashOrInternal</code> routes valid internal keys directly to the handler, bypassing QStash when appropriate.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/qstash.test.ts</li>
<li>apps/web/utils/qstash.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-digest-schedule-an...</td><td>February 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1789?tool=ast&topic=QStash+Signature+Fallback>QStash Signature Fallback</a>
        </td><td>Retain <code>verifySignatureAppRouter</code> verification when no internal key exists to keep QStash signature checks active in other cases.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/qstash.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-cron-fallback-for-...</td><td>February 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1789?tool=ast>(Baz)</a>.