### PR TITLE
Drive: remove outdated full-access warning

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
@@ -153,10 +153,6 @@ export function ConnectDrive() {
                 <p className="text-xs text-muted-foreground">
                   Use your existing folders
                 </p>
-                <p className="mt-1 text-xs text-amber-600">
-                  Google will show a warning — we&apos;re working on
-                  verification
-                </p>
               </div>
               <Button
                 size="sm"


### PR DESCRIPTION
# User description
Removes outdated copy from the Google Drive connection dialog.

- remove the stale verification warning from the full-access option
- keep the existing access choices and connection flow unchanged

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>ConnectDrive</code> dialog to remove the outdated warning about verification while preserving the folder access reminder. Maintain the existing access choices and connection flow within that component.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>feat-Implement-full-Go...</td><td>January 31, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1930?tool=ast>(Baz)</a>.