### PR TITLE
Apply markdown-to-mrkdwn conversion for Slack responses

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -43,6 +43,7 @@ import { createScopedLogger, type Logger } from "@/utils/logger";
 import { consumeMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code-consume";
 import type { MessagingPlatform } from "@/utils/messaging/platforms";
 import { buildPendingEmailPreview } from "@/utils/messaging/pending-email-preview";
+import { markdownToSlackMrkdwn } from "@/utils/messaging/providers/slack/format";
 import { markdownToTelegramText } from "@/utils/messaging/providers/telegram/format";
 import {
   expandPromptCommand,
@@ -2174,6 +2175,10 @@ function getMessagingAssistantPostPayload({
 }) {
   if (provider === "telegram") {
     return markdownToTelegramText(text);
+  }
+
+  if (provider === "slack") {
+    return { markdown: markdownToSlackMrkdwn(text) };
   }
 
   return { markdown: text };


### PR DESCRIPTION
# User description
## Summary
- The `markdownToSlackMrkdwn` converter existed but was never applied to AI assistant chat responses sent to Slack
- Raw markdown (`## headers`, `**bold**`) was showing as literal text in Slack instead of being converted to Slack mrkdwn format (`*bold*`, `• bullets`)
- Added the converter call in `getMessagingAssistantPostPayload` for the Slack provider, matching the existing pattern for Telegram

## Test plan
- [ ] Send a triage request in Slack and verify headers render as bold text, not literal `##`
- [ ] Verify `**bold**` renders as bold, not literal asterisks
- [ ] Verify bullet points render as `•` characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Apply markdown conversion for Slack assistant replies by invoking <code>markdownToSlackMrkdwn</code> in <code>getMessagingAssistantPostPayload</code> so Slack receives proper mrkdwn instead of raw Markdown. Ensure Slack payload mirrors the Telegram handling pattern for consistent formatting.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-slash-commands-for...</td><td>March 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1806?tool=ast>(Baz)</a>.