### PR TITLE
Redesign chat rule card UI with cleaner layout

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -2,12 +2,17 @@
 
 import { Suspense } from "react";
 import { Container } from "@/components/Container";
-import { MutedText } from "@/components/Typography";
+import {
+  PageHeading,
+  SectionHeader,
+  MutedText,
+} from "@/components/Typography";
 import {
   AddToKnowledgeBase,
   BasicToolInfo,
   CreatedRuleToolCard,
   UpdatedRuleConditions,
+  UpdatedRuleActions,
   UpdatedLearnedPatterns,
   ForwardEmailResult,
   ManageInboxResult,
@@ -26,11 +31,336 @@ export default function ToolsPage() {
 
   return (
     <Container>
-      <div className="space-y-8 py-8">
-        <h1>Assistant Tools</h1>
+      <div className="space-y-10 py-8">
+        <PageHeading>Assistant Tools</PageHeading>
 
-        <div className="mt-4 space-y-4">
-          <MutedText>Input states:</MutedText>
+        {/* Rule Cards */}
+        <section className="space-y-4">
+          <SectionHeader>Rule Cards</SectionHeader>
+
+          <MutedText>Created rules:</MutedText>
+          <CreatedRuleToolCard
+            preview
+            args={{
+              name: "Hiring",
+              condition: {
+                aiInstructions:
+                  "Emails related to hiring, job applications, or candidate communication",
+                static: null,
+                conditionalOperator: null,
+              },
+              actions: [
+                ruleAction(ActionType.FORWARD, { to: "jim@company.com" }),
+                ruleAction(ActionType.LABEL, { label: "Recruiting" }),
+              ],
+            }}
+          />
+          <CreatedRuleToolCard
+            preview
+            args={{
+              name: "Newsletter Archive",
+              condition: {
+                aiInstructions: "Newsletter and marketing emails",
+                static: {
+                  from: "newsletter@example.com",
+                  to: null,
+                  subject: null,
+                },
+                conditionalOperator: "OR",
+              },
+              actions: [
+                ruleAction(ActionType.ARCHIVE),
+                ruleAction(ActionType.LABEL, { label: "Newsletter" }),
+                ruleAction(ActionType.MARK_READ),
+              ],
+            }}
+          />
+          <CreatedRuleToolCard
+            preview
+            args={{
+              name: "Billing Alerts",
+              condition: {
+                aiInstructions: null,
+                static: {
+                  from: "billing@stripe.com",
+                  to: null,
+                  subject: "invoice",
+                },
+                conditionalOperator: null,
+              },
+              actions: [
+                ruleAction(ActionType.LABEL, { label: "Billing" }),
+                ruleAction(ActionType.FORWARD, {
+                  to: "finance@company.com",
+                }),
+              ],
+            }}
+          />
+
+          <MutedText>Updated conditions (no diff):</MutedText>
+          <UpdatedRuleConditions
+            preview
+            ruleId="demo-rule"
+            args={{
+              ruleName: "Hiring",
+              condition: {
+                aiInstructions:
+                  "Emails related to hiring, job applications, or candidate communication",
+                static: { from: "hr@company.com", to: null, subject: null },
+                conditionalOperator: "AND",
+              },
+            }}
+            actions={[
+              ruleAction(ActionType.FORWARD, { to: "jim@company.com" }),
+              ruleAction(ActionType.LABEL, { label: "Recruiting" }),
+            ]}
+          />
+
+          <MutedText>Updated conditions (with diff):</MutedText>
+          <UpdatedRuleConditions
+            preview
+            ruleId="demo-rule"
+            args={{
+              ruleName: "Newsletter",
+              condition: {
+                aiInstructions:
+                  "Emails that are newsletters, marketing, or promotional content",
+                static: null,
+                conditionalOperator: null,
+              },
+            }}
+            actions={[
+              ruleAction(ActionType.ARCHIVE),
+              ruleAction(ActionType.LABEL, { label: "Newsletter" }),
+              ruleAction(ActionType.MARK_READ),
+            ]}
+            originalConditions={{
+              aiInstructions:
+                "Emails that look like newsletters or marketing",
+              conditionalOperator: null,
+            }}
+            updatedConditions={{
+              aiInstructions:
+                "Emails that are newsletters, marketing, or promotional content",
+              conditionalOperator: null,
+            }}
+          />
+
+          <MutedText>Updated actions:</MutedText>
+          <UpdatedRuleActions
+            preview
+            ruleId="demo-rule"
+            args={{
+              ruleName: "Newsletter Archive",
+              actions: [
+                ruleAction(ActionType.ARCHIVE),
+                ruleAction(ActionType.LABEL, { label: "Newsletter" }),
+                ruleAction(ActionType.MARK_READ),
+              ] as any,
+            }}
+            condition={{
+              aiInstructions: "Newsletter and marketing emails",
+              static: {
+                from: "newsletter@example.com",
+              },
+              conditionalOperator: "OR",
+            }}
+          />
+          <UpdatedRuleActions
+            preview
+            ruleId="demo-rule"
+            args={{
+              ruleName: "Hiring",
+              actions: [
+                ruleAction(ActionType.FORWARD, { to: "jim@company.com" }),
+                ruleAction(ActionType.LABEL, { label: "Recruiting" }),
+              ] as any,
+            }}
+            condition={{
+              aiInstructions:
+                "Emails related to hiring, job applications, or candidate communication",
+            }}
+            originalActions={[
+              {
+                type: ActionType.LABEL,
+                fields: { label: "Recruiting" },
+              },
+            ]}
+            updatedActions={[
+              {
+                type: ActionType.FORWARD,
+                fields: { to: "jim@company.com" },
+                delayInMinutes: null,
+              },
+              {
+                type: ActionType.LABEL,
+                fields: { label: "Recruiting" },
+                delayInMinutes: null,
+              },
+            ]}
+          />
+
+          <MutedText>Updated learned patterns:</MutedText>
+          <UpdatedLearnedPatterns
+            preview
+            ruleId="demo-rule"
+            args={{
+              ruleName: "Newsletter",
+              learnedPatterns: [
+                {
+                  include: {
+                    from: "@substack.com",
+                    subject: null,
+                  },
+                  exclude: null,
+                },
+                {
+                  include: null,
+                  exclude: {
+                    from: "team@company.com",
+                    subject: null,
+                  },
+                },
+              ],
+            }}
+          />
+        </section>
+
+        {/* Email Actions */}
+        <section className="space-y-4">
+          <SectionHeader>Email Actions</SectionHeader>
+          <Suspense
+            fallback={<BasicToolInfo text="Loading email action states..." />}
+          >
+            <ChatProvider>
+              <AssistantEmailActionStates />
+            </ChatProvider>
+          </Suspense>
+        </section>
+
+        {/* Search & Read Results */}
+        <section className="space-y-4">
+          <SectionHeader>Search & Read Results</SectionHeader>
+          <SearchInboxResult output={getAssistantSearchInboxOutput()} />
+          <ReadEmailResult output={getAssistantReadEmailOutput()} />
+        </section>
+
+        {/* Manage Inbox Results */}
+        <section className="space-y-4">
+          <SectionHeader>Manage Inbox Results</SectionHeader>
+          <ManageInboxResult
+            input={{
+              action: "archive_threads",
+              threadIds: ["thread-1", "thread-2"],
+            }}
+            output={{
+              action: "archive_threads",
+              requestedCount: 2,
+              successCount: 2,
+              failedCount: 0,
+            }}
+            threadIds={["thread-1", "thread-2"]}
+            threadLookup={assistantToolThreadLookup}
+          />
+          <ManageInboxResult
+            input={{
+              action: "archive_threads",
+              threadIds: ["thread-1", "thread-2", "thread-3"],
+              label: "Newsletter",
+            }}
+            output={{
+              action: "archive_threads",
+              requestedCount: 3,
+              successCount: 2,
+              failedCount: 1,
+              failedThreadIds: ["thread-3"],
+            }}
+            threadIds={["thread-1", "thread-2", "thread-3"]}
+            threadLookup={assistantToolThreadLookup}
+          />
+          <ManageInboxResult
+            input={{
+              action: "mark_read_threads",
+              threadIds: ["thread-1", "thread-3"],
+              read: true,
+            }}
+            output={{
+              action: "mark_read_threads",
+              requestedCount: 2,
+              successCount: 2,
+              failedCount: 0,
+            }}
+            threadIds={["thread-1", "thread-3"]}
+            threadLookup={assistantToolThreadLookup}
+          />
+          <ManageInboxResult
+            input={{
+              action: "mark_read_threads",
+              threadIds: ["thread-2"],
+              read: false,
+            }}
+            output={{
+              action: "mark_read_threads",
+              requestedCount: 1,
+              successCount: 1,
+              failedCount: 0,
+            }}
+            threadIds={["thread-2"]}
+            threadLookup={assistantToolThreadLookup}
+          />
+          <ManageInboxResult
+            input={{
+              action: "bulk_archive_senders",
+              fromEmails: ["updates@example.com", "news@example.com"],
+            }}
+            output={{
+              action: "bulk_archive_senders",
+              sendersCount: 2,
+              senders: ["updates@example.com", "news@example.com"],
+            }}
+            threadLookup={assistantToolThreadLookup}
+          />
+          <ManageInboxResult
+            input={{
+              action: "unsubscribe_senders",
+              fromEmails: ["updates@example.com", "deals@example.com"],
+            }}
+            output={{
+              action: "unsubscribe_senders",
+              sendersCount: 2,
+              senders: ["updates@example.com", "deals@example.com"],
+              successCount: 2,
+              failedCount: 0,
+            }}
+            threadLookup={assistantToolThreadLookup}
+          />
+        </section>
+
+        {/* Settings & Knowledge */}
+        <section className="space-y-4">
+          <SectionHeader>Settings & Knowledge</SectionHeader>
+          <UpdateAbout
+            args={{
+              about:
+                "I prefer concise responses and want newsletters archived by default.",
+              mode: "replace",
+            }}
+          />
+          <Suspense>
+            <AddToKnowledgeBase
+              args={{
+                title: "Escalation preference",
+                content:
+                  "Escalate billing emails quickly and keep status updates short.",
+              }}
+            />
+          </Suspense>
+        </section>
+
+        {/* Basic Tool Info States */}
+        <section className="space-y-4">
+          <SectionHeader>Basic Tool Info States</SectionHeader>
+          <MutedText>Input states (loading indicators):</MutedText>
           <div className="grid gap-2 md:grid-cols-2">
             <BasicToolInfo text="Loading account overview..." />
             <BasicToolInfo text="Loading assistant capabilities..." />
@@ -59,253 +389,18 @@ export default function ToolsPage() {
             <BasicToolInfo text="Searching memories..." />
           </div>
 
-          <MutedText>Output states:</MutedText>
-          <div className="space-y-4">
+          <MutedText>Output states (completion messages):</MutedText>
+          <div className="grid gap-2 md:grid-cols-2">
             <BasicToolInfo text="Loaded account overview" />
             <BasicToolInfo text="Loaded assistant capabilities" />
             <BasicToolInfo text="Updated settings (2 changes)" />
-            <SearchInboxResult output={getAssistantSearchInboxOutput()} />
-            <ReadEmailResult output={getAssistantReadEmailOutput()} />
-            <ManageInboxResult
-              input={{
-                action: "archive_threads",
-                threadIds: ["thread-1", "thread-2"],
-              }}
-              output={{
-                action: "archive_threads",
-                requestedCount: 2,
-                successCount: 2,
-                failedCount: 0,
-              }}
-              threadIds={["thread-1", "thread-2"]}
-              threadLookup={assistantToolThreadLookup}
-            />
-            <ManageInboxResult
-              input={{
-                action: "archive_threads",
-                threadIds: ["thread-1", "thread-2", "thread-3"],
-                label: "Newsletter",
-              }}
-              output={{
-                action: "archive_threads",
-                requestedCount: 3,
-                successCount: 2,
-                failedCount: 1,
-                failedThreadIds: ["thread-3"],
-              }}
-              threadIds={["thread-1", "thread-2", "thread-3"]}
-              threadLookup={assistantToolThreadLookup}
-            />
-            <ManageInboxResult
-              input={{
-                action: "mark_read_threads",
-                threadIds: ["thread-1", "thread-3"],
-                read: true,
-              }}
-              output={{
-                action: "mark_read_threads",
-                requestedCount: 2,
-                successCount: 2,
-                failedCount: 0,
-              }}
-              threadIds={["thread-1", "thread-3"]}
-              threadLookup={assistantToolThreadLookup}
-            />
-            <ManageInboxResult
-              input={{
-                action: "mark_read_threads",
-                threadIds: ["thread-2"],
-                read: false,
-              }}
-              output={{
-                action: "mark_read_threads",
-                requestedCount: 1,
-                successCount: 1,
-                failedCount: 0,
-              }}
-              threadIds={["thread-2"]}
-              threadLookup={assistantToolThreadLookup}
-            />
-            <ManageInboxResult
-              input={{
-                action: "bulk_archive_senders",
-                fromEmails: ["updates@example.com", "news@example.com"],
-              }}
-              output={{
-                action: "bulk_archive_senders",
-                sendersCount: 2,
-                senders: ["updates@example.com", "news@example.com"],
-              }}
-              threadLookup={assistantToolThreadLookup}
-            />
-            <ManageInboxResult
-              input={{
-                action: "unsubscribe_senders",
-                fromEmails: ["updates@example.com", "deals@example.com"],
-              }}
-              output={{
-                action: "unsubscribe_senders",
-                sendersCount: 2,
-                senders: ["updates@example.com", "deals@example.com"],
-                successCount: 2,
-                failedCount: 0,
-              }}
-              threadLookup={assistantToolThreadLookup}
-            />
             <BasicToolInfo text="Updated inbox features" />
-            <Suspense
-              fallback={<BasicToolInfo text="Loading email action states..." />}
-            >
-              <ChatProvider>
-                <AssistantEmailActionStates />
-              </ChatProvider>
-            </Suspense>
             <BasicToolInfo text="Read rules and settings" />
             <BasicToolInfo text="Read learned patterns" />
-
-            <MutedText>Created rule cards:</MutedText>
-            <CreatedRuleToolCard
-              preview
-              args={{
-                name: "Hiring",
-                condition: {
-                  aiInstructions:
-                    "Emails related to hiring, job applications, or candidate communication",
-                  static: null,
-                  conditionalOperator: null,
-                },
-                actions: [
-                  ruleAction(ActionType.FORWARD, { to: "jim@company.com" }),
-                  ruleAction(ActionType.LABEL, { label: "Recruiting" }),
-                ],
-              }}
-            />
-            <CreatedRuleToolCard
-              preview
-              args={{
-                name: "Newsletter Archive",
-                condition: {
-                  aiInstructions: "Newsletter and marketing emails",
-                  static: {
-                    from: "newsletter@example.com",
-                    to: null,
-                    subject: null,
-                  },
-                  conditionalOperator: "OR",
-                },
-                actions: [
-                  ruleAction(ActionType.ARCHIVE),
-                  ruleAction(ActionType.LABEL, { label: "Newsletter" }),
-                  ruleAction(ActionType.MARK_READ),
-                ],
-              }}
-            />
-            <CreatedRuleToolCard
-              preview
-              args={{
-                name: "Billing Alerts",
-                condition: {
-                  aiInstructions: null,
-                  static: {
-                    from: "billing@stripe.com",
-                    to: null,
-                    subject: "invoice",
-                  },
-                  conditionalOperator: null,
-                },
-                actions: [
-                  ruleAction(ActionType.LABEL, { label: "Billing" }),
-                  ruleAction(ActionType.FORWARD, {
-                    to: "finance@company.com",
-                  }),
-                ],
-              }}
-            />
-            <MutedText>Updated rule conditions (no diff):</MutedText>
-            <UpdatedRuleConditions
-              preview
-              ruleId="demo-rule"
-              args={{
-                ruleName: "Hiring",
-                condition: {
-                  aiInstructions:
-                    "Emails related to hiring, job applications, or candidate communication",
-                  static: { from: "hr@company.com", to: null, subject: null },
-                  conditionalOperator: "AND",
-                },
-              }}
-            />
-
-            <MutedText>Updated rule conditions (with diff):</MutedText>
-            <UpdatedRuleConditions
-              preview
-              ruleId="demo-rule"
-              args={{
-                ruleName: "Newsletter",
-                condition: {
-                  aiInstructions:
-                    "Emails that are newsletters, marketing, or promotional content",
-                  static: null,
-                  conditionalOperator: null,
-                },
-              }}
-              originalConditions={{
-                aiInstructions:
-                  "Emails that look like newsletters or marketing",
-                conditionalOperator: null,
-              }}
-              updatedConditions={{
-                aiInstructions:
-                  "Emails that are newsletters, marketing, or promotional content",
-                conditionalOperator: null,
-              }}
-            />
-
-            <MutedText>Updated learned patterns:</MutedText>
-            <UpdatedLearnedPatterns
-              preview
-              ruleId="demo-rule"
-              args={{
-                ruleName: "Newsletter",
-                learnedPatterns: [
-                  {
-                    include: {
-                      from: "@substack.com",
-                      subject: null,
-                    },
-                    exclude: null,
-                  },
-                  {
-                    include: null,
-                    exclude: {
-                      from: "team@company.com",
-                      subject: null,
-                    },
-                  },
-                ],
-              }}
-            />
-
-            <UpdateAbout
-              args={{
-                about:
-                  "I prefer concise responses and want newsletters archived by default.",
-                mode: "replace",
-              }}
-            />
-            <Suspense>
-              <AddToKnowledgeBase
-                args={{
-                  title: "Escalation preference",
-                  content:
-                    "Escalate billing emails quickly and keep status updates short.",
-                }}
-              />
-            </Suspense>
             <BasicToolInfo text="Memory saved" />
             <BasicToolInfo text="Found 2 memories" />
           </div>
-        </div>
+        </section>
       </div>
     </Container>
   );
@@ -314,8 +409,6 @@ export default function ToolsPage() {
 function AssistantEmailActionStates() {
   return (
     <div className="space-y-4">
-      <MutedText>Email action states:</MutedText>
-
       <div className="space-y-3">
         <MutedText>Send — pending</MutedText>
         <SendEmailResult

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -11,6 +11,7 @@ import type {
   CreateRuleTool,
   ManageInboxTool,
 } from "@/utils/ai/assistant/chat";
+import { cn } from "@/utils";
 import { isDefined } from "@/utils/types";
 import {
   Card,
@@ -23,9 +24,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallbackColor } from "@/components/ui/avatar";
 import {
   ChevronRightIcon,
-  SparklesIcon,
   TrashIcon,
-  FileDiffIcon,
   ExternalLinkIcon,
   Loader2,
   PencilIcon,
@@ -48,7 +47,6 @@ import { Badge } from "@/components/Badge";
 import { getActionDisplay, getActionIcon } from "@/utils/action-display";
 import { getActionColor } from "@/components/PlanBadge";
 import type { ActionType } from "@/generated/prisma/enums";
-import { getEmailTerminology } from "@/utils/terminology";
 import { formatShortDate } from "@/utils/date";
 import { trimToNonEmptyString } from "@/utils/string";
 import { getEmailSearchUrl, getEmailUrlForMessage } from "@/utils/url";
@@ -580,9 +578,7 @@ function EmailActionResult({
       <CardContent className="p-0">
         {displaySubject && (
           <div className="flex items-center gap-2 border-b px-4 py-2.5">
-            <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              Subject
-            </span>
+            <FieldLabel>Subject</FieldLabel>
             <span className="truncate text-sm font-medium text-foreground">
               {actionType !== "send_email" ? "Re: " : ""}
               {displaySubject}
@@ -707,67 +703,30 @@ export function CreatedRuleToolCard({
   ruleId?: string;
   preview?: boolean;
 }) {
-  const conditionParts: string[] = [];
-  if (args.condition.aiInstructions)
-    conditionParts.push(args.condition.aiInstructions);
-  if (args.condition.static) {
-    const s = args.condition.static;
-    const staticParts = [
-      s.from && `From: ${s.from}`,
-      s.to && `To: ${s.to}`,
-      s.subject && `Subject: ${s.subject}`,
-    ].filter(Boolean);
-    if (staticParts.length > 0) conditionParts.push(staticParts.join(", "));
-  }
-
-  const conditionText = conditionParts.join(
-    ` ${args.condition.conditionalOperator || "AND"} `,
-  );
+  const conditionText = buildConditionText(args.condition);
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3.5">
-        <h3 className="text-base font-semibold">{args.name}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">{args.name}</h3>
+          <Badge color="green" className="text-[10px]">
+            Created
+          </Badge>
+        </div>
         {ruleId && <RuleActions ruleId={ruleId} />}
         {preview && <RuleActionsPreview />}
       </CardHeader>
 
       <CardContent className="space-y-3 px-4 py-3.5">
         <div className="flex gap-4 text-sm">
-          <span className="shrink-0 pt-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            When
-          </span>
+          <FieldLabel className="pt-0.5">When</FieldLabel>
           <p>{conditionText}</p>
         </div>
 
         <div className="flex gap-4 text-sm">
-          <span className="shrink-0 pt-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Then
-          </span>
-          <div className="flex flex-wrap gap-1.5">
-            {args.actions.map((action, i) => {
-              const Icon = getActionIcon(action.type as ActionType);
-              return (
-                <Badge
-                  key={i}
-                  color={getActionColor(action.type as ActionType)}
-                  className="w-fit shrink-0"
-                >
-                  <Icon className="mr-1.5 size-3" />
-                  {getActionDisplay(
-                    {
-                      type: action.type as ActionType,
-                      label: action.fields?.label,
-                      to: action.fields?.to,
-                      content: action.fields?.content,
-                    },
-                    "",
-                    [],
-                  )}
-                </Badge>
-              );
-            })}
-          </div>
+          <FieldLabel className="pt-0.5">Then</FieldLabel>
+          <ActionBadgeList actions={args.actions} />
         </div>
       </CardContent>
     </Card>
@@ -779,85 +738,59 @@ export function UpdatedRuleConditions({
   ruleId,
   originalConditions,
   updatedConditions,
+  actions,
   preview,
 }: {
   args: UpdateRuleConditionsTool["input"];
   ruleId: string;
   originalConditions?: UpdateRuleConditionsOutput["originalConditions"];
   updatedConditions?: UpdateRuleConditionsOutput["updatedConditions"];
+  actions?: Array<{ type: string; fields?: RuleActionFields | null }>;
   preview?: boolean;
 }) {
-  const [showChanges, setShowChanges] = useState(false);
-
-  const staticConditions =
-    args.condition.static?.from ||
-    args.condition.static?.to ||
-    args.condition.static?.subject
-      ? args.condition.static
-      : null;
-
-  const conditionsArray = [
-    args.condition.aiInstructions,
-    staticConditions,
-  ].filter(Boolean);
-
   const hasChanges =
     originalConditions &&
     updatedConditions &&
     originalConditions.aiInstructions !== updatedConditions.aiInstructions;
 
+  const conditionText = buildConditionText(args.condition);
+
   return (
-    <ToolCard>
-      <ToolCardHeader
-        title={<>Updated Conditions</>}
-        actions={
-          <div className="flex items-center gap-1">
-            {hasChanges && (
-              <DiffToggleButton
-                showChanges={showChanges}
-                onToggle={() => setShowChanges(!showChanges)}
-              />
-            )}
-            {preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />}
-          </div>
-        }
-      />
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">{args.ruleName}</h3>
+          <Badge color="blue" className="text-[10px]">
+            Updated
+          </Badge>
+        </div>
+        {preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />}
+      </CardHeader>
 
-      <div className="rounded-md bg-muted p-2 text-sm">
-        {args.condition.aiInstructions && (
-          <div className="flex items-center">
-            <SparklesIcon className="mr-2 size-5" />
-            {args.condition.aiInstructions}
-          </div>
-        )}
-        {conditionsArray.length > 1 && (
-          <div className="my-2 font-mono text-xs">
-            {args.condition.conditionalOperator || "AND"}
-          </div>
-        )}
-        {staticConditions && (
-          <div className="mt-1">
-            <span className="font-medium">Static Conditions:</span>
-            <ul className="mt-1 list-inside list-disc">
-              {staticConditions.from && <li>From: {staticConditions.from}</li>}
-              {staticConditions.to && <li>To: {staticConditions.to}</li>}
-              {staticConditions.subject && (
-                <li>Subject: {staticConditions.subject}</li>
-              )}
-            </ul>
-          </div>
-        )}
-      </div>
+      <CardContent className="space-y-3 px-4 py-3.5">
+        <div className="flex gap-4 text-sm">
+          <FieldLabel className="pt-0.5">When</FieldLabel>
+          <p>{conditionText}</p>
+        </div>
 
-      {hasChanges && (
-        <CollapsibleDiff
-          showChanges={showChanges}
-          title="Instructions:"
-          originalText={originalConditions?.aiInstructions || undefined}
-          updatedText={updatedConditions?.aiInstructions || undefined}
-        />
-      )}
-    </ToolCard>
+        {actions && actions.length > 0 && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">Then</FieldLabel>
+            <ActionBadgeList actions={actions} />
+          </div>
+        )}
+
+        {hasChanges && (
+          <ViewChangesCollapsible>
+            <CollapsibleDiffContent
+              title="Instructions:"
+              originalText={originalConditions?.aiInstructions || undefined}
+              updatedText={updatedConditions?.aiInstructions || undefined}
+            />
+          </ViewChangesCollapsible>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -866,90 +799,67 @@ export function UpdatedRuleActions({
   ruleId,
   originalActions,
   updatedActions,
+  condition,
+  preview,
 }: {
   args: UpdateRuleActionsTool["input"];
   ruleId: string;
   originalActions?: UpdateRuleActionsOutput["originalActions"];
   updatedActions?: UpdateRuleActionsOutput["updatedActions"];
+  condition?: {
+    aiInstructions?: string | null;
+    static?: {
+      from?: string | null;
+      to?: string | null;
+      subject?: string | null;
+    } | null;
+    conditionalOperator?: string | null;
+  };
+  preview?: boolean;
 }) {
-  const { provider } = useAccount();
-  const [showChanges, setShowChanges] = useState(false);
-
-  // Check if actions have changed by comparing serialized versions
   const hasChanges =
     originalActions &&
     updatedActions &&
     JSON.stringify(originalActions) !== JSON.stringify(updatedActions);
 
-  const formatActions = <
-    T extends { type: string; fields: Record<string, string | null> },
-  >(
-    actions: T[],
-  ) => {
-    return actions
-      .map((action) => {
-        const parts = [`Type: ${action.type}`];
-        if (action.fields?.label)
-          parts.push(
-            `${getEmailTerminology(provider).label.action}: ${action.fields.label}`,
-          );
-        if (action.fields?.content)
-          parts.push(`Content: ${action.fields.content}`);
-        if (action.fields?.to) parts.push(`To: ${action.fields.to}`);
-        if (action.fields?.cc) parts.push(`CC: ${action.fields.cc}`);
-        if (action.fields?.bcc) parts.push(`BCC: ${action.fields.bcc}`);
-        if (action.fields?.subject)
-          parts.push(`Subject: ${action.fields.subject}`);
-        if (action.fields?.webhookUrl || action.fields?.url)
-          parts.push(
-            `Webhook: ${action.fields.webhookUrl || action.fields.url}`,
-          );
-        return parts.join(", ");
-      })
-      .join("\n");
-  };
+  const conditionText = condition ? buildConditionText(condition) : null;
 
   return (
-    <ToolCard>
-      <ToolCardHeader
-        title={<>Updated Actions</>}
-        actions={
-          <div className="flex items-center gap-1">
-            {hasChanges && (
-              <DiffToggleButton
-                showChanges={showChanges}
-                onToggle={() => setShowChanges(!showChanges)}
-              />
-            )}
-            <RuleActions ruleId={ruleId} />
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">{args.ruleName}</h3>
+          <Badge color="blue" className="text-[10px]">
+            Updated
+          </Badge>
+        </div>
+        {preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />}
+      </CardHeader>
+
+      <CardContent className="space-y-3 px-4 py-3.5">
+        {conditionText && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">When</FieldLabel>
+            <p>{conditionText}</p>
           </div>
-        }
-      />
+        )}
 
-      <div className="space-y-2">
-        {args.actions.map((actionItem, i) => {
-          if (!actionItem) return null;
+        <div className="flex gap-4 text-sm">
+          <FieldLabel className="pt-0.5">Then</FieldLabel>
+          <ActionBadgeList actions={args.actions} />
+        </div>
 
-          return (
-            <div key={i} className="rounded-md bg-muted p-2 text-sm">
-              <div className="font-medium capitalize">
-                {actionItem.type.toLowerCase().replace("_", " ")}
-              </div>
-              {actionItem.fields && renderActionFields(actionItem.fields)}
-            </div>
-          );
-        })}
-      </div>
-
-      {hasChanges && (
-        <CollapsibleDiff
-          showChanges={showChanges}
-          title="Actions:"
-          originalText={formatActions(originalActions || [])}
-          updatedText={formatActions(updatedActions || [])}
-        />
-      )}
-    </ToolCard>
+        {hasChanges && (
+          <ViewChangesCollapsible>
+            <CollapsibleDiffContent
+              title="Actions:"
+              originalText={formatActionsForDiff(originalActions || [])}
+              updatedText={formatActionsForDiff(updatedActions || [])}
+            />
+          </ViewChangesCollapsible>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -963,53 +873,55 @@ export function UpdatedLearnedPatterns({
   preview?: boolean;
 }) {
   return (
-    <ToolCard>
-      <ToolCardHeader
-        title={<>Updated Learned Patterns</>}
-        actions={
-          preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />
-        }
-      />
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3.5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-base font-semibold">{args.ruleName}</h3>
+          <Badge color="purple" className="text-[10px]">
+            Updated Patterns
+          </Badge>
+        </div>
+        {preview ? (
+          <Tooltip content="Edit rule">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0 text-muted-foreground"
+            >
+              <PencilIcon className="size-4" />
+            </Button>
+          </Tooltip>
+        ) : (
+          <LearnedPatternsActions ruleId={ruleId} />
+        )}
+      </CardHeader>
 
-      <div className="space-y-2">
+      <CardContent className="space-y-2 px-4 py-3.5">
         {args.learnedPatterns.map((pattern, i) => {
           if (!pattern) return null;
+          const includeParts = formatPatternParts(pattern.include);
+          const excludeParts = formatPatternParts(pattern.exclude);
+          if (!includeParts && !excludeParts) return null;
 
           return (
-            <div key={i} className="rounded-md bg-muted p-2 text-sm">
-              {pattern.include &&
-                Object.values(pattern.include).some(Boolean) && (
-                  <div className="mb-1">
-                    <span className="font-medium">Include:</span>
-                    <ul className="mt-1 list-inside list-disc">
-                      {pattern.include.from && (
-                        <li>From: {pattern.include.from}</li>
-                      )}
-                      {pattern.include.subject && (
-                        <li>Subject: {pattern.include.subject}</li>
-                      )}
-                    </ul>
-                  </div>
-                )}
-              {pattern.exclude &&
-                Object.values(pattern.exclude).some(Boolean) && (
-                  <div>
-                    <span className="font-medium">Exclude:</span>
-                    <ul className="mt-1 list-inside list-disc">
-                      {pattern.exclude.from && (
-                        <li>From: {pattern.exclude.from}</li>
-                      )}
-                      {pattern.exclude.subject && (
-                        <li>Subject: {pattern.exclude.subject}</li>
-                      )}
-                    </ul>
-                  </div>
-                )}
+            <div key={i} className="flex gap-4 text-sm">
+              {includeParts && (
+                <>
+                  <FieldLabel className="pt-0.5">Include</FieldLabel>
+                  <p>{includeParts}</p>
+                </>
+              )}
+              {excludeParts && (
+                <>
+                  <FieldLabel className="pt-0.5">Exclude</FieldLabel>
+                  <p>{excludeParts}</p>
+                </>
+              )}
             </div>
           );
         })}
-      </div>
-    </ToolCard>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -1057,42 +969,45 @@ function RuleActions({ ruleId }: { ruleId: string }) {
 
   return (
     <>
-      {/* Don't use tooltips as they force scroll to bottom */}
       <div className="flex items-center gap-1.5">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0"
-          onClick={() => ruleDialog.onOpen({ ruleId })}
-        >
-          <PencilIcon className="size-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0"
-          onClick={async () => {
-            const yes = confirm("Are you sure you want to delete this rule?");
-            if (yes) {
-              try {
-                const result = await deleteRuleAction(emailAccountId, {
-                  id: ruleId,
-                });
-                if (result?.serverError) {
-                  toastError({ description: result.serverError });
-                } else {
-                  toastSuccess({
-                    description: "The rule has been deleted.",
+        <Tooltip content="Edit rule">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-muted-foreground"
+            onClick={() => ruleDialog.onOpen({ ruleId })}
+          >
+            <PencilIcon className="size-4" />
+          </Button>
+        </Tooltip>
+        <Tooltip content="Delete rule">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 text-muted-foreground"
+            onClick={async () => {
+              const yes = confirm("Are you sure you want to delete this rule?");
+              if (yes) {
+                try {
+                  const result = await deleteRuleAction(emailAccountId, {
+                    id: ruleId,
                   });
+                  if (result?.serverError) {
+                    toastError({ description: result.serverError });
+                  } else {
+                    toastSuccess({
+                      description: "The rule has been deleted.",
+                    });
+                  }
+                } catch {
+                  toastError({ description: "Failed to delete rule." });
                 }
-              } catch {
-                toastError({ description: "Failed to delete rule." });
               }
-            }
-          }}
-        >
-          <TrashIcon className="size-4" />
-        </Button>
+            }}
+          >
+            <TrashIcon className="size-4" />
+          </Button>
+        </Tooltip>
         <Switch
           checked={enabled}
           onCheckedChange={async (checked) => {
@@ -1128,14 +1043,53 @@ function RuleActions({ ruleId }: { ruleId: string }) {
 function RuleActionsPreview() {
   return (
     <div className="flex items-center gap-1.5">
-      <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-        <PencilIcon className="size-4" />
-      </Button>
-      <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-        <TrashIcon className="size-4" />
-      </Button>
+      <Tooltip content="Edit rule">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground"
+        >
+          <PencilIcon className="size-4" />
+        </Button>
+      </Tooltip>
+      <Tooltip content="Delete rule">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground"
+        >
+          <TrashIcon className="size-4" />
+        </Button>
+      </Tooltip>
       <Switch checked={true} />
     </div>
+  );
+}
+
+function LearnedPatternsActions({ ruleId }: { ruleId: string }) {
+  const { emailAccountId } = useAccount();
+  const ruleDialog = useDialogState<{ ruleId: string }>();
+
+  return (
+    <>
+      <Tooltip content="Edit rule">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-muted-foreground"
+          onClick={() => ruleDialog.onOpen({ ruleId })}
+        >
+          <PencilIcon className="size-4" />
+        </Button>
+      </Tooltip>
+
+      <RuleDialog
+        ruleId={ruleDialog.data?.ruleId}
+        isOpen={ruleDialog.isOpen}
+        onClose={ruleDialog.onClose}
+        editMode={true}
+      />
+    </>
   );
 }
 
@@ -1158,102 +1112,44 @@ function ToolCardHeader({
   );
 }
 
-function DiffToggleButton({
-  showChanges,
-  onToggle,
-}: {
-  showChanges: boolean;
-  onToggle: () => void;
-}) {
+function ViewChangesCollapsible({ children }: { children: React.ReactNode }) {
   return (
-    <Tooltip content={showChanges ? "Hide Changes" : "Show Changes"}>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-8 w-8 p-0"
-        onClick={onToggle}
-      >
-        <FileDiffIcon className="size-4" />
-      </Button>
-    </Tooltip>
+    <Collapsible>
+      <CollapsibleTrigger className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <ChevronRightIcon className="size-4 transition-transform [[data-state=open]>&]:rotate-90" />
+        View changes
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">{children}</CollapsibleContent>
+    </Collapsible>
   );
 }
 
-function CollapsibleDiff({
-  showChanges,
+function CollapsibleDiffContent({
   title,
   originalText,
   updatedText,
 }: {
-  showChanges: boolean;
   title: string;
   originalText?: string;
   updatedText?: string;
 }) {
-  if (!showChanges) return null;
-
   return (
-    <div className="overflow-hidden">
-      <div className="space-y-2">
-        <div className="text-xs font-medium text-muted-foreground">{title}</div>
-        <div className="rounded-md border bg-muted/30 p-3 font-mono text-sm overflow-auto max-h-96">
-          {originalText && (
-            <div className="mb-2 rounded bg-red-50 px-2 py-1 text-red-800 dark:bg-red-950/30 dark:text-red-200 whitespace-pre-wrap break-words overflow-auto max-h-48">
-              <span className="mr-2 text-red-500">-</span>
-              {originalText}
-            </div>
-          )}
-          {updatedText && (
-            <div className="rounded bg-green-50 px-2 py-1 text-green-800 dark:bg-green-950/30 dark:text-green-200 whitespace-pre-wrap break-words overflow-auto max-h-48">
-              <span className="mr-2 text-green-500">+</span>
-              {updatedText}
-            </div>
-          )}
-        </div>
+    <div className="space-y-2">
+      <div className="text-xs font-medium text-muted-foreground">{title}</div>
+      <div className="max-h-96 overflow-auto rounded-md border bg-muted/30 p-3 font-mono text-sm">
+        {originalText && (
+          <div className="mb-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-red-50 px-2 py-1 text-red-800 dark:bg-red-950/30 dark:text-red-200">
+            <span className="mr-2 text-red-500">-</span>
+            {originalText}
+          </div>
+        )}
+        {updatedText && (
+          <div className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-green-50 px-2 py-1 text-green-800 dark:bg-green-950/30 dark:text-green-200">
+            <span className="mr-2 text-green-500">+</span>
+            {updatedText}
+          </div>
+        )}
       </div>
-    </div>
-  );
-}
-
-// Helper function to render action fields
-function renderActionFields(fields: {
-  label?: string | null;
-  content?: string | null;
-  to?: string | null;
-  cc?: string | null;
-  bcc?: string | null;
-  subject?: string | null;
-  url?: string | null;
-  webhookUrl?: string | null;
-}) {
-  const fieldEntries = [];
-
-  // Only add fields that have actual values
-  if (fields.label) fieldEntries.push(["Label", fields.label]);
-  if (fields.subject) fieldEntries.push(["Subject", fields.subject]);
-  if (fields.to) fieldEntries.push(["To", fields.to]);
-  if (fields.cc) fieldEntries.push(["CC", fields.cc]);
-  if (fields.bcc) fieldEntries.push(["BCC", fields.bcc]);
-  if (fields.content) fieldEntries.push(["Content", fields.content]);
-  if (fields.url || fields.webhookUrl)
-    fieldEntries.push(["URL", fields.url || fields.webhookUrl]);
-
-  if (fieldEntries.length === 0) return null;
-
-  return (
-    <div className="mt-1">
-      <ul className="list-inside list-disc">
-        {fieldEntries.map(([key, value]) => (
-          <li key={key}>
-            {key}:{" "}
-            {key === "Content" ? (
-              <span className="font-mono text-xs">{value}</span>
-            ) : (
-              value
-            )}
-          </li>
-        ))}
-      </ul>
     </div>
   );
 }
@@ -1502,6 +1398,120 @@ function asString(value: unknown): string | null {
   return trimToNonEmptyString(value) ?? null;
 }
 
+type RuleActionFields = {
+  label?: string | null;
+  content?: string | null;
+  to?: string | null;
+  cc?: string | null;
+  bcc?: string | null;
+  subject?: string | null;
+  webhookUrl?: string | null;
+};
+
+function ActionBadgeList({
+  actions,
+}: {
+  actions: Array<{ type: string; fields?: RuleActionFields | null }>;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {actions.map((action, i) => {
+        if (!action) return null;
+        const Icon = getActionIcon(action.type as ActionType);
+        return (
+          <Badge
+            key={i}
+            color={getActionColor(action.type as ActionType)}
+            className="w-fit shrink-0"
+          >
+            <Icon className="mr-1.5 size-3" />
+            {getActionDisplay(
+              {
+                type: action.type as ActionType,
+                label: action.fields?.label,
+                to: action.fields?.to,
+                content: action.fields?.content,
+              },
+              "",
+              [],
+            )}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatPatternParts(
+  pattern: { from?: string | null; subject?: string | null } | null | undefined,
+): string | null {
+  if (!pattern) return null;
+  const parts = [
+    pattern.from && `From: ${pattern.from}`,
+    pattern.subject && `Subject: ${pattern.subject}`,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function buildConditionText(condition: {
+  aiInstructions?: string | null;
+  static?: {
+    from?: string | null;
+    to?: string | null;
+    subject?: string | null;
+  } | null;
+  conditionalOperator?: string | null;
+}): string {
+  const parts: string[] = [];
+  if (condition.aiInstructions) parts.push(condition.aiInstructions);
+  if (condition.static) {
+    const s = condition.static;
+    const staticParts = [
+      s.from && `From: ${s.from}`,
+      s.to && `To: ${s.to}`,
+      s.subject && `Subject: ${s.subject}`,
+    ].filter(Boolean);
+    if (staticParts.length > 0) parts.push(staticParts.join(", "));
+  }
+  return parts.join(` ${condition.conditionalOperator || "AND"} `);
+}
+
+function formatActionsForDiff(
+  actions: Array<{ type: string; fields: Record<string, string | null> }>,
+): string {
+  return actions
+    .map((action) => {
+      const parts = [action.type];
+      if (action.fields?.label) parts.push(`Label: ${action.fields.label}`);
+      if (action.fields?.to) parts.push(`To: ${action.fields.to}`);
+      if (action.fields?.content)
+        parts.push(`Content: ${action.fields.content}`);
+      if (action.fields?.webhookUrl)
+        parts.push(`Webhook: ${action.fields.webhookUrl}`);
+      return parts.join(", ");
+    })
+    .join("\n");
+}
+
+function FieldLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
 }


### PR DESCRIPTION
# User description
Improve visual design of rule cards in chat assistant with structured WHEN/THEN layout instead of dense condition/action display. Replace eye icon with edit icon, add enable/disable toggle switch, and render actions as colored badges with icons. Also fix edge case where empty static conditions would display.

📝 Changes:
- New CreatedRuleToolCard layout with header, divider, and WHEN/THEN sections
- Action badges styled with icons and colors (reusing existing Badge, getActionIcon, getActionColor)
- RuleActions component now has edit (pen icon), delete (trash icon), and enable toggle (Switch)
- RuleDialog opens in edit mode instead of view-only mode
- Fix empty static conditions display in both CreatedRuleToolCard and UpdatedRuleConditions

🧪 Tested: TypeScript type-checking passes

🤖 Generated with Claude Code

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Redesign the rule card helpers by introducing structured WHEN/THEN layouts that surface AI/static conditions, badge-based actions, and clearer condition/action diff views via the refreshed card components. Refresh the rule controls so edits open in edit mode, add a Switch-based enable/disable toggle, reuse the new badge helpers, and keep learned-pattern/condition previews consistent with the new layout.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1875?tool=ast&topic=Rule+action+controls>Rule action controls</a>
        </td><td>Explain how the rule actions toolbar now always opens the rule dialog in edit mode, swaps the eye icon for a pen, introduces the enable/disable <code>Switch</code>, and updates the preview actions to mirror the editable controls.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-use-label-names-in...</td><td>March 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1875?tool=ast&topic=Rule+card+UI+refresh>Rule card UI refresh</a>
        </td><td>Describe how the newly introduced <code>CreatedRuleToolCard</code>, <code>UpdatedRuleConditions</code>, <code>UpdatedRuleActions</code>, and <code>UpdatedLearnedPatterns</code> components now render WHEN/THEN headers, reformatted conditions, and colored action badges so rule previews match the redesigned UI and avoid empty static condition output.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(landing)/components/tools/page.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-use-label-names-in...</td><td>March 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1875?tool=ast>(Baz)</a>.