### PR TITLE
Fix email expand error in assistant chat

### DIFF
--- a/apps/web/app/api/threads/[id]/route.ts
+++ b/apps/web/app/api/threads/[id]/route.ts
@@ -27,7 +27,6 @@ export const GET = withEmailProvider(
   "threads/detail",
   async (request, context) => {
     const { emailProvider } = request;
-    const { emailAccountId } = request.auth;
 
     const params = await context.params;
     const { id } = threadQuery.parse(params);
@@ -35,19 +34,7 @@ export const GET = withEmailProvider(
     const { searchParams } = new URL(request.url);
     const includeDrafts = searchParams.get("includeDrafts") === "true";
 
-    try {
-      const thread = await getThread(id, includeDrafts, emailProvider);
-      return NextResponse.json(thread);
-    } catch (error) {
-      request.logger.error("Error fetching thread", {
-        error,
-        emailAccountId,
-        threadId: id,
-      });
-      return NextResponse.json(
-        { error: "Failed to fetch thread" },
-        { status: 500 },
-      );
-    }
+    const thread = await getThread(id, includeDrafts, emailProvider);
+    return NextResponse.json(thread);
   },
 );

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -79,6 +79,7 @@ const fetcher = async (
 
     const errorMessage =
       (errorData.message as string) ||
+      (errorData.error as string) ||
       "An error occurred while fetching the data.";
     const error: Error & { info?: Record<string, unknown>; status?: number } =
       new Error(errorMessage);

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -17,6 +17,7 @@ import {
   NO_REFRESH_TOKEN_ERROR_CODE,
 } from "@/utils/config";
 import { prefixPath } from "@/utils/path";
+import { getSWRFetchErrorMessage } from "./swr-error";
 
 // https://swr.vercel.app/docs/error-handling#status-code-and-error-object
 const fetcher = async (
@@ -77,10 +78,7 @@ const fetcher = async (
       }
     }
 
-    const errorMessage =
-      (errorData.message as string) ||
-      (errorData.error as string) ||
-      "An error occurred while fetching the data.";
+    const errorMessage = getSWRFetchErrorMessage(errorData);
     const error: Error & { info?: Record<string, unknown>; status?: number } =
       new Error(errorMessage);
 

--- a/apps/web/providers/swr-error.test.ts
+++ b/apps/web/providers/swr-error.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getSWRFetchErrorMessage } from "./swr-error";
+
+describe("getSWRFetchErrorMessage", () => {
+  it("returns the message field when it is a string", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        message: "Failed to fetch thread",
+        error: { issues: [{ message: "Validation error" }] },
+      }),
+    ).toBe("Failed to fetch thread");
+  });
+
+  it("returns the error field when it is a string", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        error: "Authorization required. Please grant permissions.",
+      }),
+    ).toBe("Authorization required. Please grant permissions.");
+  });
+
+  it("formats zod-style issues into a readable message", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        error: {
+          issues: [{ message: "Email is required" }, { message: "Invalid ID" }],
+        },
+      }),
+    ).toBe("Email is required, Invalid ID");
+  });
+
+  it("falls back to the default message for non-string non-issues errors", () => {
+    expect(
+      getSWRFetchErrorMessage({
+        error: { detail: "Not directly user-facing" },
+      }),
+    ).toBe("An error occurred while fetching the data.");
+  });
+});

--- a/apps/web/providers/swr-error.ts
+++ b/apps/web/providers/swr-error.ts
@@ -1,0 +1,35 @@
+export function getSWRFetchErrorMessage(
+  errorData: Record<string, unknown>,
+): string {
+  return (
+    getStringValue(errorData.message) ||
+    getStructuredErrorMessage(errorData.error) ||
+    "An error occurred while fetching the data."
+  );
+}
+
+function getStructuredErrorMessage(error: unknown): string | null {
+  if (typeof error === "string") return error;
+  if (!error || typeof error !== "object") return null;
+
+  if ("issues" in error && Array.isArray(error.issues)) {
+    const messages = error.issues
+      .map((issue) => getIssueMessage(issue) || "Validation error")
+      .join(", ");
+
+    return messages || null;
+  }
+
+  return null;
+}
+
+function getStringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function getIssueMessage(issue: unknown): string | null {
+  if (!issue || typeof issue !== "object") return null;
+  return "message" in issue && typeof issue.message === "string"
+    ? issue.message
+    : null;
+}


### PR DESCRIPTION
# User description
## Summary
- Remove redundant try/catch in the thread detail API route that was swallowing provider errors (rate limits, auth expiry, permission issues) and returning a generic 500, preventing the shared `withMiddleware` handler from applying proper error handling
- Fix the SWR fetcher to read API error responses correctly — all API routes return errors under the `error` key but the fetcher only checked `message`, causing every error to display the generic fallback text

Fixes INB-125

## Test plan
- [ ] Open the assistant chat and ask about inbox contents
- [ ] Expand an email item — should now load the email preview
- [ ] If the provider returns an error (e.g. rate limit), verify the user sees the actual error message instead of the generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the thread detail flow by returning the <code>getThread</code> result directly so <code>withMiddleware</code> can report provider errors instead of a hidden 500. Normalize the SWR fetcher so <code>getSWRFetchErrorMessage</code> reads the shared <code>error</code> payload (with structured issue handling) before throwing an error message.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1858?tool=ast&topic=SWR+error+parsing>SWR error parsing</a>
        </td><td>Normalize the SWR fetcher error parsing by using <code>getSWRFetchErrorMessage</code> (plus its smoke tests) to read the shared <code>error</code> payload and format validation issues before raising the error text.<details><summary>Modified files (3)</summary><ul><li>apps/web/providers/SWRProvider.tsx</li>
<li>apps/web/providers/swr-error.test.ts</li>
<li>apps/web/providers/swr-error.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr>
<tr><td>elie222</td><td>catch-sentry-error</td><td>December 19, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1858?tool=ast&topic=Thread+error+flow>Thread error flow</a>
        </td><td>Allow the <code>/api/threads/[id]</code> route to surface provider errors by dropping the redundant catch so <code>withMiddleware</code> can log and relay rate-limit/auth exceptions instead of masking them behind a generic status.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/threads/[id]/route.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-chat-components-sh...</td><td>March 05, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix-all-comments</td><td>July 11, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1858?tool=ast>(Baz)</a>.