### PR TITLE
Fix bulk action buttons disabled on partial failure

### DIFF
--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -47,7 +47,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
         toastSuccess({
           description: `Archived ${results.length - failedCount} of ${results.length} emails`,
         });
-        setArchiveAllState("done");
+        setArchiveAllState("idle");
       } else {
         toastSuccess({ description: `Archived ${threadIds.length} emails` });
         setArchiveAllState("done");
@@ -75,7 +75,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
         toastSuccess({
           description: `Marked ${results.length - failedCount} of ${results.length} as read`,
         });
-        setMarkReadState("done");
+        setMarkReadState("idle");
       } else {
         toastSuccess({ description: `Marked ${threadIds.length} as read` });
         setMarkReadState("done");


### PR DESCRIPTION
# User description
Keep buttons active on partial archive/mark-read failures so users can retry instead of disabling them after partial success.

Addresses review feedback: partial failures should keep state as idle to maintain button actionability.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify InlineEmailList bulk-archive and bulk-mark-read behavior by keeping <code>handleArchiveAll</code> and <code>handleMarkAllRead</code> states idle after partial failures so buttons stay actionable. Keep button actionability by letting partial successes leave the state idle rather than marking them done.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-archive-button-err...</td><td>March 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1862?tool=ast>(Baz)</a>.