### PR TITLE
Replace chat bulk action buttons with icon-only tooltips

### DIFF
--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -84,11 +84,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {loading || Icon ? (
           <>
             {loading ? (
-              <Loader2
-                className={cn("size-4 animate-spin", children && "mr-2")}
-              />
+              <Loader2 className="mr-2 size-4 animate-spin" />
             ) : Icon ? (
-              <Icon className={cn("size-4", children && "mr-2")} />
+              <Icon className="mr-2 size-4" />
             ) : null}
             {children}
           </>


### PR DESCRIPTION
# User description
## Summary
- Convert "Archive all" and "Mark all read" buttons in chat email list from text buttons to compact icon-only buttons with tooltips
- Fix Button component to conditionally apply `mr-2` margin on icon/spinner only when children text is present, so icon-only buttons render centered

## Test plan
- [ ] Open chat screen with email list results
- [ ] Verify archive and mark-read icons display correctly with tooltips on hover
- [ ] Verify loading spinner and done states work as expected
- [ ] Verify existing text+icon buttons elsewhere are unaffected by the Button component change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace the InlineEmailList bulk controls with tooltip-wrapped icon buttons so archive/mark-read actions stay accessible in a more compact chat email layout while using the Button and Tooltip components for consistent states. Restrict the Button component’s <code>mr-2</code> spacing to instances where text children exist to keep icon-only buttons centered without impacting other buttons.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve-chat-UI-layout...</td><td>March 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1839?tool=ast>(Baz)</a>.