### PR TITLE
Constrain calendars page card width

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
@@ -12,7 +12,7 @@ export default async function CalendarsPage() {
         title="Calendars"
         description="Powering AI scheduling and meeting briefs."
       />
-      <div className="mt-6 space-y-4">
+      <div className="mt-6 max-w-4xl space-y-4">
         <CalendarConnections />
         <CalendarSettings />
       </div>


### PR DESCRIPTION
# User description
## Summary
- Add `max-w-4xl` to calendars page content wrapper to match assistant settings page width

## Test plan
- [ ] Visit calendars page and verify cards are narrower
- [ ] Compare width with assistant settings page


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the CalendarsPage content wrapper with assistant settings by constraining it with <code>max-w-4xl</code>, keeping the cards at the same width as related controls. Maintain the <code>CalendarConnections</code> and <code>CalendarSettings</code> flow inside the constrained container so their spacing is preserved.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-calendar-page-redi...</td><td>March 10, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Use-outlook-endpoint</td><td>October 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1865?tool=ast>(Baz)</a>.