### PR TITLE
Add A/B test for hero social proof position

### DIFF
--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -28,6 +28,8 @@ import {
   Badge,
   type BadgeVariant,
 } from "@/components/new-landing/common/Badge";
+import { useHeroLayoutVariant } from "@/hooks/useFeatureFlags";
+import { BrandScroller } from "@/components/new-landing/BrandScroller";
 
 interface HeroProps {
   badge?: React.ReactNode;
@@ -122,5 +124,25 @@ export function HeroVideoPlayer() {
         </div>
       </div>
     </BlurFade>
+  );
+}
+
+export function HeroContent() {
+  const variant = useHeroLayoutVariant();
+
+  if (variant === "social-proof-first") {
+    return (
+      <>
+        <BrandScroller />
+        <HeroVideoPlayer />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <HeroVideoPlayer />
+      <BrandScroller />
+    </>
   );
 }

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Testimonials } from "@/components/new-landing/sections/Testimonials";
-import { Hero, HeroVideoPlayer } from "@/app/(landing)/home/Hero";
+import { Hero, HeroContent } from "@/app/(landing)/home/Hero";
 import { Pricing } from "@/components/new-landing/sections/Pricing";
 import { Awards } from "@/components/new-landing/sections/Awards";
 import { EverythingElseSection } from "@/components/new-landing/sections/EverythingElseSection";
@@ -12,7 +12,6 @@ import { BasicLayout } from "@/components/layouts/BasicLayout";
 import { FAQs } from "@/app/(landing)/home/FAQs";
 import { FinalCTA } from "@/app/(landing)/home/FinalCTA";
 import { WordReveal } from "@/components/new-landing/common/WordReveal";
-import { BrandScroller } from "@/components/new-landing/BrandScroller";
 import { env } from "@/env";
 import { BRAND_NAME } from "@/utils/branding";
 
@@ -50,8 +49,7 @@ export default function NewLanding() {
         }
         subtitle={`${BRAND_NAME} organizes your inbox and calendar, drafts replies in your voice, and helps you reach inbox zero fast. Never miss an important email again.`}
       >
-        <HeroVideoPlayer />
-        <BrandScroller />
+        <HeroContent />
       </Hero>
       <OrganizedInbox
         title={

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -67,3 +67,13 @@ export function useTestimonialsVariant() {
     "control"
   );
 }
+
+export type HeroLayoutVariant = "control" | "social-proof-first";
+
+export function useHeroLayoutVariant() {
+  return (
+    (useFeatureFlagVariantKey(
+      "hero-social-proof-position",
+    ) as HeroLayoutVariant) || "control"
+  );
+}


### PR DESCRIPTION
# User description
## Summary
- Adds a PostHog A/B test variant (`hero-social-proof-position`) to test rendering the brand scroller (social proof) above the video in the landing page hero section
- New `useHeroLayoutVariant` hook in `useFeatureFlags.ts` with `control` and `social-proof-first` variants
- New `HeroContent` component in `Hero.tsx` that conditionally reorders the video and brand scroller based on the active variant

## Test plan
- [ ] Create `hero-social-proof-position` experiment in PostHog with `social-proof-first` variant
- [ ] Verify control renders video then brand scroller (unchanged behavior)
- [ ] Verify `social-proof-first` variant renders brand scroller above video
- [ ] Confirm no layout shift thanks to existing BlurFade animation delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a hero layout variant hook that reads the <code>hero-social-proof-position</code> PostHog experiment so the landing hero can decide whether to surface the brand scroller or video first. Render the new <code>HeroContent</code> structure inside the hero section so the brand scroller and video swap order when the <code>social-proof-first</code> variant is active.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1851?tool=ast&topic=Hero+Content+Order>Hero Content Order</a>
        </td><td>Reorder hero video and brand scroller inside <code>HeroContent</code> to show the social proof block first when the experiment variant dictates.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(landing)/home/Hero.tsx</li>
<li>apps/web/app/(landing)/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-lint-errors-across...</td><td>March 08, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix-up-animations-in-hero</td><td>November 16, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1851?tool=ast&topic=Hero+Layout+Variant>Hero Layout Variant</a>
        </td><td>Provide hero layout variant hook that resolves the <code>hero-social-proof-position</code> experiment and defaults to control.<details><summary>Modified files (1)</summary><ul><li>apps/web/hooks/useFeatureFlags.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-reorganize-sideb...</td><td>February 09, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix-useCleanerEnabled-...</td><td>December 30, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1851?tool=ast>(Baz)</a>.