### PR TITLE
Fix JSX runtime imports for Vitest

### DIFF
--- a/apps/web/components/ai-elements/response.test.tsx
+++ b/apps/web/components/ai-elements/response.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import type { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Response } from "@/components/ai-elements/response";

--- a/apps/web/components/ai-elements/response.tsx
+++ b/apps/web/components/ai-elements/response.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/utils/index";
-import { type ComponentProps, memo } from "react";
+import React, { type ComponentProps, memo } from "react";
 import { Streamdown } from "streamdown";
 import {
   InlineEmailCard,

--- a/apps/web/components/assistant-chat/inline-email-card.test.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import type { MouseEvent, ReactNode } from "react";
+import React, { type MouseEvent, type ReactNode } from "react";
 import {
   cleanup,
   fireEvent,


### PR DESCRIPTION
# User description
This restores value imports for React where the Vitest JSX runtime requires them.
It fixes the failing test workflow by aligning the response component and related tests with the runtime used in CI.

- Add React value imports to the response component and affected tests
- Verify with the targeted tests and the full inbox-zero-ai test suite

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure React default import is retained in the <code>Response</code> component so Vitest can hook into the correct JSX runtime while keeping memoized rendering intact. Align inline email card and response tests with the CI runtime by importing React alongside their typed helpers for consistent JSX handling.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-assistant-email-ca...</td><td>March 11, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1882?tool=ast>(Baz)</a>.