### PR TITLE
calendar: fix stale onboarding redirect on calendars page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
@@ -1,24 +1,10 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 import { PageWrapper } from "@/components/PageWrapper";
 import { PageHeader } from "@/components/PageHeader";
 import { CalendarConnections } from "./CalendarConnections";
 import { CalendarSettings } from "./CalendarSettings";
 import { TimezoneDetector } from "./TimezoneDetector";
-import { CALENDAR_ONBOARDING_RETURN_COOKIE } from "@/utils/calendar/constants";
-import { isInternalPath } from "@/utils/path";
 
 export default async function CalendarsPage() {
-  const cookieStore = await cookies();
-  const returnPathCookie = cookieStore.get(CALENDAR_ONBOARDING_RETURN_COOKIE);
-
-  if (returnPathCookie?.value) {
-    const returnPath = decodeURIComponent(returnPathCookie.value);
-    if (isInternalPath(returnPath)) {
-      redirect(returnPath);
-    }
-  }
-
   return (
     <PageWrapper>
       <TimezoneDetector />

--- a/apps/web/utils/calendar/handle-calendar-callback.ts
+++ b/apps/web/utils/calendar/handle-calendar-callback.ts
@@ -4,7 +4,6 @@ import type { Logger } from "@/utils/logger";
 import type { CalendarOAuthProvider } from "./oauth-types";
 import {
   validateOAuthCallback,
-  buildCalendarRedirectUrl,
   checkExistingConnection,
   createCalendarConnection,
 } from "./oauth-callback-helpers";
@@ -34,17 +33,19 @@ export async function handleCalendarCallback(
 
   try {
     // Step 1: Validate OAuth callback parameters
-    const { code, response, calendarState } = await validateOAuthCallback(
-      request,
-      logger,
-    );
+    const {
+      code,
+      response,
+      calendarState,
+      redirectUrl: finalRedirectUrl,
+    } = await validateOAuthCallback(request, logger);
     redirectHeaders = response.headers;
 
     // Step 1.5: Check for duplicate OAuth code processing
     const cachedResult = await getOAuthCodeResult(code);
     if (cachedResult) {
       logger.info("OAuth code already processed, returning cached result");
-      const cachedRedirectUrl = new URL("/calendars", env.NEXT_PUBLIC_BASE_URL);
+      const cachedRedirectUrl = new URL(finalRedirectUrl);
       for (const [key, value] of Object.entries(cachedResult.params)) {
         cachedRedirectUrl.searchParams.set(key, value);
       }
@@ -59,7 +60,7 @@ export async function handleCalendarCallback(
     const acquiredLock = await acquireOAuthCodeLock(code);
     if (!acquiredLock) {
       logger.info("OAuth code is being processed by another request");
-      const lockRedirectUrl = new URL("/calendars", env.NEXT_PUBLIC_BASE_URL);
+      const lockRedirectUrl = new URL(finalRedirectUrl);
       response.cookies.delete(CALENDAR_STATE_COOKIE_NAME);
       return redirectWithMessage(
         lockRedirectUrl,
@@ -69,9 +70,6 @@ export async function handleCalendarCallback(
     }
 
     const { emailAccountId } = calendarState;
-
-    // Step 3: Update redirect URL to include emailAccountId
-    const finalRedirectUrl = buildCalendarRedirectUrl(emailAccountId);
 
     // Step 4: Verify user owns this email account
     await verifyEmailAccountAccess(

--- a/apps/web/utils/calendar/oauth-callback-helpers.test.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildCalendarRedirectUrl,
   extractAadstsCode,
   getSafeOAuthErrorDescription,
+  getCalendarRedirectPath,
   mapCalendarOAuthError,
 } from "./oauth-callback-helpers";
 
@@ -83,6 +85,60 @@ describe("calendar OAuth callback helpers", () => {
 
     it("returns null when no AADSTS code is present", () => {
       expect(getSafeOAuthErrorDescription("Something else")).toBeNull();
+    });
+  });
+
+  describe("getCalendarRedirectPath", () => {
+    it("falls back to the calendars page when no return path is provided", () => {
+      expect(getCalendarRedirectPath("acc_123")).toBe("/acc_123/calendars");
+    });
+
+    it("uses a same-account onboarding return path", () => {
+      expect(
+        getCalendarRedirectPath(
+          "acc_123",
+          encodeURIComponent("/acc_123/onboarding-brief?step=2"),
+        ),
+      ).toBe("/acc_123/onboarding-brief?step=2");
+    });
+
+    it("ignores return paths for a different account", () => {
+      expect(
+        getCalendarRedirectPath(
+          "acc_123",
+          encodeURIComponent("/acc_456/briefs"),
+        ),
+      ).toBe("/acc_123/calendars");
+    });
+
+    it("ignores return paths that normalize into a different account", () => {
+      expect(
+        getCalendarRedirectPath(
+          "acc_123",
+          encodeURIComponent("/acc_123/../acc_456/briefs"),
+        ),
+      ).toBe("/acc_123/calendars");
+    });
+
+    it("ignores external return paths", () => {
+      expect(
+        getCalendarRedirectPath(
+          "acc_123",
+          encodeURIComponent("https://example.com/briefs"),
+        ),
+      ).toBe("/acc_123/calendars");
+    });
+  });
+
+  describe("buildCalendarRedirectUrl", () => {
+    it("preserves same-account return path query params", () => {
+      const redirectUrl = buildCalendarRedirectUrl(
+        "acc_123",
+        encodeURIComponent("/acc_123/onboarding-brief?step=2"),
+      );
+
+      expect(redirectUrl.pathname).toBe("/acc_123/onboarding-brief");
+      expect(redirectUrl.searchParams.get("step")).toBe("2");
     });
   });
 });

--- a/apps/web/utils/calendar/oauth-callback-helpers.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.ts
@@ -2,9 +2,12 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import prisma from "@/utils/prisma";
-import { CALENDAR_STATE_COOKIE_NAME } from "@/utils/calendar/constants";
+import {
+  CALENDAR_ONBOARDING_RETURN_COOKIE,
+  CALENDAR_STATE_COOKIE_NAME,
+} from "@/utils/calendar/constants";
 import { parseOAuthState } from "@/utils/oauth/state";
-import { prefixPath } from "@/utils/path";
+import { isInternalPath, prefixPath } from "@/utils/path";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
 import type {
@@ -39,6 +42,7 @@ export async function validateOAuthCallback(
   const response = NextResponse.redirect(baseRedirectUrl);
 
   response.cookies.delete(CALENDAR_STATE_COOKIE_NAME);
+  response.cookies.delete(CALENDAR_ONBOARDING_RETURN_COOKIE);
 
   if (!storedState || !receivedState || storedState !== receivedState) {
     logger.warn("Invalid state during calendar callback", {
@@ -56,7 +60,10 @@ export async function validateOAuthCallback(
     response.headers,
   );
 
-  const redirectUrl = buildCalendarRedirectUrl(calendarState.emailAccountId);
+  const redirectUrl = buildCalendarRedirectUrl(
+    calendarState.emailAccountId,
+    request.cookies.get(CALENDAR_ONBOARDING_RETURN_COOKIE)?.value,
+  );
 
   if (oauthError) {
     const aadstsCode = extractAadstsCode(errorDescription);
@@ -122,11 +129,42 @@ export function parseAndValidateCalendarState(
 /**
  * Build redirect URL with emailAccountId
  */
-export function buildCalendarRedirectUrl(emailAccountId: string): URL {
+export function buildCalendarRedirectUrl(
+  emailAccountId: string,
+  onboardingReturnPath?: string,
+): URL {
   return new URL(
-    prefixPath(emailAccountId, "/calendars"),
+    getCalendarRedirectPath(emailAccountId, onboardingReturnPath),
     env.NEXT_PUBLIC_BASE_URL,
   );
+}
+
+export function getCalendarRedirectPath(
+  emailAccountId: string,
+  onboardingReturnPath?: string,
+): string {
+  const defaultPath = prefixPath(emailAccountId, "/calendars");
+  if (!onboardingReturnPath) return defaultPath;
+
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(onboardingReturnPath);
+  } catch {
+    return defaultPath;
+  }
+
+  if (!isInternalPath(decodedPath)) return defaultPath;
+
+  const normalizedUrl = new URL(decodedPath, env.NEXT_PUBLIC_BASE_URL);
+  const normalizedPath = normalizedUrl.pathname;
+  if (
+    normalizedPath !== `/${emailAccountId}` &&
+    !normalizedPath.startsWith(`/${emailAccountId}/`)
+  ) {
+    return defaultPath;
+  }
+
+  return `${normalizedPath}${normalizedUrl.search}${normalizedUrl.hash}`;
 }
 
 /**


### PR DESCRIPTION
# User description
Direct visits to the calendars page were reusing a stale onboarding return cookie, which could send users to the wrong page and switch the active account. This moves that redirect handling into the calendar OAuth callback so it is consumed once and scoped to the correct account.

- stop redirecting from the calendars page based on a lingering return cookie
- consume and clear the return cookie inside the OAuth callback and reuse that target for duplicate callback paths
- normalize and validate same-account return paths, with regression tests for cross-account and traversal cases

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Move onboarding redirect handling into <code>handleCalendarCallback</code> so <code>validateOAuthCallback</code> consumes and clears <code>CALENDAR_ONBOARDING_RETURN_COOKIE</code> while <code>CalendarsPage</code> solely renders the calendar UI. Normalize <code>getCalendarRedirectPath</code> to ensure return paths stay within the target account and cover the logic with regression tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1849?tool=ast&topic=OAuth+callback+cleanup>OAuth callback cleanup</a>
        </td><td>Update <code>handleCalendarCallback</code> so <code>validateOAuthCallback</code> clears <code>CALENDAR_ONBOARDING_RETURN_COOKIE</code>, returns a <code>finalRedirectUrl</code>, and cached/lock paths reuse that target while <code>CalendarsPage</code> no longer redirects based on stale cookies.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/calendars/page.tsx</li>
<li>apps/web/utils/calendar/handle-calendar-callback.ts</li>
<li>apps/web/utils/calendar/oauth-callback-helpers.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-add-project-spec...</td><td>February 05, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Use-outlook-endpoint</td><td>October 09, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1849?tool=ast&topic=Redirect+path+validation>Redirect path validation</a>
        </td><td>Validate <code>getCalendarRedirectPath</code> to only accept same-account internal return paths, rejecting cross-account or external navigation, and exercise the cases with regression tests.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/calendar/oauth-callback-helpers.test.ts</li>
<li>apps/web/utils/calendar/oauth-callback-helpers.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-add-project-spec...</td><td>February 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1849?tool=ast>(Baz)</a>.