### PR TITLE
settings: simplify billing invoices action

### DIFF
--- a/apps/web/app/(app)/premium/ManageSubscription.tsx
+++ b/apps/web/app/(app)/premium/ManageSubscription.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CreditCardIcon, ReceiptIcon } from "lucide-react";
+import { CreditCardIcon } from "lucide-react";
 import Link from "next/link";
 import { env } from "@/env";
 import { Button } from "@/components/ui/button";
@@ -65,24 +65,22 @@ export function ViewInvoicesButton({
     <>
       {stripeCustomerId && (
         <Button
-          variant="outline"
+          variant="link"
           size="sm"
           loading={loading}
           onClick={openBillingPortal}
         >
-          <ReceiptIcon className="mr-2 h-4 w-4" />
-          View{hasBoth ? " Stripe" : ""} invoices
+          {hasBoth ? "Stripe invoices" : "Invoices"}
         </Button>
       )}
 
       {lemonSqueezyCustomerId && (
-        <Button asChild variant="outline" size="sm">
+        <Button asChild variant="link" size="sm">
           <Link
             href={`https://${env.NEXT_PUBLIC_LEMON_STORE_ID}.lemonsqueezy.com/billing`}
             target="_blank"
           >
-            <ReceiptIcon className="mr-2 h-4 w-4" />
-            View{hasBoth ? " Lemon" : ""} invoices
+            {hasBoth ? "Lemon invoices" : "Invoices"}
           </Link>
         </Button>
       )}


### PR DESCRIPTION
# User description
This updates the billing settings row so the invoices action reads more cleanly and no longer uses an outlined button style.

- switch the invoices action to the existing link button variant
- remove the invoice icon and shorten the single-provider label to "Invoices"

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refresh the <code>ManageSubscription</code> flow so <code>ViewInvoicesButton</code> renders invoices as link buttons instead of outlined ones. Simplify the invoices copy by removing the icon and shortening the provider label for single-provider setups.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-View-Invoices-butt...</td><td>March 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1906?tool=ast>(Baz)</a>.