### PR TITLE
Redesign email action cards in chat

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -185,74 +185,77 @@ export default function ToolsPage() {
 
 function AssistantEmailActionStates() {
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       <MutedText>Email action states:</MutedText>
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="space-y-2">
-          <MutedText>Send</MutedText>
-          <SendEmailResult
-            output={getAssistantSendEmailOutput("pending")}
-            chatMessageId="assistant-demo-send-pending"
-            toolCallId="assistant-demo-send-pending"
-            disableConfirm={true}
-          />
-          <SendEmailResult
-            output={getAssistantSendEmailOutput("processing")}
-            chatMessageId="assistant-demo-send-processing"
-            toolCallId="assistant-demo-send-processing"
-            disableConfirm={true}
-          />
-          <SendEmailResult
-            output={getAssistantSendEmailOutput("confirmed")}
-            chatMessageId="assistant-demo-send-confirmed"
-            toolCallId="assistant-demo-send-confirmed"
-            disableConfirm={true}
-          />
-        </div>
 
-        <div className="space-y-2">
-          <MutedText>Reply</MutedText>
-          <ReplyEmailResult
-            output={getAssistantReplyEmailOutput("pending")}
-            chatMessageId="assistant-demo-reply-pending"
-            toolCallId="assistant-demo-reply-pending"
-            disableConfirm={true}
-          />
-          <ReplyEmailResult
-            output={getAssistantReplyEmailOutput("processing")}
-            chatMessageId="assistant-demo-reply-processing"
-            toolCallId="assistant-demo-reply-processing"
-            disableConfirm={true}
-          />
-          <ReplyEmailResult
-            output={getAssistantReplyEmailOutput("confirmed")}
-            chatMessageId="assistant-demo-reply-confirmed"
-            toolCallId="assistant-demo-reply-confirmed"
-            disableConfirm={true}
-          />
-        </div>
+      <div className="space-y-3">
+        <MutedText>Send — pending</MutedText>
+        <SendEmailResult
+          output={getAssistantSendEmailOutput("pending")}
+          chatMessageId="assistant-demo-send-pending"
+          toolCallId="assistant-demo-send-pending"
+          disableConfirm={true}
+        />
+      </div>
 
-        <div className="space-y-2">
-          <MutedText>Forward</MutedText>
-          <ForwardEmailResult
-            output={getAssistantForwardEmailOutput("pending")}
-            chatMessageId="assistant-demo-forward-pending"
-            toolCallId="assistant-demo-forward-pending"
-            disableConfirm={true}
-          />
-          <ForwardEmailResult
-            output={getAssistantForwardEmailOutput("processing")}
-            chatMessageId="assistant-demo-forward-processing"
-            toolCallId="assistant-demo-forward-processing"
-            disableConfirm={true}
-          />
-          <ForwardEmailResult
-            output={getAssistantForwardEmailOutput("confirmed")}
-            chatMessageId="assistant-demo-forward-confirmed"
-            toolCallId="assistant-demo-forward-confirmed"
-            disableConfirm={true}
-          />
-        </div>
+      <div className="space-y-3">
+        <MutedText>Send — processing</MutedText>
+        <SendEmailResult
+          output={getAssistantSendEmailOutput("processing")}
+          chatMessageId="assistant-demo-send-processing"
+          toolCallId="assistant-demo-send-processing"
+          disableConfirm={true}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <MutedText>Send — confirmed</MutedText>
+        <SendEmailResult
+          output={getAssistantSendEmailOutput("confirmed")}
+          chatMessageId="assistant-demo-send-confirmed"
+          toolCallId="assistant-demo-send-confirmed"
+          disableConfirm={true}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <MutedText>Reply — pending</MutedText>
+        <ReplyEmailResult
+          output={getAssistantReplyEmailOutput("pending")}
+          chatMessageId="assistant-demo-reply-pending"
+          toolCallId="assistant-demo-reply-pending"
+          disableConfirm={true}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <MutedText>Reply — confirmed</MutedText>
+        <ReplyEmailResult
+          output={getAssistantReplyEmailOutput("confirmed")}
+          chatMessageId="assistant-demo-reply-confirmed"
+          toolCallId="assistant-demo-reply-confirmed"
+          disableConfirm={true}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <MutedText>Forward — pending</MutedText>
+        <ForwardEmailResult
+          output={getAssistantForwardEmailOutput("pending")}
+          chatMessageId="assistant-demo-forward-pending"
+          toolCallId="assistant-demo-forward-pending"
+          disableConfirm={true}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <MutedText>Forward — confirmed</MutedText>
+        <ForwardEmailResult
+          output={getAssistantForwardEmailOutput("confirmed")}
+          chatMessageId="assistant-demo-forward-confirmed"
+          toolCallId="assistant-demo-forward-confirmed"
+          disableConfirm={true}
+        />
       </div>
     </div>
   );
@@ -389,6 +392,8 @@ function getAssistantReplyEmailOutput(state: EmailActionState) {
       threadId: "thread-3",
       from: "Support <support@example.com>",
       subject: "Ticket follow-up",
+      snippet:
+        "Hi there, checking in on your request. Let us know if you need anything else.",
     },
     ...(state === "confirmed"
       ? {
@@ -422,6 +427,7 @@ function getAssistantForwardEmailOutput(state: EmailActionState) {
       threadId: "thread-2",
       from: "Product Team <product@example.com>",
       subject: "Release notes",
+      snippet: "New changes shipped today including performance improvements and bug fixes.",
     },
     ...(state === "confirmed"
       ? {

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -12,16 +12,28 @@ import type {
   ManageInboxTool,
 } from "@/utils/ai/assistant/chat";
 import { isDefined } from "@/utils/types";
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Avatar, AvatarFallbackColor } from "@/components/ui/avatar";
 import {
   ChevronRightIcon,
+  ChevronDownIcon,
   EyeIcon,
   SparklesIcon,
   TrashIcon,
   FileDiffIcon,
   ExternalLinkIcon,
   Loader2,
+  PencilIcon,
+  CopyIcon,
+  CheckIcon,
+  SendIcon,
 } from "lucide-react";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Tooltip } from "@/components/Tooltip";
@@ -413,6 +425,9 @@ function EmailActionResult({
   const [isConfirming, setIsConfirming] = useState(false);
   const [confirmationResultOverride, setConfirmationResultOverride] =
     useState<EmailConfirmationResult | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const pendingAction = getOutputField<Record<string, unknown>>(
     output,
@@ -453,8 +468,10 @@ function EmailActionResult({
   });
   const referenceFrom = getPendingString(reference, "from");
   const referenceSubject = getPendingString(reference, "subject");
+  const referenceSnippet = getPendingString(reference, "snippet");
   const displaySubject = subject || referenceSubject;
   const body = getActionBodyText({ actionType, pendingAction });
+  const [editedBody, setEditedBody] = useState(body || "");
 
   const messageId =
     confirmationResult?.messageId ||
@@ -470,116 +487,225 @@ function EmailActionResult({
     userEmail,
     provider,
   });
-  const summary = getEmailActionSummary({
-    actionType,
-    isConfirmed,
-    isProcessing,
-    to: confirmationResult?.to || to,
-  });
+
+  const actionLabel = getEmailActionLabel(actionType);
+  const recipientInitial = to ? to.charAt(0).toUpperCase() : "?";
+  const providerName = provider === "microsoft" ? "Outlook" : "Gmail";
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(editedBody || body || "").catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSend = async () => {
+    setIsConfirming(true);
+    try {
+      if (!chatId) {
+        toastError({ description: "Could not confirm this email action." });
+        return;
+      }
+
+      const result = await confirmAssistantEmailAction(emailAccountId, {
+        chatId,
+        chatMessageId,
+        toolCallId,
+        actionType,
+      });
+
+      if (result?.serverError) {
+        toastError({ description: result.serverError });
+        return;
+      }
+
+      const parsed = parseConfirmationResult(result?.data?.confirmationResult);
+      if (!parsed) {
+        toastError({ description: "Could not confirm this email action." });
+        return;
+      }
+
+      setConfirmationResultOverride(parsed);
+      toastSuccess({
+        description: getAssistantEmailSuccessMessage(actionType),
+      });
+    } catch {
+      toastError({ description: "Could not confirm this email action." });
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
+  const sentLabel = isConfirmed
+    ? getEmailActionSentLabel(actionType)
+    : actionLabel;
 
   return (
-    <CollapsibleToolCard summary={summary} initialOpen={!isConfirmed}>
-      <div className="space-y-2 text-sm">
-        {to && <ToolDetailRow label="To" value={to} />}
-        {cc && <ToolDetailRow label="CC" value={cc} />}
-        {bcc && <ToolDetailRow label="BCC" value={bcc} />}
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-3 space-y-0 border-b px-4 py-3.5">
+        <Avatar className="size-8">
+          <AvatarFallbackColor content={recipientInitial} className="text-xs" />
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold leading-tight">
+            {sentLabel ? `${sentLabel} ` : ""}
+            {to}
+          </div>
+          {cc && (
+            <div className="mt-0.5 text-xs text-muted-foreground">CC: {cc}</div>
+          )}
+          {bcc && (
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              BCC: {bcc}
+            </div>
+          )}
+        </div>
+        {isConfirmed && (
+          <div className="flex items-center gap-1 text-xs font-medium text-green-600">
+            <CheckIcon className="size-3.5" />
+            Sent
+          </div>
+        )}
+      </CardHeader>
+
+      <CardContent className="p-0">
         {displaySubject && (
-          <ToolDetailRow label="Subject" value={displaySubject} />
-        )}
-        {referenceFrom && actionType !== "send_email" && (
-          <ToolDetailRow
-            label={actionType === "reply_email" ? "In reply to" : "From"}
-            value={referenceFrom}
-          />
-        )}
-        {body && (
-          <div className="space-y-1">
-            <div className="text-xs font-medium text-muted-foreground">
-              Message
-            </div>
-            <div className="rounded-md bg-muted p-2 text-xs">
-              <div className="break-words whitespace-pre-wrap">{body}</div>
-            </div>
+          <div className="flex items-center gap-2 border-b px-4 py-2.5">
+            <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Subject
+            </span>
+            <span className="truncate text-sm font-medium text-foreground">
+              {actionType !== "send_email" ? "Re: " : ""}
+              {displaySubject}
+            </span>
           </div>
         )}
 
-        {(externalUrl || (requiresConfirmation && !isConfirmed)) && (
-          <div className="flex items-center gap-2">
-            {externalUrl && (
-              <ToolExternalLink href={externalUrl}>
-                Open in {provider === "microsoft" ? "Outlook" : "Gmail"}
-              </ToolExternalLink>
-            )}
+        {referenceSnippet && actionType !== "send_email" && (
+          <div className="border-b px-4">
+            <Collapsible open={showOriginal} onOpenChange={setShowOriginal}>
+              <CollapsibleTrigger className="flex w-full items-center gap-1 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
+                <ChevronDownIcon
+                  className={`size-4 transition-transform ${showOriginal ? "rotate-180" : ""}`}
+                />
+                Original message
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="mb-3 text-xs leading-relaxed text-muted-foreground">
+                  {referenceFrom && (
+                    <div className="mb-1 font-medium">{referenceFrom}</div>
+                  )}
+                  {referenceSnippet}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        )}
 
-            {requiresConfirmation && !isConfirmed && (
+        <div className="px-4 py-3.5">
+          {isEditing ? (
+            <div className="space-y-2">
+              <Textarea
+                value={editedBody}
+                onChange={(e) => setEditedBody(e.target.value)}
+                className="min-h-[140px] resize-y text-sm leading-relaxed"
+              />
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setEditedBody(body || "");
+                    setIsEditing(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={() => setIsEditing(false)}>
+                  Save changes
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="whitespace-pre-line text-sm leading-relaxed text-foreground">
+              {editedBody || body}
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      {!isEditing && (
+        <CardFooter className="flex items-center justify-between border-t px-4 py-3">
+          <div className="flex items-center gap-1">
+            {!isConfirmed && requiresConfirmation && (
               <Button
+                variant="ghost"
                 size="sm"
-                className="w-fit"
-                disabled={isConfirming || isProcessing || isChatBusy}
-                onClick={async () => {
-                  setIsConfirming(true);
-                  try {
-                    if (!chatId) {
-                      toastError({
-                        description: "Could not confirm this email action.",
-                      });
-                      return;
-                    }
-
-                    const result = await confirmAssistantEmailAction(
-                      emailAccountId,
-                      {
-                        chatId,
-                        chatMessageId,
-                        toolCallId,
-                        actionType,
-                      },
-                    );
-
-                    if (result?.serverError) {
-                      toastError({ description: result.serverError });
-                      return;
-                    }
-
-                    const confirmationResult = parseConfirmationResult(
-                      result?.data?.confirmationResult,
-                    );
-                    if (!confirmationResult) {
-                      toastError({
-                        description: "Could not confirm this email action.",
-                      });
-                      return;
-                    }
-
-                    setConfirmationResultOverride(confirmationResult);
-                    toastSuccess({
-                      description: getAssistantEmailSuccessMessage(actionType),
-                    });
-                  } catch {
-                    toastError({
-                      description: "Could not confirm this email action.",
-                    });
-                  } finally {
-                    setIsConfirming(false);
-                  }
-                }}
+                className="h-8 gap-1.5 text-xs text-muted-foreground"
+                onClick={() => setIsEditing(true)}
               >
-                {isProcessing ? (
-                  "Sending..."
-                ) : isConfirming ? (
-                  <>
-                    <Loader2 className="mr-2 size-4 animate-spin" />
-                    Sending...
-                  </>
-                ) : (
-                  "Send"
-                )}
+                <PencilIcon className="size-3.5" />
+                <span className="hidden sm:inline">Edit</span>
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className={`h-8 gap-1.5 text-xs ${
+                copied ? "text-green-600" : "text-muted-foreground"
+              }`}
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <CheckIcon className="size-3.5" />
+              ) : (
+                <CopyIcon className="size-3.5" />
+              )}
+              <span className="hidden sm:inline">
+                {copied ? "Copied" : "Copy"}
+              </span>
+            </Button>
+            {externalUrl && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1.5 text-xs text-muted-foreground"
+                asChild
+              >
+                <a href={externalUrl} target="_blank" rel="noopener noreferrer">
+                  <ExternalLinkIcon className="size-3.5" />
+                  <span className="hidden sm:inline">
+                    Open in {providerName}
+                  </span>
+                </a>
               </Button>
             )}
           </div>
-        )}
-      </div>
-    </CollapsibleToolCard>
+
+          {!isConfirmed && requiresConfirmation && (
+            <Button
+              onClick={handleSend}
+              disabled={isConfirming || isProcessing || isChatBusy}
+              size="sm"
+              className="gap-2"
+            >
+              {isProcessing ? (
+                "Sending..."
+              ) : isConfirming ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                <>
+                  <SendIcon className="hidden size-3.5 sm:inline" />
+                  Send
+                </>
+              )}
+            </Button>
+          )}
+        </CardFooter>
+      )}
+    </Card>
   );
 }
 
@@ -1269,6 +1395,18 @@ function getEmailActionSummary({
   if (actionType === "send_email") return `Sent email${to ? ` to ${to}` : ""}`;
   if (actionType === "reply_email") return "Sent reply";
   return `Forwarded email${to ? ` to ${to}` : ""}`;
+}
+
+function getEmailActionLabel(actionType: PendingEmailActionType) {
+  if (actionType === "reply_email") return "Reply to";
+  if (actionType === "forward_email") return "Forward to";
+  return "";
+}
+
+function getEmailActionSentLabel(actionType: PendingEmailActionType) {
+  if (actionType === "send_email") return "Sent email to";
+  if (actionType === "reply_email") return "Replied to";
+  return "Forwarded to";
 }
 
 function getAssistantEmailSuccessMessage(actionType: PendingEmailActionType) {


### PR DESCRIPTION
# User description
Improves the UI for email drafts and actions in the chat interface by replacing the collapsible tool card format with a proper email-style card design. The new card features a header with colored avatar and recipient info, editable message body, subject line, collapsible original message context, and a footer with action buttons. Mobile-responsive design hides button text on small screens while keeping the Send button text visible. Also updates the component demo page to display states vertically for better readability.

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Revamp <code>EmailActionResult</code> into email-style cards that show recipient info in an avatar header, expose subject/original message context, allow editing/copying, and surface responsive footer actions for confirmation and sending. Rearrange <code>AssistantEmailActionStates</code> to present each send/reply/forward state vertically and refresh the reference snippets so the new card variations are displayed clearly.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1829?tool=ast&topic=Demo+layout>Demo layout</a>
        </td><td>Rearrange <code>AssistantEmailActionStates</code> demo to stack each pending/confirmed state vertically and update reference snippets for better readability.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(landing)/components/tools/page.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-chat-components-sh...</td><td>March 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1829?tool=ast&topic=Email+card+UI>Email card UI</a>
        </td><td>Revamp <code>EmailActionResult</code> into email-style cards with avatar headers, collapsible context, editable body text, copy/send controls, and responsive footer actions that respect confirmation state.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-clarify-pend...</td><td>March 03, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1829?tool=ast>(Baz)</a>.