### PR TITLE
Wire edited email content through to backend

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -392,8 +392,6 @@ function getAssistantReplyEmailOutput(state: EmailActionState) {
       threadId: "thread-3",
       from: "Support <support@example.com>",
       subject: "Ticket follow-up",
-      snippet:
-        "Hi there, checking in on your request. Let us know if you need anything else.",
     },
     ...(state === "confirmed"
       ? {
@@ -427,7 +425,6 @@ function getAssistantForwardEmailOutput(state: EmailActionState) {
       threadId: "thread-2",
       from: "Product Team <product@example.com>",
       subject: "Release notes",
-      snippet: "New changes shipped today including performance improvements and bug fixes.",
     },
     ...(state === "confirmed"
       ? {

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -23,7 +23,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallbackColor } from "@/components/ui/avatar";
 import {
   ChevronRightIcon,
-  ChevronDownIcon,
   EyeIcon,
   SparklesIcon,
   TrashIcon,
@@ -426,7 +425,6 @@ function EmailActionResult({
   const [confirmationResultOverride, setConfirmationResultOverride] =
     useState<EmailConfirmationResult | null>(null);
   const [isEditing, setIsEditing] = useState(false);
-  const [showOriginal, setShowOriginal] = useState(false);
   const [copied, setCopied] = useState(false);
 
   const pendingAction = getOutputField<Record<string, unknown>>(
@@ -466,9 +464,7 @@ function EmailActionResult({
     output,
     key: "subject",
   });
-  const referenceFrom = getPendingString(reference, "from");
   const referenceSubject = getPendingString(reference, "subject");
-  const referenceSnippet = getPendingString(reference, "snippet");
   const displaySubject = subject || referenceSubject;
   const body = getActionBodyText({ actionType, pendingAction });
   const [editedBody, setEditedBody] = useState(body || "");
@@ -506,11 +502,13 @@ function EmailActionResult({
         return;
       }
 
+      const hasEdits = editedBody && editedBody !== body;
       const result = await confirmAssistantEmailAction(emailAccountId, {
         chatId,
         chatMessageId,
         toolCallId,
         actionType,
+        ...(hasEdits ? { contentOverride: editedBody } : {}),
       });
 
       if (result?.serverError) {
@@ -577,27 +575,6 @@ function EmailActionResult({
               {actionType !== "send_email" ? "Re: " : ""}
               {displaySubject}
             </span>
-          </div>
-        )}
-
-        {referenceSnippet && actionType !== "send_email" && (
-          <div className="border-b px-4">
-            <Collapsible open={showOriginal} onOpenChange={setShowOriginal}>
-              <CollapsibleTrigger className="flex w-full items-center gap-1 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
-                <ChevronDownIcon
-                  className={`size-4 transition-transform ${showOriginal ? "rotate-180" : ""}`}
-                />
-                Original message
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="mb-3 text-xs leading-relaxed text-muted-foreground">
-                  {referenceFrom && (
-                    <div className="mb-1 font-medium">{referenceFrom}</div>
-                  )}
-                  {referenceSnippet}
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
           </div>
         )}
 

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -56,13 +56,20 @@ export const confirmAssistantEmailAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId, provider, logger },
-      parsedInput: { chatId, chatMessageId, toolCallId, actionType },
+      parsedInput: {
+        chatId,
+        chatMessageId,
+        toolCallId,
+        actionType,
+        contentOverride,
+      },
     }) =>
       confirmAssistantEmailActionForAccount({
         chatId,
         chatMessageId,
         toolCallId,
         actionType,
+        contentOverride,
         emailAccountId,
         provider,
         logger,
@@ -74,6 +81,7 @@ export async function confirmAssistantEmailActionForAccount({
   chatMessageId,
   toolCallId,
   actionType,
+  contentOverride,
   emailAccountId,
   provider,
   logger,
@@ -82,6 +90,7 @@ export async function confirmAssistantEmailActionForAccount({
   chatMessageId: string;
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
+  contentOverride?: string;
   emailAccountId: string;
   provider: string;
   logger: Logger;
@@ -116,6 +125,7 @@ export async function confirmAssistantEmailActionForAccount({
       output: reservation.output,
       emailProvider,
       emailAccountId,
+      contentOverride,
     });
   } catch (error) {
     await clearAssistantEmailPartProcessing({
@@ -170,10 +180,12 @@ async function executeAssistantEmailAction({
   output,
   emailProvider,
   emailAccountId,
+  contentOverride,
 }: {
   output: AssistantPendingEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   emailAccountId: string;
+  contentOverride?: string;
 }): Promise<AssistantEmailConfirmationResult> {
   const confirmedAt = new Date().toISOString();
 
@@ -184,18 +196,21 @@ async function executeAssistantEmailAction({
         emailProvider,
         emailAccountId,
         confirmedAt,
+        contentOverride,
       });
     case "reply_email":
       return confirmPendingReplyEmailAction({
         output,
         emailProvider,
         confirmedAt,
+        contentOverride,
       });
     case "forward_email":
       return confirmPendingForwardEmailAction({
         output,
         emailProvider,
         confirmedAt,
+        contentOverride,
       });
   }
 }
@@ -205,22 +220,28 @@ async function confirmPendingSendEmailAction({
   emailProvider,
   emailAccountId,
   confirmedAt,
+  contentOverride,
 }: {
   output: PendingSendEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   emailAccountId: string;
   confirmedAt: string;
+  contentOverride?: string;
 }) {
   const from =
     output.pendingAction.from ||
     (await getFormattedSenderAddress({ emailAccountId }));
+
+  const messageHtml = contentOverride
+    ? plainTextToHtml(contentOverride)
+    : output.pendingAction.messageHtml;
 
   const result = await emailProvider.sendEmailWithHtml({
     to: output.pendingAction.to,
     cc: output.pendingAction.cc || undefined,
     bcc: output.pendingAction.bcc || undefined,
     subject: output.pendingAction.subject,
-    messageHtml: output.pendingAction.messageHtml,
+    messageHtml,
     ...(from ? { from } : {}),
   });
 
@@ -238,15 +259,20 @@ async function confirmPendingReplyEmailAction({
   output,
   emailProvider,
   confirmedAt,
+  contentOverride,
 }: {
   output: PendingReplyEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   confirmedAt: string;
+  contentOverride?: string;
 }) {
   const message = await emailProvider.getMessage(
     output.pendingAction.messageId,
   );
-  await emailProvider.replyToEmail(message, output.pendingAction.content);
+  await emailProvider.replyToEmail(
+    message,
+    contentOverride || output.pendingAction.content,
+  );
 
   const latestMessage = await getLatestMessageInThreadSafe(
     emailProvider,
@@ -267,10 +293,12 @@ async function confirmPendingForwardEmailAction({
   output,
   emailProvider,
   confirmedAt,
+  contentOverride,
 }: {
   output: PendingForwardEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   confirmedAt: string;
+  contentOverride?: string;
 }) {
   const message = await emailProvider.getMessage(
     output.pendingAction.messageId,
@@ -279,7 +307,7 @@ async function confirmPendingForwardEmailAction({
     to: output.pendingAction.to,
     cc: output.pendingAction.cc || undefined,
     bcc: output.pendingAction.bcc || undefined,
-    content: output.pendingAction.content || undefined,
+    content: contentOverride || output.pendingAction.content || undefined,
   });
 
   const latestMessage = await getLatestMessageInThreadSafe(
@@ -772,6 +800,14 @@ function parsePendingForwardEmailOutput(output: unknown) {
 function getOutputWithoutProcessingMetadata(output: Record<string, unknown>) {
   const { confirmationProcessingAt: _, ...rest } = output;
   return rest;
+}
+
+function plainTextToHtml(text: string) {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped.replace(/\n/g, "<br>");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -103,6 +103,7 @@ export const confirmAssistantEmailActionBody = z.object({
   chatMessageId: z.string().trim().min(1),
   toolCallId: z.string().trim().min(1),
   actionType: assistantPendingEmailActionTypeSchema,
+  contentOverride: z.string().trim().min(1).optional(),
 });
 export type ConfirmAssistantEmailActionBody = z.infer<
   typeof confirmAssistantEmailActionBody


### PR DESCRIPTION
# User description
## Summary
- Adds `contentOverride` field to the email confirmation action so user edits in the chat email card are actually sent to the email provider
- Threads the override through all three action types (send, reply, forward)
- For send_email, converts edited plain text back to HTML
- Removes the unused original message snippet section (backend never populates `reference.snippet`)
- Cleans up unused imports

## Test plan
- [ ] Edit an email draft in the chat card and send — verify the edited text is what gets sent
- [ ] Send without editing — verify original draft is sent unchanged
- [ ] Test reply and forward edit flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Propagate edited email drafts from <code>EmailActionResult</code> through <code>confirmAssistantEmailAction</code> into each provider-confirming helper so sends, replies, and forwards honor the <code>contentOverride</code>. Convert plain-text overrides to HTML in <code>confirmPendingSendEmailAction</code> while trimming the unused snippet UI so the confirmed message matches the chat edits.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1830?tool=ast&topic=Send+conversion>Send conversion</a>
        </td><td>Convert edited plain text to HTML in <code>confirmPendingSendEmailAction</code> and remove the unused snippet presentation so the UI and send flow reflect the same edited content.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(landing)/components/tools/page.tsx</li>
<li>apps/web/utils/actions/assistant-chat.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1830?tool=ast&topic=Draft+override+flow>Draft override flow</a>
        </td><td>Capture edits in <code>EmailActionResult</code> and thread the <code>contentOverride</code> through <code>confirmAssistantEmailAction</code>, <code>executeAssistantEmailAction</code>, and the pending confirmation helpers so send, reply, and forward flows each receive the edited body.<details><summary>Modified files (3)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li>
<li>apps/web/utils/actions/assistant-chat.ts</li>
<li>apps/web/utils/actions/assistant-chat.validation.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1830?tool=ast>(Baz)</a>.