### PR TITLE
Fix archive button error in AI chat email cards

### DIFF
--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -34,15 +34,26 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
     if (archiveAllState !== "idle" || threadIds.length === 0) return;
     setArchiveAllState("loading");
     try {
-      await Promise.all(
+      const results = await Promise.all(
         threadIds.map((threadId) =>
           archiveThreadAction(emailAccountId, { threadId }),
         ),
       );
-      toastSuccess({ description: `Archived ${threadIds.length} emails` });
-      setArchiveAllState("done");
+      const failedCount = results.filter((r) => r?.serverError).length;
+      if (failedCount === results.length) {
+        toastError({ description: "Failed to archive emails" });
+        setArchiveAllState("idle");
+      } else if (failedCount > 0) {
+        toastSuccess({
+          description: `Archived ${results.length - failedCount} of ${results.length} emails`,
+        });
+        setArchiveAllState("done");
+      } else {
+        toastSuccess({ description: `Archived ${threadIds.length} emails` });
+        setArchiveAllState("done");
+      }
     } catch {
-      toastError({ description: "Failed to archive some emails" });
+      toastError({ description: "Failed to archive emails" });
       setArchiveAllState("idle");
     }
   }
@@ -51,15 +62,26 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
     if (markReadState !== "idle" || threadIds.length === 0) return;
     setMarkReadState("loading");
     try {
-      await Promise.all(
+      const results = await Promise.all(
         threadIds.map((threadId) =>
           markReadThreadAction(emailAccountId, { threadId, read: true }),
         ),
       );
-      toastSuccess({ description: `Marked ${threadIds.length} as read` });
-      setMarkReadState("done");
+      const failedCount = results.filter((r) => r?.serverError).length;
+      if (failedCount === results.length) {
+        toastError({ description: "Failed to mark emails as read" });
+        setMarkReadState("idle");
+      } else if (failedCount > 0) {
+        toastSuccess({
+          description: `Marked ${results.length - failedCount} of ${results.length} as read`,
+        });
+        setMarkReadState("done");
+      } else {
+        toastSuccess({ description: `Marked ${threadIds.length} as read` });
+        setMarkReadState("done");
+      }
     } catch {
-      toastError({ description: "Failed to mark some emails as read" });
+      toastError({ description: "Failed to mark emails as read" });
       setMarkReadState("idle");
     }
   }
@@ -80,9 +102,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
               loading={archiveAllState === "loading"}
               disabled={archiveAllState === "done"}
               onClick={handleArchiveAll}
-              Icon={
-                archiveAllState === "done" ? CheckIcon : ArchiveIcon
-              }
+              Icon={archiveAllState === "done" ? CheckIcon : ArchiveIcon}
             />
           </Tooltip>
           <Tooltip
@@ -97,9 +117,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
               loading={markReadState === "loading"}
               disabled={markReadState === "done"}
               onClick={handleMarkAllRead}
-              Icon={
-                markReadState === "done" ? CheckIcon : MailOpenIcon
-              }
+              Icon={markReadState === "done" ? CheckIcon : MailOpenIcon}
             />
           </Tooltip>
         </div>

--- a/apps/web/store/archive-queue.ts
+++ b/apps/web/store/archive-queue.ts
@@ -210,7 +210,7 @@ export function processQueue({
                 // when Gmail API returns a rate limit error, throw an error so it can be retried
                 if (result?.serverError) {
                   await sleep(exponentialBackoff(attemptCount, 1000));
-                  throw new Error(result.error);
+                  throw new Error(result.serverError);
                 }
                 onSuccess?.(threadId);
               },

--- a/apps/web/utils/actions/mail.ts
+++ b/apps/web/utils/actions/mail.ts
@@ -25,11 +25,16 @@ export const archiveThreadAction = actionClient
         logger,
       });
 
-      await emailProvider.archiveThreadWithLabel(
-        threadId,
-        emailAccount.email,
-        labelId,
-      );
+      try {
+        await emailProvider.archiveThreadWithLabel(
+          threadId,
+          emailAccount.email,
+          labelId,
+        );
+      } catch (error) {
+        logger.error("Failed to archive thread", { error });
+        throw new SafeError("Failed to archive email. Please try again.");
+      }
     },
   );
 
@@ -47,7 +52,12 @@ export const trashThreadAction = actionClient
         logger,
       });
 
-      await emailProvider.trashThread(threadId, emailAccount.email, "user");
+      try {
+        await emailProvider.trashThread(threadId, emailAccount.email, "user");
+      } catch (error) {
+        logger.error("Failed to trash thread", { error });
+        throw new SafeError("Failed to delete email. Please try again.");
+      }
     },
   );
 
@@ -65,7 +75,14 @@ export const markReadThreadAction = actionClient
         logger,
       });
 
-      await emailProvider.markReadThread(threadId, read);
+      try {
+        await emailProvider.markReadThread(threadId, read);
+      } catch (error) {
+        logger.error("Failed to mark thread read state", { error });
+        throw new SafeError(
+          `Failed to mark email as ${read ? "read" : "unread"}. Please try again.`,
+        );
+      }
     },
   );
 


### PR DESCRIPTION
# User description
## Summary
- Wrap `archiveThreadAction`, `trashThreadAction`, and `markReadThreadAction` provider calls in try-catch with `SafeError` so descriptive error messages appear instead of generic "An unknown error occurred."
- Fix `handleArchiveAll` and `handleMarkAllRead` in inline email cards to check individual results for `serverError` (next-safe-action never rejects — it returns result objects)
- Fix `result.error` → `result.serverError` typo in archive queue

Fixes INB-124

## Test plan
- [ ] Open AI chat, ask about inbox emails
- [ ] Click Archive on a single email card — should archive successfully or show "Failed to archive email" on error
- [ ] Click "Archive all" on email list — should show correct success/partial/failure toasts
- [ ] Click "Mark all read" — should show correct success/partial/failure toasts
- [ ] Bulk archive from main inbox view — verify queue still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Wrap <code>archiveThreadAction</code>, <code>trashThreadAction</code>, and <code>markReadThreadAction</code> calls in <code>SafeError</code> so inline email card flows surface descriptive errors during chat-based inbox actions. Update inline bulk archive/mark handlers and archive queue retries to inspect <code>serverError</code> results so toast feedback reflects partial failures accurately.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1860?tool=ast&topic=Inline+bulk+feedback>Inline bulk feedback</a>
        </td><td>Update <code>InlineEmailList</code> bulk archive/mark handlers to inspect <code>serverError</code> results and report accurate success/partial/failure toasts.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/inline-email-card.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Replace-chat-bulk-acti...</td><td>March 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1860?tool=ast&topic=Thread+action+errors>Thread action errors</a>
        </td><td>Wrap <code>archiveThreadAction</code>, <code>trashThreadAction</code>, and <code>markReadThreadAction</code> in <code>SafeError</code> and log failures so inbox actions surface descriptive errors and archive queue retries inspect <code>serverError</code>.<details><summary>Modified files (2)</summary><ul><li>apps/web/store/archive-queue.ts</li>
<li>apps/web/utils/actions/mail.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-filter-error</td><td>December 18, 2025</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>unify-routes</td><td>July 04, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1860?tool=ast>(Baz)</a>.