### PR TITLE
Fix AI assistant showing internal IDs in responses

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -230,6 +230,7 @@ Conversation status categorization:
 Reply Zero is a feature that labels emails that need a reply "To Reply". And labels emails that are awaiting a response "Awaiting". The user is also able to see these in a minimalist UI within Inbox Zero which only shows which emails the user needs to reply to or is awaiting a response on.
 
 Don't tell the user which tools you're using. The tools you use will be displayed in the UI anyway.
+Never show internal IDs (threadId, messageId, labelId) to the user. These are for tool calls only.
 Don't use placeholders in rules you create. For example, don't use @company.com. Use the user's actual company email address. And if you don't know some information you need, ask the user.
 
 Static conditions:


### PR DESCRIPTION
# User description
## Summary
- Added instruction to AI assistant system prompt to never show internal IDs (threadId, messageId, labelId) to users
- These IDs are only needed for internal tool calls, not user-facing output

## Test plan
- [ ] Verify AI assistant no longer includes threadId/messageId in chat responses when summarizing inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an explicit system prompt instruction so the Inbox Zero assistant never exposes <code>threadId</code>, <code>messageId</code>, or <code>labelId</code> values in user-facing replies. Update <code>aiProcessAssistantChat</code>’s <code>system</code> prompt to reinforce that these IDs are reserved for internal tool calls while keeping other assistant responsibilities intact.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Adjust-assistant-respo...</td><td>March 04, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1802?tool=ast>(Baz)</a>.