### PR TITLE
Skip inbox filter creation for non-recent signups

### DIFF
--- a/apps/web/utils/actions/whitelist.ts
+++ b/apps/web/utils/actions/whitelist.ts
@@ -5,12 +5,26 @@ import { GmailLabel } from "@/utils/gmail/label";
 import { actionClient } from "@/utils/actions/safe-action";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { createEmailProvider } from "@/utils/email/provider";
+import prisma from "@/utils/prisma";
+
+const RECENT_SIGNUP_DAYS = 1;
 
 export const whitelistInboxZeroAction = actionClient
   .metadata({ name: "whitelistInboxZero" })
-  .action(async ({ ctx: { emailAccountId, provider, logger } }) => {
+  .action(async ({ ctx: { emailAccountId, userId, provider, logger } }) => {
     if (!env.WHITELIST_FROM) return;
     if (!isGoogleProvider(provider)) return;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true },
+    });
+
+    if (!user) return;
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - RECENT_SIGNUP_DAYS);
+    if (user.createdAt < cutoff) return;
 
     const emailProvider = await createEmailProvider({
       emailAccountId,


### PR DESCRIPTION
# User description
## Summary
- Only create the whitelist Gmail filter for users who signed up within the last day
- Existing users are no longer affected by this filter creation on each session

## Test plan
- [ ] New user signup: verify filter is created
- [ ] Existing user (>1 day old): verify filter is not created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Restrict the <code>whitelistInboxZeroAction</code> flow that seeds Gmail filters so it only runs for accounts created within <code>RECENT_SIGNUP_DAYS</code>, using the <code>prisma</code> client to load the requesting user's <code>createdAt</code> timestamp. Skip filter creation for older accounts so <code>createEmailProvider</code> is invoked only for new users and existing sessions stop receiving redundant whitelist operations.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Skip-inbox-filter-crea...</td><td>March 10, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor-and-PR-feedback</td><td>August 14, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1842?tool=ast>(Baz)</a>.