### PR TITLE
Use existing string helpers and persist edits in chat history

### DIFF
--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -7,6 +7,7 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
+import { convertNewlinesToBr, escapeHtml } from "@/utils/string";
 import {
   type AssistantEmailConfirmationResult,
   type AssistantPendingEmailActionType,
@@ -151,6 +152,7 @@ export async function confirmAssistantEmailActionForAccount({
     parts: reservation.parts,
     partIndex: reservation.partIndex,
     confirmationResult,
+    contentOverride,
   });
 
   try {
@@ -233,7 +235,7 @@ async function confirmPendingSendEmailAction({
     (await getFormattedSenderAddress({ emailAccountId }));
 
   const messageHtml = contentOverride
-    ? plainTextToHtml(contentOverride)
+    ? convertNewlinesToBr(escapeHtml(contentOverride))
     : output.pendingAction.messageHtml;
 
   const result = await emailProvider.sendEmailWithHtml({
@@ -366,10 +368,12 @@ function updateAssistantEmailPartWithConfirmation({
   parts,
   partIndex,
   confirmationResult,
+  contentOverride,
 }: {
   parts: unknown[];
   partIndex: number;
   confirmationResult: AssistantEmailConfirmationResult;
+  contentOverride?: string;
 }) {
   return updateAssistantEmailPartOutput({
     parts,
@@ -379,6 +383,12 @@ function updateAssistantEmailPartWithConfirmation({
       confirmationState: "confirmed",
       confirmationResult,
     },
+    pendingActionPatch: contentOverride
+      ? getPendingActionContentPatch(
+          confirmationResult.actionType,
+          contentOverride,
+        )
+      : undefined,
   });
 }
 
@@ -632,10 +642,12 @@ function updateAssistantEmailPartOutput({
   parts,
   partIndex,
   outputPatch,
+  pendingActionPatch,
 }: {
   parts: unknown[];
   partIndex: number;
   outputPatch: Record<string, unknown>;
+  pendingActionPatch?: Record<string, unknown>;
 }) {
   return parts.map((part, index) => {
     if (index !== partIndex || !isRecord(part)) return part;
@@ -643,12 +655,22 @@ function updateAssistantEmailPartOutput({
     const existingOutput = isRecord(part.output) ? part.output : {};
     const outputWithoutProcessing =
       getOutputWithoutProcessingMetadata(existingOutput);
+
+    const patchedOutput = {
+      ...outputWithoutProcessing,
+      ...outputPatch,
+    };
+
+    if (pendingActionPatch && isRecord(patchedOutput.pendingAction)) {
+      patchedOutput.pendingAction = {
+        ...patchedOutput.pendingAction,
+        ...pendingActionPatch,
+      };
+    }
+
     return {
       ...part,
-      output: {
-        ...outputWithoutProcessing,
-        ...outputPatch,
-      },
+      output: patchedOutput,
     };
   });
 }
@@ -802,12 +824,14 @@ function getOutputWithoutProcessingMetadata(output: Record<string, unknown>) {
   return rest;
 }
 
-function plainTextToHtml(text: string) {
-  const escaped = text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-  return escaped.replace(/\n/g, "<br>");
+function getPendingActionContentPatch(
+  actionType: AssistantPendingEmailActionType,
+  contentOverride: string,
+): Record<string, string> {
+  if (actionType === "send_email") {
+    return { messageHtml: convertNewlinesToBr(escapeHtml(contentOverride)) };
+  }
+  return { content: contentOverride };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
# User description
## Summary
- Replace custom `plainTextToHtml` with existing `escapeHtml`/`convertNewlinesToBr` from `utils/string.ts`
- Persist edited email content in chat message parts so users see what was actually sent
- Add `getPendingActionContentPatch` helper to compute the correct field patch per action type

## Test plan
- [ ] Edit an email draft in chat, confirm send, verify the edited content is sent
- [ ] Verify chat history shows the edited content after confirmation
- [ ] Verify non-edited emails still send correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace the custom HTML conversion in the assistant email confirmation flow with the shared string helpers so pending send actions always produce safe HTML content. Persist any user edits by patching the chat output’s pending action fields so history and outgoing messages reflect what was actually confirmed.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1832?tool=ast&topic=Send+Content>Send Content</a>
        </td><td>Update the assistant send workflow to run content updates through <code>escapeHtml</code>/<code>convertNewlinesToBr</code> so <code>confirmPendingSendEmailAction</code> always delivers safe HTML when <code>contentOverride</code> is provided.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/actions/assistant-chat.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Wire-edited-email-cont...</td><td>March 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1832?tool=ast&topic=History+Patch>History Patch</a>
        </td><td>Persist edited drafts in the chat by patching the output’s pending action via <code>getPendingActionContentPatch</code>, which records the confirmed <code>messageHtml</code> or <code>content</code> depending on the action type.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/actions/assistant-chat.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Wire-edited-email-cont...</td><td>March 09, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1832?tool=ast>(Baz)</a>.