### PR TITLE
feat: add keyboard shortcuts to mail view

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
@@ -504,11 +504,11 @@ function useReplyTrackerKeyboardNav(
 ) {
   const handleKeyAction = useCallback(
     (index: number, key: string, event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
-        return;
-      if (key === "r") onAction(index, "reply");
-      else if (key === "d") onAction(index, "resolve");
-      else if (key === "n") onAction(index, "unresolve");
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const normalizedKey = key.toLowerCase();
+      if (normalizedKey === "r") onAction(index, "reply");
+      else if (normalizedKey === "d") onAction(index, "resolve");
+      else if (normalizedKey === "n") onAction(index, "unresolve");
     },
     [onAction],
   );

--- a/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/reply-zero/ReplyTrackerEmails.tsx
@@ -503,7 +503,9 @@ function useReplyTrackerKeyboardNav(
   ) => Promise<void>,
 ) {
   const handleKeyAction = useCallback(
-    (index: number, key: string) => {
+    (index: number, key: string, event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+        return;
       if (key === "r") onAction(index, "reply");
       else if (key === "d") onAction(index, "resolve");
       else if (key === "n") onAction(index, "unresolve");

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -313,22 +313,21 @@ export function EmailList({
     });
 
   // Sync keyboard selection with the opened thread panel
-  const prevSelectedIndexRef = useRef(selectedIndex);
+  const prevSelectionRef = useRef({ index: selectedIndex, threadId: "" });
   useEffect(() => {
-    if (
-      selectedIndex >= 0 &&
-      selectedIndex !== prevSelectedIndexRef.current &&
-      threads[selectedIndex]
-    ) {
-      const thread = threads[selectedIndex];
-      setOpenThreadId(thread.id);
-      markReadThreads({
-        threadIds: [thread.id],
-        onSuccess: () => refetch(),
-        emailAccountId,
-      });
-    }
-    prevSelectedIndexRef.current = selectedIndex;
+    const thread = selectedIndex >= 0 ? threads[selectedIndex] : null;
+    if (!thread) return;
+
+    const prev = prevSelectionRef.current;
+    if (prev.index === selectedIndex && prev.threadId === thread.id) return;
+
+    prevSelectionRef.current = { index: selectedIndex, threadId: thread.id };
+    setOpenThreadId(thread.id);
+    markReadThreads({
+      threadIds: [thread.id],
+      onSuccess: () => refetch(),
+      emailAccountId,
+    });
   }, [selectedIndex, threads, setOpenThreadId, refetch, emailAccountId]);
 
   const onArchiveBulk = useCallback(async () => {

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -312,10 +312,16 @@ export function EmailList({
       onArchive: onKeyboardArchive,
     });
 
-  // Sync keyboard selection with the opened thread panel
+  // Sync keyboard selection with the opened thread panel.
+  // Use a ref for threads to avoid re-triggering on thread list updates
+  // (e.g. after refetch), which would cause repeated mark-read/refetch cycles.
   const prevSelectionRef = useRef({ index: selectedIndex, threadId: "" });
+  const threadsRef = useRef(threads);
+  threadsRef.current = threads;
+
   useEffect(() => {
-    const thread = selectedIndex >= 0 ? threads[selectedIndex] : null;
+    const currentThreads = threadsRef.current;
+    const thread = selectedIndex >= 0 ? currentThreads[selectedIndex] : null;
     if (!thread) return;
 
     const prev = prevSelectionRef.current;
@@ -325,10 +331,9 @@ export function EmailList({
     setOpenThreadId(thread.id);
     markReadThreads({
       threadIds: [thread.id],
-      onSuccess: () => refetch(),
       emailAccountId,
     });
-  }, [selectedIndex, threads, setOpenThreadId, refetch, emailAccountId]);
+  }, [selectedIndex, setOpenThreadId, emailAccountId]);
 
   const onArchiveBulk = useCallback(async () => {
     toast.promise(

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState, useMemo } from "react";
+import { useCallback, useRef, useState, useMemo, useEffect } from "react";
 import { useQueryState } from "nuqs";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -31,6 +31,7 @@ import {
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMailKeyboardNavigation } from "@/hooks/useMailKeyboardNavigation";
 
 export function List({
   emails,
@@ -278,6 +279,50 @@ export function EmailList({
     setOpenThreadId(prevOrNextRowId);
   }
 
+  // Keyboard shortcuts: Arrow Up/Down to navigate, R to reply, E to archive
+  const onKeyboardReply = useCallback(
+    (index: number) => {
+      const thread = threads[index];
+      if (!thread) return;
+      setOpenThreadId(thread.id);
+      // Dispatch a custom event so EmailMessage can open its reply form.
+      // Small delay to allow the panel to render before triggering reply.
+      setTimeout(() => {
+        window.dispatchEvent(new CustomEvent("mail:reply"));
+      }, 100);
+    },
+    [threads, setOpenThreadId],
+  );
+
+  const onKeyboardArchive = useCallback(
+    (index: number) => {
+      const thread = threads[index];
+      if (!thread) return;
+      onArchive(thread);
+    },
+    [threads, onArchive],
+  );
+
+  const { selectedIndex, setSelectedIndex, getRefCallback } =
+    useMailKeyboardNavigation({
+      threads,
+      onReply: onKeyboardReply,
+      onArchive: onKeyboardArchive,
+    });
+
+  // Sync keyboard selection with the opened thread panel
+  useEffect(() => {
+    if (selectedIndex >= 0 && threads[selectedIndex]) {
+      const thread = threads[selectedIndex];
+      setOpenThreadId(thread.id);
+      markReadThreads({
+        threadIds: [thread.id],
+        onSuccess: () => refetch(),
+        emailAccountId,
+      });
+    }
+  }, [selectedIndex, threads, setOpenThreadId, refetch, emailAccountId]);
+
   const onArchiveBulk = useCallback(async () => {
     toast.promise(
       async () => {
@@ -407,10 +452,11 @@ export function EmailList({
               className="divide-y divide-border overflow-y-auto scroll-smooth"
               ref={listRef}
             >
-              {threads.map((thread) => {
+              {threads.map((thread, index) => {
                 const onOpen = () => {
                   const alreadyOpen = !!openThreadId;
                   setOpenThreadId(thread.id);
+                  setSelectedIndex(index);
 
                   if (!alreadyOpen) scrollToId(thread.id);
 
@@ -420,6 +466,8 @@ export function EmailList({
                     emailAccountId,
                   });
                 };
+
+                const keyboardRefCallback = getRefCallback(index);
 
                 return (
                   <EmailListItem
@@ -431,6 +479,8 @@ export function EmailList({
                       } else {
                         map.delete(thread.id);
                       }
+                      // Also register with keyboard navigation
+                      keyboardRefCallback(node);
                     }}
                     userEmail={userEmail}
                     provider={provider}

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -288,7 +288,9 @@ export function EmailList({
       // Dispatch a custom event so EmailMessage can open its reply form.
       // Small delay to allow the panel to render before triggering reply.
       setTimeout(() => {
-        window.dispatchEvent(new CustomEvent("mail:reply"));
+        window.dispatchEvent(
+          new CustomEvent("mail:reply", { detail: { threadId: thread.id } }),
+        );
       }, 100);
     },
     [threads, setOpenThreadId],
@@ -311,8 +313,13 @@ export function EmailList({
     });
 
   // Sync keyboard selection with the opened thread panel
+  const prevSelectedIndexRef = useRef(selectedIndex);
   useEffect(() => {
-    if (selectedIndex >= 0 && threads[selectedIndex]) {
+    if (
+      selectedIndex >= 0 &&
+      selectedIndex !== prevSelectedIndexRef.current &&
+      threads[selectedIndex]
+    ) {
       const thread = threads[selectedIndex];
       setOpenThreadId(thread.id);
       markReadThreads({
@@ -321,6 +328,7 @@ export function EmailList({
         emailAccountId,
       });
     }
+    prevSelectedIndexRef.current = selectedIndex;
   }, [selectedIndex, threads, setOpenThreadId, refetch, emailAccountId]);
 
   const onArchiveBulk = useCallback(async () => {

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, useState, useRef, useEffect } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from "react";
 import {
   ForwardIcon,
   ReplyIcon,
@@ -52,6 +58,15 @@ export function EmailMessage({
   const [showDetails, setShowDetails] = useState(false);
 
   const onReply = useCallback(() => setShowReply(true), []);
+
+  // Listen for keyboard shortcut reply event (R key from mail list)
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handleMailReply = () => setShowReply(true);
+    window.addEventListener("mail:reply", handleMailReply);
+    return () => window.removeEventListener("mail:reply", handleMailReply);
+  }, [expanded]);
   const [showForward, setShowForward] = useState(false);
   const onForward = useCallback(() => setShowForward(true), []);
 

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -63,10 +63,14 @@ export function EmailMessage({
   useEffect(() => {
     if (!expanded) return;
 
-    const handleMailReply = () => setShowReply(true);
+    const handleMailReply = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.threadId && detail.threadId !== message.threadId) return;
+      setShowReply(true);
+    };
     window.addEventListener("mail:reply", handleMailReply);
     return () => window.removeEventListener("mail:reply", handleMailReply);
-  }, [expanded]);
+  }, [expanded, message.threadId]);
   const [showForward, setShowForward] = useState(false);
   const onForward = useCallback(() => setShowForward(true), []);
 

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useRef,
-} from "react";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import {
   ForwardIcon,
   ReplyIcon,
@@ -42,6 +36,7 @@ export function EmailMessage({
   expanded,
   onExpand,
   onSendSuccess,
+  isLastMessage,
   generateNudge,
 }: {
   message: ThreadMessage;
@@ -52,6 +47,7 @@ export function EmailMessage({
   expanded: boolean;
   onExpand: () => void;
   onSendSuccess: (messageId: string, threadId: string) => void;
+  isLastMessage?: boolean;
   generateNudge?: boolean;
 }) {
   const [showReply, setShowReply] = useState(defaultShowReply || false);
@@ -59,9 +55,11 @@ export function EmailMessage({
 
   const onReply = useCallback(() => setShowReply(true), []);
 
-  // Listen for keyboard shortcut reply event (R key from mail list)
+  // Listen for keyboard shortcut reply event (R key from mail list).
+  // Only the last expanded message in the thread should handle this to avoid
+  // multiple messages opening their reply forms simultaneously.
   useEffect(() => {
-    if (!expanded) return;
+    if (!expanded || !isLastMessage) return;
 
     const handleMailReply = (e: Event) => {
       const detail = (e as CustomEvent).detail;
@@ -70,7 +68,7 @@ export function EmailMessage({
     };
     window.addEventListener("mail:reply", handleMailReply);
     return () => window.removeEventListener("mail:reply", handleMailReply);
-  }, [expanded, message.threadId]);
+  }, [expanded, isLastMessage, message.threadId]);
   const [showForward, setShowForward] = useState(false);
   const onForward = useCallback(() => setShowForward(true), []);
 

--- a/apps/web/components/email-list/EmailThread.tsx
+++ b/apps/web/components/email-list/EmailThread.tsx
@@ -63,7 +63,7 @@ export function EmailThread({
         </div>
       )}
       <ul className="mt-4 space-y-2 sm:space-y-4">
-        {organizedMessages.map(({ message, draftMessage }) => {
+        {organizedMessages.map(({ message, draftMessage }, idx) => {
           const defaultShowReply =
             autoOpenReplyForMessageId === message.id || Boolean(draftMessage);
           return (
@@ -89,6 +89,7 @@ export function EmailThread({
 
                 onSendSuccess?.(messageId, message.threadId);
               }}
+              isLastMessage={idx === organizedMessages.length - 1}
               generateNudge={defaultShowReply && !draftMessage?.textHtml}
             />
           );

--- a/apps/web/hooks/useMailKeyboardNavigation.ts
+++ b/apps/web/hooks/useMailKeyboardNavigation.ts
@@ -2,9 +2,9 @@ import { useCallback } from "react";
 import { useTableKeyboardNavigation } from "@/hooks/useTableKeyboardNavigation";
 
 interface UseMailKeyboardNavigationOptions {
-  threads: { id: string }[];
-  onReply: (index: number) => void;
   onArchive: (index: number) => void;
+  onReply: (index: number) => void;
+  threads: { id: string }[];
 }
 
 export function useMailKeyboardNavigation({
@@ -13,10 +13,14 @@ export function useMailKeyboardNavigation({
   onArchive,
 }: UseMailKeyboardNavigationOptions) {
   const handleKeyAction = useCallback(
-    (index: number, key: string) => {
-      if (key === "r" || key === "R") {
+    (index: number, key: string, event: KeyboardEvent) => {
+      // Skip modified key combos to avoid conflicts with browser/OS shortcuts
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+        return;
+
+      if (key === "r") {
         onReply(index);
-      } else if (key === "e" || key === "E") {
+      } else if (key === "e") {
         onArchive(index);
       }
     },

--- a/apps/web/hooks/useMailKeyboardNavigation.ts
+++ b/apps/web/hooks/useMailKeyboardNavigation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useTableKeyboardNavigation } from "@/hooks/useTableKeyboardNavigation";
+
+interface UseMailKeyboardNavigationOptions {
+  threads: { id: string }[];
+  onReply: (index: number) => void;
+  onArchive: (index: number) => void;
+}
+
+export function useMailKeyboardNavigation({
+  threads,
+  onReply,
+  onArchive,
+}: UseMailKeyboardNavigationOptions) {
+  const handleKeyAction = useCallback(
+    (index: number, key: string) => {
+      if (key === "r" || key === "R") {
+        onReply(index);
+      } else if (key === "e" || key === "E") {
+        onArchive(index);
+      }
+    },
+    [onReply, onArchive],
+  );
+
+  return useTableKeyboardNavigation({
+    items: threads,
+    onKeyAction: handleKeyAction,
+  });
+}

--- a/apps/web/hooks/useMailKeyboardNavigation.ts
+++ b/apps/web/hooks/useMailKeyboardNavigation.ts
@@ -15,12 +15,12 @@ export function useMailKeyboardNavigation({
   const handleKeyAction = useCallback(
     (index: number, key: string, event: KeyboardEvent) => {
       // Skip modified key combos to avoid conflicts with browser/OS shortcuts
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
-        return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
 
-      if (key === "r") {
+      const normalizedKey = key.toLowerCase();
+      if (normalizedKey === "r") {
         onReply(index);
-      } else if (key === "e") {
+      } else if (normalizedKey === "e") {
         onArchive(index);
       }
     },

--- a/apps/web/hooks/useTableKeyboardNavigation.ts
+++ b/apps/web/hooks/useTableKeyboardNavigation.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, type RefCallback } from "react";
 
 interface UseTableKeyboardNavigationOptions<T> {
   items: T[];
-  onKeyAction?: (index: number, key: string) => void;
+  onKeyAction?: (index: number, key: string, event: KeyboardEvent) => void;
 }
 
 export function useTableKeyboardNavigation<T>({
@@ -49,7 +49,7 @@ export function useTableKeyboardNavigation<T>({
         );
       } else if (onKeyAction && selectedIndex >= 0) {
         if (e.metaKey || e.ctrlKey || e.altKey) return;
-        onKeyAction(selectedIndex, e.key);
+        onKeyAction(selectedIndex, e.key, e);
       }
     },
     [items.length, onKeyAction, selectedIndex],

--- a/apps/web/hooks/useTableKeyboardNavigation.ts
+++ b/apps/web/hooks/useTableKeyboardNavigation.ts
@@ -48,6 +48,7 @@ export function useTableKeyboardNavigation<T>({
           prev >= items.length - 1 ? items.length - 1 : prev + 1,
         );
       } else if (onKeyAction && selectedIndex >= 0) {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
         onKeyAction(selectedIndex, e.key);
       }
     },


### PR DESCRIPTION
## Summary
- Added keyboard shortcuts to the mail view following existing patterns from the reply tracker
- **R** — opens reply form on the current email
- **E** — archives the current email
- **Arrow Up/Down** — navigates between emails in the list
- Shortcuts are disabled when focus is in an input/textarea/contenteditable
- Created `useMailKeyboardNavigation` hook wrapping `useTableKeyboardNavigation`

## Test plan
- [ ] Open the mail view
- [ ] Press Arrow Down/Up to navigate between emails
- [ ] Press R to open reply form on selected email
- [ ] Press E to archive selected email
- [ ] Verify shortcuts don't fire when typing in an input field

Fixes #343