### PR TITLE
rules: refine extension tab sync mapping

### DIFF
--- a/apps/web/utils/rule/mapRulesToExtensionTabs.test.ts
+++ b/apps/web/utils/rule/mapRulesToExtensionTabs.test.ts
@@ -59,6 +59,21 @@ describe("mapRulesToExtensionTabs", () => {
     ]);
   });
 
+  it("dedupes built-in labels that only differ by punctuation", () => {
+    const rules = [
+      getRule("sync follow up", [getAction({ label: "Follow up" })]),
+      getRule("skip duplicate follow-up", [getAction({ label: "Follow-up" })]),
+    ];
+
+    expect(mapRulesToExtensionTabs(rules)).toEqual([
+      {
+        type: "enable_default",
+        tabId: "follow-up",
+        displayLabel: "Follow-up",
+      },
+    ]);
+  });
+
   it("preserves distinct custom labels that only differ by punctuation", () => {
     const rules = [
       getRule("sync project dotted", [getAction({ label: "Project.One" })]),

--- a/apps/web/utils/rule/mapRulesToExtensionTabs.ts
+++ b/apps/web/utils/rule/mapRulesToExtensionTabs.ts
@@ -59,10 +59,12 @@ export function mapRulesToExtensionTabs(rules: RulesResponse): SyncTab[] {
       const normalizedLabel = normalizeLabelName(label);
       const seenLabelKey = normalizeSeenLabel(label);
       if (!label) continue;
-      if (seenLabels.has(seenLabelKey)) continue;
-      seenLabels.add(seenLabelKey);
 
       const defaultTab = LABEL_TO_DEFAULT_TAB[normalizedLabel];
+      const dedupeKey = defaultTab ? normalizedLabel : seenLabelKey;
+      if (seenLabels.has(dedupeKey)) continue;
+      seenLabels.add(dedupeKey);
+
       if (defaultTab) {
         tabs.push({
           type: "enable_default",


### PR DESCRIPTION
# User description
Adjust extension tab sync selection so built-in tabs are recognized consistently and archived rules are excluded from sync.

- map extension-supported labels to existing built-in tabs
- skip archived rules when generating sync tabs
- add focused tests for built-in, custom, and archived rule cases

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update mapRulesToExtensionTabs and its DEFAULT_TABS config to recognize normalized labels for built-in tabs, dedupe punctuation variants, and sort them by normalized order. Add focused tests covering built-in, custom, and archived rule cases to ensure extension tab sync selection only includes relevant tabs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1936?tool=ast&topic=Archived+rule+skip>Archived rule skip</a>
        </td><td>Exclude rules with <code>ActionType.ARCHIVE</code> actions before tab generation so archived rules never populate the sync tabs.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/rule/mapRulesToExtensionTabs.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-sync-to-browser-ex...</td><td>March 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/1936?tool=ast&topic=Tab+sync+mapping>Tab sync mapping</a>
        </td><td>Refine mapRulesToExtensionTabs by normalizing labels, mapping normalized names to DEFAULT_TABS entries, deduplicating on the normalized key, and sorting via normalized order while validating built-in and custom cases with new tests so tab sync behavior stays deterministic.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/rule/mapRulesToExtensionTabs.test.ts</li>
<li>apps/web/utils/rule/mapRulesToExtensionTabs.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-sync-to-browser-ex...</td><td>March 11, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1936?tool=ast>(Baz)</a>.