### PR TITLE
footer: add industry landing links

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -29,6 +29,12 @@ export const footerNavigation = {
     { name: "Customer Support", href: "/support" },
     { name: "E-commerce", href: "/ecommerce" },
   ],
+  industries: [
+    { name: "MSPs", href: "/msp" },
+    { name: "Property Management", href: "/property-management" },
+    { name: "Law Firms", href: "/law-firms" },
+    { name: "Accounting Firms", href: "/accounting-firms" },
+  ],
   compare: [
     { name: "vs Fyxer.ai", href: "/best-fyxer-alternative" },
     {
@@ -205,6 +211,13 @@ export function Footer() {
           </div>
           <div>
             <FooterList title="Use Cases" items={footerNavigation.useCases} />
+
+            <div className="mt-6">
+              <FooterList
+                title="Industries"
+                items={footerNavigation.industries}
+              />
+            </div>
 
             <div className="mt-6">
               <FooterList title="Compare" items={footerNavigation.compare} />

--- a/apps/web/components/new-landing/sections/Footer.tsx
+++ b/apps/web/components/new-landing/sections/Footer.tsx
@@ -88,6 +88,12 @@ export function Footer({ className, variant = "default" }: FooterProps) {
           </div>
           <div>
             <FooterList title="Use Cases" items={footerNavigation.useCases} />
+            <div className="mt-6">
+              <FooterList
+                title="Industries"
+                items={footerNavigation.industries}
+              />
+            </div>
           </div>
           <div>
             <FooterList title="Support" items={footerNavigation.support} />


### PR DESCRIPTION
# User description
Adds a small Industries subsection to the footer so a few of the new GTM pages are discoverable without overloading the main site navigation.

- add footer links for MSPs, Property Management, Law Firms, and Accounting Firms
- render the new subsection in both footer implementations

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>Industries</code> subsections to both footer implementations so the MSP, Property Management, Law Firms, and Accounting Firms landing pages are surfaced from the landing navigation. Link these new entries through the shared <code>footerNavigation</code> structure so the primary and new landing flows stay in sync.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-env-driven-white-l...</td><td>February 22, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Update-styling-of-blog...</td><td>November 16, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1811?tool=ast>(Baz)</a>.