### PR TITLE
Increase Google thinking budget

### DIFF
--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -18,7 +18,7 @@ import { createScopedLogger } from "@/utils/logger";
 import { SafeError } from "../error";
 
 // Thinking budgets for Google-family models (set low to minimize cost)
-const GOOGLE_THINKING_BUDGET = 50;
+const GOOGLE_THINKING_BUDGET = 128;
 
 const logger = createScopedLogger("llms/model");
 


### PR DESCRIPTION
# User description
## Summary
- Increased Google thinking budget from 50 to 128
- Applies to both Google Gemini and Vertex AI models

## Testing
Verify Google models use the new thinking budget configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Raise the Google thinking budget constant in the shared LLM model config so Gemini and Vertex AI models can use a higher reasoning allowance. Confirm the new <code>GOOGLE_THINKING_BUDGET</code> value applies uniformly to both Google-family models.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Increase-Google-thinki...</td><td>March 05, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add-OpenAI-compatible-...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1798?tool=ast>(Baz)</a>.