### PR TITLE
Show active account in Telegram/Teams bot responses

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -676,11 +676,10 @@ async function processMessagingAssistantMessage({
         );
       }
 
-      const rawText = normalizeMessagingAssistantText({
-        text: getUiMessageText(assistantUiMessage),
-      });
       const fullText = prependAccountIndicator({
-        text: rawText,
+        text: normalizeMessagingAssistantText({
+          text: getUiMessageText(assistantUiMessage),
+        }),
         email: emailAccountUser.email,
         hasMultipleAccounts: context.hasMultipleAccounts,
       });
@@ -1838,7 +1837,8 @@ async function resolveLinkedProviderMessagingContext({
   return {
     provider,
     emailAccountId: linkedChannel.emailAccountId,
-    hasMultipleAccounts: candidates.length > 1,
+    hasMultipleAccounts:
+      new Set(candidates.map((c) => c.emailAccountId)).size > 1,
     hasUnsupportedAttachments: identity.hasUnsupportedAttachments,
     imageParts,
     messageText: identity.messageText,


### PR DESCRIPTION
# User description
## Summary
- When a user has multiple accounts connected to Telegram or Teams, bot responses now show which account is active by prepending `[email@example.com]` to each reply
- Only shown when multiple accounts are detected — single-account users see no change
- Helps multi-account users stay oriented, especially after long gaps between interactions

Resolves INB-119

## Test plan
- [ ] Connect multiple accounts to Telegram, send a message — response should show `[email]` prefix
- [ ] Connect a single account to Telegram, send a message — no prefix should appear
- [ ] Use `/switch` to change accounts, send another message — prefix should reflect the new account
- [ ] Verify Slack responses are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add account prefixing to assistant responses by wrapping normalized text from <code>processMessagingAssistantMessage</code> in a <code>prependAccountIndicator</code> call when <code>hasMultipleAccounts</code> is true, keeping Slack context unchanged. Update <code>resolveLinkedProviderMessagingContext</code> to compute <code>hasMultipleAccounts</code> from the linked channels so the bot can target the active account on Telegram and Teams.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>deps-update-packages-a...</td><td>March 06, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1857?tool=ast>(Baz)</a>.