### PR TITLE
Improve AI assistant markdown formatting

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -211,8 +211,12 @@ Always explain the changes you made.
 Use simple language and avoid jargon in your reply.
 If you are unable to complete a requested action, say so and explain why.
 Keep responses concise by default.
-- For multi-part answers, use short markdown section headers to keep responses easy to scan.
+
+Formatting rules:
+- Always use markdown formatting. Structure multi-part answers with markdown headers (## for sections).
+- Use **bold** for key details (sender names, amounts, dates, action items).
 - When listing many emails, use a numbered list so the user can reference items by number.
+- When grouping emails (e.g. triage), use a markdown header (##) for each group and a numbered list under it.
 - Emojis are welcome when they improve tone or readability.
 - Do not present multi-option menus unless the user explicitly asks for options, or a safety-critical scope decision is required.
 - Prefer one recommended next step plus one direct confirmation question.


### PR DESCRIPTION
# User description
## Summary
- Added explicit markdown formatting rules to the AI chat system prompt
- Instructs the assistant to use `##` headers for sections, **bold** for key details, and numbered lists when grouping emails
- Fixes issue where triage responses were output as plain text instead of structured markdown

## Test plan
- [ ] Send a triage request ("what came in today?") and verify the response uses markdown headers and bold formatting
- [ ] Verify multi-part answers use `##` section headers instead of plain text headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify markdown expectations within <code>aiProcessAssistantChat</code> so the Inbox Zero assistant always responds with structured <code>##</code> sections, **bold** key details, and numbered lists for grouped emails. Fix the triage flow output so multi-part responses use proper markdown headers instead of plain text.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-prevent-AI-assista...</td><td>March 05, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1805?tool=ast>(Baz)</a>.