### PR TITLE
chore: update browser testing to use headless Chrome with saved profile

### DIFF
--- a/.claude/skills/test-feature/SKILL.md
+++ b/.claude/skills/test-feature/SKILL.md
@@ -67,13 +67,42 @@ Use the `agent-browser` skill for all browser interactions. The core loop is: op
 
 #### Browser authentication
 
-The app requires OAuth login. agent-browser can't complete OAuth in headless mode, so you need the user's real browser session. Options (in order of preference):
+The app requires OAuth login. agent-browser can't complete OAuth, so you need a Chrome profile with an existing logged-in session.
 
-1. **Connect to user's Chrome via CDP**: Ask the user to launch Chrome with `--remote-debugging-port=9222` (or check if it's already running). Then use `agent-browser --cdp 9222`. This reuses their existing logged-in session.
-2. **Headed mode with profile**: Use `agent-browser --headed --profile <path>` to open a visible Chrome window. The user signs in once and the profile persists for future runs.
+**Preferred approach: headless Chrome with a saved profile**
+
+The user should have a dedicated Chrome profile directory with a logged-in session (stored outside the repo, e.g. `~/.chrome-debug-inbox-zero`). Check the user's auto-memory for the profile path. Then launch Chrome headless and connect:
+
+```bash
+# 1. Check if CDP is already running
+curl -s http://127.0.0.1:9222/json/version
+
+# 2. If not, launch Chrome headless with the saved profile
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless=new \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.chrome-debug-<name>" &>/dev/null &
+sleep 3
+
+# 3. Connect agent-browser
+agent-browser close
+curl -s -X PUT "http://127.0.0.1:9222/json/new?about:blank" > /dev/null
+sleep 2
+agent-browser --cdp 9222 open http://localhost:3000/automation
+```
+
+This runs entirely in the background — the user doesn't need to do anything.
+
+**Important caveats:**
+- Chrome won't allow two instances with the same `--user-data-dir` — kill any existing debug Chrome before launching.
+- If auth cookies have expired, the user needs to launch Chrome **headed** (without `--headless=new`) once to re-login via OAuth, then you can go back to headless.
+- Google OAuth blocks agent-browser's built-in Chromium ("This browser or app may not be secure") — must use real Chrome.
+- `agent-browser` may attach to `chrome://` internal pages — close those via `agent-browser close` before connecting.
+
+**Fallback options:**
+1. **Connect to user's running Chrome via CDP**: If the user already has Chrome open with `--remote-debugging-port=9222`, just use `agent-browser --cdp 9222`.
+2. **Headed mode with profile**: Use `agent-browser --headed --profile <path>` to open a visible Chrome window.
 3. **State file**: After signing in, save with `agent-browser state save ./auth.json` and reload later with `agent-browser --state ./auth.json`. Note: state files can expire.
-
-If the session hangs or API calls fail in the browser, the auth is likely stale — have the user sign in again.
 
 ### API testing
 - If testing an API, get an API key from the UI first (Settings → API Keys) and screenshot the process


### PR DESCRIPTION
# User description
Update test-feature skill to launch Chrome headless automatically instead of requiring manual Chrome launch.

- Use `--headless=new` with a saved Chrome profile for browser QA tests
- Document the full connection flow (launch, connect, fallback options)
- Add caveats about profile locking and auth expiry

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refines the browser QA instructions in the test-feature skill by prescribing a headless Chrome flow with saved profiles and explicit <code>agent-browser</code> connection steps. Includes Chrome auth caveats and fallback options to keep OAuth sessions working without manual launches.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1923?tool=ast&topic=Usage+Caveats>Usage Caveats</a>
        </td><td>Detail caveats around profile locking, expired OAuth, Chrome security checks, and provide fallback avenues via existing CDP sessions or headed mode.<details><summary>Modified files (1)</summary><ul><li>.claude/skills/test-feature/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-API-key-creation-o...</td><td>March 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1923?tool=ast&topic=Headless+QA+Flow>Headless QA Flow</a>
        </td><td>Outline headless Chrome setup with <code>--headless=new</code>, a dedicated profile directory, and <code>agent-browser</code> CDP commands so the QA flow runs entirely in the background.<details><summary>Modified files (1)</summary><ul><li>.claude/skills/test-feature/SKILL.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix-API-key-creation-o...</td><td>March 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1923?tool=ast>(Baz)</a>.