### PR TITLE
qa-run: add --base-url flag

### DIFF
--- a/.claude/skills/qa-run/SKILL.md
+++ b/.claude/skills/qa-run/SKILL.md
@@ -14,6 +14,13 @@ Usage:
 - `/qa-run --all [--parallel] [--max-parallel=3]`
 - `/qa-run --only=flow-a,flow-b [--parallel] [--max-parallel=3]`
 - `/qa-run --group=api [--parallel]`
+- `/qa-run --all --base-url=http://localhost:3000`
+
+Base URL:
+- `--base-url=<url>` sets the Inbox Zero app URL (e.g. `http://localhost:3000`, `https://www.getinboxzero.com`, or any self-hosted URL).
+- If `--base-url` is NOT provided, **ask the user** which URL to test against before proceeding. Do not assume production or localhost.
+- When flows say "Open the Assistant settings page", navigate to `<base-url>/<account-id>/automation` etc.
+- Gmail/Outlook URLs (mail.google.com, outlook.live.com) are unaffected by this flag.
 
 Filtering:
 - By default (without `--all` or `--only`), only `priority: high` flows run. Low-priority flows are skipped.


### PR DESCRIPTION
## Summary
- Adds `--base-url` flag to the qa-run skill so users can specify which Inbox Zero instance to test against
- If `--base-url` is not provided, asks the user instead of assuming production or localhost
- Supports localhost, production, and self-hosted URLs

## Test plan
- [ ] Run `/qa-run --all --base-url=https://www.getinboxzero.com` and verify it targets production
- [ ] Run `/qa-run --all` without `--base-url` and verify it prompts the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)