### PR TITLE
Fix: allow opening channel selector on load error

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -400,7 +400,6 @@ function ConnectedChannelRow({
             }}
             disabled={
               isLoadingTargets ||
-              hasTargetLoadError ||
               setTargetStatus === "executing"
             }
             onOpenChange={(open) => {


### PR DESCRIPTION
# User description
## Summary
- Removed `hasTargetLoadError` from the Select's `disabled` prop so users can still open the dropdown and click Retry when channel loading fails

Follow-up fix from PR #1814 review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Allow channel dropdown to stay interactive in <code>ConnectedChannelRow</code> so that the retry flow remains accessible even when channel loading fails, while still disabling the selector during ongoing target loads or status executions.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Reorganize-settings-pa...</td><td>March 06, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1816?tool=ast>(Baz)</a>.