### PR TITLE
assistant-chat: collapse reasoning by default

### DIFF
--- a/apps/web/components/ai-elements/reasoning.tsx
+++ b/apps/web/components/ai-elements/reasoning.tsx
@@ -45,7 +45,7 @@ export const Reasoning = memo(
     className,
     isStreaming = false,
     open,
-    defaultOpen = true,
+    defaultOpen = false,
     onOpenChange,
     duration: durationProp,
     children,


### PR DESCRIPTION
Collapse assistant reasoning output by default so it is hidden unless expanded.

- Set Reasoning default open state to false.
- Preserve existing manual expand/collapse behavior and streaming logic.