### PR TITLE
ui: Fix sidebar menu placement

### DIFF
--- a/apps/web/components/NavUser.tsx
+++ b/apps/web/components/NavUser.tsx
@@ -27,7 +27,7 @@ import { logOut } from "@/utils/user";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { useTheme } from "next-themes";
 import { ProfileImage } from "@/components/ProfileImage";
-import { SidebarMenuButton } from "@/components/ui/sidebar";
+import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { EXTENSION_URL } from "@/utils/config";
 import { useUser } from "@/hooks/useUser";
@@ -35,6 +35,7 @@ import { env } from "@/env";
 
 export function NavUser() {
   const { emailAccountId, emailAccount, provider } = useAccount();
+  const { isMobile } = useSidebar();
   const { theme, setTheme } = useTheme();
   const { data: user } = useUser();
 
@@ -78,8 +79,8 @@ export function NavUser() {
         </SidebarMenuButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="min-w-52 origin-top-right rounded-md"
-        side="bottom"
+        className="min-w-52 rounded-md md:w-[--radix-dropdown-menu-trigger-width]"
+        side={isMobile ? "bottom" : "right"}
         align="end"
         sideOffset={4}
       >


### PR DESCRIPTION
# User description
Adjust the sidebar account menu so it opens out from the nav on desktop instead of covering it.
This keeps the current mobile behavior intact.

- open the account dropdown on the right for desktop layouts
- keep bottom placement on mobile and match the dropdown width to its trigger

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjusts the <code>NavUser</code> account dropdown to rely on the sidebar’s <code>isMobile</code> flag so desktop layouts open to the right with width tied to the trigger. Keeps the bottom placement for mobile to preserve the existing navigation behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Globalize-settings-rou...</td><td>February 10, 2026</td></tr>
<tr><td>elie222</td><td>Hide-premium-billing-i...</td><td>November 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1887?tool=ast>(Baz)</a>.