### PR TITLE
bulk archive: prevent accidental setup dismissal

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -1,0 +1,71 @@
+/** @vitest-environment jsdom */
+
+import React, { type ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+(globalThis as { React?: typeof React }).React = React;
+
+const mockSetupDialog = vi.fn();
+const mockUseAccount = vi.fn();
+const mockUseCategorizeProgress = vi.fn();
+
+vi.mock("@/components/SetupCard", () => ({
+  SetupDialog: (props: { children: ReactNode }) => {
+    mockSetupDialog(props);
+    return <div>{props.children}</div>;
+  },
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress", () => ({
+  useCategorizeProgress: () => mockUseCategorizeProgress(),
+}));
+
+vi.mock("@/utils/actions/categorize", () => ({
+  bulkCategorizeSendersAction: vi.fn(),
+}));
+
+vi.mock("@/components/Toast", () => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+describe("AutoCategorizationSetup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+    });
+
+    mockUseCategorizeProgress.mockReturnValue({
+      setIsBulkCategorizing: vi.fn(),
+    });
+  });
+
+  it("prevents accidental dismissal from the backdrop or escape key", async () => {
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
+    );
+
+    render(<AutoCategorizationSetup open />);
+
+    const setupDialogProps = mockSetupDialog.mock.calls[0]?.[0];
+
+    expect(setupDialogProps.dialogContentProps.hideCloseButton).toBe(true);
+
+    const interactOutsideEvent = { preventDefault: vi.fn() };
+    setupDialogProps.dialogContentProps.onInteractOutside(
+      interactOutsideEvent,
+    );
+    expect(interactOutsideEvent.preventDefault).toHaveBeenCalledTimes(1);
+
+    const escapeKeyEvent = { preventDefault: vi.fn() };
+    setupDialogProps.dialogContentProps.onEscapeKeyDown(escapeKeyEvent);
+    expect(escapeKeyEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -74,6 +74,11 @@ export function AutoCategorizationSetup({
     <SetupDialog
       open={open}
       onOpenChange={onOpenChange}
+      dialogContentProps={{
+        hideCloseButton: true,
+        onInteractOutside: (event) => event.preventDefault(),
+        onEscapeKeyDown: (event) => event.preventDefault(),
+      }}
       imageSrc="/images/illustrations/working-vacation.svg"
       imageAlt="Bulk Archive"
       title="Bulk Archive"

--- a/apps/web/components/SetupCard.tsx
+++ b/apps/web/components/SetupCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import Image from "next/image";
 import { Card, CardFooter } from "@/components/ui/card";
 import { SectionDescription, TypographyH3 } from "@/components/Typography";
@@ -18,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/utils";
 
 type FeatureItem = {
   icon: ReactNode;
@@ -45,14 +46,18 @@ export function SetupCard(props: SetupContentProps) {
 export function SetupDialog({
   open,
   onOpenChange,
+  dialogContentProps,
   ...props
 }: SetupContentProps & {
   open: boolean;
   onOpenChange?: (open: boolean) => void;
+  dialogContentProps?: Omit<ComponentProps<typeof DialogContent>, "children">;
 }) {
+  const { className, ...contentProps } = dialogContentProps ?? {};
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className={cn("max-w-lg", className)} {...contentProps}>
         <DialogHeader className="sr-only">
           <DialogTitle>{props.title}</DialogTitle>
           <DialogDescription>{props.description}</DialogDescription>


### PR DESCRIPTION
# User description
Prevent the bulk archive setup dialog from being dismissed before categorization starts.

- pass dialog content props through the shared setup dialog
- block backdrop and escape dismissal for the bulk archive onboarding flow
- add a focused regression test for accidental dismiss attempts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent dialog dismissal in the bulk archive onboarding by passing content props through <code>SetupDialog</code> and enforcing backdrop/escape handling inside <code>AutoCategorizationSetup</code>. Include a regression test that exercises those protected interactions to keep the onboarding open until categorization begins.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1894?tool=ast&topic=Bulk+Archive+Setup>Bulk Archive Setup</a>
        </td><td>Prevent accidental dismissal for the bulk archive onboarding by hiding the close button and intercepting backdrop and escape events on the <code>SetupDialog</code> used by <code>AutoCategorizationSetup</code>, plus cover the scenario in a focused regression test.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-allow-non-premium-...</td><td>January 11, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1894?tool=ast&topic=Setup+Dialog+Props>Setup Dialog Props</a>
        </td><td>Allow callers to inject <code>DialogContent</code> props so shared setup flows can customize behavior like dismissal handling without changing the wrapper.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/SetupCard.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-allow-non-premium-...</td><td>January 11, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Clean-up-setup-flow-fo...</td><td>January 07, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1894?tool=ast>(Baz)</a>.