### PR TITLE
Fix digest queue retry storm

### DIFF
--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -71,10 +71,12 @@ export const POST = withError(
     } catch (error) {
       logger.error("Error sending digest email", { error });
       captureException(error, { emailAccountId });
-      return NextResponse.json(
-        { success: false, error: "Error sending digest email" },
-        { status: 500 },
-      );
+      // Return 200 to prevent queue retries — failed digests are already marked
+      // FAILED in the DB, and retrying won't help (expired tokens, timeouts, etc.)
+      return NextResponse.json({
+        success: false,
+        error: "Error sending digest email",
+      });
     }
   }),
 );


### PR DESCRIPTION
# User description
## Summary
- Return 200 instead of 500 from the digest send endpoint on failure
- Prevents the queue from retrying indefinitely (was causing ~6.4K retries on ~88 jobs)
- Errors are still logged and captured in Sentry, and failed digests are already marked FAILED in the DB

## Test plan
- [ ] Verify digest send errors no longer trigger queue retries
- [ ] Confirm errors still appear in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Serve the digest send endpoint with <code>NextResponse</code> to report failures without triggering retries. Clarify that failed digests are already marked FAILED so queue retries are unnecessary even when errors are logged.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-digest-schedule-an...</td><td>February 07, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Add-second-bypass</td><td>August 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1807?tool=ast>(Baz)</a>.