### PR TITLE
chore: remove sub-agent review gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,3 @@ See `.claude/skills/fullstack-workflow/SKILL.md` for full examples and templates
 - Data fetching: SWR on the client. Call `mutate()` after mutations.
 - Forms: React Hook Form + `useAction` hook. Use `getActionErrorMessage(error.error)` for errors.
 - Loading states: use `LoadingContent` component.
-
-## Sub-Agent Review Gate
-- When a task is completed and ready for PR, invoke the `reviewer` sub-agent (`.claude/agents/reviewer.md`) before opening the PR.


### PR DESCRIPTION
# User description
Remove mandatory reviewer sub-agent gate from AGENTS.md

The sub-agent review gate slowed down every PR. The reviewer agent is still available for on-demand use.

- Removed the "Sub-Agent Review Gate" section from AGENTS.md

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify that AGENTS guidance no longer mandates invoking the reviewer sub-agent before PRs, leaving the reviewer agent as an optional on-demand tool. Highlight that the document now focuses on the remaining flow guidance without the removed gate.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore-consolidate-test...</td><td>March 13, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1911?tool=ast>(Baz)</a>.