### PR TITLE
fix: document filing schema fails with Anthropic structured output

### DIFF
--- a/apps/web/utils/ai/document-filing/analyze-document.ts
+++ b/apps/web/utils/ai/document-filing/analyze-document.ts
@@ -25,8 +25,6 @@ const documentAnalysisSchema = z
       ),
     confidence: z
       .number()
-      .min(0)
-      .max(1)
       .describe(
         "Confidence score from 0 to 1. Use 0.9+ only when very certain.",
       ),


### PR DESCRIPTION
## Summary
- Same class of bug as #1984 — Anthropic rejects `.min()/.max()` on number fields in structured output schemas
- Removes `min(0)` and `max(1)` constraints from the `confidence` field in `documentAnalysisSchema`, relying on the existing `.describe()` hint instead
- Found during QA of PR #1978

## Test plan
- [x] `pnpm test-ai eval/analyze-document` passes (3/3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)