### PR TITLE
Fix outbound reply labeling respecting disabled rules

### DIFF
--- a/apps/web/utils/reply-tracker/outbound.test.ts
+++ b/apps/web/utils/reply-tracker/outbound.test.ts
@@ -47,8 +47,12 @@ describe("handleOutboundReply", () => {
       threadId: "thread1",
     });
 
-    // Mock tracking enabled
-    prisma.rule.findFirst.mockResolvedValue({ id: "rule1" } as any);
+    // Mock all conversation status rules enabled
+    prisma.rule.findMany.mockResolvedValue([
+      { systemType: SystemType.AWAITING_REPLY },
+      { systemType: SystemType.TO_REPLY },
+      { systemType: SystemType.ACTIONED },
+    ] as any);
 
     // Mock thread messages - sortByInternalDate sorts asc by default (oldest first)
     // We mock getThreadMessages to return messages that our internal sortByInternalDate will sort
@@ -87,8 +91,8 @@ describe("handleOutboundReply", () => {
   it("should return early if outbound tracking is disabled", async () => {
     const message = getMockMessage({ id: "sent-msg-1", threadId: "thread1" });
 
-    // Mock tracking disabled
-    prisma.rule.findFirst.mockResolvedValue(null);
+    // Mock no enabled rules
+    prisma.rule.findMany.mockResolvedValue([]);
 
     await handleOutboundReply({
       emailAccount,
@@ -105,7 +109,9 @@ describe("handleOutboundReply", () => {
   it("should return early when outbound thread status is already processed", async () => {
     const message = getMockMessage({ id: "sent-msg-1", threadId: "thread1" });
 
-    prisma.rule.findFirst.mockResolvedValue({ id: "rule1" } as any);
+    prisma.rule.findMany.mockResolvedValue([
+      { systemType: SystemType.TO_REPLY },
+    ] as any);
     vi.mocked(acquireOutboundThreadStatusLock).mockResolvedValue(null);
 
     await handleOutboundReply({
@@ -121,10 +127,40 @@ describe("handleOutboundReply", () => {
     expect(clearOutboundThreadStatusLock).not.toHaveBeenCalled();
   });
 
+  it("should skip labeling when the determined status rule is disabled", async () => {
+    const message = getMockMessage({ id: "sent-msg-1", threadId: "thread1" });
+
+    // Only TO_REPLY is enabled — AWAITING_REPLY is not
+    prisma.rule.findMany.mockResolvedValue([
+      { systemType: SystemType.TO_REPLY },
+    ] as any);
+
+    provider.getThreadMessages.mockResolvedValue([message]);
+
+    // AI picks AWAITING_REPLY, but that rule is disabled
+    vi.mocked(aiDetermineThreadStatus).mockResolvedValue({
+      status: SystemType.AWAITING_REPLY,
+      rationale: "Waiting for response",
+    });
+
+    await handleOutboundReply({
+      emailAccount,
+      message: message as any,
+      provider: provider as any,
+      logger,
+    });
+
+    expect(aiDetermineThreadStatus).toHaveBeenCalled();
+    expect(applyThreadStatusLabel).not.toHaveBeenCalled();
+    expect(updateThreadTrackers).not.toHaveBeenCalled();
+  });
+
   it("should clear idempotency lock if processing exits early", async () => {
     const message = getMockMessage({ id: "sent-msg-1", threadId: "thread1" });
 
-    prisma.rule.findFirst.mockResolvedValue({ id: "rule1" } as any);
+    prisma.rule.findMany.mockResolvedValue([
+      { systemType: SystemType.TO_REPLY },
+    ] as any);
     provider.getThreadMessages.mockResolvedValue([]);
 
     await handleOutboundReply({

--- a/apps/web/utils/reply-tracker/outbound.ts
+++ b/apps/web/utils/reply-tracker/outbound.ts
@@ -8,7 +8,10 @@ import { internalDateToDate, sortByInternalDate } from "@/utils/date";
 import type { EmailProvider } from "@/utils/email/types";
 import { applyThreadStatusLabel } from "./label-helpers";
 import { updateThreadTrackers } from "@/utils/reply-tracker/handle-conversation-status";
-import { CONVERSATION_STATUS_TYPES } from "@/utils/reply-tracker/conversation-status-config";
+import {
+  CONVERSATION_STATUS_TYPES,
+  type ConversationStatus,
+} from "@/utils/reply-tracker/conversation-status-config";
 import {
   acquireOutboundThreadStatusLock,
   clearOutboundThreadStatusLock,
@@ -32,10 +35,10 @@ export async function handleOutboundReply({
     threadId: message.threadId,
   });
 
-  const isEnabled = await isOutboundTrackingEnabled({
+  const enabledStatuses = await getEnabledStatuses({
     emailAccountId: emailAccount.id,
   });
-  if (!isEnabled) {
+  if (!enabledStatuses.length) {
     logger.info("Outbound reply tracking disabled, skipping.");
     return;
   }
@@ -101,6 +104,14 @@ export async function handleOutboundReply({
 
     logger.info("AI determined thread status", { status: aiResult.status });
 
+    if (!enabledStatuses.includes(aiResult.status)) {
+      logger.info(
+        "Rule for determined status is disabled, skipping label application",
+        { status: aiResult.status },
+      );
+      return;
+    }
+
     await Promise.all([
       applyThreadStatusLabel({
         emailAccountId: emailAccount.id,
@@ -153,19 +164,22 @@ export async function handleOutboundReply({
   }
 }
 
-async function isOutboundTrackingEnabled({
+async function getEnabledStatuses({
   emailAccountId,
 }: {
   emailAccountId: string;
-}): Promise<boolean> {
-  const enabledRule = await prisma.rule.findFirst({
+}): Promise<ConversationStatus[]> {
+  const enabledRules = await prisma.rule.findMany({
     where: {
       emailAccountId,
       systemType: { in: CONVERSATION_STATUS_TYPES },
       enabled: true,
     },
+    select: { systemType: true },
   });
-  return !!enabledRule;
+  return enabledRules
+    .map((r) => r.systemType)
+    .filter((s): s is ConversationStatus => s != null);
 }
 
 function isMessageLatestInThread(


### PR DESCRIPTION
# User description
When users disable conversation status rules (e.g. Awaiting Reply, Actioned), outbound emails were still being labeled automatically. The outbound reply tracking path wasn't checking if the rule was enabled before applying labels.

Now fetches enabled statuses upfront and skips labeling if the AI-determined status has a disabled rule.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fetch enabled conversation status rules before applying outbound labels and gate <code>handleOutboundReply</code> so it skips labeling when AI picks a status whose rule is disabled. Update <code>getEnabledStatuses</code> to return the list of enabled statuses and use that list to short-circuit outbound tracking and skip label application when needed.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1823?tool=ast&topic=Outbound+gating>Outbound gating</a>
        </td><td>Prevent labeling when the detected conversation status rule is disabled so outbound reply tracking respects the enabled-state of each status.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/reply-tracker/outbound.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-digest-limits-and-...</td><td>February 23, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-webhook-email-proc...</td><td>July 04, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1823?tool=ast&topic=Outbound+tests>Outbound tests</a>
        </td><td>Cover the disabled-rule scenario plus the new enabled-status lookup in outbound reply tests to ensure the new guard behaves as expected.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/reply-tracker/outbound.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-digest-limits-and-...</td><td>February 23, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1823?tool=ast>(Baz)</a>.