### PR TITLE
assistant-chat: add mobile confirm-email-action route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ See `.claude/skills/fullstack-workflow/SKILL.md` for full examples and templates
 
 - API route middleware: `withError` (public, no auth), `withAuth` (user-level), `withEmailAccount` (email-account-level). Export response type via `Awaited<ReturnType<typeof getData>>`.
 - Mutations: use server actions with `next-safe-action`, NOT POST API routes.
+- Exception: mobile-native integrations may use POST API routes when they require a stable HTTP contract.
 - Validation: Zod schemas in `utils/actions/*.validation.ts`. Infer types with `z.infer`.
 - Data fetching: SWR on the client. Call `mutate()` after mutations.
 - Forms: React Hook Form + `useAction` hook. Use `getActionErrorMessage(error.error)` for errors.

--- a/apps/web/app/api/chat/confirm-email-action/route.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { confirmAssistantEmailActionForAccount } from "@/utils/actions/assistant-chat";
+import { confirmAssistantEmailActionBody } from "@/utils/actions/assistant-chat.validation";
+import { withEmailAccount } from "@/utils/middleware";
+import { getEmailAccountWithAi } from "@/utils/user/get";
+
+export const maxDuration = 120;
+
+// Mobile clients call this endpoint directly; web uses the server action path.
+export const POST = withEmailAccount(
+  "chat/confirm-email-action",
+  async (request) => {
+    const emailAccountId = request.auth.emailAccountId;
+
+    const user = await getEmailAccountWithAi({ emailAccountId });
+    if (!user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const json = await request.json();
+    const { data, error } = confirmAssistantEmailActionBody.safeParse(json);
+    if (error) {
+      return NextResponse.json({ error: error.errors }, { status: 400 });
+    }
+
+    const result = await confirmAssistantEmailActionForAccount({
+      chatId: data.chatId,
+      chatMessageId: data.chatMessageId,
+      toolCallId: data.toolCallId,
+      actionType: data.actionType,
+      contentOverride: data.contentOverride,
+      emailAccountId,
+      provider: user.account.provider,
+      logger: request.logger,
+    });
+
+    return NextResponse.json(result);
+  },
+);


### PR DESCRIPTION
Adds a dedicated authenticated API route for confirming assistant email actions from mobile clients. It mirrors server action behavior and validates payloads with the shared schema.

- add POST /api/chat/confirm-email-action using withEmailAccount
- call confirmAssistantEmailActionForAccount with account/provider context
- document that mobile-native integrations may use POST API routes in AGENTS.md