### PR TITLE
docs: Add README sanity check note

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Open http://localhost:3000
 
 See the **[Contributing Guide](https://docs.getinboxzero.com/contributing)** for more details including devcontainer setup.
 
+For a quick sanity check after setup, run `pnpm lint` and `pnpm test`.
+
 ## Contributing
 
 View open tasks in [GitHub Issues](https://github.com/elie222/inbox-zero/issues) and join our [Discord](https://www.getinboxzero.com/discord) to discuss what's being worked on.


### PR DESCRIPTION
# User description
Add a small local-development note to the README.

This keeps the change intentionally limited to docs and gives contributors a quick post-setup verification step.

- add a sanity-check note after the local development setup steps
- recommend running `pnpm lint` and `pnpm test` after setup

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a quick sanity-check reminder to the README, directing contributors to run <code>pnpm lint</code> and <code>pnpm test</code> after completing the local development setup so they can verify their environment. Keep the note concise and directly tied to the contributor setup flow.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>deps-update-packages-a...</td><td>March 06, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>feat-add-devcontainer-...</td><td>January 04, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1915?tool=ast>(Baz)</a>.