### PR TITLE
docs: merge changelog updates

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Latest updates and improvements to Inbox Zero"
 ---
 
+<Update label="March 13, 2026" description="Assistant Stays in Sync">
+  The AI assistant now tracks actions you take directly in your inbox — archiving or marking emails as read updates the chat so it won't suggest work you've already done.
+
+  - Clickable links preserved in draft replies
+  - Receive Slack check-ins as a DM instead of a channel post
+  - Marketing emails with personal tone no longer misclassified as conversations
+</Update>
+
 <Update label="March 12, 2026" description="Richer Chat Previews">
   The assistant chat now renders full email previews — headers, body, and attachments — right in the conversation, so you can read and act on emails without switching to your inbox.
 


### PR DESCRIPTION
# User description
Combine the pending changelog documentation updates into a single conflict-free PR.

- merge three docs-only changelog branches
- resolve ordering conflicts in the changelog file
- preserve reverse-chronological update entries

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Merge the pending changelog entries into a single conflict-free document while preserving reverse-chronological ordering to capture recent Inbox Zero assistant improvements. Highlight assistant sync tracking, richer chat previews, and broader attachment auto-filing so the latest behaviors are documented alongside actionable notes.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>cursor[bot]</td><td>Changelog-Act-on-Email...</td><td>March 13, 2026</td></tr>
<tr><td>elie222</td><td>Add-changelog-page-to-...</td><td>March 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1908?tool=ast>(Baz)</a>.