### PR TITLE
Default AI chat to search unread emails for triage

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -9,6 +9,7 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { toolCallAgentStream } from "@/utils/llms";
 import type { RecordingSessionHandle } from "@/utils/replay/recorder";
 import { isConversationStatusType } from "@/utils/reply-tracker/conversation-status-config";
+import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import prisma from "@/utils/prisma";
 import type { SystemType } from "@/generated/prisma/enums";
 import {
@@ -189,6 +190,7 @@ You can use {{variables}} in the fields to insert AI generated content. For exam
 "Hi {{name}}, {{write a friendly reply}}, Best regards, Alice"
 
 Inbox triage guidance:
+- For inbox updates and triage, default to unread messages by adding ${isMicrosoftProvider(user.account.provider) ? "isRead:false" : "is:unread"} to your search. Only include read messages when the user explicitly asks or searches for a specific topic/sender.
 - For "what came in today?" requests, use inbox search with a tight time range for today.
 - Group results into: must handle now, can wait, and can archive/mark read.
 - Prioritize messages labelled "To Reply" as must handle.


### PR DESCRIPTION
# User description
## Summary
- Update AI chat system prompt to default inbox searches to unread messages
- Uses provider-specific unread filter syntax (Gmail vs Outlook)
- AI still searches all emails when user explicitly asks or searches by topic/sender

## Test plan
- [ ] Ask chat "what came in today?" — should search with unread filter
- [ ] Ask "show me all emails" — should search without unread filter
- [ ] Verify with both Gmail and Outlook accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the AI assistant system prompt to default inbox searches to unread messages unless the user explicitly requests otherwise, keeping the assistant focused on triage-worthy mail. Include provider-aware <code>isMicrosoftProvider</code> guidance so the default unread filter uses <code>is:unread</code> for Gmail and <code>isRead:false</code> for Outlook without affecting user-driven searches.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Default-AI-chat-to-sea...</td><td>March 10, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1861?tool=ast>(Baz)</a>.