### PR TITLE
llms: add AI Gateway app attribution

### DIFF
--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -453,6 +453,10 @@ describe("Models", () => {
       });
       expect(createGateway).toHaveBeenCalledWith({
         apiKey: "test-ai-gateway-key",
+        headers: {
+          "http-referer": "https://www.getinboxzero.com",
+          "x-title": "Inbox Zero",
+        },
       });
     });
 

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -208,7 +208,13 @@ function selectModel(
     case Provider.AI_GATEWAY: {
       const modelName = aiModel || "google/gemini-3-flash";
       const aiGatewayApiKey = resolveApiKey(aiApiKey, env.AI_GATEWAY_API_KEY);
-      const gateway = createGateway({ apiKey: aiGatewayApiKey });
+      const gateway = createGateway({
+        apiKey: aiGatewayApiKey,
+        headers: {
+          "http-referer": "https://www.getinboxzero.com",
+          "x-title": "Inbox Zero",
+        },
+      });
       return {
         provider: Provider.AI_GATEWAY,
         modelName,


### PR DESCRIPTION
# User description
This updates the AI Gateway provider to send Inbox Zero app attribution headers so requests are labeled consistently.

- add the Vercel AI Gateway referer and title headers in the shared model selector
- extend the existing model unit test to cover the gateway configuration

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Send AI Gateway requests from the shared model selector with Inbox Zero referer and title attribution so the provider is consistently labeled, and cover that configuration in the model unit test.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>llms-make-Gemini-think...</td><td>March 12, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add-OpenAI-compatible-...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1946?tool=ast>(Baz)</a>.