### PR TITLE
Fix email list rendered as raw XML in AI chat

### DIFF
--- a/apps/web/components/ai-elements/response.tsx
+++ b/apps/web/components/ai-elements/response.tsx
@@ -25,6 +25,7 @@ export const Response = memo(
       allowedTags={customAllowedTags}
       components={customComponents}
       literalTagContent={customLiteralContent}
+      normalizeHtmlIndentation
       {...props}
     />
   ),


### PR DESCRIPTION
# User description
## Summary
- Enable `normalizeHtmlIndentation` on the Streamdown markdown renderer to prevent AI-generated custom XML tags from being treated as code blocks when indented 4+ spaces
- Fixes issue where inline email card lists appeared as raw XML text instead of interactive components

## Test plan
- [ ] Open AI chat and trigger an email triage/inbox summary response
- [ ] Verify `<emails>`/`<email>` tags render as interactive inline email cards, not raw XML
- [ ] Verify non-indented XML tags still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable <code>normalizeHtmlIndentation</code> on the <code>Streamdown</code> renderer within the AI response pipeline so <code><emails></code>/<code><email></code> tags continue to render as interactive cards instead of raw XML. Keep custom literal handling intact while avoiding code-block treatment for indented XML tags.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-inline-email-cards...</td><td>March 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1845?tool=ast>(Baz)</a>.