### PR TITLE
fix: preserve email draft link labels

### DIFF
--- a/apps/web/utils/email/render-safe-links.test.ts
+++ b/apps/web/utils/email/render-safe-links.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { renderEmailTextWithSafeLinks } from "./render-safe-links";
 
 describe("renderEmailTextWithSafeLinks", () => {
-  it("renders markdown links as sanitized anchors with the destination visible", () => {
+  it("renders markdown links as sanitized anchors while preserving the label", () => {
     const result = renderEmailTextWithSafeLinks(
       "Use [the login page](https://example.com/login) to continue.",
     );
 
     expect(result).toContain(
-      '<a href="https://example.com/login">the login page (example.com)</a>',
+      '<a href="https://example.com/login">the login page</a>',
     );
   });
 
@@ -18,7 +18,7 @@ describe("renderEmailTextWithSafeLinks", () => {
     );
 
     expect(result).toContain(
-      '<a href="https://example.com/login">the login page (example.com)</a>',
+      '<a href="https://example.com/login">the login page</a>',
     );
     expect(result).not.toContain('<div style="display:none">');
     expect(result).toContain("&lt;div");
@@ -41,7 +41,7 @@ describe("renderEmailTextWithSafeLinks", () => {
     );
 
     expect(result).toContain(
-      '<a href="https://example.com/login">Tom &amp; Jerry (example.com)</a>',
+      '<a href="https://example.com/login">Tom &amp; Jerry</a>',
     );
     expect(result).not.toContain("&amp;amp;");
   });
@@ -52,7 +52,17 @@ describe("renderEmailTextWithSafeLinks", () => {
     );
 
     expect(result).toContain(
-      '<a href="https://example.com/path_(1)">the docs (example.com)</a>',
+      '<a href="https://example.com/path_(1)">the docs</a>',
+    );
+  });
+
+  it("falls back to the destination when a link label is empty after sanitization", () => {
+    const result = renderEmailTextWithSafeLinks(
+      'Use <a href="mailto:help@example.com"><span></span></a> if needed.',
+    );
+
+    expect(result).toContain(
+      '<a href="mailto:help@example.com">help@example.com</a>',
     );
   });
 

--- a/apps/web/utils/email/render-safe-links.ts
+++ b/apps/web/utils/email/render-safe-links.ts
@@ -97,17 +97,7 @@ function findMarkdownLinkMatches(text: string) {
 
 function formatLinkLabel(label: string, url: string) {
   const normalizedLabel = normalizeWhitespace(stripHtmlTags(label));
-  const destinationLabel = getLinkDestinationLabel(url);
-
-  if (!normalizedLabel) return destinationLabel;
-  if (
-    normalizedLabel.toLowerCase().includes(destinationLabel.toLowerCase()) ||
-    normalizedLabel.toLowerCase().includes(url.toLowerCase())
-  ) {
-    return normalizedLabel;
-  }
-
-  return `${normalizedLabel} (${destinationLabel})`;
+  return normalizedLabel || getLinkDestinationLabel(url);
 }
 
 function getLinkDestinationLabel(url: string) {

--- a/apps/web/utils/gmail/mail.test.ts
+++ b/apps/web/utils/gmail/mail.test.ts
@@ -68,12 +68,12 @@ describe("convertTextToHtmlParagraphs", () => {
 
     const plainText = buildReplyMessageText({
       textContent:
-        'Use <a href="https://example.com/login">the login page (example.com)</a>\n\n<p>Best regards,<br>John</p>',
+        'Use <a href="https://example.com/login">the login page</a>\n\n<p>Best regards,<br>John</p>',
       message,
     });
 
     expect(plainText).toContain(
-      "Use the login page (example.com) [https://example.com/login]",
+      "Use the login page [https://example.com/login]",
     );
     expect(plainText).toContain("Best regards,\nJohn");
     const quotedHeader = `\n\nOn ${formatEmailDate(new Date(message.headers.date))}, John Doe <john@example.com> wrote:\n\n`;

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -299,15 +299,13 @@ describe("fetchMessagesAndGenerateDraft - AI content escaping", () => {
 
     expect(result).toContain("Thanks for reaching out.");
     expect(result).toContain(
-      '<a href="https://example.com/login">the login page (example.com)</a>',
+      '<a href="https://example.com/login">the login page</a>',
     );
-    expect(result).toContain(
-      '<a href="mailto:help@example.com">support (help@example.com)</a>',
-    );
+    expect(result).toContain('<a href="mailto:help@example.com">support</a>');
     expect(result).not.toContain("[the login page](https://example.com/login)");
     expect(result).not.toContain("[support](mailto:help@example.com)");
     expect(result).toContain(
-      '\n\nUse <a href="https://example.com/login">the login page (example.com)</a>',
+      '\n\nUse <a href="https://example.com/login">the login page</a>',
     );
   });
 });


### PR DESCRIPTION
# User description
Preserves visible link labels in generated email drafts instead of appending the destination hostname.

- Keeps safe fallback behavior when a sanitized link label is empty.
- Updates reply-draft and Gmail plain-text expectations to match the rendered output.
- Verified with focused unit tests for safe-link rendering and draft formatting.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve rendered link labels when sanitizing email links by keeping the normalized label text in <code>formatLinkLabel</code>/<code>renderEmailTextWithSafeLinks</code>, only falling back to the destination when the label becomes empty. Update the Gmail reply formatter and reply-draft generator to expect the preserved labels when emitting the draft plain-text versions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1928?tool=ast&topic=Draft+formatting>Draft formatting</a>
        </td><td>Align Gmail plain-text replies and reply-draft messages with the updated safe link rendering so their expected outputs keep the original labels and omit the appended hostnames.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/gmail/mail.test.ts</li>
<li>apps/web/utils/reply-tracker/generate-draft.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-safe-link-renderin...</td><td>March 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix</td><td>January 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1928?tool=ast&topic=Safe+link+rendering>Safe link rendering</a>
        </td><td>Preserve sanitized link labels in <code>renderEmailTextWithSafeLinks</code> so the rendered anchor text stays the same as the original normalized label, and add a safe fallback to the destination label when the sanitized label is empty.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/email/render-safe-links.test.ts</li>
<li>apps/web/utils/email/render-safe-links.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-safe-link-renderin...</td><td>March 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1928?tool=ast>(Baz)</a>.