### PR TITLE
devtools: add optional gitleaks pre-push scan

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,6 +5,22 @@ if ! command -v gitleaks >/dev/null 2>&1; then
 fi
 
 zero_oid="0000000000000000000000000000000000000000"
+remote_name="${1:-origin}"
+remote_default_ref=$(git symbolic-ref "refs/remotes/$remote_name/HEAD" 2>/dev/null || true)
+
+if [ -z "$remote_default_ref" ]; then
+  remote_head_branch=$(git remote show "$remote_name" 2>/dev/null | sed -n '/HEAD branch/s/.*: //p' | head -n 1)
+
+  if [ -n "$remote_head_branch" ]; then
+    remote_default_ref="$remote_name/$remote_head_branch"
+  fi
+else
+  remote_default_ref=${remote_default_ref#refs/remotes/}
+fi
+
+if [ -z "$remote_default_ref" ]; then
+  remote_default_ref="$remote_name/main"
+fi
 
 while read -r local_ref local_oid remote_ref remote_oid
 do
@@ -13,7 +29,7 @@ do
   fi
 
   if [ "$remote_oid" = "$zero_oid" ]; then
-    merge_base=$(git merge-base "$local_oid" origin/main 2>/dev/null)
+    merge_base=$(git merge-base "$local_oid" "$remote_default_ref" 2>/dev/null)
 
     if [ -n "$merge_base" ]; then
       log_opts="$merge_base..$local_oid"


### PR DESCRIPTION
# User description
Adds a local pre-push hook that scans outgoing commits for secrets with gitleaks.

- scans only the commits included in the push
- skips scanning when gitleaks is not installed locally

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an optional <code>gitleaks</code> pre-push hook that scans only the commits being pushed and blocks the push when secrets are detected, while allowing hooks to exit cleanly if <code>gitleaks</code> isn’t installed locally. Detect the remote default ref or merge-base for new branches so the hook can compute the correct commit range before running <code>gitleaks git --no-banner --redact</code> from <code>.husky/pre-push</code>.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/1977?tool=ast>(Baz)</a>.