### PR TITLE
assistant-chat: Narrow preview attachment prop type

### DIFF
--- a/apps/web/components/assistant-chat/preview-attachment.tsx
+++ b/apps/web/components/assistant-chat/preview-attachment.tsx
@@ -5,12 +5,14 @@ import { XIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { Attachment } from "@/providers/ChatProvider";
 
+type PreviewableAttachment = Pick<Attachment, "name" | "url" | "contentType">;
+
 export function PreviewAttachment({
   attachment,
   onRemove,
   isUploading,
 }: {
-  attachment: Attachment;
+  attachment: PreviewableAttachment;
   onRemove?: () => void;
   isUploading?: boolean;
 }) {


### PR DESCRIPTION
# User description
Fixes the assistant chat build failure caused by passing an upload placeholder without an attachment ID into the preview component.

- narrow the preview component prop to the fields it actually renders
- keep the fix scoped to the build-breaking type mismatch

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust <code>PreviewAttachment</code> to accept only the <code>name</code>, <code>url</code>, and <code>contentType</code> fields it renders so that upload placeholders without IDs no longer break the build. Keep the fix scoped to the type mismatch that the assistant chat preview component relies on.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chat-add-image-attachm...</td><td>March 05, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1809?tool=ast>(Baz)</a>.