### PR TITLE
assistant: Align history rule select ordering

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { parseAsString, useQueryState } from "nuqs";
 import { ChevronDown, Tag } from "lucide-react";
+import { sortRulesForAutomation } from "@/utils/rule/sort";
 
 export function RulesSelect() {
   const { data, isLoading, error } = useRules();
@@ -17,11 +18,12 @@ export function RulesSelect() {
     "ruleId",
     parseAsString.withDefault("all"),
   );
+  const sortedRules = data ? sortRulesForAutomation(data) : undefined;
 
   const getCurrentLabel = () => {
     if (ruleId === "all") return "All rules";
     if (ruleId === "skipped") return "No match";
-    const rule = data?.find((rule) => rule.id === ruleId);
+    const rule = sortedRules?.find((rule) => rule.id === ruleId);
     if (!rule) return "All rules";
     return rule.enabled ? rule.name : `${rule.name} (disabled)`;
   };
@@ -51,7 +53,7 @@ export function RulesSelect() {
           <DropdownMenuItem onClick={() => setRuleId("skipped")}>
             No match
           </DropdownMenuItem>
-          {data?.map((rule) => (
+          {sortedRules?.map((rule) => (
             <DropdownMenuItem key={rule.id} onClick={() => setRuleId(rule.id)}>
               {rule.name}
               {!rule.enabled && (


### PR DESCRIPTION
# User description
Updates the History tab rule filter to use the shared rule ordering helper.

- Render rule options with the shared sorter already used elsewhere in the assistant
- Keep disabled rules at the end so rule ordering stays consistent across pages
- Verified the edited file with Biome after installing workspace dependencies

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the history tab rule filter to use the shared <code>sortRulesForAutomation</code> helper so rule options render consistently with other assistant pages. Ensure disabled rules stay listed last when generating labels and dropdown items in <code>RulesSelect</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-disabled-label-to-...</td><td>March 15, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove-unused-import</td><td>November 20, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1935?tool=ast>(Baz)</a>.