### PR TITLE
web: Fix build typing in tool cards

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -335,11 +335,7 @@ export default function ToolsPage() {
         <section className="space-y-4">
           <SectionHeader>Settings & Knowledge</SectionHeader>
           <UpdatePersonalInstructions
-            args={{
-              about:
-                "I prefer concise responses and want newsletters archived by default.",
-              mode: "replace",
-            }}
+            text="I prefer concise responses and want newsletters archived by default."
           />
           <Suspense>
             <AddToKnowledgeBase

--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -429,7 +429,11 @@ export function MessagePart({
         return (
           <UpdatePersonalInstructions
             key={toolCallId}
-            text={updatedAbout ?? part.input.about}
+            text={
+              updatedAbout ??
+              part.input?.about ??
+              "Personal instructions updated."
+            }
           />
         );
       },


### PR DESCRIPTION
# User description
Fixes build-time type mismatches in the tool card UI and assistant message renderer. This keeps the production build passing without changing behavior.

- align the landing page example with the shared component props
- add a safe fallback string for personal instruction updates during render

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the landing page’s <code>ToolsPage</code> UpdatePersonalInstructions usage with the shared props and add a safe fallback string in the assistant chat renderer so typing stays satisfied without behavior changes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1924?tool=ast&topic=Assistant+messages>Assistant messages</a>
        </td><td>Provide a fallback instruction string in <code>MessagePart</code> so UpdatePersonalInstructions always receives text during assistant message rendering.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-chat-expand-...</td><td>March 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1924?tool=ast&topic=Landing+tools>Landing tools</a>
        </td><td>Align UpdatePersonalInstructions in ToolsPage to use the shared <code>text</code> prop so props match the component interface and keep the landing flow typed.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(landing)/components/tools/page.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-chat-expand-...</td><td>March 15, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1924?tool=ast>(Baz)</a>.