### PR TITLE
dev: support custom workspace ports

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "run": "PORT=$CONDUCTOR_PORT pnpm dev"
+    "run": "PORT=${PORT:-$CONDUCTOR_PORT}; NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL:-http://localhost:$PORT}; export PORT NEXT_PUBLIC_BASE_URL; pnpm dev"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "globalPassThroughEnv": ["PORT", "CONDUCTOR_PORT"],
+  "globalPassThroughEnv": ["PORT", "CONDUCTOR_PORT", "NEXT_PUBLIC_BASE_URL"],
   "tasks": {
     "build": {
       "env": [


### PR DESCRIPTION
Allow development runs to respect configured port overrides in local and Conductor environments.

- pass `PORT`, `CONDUCTOR_PORT`, and `NEXT_PUBLIC_BASE_URL` through Turbo strict env handling
- run the Conductor startup script with the assigned workspace port and matching localhost base URL