### PR TITLE
categorization: restore sender fallback behavior

### DIFF
--- a/apps/web/__tests__/ai-categorize-senders.test.ts
+++ b/apps/web/__tests__/ai-categorize-senders.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import {
-  aiCategorizeSenders,
-  REQUEST_MORE_INFORMATION_CATEGORY,
-} from "@/utils/ai/categorize-sender/ai-categorize-senders";
+import { aiCategorizeSenders } from "@/utils/ai/categorize-sender/ai-categorize-senders";
 import { defaultCategory } from "@/utils/categories";
 import { aiCategorizeSender } from "@/utils/ai/categorize-sender/ai-categorize-single-sender";
 import { getEmailAccount } from "@/__tests__/helpers";
@@ -135,9 +132,7 @@ describe.runIf(isAiTest)("AI Sender Categorization", () => {
           });
 
           if (expectedCategory === "Unknown") {
-            expect([REQUEST_MORE_INFORMATION_CATEGORY, "Unknown"]).toContain(
-              result?.category,
-            );
+            expect(result).toBeNull();
           } else {
             expect(result?.category).toBe(expectedCategory);
           }
@@ -161,9 +156,7 @@ describe.runIf(isAiTest)("AI Sender Categorization", () => {
           categories: getEnabledCategories(),
         });
 
-        expect([REQUEST_MORE_INFORMATION_CATEGORY, "Unknown"]).toContain(
-          result?.category,
-        );
+        expect(result).toBeNull();
       },
       TIMEOUT,
     );
@@ -202,6 +195,11 @@ describe.runIf(isAiTest)("AI Sender Categorization", () => {
           const singleResult = singleResults.find(
             (r) => r.sender === emailAddress,
           );
+
+          if (expectedCategory === "Unknown") {
+            expect(singleResult?.category).toBeUndefined();
+            continue;
+          }
 
           // Both should either have a category or both be undefined
           if (bulkResult?.category || singleResult?.category) {

--- a/apps/web/__tests__/eval/categorize-senders.test.ts
+++ b/apps/web/__tests__/eval/categorize-senders.test.ts
@@ -16,7 +16,7 @@ const TIMEOUT = 60_000;
 //
 // Each test case represents a SENDER being categorized based on previous emails.
 // Multi-email cases test pattern recognition; single-email cases test whether
-// models can categorize with minimal context or correctly defer to "Other".
+// models can categorize with minimal context or safely abstain when signal is missing.
 // Senders use generic addresses to force classification based on content.
 const testCases = [
   // --- Newsletter senders ---
@@ -268,6 +268,12 @@ const testCases = [
     ],
     expected: "Other",
   },
+  // No prior email context should not force a category
+  {
+    sender: "unknown@example.com",
+    emails: [],
+    expected: null,
+  },
   // SaaS that mixes marketing and notifications — but this sender's pattern is updates
   {
     sender: "hello@company.io",
@@ -354,8 +360,9 @@ describe.runIf(isAiTest)("Eval: Categorize Senders", () => {
 
   describeEvalMatrix("categorize", (model, emailAccount) => {
     for (const tc of testCases) {
+      const expectedLabel = tc.expected ?? "none";
       test(
-        `${tc.sender} → ${tc.expected}`,
+        `${tc.sender} → ${expectedLabel}`,
         async () => {
           const result = await aiCategorizeSender({
             emailAccount,
@@ -365,16 +372,17 @@ describe.runIf(isAiTest)("Eval: Categorize Senders", () => {
           });
 
           const actual = result?.category ?? "none";
-          const pass = actual === tc.expected;
+          const expected = tc.expected ?? "none";
+          const pass = actual === expected;
           evalReporter.record({
-            testName: `${tc.sender} → ${tc.expected}`,
+            testName: `${tc.sender} → ${expectedLabel}`,
             model: model.label,
             pass,
-            expected: tc.expected,
+            expected: expectedLabel,
             actual,
           });
 
-          expect(result?.category).toBe(tc.expected);
+          expect(actual).toBe(expected);
         },
         TIMEOUT,
       );

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
@@ -41,8 +41,8 @@ ${formatCategoriesForPrompt(categories)}
 1. Analyze the sender's name and email address for clues about their category.
 2. Review the content of previous emails to gain more context about the account's relationship with us.
 3. If the category is clear, assign it.
-4. If you're not certain or multiple categories seem possible, choose the best matching category from the list above.
-5. You must pick exactly one category from the list above.
+4. If you're not certain, respond with "Unknown".
+5. If multiple categories are possible, respond with "Unknown".
 6. Return your response in JSON format.
 </instructions>`;
 

--- a/apps/web/utils/categories.ts
+++ b/apps/web/utils/categories.ts
@@ -15,7 +15,7 @@ export const defaultCategory = {
     name: "Marketing",
     enabled: true,
     description:
-      "Mass promotional emails, product launches, and marketing campaigns from companies",
+      "Promotional content, product launches, and marketing campaigns",
   },
   RECEIPT: {
     name: "Receipt",

--- a/apps/web/utils/categorize/senders/categorize.test.ts
+++ b/apps/web/utils/categorize/senders/categorize.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEmailAccount } from "@/__tests__/helpers";
+import { defaultCategory } from "@/utils/categories";
+import { categorizeSender } from "@/utils/categorize/senders/categorize";
+import { aiCategorizeSender } from "@/utils/ai/categorize-sender/ai-categorize-single-sender";
+import { upsertSenderRecord } from "@/utils/senders/record";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/ai/categorize-sender/ai-categorize-single-sender", () => ({
+  aiCategorizeSender: vi.fn(),
+}));
+
+vi.mock("@/utils/senders/record", () => ({
+  upsertSenderRecord: vi.fn(),
+}));
+
+describe("categorizeSender", () => {
+  const emailAccount = getEmailAccount();
+  const categories = [
+    {
+      id: "cat-other",
+      name: defaultCategory.OTHER.name,
+      description: defaultCategory.OTHER.description,
+    },
+    {
+      id: "cat-notification",
+      name: defaultCategory.NOTIFICATION.name,
+      description: defaultCategory.NOTIFICATION.description,
+    },
+  ];
+  const provider = {
+    getThreadsFromSenderWithSubject: vi.fn(),
+  } as unknown as {
+    getThreadsFromSenderWithSubject: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider.getThreadsFromSenderWithSubject.mockResolvedValue([]);
+  });
+
+  it("defaults abstained single-sender categorization to Other", async () => {
+    vi.mocked(aiCategorizeSender).mockResolvedValue(null);
+    vi.mocked(upsertSenderRecord).mockResolvedValue({
+      categoryId: "cat-other",
+    } as Awaited<ReturnType<typeof upsertSenderRecord>>);
+
+    const result = await categorizeSender(
+      "unknown@example.com",
+      emailAccount,
+      provider as never,
+      categories,
+    );
+
+    expect(upsertSenderRecord).toHaveBeenCalledWith({
+      emailAccountId: emailAccount.id,
+      newsletterEmail: "unknown@example.com",
+      changes: {
+        categoryId: "cat-other",
+      },
+    });
+    expect(result).toEqual({ categoryId: "cat-other" });
+  });
+});

--- a/apps/web/utils/categorize/senders/categorize.ts
+++ b/apps/web/utils/categorize/senders/categorize.ts
@@ -38,24 +38,39 @@ export async function categorizeSender(
     categories,
   });
 
-  if (aiResult) {
-    const { newsletter } = await updateSenderCategory({
-      sender: senderAddress,
-      senderName,
-      categories,
-      categoryName: aiResult.category,
-      emailAccountId: emailAccount.id,
-    });
+  const fallbackCategory = categories.find(
+    (category) => category.name === defaultCategory.OTHER.name,
+  );
+  const categoryName = aiResult?.category ?? fallbackCategory?.name;
 
-    return { categoryId: newsletter.categoryId };
+  if (!categoryName) {
+    logger.info(
+      "AI categorization abstained with no Other category available",
+      {
+        userEmail: emailAccount.email,
+        senderAddress,
+      },
+    );
+
+    return { categoryId: undefined };
   }
 
-  logger.error("No AI result for sender", {
-    userEmail: emailAccount.email,
-    senderAddress,
+  const { newsletter } = await updateSenderCategory({
+    sender: senderAddress,
+    senderName,
+    categories,
+    categoryName,
+    emailAccountId: emailAccount.id,
   });
 
-  return { categoryId: undefined };
+  if (!aiResult) {
+    logger.info("AI categorization abstained; defaulting sender to Other", {
+      userEmail: emailAccount.email,
+      senderAddress,
+    });
+  }
+
+  return { categoryId: newsletter.categoryId };
 }
 
 export async function updateSenderCategory({


### PR DESCRIPTION
# User description
Restore safer single-sender categorization behavior and keep category fallback handling consistent without carrying the low-signal description change.

- allow single-sender categorization to abstain instead of forcing a category
- normalize abstentions to Other only when that category exists and cover the path with tests
- keep the Marketing category description on the prior wording

Tested:
- pnpm --filter ./apps/web exec vitest run utils/categorize/senders/categorize.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify single-sender categorization instructions so <code>aiCategorizeSender</code> can respond with <code>Unknown</code> and the flow normalizes that abstention through <code>categorizeSender</code> only when <code>defaultCategory.OTHER</code> is available. Adjust the helper and shared category metadata to keep the Marketing description unchanged while ensuring AI-driven classification and fallback logging stay consistent.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1898?tool=ast&topic=Categorization+tests>Categorization tests</a>
        </td><td>Cover abstention cases in the unit and evaluation suites so both the AI categorization and grouping tests expect <code>null</code>/<code>none</code> when signal is missing.<details><summary>Modified files (3)</summary><ul><li>apps/web/__tests__/ai-categorize-senders.test.ts</li>
<li>apps/web/__tests__/eval/categorize-senders.test.ts</li>
<li>apps/web/utils/categorize/senders/categorize.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-eval-infrastructur...</td><td>March 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Reduce-sender-categori...</td><td>January 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1898?tool=ast&topic=Single-sender+fallback>Single-sender fallback</a>
        </td><td>Restore single-sender abstention by letting <code>aiCategorizeSender</code> return <code>Unknown</code>, falling back to <code>defaultCategory.OTHER</code> only when present, and retaining the prior Marketing description while logging when no fallback exists.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts</li>
<li>apps/web/utils/categories.ts</li>
<li>apps/web/utils/categorize/senders/categorize.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-eval-infrastructur...</td><td>March 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Display-sender-names-i...</td><td>January 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1898?tool=ast>(Baz)</a>.