### PR TITLE
Fix duplicate React keys in FeatureCardGrid

### DIFF
--- a/apps/web/components/new-landing/FeatureCardGrid.tsx
+++ b/apps/web/components/new-landing/FeatureCardGrid.tsx
@@ -35,7 +35,7 @@ export function FeatureCardGrid({
       <SectionContent className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 max-w-5xl mx-auto px-4">
         <CardWrapper className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 col-span-full">
           {items.map((item, index) => (
-            <BlurFade key={String(item.title)} delay={index * 0.1} inView>
+            <BlurFade key={index} delay={index * 0.1} inView>
               <Card variant="extra-rounding" className="h-full">
                 <CardContent className="flex flex-col gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-b from-[#EBF0FE] to-[#D6E1FC] text-[#2965EC]">


### PR DESCRIPTION
# User description
## Summary
- Use `index` as key instead of `String(item.title)` to avoid `[object Object]` duplicate keys when title is JSX

## Test plan
- [x] CLI page uses JSX titles — no more duplicate key warnings

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent duplicate React keys in FeatureCardGrid by using the iteration <code>index</code> when rendering <code>BlurFade</code>, ensuring JSX titles don’t produce identical keys. Use <code>BlurFade</code> to animate grid items while keeping keys unique.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix-duplicate-React-ke...</td><td>March 16, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1942?tool=ast>(Baz)</a>.