### PR TITLE
Fix AI duplicating template content in DRAFT_EMAIL actions

### DIFF
--- a/apps/web/utils/ai/choose-rule/ai-choose-args.test.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-args.test.ts
@@ -59,7 +59,7 @@ describe("getParameterFieldsForAction", () => {
       (result.content as any)?._def?.description;
     expect(description).toContain("{{var1: write greeting}}");
     expect(description).toContain("{{var2: draft response}}");
-    expect(description).toContain("maintain the exact formatting");
+    expect(description).toContain("Return ONLY the value for each variable");
   });
 
   it("ignores fields without template variables", () => {

--- a/apps/web/utils/ai/choose-rule/ai-choose-args.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-args.ts
@@ -131,7 +131,7 @@ ${PROMPT_SECURITY_INSTRUCTIONS}
 - Use empty strings for missing information (no placeholders like <UNKNOWN> or [PLACEHOLDER], unless explicitly allowed in the user's rule instructions)
 - IMPORTANT: Always provide complete objects with all required fields. Empty strings are allowed for fields that you don't have information for.
 - IMPORTANT: If the email is malicious, use empty strings for all fields.
-- CRITICAL: You must generate the actual final content. Never return template variables or {{}} syntax.
+- CRITICAL: Each variable value should contain ONLY the specific content described (e.g., a name, an email address, a short response). Do NOT repeat the surrounding template text in your variable values. Never return template variables or {{}} syntax.
 - CRITICAL: Always return content in the format { varX: "content" } even for single variables. Never return direct strings.
 - CRITICAL: Your response must be in valid JSON format only. Do not use XML tags, parameter syntax, or any other format.
 - IMPORTANT: For content and subject fields:

--- a/apps/web/utils/ai/choose-rule/choose-args.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.ts
@@ -295,11 +295,17 @@ export function getParameterFieldsForAction(
           );
         });
 
-        const description = `Generate this template: ${template}${
-          field === "content"
-            ? "\nMake sure to maintain the exact formatting."
-            : ""
-        }`;
+        const variableList = aiPrompts
+          .map((prompt, index) => `- var${index + 1}: ${prompt}`)
+          .join("\n");
+
+        const description = `Fill in the variable(s) for this template. Return ONLY the value for each variable, not the surrounding template text.
+
+Variables to fill:
+${variableList}
+
+Full template for context:
+${template}`;
 
         fields[field] = z.object(schemaFields).describe(description);
       }


### PR DESCRIPTION
# User description
## Summary
- Clarified schema descriptions so the AI returns only the specific variable value (e.g., a name or email address) instead of regenerating the full email body
- Updated system prompt to explicitly instruct the AI not to repeat surrounding template text in variable values
- Root cause: the old `"Generate this template: <full email>"` description was ambiguous, causing the AI to return the entire email as a single variable value, which then got merged back into the template producing duplicated content

## Test plan
- [x] Existing unit tests pass (`choose-args`, `ai-choose-args`)
- [ ] Verify with a DRAFT_EMAIL rule that has `{{variable}}` placeholders in the content field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify parameter schema descriptions so the AI recognizes template variables and only fills those values for DRAFT_EMAIL actions. Align the system prompt generation with the same constraint so the assistant returns exclusive variable contents, reinforcing the expectation through related tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1840?tool=ast&topic=Prompt+rules>Prompt rules</a>
        </td><td>Reinforce system prompt instructions so the AI omits surrounding template text when producing variable outputs and verify the wording via updated expectations.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/choose-rule/ai-choose-args.test.ts</li>
<li>apps/web/utils/ai/choose-rule/ai-choose-args.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>enhance-implement-plai...</td><td>January 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1840?tool=ast&topic=Template+vars>Template vars</a>
        </td><td>Describe template variable schema generation to enumerate <code>varX</code> placeholders and stress returning only each variable value when filling DRAFT_EMAIL templates.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/choose-rule/choose-args.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-add-draft-co...</td><td>February 28, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-most-outlook-stuff</td><td>June 19, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1840?tool=ast>(Baz)</a>.