### PR TITLE
rules: refine conversation rule evals

### DIFF
--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -277,9 +277,9 @@ You're receiving this email because you joined MindfulPath. To stop receiving th
   },
   {
     email: getEmail({
-      from: "Maya from ToolStack <maya@research.toolstack.io>",
+      from: "Maya from ToolStack <maya@research.example>",
       subject: "Your feedback + a $25 gift card",
-      listUnsubscribe: "<https://research.toolstack.io/unsubscribe?id=xyz789>",
+      listUnsubscribe: "<https://research.example/unsubscribe?id=xyz789>",
       content: `Hi there,
 
 I'm Maya from the ToolStack research team. We're reaching out to a small, hand-picked group of power users to learn about their experience with our platform. You were selected because you've been one of our most engaged users over the past quarter, and your insights would be particularly meaningful to our team.
@@ -288,7 +288,7 @@ The session is a casual 15-minute video call where we'll walk through your typic
 
 As a thank you for your time, every participant receives a $25 gift card — no strings attached.
 
-If you're interested, just grab a time on my calendar that works for you: https://cal.toolstack.io/maya/user-interview
+If you're interested, just grab a time on my calendar that works for you: https://cal.example/maya/user-interview
 
 I really hope we get to chat!
 

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -83,9 +83,8 @@ EXCLUDE:
 - Emails with List-Unsubscribe headers or unsubscribe links are a strong signal of mass/automated emails
 
 IMPORTANT:
-- This rule is ONLY for human-to-human communication.
-- If the email is automated or system-generated and another rule is a better fit, do not use this rule.
-- Keep this rule as the primary match for genuine human conversations.`;
+- Only use this rule for human-to-human communication. If an email is automated or system-generated and another rule is a better fit, do not use this rule.
+- When this rule matches, it should typically be the primary match.`;
 
 export async function runRules({
   provider,


### PR DESCRIPTION
# User description
Tightens a conversation-rule clarification and adds focused eval coverage for rule selection edge cases.

- keep the prompt change local to conversation matching
- add eval cases for problematic automated message patterns
- validate the current behavior against Gemini 2.5 Flash

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the <code>runRules</code> conversation-tracking guidance to emphasize it should only match human-to-human emails and remain the primary match for conversational flow. Expand the <code>choose-rule</code> evaluations to cover reported automated notification patterns—including Gemini 2.5 Flash edge cases—and adjust the marketing sample to expect marketing, notification, and conversation rules.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1913?tool=ast&topic=Conversation+Rule+Guidance>Conversation Rule Guidance</a>
        </td><td>Clarify the <code>CONVERSATION_TRACKING_INSTRUCTIONS</code> in <code>runRules</code> to stress humans-only coverage and remind reviewers that it should typically be the primary match.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/choose-rule/run-rules.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-dont-mark-marketin...</td><td>March 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1913?tool=ast&topic=Evaluation+Coverage>Evaluation Coverage</a>
        </td><td>Add focused evals in <code>choose-rule.test.ts</code> for known problematic automated emails, including notification and receipt scenarios, and widen the marketing sample to expect Marketing, Notification, and Conversations matches.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/eval/choose-rule.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-dont-mark-marketin...</td><td>March 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1913?tool=ast>(Baz)</a>.