### PR TITLE
skills: prevent premature PR watch exit

### DIFF
--- a/.claude/skills/pr-loop/SKILL.md
+++ b/.claude/skills/pr-loop/SKILL.md
@@ -187,5 +187,5 @@ git add <changed-files> && git commit -m "<generic message about addressing revi
 ### 5e. Repeat
 
 Go back to step 5a. Exit when:
-- 0 unresolved threads remain, OR
+- All exit conditions in step 5b are met, OR
 - Max iterations reached (report "max iterations reached, may still have comments")

--- a/.claude/skills/pr-watch/SKILL.md
+++ b/.claude/skills/pr-watch/SKILL.md
@@ -26,12 +26,10 @@ Parse `$ARGUMENTS` for options:
    > - If there are unaddressed comments: run /address-pr-comments to address them. Do NOT auto-resolve threads — let the reviewer handle resolution.
    > - **Exit condition — only cancel this task when ALL of the following are true:**
    >   1. No new comments you haven't already seen and addressed.
-   >   2. You did NOT push any fixes in this cycle (if you pushed, reviewers need time to re-review — always wait at least one more cycle).
-   >   3. All reviewer check runs have completed — run `gh pr checks` and verify no reviewer checks (e.g. "Baz Reviewer", "cubic · AI code reviewer") are pending or in_progress. If any reviewer check is still running, they haven't finished posting comments yet — wait for the next cycle.
-   >   If any condition is false, let the cron run for another cycle instead of cancelling.
+   >   2. You did NOT push any fixes in this iteration (if you pushed, reviewers need time to re-review — always wait at least one more iteration).
+   >   3. All reviewer check runs have completed — run `gh pr checks` and verify no reviewer checks (e.g. "Baz Reviewer", "cubic · AI code reviewer") are pending or in_progress. If any reviewer check is still running, they haven't finished posting comments yet — wait for the next iteration.
+   >   If any condition is false, let the cron run for another iteration instead of cancelling.
    >
    > Important: AI review bots (e.g. cubic-dev-ai, coderabbit, copilot) do NOT have full context of the project. Use your own judgment — their suggestions may be wrong or inapplicable. Don't blindly implement bot feedback.
-   >
-   > Important: Pushing fix commits triggers new reviews from bots. Do not assume the PR is "done" just because earlier comments were addressed — wait for the re-review to complete before cancelling.
 
 3. Confirm to the user: "Watching PR #X every {interval}. I'll address new comments automatically and stop when everything is handled."


### PR DESCRIPTION
# User description
## Summary
- Updated `pr-watch` and `pr-loop` skills to prevent the agent from cancelling monitoring too early
- Exit now requires all reviewer check runs (via `gh pr checks`) to have completed — not just that existing comments were addressed
- After pushing fixes, the agent must always wait at least one more cycle for re-review

## Test plan
- [ ] Run `/pr-watch` on a PR with bot reviewers and verify it waits for check runs to finish
- [ ] Verify the agent doesn't cancel after pushing fixes until the next cycle confirms no new comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Require the <code>pr-loop</code> and <code>pr-watch</code> skills to wait for reviewer checks and an extra cycle before terminating monitoring, using <code>gh pr checks</code>-based gating. Highlight that neither automation cancels until no new comments remain and no fixes were pushed in the previous iteration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add-pr-watch-skill-for...</td><td>March 17, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1963?tool=ast>(Baz)</a>.