### PR TITLE
llm: align gateway reasoning summary option

### DIFF
--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -388,6 +388,7 @@ describe("Models", () => {
       expect(result.providerOptions).toEqual({
         openai: {
           reasoningEffort: "low",
+          reasoningSummary: "concise",
         },
       });
       expect(createGateway).toHaveBeenCalledWith({
@@ -412,6 +413,7 @@ describe("Models", () => {
       expect(result.providerOptions).toEqual({
         openai: {
           reasoningEffort: "low",
+          reasoningSummary: "concise",
         },
       });
     });

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -40,6 +40,7 @@ type AiGatewayProviderOptions = {
   google?: GoogleGenerativeAIProviderOptions;
   openai?: {
     reasoningEffort: "low";
+    reasoningSummary: "concise";
   };
 };
 
@@ -712,6 +713,7 @@ function getAiGatewayProviderOptions(
       // Azure OpenAI models use OpenAI provider options in AI Gateway.
       openai: {
         reasoningEffort: "low",
+        reasoningSummary: "concise",
       },
     };
   }


### PR DESCRIPTION
Ensure gateway OpenAI-style provider options include both reasoning fields required for reasoning output.

- set reasoningSummary to concise alongside low reasoning effort for gateway OpenAI/Azure model names
- update model tests to assert the full provider option shape