### PR TITLE
Add disabled label to rules select dropdown

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
@@ -21,7 +21,9 @@ export function RulesSelect() {
   const getCurrentLabel = () => {
     if (ruleId === "all") return "All rules";
     if (ruleId === "skipped") return "No match";
-    return data?.find((rule) => rule.id === ruleId)?.name || "All rules";
+    const rule = data?.find((rule) => rule.id === ruleId);
+    if (!rule) return "All rules";
+    return rule.enabled ? rule.name : `${rule.name} (disabled)`;
   };
 
   return (
@@ -52,6 +54,9 @@ export function RulesSelect() {
           {data?.map((rule) => (
             <DropdownMenuItem key={rule.id} onClick={() => setRuleId(rule.id)}>
               {rule.name}
+              {!rule.enabled && (
+                <span className="ml-1 text-muted-foreground">(disabled)</span>
+              )}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>


### PR DESCRIPTION
# User description
Show "(disabled)" indicator next to disabled rules in the history tab's rules select dropdown. The disabled label appears both in the dropdown items and in the trigger button when a disabled rule is selected.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Show disabled rules with an explicit “(disabled)” suffix in <code>RulesSelect</code> so the trigger label and dropdown entries describe the rule state. Indicate disabled entries in the dropdown menu with a muted caption to highlight why they behave differently.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>use-nuqs</td><td>November 26, 2025</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove-unused-import</td><td>November 20, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1932?tool=ast>(Baz)</a>.