### PR TITLE
Fix Outlook bulk archive not finding emails

### DIFF
--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -759,17 +759,17 @@ export class OutlookProvider implements EmailProvider {
       });
       const inboxFolderId = folderIds.inbox;
 
-      const escapedThreadId = escapeODataString(threadId);
-      const filterParts = [`conversationId eq '${escapedThreadId}'`];
-      if (inboxFolderId) {
-        filterParts.push(
-          `parentFolderId eq '${escapeODataString(inboxFolderId)}'`,
-        );
+      if (!inboxFolderId) {
+        throw new Error("Could not resolve inbox folder ID");
       }
+
+      const escapedThreadId = escapeODataString(threadId);
 
       const response = await client
         .api("/me/messages")
-        .filter(filterParts.join(" and "))
+        .filter(
+          `conversationId eq '${escapedThreadId}' and parentFolderId eq '${escapeODataString(inboxFolderId)}'`,
+        )
         .select(MESSAGE_SELECT_FIELDS)
         .get();
 

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -193,9 +193,10 @@ export async function moveMessagesForSenders({
     });
     inboxFolderId = folderIds.inbox;
     if (!inboxFolderId) {
-      logger.warn(
-        "Could not resolve inbox folder ID — archiving all messages from senders without folder filter",
+      logger.error(
+        "Could not resolve inbox folder ID — aborting bulk archive to avoid archiving from all folders",
       );
+      return;
     }
   }
 
@@ -205,10 +206,9 @@ export async function moveMessagesForSenders({
     const processedMessageIds = new Set<string>();
     const publishedThreadIds = new Set<string>();
     const fromFilter = `from/emailAddress/address eq '${escapeODataString(sender)}'`;
-    const filterExpression =
-      action === "archive" && inboxFolderId
-        ? `${fromFilter} and parentFolderId eq '${escapeODataString(inboxFolderId)}'`
-        : fromFilter;
+    const filterExpression = inboxFolderId
+      ? `${fromFilter} and parentFolderId eq '${escapeODataString(inboxFolderId)}'`
+      : fromFilter;
 
     // Use @odata.nextLink directly for pagination instead of extracting $skiptoken
     // This is more reliable as Microsoft Graph may use different token formats


### PR DESCRIPTION
# User description
## Summary
- Fixed OData filters comparing `parentFolderId` against well-known folder names (e.g. `'inbox'`) instead of actual folder IDs (GUIDs), which caused the filter to match zero messages
- Applied the fix across all three affected locations: `moveMessagesForSenders` (bulk archive), `getThreadMessagesInInbox`, and `getThreadsWithQuery`
- Added `escapeODataString` to a previously unescaped `labelId` interpolation

## Test plan
- [ ] Verify Outlook bulk archive finds and archives emails from a sender
- [ ] Verify chat AI bulk archive tool works for Outlook accounts
- [ ] Verify inbox thread listing works correctly for Outlook accounts
- [ ] Check Axiom logs to confirm filter expressions contain real folder GUIDs

Closes INB-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolve Outlook folder IDs before building message filters in <code>OutlookProvider</code> so threaded queries match real inbox and archive folders. Update <code>moveMessagesForSenders</code> to bail when the inbox ID can’t be found and to filter bulk archival queries using the resolved GUID.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1844?tool=ast&topic=Folder+Filters>Folder Filters</a>
        </td><td>Resolve Outlook folder IDs when querying threads or lists so filters compare against real folder GUIDs instead of well-known names.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/email/microsoft.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Simplify-AI-chat-email...</td><td>March 04, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Fix-auto-filer-reply-s...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1844?tool=ast&topic=Bulk+Archive>Bulk Archive</a>
        </td><td>Ensure bulk archive filters reference the resolved inbox GUID and abort when it cannot be determined to avoid wide archive sweeps.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/batch.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>logger</td><td>December 18, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1844?tool=ast>(Baz)</a>.