### PR TITLE
Fix scheduled check-in stale and reschedule behavior

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
@@ -382,7 +382,7 @@ function formatMessagingChannelLabel(channel: {
 
   if (channel.provider === "TEAMS") return "Teams destination";
   if (channel.provider === "TELEGRAM") return "Telegram destination";
-  return "Slack destination";
+  return "Slack workspace";
 }
 
 const SLACK_MESSAGES = [

--- a/apps/web/app/api/cron/automation-jobs/route.ts
+++ b/apps/web/app/api/cron/automation-jobs/route.ts
@@ -94,8 +94,19 @@ async function enqueueDueAutomationJobs(logger: Logger) {
 
     try {
       if (!isAutomationMessagingChannelReady(job.messagingChannel)) {
+        const nextRunAt = await deferAutomationJobUntilNextRun({
+          automationJobId: job.id,
+          scheduledFor: job.nextRunAt,
+          cronExpression: job.cronExpression,
+          now,
+        });
+
         jobLogger.info(
           "Skipped automation job because messaging channel is not ready",
+          {
+            deferred: Boolean(nextRunAt),
+            nextRunAt,
+          },
         );
         skipped += 1;
         continue;
@@ -213,4 +224,35 @@ async function claimDueJobRun({
 
     throw error;
   }
+}
+
+async function deferAutomationJobUntilNextRun({
+  automationJobId,
+  scheduledFor,
+  cronExpression,
+  now,
+}: {
+  automationJobId: string;
+  scheduledFor: Date;
+  cronExpression: string;
+  now: Date;
+}) {
+  const baselineFromDate = scheduledFor > now ? scheduledFor : now;
+  const nextRunAt = getNextAutomationJobRunAt({
+    cronExpression,
+    fromDate: baselineFromDate,
+  });
+
+  const update = await prisma.automationJob.updateMany({
+    where: {
+      id: automationJobId,
+      enabled: true,
+      nextRunAt: scheduledFor,
+    },
+    data: { nextRunAt },
+  });
+
+  if (update.count === 0) return null;
+
+  return nextRunAt;
 }

--- a/apps/web/utils/ai/assistant/chat-settings-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.ts
@@ -1166,7 +1166,7 @@ function formatMessagingChannelLabel({
   if (provider === MessagingProvider.TEAMS) return "Teams destination";
   if (provider === MessagingProvider.TELEGRAM) return "Telegram destination";
 
-  return "Slack destination";
+  return "Slack workspace";
 }
 
 function requiresScheduledCheckInsPremium({

--- a/apps/web/utils/automation-jobs/execute.ts
+++ b/apps/web/utils/automation-jobs/execute.ts
@@ -80,11 +80,7 @@ export async function executeAutomationJobRun({
     return new Response("Run already processed", { status: 200 });
   }
 
-  const isStaleRun =
-    isStaleAutomationJobRun({ scheduledFor: run.scheduledFor }) ||
-    isStaleAutomationJobRun({ scheduledFor: run.createdAt });
-
-  if (isStaleRun) {
+  if (isStaleAutomationJobRun({ scheduledFor: run.scheduledFor })) {
     const skipped = await prisma.automationJobRun.updateMany({
       where: {
         id: automationJobRunId,


### PR DESCRIPTION
# User description
## Summary\n- remove stale-run gating based on creation time and use scheduled time only\n- defer jobs with unready messaging channels by advancing next run time\n- keep Slack fallback copy consistent as "Slack workspace" when no channel/team label is available\n\n## Validation\n- pnpm test --run utils/automation-jobs/messaging.test.ts utils/automation-jobs/stale.test.ts utils/ai/assistant/chat-settings-tools.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify automation job scheduling by basing stale detection solely on scheduled times and deferring runs when messaging channels are unavailable, using the new <code>deferAutomationJobUntilNextRun</code> helper to advance <code>nextRunAt</code> and report deferral metadata. Maintain consistent naming for Slack fallbacks across proactive update settings and assistant chat tools so they now reference a <code>Slack workspace</code> destination.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1794?tool=ast&topic=Check-in+scheduling>Check-in scheduling</a>
        </td><td>Advance automation job run scheduling when messaging channels are not ready and only treat runs as stale based on their scheduled timestamps via the new helper and the <code>executeAutomationJobRun</code> stale check.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/cron/automation-jobs/route.ts</li>
<li>apps/web/utils/automation-jobs/execute.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Generalize-scheduled-c...</td><td>March 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1794?tool=ast&topic=Slack+labeling>Slack labeling</a>
        </td><td>Align Slack destination wording in proactive update controls and assistant chat helpers to refer to the <code>Slack workspace</code> fallback when channel or team labels are absent.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx</li>
<li>apps/web/utils/ai/assistant/chat-settings-tools.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Generalize-scheduled-c...</td><td>March 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1794?tool=ast>(Baz)</a>.