### PR TITLE
outlook: fix upload helper return typing

### DIFF
--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -663,7 +663,7 @@ async function uploadAttachmentChunk({
   start: number;
   end: number;
   totalSize: number;
-}) {
+}): Promise<number> {
   const response = await fetch(uploadUrl, {
     method: "PUT",
     headers: {
@@ -710,14 +710,19 @@ async function uploadAttachmentChunk({
     );
   }
 
-  await throwOutlookResponseError(response, "upload Outlook attachment chunk");
+  return await throwOutlookResponseError(
+    response,
+    "upload Outlook attachment chunk",
+  );
 }
 
 interface UploadSessionStatus {
   nextExpectedRanges?: string[];
 }
 
-async function getUploadSessionStatus(uploadUrl: string) {
+async function getUploadSessionStatus(
+  uploadUrl: string,
+): Promise<UploadSessionStatus | null> {
   const response = await fetch(uploadUrl, { method: "GET" });
 
   if (response.status === 404 || response.status === 405) {
@@ -725,7 +730,7 @@ async function getUploadSessionStatus(uploadUrl: string) {
   }
 
   if (!response.ok) {
-    await throwOutlookResponseError(
+    return await throwOutlookResponseError(
       response,
       "fetch Outlook upload session status",
     );
@@ -745,7 +750,10 @@ function getNextExpectedRangeStart(nextExpectedRanges?: string[]) {
   return Number.isNaN(parsedRangeStart) ? null : parsedRangeStart;
 }
 
-async function throwOutlookResponseError(response: Response, action: string) {
+async function throwOutlookResponseError(
+  response: Response,
+  action: string,
+): Promise<never> {
   const errorText = await response.text();
   const error = new Error(
     `Failed to ${action}: ${response.status} ${


### PR DESCRIPTION
# User description
Tightens async return typing in the Outlook attachment upload path so the production build can complete successfully.

- make the chunk upload helper return type explicit
- return throw-only async branches explicitly so TypeScript control flow stays narrow
- verify with the focused Outlook mail test file and a fresh Next.js production build

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve Outlook attachment upload helpers by tightening their async returns so control flow remains narrow for production builds. Clarify and reinforce the behavior of the chunk upload, session status, and error helpers so their roles in managing Outlook upload responses are explicit.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-drive-backed-rule-...</td><td>March 16, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Stabilize-Outlook-auto...</td><td>February 26, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1948?tool=ast>(Baz)</a>.