### PR TITLE
Generalize scheduled check-in messaging and queue handling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
@@ -62,18 +62,15 @@ export function ProactiveUpdatesSetting() {
     mutate: mutateChannels,
   } = useMessagingChannels();
 
-  const connectedSlackChannels = useMemo(
+  const connectedMessagingChannels = useMemo(
     () =>
       channelsData?.channels.filter(
-        (channel) =>
-          channel.provider === "SLACK" &&
-          channel.isConnected &&
-          channel.hasSendDestination,
+        (channel) => channel.isConnected && channel.hasSendDestination,
       ) ?? [],
     [channelsData?.channels],
   );
 
-  const hasConnectedSlack = connectedSlackChannels.length > 0;
+  const hasConnectedMessagingChannel = connectedMessagingChannels.length > 0;
   const job = data?.job ?? null;
   const enabled = Boolean(job?.enabled);
 
@@ -97,17 +94,17 @@ export function ProactiveUpdatesSetting() {
   useEffect(() => {
     if (!open) return;
 
-    const hasSelectedConnectedChannel = connectedSlackChannels.some(
+    const hasSelectedConnectedChannel = connectedMessagingChannels.some(
       (channel) => channel.id === messagingChannelId,
     );
 
     if (hasSelectedConnectedChannel) return;
 
-    const fallbackChannelId = connectedSlackChannels[0]?.id ?? "";
+    const fallbackChannelId = connectedMessagingChannels[0]?.id ?? "";
     if (messagingChannelId === fallbackChannelId) return;
 
     setMessagingChannelId(fallbackChannelId);
-  }, [open, connectedSlackChannels, messagingChannelId]);
+  }, [open, connectedMessagingChannels, messagingChannelId]);
 
   const { execute: executeToggle, status: toggleStatus } = useAction(
     toggleAutomationJobAction.bind(null, emailAccountId),
@@ -142,7 +139,7 @@ export function ProactiveUpdatesSetting() {
     triggerTestCheckInAction.bind(null, emailAccountId),
     {
       onSuccess: () => {
-        toastSuccess({ description: "Test check-in sent to Slack" });
+        toastSuccess({ description: "Test check-in sent" });
       },
       onError: createSettingActionErrorHandler({
         defaultMessage: "Failed to send test check-in",
@@ -152,10 +149,11 @@ export function ProactiveUpdatesSetting() {
 
   const handleToggle = useCallback(
     (nextEnabled: boolean) => {
-      if (!emailAccountId || (!hasConnectedSlack && nextEnabled)) return;
+      if (!emailAccountId || (!hasConnectedMessagingChannel && nextEnabled))
+        return;
       executeToggle({ enabled: nextEnabled });
     },
-    [emailAccountId, hasConnectedSlack, executeToggle],
+    [emailAccountId, hasConnectedMessagingChannel, executeToggle],
   );
 
   const selectedPreset = useMemo(() => {
@@ -186,15 +184,15 @@ export function ProactiveUpdatesSetting() {
   return (
     <SettingCard
       title="Scheduled check-ins"
-      description="Your AI checks in on Slack with updates you can act on."
+      description="Your AI checks in with updates you can act on."
       right={
         showLoading ? (
           <Skeleton className="h-5 w-24" />
         ) : (
           <div className="flex items-center gap-2">
-            {!hasConnectedSlack && (
+            {!hasConnectedMessagingChannel && (
               <Button asChild variant="outline" size="sm">
-                <Link href="/settings">Connect Slack</Link>
+                <Link href="/settings">Connect channel</Link>
               </Button>
             )}
 
@@ -212,26 +210,26 @@ export function ProactiveUpdatesSetting() {
                         <DialogTitle>Scheduled check-ins</DialogTitle>
                         <DialogDescription>
                           Get notified about important emails and take action
-                          directly from Slack.
+                          directly from your connected chat app.
                         </DialogDescription>
                       </DialogHeader>
 
                       <div className="mt-6 space-y-6">
                         <div className="space-y-2">
                           <Label htmlFor="scheduled-checkins-channel">
-                            Slack channel
+                            Messaging destination
                           </Label>
                           <Select
                             value={messagingChannelId}
                             onValueChange={setMessagingChannelId}
                           >
                             <SelectTrigger id="scheduled-checkins-channel">
-                              <SelectValue placeholder="Select a Slack channel" />
+                              <SelectValue placeholder="Select a destination" />
                             </SelectTrigger>
                             <SelectContent>
-                              {connectedSlackChannels.map((channel) => (
+                              {connectedMessagingChannels.map((channel) => (
                                 <SelectItem key={channel.id} value={channel.id}>
-                                  {formatSlackChannelLabel(channel)}
+                                  {formatMessagingChannelLabel(channel)}
                                 </SelectItem>
                               ))}
                             </SelectContent>
@@ -362,7 +360,7 @@ export function ProactiveUpdatesSetting() {
               disabled={
                 toggleStatus === "executing" ||
                 !emailAccountId ||
-                (!hasConnectedSlack && !enabled)
+                (!hasConnectedMessagingChannel && !enabled)
               }
             />
           </div>
@@ -372,7 +370,8 @@ export function ProactiveUpdatesSetting() {
   );
 }
 
-function formatSlackChannelLabel(channel: {
+function formatMessagingChannelLabel(channel: {
+  provider: "SLACK" | "TEAMS" | "TELEGRAM";
   channelName: string | null;
   channelId: string | null;
   teamName: string | null;
@@ -380,7 +379,10 @@ function formatSlackChannelLabel(channel: {
   if (channel.channelName) return `#${channel.channelName}`;
   if (channel.channelId) return `Channel ${channel.channelId}`;
   if (channel.teamName) return channel.teamName;
-  return "Slack workspace";
+
+  if (channel.provider === "TEAMS") return "Teams destination";
+  if (channel.provider === "TELEGRAM") return "Telegram destination";
+  return "Slack destination";
 }
 
 const SLACK_MESSAGES = [

--- a/apps/web/app/api/automation-jobs/execute/queue/route.ts
+++ b/apps/web/app/api/automation-jobs/execute/queue/route.ts
@@ -4,6 +4,7 @@ import {
   executeAutomationJobBody,
   executeAutomationJobRun,
 } from "@/utils/automation-jobs/execute";
+import { captureException } from "@/utils/error";
 import { createScopedLogger } from "@/utils/logger";
 import { getQueueRetryBackoffSeconds } from "@/utils/queue/retry";
 
@@ -28,19 +29,25 @@ export const POST = handleCallback<z.infer<typeof executeAutomationJobBody>>(
       deliveryCount: metadata.deliveryCount,
     });
 
-    const response = await executeAutomationJobRun({
-      automationJobRunId: parseResult.data.automationJobRunId,
-      logger: runLogger,
-    });
+    try {
+      const response = await executeAutomationJobRun({
+        automationJobRunId: parseResult.data.automationJobRunId,
+        logger: runLogger,
+      });
 
-    if (response.status >= 500) {
-      throw new Error(
-        `Automation job queue execution failed with status ${response.status}`,
-      );
+      if (response.status >= 500) {
+        throw new Error(
+          `Automation job queue execution failed with status ${response.status}`,
+        );
+      }
+    } catch (error) {
+      runLogger.error("Failed queued automation job run", { error });
+      captureException(error);
+      throw error;
     }
   },
   {
-    visibilityTimeoutSeconds: 290,
+    visibilityTimeoutSeconds: 330,
     retry: (_error, metadata) => {
       return {
         afterSeconds: getQueueRetryBackoffSeconds({

--- a/apps/web/app/api/cron/automation-jobs/route.ts
+++ b/apps/web/app/api/cron/automation-jobs/route.ts
@@ -5,13 +5,14 @@ import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
 import { captureException } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import { getNextAutomationJobRunAt } from "@/utils/automation-jobs/cron";
-import {
-  AutomationJobRunStatus,
-  MessagingProvider,
-} from "@/generated/prisma/enums";
+import { AutomationJobRunStatus } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getPremiumUserFilter } from "@/utils/premium";
 import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
+import {
+  isAutomationMessagingChannelReady,
+  SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS,
+} from "@/utils/automation-jobs/messaging-channel";
 
 export const maxDuration = 300;
 
@@ -51,8 +52,7 @@ async function enqueueDueAutomationJobs(logger: Logger) {
       nextRunAt: { lte: now },
       messagingChannel: {
         isConnected: true,
-        provider: MessagingProvider.SLACK,
-        accessToken: { not: null },
+        provider: { in: SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS },
         emailAccount: {
           ...getPremiumUserFilter(),
         },
@@ -63,6 +63,15 @@ async function enqueueDueAutomationJobs(logger: Logger) {
       emailAccountId: true,
       nextRunAt: true,
       cronExpression: true,
+      messagingChannel: {
+        select: {
+          provider: true,
+          isConnected: true,
+          accessToken: true,
+          providerUserId: true,
+          channelId: true,
+        },
+      },
     },
     orderBy: { nextRunAt: "asc" },
     take: BATCH_SIZE,
@@ -84,6 +93,14 @@ async function enqueueDueAutomationJobs(logger: Logger) {
     let runId: string | null = null;
 
     try {
+      if (!isAutomationMessagingChannelReady(job.messagingChannel)) {
+        jobLogger.info(
+          "Skipped automation job because messaging channel is not ready",
+        );
+        skipped += 1;
+        continue;
+      }
+
       runId = await claimDueJobRun({
         automationJobId: job.id,
         scheduledFor: job.nextRunAt,

--- a/apps/web/utils/actions/automation-jobs.ts
+++ b/apps/web/utils/actions/automation-jobs.ts
@@ -25,6 +25,11 @@ import {
   createAutomationJob,
 } from "@/utils/actions/automation-jobs.helpers";
 import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
+import {
+  isAutomationMessagingChannelReady,
+  isSupportedAutomationMessagingProvider,
+  SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS,
+} from "@/utils/automation-jobs/messaging-channel";
 
 const AUTOMATION_JOBS_TOPIC = "automation-jobs-execute";
 
@@ -108,16 +113,14 @@ export const saveAutomationJobAction = actionClient
         throw new SafeError("Messaging channel not found");
       }
 
-      if (channel.provider !== MessagingProvider.SLACK) {
-        throw new SafeError("Only Slack is supported");
+      if (!isSupportedAutomationMessagingProvider(channel.provider)) {
+        throw new SafeError("Messaging provider is not supported");
       }
 
-      if (!channel.isConnected || !channel.accessToken) {
-        throw new SafeError("Slack channel is not connected");
-      }
-
-      if (!channel.providerUserId && !channel.channelId) {
-        throw new SafeError("Select a Slack destination first");
+      const validationError =
+        getAutomationMessagingChannelValidationError(channel);
+      if (validationError) {
+        throw new SafeError(validationError);
       }
 
       const existingJob = await prisma.automationJob.findUnique({
@@ -188,13 +191,10 @@ export const triggerTestCheckInAction = actionClient
     }
 
     const channel = job.messagingChannel;
-    if (
-      channel.provider !== MessagingProvider.SLACK ||
-      !channel.isConnected ||
-      !channel.accessToken ||
-      (!channel.providerUserId && !channel.channelId)
-    ) {
-      throw new SafeError("Slack channel is not connected");
+    const validationError =
+      getAutomationMessagingChannelValidationError(channel);
+    if (validationError) {
+      throw new SafeError(validationError);
     }
 
     const run = await prisma.automationJobRun.create({
@@ -219,21 +219,62 @@ export const triggerTestCheckInAction = actionClient
   });
 
 async function getDefaultMessagingChannel(emailAccountId: string) {
-  const channel = await prisma.messagingChannel.findFirst({
+  const channels = await prisma.messagingChannel.findMany({
     where: {
       emailAccountId,
-      provider: MessagingProvider.SLACK,
       isConnected: true,
-      accessToken: { not: null },
-      OR: [{ providerUserId: { not: null } }, { channelId: { not: null } }],
+      provider: {
+        in: SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS,
+      },
     },
-    select: { id: true },
+    select: {
+      id: true,
+      provider: true,
+      isConnected: true,
+      accessToken: true,
+      providerUserId: true,
+      channelId: true,
+    },
     orderBy: { updatedAt: "desc" },
   });
 
+  const channel = channels.find((candidate) =>
+    isAutomationMessagingChannelReady(candidate),
+  );
+
   if (!channel) {
-    throw new SafeError("Connect Slack before enabling proactive updates");
+    throw new SafeError(
+      "Connect a supported messaging channel before enabling proactive updates",
+    );
   }
 
   return channel;
+}
+
+function getAutomationMessagingChannelValidationError(channel: {
+  provider: MessagingProvider;
+  isConnected: boolean;
+  accessToken: string | null;
+  providerUserId: string | null;
+  channelId: string | null;
+}) {
+  if (!isSupportedAutomationMessagingProvider(channel.provider)) {
+    return "Messaging provider is not supported";
+  }
+
+  if (!channel.isConnected) return "Messaging channel is not connected";
+
+  if (channel.provider === MessagingProvider.SLACK && !channel.accessToken) {
+    return "Slack channel is not connected";
+  }
+
+  if (!channel.providerUserId && !channel.channelId) {
+    return "Select a messaging destination first";
+  }
+
+  if (!isAutomationMessagingChannelReady(channel)) {
+    return "Messaging channel is not connected";
+  }
+
+  return null;
 }

--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -477,7 +477,7 @@ describe("chat settings tools", () => {
 
     expect(result).toEqual({
       error:
-        "Provide a messagingChannelId when enabling scheduled check-ins. Ask the user to choose a Slack destination from availableChannels.",
+        "Provide a messagingChannelId when enabling scheduled check-ins. Ask the user to choose a destination from availableChannels.",
     });
     expect(prisma.automationJob.create).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/ai/assistant/chat-settings-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.ts
@@ -7,6 +7,7 @@ import { posthogCaptureEvent } from "@/utils/posthog";
 import { ActionType, MessagingProvider } from "@/generated/prisma/enums";
 import { describeCronSchedule } from "@/utils/automation-jobs/describe";
 import { DEFAULT_AUTOMATION_JOB_CRON } from "@/utils/automation-jobs/defaults";
+import { SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS } from "@/utils/automation-jobs/messaging-channel";
 import {
   getNextAutomationJobRunAt,
   validateAutomationCronExpression,
@@ -260,13 +261,27 @@ const accountSettingsSnapshotRawSelect = {
   },
   messagingChannels: {
     where: {
-      provider: MessagingProvider.SLACK,
       isConnected: true,
-      accessToken: { not: null },
-      OR: [{ providerUserId: { not: null } }, { channelId: { not: null } }],
+      provider: {
+        in: SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS,
+      },
+      OR: [
+        {
+          provider: MessagingProvider.SLACK,
+          accessToken: { not: null },
+          OR: [{ providerUserId: { not: null } }, { channelId: { not: null } }],
+        },
+        {
+          provider: {
+            in: [MessagingProvider.TEAMS, MessagingProvider.TELEGRAM],
+          },
+          providerUserId: { not: null },
+        },
+      ],
     },
     select: {
       id: true,
+      provider: true,
       channelName: true,
       teamName: true,
       isConnected: true,
@@ -298,6 +313,7 @@ const scheduledCheckInsAutomationJobSelect = {
   messagingChannelId: true,
   messagingChannel: {
     select: {
+      provider: true,
       channelName: true,
       teamName: true,
     },
@@ -1012,7 +1028,7 @@ function resolveScheduledCheckInsConfig({
 
   if (enabled && !messagingChannelId) {
     throw new Error(
-      "Provide a messagingChannelId when enabling scheduled check-ins. Ask the user to choose a Slack destination from availableChannels.",
+      "Provide a messagingChannelId when enabling scheduled check-ins. Ask the user to choose a destination from availableChannels.",
     );
   }
 
@@ -1024,7 +1040,7 @@ function resolveScheduledCheckInsConfig({
     )
   ) {
     throw new Error(
-      "Selected Slack channel is unavailable. Refresh capabilities and choose another channel.",
+      "Selected messaging destination is unavailable. Refresh capabilities and choose another channel.",
     );
   }
 
@@ -1106,7 +1122,8 @@ function buildScheduledCheckInsSnapshot(
     )
     .map((channel) => ({
       id: channel.id,
-      label: formatSlackChannelLabel({
+      label: formatMessagingChannelLabel({
+        provider: channel.provider,
         channelName: channel.channelName,
         teamName: channel.teamName,
       }),
@@ -1123,7 +1140,8 @@ function buildScheduledCheckInsSnapshot(
     nextRunAt: emailAccount.automationJob?.nextRunAt.toISOString() ?? null,
     messagingChannelId: emailAccount.automationJob?.messagingChannelId ?? null,
     messagingChannelName: emailAccount.automationJob?.messagingChannel
-      ? formatSlackChannelLabel({
+      ? formatMessagingChannelLabel({
+          provider: emailAccount.automationJob.messagingChannel.provider,
           channelName: emailAccount.automationJob.messagingChannel.channelName,
           teamName: emailAccount.automationJob.messagingChannel.teamName,
         })
@@ -1132,16 +1150,23 @@ function buildScheduledCheckInsSnapshot(
   };
 }
 
-function formatSlackChannelLabel({
+function formatMessagingChannelLabel({
+  provider,
   channelName,
   teamName,
 }: {
+  provider: MessagingProvider;
   channelName: string | null;
   teamName: string | null;
 }) {
   if (channelName && teamName) return `#${channelName} (${teamName})`;
   if (channelName) return `#${channelName}`;
-  return teamName || "Slack destination";
+  if (teamName) return teamName;
+
+  if (provider === MessagingProvider.TEAMS) return "Teams destination";
+  if (provider === MessagingProvider.TELEGRAM) return "Telegram destination";
+
+  return "Slack destination";
 }
 
 function requiresScheduledCheckInsPremium({

--- a/apps/web/utils/automation-jobs/execute.ts
+++ b/apps/web/utils/automation-jobs/execute.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
-import {
-  AutomationJobRunStatus,
-  MessagingProvider,
-} from "@/generated/prisma/enums";
-import {
-  AutomationJobConfigurationError,
-  sendAutomationMessageToSlack,
-} from "@/utils/automation-jobs/slack";
+import { AutomationJobRunStatus } from "@/generated/prisma/enums";
+import { AutomationJobConfigurationError } from "@/utils/automation-jobs/slack";
 import { isStaleAutomationJobRun } from "@/utils/automation-jobs/stale";
 import { createEmailProvider } from "@/utils/email/provider";
 import { getAutomationJobMessage } from "@/utils/automation-jobs/message";
@@ -14,6 +8,7 @@ import type { Logger } from "@/utils/logger";
 import { isActivePremium } from "@/utils/premium";
 import prisma from "@/utils/prisma";
 import { getUserPremium } from "@/utils/user/get";
+import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 
 export const executeAutomationJobBody = z.object({
   automationJobRunId: z.string().min(1, "Automation job run ID is required"),
@@ -85,7 +80,11 @@ export async function executeAutomationJobRun({
     return new Response("Run already processed", { status: 200 });
   }
 
-  if (isStaleAutomationJobRun({ scheduledFor: run.scheduledFor })) {
+  const isStaleRun =
+    isStaleAutomationJobRun({ scheduledFor: run.scheduledFor }) ||
+    isStaleAutomationJobRun({ scheduledFor: run.createdAt });
+
+  if (isStaleRun) {
     const skipped = await prisma.automationJobRun.updateMany({
       where: {
         id: automationJobRunId,
@@ -165,14 +164,6 @@ export async function executeAutomationJobRun({
       return new Response("Messaging channel disconnected", { status: 200 });
     }
 
-    if (
-      run.automationJob.messagingChannel.provider !== MessagingProvider.SLACK
-    ) {
-      throw new AutomationJobConfigurationError(
-        "Unsupported messaging provider for automation job",
-      );
-    }
-
     const provider =
       run.automationJob.messagingChannel.emailAccount.account.provider;
     if (!provider) {
@@ -194,7 +185,7 @@ export async function executeAutomationJobRun({
       logger: runLogger,
     });
 
-    const slackResult = await sendAutomationMessageToSlack({
+    const messagingResult = await sendAutomationMessage({
       channel: run.automationJob.messagingChannel,
       text: outboundMessage,
       logger: runLogger,
@@ -206,7 +197,7 @@ export async function executeAutomationJobRun({
         status: AutomationJobRunStatus.SENT,
         processedAt: new Date(),
         outboundMessage,
-        providerMessageId: slackResult.messageId,
+        providerMessageId: messagingResult.messageId,
         error: null,
       },
     });

--- a/apps/web/utils/automation-jobs/messaging-channel.ts
+++ b/apps/web/utils/automation-jobs/messaging-channel.ts
@@ -1,0 +1,48 @@
+import { MessagingProvider } from "@/generated/prisma/enums";
+
+export const SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS: MessagingProvider[] = [
+  MessagingProvider.SLACK,
+  MessagingProvider.TEAMS,
+  MessagingProvider.TELEGRAM,
+];
+
+export type AutomationMessagingChannel = {
+  provider: MessagingProvider;
+  isConnected: boolean;
+  accessToken: string | null;
+  providerUserId: string | null;
+  channelId: string | null;
+};
+
+export function isSupportedAutomationMessagingProvider(
+  provider: MessagingProvider,
+) {
+  return SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS.includes(provider);
+}
+
+export function hasAutomationMessagingDestination(
+  channel: Pick<
+    AutomationMessagingChannel,
+    "provider" | "providerUserId" | "channelId"
+  >,
+) {
+  if (channel.provider === MessagingProvider.SLACK) {
+    return Boolean(channel.providerUserId || channel.channelId);
+  }
+
+  return Boolean(channel.providerUserId);
+}
+
+export function isAutomationMessagingChannelReady(
+  channel: AutomationMessagingChannel,
+) {
+  if (!channel.isConnected) return false;
+  if (!isSupportedAutomationMessagingProvider(channel.provider)) return false;
+  if (!hasAutomationMessagingDestination(channel)) return false;
+
+  if (channel.provider === MessagingProvider.SLACK && !channel.accessToken) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/web/utils/automation-jobs/messaging.test.ts
+++ b/apps/web/utils/automation-jobs/messaging.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { MessagingProvider } from "@/generated/prisma/enums";
+import {
+  hasAutomationMessagingDestination,
+  isAutomationMessagingChannelReady,
+  isSupportedAutomationMessagingProvider,
+} from "@/utils/automation-jobs/messaging-channel";
+
+describe("automation job messaging channel helpers", () => {
+  it("accepts supported providers", () => {
+    expect(
+      isSupportedAutomationMessagingProvider(MessagingProvider.SLACK),
+    ).toBe(true);
+    expect(
+      isSupportedAutomationMessagingProvider(MessagingProvider.TEAMS),
+    ).toBe(true);
+    expect(
+      isSupportedAutomationMessagingProvider(MessagingProvider.TELEGRAM),
+    ).toBe(true);
+  });
+
+  it("requires slack destination via DM user or channel", () => {
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.SLACK,
+        providerUserId: null,
+        channelId: "C123",
+      }),
+    ).toBe(true);
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.SLACK,
+        providerUserId: "U123",
+        channelId: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.SLACK,
+        providerUserId: null,
+        channelId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires providerUserId for Teams and Telegram destinations", () => {
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.TEAMS,
+        providerUserId: "29:teams-user",
+        channelId: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.TELEGRAM,
+        providerUserId: "12345",
+        channelId: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasAutomationMessagingDestination({
+        provider: MessagingProvider.TEAMS,
+        providerUserId: null,
+        channelId: "channel-id-is-not-enough",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires access token for Slack readiness", () => {
+    expect(
+      isAutomationMessagingChannelReady({
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+        providerUserId: "U123",
+        channelId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      isAutomationMessagingChannelReady({
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: "U123",
+        channelId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats Teams and Telegram as ready when connected with destination", () => {
+    expect(
+      isAutomationMessagingChannelReady({
+        provider: MessagingProvider.TEAMS,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: "29:teams-user",
+        channelId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      isAutomationMessagingChannelReady({
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: "12345",
+        channelId: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/utils/automation-jobs/messaging.ts
+++ b/apps/web/utils/automation-jobs/messaging.ts
@@ -1,0 +1,150 @@
+import { MessagingProvider } from "@/generated/prisma/enums";
+import type { AutomationMessagingChannel } from "@/utils/automation-jobs/messaging-channel";
+import {
+  AutomationJobConfigurationError,
+  sendAutomationMessageToSlack,
+} from "@/utils/automation-jobs/slack";
+import type { Logger } from "@/utils/logger";
+import { getMessagingChatSdkBot } from "@/utils/messaging/chat-sdk/bot";
+
+export async function sendAutomationMessage({
+  channel,
+  text,
+  logger,
+}: {
+  channel: Pick<
+    AutomationMessagingChannel,
+    "provider" | "accessToken" | "providerUserId" | "channelId"
+  >;
+  text: string;
+  logger: Logger;
+}) {
+  switch (channel.provider) {
+    case MessagingProvider.SLACK: {
+      return sendAutomationMessageToSlack({
+        channel,
+        text,
+        logger,
+      });
+    }
+    case MessagingProvider.TEAMS: {
+      return sendAutomationMessageToTeams({
+        providerUserId: channel.providerUserId,
+        text,
+        logger,
+      });
+    }
+    case MessagingProvider.TELEGRAM: {
+      return sendAutomationMessageToTelegram({
+        providerUserId: channel.providerUserId,
+        text,
+        logger,
+      });
+    }
+    default: {
+      throw new AutomationJobConfigurationError(
+        "Unsupported messaging provider for automation job",
+      );
+    }
+  }
+}
+
+async function sendAutomationMessageToTeams({
+  providerUserId,
+  text,
+  logger,
+}: {
+  providerUserId: string | null;
+  text: string;
+  logger: Logger;
+}) {
+  if (!providerUserId) {
+    throw new AutomationJobConfigurationError(
+      "Teams channel is missing provider user ID",
+    );
+  }
+
+  let teamsAdapter: ReturnType<
+    typeof getMessagingChatSdkBot
+  >["adapters"]["teams"];
+  try {
+    teamsAdapter = getMessagingChatSdkBot().adapters.teams;
+  } catch {
+    throw new AutomationJobConfigurationError(
+      "Teams adapter is not configured",
+    );
+  }
+
+  if (!teamsAdapter) {
+    throw new AutomationJobConfigurationError(
+      "Teams adapter is not configured",
+    );
+  }
+
+  const teamsLogger = logger.with({
+    component: "sendAutomationMessageToTeams",
+    destination: providerUserId,
+  });
+
+  teamsLogger.info("Sending Teams automation message");
+
+  const threadId = await teamsAdapter.openDM(providerUserId);
+  const response = await teamsAdapter.postMessage(threadId, text);
+
+  teamsLogger.info("Teams automation message sent");
+
+  return {
+    channelId: threadId,
+    messageId: response.id ?? null,
+  };
+}
+
+async function sendAutomationMessageToTelegram({
+  providerUserId,
+  text,
+  logger,
+}: {
+  providerUserId: string | null;
+  text: string;
+  logger: Logger;
+}) {
+  if (!providerUserId) {
+    throw new AutomationJobConfigurationError(
+      "Telegram channel is missing provider user ID",
+    );
+  }
+
+  let telegramAdapter: ReturnType<
+    typeof getMessagingChatSdkBot
+  >["adapters"]["telegram"];
+  try {
+    telegramAdapter = getMessagingChatSdkBot().adapters.telegram;
+  } catch {
+    throw new AutomationJobConfigurationError(
+      "Telegram adapter is not configured",
+    );
+  }
+
+  if (!telegramAdapter) {
+    throw new AutomationJobConfigurationError(
+      "Telegram adapter is not configured",
+    );
+  }
+
+  const telegramLogger = logger.with({
+    component: "sendAutomationMessageToTelegram",
+    destination: providerUserId,
+  });
+
+  telegramLogger.info("Sending Telegram automation message");
+
+  const threadId = await telegramAdapter.openDM(providerUserId);
+  const response = await telegramAdapter.postMessage(threadId, text);
+
+  telegramLogger.info("Telegram automation message sent");
+
+  return {
+    channelId: threadId,
+    messageId: response.id ?? null,
+  };
+}


### PR DESCRIPTION
# User description
## Summary\n- remove Slack-only gating for scheduled check-ins in cron enqueue, action validation, and execution\n- add provider-aware messaging channel readiness checks for Slack, Teams, and Telegram\n- add provider-aware automation message sender with Teams and Telegram DM delivery support\n- update scheduled check-in settings copy and channel selection to use generic messaging destinations\n- improve queue callback observability and set a safer queue visibility timeout\n\n## Validation\n- pnpm test --run utils/automation-jobs/messaging.test.ts utils/automation-jobs/stale.test.ts utils/ai/assistant/chat-settings-tools.test.ts\n- pnpm --filter inbox-zero-ai exec biome check app/api/automation-jobs/execute/queue/route.ts app/api/cron/automation-jobs/route.ts app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx utils/actions/automation-jobs.ts utils/automation-jobs/execute.ts utils/automation-jobs/messaging.ts utils/automation-jobs/messaging-channel.ts utils/automation-jobs/messaging.test.ts utils/ai/assistant/chat-settings-tools.ts utils/ai/assistant/chat-settings-tools.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Broaden scheduled check-in messaging so the settings UI, action helpers, and new <code>sendAutomationMessage</code>/messaging channel helpers work with Slack, Teams, or Telegram destinations and surface clearer copy for generic channels. Harden the cron enqueue path and queue execution route by gating on messaging channel readiness, extending visibility timeout, and capturing failures while reusing the automated job executor to keep runs reliable.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1792?tool=ast&topic=Messaging+destinations>Messaging destinations</a>
        </td><td>Describe multi-provider messaging by updating helpers, validation, UI copy, and tests so the flow works with Slack, Teams, or Telegram destinations (<code>messaging-channel</code>, <code>messaging</code>, <code>actions</code>, settings UI, and chat-settings helpers/tests cover readiness, validation, and labeling).<details><summary>Modified files (7)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx</li>
<li>apps/web/utils/actions/automation-jobs.ts</li>
<li>apps/web/utils/ai/assistant/chat-settings-tools.test.ts</li>
<li>apps/web/utils/ai/assistant/chat-settings-tools.ts</li>
<li>apps/web/utils/automation-jobs/messaging-channel.ts</li>
<li>apps/web/utils/automation-jobs/messaging.test.ts</li>
<li>apps/web/utils/automation-jobs/messaging.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>queue-add-dual-vercel-...</td><td>March 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1792?tool=ast&topic=Job+execution+safety>Job execution safety</a>
        </td><td>Explain job-run reliability by skipping enqueue for unready channels, validating readiness before execution, improving queue logging/exception capture, extending visibility timeout, and reusing the generalized executor so cron enqueue, queue route, and execution stay resilient.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/api/automation-jobs/execute/queue/route.ts</li>
<li>apps/web/app/api/cron/automation-jobs/route.ts</li>
<li>apps/web/utils/automation-jobs/execute.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>automation-jobs-execut...</td><td>March 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1792?tool=ast>(Baz)</a>.