### PR TITLE
Fix chat draft reply language to match email thread

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -130,7 +130,7 @@ ${
   emailSendToolsEnabled
     ? `${getSendEmailSurfacePolicy({ responseSurface, messagingPlatform })}
 - When the user asks to "draft" an email or reply, use sendEmail/replyEmail/forwardEmail. The pending-action confirmation flow acts as a draft — the user reviews and confirms before anything is sent.
-- When replying to a thread, write the reply in the same language as the latest message in the thread, not the chat language.
+- When replying to a thread, write the reply in the same language as the latest message in the thread.
 - When the user asks to forward an existing email, use forwardEmail with a messageId from searchInbox results. Do not recreate forwards with sendEmail.
 - When the user asks to reply to an existing email, use replyEmail with a messageId from searchInbox results. Do not recreate replies with sendEmail.
 - Only send emails when the user clearly asks to send now.


### PR DESCRIPTION
# User description
## Summary
- Chat assistant was drafting email replies in the language the user was chatting in, instead of the language of the email thread being replied to
- Added instruction to the chat system prompt to write reply content in the same language as the latest message in the thread, keeping chat language and email language as separate contexts

Fixes INB-118

## Test plan
- [ ] Open chat and find an email in a specific language (e.g., English)
- [ ] Ask the chat in a different language (e.g., Portuguese) to draft a reply
- [ ] Verify the draft reply is written in the email's language, not the chat language

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the assistant system prompt so it always drafts replies in the latest thread message language while keeping other email handling rules intact. Maintain guidance for send/reply/forward tools while adding the new language-specific instruction to the assistant behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-AI-to-use-send-too...</td><td>March 10, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1853?tool=ast>(Baz)</a>.