### PR TITLE
docs: clarify rebuild requirement for external API env var

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -26,7 +26,7 @@ API keys are scoped to a specific inbox account and only grant access to the per
 
 ### Self-Hosting
 
-If you are self-hosting Inbox Zero, set the `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true` environment variable to enable the API, and use your deployment URL as the base URL for requests (for example, `https://your-domain.com/api/v1`).
+If you are self-hosting Inbox Zero, set the `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true` environment variable and rebuild the app to enable the API. Use your deployment URL as the base URL for requests (for example, `https://your-domain.com/api/v1`).
 
 ## Base URL
 


### PR DESCRIPTION
# User description
docs: clarify rebuild requirement for external API env var

Add note that self-hosted deployments must rebuild the app after setting `NEXT_PUBLIC_EXTERNAL_API_ENABLED` since `NEXT_PUBLIC_` vars are inlined at build time.

- Add "and rebuild the app" to self-hosting docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Emphasize that the self-hosting documentation must remind operators to rebuild the app after enabling <code>NEXT_PUBLIC_EXTERNAL_API_ENABLED</code> because <code>NEXT_PUBLIC_</code> variables are inlined at build time. Mention that the doc now pairs this rebuild reminder with the external API configuration steps for clarity.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-API-key-creation-o...</td><td>March 14, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1919?tool=ast>(Baz)</a>.