### PR TITLE
fix: LLM rule creation fails with Anthropic structured output

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RulesPromptNew.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RulesPromptNew.tsx
@@ -137,6 +137,7 @@ function RulesPromptForm({
           return `${rules.length} rules created!`;
         },
         error: (err) => {
+          setIsProcessingDialogOpen(false);
           return `Error creating rules: ${err.message}`;
         },
       },

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -27,6 +27,15 @@ export const delayInMinutesSchema = z
     "Minutes to wait before executing this action. Only add when the user asks for a delay.",
   );
 
+// LLM-safe version: no .min()/.max() (Anthropic structured output rejects them).
+// Constraints are conveyed via .describe() instead.
+export const delayInMinutesLlmSchema = z
+  .number()
+  .nullish()
+  .describe(
+    `Minutes to wait before executing this action (minimum 1, maximum ${NINETY_DAYS_MINUTES}). Only add when the user asks for a delay.`,
+  );
+
 export const updateRuleConditionSchema = z.object({
   ruleName: z.string().describe("The name of the rule to update"),
   condition: z.object({

--- a/apps/web/utils/ai/assistant/chat-rule-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.ts
@@ -23,7 +23,7 @@ import { saveLearnedPatterns } from "@/utils/rule/learned-patterns";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { filterNullProperties } from "@/utils";
 import {
-  delayInMinutesSchema,
+  delayInMinutesLlmSchema,
   updateRuleConditionSchema,
 } from "@/utils/actions/rule.validation";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
@@ -532,7 +532,7 @@ export const updateRuleActionsTool = ({
               subject: z.string().nullish(),
               folderName: z.string().nullish(),
             }),
-            delayInMinutes: delayInMinutesSchema,
+            delayInMinutes: delayInMinutesLlmSchema,
           })
           .superRefine((action, ctx) => {
             addMissingRecipientIssue({

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -4,7 +4,7 @@ import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { isDefined } from "@/utils/types";
 import { env } from "@/env";
 import { addMissingRecipientIssue } from "@/utils/rule/recipient-validation";
-import { delayInMinutesSchema } from "@/utils/actions/rule.validation";
+import { delayInMinutesLlmSchema } from "@/utils/actions/rule.validation";
 import {
   AI_INSTRUCTIONS_PROMPT_DESCRIPTION,
   INVALID_STATIC_FROM_MESSAGE,
@@ -125,7 +125,7 @@ const actionSchema = (provider: string) =>
         .describe(
           "The fields to use for the action. Static text can be combined with dynamic values using double braces {{}}. For example: 'Hi {{sender's name}}' or 'Re: {{subject}}' or '{{when I'm available for a meeting}}'. Dynamic values will be replaced with actual email data when the rule is executed. Dynamic values are generated in real time by the AI. Only use dynamic values where absolutely necessary. Otherwise, use plain static text. A field can be also be fully static or fully dynamic.",
         ),
-      delayInMinutes: delayInMinutesSchema,
+      delayInMinutes: delayInMinutesLlmSchema,
     })
     .superRefine((action, ctx) => {
       addMissingRecipientIssue({


### PR DESCRIPTION
## Summary
- Anthropic's structured output rejects Zod schemas with `.min()`/`.max()` on number fields. Created `delayInMinutesLlmSchema` without these constraints for LLM schemas — constraints are conveyed via `.describe()` instead. Frontend validation keeps the original schema unchanged.
- When `createRulesAction` fails, the `ProcessingPromptFileDialog` stays open showing "Creating rules..." spinner indefinitely with no error feedback. Now closes the dialog on error so the user sees the error toast.

## Test plan
- [ ] Open Automation page → click "Add Rule" → enter a natural language prompt → click "Create rules" → verify rules are created successfully
- [ ] Verify the same flow works in the AI Chat panel (createRule tool)
- [ ] Force an error (e.g. duplicate rule name) and verify the dialog closes and error toast appears
- [ ] Verify `delayInMinutes` still works in manually created rules (frontend validation unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)