### PR TITLE
setup: update progress after step dismissal

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -277,7 +277,7 @@ function Checklist({
     completed: boolean;
     organizationId: string | undefined;
   } | null;
-  onSetupProgressChanged: () => void;
+  onSetupProgressChanged: (stepKey: DismissibleSetupStep) => void;
 }) {
   const { executeAsync: dismissSetupStep, isExecuting: isDismissingStep } =
     useAction(dismissHintAction);
@@ -305,7 +305,7 @@ function Checklist({
           return;
         }
 
-        onSetupProgressChanged();
+        onSetupProgressChanged(stepKey);
       } finally {
         setPendingStep(null);
       }
@@ -433,6 +433,18 @@ export function SetupContent() {
   const { data, isLoading, error, mutate } = useSetupProgress();
   const searchParams = useSearchParams();
   const forceSetupMode = searchParams.get("forceSetup") === "1";
+  const handleSetupProgressChanged = useCallback(
+    (stepKey: DismissibleSetupStep) => {
+      mutate(
+        (currentData) =>
+          currentData
+            ? getUpdatedSetupProgress(currentData, stepKey)
+            : currentData,
+        { revalidate: true },
+      );
+    },
+    [mutate],
+  );
 
   return (
     <LoadingContent loading={isLoading} error={error}>
@@ -449,9 +461,7 @@ export function SetupContent() {
           isSetupComplete={data.isComplete}
           forceSetupMode={forceSetupMode}
           teamInvite={data.teamInvite}
-          onSetupProgressChanged={() => {
-            mutate();
-          }}
+          onSetupProgressChanged={handleSetupProgressChanged}
         />
       )}
     </LoadingContent>
@@ -486,7 +496,7 @@ function SetupPageContent({
     completed: boolean;
     organizationId: string | undefined;
   } | null;
-  onSetupProgressChanged: () => void;
+  onSetupProgressChanged: (stepKey: DismissibleSetupStep) => void;
 }) {
   const shouldShowSetupChecklist = forceSetupMode || !isSetupComplete;
 
@@ -521,4 +531,57 @@ function SetupPageContent({
       )}
     </div>
   );
+}
+
+function getUpdatedSetupProgress(
+  currentData: NonNullable<ReturnType<typeof useSetupProgress>["data"]>,
+  stepKey: DismissibleSetupStep,
+) {
+  if (stepKey === "tabsExtension") {
+    return currentData.tabsExtensionCompleted
+      ? currentData
+      : { ...currentData, tabsExtensionCompleted: true };
+  }
+
+  const nextSteps = { ...currentData.steps };
+  let completedIncrement = 0;
+
+  if (stepKey === "teamInvite") {
+    if (!currentData.teamInvite || currentData.teamInvite.completed) {
+      return currentData;
+    }
+
+    completedIncrement = 1;
+
+    return {
+      ...currentData,
+      completed: Math.min(
+        currentData.completed + completedIncrement,
+        currentData.total,
+      ),
+      isComplete:
+        currentData.completed + completedIncrement >= currentData.total,
+      teamInvite: {
+        ...currentData.teamInvite,
+        completed: true,
+      },
+    };
+  }
+
+  if (nextSteps[stepKey]) {
+    return currentData;
+  }
+
+  nextSteps[stepKey] = true;
+  completedIncrement = 1;
+
+  return {
+    ...currentData,
+    steps: nextSteps,
+    completed: Math.min(
+      currentData.completed + completedIncrement,
+      currentData.total,
+    ),
+    isComplete: currentData.completed + completedIncrement >= currentData.total,
+  };
 }


### PR DESCRIPTION
# User description
Update the setup checklist immediately after a step is marked done, while still revalidating against the server.

- update the SWR cache for the dismissed step so row state and progress refresh right away
- keep the server as the source of truth by revalidating in the background

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update SetupContent to use <code>handleSetupProgressChanged</code> so dismissing steps applies <code>getUpdatedSetupProgress</code> via <code>mutate</code> and revalidates <code>useSetupProgress</code> while Checklist now invokes the new callback signature. Keep the UI responsive to step dismissal by refreshing progress state immediately even as server revalidation keeps the data authoritative.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>setup-sync-dismissed-s...</td><td>March 13, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Refresh-onboarding-flo...</td><td>February 03, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1904?tool=ast>(Baz)</a>.