### PR TITLE
ci: optimize smoke test workflow

### DIFF
--- a/.github/workflows/local-bypass-smoke.yml
+++ b/.github/workflows/local-bypass-smoke.yml
@@ -3,6 +3,15 @@ name: Local Bypass Smoke
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "apps/web/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - "tsconfig.json"
+      - ".github/workflows/local-bypass-smoke.yml"
   workflow_dispatch:
 
 permissions:
@@ -62,6 +71,14 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
+      - name: Setup Playwright cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Apply database migrations
         run: pnpm -F inbox-zero-ai exec prisma migrate deploy


### PR DESCRIPTION
# User description
Reduce unnecessary CI time in the smoke workflow while keeping the integration check in place.

- limit the local bypass smoke workflow to app-related changes
- cache Playwright browser binaries between runs to reduce setup time

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Limit the local bypass smoke workflow to application and workspace granularity so it only triggers for relevant changes. Cache Playwright browser binaries between runs to reduce setup time in this workflow.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Update-dependencies-an...</td><td>March 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1934?tool=ast>(Baz)</a>.