### PR TITLE
Fix assistant email card thread ids

### DIFF
--- a/apps/web/components/ai-elements/response.test.tsx
+++ b/apps/web/components/ai-elements/response.test.tsx
@@ -1,0 +1,91 @@
+/** @vitest-environment jsdom */
+
+import type { ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Response } from "@/components/ai-elements/response";
+
+const mockUseAccount = vi.fn();
+const mockUseEmailLookup = vi.fn();
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/components/assistant-chat/email-lookup-context", () => ({
+  useEmailLookup: () => mockUseEmailLookup(),
+}));
+
+vi.mock("@/components/Toast", () => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children?: ReactNode }) => (
+    <button type="button">{children || "icon-button"}</button>
+  ),
+}));
+
+vi.mock("@/utils/actions/mail", () => ({
+  archiveThreadAction: vi.fn(),
+  markReadThreadAction: vi.fn(),
+}));
+
+vi.mock("@/hooks/useThread", () => ({
+  useThread: () => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Response", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      provider: "google",
+      userEmail: "user@example.com",
+    });
+
+    mockUseEmailLookup.mockReturnValue(
+      new Map([
+        [
+          "thread-1",
+          {
+            messageId: "msg-thread-1",
+            from: "Sender",
+            subject: "Subject",
+            snippet: "Snippet",
+            date: "2026-03-11T10:00:00.000Z",
+            isUnread: false,
+          },
+        ],
+      ]),
+    );
+  });
+
+  it("passes the threadid attribute through to inline email cards", () => {
+    render(
+      <Response>
+        {
+          '\n<emails>\n<email threadid="thread-1" action="none">Review</email>\n</emails>\n'
+        }
+      </Response>,
+    );
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "https://mail.google.com/mail/u/user@example.com/#all/msg-thread-1",
+    );
+  });
+});

--- a/apps/web/components/ai-elements/response.tsx
+++ b/apps/web/components/ai-elements/response.tsx
@@ -10,7 +10,7 @@ import {
 
 type ResponseProps = ComponentProps<typeof Streamdown>;
 
-const customAllowedTags = { emails: [], email: ["id", "action"] };
+const customAllowedTags = { emails: [], email: ["id", "threadid", "action"] };
 const customComponents = { emails: InlineEmailList, email: InlineEmailCard };
 const customLiteralContent = ["email"];
 

--- a/apps/web/components/assistant-chat/inline-email-card.test.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.test.tsx
@@ -1,0 +1,186 @@
+/** @vitest-environment jsdom */
+
+import type { MouseEvent, ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  InlineEmailCard,
+  InlineEmailList,
+} from "@/components/assistant-chat/inline-email-card";
+
+const mockUseAccount = vi.fn();
+const mockUseEmailLookup = vi.fn();
+const mockArchiveThreadAction = vi.fn();
+const mockMarkReadThreadAction = vi.fn();
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/components/assistant-chat/email-lookup-context", () => ({
+  useEmailLookup: () => mockUseEmailLookup(),
+}));
+
+vi.mock("@/utils/actions/mail", () => ({
+  archiveThreadAction: (...args: unknown[]) => mockArchiveThreadAction(...args),
+  markReadThreadAction: (...args: unknown[]) =>
+    mockMarkReadThreadAction(...args),
+}));
+
+vi.mock("@/components/Toast", () => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: ReactNode;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children || "icon-button"}
+    </button>
+  ),
+}));
+
+vi.mock("@/hooks/useThread", () => ({
+  useThread: () => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InlineEmailCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      provider: "google",
+      userEmail: "user@example.com",
+    });
+
+    mockUseEmailLookup.mockReturnValue(
+      new Map([
+        [
+          "19cdca06580b38e9",
+          {
+            messageId: "msg-1",
+            from: "Sender One",
+            subject: "Subject One",
+            snippet: "Snippet One",
+            date: "2026-03-11T10:00:00.000Z",
+            isUnread: true,
+          },
+        ],
+        [
+          "thread-1",
+          {
+            messageId: "msg-thread-1",
+            from: "Sender Two",
+            subject: "Subject Two",
+            snippet: "Snippet Two",
+            date: "2026-03-11T11:00:00.000Z",
+            isUnread: false,
+          },
+        ],
+        [
+          "thread-2",
+          {
+            messageId: "msg-thread-2",
+            from: "Sender Three",
+            subject: "Subject Three",
+            snippet: "Snippet Three",
+            date: "2026-03-11T12:00:00.000Z",
+            isUnread: false,
+          },
+        ],
+      ]),
+    );
+
+    mockArchiveThreadAction.mockResolvedValue({});
+    mockMarkReadThreadAction.mockResolvedValue({});
+  });
+
+  it("normalizes legacy prefixed ids for the Gmail link and archive action", async () => {
+    render(
+      <InlineEmailCard id="user-content-19cdca06580b38e9" action="archive">
+        Follow up
+      </InlineEmailCard>,
+    );
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe(
+      "https://mail.google.com/mail/u/user@example.com/#all/msg-1",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(mockArchiveThreadAction).toHaveBeenCalledWith("account-1", {
+        threadId: "19cdca06580b38e9",
+      });
+    });
+  });
+});
+
+describe("InlineEmailList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      provider: "google",
+      userEmail: "user@example.com",
+    });
+
+    mockUseEmailLookup.mockReturnValue(new Map());
+    mockArchiveThreadAction.mockResolvedValue({});
+    mockMarkReadThreadAction.mockResolvedValue({});
+  });
+
+  it("archives all cards using the dedicated threadid attribute", async () => {
+    render(
+      <InlineEmailList>
+        <InlineEmailCard threadid="thread-1" action="none">
+          First
+        </InlineEmailCard>
+        <InlineEmailCard threadid="thread-2" action="none">
+          Second
+        </InlineEmailCard>
+      </InlineEmailList>,
+    );
+
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    await waitFor(() => {
+      expect(mockArchiveThreadAction).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockArchiveThreadAction).toHaveBeenNthCalledWith(1, "account-1", {
+      threadId: "thread-1",
+    });
+    expect(mockArchiveThreadAction).toHaveBeenNthCalledWith(2, "account-1", {
+      threadId: "thread-2",
+    });
+  });
+});

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Children, isValidElement, useState, type ReactNode } from "react";
+import React, {
+  Children,
+  isValidElement,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   ArchiveIcon,
   CheckIcon,
@@ -129,10 +134,12 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
 
 export function InlineEmailCard({
   id,
+  threadid,
   action,
   children,
 }: {
   id?: string;
+  threadid?: string;
   action?: string;
   children?: ReactNode;
 }) {
@@ -140,20 +147,26 @@ export function InlineEmailCard({
   const { emailAccountId, provider, userEmail } = useAccount();
   const [actionState, setActionState] = useState<ActionState>("idle");
   const [expanded, setExpanded] = useState(false);
+  const threadId = resolveInlineEmailThreadId({ id, threadid });
 
-  const meta = id ? emailLookup.get(id) : undefined;
+  const meta = threadId ? emailLookup.get(threadId) : undefined;
 
-  const externalUrl = id
-    ? getEmailUrlForMessage(meta?.messageId ?? id, id, userEmail, provider)
+  const externalUrl = threadId
+    ? getEmailUrlForMessage(
+        meta?.messageId ?? threadId,
+        threadId,
+        userEmail,
+        provider,
+      )
     : null;
 
   async function handleArchive(e: React.MouseEvent) {
     e.stopPropagation();
-    if (!id || actionState !== "idle") return;
+    if (!threadId || actionState !== "idle") return;
     setActionState("loading");
     try {
       const result = await archiveThreadAction(emailAccountId, {
-        threadId: id,
+        threadId,
       });
       if (result?.serverError) {
         toastError({ description: result.serverError });
@@ -169,23 +182,23 @@ export function InlineEmailCard({
   }
 
   const isDone = actionState === "done";
-  const showArchive = id && (!action || action === "archive");
+  const showArchive = threadId && (!action || action === "archive");
 
   return (
     <div>
       <div
-        role={id ? "button" : undefined}
-        tabIndex={id ? 0 : undefined}
-        className={`group flex items-center border-b border-border/40 px-3 py-2 text-sm last:border-b-0 ${id ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
-        onClick={() => id && setExpanded(!expanded)}
+        role={threadId ? "button" : undefined}
+        tabIndex={threadId ? 0 : undefined}
+        className={`group flex items-center border-b border-border/40 px-3 py-2 text-sm last:border-b-0 ${threadId ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
+        onClick={() => threadId && setExpanded(!expanded)}
         onKeyDown={(e) => {
-          if (id && (e.key === "Enter" || e.key === " ")) {
+          if (threadId && (e.key === "Enter" || e.key === " ")) {
             e.preventDefault();
             setExpanded(!expanded);
           }
         }}
       >
-        {id && (
+        {threadId && (
           <div className="mr-1 flex w-4 shrink-0 justify-center text-muted-foreground">
             {expanded ? (
               <ChevronDownIcon className="size-3.5" />
@@ -268,7 +281,7 @@ export function InlineEmailCard({
         </div>
       </div>
 
-      {expanded && id && <EmailPreview threadId={id} />}
+      {expanded && threadId && <EmailPreview threadId={threadId} />}
     </div>
   );
 }
@@ -276,8 +289,11 @@ export function InlineEmailCard({
 function collectThreadIds(children: ReactNode): string[] {
   const ids: string[] = [];
   Children.forEach(children, (child) => {
-    if (isValidElement<{ id?: string }>(child) && child.props.id) {
-      ids.push(child.props.id);
+    if (!isValidElement<{ id?: string; threadid?: string }>(child)) return;
+
+    const threadId = resolveInlineEmailThreadId(child.props);
+    if (threadId) {
+      ids.push(threadId);
     }
   });
   return ids;
@@ -317,4 +333,19 @@ function EmailPreview({ threadId }: { threadId: string }) {
       {text}
     </div>
   );
+}
+
+function resolveInlineEmailThreadId({
+  id,
+  threadid,
+}: {
+  id?: string;
+  threadid?: string;
+}) {
+  if (threadid) return threadid;
+  if (!id) return undefined;
+  if (id.startsWith("user-content-")) {
+    return id.slice("user-content-".length) || undefined;
+  }
+  return id;
 }

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -609,10 +609,10 @@ Inline email cards:
 - When presenting emails for triage or inbox summary, use <email> tags wrapped in an <emails> container to render an interactive inbox-style table.
 - Format:
 <emails>
-<email id="THREAD_ID" action="archive">Brief context</email>
-<email id="THREAD_ID" action="none">Brief context</email>
+<email threadid="THREAD_ID" action="archive">Brief context</email>
+<email threadid="THREAD_ID" action="none">Brief context</email>
 </emails>
-- The id attribute must be a threadId from searchInbox results.
+- The threadid attribute must be a threadId from searchInbox results. Do not use the HTML id attribute.
 - The action attribute controls which button to show: "archive" (or omitted) shows an Archive button, "none" hides the action button.
 - The inner text is your brief context or recommendation (e.g. "Subscription cancellation — confirm and outline next steps").
 - The UI automatically resolves the full email metadata (sender, subject, date) from the thread ID, so do NOT repeat those details in the tag content.


### PR DESCRIPTION
# User description
Fix assistant email card thread identifier handling in chat responses.

This updates inline email card rendering to normalize legacy ids, accept a dedicated threadid attribute, and use the resolved thread identifier for archive and external-link actions. It also updates the assistant formatting guidance to emit threadid for new responses and adds regression tests for legacy ids, bulk archive behavior, and response rendering.

Testing: `cd apps/web && pnpm test --run components/assistant-chat/inline-email-card.test.tsx components/ai-elements/response.test.tsx`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update Response and InlineEmailCard to normalize inline email thread identifiers, accept the explicit <code>threadid</code> attribute, and reuse the resolved ID for archive/link actions. Emit the <code>threadid</code> guidance in assistant formatting so responses keep thread context consistent while adding regression coverage for inline card and response rendering behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1877?tool=ast&topic=Inline+Thread+Handling>Inline Thread Handling</a>
        </td><td>Normalize legacy <code>id</code> values and honor the explicit <code>threadid</code> attribute when rendering inline email cards, resolving the identifier used for metadata lookup, archive actions, and archive/external links.<details><summary>Modified files (3)</summary><ul><li>apps/web/components/ai-elements/response.tsx</li>
<li>apps/web/components/assistant-chat/inline-email-card.tsx</li>
<li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-use-label-names-in...</td><td>March 10, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix-Anthropic-System-M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1877?tool=ast&topic=Inline+Card+Tests>Inline Card Tests</a>
        </td><td>Exercise the updated inline email card flow through regression tests covering legacy IDs, threadid-driven bulk archive, and response rendering to keep behavior stable.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/ai-elements/response.test.tsx</li>
<li>apps/web/components/assistant-chat/inline-email-card.test.tsx</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1877?tool=ast>(Baz)</a>.