### PR TITLE
Add terminal rule processing support

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
@@ -1,0 +1,362 @@
+import type { ModelMessage } from "ai";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  captureAssistantChatToolCalls,
+  summarizeRecordedToolCalls,
+  type RecordedToolCall,
+} from "@/__tests__/eval/assistant-chat-eval-utils";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import {
+  buildDefaultSystemRuleRows,
+  configureRuleEvalPrisma,
+  configureRuleEvalProvider,
+  configureRuleMutationMocks,
+  senderListHasValue,
+} from "@/__tests__/eval/assistant-chat-rule-eval-test-utils";
+import type { getEmailAccount } from "@/__tests__/helpers";
+import {
+  ActionType,
+  GroupItemType,
+  LogicalOperator,
+  type SystemType,
+} from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+
+// pnpm test-ai eval/assistant-chat-rule-editing-overlap-exceptions
+// Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing-overlap-exceptions
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 120_000;
+const evalReporter = createEvalReporter();
+const logger = createScopedLogger(
+  "eval-assistant-chat-rule-editing-overlap-exceptions",
+);
+const ruleUpdatedAt = new Date("2026-03-13T00:00:00.000Z");
+const defaultRuleRows = buildDefaultSystemRuleRows(ruleUpdatedAt);
+const about = "I manage a company inbox.";
+
+const keepInInboxRule = {
+  id: "keep-in-inbox-rule-id",
+  name: "Things to keep in Inbox",
+  instructions: null,
+  updatedAt: ruleUpdatedAt,
+  from: "vip@important.example",
+  to: null,
+  subject: null,
+  conditionalOperator: LogicalOperator.AND,
+  enabled: true,
+  runOnThreads: true,
+  systemType: null as SystemType | null,
+  actions: [
+    {
+      type: ActionType.LABEL,
+      content: null,
+      label: "IMPORTANT",
+      to: null,
+      cc: null,
+      bcc: null,
+      subject: null,
+      url: null,
+      folderName: null,
+    },
+  ],
+};
+
+const ruleRows = [...defaultRuleRows, keepInInboxRule];
+
+const {
+  mockCreateRule,
+  mockPartialUpdateRule,
+  mockUpdateRuleActions,
+  mockSaveLearnedPatterns,
+  mockCreateEmailProvider,
+  mockPosthogCaptureEvent,
+  mockRedis,
+  mockUnsubscribeSenderAndMark,
+} = vi.hoisted(() => ({
+  mockCreateRule: vi.fn(),
+  mockPartialUpdateRule: vi.fn(),
+  mockUpdateRuleActions: vi.fn(),
+  mockSaveLearnedPatterns: vi.fn(),
+  mockCreateEmailProvider: vi.fn(),
+  mockPosthogCaptureEvent: vi.fn(),
+  mockRedis: {
+    set: vi.fn(),
+    rpush: vi.fn(),
+    hincrby: vi.fn(),
+    expire: vi.fn(),
+    keys: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    llen: vi.fn().mockResolvedValue(0),
+    lrange: vi.fn().mockResolvedValue([]),
+  },
+  mockUnsubscribeSenderAndMark: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/rule", () => ({
+  createRule: mockCreateRule,
+  partialUpdateRule: mockPartialUpdateRule,
+  updateRuleActions: mockUpdateRuleActions,
+}));
+
+vi.mock("@/utils/rule/learned-patterns", () => ({
+  saveLearnedPatterns: mockSaveLearnedPatterns,
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: mockCreateEmailProvider,
+}));
+
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: mockPosthogCaptureEvent,
+  getPosthogLlmClient: () => null,
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: mockRedis,
+}));
+
+vi.mock("@/utils/senders/unsubscribe", () => ({
+  unsubscribeSenderAndMark: mockUnsubscribeSenderAndMark,
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_EMAIL_SEND_ENABLED: true,
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+describe.runIf(shouldRunEval)("Eval: assistant chat overlap exceptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    configureRuleMutationMocks({
+      mockCreateRule,
+      mockPartialUpdateRule,
+      mockUpdateRuleActions,
+      mockSaveLearnedPatterns,
+    });
+
+    configureRuleEvalPrisma({
+      about,
+      ruleRows,
+      groupItemsByRuleName: {
+        Newsletter: [
+          {
+            type: GroupItemType.FROM,
+            value: "daily@briefing.example",
+            exclude: false,
+          },
+        ],
+        "Things to keep in Inbox": [
+          {
+            type: GroupItemType.FROM,
+            value: "vip@important.example",
+            exclude: false,
+          },
+        ],
+      },
+    });
+
+    configureRuleEvalProvider({
+      mockCreateEmailProvider,
+      ruleRows,
+    });
+  });
+
+  describeEvalMatrix(
+    "assistant-chat overlap exceptions",
+    (model, emailAccount) => {
+      test(
+        "moves a sender from Newsletter into an existing keep-in-inbox rule",
+        async () => {
+          const { toolCalls, actual, didSaveLearnedPatterns } =
+            await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "I already have Newsletter and Things to keep in Inbox rules. Emails from daily@briefing.example should stay in my inbox and stop getting treated like Newsletter emails. Update my existing rules.",
+                },
+              ],
+            });
+
+          const keepUpdate = getMatchingLearnedPatternsUpdate(toolCalls, {
+            ruleName: "Things to keep in Inbox",
+            includes: ["daily@briefing.example"],
+          });
+          const newsletterUpdate = getMatchingLearnedPatternsUpdate(toolCalls, {
+            ruleName: "Newsletter",
+            excludes: ["daily@briefing.example"],
+          });
+
+          const pass =
+            !!keepUpdate &&
+            !!newsletterUpdate &&
+            !toolCalls.some((toolCall) => toolCall.toolName === "createRule") &&
+            !toolCalls.some(
+              (toolCall) => toolCall.toolName === "updateRuleConditions",
+            ) &&
+            !toolCalls.some(
+              (toolCall) => toolCall.toolName === "updateRuleActions",
+            ) &&
+            didSaveLearnedPatterns;
+
+          evalReporter.record({
+            testName: "move sender into keep-in-inbox rule",
+            model: model.label,
+            pass,
+            actual,
+          });
+
+          expect(pass).toBe(true);
+        },
+        TIMEOUT,
+      );
+    },
+  );
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+type UpdateLearnedPatternsInput = {
+  ruleName: string;
+  learnedPatterns: Array<{
+    include?: {
+      from?: string | null;
+      subject?: string | null;
+    } | null;
+    exclude?: {
+      from?: string | null;
+      subject?: string | null;
+    } | null;
+  }>;
+};
+
+async function runAssistantChat({
+  emailAccount,
+  messages,
+}: {
+  emailAccount: ReturnType<typeof getEmailAccount>;
+  messages: ModelMessage[];
+}) {
+  const saveLearnedPatternsCallsBefore =
+    mockSaveLearnedPatterns.mock.calls.length;
+  const toolCalls = await captureAssistantChatToolCalls({
+    messages,
+    emailAccount,
+    logger,
+  });
+  const saveLearnedPatternsCallsAfter =
+    mockSaveLearnedPatterns.mock.calls.length;
+
+  return {
+    toolCalls,
+    actual: summarizeRecordedToolCalls(toolCalls, summarizeToolCall),
+    didSaveLearnedPatterns:
+      saveLearnedPatternsCallsAfter > saveLearnedPatternsCallsBefore,
+  };
+}
+
+function getMatchingLearnedPatternsUpdate(
+  toolCalls: RecordedToolCall[],
+  {
+    ruleName,
+    includes = [],
+    excludes = [],
+  }: {
+    ruleName: string;
+    includes?: string[];
+    excludes?: string[];
+  },
+) {
+  for (let index = toolCalls.length - 1; index >= 0; index -= 1) {
+    const toolCall = toolCalls[index];
+    if (toolCall.toolName !== "updateLearnedPatterns") continue;
+    if (!isUpdateLearnedPatternsInput(toolCall.input)) continue;
+    if (toolCall.input.ruleName !== ruleName) continue;
+    if (
+      !includes.every((expectedFrom) =>
+        hasIncludedFrom(toolCall.input.learnedPatterns, expectedFrom),
+      )
+    ) {
+      continue;
+    }
+    if (
+      !excludes.every((expectedFrom) =>
+        hasExcludedFrom(toolCall.input.learnedPatterns, expectedFrom),
+      )
+    ) {
+      continue;
+    }
+
+    return toolCall.input;
+  }
+
+  return null;
+}
+
+function isUpdateLearnedPatternsInput(
+  input: unknown,
+): input is UpdateLearnedPatternsInput {
+  if (!input || typeof input !== "object") return false;
+
+  const value = input as {
+    ruleName?: unknown;
+    learnedPatterns?: unknown;
+  };
+
+  return (
+    typeof value.ruleName === "string" && Array.isArray(value.learnedPatterns)
+  );
+}
+
+function hasIncludedFrom(
+  learnedPatterns: UpdateLearnedPatternsInput["learnedPatterns"],
+  expectedFrom: string,
+) {
+  return learnedPatterns.some(
+    (pattern) =>
+      !!pattern.include?.from &&
+      senderListHasValue(pattern.include.from, expectedFrom),
+  );
+}
+
+function hasExcludedFrom(
+  learnedPatterns: UpdateLearnedPatternsInput["learnedPatterns"],
+  expectedFrom: string,
+) {
+  return learnedPatterns.some(
+    (pattern) =>
+      !!pattern.exclude?.from &&
+      senderListHasValue(pattern.exclude.from, expectedFrom),
+  );
+}
+
+function summarizeToolCall(toolCall: RecordedToolCall) {
+  if (!isUpdateLearnedPatternsInput(toolCall.input)) {
+    return toolCall.toolName;
+  }
+
+  const includeValues = toolCall.input.learnedPatterns
+    .flatMap((pattern) => [pattern.include?.from ?? null])
+    .filter((value): value is string => Boolean(value));
+  const excludeValues = toolCall.input.learnedPatterns
+    .flatMap((pattern) => [pattern.exclude?.from ?? null])
+    .filter((value): value is string => Boolean(value));
+
+  return `${toolCall.toolName}(rule=${toolCall.input.ruleName}; include=${includeValues.join("|") || "none"}; exclude=${excludeValues.join("|") || "none"})`;
+}

--- a/apps/web/__tests__/eval/assistant-chat-static-sender-rules-static-from.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-static-sender-rules-static-from.test.ts
@@ -58,6 +58,13 @@ const scenarios = [
       "anything from dispatch@itinerary.example should land in Travel Plans.",
     senders: ["dispatch@itinerary.example"],
   },
+  {
+    title: "uses static.from for a bare keep-in-inbox sender rule",
+    reportName: "keep in inbox bare sender rule (current)",
+    prompt:
+      "create a rule called Things to keep in Inbox for daily@briefing.example and just leave those emails in the inbox",
+    senders: ["daily@briefing.example"],
+  },
 ] as const;
 
 const {

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -261,6 +261,7 @@ Learned patterns:
 - There's some similarity to static rules, but you can only use one static condition for a rule. But you can use multiple learned patterns. And over time the list of learned patterns will grow.
 - You can use includes or excludes for learned patterns. Usually you will use includes, but if the user has explained that an email is being wrongly labelled, check if we have a learned pattern for it and then fix it to be an exclude instead.
 - When an existing category rule already fits and the user wants to add or remove recurring senders, use updateLearnedPatterns to extend that rule instead of creating a new rule or editing static from/to fields.
+- If the user wants a recurring sender moved from one existing rule to another existing rule, use updateLearnedPatterns on both rules: add an include to the desired rule and an exclude to the conflicting rule. Do not use updateRuleConditions for that case.
 
 Knowledge base:
 - Activate "knowledge" before using addToKnowledgeBase.


### PR DESCRIPTION
# User description
The user likes the current state of the code.

There are 3 uncommitted changes.
The current branch is keep-inbox-overlaps.
The target branch is origin/main.

There is no upstream branch yet.
The user requested a PR.

Follow these steps to create a PR:

- If you have any skills related to creating PRs, invoke them now. Instructions there should take precedence over these instructions.
- Run `git diff` to review uncommitted changes
- Commit them. Follow any instructions the user gave you about writing commit messages.
- Push to origin.
- Use `git diff origin/main...` to review the PR diff
- Use `gh pr create --base main --title <title> --body <description>` to create a PR onto the target branch.

If any of these steps fail, ask the user for help.

## PR Title

The user has provided this PR title. Use it exactly as-is:
Add terminal rule processing support

## PR Description

The user has provided this PR description. Use it exactly as-is:

This adds terminal rule support so a matched rule can stop later rule processing.

It allows zero-action terminal rules, wires the new flag through manual editing, chat, import/export, and the v1 rules API, and persists it in rule history.

It also adds validation and matcher regressions for terminal and non-terminal stacking behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable terminal rule processing by threading the terminal flag through assistant chat guidance, rule editing flows, import/export, and the v1 rules API while persisting the state in rule history so matched rules can stop downstream processing. Add validation and matcher regressions to catch terminal and non-terminal stacking behavior, including moving senders between newsletter and keep-in-inbox coverage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2009?tool=ast&topic=Terminal+rule+flow>Terminal rule flow</a>
        </td><td>Thread the terminal flag through assistant chat, rule editing, import/export, and the v1 rules API so matched rules can stop downstream processing and persist the state in rule history.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: Chat create...</td><td>March 21, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix Anthropic System M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2009?tool=ast&topic=Overlap+tests>Overlap tests</a>
        </td><td>Add regression coverage to assistant chat overlap and static sender rule tests to validate learned-pattern stacking for terminal versus non-terminal matches.<details><summary>Modified files (2)</summary><ul><li>apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts</li>
<li>apps/web/__tests__/eval/assistant-chat-static-sender-rules-static-from.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: refine rule promp...</td><td>March 17, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2009?tool=ast>(Baz)</a>.