### PR TITLE
Fix email deep link using wrong ID for Outlook provider

### DIFF
--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -89,15 +89,15 @@ describe("getEmailUrlForMessage", () => {
   });
 
   describe("Microsoft provider", () => {
-    it("uses threadId for Microsoft", () => {
+    it("uses messageId for Microsoft", () => {
       const result = getEmailUrlForMessage(
         "messageId123",
         "threadId456",
         "user@outlook.com",
         "microsoft",
       );
-      expect(result).toContain("threadId456");
-      expect(result).not.toContain("messageId123");
+      expect(result).toContain("messageId123");
+      expect(result).not.toContain("threadId456");
     });
   });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -24,7 +24,7 @@ const PROVIDER_CONFIG: Record<
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
       return `${getOutlookBaseUrl()}/inbox/id/${encodedMessageId}`;
     },
-    selectId: (_messageId: string, threadId: string) => threadId,
+    selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, _emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
       return `${getOutlookBaseUrl()}/search/q/${query}`;


### PR DESCRIPTION
# User description
## Summary
- Fixed the "Open in email" button in AI chat redirecting to inbox home instead of opening the specific email
- The Outlook provider's URL builder was using the conversation ID (`threadId`) instead of the individual message ID, causing deep links to fail

## Test plan
- [x] Unit tests updated and passing (`url.test.ts` — 27 tests pass)
- [x] Type-check build passes
- [ ] Manual: Use AI chat to search inbox on an Outlook account, click "Open in email" → should open the specific message

Fixes INB-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Correct Outlook provider URL builder to select message IDs so the AI chat “Open in email” flow deep links to the specific message. Update Microsoft provider tests to assert message IDs are included while thread IDs are excluded for the deep-link URL.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1854?tool=ast&topic=Provider+tests>Provider tests</a>
        </td><td>Update Microsoft provider tests to assert the URL now includes <code>messageId</code> and excludes <code>threadId</code> for Outlook deep links.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/url.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-harden-email-URL-p...</td><td>February 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1854?tool=ast&topic=Outlook+deep+link>Outlook deep link</a>
        </td><td>Fix Outlook URL builder to select message IDs in <code>getEmailUrlForMessage</code> so AI chat deep links open the targeted email instead of the inbox.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/url.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-harden-email-URL-p...</td><td>February 26, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Bugfixes.-Update-readm...</td><td>August 04, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1854?tool=ast>(Baz)</a>.