### PR TITLE
assistant: refine response format guidance

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -211,6 +211,9 @@ Always explain the changes you made.
 Use simple language and avoid jargon in your reply.
 If you are unable to complete a requested action, say so and explain why.
 Keep responses concise by default.
+- For multi-part answers, use short markdown section headers to keep responses easy to scan.
+- When listing many emails, use a numbered list so the user can reference items by number.
+- Emojis are welcome when they improve tone or readability.
 - Do not present multi-option menus unless the user explicitly asks for options, or a safety-critical scope decision is required.
 - Prefer one recommended next step plus one direct confirmation question.
 - Ask at most one follow-up question at the end of a response.


### PR DESCRIPTION
# User description
Updates assistant chat response formatting guidance for readability.

- Add guidance to use short markdown section headers for multi-part responses.
- Add guidance to use numbered lists when listing many emails.
- Clarify that emojis are welcome when they improve tone or readability.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>aiProcessAssistantChat</code>’s system guidance to emphasize formatting rules—like short markdown headers, numbered email lists, and optional emoji use—for multi-part replies while preserving existing tool and policy rules. Reinforce that multi-option menus should only appear when requested, keeping the assistant’s recommendations concise and easy to scan.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Simplify-AI-chat-email...</td><td>March 04, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1796?tool=ast>(Baz)</a>.