### PR TITLE
follow-up: remove stale drafts after replies

### DIFF
--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -270,13 +270,16 @@ describe("clearFollowUpLabel", () => {
     vi.clearAllMocks();
   });
 
-  it("removes label and clears tracker when thread has follow-up label in DB", async () => {
+  it("removes label and clears tracker when thread has follow-up applied", async () => {
     const mockProvider = createMockEmailProvider({
       getLabelByName: vi
         .fn()
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
 
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: null },
+    ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
 
     await clearFollowUpLabel({
@@ -286,12 +289,164 @@ describe("clearFollowUpLabel", () => {
       logger,
     });
 
-    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+    expect(prisma.threadTracker.findMany).toHaveBeenCalledWith({
       where: {
         emailAccountId: "account-1",
         threadId: "thread-1",
-        followUpAppliedAt: { not: null },
-        resolved: false,
+        OR: [
+          { followUpAppliedAt: { not: null } },
+          { followUpDraftId: { not: null } },
+        ],
+      },
+      select: {
+        id: true,
+        followUpDraftId: true,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpAppliedAt: null,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpDraftId: null,
+      },
+    });
+    expect(mockProvider.deleteDraft).not.toHaveBeenCalled();
+    expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
+      "thread-1",
+      "label-123",
+    );
+  });
+
+  it("deletes follow-up draft from provider when tracker has draftId", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+      deleteDraft: vi.fn().mockResolvedValue(undefined),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: "draft-abc" },
+    ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(mockProvider.deleteDraft).toHaveBeenCalledWith("draft-abc");
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpAppliedAt: null,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpDraftId: null,
+      },
+    });
+    expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
+      "thread-1",
+      "label-123",
+    );
+  });
+
+  it("cleans up follow-up state even when the tracker was already resolved", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+      deleteDraft: vi.fn().mockResolvedValue(undefined),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: "draft-abc" },
+    ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.findMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        OR: [
+          { followUpAppliedAt: { not: null } },
+          { followUpDraftId: { not: null } },
+        ],
+      },
+      select: {
+        id: true,
+        followUpDraftId: true,
+      },
+    });
+    expect(mockProvider.deleteDraft).toHaveBeenCalledWith("draft-abc");
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpAppliedAt: null,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpDraftId: null,
+      },
+    });
+  });
+
+  it("preserves follow-up draft id when draft deletion fails", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+      deleteDraft: vi.fn().mockRejectedValue(new Error("Draft not found")),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: "draft-abc" },
+    ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(mockProvider.deleteDraft).toHaveBeenCalledWith("draft-abc");
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
       },
       data: {
         followUpAppliedAt: null,
@@ -303,9 +458,22 @@ describe("clearFollowUpLabel", () => {
     );
   });
 
-  it("does nothing when no trackers updated", async () => {
-    const mockProvider = createMockEmailProvider();
-    prisma.threadTracker.updateMany.mockResolvedValue({ count: 0 });
+  it("only clears draft ids for trackers whose draft cleanup succeeded", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+      deleteDraft: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("Network failure")),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: "draft-abc" },
+      { id: "tracker-2", followUpDraftId: "draft-def" },
+    ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 2 });
 
     await clearFollowUpLabel({
       emailAccountId: "account-1",
@@ -314,6 +482,38 @@ describe("clearFollowUpLabel", () => {
       logger,
     });
 
+    expect(mockProvider.deleteDraft).toHaveBeenNthCalledWith(1, "draft-abc");
+    expect(mockProvider.deleteDraft).toHaveBeenNthCalledWith(2, "draft-def");
+    expect(prisma.threadTracker.updateMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        id: { in: ["tracker-1", "tracker-2"] },
+      },
+      data: {
+        followUpAppliedAt: null,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpDraftId: null,
+      },
+    });
+  });
+
+  it("does nothing when no trackers found", async () => {
+    const mockProvider = createMockEmailProvider();
+    prisma.threadTracker.findMany.mockResolvedValue([]);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
     expect(mockProvider.removeThreadLabel).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -3,6 +3,7 @@ import { withPrismaRetry } from "@/utils/prisma-retry";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 import { FOLLOW_UP_LABEL } from "@/utils/label";
 import type { Logger } from "@/utils/logger";
+import { captureException } from "@/utils/error";
 
 export async function getOrCreateFollowUpLabel(
   provider: EmailProvider,
@@ -124,14 +125,50 @@ export async function clearFollowUpLabel({
   if (!threadId) return;
 
   try {
-    const { count } = await withPrismaRetry(
+    const trackersToClean = await prisma.threadTracker.findMany({
+      where: {
+        emailAccountId,
+        threadId,
+        OR: [
+          { followUpAppliedAt: { not: null } },
+          { followUpDraftId: { not: null } },
+        ],
+      },
+      select: {
+        id: true,
+        followUpDraftId: true,
+      },
+    });
+
+    if (trackersToClean.length === 0) return;
+
+    const trackerIdsToClearDraftId: string[] = [];
+
+    for (const tracker of trackersToClean) {
+      if (!tracker.followUpDraftId) {
+        trackerIdsToClearDraftId.push(tracker.id);
+        continue;
+      }
+
+      try {
+        await provider.deleteDraft(tracker.followUpDraftId);
+        trackerIdsToClearDraftId.push(tracker.id);
+        logger.info("Deleted follow-up draft", {
+          trackerId: tracker.id,
+        });
+      } catch (error) {
+        logger.error("Failed to delete follow-up draft", {
+          trackerId: tracker.id,
+          error,
+        });
+      }
+    }
+
+    await withPrismaRetry(
       () =>
         prisma.threadTracker.updateMany({
           where: {
-            emailAccountId,
-            threadId,
-            followUpAppliedAt: { not: null },
-            resolved: false,
+            id: { in: trackersToClean.map((tracker) => tracker.id) },
           },
           data: {
             followUpAppliedAt: null,
@@ -140,18 +177,30 @@ export async function clearFollowUpLabel({
       { logger },
     );
 
-    if (count === 0) {
-      return;
+    if (trackerIdsToClearDraftId.length > 0) {
+      await withPrismaRetry(
+        () =>
+          prisma.threadTracker.updateMany({
+            where: {
+              id: { in: trackerIdsToClearDraftId },
+            },
+            data: {
+              followUpDraftId: null,
+            },
+          }),
+        { logger },
+      );
     }
 
     logger.info("Removing follow-up label", { threadId });
 
     await removeFollowUpLabel({ provider, threadId, logger });
 
-    logger.info("Removed follow-up label and cleared tracker", {
+    logger.info("Removed follow-up label and cleaned up trackers", {
       threadId,
     });
   } catch (error) {
-    logger.error("Failed to remove follow-up label", { threadId, error });
+    logger.error("Failed to clear follow-up label", { threadId, error });
+    captureException(error, { emailAccountId });
   }
 }


### PR DESCRIPTION
# User description
Clear tracked follow-up drafts when an inbound reply resolves the thread, and keep draft IDs when provider deletion fails so cleanup can retry safely.

- delete tracked follow-up drafts during follow-up label clearing
- clean up follow-up state even when the original tracker was already resolved
- add focused regression coverage for successful and partial-failure cleanup

Tested: cd apps/web && pnpm test --run utils/follow-up/labels.test.ts

Ref: INB-120

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure <code>clearFollowUpLabel</code> now inspects all tracked threads, deletes reachable follow-up drafts via the email provider, preserves draft IDs when deletions fail, logs outcomes, and clears both applied state and draft references in <code>threadTracker</code> before label removal. Improve error capture for label cleanup and validate the updated behavior with regression tests targeting successful, partial, and no-op cleanup scenarios.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1850?tool=ast&topic=Follow-up+Tests>Follow-up Tests</a>
        </td><td>Add regression tests that cover follow-up label removal when drafts exist, when tracker records are resolved, and when draft deletions partially fail.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/follow-up/labels.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>refactor-polish-follow...</td><td>January 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1850?tool=ast&topic=Follow-up+Cleanup>Follow-up Cleanup</a>
        </td><td>Ensure <code>clearFollowUpLabel</code> cleans tracker state by fetching all follow-up trackers, deleting drafts when available, retaining IDs on failures, logging progress, and removing follow-up metadata before removing the label.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/follow-up/labels.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>follow-up-reduce-polli...</td><td>February 25, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow-up-reminders</td><td>January 08, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1850?tool=ast>(Baz)</a>.