### PR TITLE
gitignore: exclude installed skills and lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ qa/browser-flows/results/*
 
 # eval reports
 eval-results/
+
+# installed skills — install via: skills install vercel-labs/agent-browser
+.claude/skills/agent-browser/
+skills-lock.json
+


### PR DESCRIPTION
## Summary
- Gitignore `agent-browser` skill and `skills-lock.json` (installed via `skills install vercel-labs/agent-browser`, not committed to avoid 2.4k lines of context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)