### PR TITLE
ui: adjust rule action field layout

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -761,15 +761,24 @@ function renderFieldRows(
     const nextField = fields[index + 1];
 
     if (field.name === "cc" && nextField?.name === "bcc") {
-      rows.push(
-        <div
-          key={`${field.name}-${nextField.name}`}
-          className="grid gap-4 sm:grid-cols-2"
-        >
-          {renderField(field)}
-          {renderField(nextField)}
-        </div>,
-      );
+      const renderedField = renderField(field);
+      const renderedNextField = renderField(nextField);
+
+      if (renderedField && renderedNextField) {
+        rows.push(
+          <div
+            key={`${field.name}-${nextField.name}`}
+            className="grid gap-4 sm:grid-cols-2"
+          >
+            {renderedField}
+            {renderedNextField}
+          </div>,
+        );
+      } else {
+        if (renderedField) rows.push(renderedField);
+        if (renderedNextField) rows.push(renderedNextField);
+      }
+
       index += 1;
       continue;
     }


### PR DESCRIPTION
# User description
Adjust the rule action form layout for related email fields.

CC and BCC now render in a shared responsive row when they appear together in the rule editor.
This keeps those recipient fields grouped without changing the underlying rule behavior.
A file-scoped Biome check passed for the updated component.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust the rule action layout so <code>ActionCard</code> renders non-expandable and expandable inputs through a shared helper that can group adjacent recipients together. Improve the CC/BCC pairing logic in <code>renderFieldRows</code> to display those fields side by side while preserving the existing action behavior.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-env-driven-white-l...</td><td>February 22, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix-issue-when-removin...</td><td>December 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1925?tool=ast>(Baz)</a>.