### PR TITLE
Add messaging draft review workflow

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DraftReviewDeliverySetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DraftReviewDeliverySetting.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback } from "react";
+import { useAction } from "next-safe-action/hooks";
+import {
+  DraftMaterializationMode,
+  MessagingProvider,
+} from "@/generated/prisma/enums";
+import { LoadingContent } from "@/components/LoadingContent";
+import { Toggle } from "@/components/Toggle";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { useDraftReviewSettings } from "@/hooks/useDraftReviewSettings";
+import { useMessagingChannels } from "@/hooks/useMessagingChannels";
+import { saveDraftReviewSettingsAction } from "@/utils/actions/draft-review-settings";
+
+export function DraftReviewDeliverySetting() {
+  const { emailAccountId } = useAccount();
+  const {
+    data,
+    mutate,
+    isLoading,
+    error,
+  } = useDraftReviewSettings(emailAccountId);
+  const { data: channelsData } = useMessagingChannels(emailAccountId);
+
+  const slackChannels =
+    channelsData?.channels.filter(
+      (channel) =>
+        channel.provider === MessagingProvider.SLACK &&
+        channel.isConnected &&
+        channel.channelId,
+    ) ?? [];
+
+  const { executeAsync, isExecuting } = useAction(
+    saveDraftReviewSettingsAction.bind(null, emailAccountId),
+  );
+
+  const saveSettings = useCallback(
+    async (next: {
+      enabled: boolean;
+      messagingChannelId: string | null;
+      draftMaterializationMode: DraftMaterializationMode;
+    }) => {
+      try {
+        await executeAsync(next);
+        await mutate();
+        toastSuccess({ description: "Draft review delivery updated" });
+      } catch (error) {
+        toastError({
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to update draft review delivery",
+        });
+      }
+    },
+    [executeAsync, mutate],
+  );
+
+  return (
+    <LoadingContent
+      loading={isLoading}
+      error={error}
+      loadingComponent={<Skeleton className="h-28 w-full" />}
+    >
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <div className="flex items-center gap-4">
+            <div className="flex-1">
+              <h3 className="font-medium">Draft review delivery</h3>
+              <p className="text-sm text-muted-foreground">
+                Send draft replies to Slack so you can edit, send, or dismiss
+                them without opening your inbox.
+              </p>
+            </div>
+            <Toggle
+              name="draft-review-delivery"
+              enabled={data?.enabled ?? false}
+              onChange={(enabled) =>
+                saveSettings({
+                  enabled,
+                  messagingChannelId:
+                    data?.messagingChannelId ?? slackChannels[0]?.id ?? null,
+                  draftMaterializationMode:
+                    data?.draftMaterializationMode ??
+                    DraftMaterializationMode.MAILBOX_DRAFT,
+                })
+              }
+              disabled={isExecuting || (!data?.enabled && slackChannels.length === 0)}
+            />
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="draft-review-destination">Destination</Label>
+              <Select
+                value={data?.messagingChannelId ?? undefined}
+                disabled={isExecuting || slackChannels.length === 0}
+                onValueChange={(messagingChannelId) =>
+                  saveSettings({
+                    enabled: data?.enabled ?? true,
+                    messagingChannelId,
+                    draftMaterializationMode:
+                      data?.draftMaterializationMode ??
+                      DraftMaterializationMode.MAILBOX_DRAFT,
+                  })
+                }
+              >
+                <SelectTrigger id="draft-review-destination">
+                  <SelectValue
+                    placeholder={
+                      slackChannels.length === 0
+                        ? "Connect Slack first"
+                        : "Choose a Slack destination"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {slackChannels.map((channel) => (
+                    <SelectItem key={channel.id} value={channel.id}>
+                      {channel.isDm
+                        ? `${channel.teamName ?? "Slack"} DM`
+                        : `${channel.teamName ?? "Slack"} #${channel.channelName ?? "private-channel"}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="draft-materialization-mode">
+                Materialize drafts in
+              </Label>
+              <Select
+                value={
+                  data?.draftMaterializationMode ??
+                  DraftMaterializationMode.MAILBOX_DRAFT
+                }
+                disabled={isExecuting}
+                onValueChange={(value) =>
+                  saveSettings({
+                    enabled: data?.enabled ?? false,
+                    messagingChannelId:
+                      data?.messagingChannelId ?? slackChannels[0]?.id ?? null,
+                    draftMaterializationMode:
+                      value as DraftMaterializationMode,
+                  })
+                }
+              >
+                <SelectTrigger id="draft-materialization-mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={DraftMaterializationMode.MAILBOX_DRAFT}>
+                    Inbox draft + Slack
+                  </SelectItem>
+                  <SelectItem value={DraftMaterializationMode.MESSAGING_ONLY}>
+                    Slack only
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {slackChannels.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Connect Slack and choose a DM or private channel in Connected Apps
+              before enabling draft review delivery.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </LoadingContent>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import { AboutSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/AboutSetting";
 import { DigestSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DigestSetting";
 import { DraftConfidenceSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftConfidenceSetting";
+import { DraftReviewDeliverySetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftReviewDeliverySetting";
 import { DraftReplies } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftReplies";
 import { DraftKnowledgeSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftKnowledgeSetting";
 import { FollowUpRemindersSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/FollowUpRemindersSetting";
@@ -22,6 +23,7 @@ export function SettingsTab() {
       {!autoDraftDisabled && (
         <div className="space-y-2">
           <DraftReplies />
+          <DraftReviewDeliverySetting />
           <DraftConfidenceSetting />
         </div>
       )}

--- a/apps/web/app/api/messaging-notifications/execute/queue/route.ts
+++ b/apps/web/app/api/messaging-notifications/execute/queue/route.ts
@@ -1,0 +1,15 @@
+import { createForwardingQueueHandler } from "@/utils/queue/create-forwarding-queue-handler";
+import { executeMessagingNotificationBody } from "@/utils/messaging-notifications/validation";
+
+export const maxDuration = 60;
+
+export const POST = createForwardingQueueHandler({
+  loggerScope: "messaging-notifications/queue",
+  schema: executeMessagingNotificationBody,
+  path: "/api/messaging-notifications/execute",
+  invalidPayloadMessage: "Invalid messaging notification queue payload",
+  visibilityTimeoutSeconds: 55,
+  getLoggerContext: (payload) => ({
+    notificationId: payload.notificationId,
+  }),
+});

--- a/apps/web/app/api/messaging-notifications/execute/route.ts
+++ b/apps/web/app/api/messaging-notifications/execute/route.ts
@@ -1,0 +1,28 @@
+import { withError } from "@/utils/middleware";
+import { withQstashOrInternal } from "@/utils/qstash";
+import { executeMessagingNotificationBody } from "@/utils/messaging-notifications/validation";
+import { executeMessagingNotification } from "@/utils/messaging-notifications/execute";
+
+export const maxDuration = 300;
+
+export const POST = withError(
+  "messaging-notifications/execute",
+  withQstashOrInternal(async (request) => {
+    const logger = request.logger;
+    const validation = executeMessagingNotificationBody.safeParse(
+      await request.json(),
+    );
+
+    if (!validation.success) {
+      logger.error("Invalid messaging notification execute payload", {
+        errors: validation.error.errors,
+      });
+      return new Response("Invalid payload", { status: 400 });
+    }
+
+    return executeMessagingNotification({
+      notificationId: validation.data.notificationId,
+      logger,
+    });
+  }),
+);

--- a/apps/web/app/api/user/draft-review-settings/route.ts
+++ b/apps/web/app/api/user/draft-review-settings/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import {
+  DraftMaterializationMode,
+  MessagingNotificationEventType,
+} from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import { withEmailAccount } from "@/utils/middleware";
+
+export type GetDraftReviewSettingsResponse = Awaited<
+  ReturnType<typeof getData>
+>;
+
+export const GET = withEmailAccount(
+  "user/draft-review-settings",
+  async (request) => {
+    const result = await getData({
+      emailAccountId: request.auth.emailAccountId,
+    });
+
+    return NextResponse.json(result);
+  },
+);
+
+async function getData({ emailAccountId }: { emailAccountId: string }) {
+  const [emailAccount, subscription] = await Promise.all([
+    prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: {
+        draftMaterializationMode: true,
+      },
+    }),
+    prisma.messagingNotificationSubscription.findFirst({
+      where: {
+        emailAccountId,
+        eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+        enabled: true,
+      },
+      select: {
+        messagingChannelId: true,
+      },
+      orderBy: { updatedAt: "desc" },
+    }),
+  ]);
+
+  return {
+    enabled: Boolean(subscription),
+    messagingChannelId: subscription?.messagingChannelId ?? null,
+    draftMaterializationMode:
+      emailAccount?.draftMaterializationMode ??
+      DraftMaterializationMode.MAILBOX_DRAFT,
+  };
+}

--- a/apps/web/hooks/useDraftReviewSettings.ts
+++ b/apps/web/hooks/useDraftReviewSettings.ts
@@ -1,0 +1,10 @@
+import useSWR from "swr";
+import type { GetDraftReviewSettingsResponse } from "@/app/api/user/draft-review-settings/route";
+
+export function useDraftReviewSettings(emailAccountId?: string | null) {
+  return useSWR<GetDraftReviewSettingsResponse>(
+    emailAccountId
+      ? (["/api/user/draft-review-settings", emailAccountId] as const)
+      : null,
+  );
+}

--- a/apps/web/prisma/migrations/20260325013530_draft_review_delivery/migration.sql
+++ b/apps/web/prisma/migrations/20260325013530_draft_review_delivery/migration.sql
@@ -1,0 +1,157 @@
+-- CreateEnum
+CREATE TYPE "DraftMaterializationMode" AS ENUM ('MAILBOX_DRAFT', 'MESSAGING_ONLY');
+
+-- CreateEnum
+CREATE TYPE "MessagingNotificationEventType" AS ENUM ('OUTBOUND_PROPOSAL_READY');
+
+-- CreateEnum
+CREATE TYPE "MessagingNotificationDeliveryStatus" AS ENUM ('PENDING', 'SENT', 'FAILED', 'SKIPPED');
+
+-- CreateEnum
+CREATE TYPE "OutboundProposalStatus" AS ENUM ('OPEN', 'PROCESSING', 'SENT', 'DISMISSED', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "OutboundProposalCloseReason" AS ENUM ('SUPERSEDED', 'DRAFT_MISSING', 'SENT_EXTERNALLY');
+
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN     "draftMaterializationMode" "DraftMaterializationMode" NOT NULL DEFAULT 'MAILBOX_DRAFT';
+
+-- CreateTable
+CREATE TABLE "OutboundProposal" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "status" "OutboundProposalStatus" NOT NULL DEFAULT 'OPEN',
+    "closeReason" "OutboundProposalCloseReason",
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "materializationMode" "DraftMaterializationMode" NOT NULL,
+    "draftId" TEXT,
+    "to" TEXT,
+    "cc" TEXT,
+    "bcc" TEXT,
+    "subject" TEXT,
+    "originalContent" TEXT,
+    "currentContent" TEXT,
+    "selectedAttachments" JSONB,
+    "chatId" TEXT,
+    "providerMessageId" TEXT,
+    "providerThreadId" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "sentMessageId" TEXT,
+    "sentThreadId" TEXT,
+    "threadId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "executedActionId" TEXT NOT NULL,
+    "messagingChannelId" TEXT,
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "OutboundProposal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MessagingNotification" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "eventType" "MessagingNotificationEventType" NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "dedupeKey" TEXT NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "MessagingNotification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MessagingNotificationDelivery" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "status" "MessagingNotificationDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "providerMessageId" TEXT,
+    "providerThreadId" TEXT,
+    "chatId" TEXT,
+    "error" TEXT,
+    "sentAt" TIMESTAMP(3),
+    "notificationId" TEXT NOT NULL,
+    "messagingChannelId" TEXT NOT NULL,
+
+    CONSTRAINT "MessagingNotificationDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MessagingNotificationSubscription" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "eventType" "MessagingNotificationEventType" NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "filters" JSONB,
+    "emailAccountId" TEXT NOT NULL,
+    "messagingChannelId" TEXT NOT NULL,
+
+    CONSTRAINT "MessagingNotificationSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OutboundProposal_chatId_key" ON "OutboundProposal"("chatId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OutboundProposal_executedActionId_key" ON "OutboundProposal"("executedActionId");
+
+-- CreateIndex
+CREATE INDEX "OutboundProposal_emailAccountId_status_createdAt_idx" ON "OutboundProposal"("emailAccountId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "OutboundProposal_emailAccountId_threadId_status_idx" ON "OutboundProposal"("emailAccountId", "threadId", "status");
+
+-- CreateIndex
+CREATE INDEX "OutboundProposal_messagingChannelId_status_idx" ON "OutboundProposal"("messagingChannelId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessagingNotification_dedupeKey_key" ON "MessagingNotification"("dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "MessagingNotification_emailAccountId_eventType_createdAt_idx" ON "MessagingNotification"("emailAccountId", "eventType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MessagingNotification_sourceType_sourceId_idx" ON "MessagingNotification"("sourceType", "sourceId");
+
+-- CreateIndex
+CREATE INDEX "MessagingNotificationDelivery_status_createdAt_idx" ON "MessagingNotificationDelivery"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MessagingNotificationDelivery_messagingChannelId_createdAt_idx" ON "MessagingNotificationDelivery"("messagingChannelId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessagingNotificationDelivery_notificationId_messagingChann_key" ON "MessagingNotificationDelivery"("notificationId", "messagingChannelId");
+
+-- CreateIndex
+CREATE INDEX "MessagingNotificationSubscription_emailAccountId_eventType__idx" ON "MessagingNotificationSubscription"("emailAccountId", "eventType", "enabled");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessagingNotificationSubscription_emailAccountId_messagingC_key" ON "MessagingNotificationSubscription"("emailAccountId", "messagingChannelId", "eventType");
+
+-- AddForeignKey
+ALTER TABLE "OutboundProposal" ADD CONSTRAINT "OutboundProposal_executedActionId_fkey" FOREIGN KEY ("executedActionId") REFERENCES "ExecutedAction"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutboundProposal" ADD CONSTRAINT "OutboundProposal_messagingChannelId_fkey" FOREIGN KEY ("messagingChannelId") REFERENCES "MessagingChannel"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutboundProposal" ADD CONSTRAINT "OutboundProposal_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagingNotification" ADD CONSTRAINT "MessagingNotification_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagingNotificationDelivery" ADD CONSTRAINT "MessagingNotificationDelivery_notificationId_fkey" FOREIGN KEY ("notificationId") REFERENCES "MessagingNotification"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagingNotificationDelivery" ADD CONSTRAINT "MessagingNotificationDelivery_messagingChannelId_fkey" FOREIGN KEY ("messagingChannelId") REFERENCES "MessagingChannel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagingNotificationSubscription" ADD CONSTRAINT "MessagingNotificationSubscription_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagingNotificationSubscription" ADD CONSTRAINT "MessagingNotificationSubscription_messagingChannelId_fkey" FOREIGN KEY ("messagingChannelId") REFERENCES "MessagingChannel"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -140,17 +140,18 @@ model EmailAccount {
   timezone                       String? // User's timezone (IANA tz database format, e.g., "America/Los_Angeles", "Asia/Jerusalem") - handles DST automatically
   calendarBookingLink            String? // User's calendar booking link
 
-  statsEmailFrequency       Frequency            @default(WEEKLY)
-  summaryEmailFrequency     Frequency            @default(WEEKLY)
+  statsEmailFrequency       Frequency                @default(WEEKLY)
+  summaryEmailFrequency     Frequency                @default(WEEKLY)
   lastSummaryEmailAt        DateTime?
   coldEmailBlocker          ColdEmailSetting? // @deprecated
-  coldEmailDigest           Boolean              @default(false) // @deprecated
+  coldEmailDigest           Boolean                  @default(false) // @deprecated
   coldEmailPrompt           String? // @deprecated
   rulesPrompt               String? // @deprecated
-  autoCategorizeSenders     Boolean              @default(false)
-  multiRuleSelectionEnabled Boolean              @default(false)
-  draftReplyConfidence      DraftReplyConfidence @default(ALL_EMAILS)
-  allowHiddenAiDraftLinks   Boolean              @default(false)
+  autoCategorizeSenders     Boolean                  @default(false)
+  multiRuleSelectionEnabled Boolean                  @default(false)
+  draftReplyConfidence      DraftReplyConfidence     @default(ALL_EMAILS)
+  draftMaterializationMode  DraftMaterializationMode @default(MAILBOX_DRAFT)
+  allowHiddenAiDraftLinks   Boolean                  @default(false)
 
   meetingBriefingsEnabled       Boolean @default(false)
   meetingBriefingsMinutesBefore Int     @default(240) // 4 hours in minutes
@@ -164,7 +165,7 @@ model EmailAccount {
   followUpNeedsReplyDays    Float?
   followUpAutoDraftEnabled  Boolean @default(true)
 
-  digestSchedule Schedule?
+  digestSchedule      Schedule?
   learnedWritingStyle String?
 
   userId    String
@@ -172,25 +173,28 @@ model EmailAccount {
   accountId String  @unique
   account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
 
-  labels           Label[]
-  rules            Rule[]
-  executedRules    ExecutedRule[]
-  newsletters      Newsletter[]
-  coldEmails       ColdEmail[] // @deprecated - kept for backward compatibility during migration
-  groups           Group[]
-  categories       Category[]
-  threadTrackers   ThreadTracker[]
-  cleanupJobs      CleanupJob[]
-  cleanupThreads   CleanupThread[]
-  emailMessages    EmailMessage[]
-  emailTokens      EmailToken[]
-  knowledge        Knowledge[]
-  replyMemories    ReplyMemory[]
-  chats            Chat[]
-  chatMemories     ChatMemory[]
-  digests          Digest[]
-  scheduledActions ScheduledAction[]
-  responseTimes    ResponseTime[]
+  labels                             Label[]
+  rules                              Rule[]
+  executedRules                      ExecutedRule[]
+  newsletters                        Newsletter[]
+  coldEmails                         ColdEmail[] // @deprecated - kept for backward compatibility during migration
+  groups                             Group[]
+  categories                         Category[]
+  threadTrackers                     ThreadTracker[]
+  cleanupJobs                        CleanupJob[]
+  cleanupThreads                     CleanupThread[]
+  emailMessages                      EmailMessage[]
+  emailTokens                        EmailToken[]
+  knowledge                          Knowledge[]
+  replyMemories                      ReplyMemory[]
+  outboundProposals                  OutboundProposal[]
+  messagingNotifications             MessagingNotification[]
+  messagingNotificationSubscriptions MessagingNotificationSubscription[]
+  chats                              Chat[]
+  chatMemories                       ChatMemory[]
+  digests                            Digest[]
+  scheduledActions                   ScheduledAction[]
+  responseTimes                      ResponseTime[]
 
   members             Member[]
   invitations         Invitation[]
@@ -584,6 +588,7 @@ model ExecutedAction {
   draftPipelineVersion Int?
   draftContextMetadata Json?
   draftSendLog         DraftSendLog? // Will exist if the draft was sent
+  outboundProposal     OutboundProposal?
   digestItems          DigestItem[] // Relation to digest items created by this action
   scheduledAction      ScheduledAction? // Reverse relation for delayed actions
 
@@ -856,11 +861,11 @@ model ReplyMemory {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  content    String
-  kind       ReplyMemoryKind
-  scopeType  ReplyMemoryScopeType
-  scopeValue String
-  isLearnedStyleEvidence Boolean @default(false)
+  content                String
+  kind                   ReplyMemoryKind
+  scopeType              ReplyMemoryScopeType
+  scopeValue             String
+  isLearnedStyleEvidence Boolean              @default(false)
 
   emailAccountId String
   emailAccount   EmailAccount        @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
@@ -872,7 +877,7 @@ model ReplyMemory {
 }
 
 model ReplyMemorySource {
-  createdAt DateTime @default(now())
+  createdAt                     DateTime  @default(now())
   learnedWritingStyleAnalyzedAt DateTime?
 
   replyMemoryId String
@@ -969,6 +974,111 @@ model DraftSendLog {
 
   @@index([executedActionId])
   @@index([replyMemoryProcessedAt, replyMemoryAttemptCount, createdAt])
+}
+
+model OutboundProposal {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  status              OutboundProposalStatus       @default(OPEN)
+  closeReason         OutboundProposalCloseReason?
+  revision            Int                          @default(1)
+  materializationMode DraftMaterializationMode
+
+  draftId             String?
+  to                  String?
+  cc                  String?
+  bcc                 String?
+  subject             String?
+  originalContent     String?
+  currentContent      String?
+  selectedAttachments Json?
+
+  chatId            String?   @unique
+  providerMessageId String?
+  providerThreadId  String?
+  resolvedAt        DateTime?
+  sentMessageId     String?
+  sentThreadId      String?
+
+  threadId  String
+  messageId String
+
+  executedActionId String         @unique
+  executedAction   ExecutedAction @relation(fields: [executedActionId], references: [id], onDelete: Cascade)
+
+  messagingChannelId String?
+  messagingChannel   MessagingChannel? @relation(fields: [messagingChannelId], references: [id], onDelete: SetNull)
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  @@index([emailAccountId, status, createdAt])
+  @@index([emailAccountId, threadId, status])
+  @@index([messagingChannelId, status])
+}
+
+model MessagingNotification {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+
+  eventType  MessagingNotificationEventType
+  sourceType String
+  sourceId   String
+  payload    Json
+  dedupeKey  String                         @unique
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  deliveries MessagingNotificationDelivery[]
+
+  @@index([emailAccountId, eventType, createdAt])
+  @@index([sourceType, sourceId])
+}
+
+model MessagingNotificationDelivery {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  status MessagingNotificationDeliveryStatus @default(PENDING)
+
+  providerMessageId String?
+  providerThreadId  String?
+  chatId            String?
+  error             String?   @db.Text
+  sentAt            DateTime?
+
+  notificationId String
+  notification   MessagingNotification @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+
+  messagingChannelId String
+  messagingChannel   MessagingChannel @relation(fields: [messagingChannelId], references: [id], onDelete: Cascade)
+
+  @@unique([notificationId, messagingChannelId])
+  @@index([status, createdAt])
+  @@index([messagingChannelId, createdAt])
+}
+
+model MessagingNotificationSubscription {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  eventType MessagingNotificationEventType
+  enabled   Boolean                        @default(true)
+  filters   Json?
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  messagingChannelId String
+  messagingChannel   MessagingChannel @relation(fields: [messagingChannelId], references: [id], onDelete: Cascade)
+
+  @@unique([emailAccountId, messagingChannelId, eventType])
+  @@index([emailAccountId, eventType, enabled])
 }
 
 model Chat {
@@ -1113,9 +1223,12 @@ model MessagingChannel {
   sendMeetingBriefs   Boolean @default(false)
   sendDocumentFilings Boolean @default(false)
 
-  emailAccountId String
-  emailAccount   EmailAccount    @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
-  automationJobs AutomationJob[]
+  emailAccountId            String
+  emailAccount              EmailAccount                        @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  automationJobs            AutomationJob[]
+  outboundProposals         OutboundProposal[]
+  notificationDeliveries    MessagingNotificationDelivery[]
+  notificationSubscriptions MessagingNotificationSubscription[]
 
   @@unique([emailAccountId, provider, teamId])
   @@unique([id, emailAccountId])
@@ -1420,6 +1533,11 @@ enum DraftReplyConfidence {
   HIGH_CONFIDENCE
 }
 
+enum DraftMaterializationMode {
+  MAILBOX_DRAFT
+  MESSAGING_ONLY
+}
+
 enum ReplyMemoryKind {
   FACT
   PREFERENCE
@@ -1582,6 +1700,31 @@ enum MessagingProvider {
   SLACK
   TEAMS
   TELEGRAM
+}
+
+enum MessagingNotificationEventType {
+  OUTBOUND_PROPOSAL_READY
+}
+
+enum MessagingNotificationDeliveryStatus {
+  PENDING
+  SENT
+  FAILED
+  SKIPPED
+}
+
+enum OutboundProposalStatus {
+  OPEN
+  PROCESSING
+  SENT
+  DISMISSED
+  CLOSED
+}
+
+enum OutboundProposalCloseReason {
+  SUPERSEDED
+  DRAFT_MISSING
+  SENT_EXTERNALLY
 }
 
 enum AutomationJobRunStatus {

--- a/apps/web/utils/actions/draft-review-settings.test.ts
+++ b/apps/web/utils/actions/draft-review-settings.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  DraftMaterializationMode,
+  MessagingNotificationEventType,
+} from "@/generated/prisma/enums";
+import { saveDraftReviewSettingsAction } from "@/utils/actions/draft-review-settings";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+describe("saveDraftReviewSettingsAction", () => {
+  const channelId = "ckchannel0000000000000000";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: {
+        userId: "user-1",
+        provider: "google",
+      },
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: channelId,
+      channelId: "DM",
+    } as any);
+    prisma.messagingNotificationSubscription.upsert.mockResolvedValue({
+      id: "subscription-1",
+    } as any);
+    prisma.emailAccount.update.mockResolvedValue({ id: "account-1" } as any);
+  });
+
+  it("enables draft review delivery for a Slack destination", async () => {
+    await saveDraftReviewSettingsAction("account-1", {
+      enabled: true,
+      messagingChannelId: channelId,
+      draftMaterializationMode: DraftMaterializationMode.MESSAGING_ONLY,
+    });
+
+    expect(
+      prisma.messagingNotificationSubscription.upsert,
+    ).toHaveBeenCalledWith({
+      where: {
+        emailAccountId_messagingChannelId_eventType: {
+          emailAccountId: "account-1",
+          messagingChannelId: channelId,
+          eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+        },
+      },
+      create: {
+        emailAccountId: "account-1",
+        messagingChannelId: channelId,
+        eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+        enabled: true,
+      },
+      update: {
+        enabled: true,
+      },
+    });
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "account-1" },
+      data: {
+        draftMaterializationMode: DraftMaterializationMode.MESSAGING_ONLY,
+      },
+    });
+  });
+
+  it("falls back to mailbox drafts when disabling messaging-only delivery", async () => {
+    await saveDraftReviewSettingsAction("account-1", {
+      enabled: false,
+      messagingChannelId: null,
+      draftMaterializationMode: DraftMaterializationMode.MESSAGING_ONLY,
+    });
+
+    expect(
+      prisma.messagingNotificationSubscription.deleteMany,
+    ).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-1",
+        eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+      },
+    });
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "account-1" },
+      data: {
+        draftMaterializationMode: DraftMaterializationMode.MAILBOX_DRAFT,
+      },
+    });
+  });
+});

--- a/apps/web/utils/actions/draft-review-settings.ts
+++ b/apps/web/utils/actions/draft-review-settings.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import {
+  DraftMaterializationMode,
+  MessagingNotificationEventType,
+  MessagingProvider,
+} from "@/generated/prisma/enums";
+import { actionClient } from "@/utils/actions/safe-action";
+import { SafeError } from "@/utils/error";
+import prisma from "@/utils/prisma";
+import { saveDraftReviewSettingsBody } from "@/utils/actions/draft-review-settings.validation";
+
+export const saveDraftReviewSettingsAction = actionClient
+  .metadata({ name: "saveDraftReviewSettings" })
+  .inputSchema(saveDraftReviewSettingsBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { enabled, messagingChannelId, draftMaterializationMode },
+    }) => {
+      const nextMaterializationMode =
+        enabled ||
+        draftMaterializationMode !== DraftMaterializationMode.MESSAGING_ONLY
+          ? draftMaterializationMode
+          : DraftMaterializationMode.MAILBOX_DRAFT;
+
+      if (!enabled) {
+        await prisma.messagingNotificationSubscription.deleteMany({
+          where: {
+            emailAccountId,
+            eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+          },
+        });
+
+        await prisma.emailAccount.update({
+          where: { id: emailAccountId },
+          data: {
+            draftMaterializationMode: nextMaterializationMode,
+          },
+        });
+
+        return { success: true };
+      }
+
+      if (!messagingChannelId) {
+        throw new SafeError("Select a Slack destination first");
+      }
+
+      const channel = await prisma.messagingChannel.findFirst({
+        where: {
+          id: messagingChannelId,
+          emailAccountId,
+          provider: MessagingProvider.SLACK,
+          isConnected: true,
+        },
+        select: {
+          id: true,
+          channelId: true,
+        },
+      });
+
+      if (!channel) {
+        throw new SafeError("Slack destination not found");
+      }
+
+      if (!channel.channelId) {
+        throw new SafeError(
+          "Choose a Slack DM or private channel in Connected Apps before enabling draft reviews",
+        );
+      }
+
+      await prisma.messagingNotificationSubscription.deleteMany({
+        where: {
+          emailAccountId,
+          eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+          NOT: { messagingChannelId },
+        },
+      });
+
+      await prisma.messagingNotificationSubscription.upsert({
+        where: {
+          emailAccountId_messagingChannelId_eventType: {
+            emailAccountId,
+            messagingChannelId,
+            eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+          },
+        },
+        create: {
+          emailAccountId,
+          messagingChannelId,
+          eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+          enabled: true,
+        },
+        update: {
+          enabled: true,
+        },
+      });
+
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: {
+          draftMaterializationMode: nextMaterializationMode,
+        },
+      });
+
+      return { success: true };
+    },
+  );

--- a/apps/web/utils/actions/draft-review-settings.validation.ts
+++ b/apps/web/utils/actions/draft-review-settings.validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { DraftMaterializationMode } from "@/generated/prisma/enums";
+
+export const saveDraftReviewSettingsBody = z.object({
+  enabled: z.boolean(),
+  messagingChannelId: z.string().cuid().nullable(),
+  draftMaterializationMode: z.nativeEnum(DraftMaterializationMode),
+});
+
+export type SaveDraftReviewSettingsBody = z.infer<
+  typeof saveDraftReviewSettingsBody
+>;

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ActionType,
   AttachmentSourceType,
+  DraftMaterializationMode,
   DraftReplyConfidence,
 } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import { runActionFunction } from "@/utils/ai/actions";
 import {
@@ -14,6 +16,7 @@ import { createScopedLogger } from "@/utils/logger";
 import { getReplyWithConfidence } from "@/utils/redis/reply";
 import type { ParsedMessage } from "@/utils/types";
 vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
 
 vi.mock("@/utils/redis/reply", () => ({
   getReplyWithConfidence: vi.fn().mockResolvedValue(null),
@@ -44,10 +47,13 @@ describe("runActionFunction", () => {
     snippet: "",
     attachments: [],
     internalDate: "1700000000000",
-  } as ParsedMessage;
+  } as unknown as ParsedMessage;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      draftMaterializationMode: DraftMaterializationMode.MAILBOX_DRAFT,
+    } as any);
   });
 
   it("passes resolved drive attachments into draft creation", async () => {
@@ -56,6 +62,8 @@ describe("runActionFunction", () => {
     vi.mocked(getReplyWithConfidence).mockResolvedValue({
       reply: "Attached the requested PDF.",
       confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+      attribution: null,
+      draftContextMetadata: null,
       attachments: [
         {
           driveConnectionId: "drive-1",
@@ -306,5 +314,41 @@ describe("runActionFunction", () => {
         ],
       }),
     );
+  });
+
+  it("returns a messaging-only proposal result without creating a provider draft", async () => {
+    const client = createMockEmailProvider();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      draftMaterializationMode: DraftMaterializationMode.MESSAGING_ONLY,
+    } as any);
+
+    const result = await runActionFunction({
+      client,
+      email,
+      action: {
+        id: "action-1",
+        type: ActionType.DRAFT_EMAIL,
+        content: "Reply from Slack only.",
+      },
+      userEmail: "user@example.com",
+      userId: "user-1",
+      emailAccountId: "account-1",
+      executedRule: {
+        id: "executed-rule-1",
+        threadId: "thread-1",
+        emailAccountId: "account-1",
+        ruleId: "rule-1",
+      } as any,
+      logger,
+    });
+
+    expect(result).toEqual({
+      draftId: null,
+      materializationMode: DraftMaterializationMode.MESSAGING_ONLY,
+      selectedAttachments: [],
+    });
+    expect(client.draftEmail).not.toHaveBeenCalled();
+    expect(resolveDraftAttachments).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -1,5 +1,5 @@
 import { after } from "next/server";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftMaterializationMode } from "@/generated/prisma/enums";
 import type { ExecutedRule } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
 import { callWebhook } from "@/utils/webhook";
@@ -35,6 +35,12 @@ type ActionFunction<T extends Partial<Omit<ActionItem, "type">>> = (options: {
   executedRule: ExecutedRule;
   logger: Logger;
 }) => Promise<any>;
+
+export type DraftActionResult = {
+  draftId: string | null;
+  materializationMode: DraftMaterializationMode;
+  selectedAttachments: SelectedAttachment[];
+};
 
 export const runActionFunction = async (options: {
   client: EmailProvider;
@@ -179,15 +185,41 @@ const draft: ActionFunction<{
 }) => {
   if (env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED) return;
 
-  const attachments = await resolveActionAttachments({
+  const materializationMode = await getDraftMaterializationMode(emailAccountId);
+  const selectedAttachments = await getDraftSelectedAttachments({
     email,
     emailAccountId,
     executedRule,
-    userId,
     logger,
-    staticAttachments: args.staticAttachments,
-    includeAiSelectedAttachments: true,
   });
+
+  if (materializationMode === DraftMaterializationMode.MESSAGING_ONLY) {
+    return {
+      draftId: null,
+      materializationMode,
+      selectedAttachments,
+    } satisfies DraftActionResult;
+  }
+
+  const staticSelected = parseStaticAttachments(args.staticAttachments);
+  const allSelected = [
+    ...new Map(
+      [...selectedAttachments, ...staticSelected].map((attachment) => [
+        `${attachment.driveConnectionId}:${attachment.fileId}`,
+        attachment,
+      ]),
+    ).values(),
+  ];
+
+  const attachments =
+    allSelected.length > 0
+      ? await resolveDraftAttachments({
+          emailAccountId,
+          userId,
+          selectedAttachments: allSelected,
+          logger,
+        })
+      : [];
 
   const draftArgs = {
     to: args.to ?? undefined,
@@ -218,7 +250,11 @@ const draft: ActionFunction<{
     userEmail,
     executedRule,
   );
-  return { draftId: result.draftId };
+  return {
+    draftId: result.draftId || null,
+    materializationMode,
+    selectedAttachments,
+  } satisfies DraftActionResult;
 };
 
 const reply: ActionFunction<{
@@ -658,4 +694,15 @@ function parseStaticAttachments(raw: unknown): SelectedAttachment[] {
       filename: item.name,
       mimeType: "application/pdf",
     }));
+}
+
+async function getDraftMaterializationMode(emailAccountId: string) {
+  const account = await prisma.emailAccount.findUnique({
+    where: { id: emailAccountId },
+    select: { draftMaterializationMode: true },
+  });
+
+  return (
+    account?.draftMaterializationMode ?? DraftMaterializationMode.MAILBOX_DRAFT
+  );
 }

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { runActionFunction } from "@/utils/ai/actions";
+import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-management";
+import { createOutboundProposal } from "@/utils/outbound-proposals/create-outbound-proposal";
+import { emitOutboundProposalReadyNotification } from "@/utils/messaging-notifications/dispatch";
 import prisma from "@/utils/prisma";
 import type { EmailProvider } from "@/utils/email/types";
 import { createScopedLogger } from "@/utils/logger";
@@ -11,6 +14,18 @@ vi.mock("server-only", () => ({}));
 
 vi.mock("@/utils/ai/actions", () => ({
   runActionFunction: vi.fn(),
+}));
+
+vi.mock("@/utils/ai/choose-rule/draft-management", () => ({
+  updateExecutedActionWithDraftId: vi.fn(),
+}));
+
+vi.mock("@/utils/outbound-proposals/create-outbound-proposal", () => ({
+  createOutboundProposal: vi.fn(),
+}));
+
+vi.mock("@/utils/messaging-notifications/dispatch", () => ({
+  emitOutboundProposalReadyNotification: vi.fn(),
 }));
 
 vi.mock("@/utils/prisma", () => ({
@@ -57,10 +72,19 @@ describe("executeAct", () => {
 
   const mockRunActionFunction = runActionFunction as Mock;
   const mockExecutedRuleUpdate = prisma.executedRule.update as Mock;
+  const mockUpdateExecutedActionWithDraftId =
+    updateExecutedActionWithDraftId as Mock;
+  const mockCreateOutboundProposal = createOutboundProposal as Mock;
+  const mockEmitOutboundProposalReadyNotification =
+    emitOutboundProposalReadyNotification as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecutedRuleUpdate.mockResolvedValue({});
+    mockCreateOutboundProposal.mockResolvedValue({ id: "proposal-1" });
+    mockEmitOutboundProposalReadyNotification.mockResolvedValue({
+      id: "notification-1",
+    });
   });
 
   it("marks executed rule as ERROR when notify sender reports a failure", async () => {
@@ -144,6 +168,67 @@ describe("executeAct", () => {
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
       data: { status: ExecutedRuleStatus.ERROR },
+    });
+  });
+
+  it("creates and emits an outbound proposal for draft actions", async () => {
+    mockRunActionFunction.mockResolvedValueOnce({
+      draftId: "draft-1",
+      materializationMode: "MAILBOX_DRAFT",
+      selectedAttachments: [],
+    });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [
+        {
+          id: "action-1",
+          type: ActionType.DRAFT_EMAIL,
+          subject: "Draft subject",
+          content: "<p>Draft body</p>",
+          to: "sender@example.com",
+          cc: null,
+          bcc: null,
+        },
+      ],
+    } as any;
+
+    await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      userEmail: "recipient@example.com",
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      logger,
+    });
+
+    expect(mockUpdateExecutedActionWithDraftId).toHaveBeenCalledWith({
+      actionId: "action-1",
+      draftId: "draft-1",
+      logger,
+    });
+    expect(mockCreateOutboundProposal).toHaveBeenCalledWith({
+      executedActionId: "action-1",
+      emailAccountId: "email-account-1",
+      threadId: "thread-id-1",
+      messageId: "message-id-1",
+      materializationMode: "MAILBOX_DRAFT",
+      draftId: "draft-1",
+      to: "sender@example.com",
+      cc: null,
+      bcc: null,
+      subject: "Draft subject",
+      originalContent: "<p>Draft body</p>",
+      selectedAttachments: [],
+    });
+    expect(mockEmitOutboundProposalReadyNotification).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      outboundProposalId: "proposal-1",
+      executedActionId: "action-1",
+      logger: expect.objectContaining({
+        info: expect.any(Function),
+      }),
     });
   });
 });

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -1,4 +1,4 @@
-import { runActionFunction } from "@/utils/ai/actions";
+import { type DraftActionResult, runActionFunction } from "@/utils/ai/actions";
 import prisma from "@/utils/prisma";
 import type { Prisma } from "@/generated/prisma/client";
 import { ExecutedRuleStatus, ActionType } from "@/generated/prisma/enums";
@@ -7,6 +7,8 @@ import type { ParsedMessage } from "@/utils/types";
 import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-management";
 import type { EmailProvider } from "@/utils/email/types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
+import { createOutboundProposal } from "@/utils/outbound-proposals/create-outbound-proposal";
+import { emitOutboundProposalReadyNotification } from "@/utils/messaging-notifications/dispatch";
 
 const MODULE = "ai-execute-act";
 
@@ -64,12 +66,40 @@ export async function executeAct({
         actionFailures.push(actionFailure);
       }
 
-      if (action.type === ActionType.DRAFT_EMAIL && actionResult?.draftId) {
-        await updateExecutedActionWithDraftId({
-          actionId: action.id,
-          draftId: actionResult.draftId,
-          logger,
-        });
+      if (action.type === ActionType.DRAFT_EMAIL) {
+        const draftResult = getDraftActionResult(actionResult);
+
+        if (draftResult?.draftId) {
+          await updateExecutedActionWithDraftId({
+            actionId: action.id,
+            draftId: draftResult.draftId,
+            logger,
+          });
+        }
+
+        if (draftResult) {
+          const proposal = await createOutboundProposal({
+            executedActionId: action.id,
+            emailAccountId,
+            threadId: executedRule.threadId,
+            messageId: executedRule.messageId,
+            materializationMode: draftResult.materializationMode,
+            draftId: draftResult.draftId,
+            to: action.to ?? null,
+            cc: action.cc ?? null,
+            bcc: action.bcc ?? null,
+            subject: action.subject ?? null,
+            originalContent: action.content ?? null,
+            selectedAttachments: draftResult.selectedAttachments,
+          });
+
+          await emitOutboundProposalReadyNotification({
+            emailAccountId,
+            outboundProposalId: proposal.id,
+            executedActionId: action.id,
+            logger: log,
+          });
+        }
       }
     } catch (error) {
       await logErrorWithDedupe({
@@ -130,6 +160,14 @@ export async function executeAct({
     .catch((error) => {
       log.error("Failed to update executed rule", { error });
     });
+}
+
+function getDraftActionResult(actionResult: unknown): DraftActionResult | null {
+  if (!actionResult || typeof actionResult !== "object") return null;
+
+  if (!("materializationMode" in actionResult)) return null;
+
+  return actionResult as DraftActionResult;
 }
 
 function getActionFailure(

--- a/apps/web/utils/messaging-notifications/dispatch.ts
+++ b/apps/web/utils/messaging-notifications/dispatch.ts
@@ -1,0 +1,48 @@
+import { MessagingNotificationEventType } from "@/generated/prisma/enums";
+import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+
+const MESSAGING_NOTIFICATION_TOPIC = "messaging-notifications-execute";
+const MESSAGING_NOTIFICATION_QUEUE = "messaging-notifications";
+
+export async function emitOutboundProposalReadyNotification({
+  emailAccountId,
+  outboundProposalId,
+  executedActionId,
+  logger,
+}: {
+  emailAccountId: string;
+  outboundProposalId: string;
+  executedActionId: string;
+  logger: Logger;
+}) {
+  const notification = await prisma.messagingNotification.upsert({
+    where: {
+      dedupeKey: `outbound-proposal-ready:${executedActionId}`,
+    },
+    create: {
+      emailAccountId,
+      eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+      sourceType: "EXECUTED_ACTION",
+      sourceId: executedActionId,
+      payload: { outboundProposalId },
+      dedupeKey: `outbound-proposal-ready:${executedActionId}`,
+    },
+    update: {},
+    select: { id: true },
+  });
+
+  await enqueueBackgroundJob({
+    topic: MESSAGING_NOTIFICATION_TOPIC,
+    body: { notificationId: notification.id },
+    qstash: {
+      queueName: MESSAGING_NOTIFICATION_QUEUE,
+      parallelism: 1,
+      path: "/api/messaging-notifications/execute/queue",
+    },
+    logger,
+  });
+
+  return notification;
+}

--- a/apps/web/utils/messaging-notifications/execute.ts
+++ b/apps/web/utils/messaging-notifications/execute.ts
@@ -1,0 +1,276 @@
+import {
+  MessagingNotificationDeliveryStatus,
+  MessagingNotificationEventType,
+  MessagingProvider,
+  OutboundProposalStatus,
+} from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+import { getEmailUrlForMessage } from "@/utils/url";
+import { buildOutboundProposalReviewBlocks } from "@/utils/messaging/providers/slack/messages/outbound-proposal-review";
+import {
+  isSlackDmChannel,
+  sendBlocksToSlack,
+} from "@/utils/messaging/providers/slack/send";
+
+type OutboundProposalPayload = {
+  outboundProposalId?: string;
+};
+
+export async function executeMessagingNotification({
+  notificationId,
+  logger,
+}: {
+  notificationId: string;
+  logger: Logger;
+}) {
+  const notification = await prisma.messagingNotification.findUnique({
+    where: { id: notificationId },
+    include: {
+      emailAccount: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          account: { select: { provider: true } },
+        },
+      },
+    },
+  });
+
+  if (!notification) {
+    logger.warn("Messaging notification not found", { notificationId });
+    return new Response("Not found", { status: 404 });
+  }
+
+  if (
+    notification.eventType !==
+    MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY
+  ) {
+    logger.warn("Unsupported messaging notification event type", {
+      notificationId,
+      eventType: notification.eventType,
+    });
+    return new Response("Unsupported event type", { status: 200 });
+  }
+
+  const payload = notification.payload as OutboundProposalPayload | null;
+  const outboundProposalId = payload?.outboundProposalId;
+  if (!outboundProposalId) {
+    logger.error("Messaging notification missing outbound proposal id", {
+      notificationId,
+    });
+    return new Response("Invalid payload", { status: 400 });
+  }
+
+  const [proposal, subscriptions] = await Promise.all([
+    prisma.outboundProposal.findUnique({
+      where: { id: outboundProposalId },
+      include: {
+        executedAction: {
+          select: {
+            id: true,
+            content: true,
+            staticAttachments: true,
+            executedRule: {
+              select: {
+                ruleId: true,
+                rule: {
+                  select: {
+                    name: true,
+                    systemType: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.messagingNotificationSubscription.findMany({
+      where: {
+        emailAccountId: notification.emailAccountId,
+        eventType: MessagingNotificationEventType.OUTBOUND_PROPOSAL_READY,
+        enabled: true,
+        messagingChannel: {
+          provider: MessagingProvider.SLACK,
+          isConnected: true,
+        },
+      },
+      include: {
+        messagingChannel: true,
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 1,
+    }),
+  ]);
+
+  if (!proposal) {
+    logger.warn("Outbound proposal not found for notification", {
+      notificationId,
+      outboundProposalId,
+    });
+    return new Response("Missing proposal", { status: 200 });
+  }
+
+  if (proposal.status !== OutboundProposalStatus.OPEN) {
+    logger.info("Skipping notification delivery for non-open proposal", {
+      notificationId,
+      outboundProposalId,
+      status: proposal.status,
+    });
+    return new Response("Skipped", { status: 200 });
+  }
+
+  const subscription = subscriptions[0];
+  if (!subscription?.messagingChannel.accessToken) {
+    logger.info("No active Slack draft review subscription found", {
+      notificationId,
+      outboundProposalId,
+    });
+    return new Response("No subscription", { status: 200 });
+  }
+
+  const channel = subscription.messagingChannel;
+  const accessToken = channel.accessToken;
+  if (!accessToken) {
+    return new Response("No access token", { status: 200 });
+  }
+
+  const resolvedDestination = await sendBlocksToSlack({
+    accessToken,
+    channelId: channel.channelId,
+    providerUserId: channel.providerUserId,
+    text: "Review draft reply",
+    blocks: buildOutboundProposalReviewBlocks({
+      accountName:
+        notification.emailAccount.name || notification.emailAccount.email,
+      mentionUserId:
+        channel.channelId && !isSlackDmChannel(channel.channelId)
+          ? channel.providerUserId
+          : null,
+      originalFrom: proposal.to,
+      originalSubject: proposal.subject,
+      proposalContent: proposal.currentContent || proposal.originalContent,
+      sendValue: encodeOutboundProposalActionValue({
+        proposalId: proposal.id,
+        revision: proposal.revision,
+      }),
+      dismissValue: encodeOutboundProposalActionValue({
+        proposalId: proposal.id,
+        revision: proposal.revision,
+      }),
+      openInInboxUrl: proposal.draftId
+        ? getEmailUrlForMessage(
+            proposal.messageId,
+            proposal.threadId,
+            notification.emailAccount.email,
+            notification.emailAccount.account.provider,
+          )
+        : null,
+    }),
+  });
+
+  if (!resolvedDestination.ok) {
+    await prisma.messagingNotificationDelivery.upsert({
+      where: {
+        notificationId_messagingChannelId: {
+          notificationId: notification.id,
+          messagingChannelId: channel.id,
+        },
+      },
+      create: {
+        notificationId: notification.id,
+        messagingChannelId: channel.id,
+        status: MessagingNotificationDeliveryStatus.FAILED,
+        error:
+          resolvedDestination.error || "Failed to deliver Slack notification",
+      },
+      update: {
+        status: MessagingNotificationDeliveryStatus.FAILED,
+        error:
+          resolvedDestination.error || "Failed to deliver Slack notification",
+      },
+    });
+
+    return new Response("Failed", { status: 500 });
+  }
+
+  const chatId = `slack-${resolvedDestination.channelId}-${resolvedDestination.ts}`;
+
+  await prisma.$transaction([
+    prisma.messagingNotificationDelivery.upsert({
+      where: {
+        notificationId_messagingChannelId: {
+          notificationId: notification.id,
+          messagingChannelId: channel.id,
+        },
+      },
+      create: {
+        notificationId: notification.id,
+        messagingChannelId: channel.id,
+        status: MessagingNotificationDeliveryStatus.SENT,
+        providerMessageId: resolvedDestination.ts,
+        providerThreadId: resolvedDestination.ts,
+        chatId,
+        sentAt: new Date(),
+        error: null,
+      },
+      update: {
+        status: MessagingNotificationDeliveryStatus.SENT,
+        providerMessageId: resolvedDestination.ts,
+        providerThreadId: resolvedDestination.ts,
+        chatId,
+        sentAt: new Date(),
+        error: null,
+      },
+    }),
+    prisma.outboundProposal.update({
+      where: { id: proposal.id },
+      data: {
+        chatId,
+        providerMessageId: resolvedDestination.ts,
+        providerThreadId: resolvedDestination.ts,
+        messagingChannelId: channel.id,
+      },
+    }),
+  ]);
+
+  return new Response("OK", { status: 200 });
+}
+
+export function encodeOutboundProposalActionValue({
+  proposalId,
+  revision,
+}: {
+  proposalId: string;
+  revision: number;
+}) {
+  return Buffer.from(JSON.stringify({ proposalId, revision }), "utf8").toString(
+    "base64url",
+  );
+}
+
+export function decodeOutboundProposalActionValue(value: string | undefined) {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as {
+      proposalId?: string;
+      revision?: number;
+    };
+
+    if (!parsed.proposalId || typeof parsed.revision !== "number") {
+      return null;
+    }
+
+    return {
+      proposalId: parsed.proposalId,
+      revision: parsed.revision,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/utils/messaging-notifications/validation.ts
+++ b/apps/web/utils/messaging-notifications/validation.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const executeMessagingNotificationBody = z.object({
+  notificationId: z.string().min(1),
+});
+
+export type ExecuteMessagingNotificationBody = z.infer<
+  typeof executeMessagingNotificationBody
+>;

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -41,6 +41,10 @@ import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import { getRecentChatMemories } from "@/utils/ai/assistant/get-recent-chat-memories";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
 import { createScopedLogger, type Logger } from "@/utils/logger";
+import {
+  decodeOutboundProposalActionValue,
+  encodeOutboundProposalActionValue,
+} from "@/utils/messaging-notifications/execute";
 import { consumeMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code-consume";
 import type { MessagingPlatform } from "@/utils/messaging/platforms";
 import { buildPendingEmailPreview } from "@/utils/messaging/pending-email-preview";
@@ -51,6 +55,14 @@ import {
   getHelpText,
   isHelpCommand,
 } from "@/utils/messaging/prompt-commands";
+import {
+  dismissOutboundProposal,
+  findOpenOutboundProposalByChatId,
+  OUTBOUND_PROPOSAL_DISMISS_ACTION_ID,
+  OUTBOUND_PROPOSAL_SEND_ACTION_ID,
+  rewriteOutboundProposal,
+  sendOutboundProposal,
+} from "@/utils/outbound-proposals/review";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import prisma from "@/utils/prisma";
 import { getEmailUrlForMessage } from "@/utils/url";
@@ -449,6 +461,13 @@ function registerMessagingHandlers({
       await handlePendingEmailConfirmAction({ event, logger: handlerLogger });
     },
   );
+  bot.onAction(
+    [OUTBOUND_PROPOSAL_SEND_ACTION_ID, OUTBOUND_PROPOSAL_DISMISS_ACTION_ID],
+    async (event) => {
+      const handlerLogger = getHandlerLogger();
+      await handleOutboundProposalAction({ event, logger: handlerLogger });
+    },
+  );
 
   if (adapters.slack) {
     bot.onAssistantThreadStarted(async ({ channelId, threadTs }) => {
@@ -533,6 +552,18 @@ async function processMessagingAssistantMessage({
     });
 
     if (!context) return false;
+
+    const proposal = await findOpenOutboundProposalByChatId(context.chatId);
+    if (proposal) {
+      return handleOutboundProposalThreadMessage({
+        thread,
+        message,
+        provider: context.provider,
+        proposal,
+        context,
+        logger,
+      });
+    }
 
     if (context.hasUnsupportedAttachments) {
       try {
@@ -1047,6 +1078,150 @@ function getPendingEmailToolParts(parts: unknown[]): PendingEmailToolPart[] {
   return pendingParts;
 }
 
+async function handleOutboundProposalThreadMessage({
+  thread,
+  message,
+  provider,
+  proposal,
+  context,
+  logger,
+}: {
+  thread: Thread;
+  message: Message;
+  provider: SupportedPlatform;
+  proposal: Awaited<ReturnType<typeof findOpenOutboundProposalByChatId>>;
+  context: ResolvedMessagingContext;
+  logger: Logger;
+}) {
+  if (!proposal) return false;
+
+  if (context.hasUnsupportedAttachments || context.imageParts.length > 0) {
+    await postMessagingThreadMessage({
+      thread,
+      logger,
+      message:
+        "Draft review only supports text edits in-thread right now. Send the edit as a text reply.",
+      errorLogMessage: "Failed to post outbound proposal attachment guidance",
+      logMeta: { provider, proposalId: proposal.id },
+    });
+    return true;
+  }
+
+  const instruction = context.messageText.trim();
+  if (!instruction) return true;
+
+  const chat = await prisma.chat.upsert({
+    where: { id: context.chatId },
+    create: {
+      id: context.chatId,
+      emailAccountId: context.emailAccountId,
+    },
+    update: {},
+    select: { id: true },
+  });
+
+  const userMessageId = `${context.provider}-${message.id}`;
+  const userParts: UIMessage["parts"] = [{ type: "text", text: instruction }];
+
+  await prisma.chatMessage.upsert({
+    where: { id: userMessageId },
+    create: {
+      id: userMessageId,
+      chat: { connect: { id: chat.id } },
+      role: "user",
+      parts: userParts as Prisma.InputJsonValue,
+    },
+    update: {},
+  });
+
+  const assistantMessageId = `${userMessageId}-proposal-review`;
+  const existingAssistantMessage = await prisma.chatMessage.findUnique({
+    where: { id: assistantMessageId },
+    select: { id: true },
+  });
+  if (existingAssistantMessage) return true;
+
+  try {
+    const rewriteResult = await rewriteOutboundProposal({
+      proposalId: proposal.id,
+      instructions: instruction,
+      logger,
+    });
+
+    if (rewriteResult.status === "draft-missing") {
+      await thread.post(
+        getMessagingAssistantPostPayload({
+          provider,
+          text: "That draft was already sent or removed elsewhere.",
+        }),
+      );
+      return true;
+    }
+
+    if (rewriteResult.status !== "updated") {
+      await thread.post(
+        getMessagingAssistantPostPayload({
+          provider,
+          text: "That draft is no longer active. Ask me to draft a new reply.",
+        }),
+      );
+      return true;
+    }
+
+    const updatedProposal = {
+      ...proposal,
+      ...rewriteResult.proposal,
+    };
+
+    const responseText = `Updated draft.\n\n${buildOutboundProposalCardPreview({
+      content:
+        updatedProposal.currentContent ||
+        updatedProposal.originalContent ||
+        proposal.executedAction.content,
+      openInInboxUrl: updatedProposal.draftId
+        ? getEmailUrlForMessage(
+            updatedProposal.messageId,
+            updatedProposal.threadId,
+            proposal.emailAccount.email,
+            proposal.emailAccount.account.provider,
+          )
+        : undefined,
+    })}`;
+
+    await prisma.chatMessage.create({
+      data: {
+        id: assistantMessageId,
+        chat: { connect: { id: chat.id } },
+        role: "assistant",
+        parts: [{ type: "text", text: responseText }] as Prisma.InputJsonValue,
+      },
+    });
+
+    await postOutboundProposalReviewCard({
+      thread,
+      proposal: updatedProposal,
+      accountEmail: proposal.emailAccount.email,
+      accountProvider: proposal.emailAccount.account.provider,
+      title: "Updated draft",
+      provider,
+    });
+    return true;
+  } catch (error) {
+    logger.error("Failed to rewrite outbound proposal from messaging thread", {
+      error,
+      proposalId: proposal.id,
+      provider,
+    });
+    await thread.post(
+      getMessagingAssistantPostPayload({
+        provider,
+        text: "I couldn't update that draft right now. Please try again.",
+      }),
+    );
+    return true;
+  }
+}
+
 function pendingActionTypeFromToolPartType(
   type: PendingEmailToolPart["type"],
 ): AssistantPendingEmailActionType {
@@ -1175,6 +1350,163 @@ async function postPendingEmailActionFeedback({
     logger.warn("Failed to post messaging action feedback", {
       provider,
       error,
+    });
+  }
+}
+
+async function handleOutboundProposalAction({
+  event,
+  logger,
+}: {
+  event: ActionEvent;
+  logger: Logger;
+}) {
+  const thread = event.thread;
+  if (!thread) {
+    logger.warn("Missing thread for outbound proposal action");
+    return;
+  }
+
+  const provider = getSupportedPlatform(thread.adapter.name);
+  if (!provider) return;
+
+  const parsed = decodeOutboundProposalActionValue(event.value);
+  if (!parsed) {
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text: "That action is invalid or expired.",
+      logger,
+    });
+    return;
+  }
+
+  const proposal = await prisma.outboundProposal.findUnique({
+    where: { id: parsed.proposalId },
+    include: {
+      messagingChannel: true,
+      emailAccount: {
+        select: {
+          email: true,
+          account: { select: { provider: true } },
+        },
+      },
+    },
+  });
+
+  if (!proposal?.messagingChannel) {
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text: "That draft is no longer available.",
+      logger,
+    });
+    return;
+  }
+
+  const teamId = getTeamIdFromActionEvent({ provider, event });
+  if (
+    proposal.messagingChannel.providerUserId !== event.user.userId ||
+    (teamId &&
+      proposal.messagingChannel.teamId &&
+      proposal.messagingChannel.teamId !== teamId)
+  ) {
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text: "You don't have permission to manage this draft.",
+      logger,
+    });
+    return;
+  }
+
+  if (proposal.revision !== parsed.revision) {
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text: "Use the latest draft card in the thread.",
+      logger,
+    });
+    return;
+  }
+
+  try {
+    if (event.actionId === OUTBOUND_PROPOSAL_SEND_ACTION_ID) {
+      const result = await sendOutboundProposal({
+        proposalId: proposal.id,
+        logger,
+      });
+
+      if (result.status === "draft-missing") {
+        await postPendingEmailActionFeedback({
+          event,
+          provider,
+          text: "That draft was already sent or removed elsewhere.",
+          logger,
+        });
+        return;
+      }
+
+      if (result.status !== "sent") {
+        await postPendingEmailActionFeedback({
+          event,
+          provider,
+          text: "That draft is no longer active.",
+          logger,
+        });
+        return;
+      }
+
+      const emailUrl = getEmailUrlForMessage(
+        result.sendResult.messageId || proposal.messageId,
+        result.sendResult.threadId || proposal.threadId,
+        proposal.emailAccount.email,
+        proposal.emailAccount.account.provider,
+      );
+      const mailbox =
+        proposal.emailAccount.account.provider === "microsoft"
+          ? "Outlook"
+          : "Gmail";
+
+      await postPendingEmailActionFeedback({
+        event,
+        provider,
+        text: `Sent. Open in ${mailbox}: ${emailUrl}`,
+        logger,
+      });
+      return;
+    }
+
+    const result = await dismissOutboundProposal({
+      proposalId: proposal.id,
+      logger,
+    });
+
+    const text =
+      result.status === "draft-missing"
+        ? "That draft was already sent or removed elsewhere."
+        : result.status === "dismissed"
+          ? "Dismissed the draft."
+          : "That draft is no longer active.";
+
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text,
+      logger,
+    });
+  } catch (error) {
+    logger.warn("Outbound proposal action failed", {
+      provider,
+      actionId: event.actionId,
+      proposalId: proposal.id,
+      error,
+    });
+    await postPendingEmailActionFeedback({
+      event,
+      provider,
+      text: "I couldn't process that draft action. Please try again.",
+      logger,
     });
   }
 }
@@ -2318,6 +2650,105 @@ function getMessagingAssistantPostPayload({
   }
 
   return { markdown: text };
+}
+
+async function postOutboundProposalReviewCard({
+  thread,
+  proposal,
+  accountEmail,
+  accountProvider,
+  title,
+  provider,
+}: {
+  thread: Thread;
+  proposal: {
+    id: string;
+    revision: number;
+    to: string | null;
+    subject: string | null;
+    draftId: string | null;
+    messageId: string;
+    threadId: string;
+    currentContent: string | null;
+    originalContent: string | null;
+  };
+  accountEmail: string | null;
+  accountProvider: string | null;
+  title: string;
+  provider: SupportedPlatform;
+}) {
+  const summary = proposal.subject
+    ? `Subject: ${proposal.subject}`
+    : proposal.to
+      ? `Draft reply to ${proposal.to}`
+      : "Draft reply";
+  const preview = buildOutboundProposalCardPreview({
+    content: proposal.currentContent || proposal.originalContent,
+    openInInboxUrl: proposal.draftId
+      ? getEmailUrlForMessage(
+          proposal.messageId,
+          proposal.threadId,
+          accountEmail,
+          accountProvider || undefined,
+        )
+      : undefined,
+  });
+
+  const cardChildren: CardChild[] = [CardText(summary)];
+  if (preview) cardChildren.push(CardText(preview));
+  cardChildren.push(
+    Actions([
+      Button({
+        id: OUTBOUND_PROPOSAL_SEND_ACTION_ID,
+        label: "Send",
+        style: "primary",
+        value: encodeOutboundProposalActionValue({
+          proposalId: proposal.id,
+          revision: proposal.revision,
+        }),
+      }),
+      Button({
+        id: OUTBOUND_PROPOSAL_DISMISS_ACTION_ID,
+        label: "Dismiss",
+        value: encodeOutboundProposalActionValue({
+          proposalId: proposal.id,
+          revision: proposal.revision,
+        }),
+      }),
+    ]),
+  );
+
+  await thread.post(
+    provider === "slack"
+      ? Card({ title, children: cardChildren })
+      : getMessagingAssistantPostPayload({
+          provider,
+          text: `${title}\n\n${summary}\n\n${preview}`,
+        }),
+  );
+}
+
+function buildOutboundProposalCardPreview({
+  content,
+  openInInboxUrl,
+}: {
+  content?: string | null;
+  openInInboxUrl?: string;
+}) {
+  const normalizedContent = (content || "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  const preview = normalizedContent
+    ? normalizedContent.slice(0, 500)
+    : "No draft content available.";
+
+  return openInInboxUrl
+    ? `${preview}\n\nOpen in inbox: ${openInInboxUrl}`
+    : preview;
 }
 
 function toMessagingProvider(provider: SupportedPlatform) {

--- a/apps/web/utils/messaging/providers/slack/messages/outbound-proposal-review.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/outbound-proposal-review.ts
@@ -1,0 +1,131 @@
+import type { KnownBlock, Block } from "@slack/types";
+import { markdownToSlackMrkdwn } from "@/utils/messaging/providers/slack/format";
+import { truncate } from "@/utils/string";
+
+export function buildOutboundProposalReviewBlocks({
+  accountName,
+  mentionUserId,
+  originalFrom,
+  originalSubject,
+  proposalContent,
+  sendValue,
+  dismissValue,
+  openInInboxUrl,
+}: {
+  accountName?: string | null;
+  mentionUserId?: string | null;
+  originalFrom?: string | null;
+  originalSubject?: string | null;
+  proposalContent?: string | null;
+  sendValue: string;
+  dismissValue: string;
+  openInInboxUrl?: string | null;
+}): (KnownBlock | Block)[] {
+  const blocks: (KnownBlock | Block)[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Review draft reply",
+        emoji: true,
+      },
+    },
+  ];
+
+  const summaryLines = [
+    mentionUserId ? `<@${mentionUserId}>` : null,
+    originalFrom ? `*From:* ${escapeSlackText(originalFrom)}` : null,
+    originalSubject ? `*Subject:* ${escapeSlackText(originalSubject)}` : null,
+    accountName ? `*Account:* ${escapeSlackText(accountName)}` : null,
+  ].filter(Boolean);
+
+  if (summaryLines.length > 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: summaryLines.join("\n"),
+      },
+    });
+  }
+
+  const preview = buildProposalPreview(proposalContent);
+  if (preview) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Draft preview*\n${preview}`,
+      },
+    });
+  }
+
+  const elements = [
+    {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: "Send",
+        emoji: true,
+      },
+      style: "primary",
+      action_id: "draft-review-send",
+      value: sendValue,
+    },
+    {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: "Dismiss",
+        emoji: true,
+      },
+      action_id: "draft-review-dismiss",
+      value: dismissValue,
+    },
+  ];
+
+  if (openInInboxUrl) {
+    elements.push({
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: "Open in Inbox",
+        emoji: true,
+      },
+      url: openInInboxUrl,
+      action_id: "draft-review-open",
+      value: "open",
+    });
+  }
+
+  blocks.push({
+    type: "actions",
+    elements,
+  });
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: "_Reply in this thread with edits. The latest card is the active version._",
+      },
+    ],
+  });
+
+  return blocks;
+}
+
+function buildProposalPreview(content?: string | null) {
+  const trimmed = content?.trim();
+  if (!trimmed) return null;
+
+  return markdownToSlackMrkdwn(truncate(trimmed, 900));
+}
+
+function escapeSlackText(text: string) {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -1,5 +1,5 @@
 import type { KnownBlock, Block } from "@slack/types";
-import type { WebClient } from "@slack/web-api";
+import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import { createSlackClient } from "./client";
 import {
   buildMeetingBriefingBlocks,
@@ -148,19 +148,64 @@ export async function resolveSlackDestination({
   return null;
 }
 
+export async function sendBlocksToSlack({
+  accessToken,
+  channelId,
+  providerUserId,
+  text,
+  blocks,
+}: {
+  accessToken: string;
+  channelId: string | null;
+  providerUserId: string | null;
+  text: string;
+  blocks: Blocks;
+}): Promise<
+  { ok: true; channelId: string; ts: string } | { ok: false; error: string }
+> {
+  const resolvedChannelId = await resolveSlackDestination({
+    accessToken,
+    channelId,
+    providerUserId,
+  });
+
+  if (!resolvedChannelId) {
+    return { ok: false, error: "No Slack destination configured" };
+  }
+
+  try {
+    const client = createSlackClient(accessToken);
+    const response = await postMessageWithJoin(client, resolvedChannelId, {
+      text,
+      blocks,
+    });
+
+    if (!response.ts) {
+      return { ok: false, error: "Slack response missing message timestamp" };
+    }
+
+    return { ok: true, channelId: resolvedChannelId, ts: response.ts };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Slack send failed",
+    };
+  }
+}
+
 type Blocks = (KnownBlock | Block)[];
 
 async function postMessageWithJoin(
   client: WebClient,
   channelId: string,
   message: { text: string; blocks?: Blocks },
-): Promise<void> {
+): Promise<ChatPostMessageResponse> {
   const args = message.blocks
     ? { channel: channelId, blocks: message.blocks, text: message.text }
     : { channel: channelId, text: message.text };
 
   try {
-    await client.chat.postMessage(args);
+    return await client.chat.postMessage(args);
   } catch (error: unknown) {
     if (isSlackError(error) && error.data?.error === "not_in_channel") {
       try {
@@ -176,8 +221,7 @@ async function postMessageWithJoin(
         }
         throw joinError;
       }
-      await client.chat.postMessage(args);
-      return;
+      return await client.chat.postMessage(args);
     }
     throw error;
   }

--- a/apps/web/utils/outbound-proposals/create-outbound-proposal.ts
+++ b/apps/web/utils/outbound-proposals/create-outbound-proposal.ts
@@ -1,0 +1,95 @@
+import { Prisma } from "@/generated/prisma/client";
+import {
+  OutboundProposalCloseReason,
+  OutboundProposalStatus,
+  type DraftMaterializationMode,
+} from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import type { SelectedAttachment } from "@/utils/attachments/source-schema";
+
+export async function createOutboundProposal({
+  executedActionId,
+  emailAccountId,
+  threadId,
+  messageId,
+  materializationMode,
+  draftId,
+  to,
+  cc,
+  bcc,
+  subject,
+  originalContent,
+  selectedAttachments,
+}: {
+  executedActionId: string;
+  emailAccountId: string;
+  threadId: string;
+  messageId: string;
+  materializationMode: DraftMaterializationMode;
+  draftId: string | null;
+  to: string | null;
+  cc: string | null;
+  bcc: string | null;
+  subject: string | null;
+  originalContent: string | null;
+  selectedAttachments: SelectedAttachment[];
+}) {
+  const now = new Date();
+
+  const proposal = await prisma.outboundProposal.upsert({
+    where: { executedActionId },
+    create: {
+      executedActionId,
+      emailAccountId,
+      threadId,
+      messageId,
+      materializationMode,
+      draftId,
+      to,
+      cc,
+      bcc,
+      subject,
+      originalContent,
+      currentContent: originalContent,
+      selectedAttachments:
+        selectedAttachments.length > 0
+          ? (selectedAttachments as Prisma.InputJsonValue)
+          : undefined,
+    },
+    update: {
+      materializationMode,
+      draftId,
+      to,
+      cc,
+      bcc,
+      subject,
+      originalContent,
+      ...(originalContent != null ? { currentContent: originalContent } : {}),
+      selectedAttachments:
+        selectedAttachments.length > 0
+          ? (selectedAttachments as Prisma.InputJsonValue)
+          : Prisma.JsonNull,
+      status: OutboundProposalStatus.OPEN,
+      closeReason: null,
+      resolvedAt: null,
+    },
+  });
+
+  await prisma.outboundProposal.updateMany({
+    where: {
+      emailAccountId,
+      threadId,
+      status: {
+        in: [OutboundProposalStatus.OPEN, OutboundProposalStatus.PROCESSING],
+      },
+      NOT: { id: proposal.id },
+    },
+    data: {
+      status: OutboundProposalStatus.CLOSED,
+      closeReason: OutboundProposalCloseReason.SUPERSEDED,
+      resolvedAt: now,
+    },
+  });
+
+  return proposal;
+}

--- a/apps/web/utils/outbound-proposals/review.ts
+++ b/apps/web/utils/outbound-proposals/review.ts
@@ -1,0 +1,525 @@
+import type Mail from "nodemailer/lib/mailer";
+import {
+  DraftMaterializationMode,
+  OutboundProposalCloseReason,
+  OutboundProposalStatus,
+} from "@/generated/prisma/enums";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { getEmailAccountWithAi } from "@/utils/user/get";
+import { aiRewriteOutboundProposal } from "@/utils/outbound-proposals/rewrite-outbound-proposal";
+import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
+import {
+  attachmentSourceInputSchema,
+  selectedAttachmentSchema,
+} from "@/utils/attachments/source-schema";
+import { AttachmentSourceType } from "@/generated/prisma/enums";
+import { formatReplySubject } from "@/utils/email/subject";
+import { calculateSimilarity } from "@/utils/similarity-score";
+import {
+  isMeaningfulDraftEdit,
+  saveDraftSendLogReplyMemory,
+} from "@/utils/ai/reply/reply-memory";
+
+export const OUTBOUND_PROPOSAL_SEND_ACTION_ID = "draft-review-send";
+export const OUTBOUND_PROPOSAL_DISMISS_ACTION_ID = "draft-review-dismiss";
+
+const selectedAttachmentsSchema = selectedAttachmentSchema.array();
+
+const staticAttachmentsSchema = attachmentSourceInputSchema.array();
+
+export async function findOpenOutboundProposalByChatId(chatId: string) {
+  return prisma.outboundProposal.findFirst({
+    where: {
+      chatId,
+      status: OutboundProposalStatus.OPEN,
+    },
+    include: {
+      messagingChannel: true,
+      emailAccount: {
+        select: {
+          id: true,
+          email: true,
+          userId: true,
+          account: { select: { provider: true } },
+        },
+      },
+      executedAction: {
+        select: {
+          id: true,
+          content: true,
+          staticAttachments: true,
+        },
+      },
+    },
+  });
+}
+
+export async function rewriteOutboundProposal({
+  proposalId,
+  instructions,
+  logger,
+}: {
+  proposalId: string;
+  instructions: string;
+  logger: Logger;
+}) {
+  const proposal = await findProposalForReview(proposalId);
+  if (!proposal) return { status: "missing" as const };
+  if (proposal.status !== OutboundProposalStatus.OPEN) {
+    return { status: "resolved" as const, proposal };
+  }
+
+  const emailAccount = await getEmailAccountWithAi({
+    emailAccountId: proposal.emailAccountId,
+  });
+  if (!emailAccount) return { status: "missing" as const };
+
+  const emailProvider = await createEmailProvider({
+    emailAccountId: proposal.emailAccountId,
+    provider: proposal.emailAccount.account.provider,
+    logger,
+  });
+  const originalMessage = await emailProvider.getMessage(proposal.messageId);
+
+  if (
+    proposal.materializationMode === DraftMaterializationMode.MAILBOX_DRAFT &&
+    proposal.draftId
+  ) {
+    const draft = await emailProvider.getDraft(proposal.draftId);
+    if (!draft) {
+      await closeOutboundProposal({
+        proposalId: proposal.id,
+        closeReason: OutboundProposalCloseReason.DRAFT_MISSING,
+      });
+      return { status: "draft-missing" as const };
+    }
+  }
+
+  const currentContent =
+    proposal.currentContent ||
+    proposal.originalContent ||
+    proposal.executedAction.content;
+  if (!currentContent) {
+    return { status: "missing" as const };
+  }
+
+  const revisedContent = await aiRewriteOutboundProposal({
+    emailAccount,
+    originalMessage,
+    currentContent,
+    instructions,
+  });
+
+  const updatedProposal = await prisma.outboundProposal.update({
+    where: { id: proposal.id },
+    data: {
+      currentContent: revisedContent,
+      revision: { increment: 1 },
+    },
+  });
+
+  if (
+    updatedProposal.materializationMode ===
+      DraftMaterializationMode.MAILBOX_DRAFT &&
+    updatedProposal.draftId
+  ) {
+    await emailProvider.updateDraft(updatedProposal.draftId, {
+      messageHtml: revisedContent,
+      ...(updatedProposal.subject ? { subject: updatedProposal.subject } : {}),
+    });
+  }
+
+  return {
+    status: "updated" as const,
+    proposal: updatedProposal,
+  };
+}
+
+export async function sendOutboundProposal({
+  proposalId,
+  logger,
+}: {
+  proposalId: string;
+  logger: Logger;
+}) {
+  const proposal = await findProposalForReview(proposalId);
+  if (!proposal) return { status: "missing" as const };
+
+  const reserved = await prisma.outboundProposal.updateMany({
+    where: {
+      id: proposal.id,
+      status: OutboundProposalStatus.OPEN,
+    },
+    data: {
+      status: OutboundProposalStatus.PROCESSING,
+    },
+  });
+
+  if (reserved.count === 0) {
+    return { status: "resolved" as const };
+  }
+
+  try {
+    const emailProvider = await createEmailProvider({
+      emailAccountId: proposal.emailAccountId,
+      provider: proposal.emailAccount.account.provider,
+      logger,
+    });
+
+    let sendResult: { messageId: string; threadId: string };
+
+    if (
+      proposal.materializationMode === DraftMaterializationMode.MAILBOX_DRAFT
+    ) {
+      if (!proposal.draftId) {
+        await closeOutboundProposal({
+          proposalId: proposal.id,
+          closeReason: OutboundProposalCloseReason.DRAFT_MISSING,
+        });
+        return { status: "draft-missing" as const };
+      }
+
+      const draft = await emailProvider.getDraft(proposal.draftId);
+      if (!draft) {
+        await closeOutboundProposal({
+          proposalId: proposal.id,
+          closeReason: OutboundProposalCloseReason.DRAFT_MISSING,
+        });
+        return { status: "draft-missing" as const };
+      }
+
+      sendResult = await emailProvider.sendDraft(proposal.draftId);
+    } else {
+      const originalMessage = await emailProvider.getMessage(
+        proposal.messageId,
+      );
+      const attachments = await resolveOutboundProposalAttachments({
+        emailAccountId: proposal.emailAccountId,
+        userId: proposal.emailAccount.userId,
+        selectedAttachments: proposal.selectedAttachments,
+        staticAttachments: proposal.executedAction.staticAttachments,
+        logger,
+      });
+
+      sendResult = await emailProvider.sendEmailWithHtml({
+        replyToEmail: {
+          threadId: originalMessage.threadId,
+          headerMessageId: originalMessage.headers["message-id"] || "",
+          references: originalMessage.headers.references,
+          messageId: originalMessage.id,
+        },
+        to:
+          proposal.to ||
+          originalMessage.headers["reply-to"] ||
+          originalMessage.headers.from,
+        ...(proposal.cc ? { cc: proposal.cc } : {}),
+        ...(proposal.bcc ? { bcc: proposal.bcc } : {}),
+        subject:
+          proposal.subject ||
+          formatReplySubject(originalMessage.headers.subject),
+        messageHtml:
+          proposal.currentContent ||
+          proposal.originalContent ||
+          proposal.executedAction.content ||
+          "",
+        ...(attachments.length
+          ? { attachments: toProviderHtmlAttachments(attachments) }
+          : {}),
+      });
+
+      await recordMessagingOnlySendLog({
+        executedActionId: proposal.executedAction.id,
+        originalContent: proposal.executedAction.content,
+        sentContent:
+          proposal.currentContent ||
+          proposal.originalContent ||
+          proposal.executedAction.content ||
+          "",
+        sentMessageId:
+          sendResult.messageId ||
+          sendResult.threadId ||
+          `proposal-${proposal.id}`,
+      });
+    }
+
+    const updatedProposal = await prisma.outboundProposal.update({
+      where: { id: proposal.id },
+      data: {
+        status: OutboundProposalStatus.SENT,
+        resolvedAt: new Date(),
+        sentMessageId: sendResult.messageId || null,
+        sentThreadId: sendResult.threadId || null,
+      },
+    });
+
+    return {
+      status: "sent" as const,
+      proposal: updatedProposal,
+      sendResult,
+    };
+  } catch (error) {
+    await prisma.outboundProposal.update({
+      where: { id: proposal.id },
+      data: { status: OutboundProposalStatus.OPEN },
+    });
+    throw error;
+  }
+}
+
+export async function dismissOutboundProposal({
+  proposalId,
+  logger,
+}: {
+  proposalId: string;
+  logger: Logger;
+}) {
+  const proposal = await findProposalForReview(proposalId);
+  if (!proposal) return { status: "missing" as const };
+
+  const reserved = await prisma.outboundProposal.updateMany({
+    where: {
+      id: proposal.id,
+      status: OutboundProposalStatus.OPEN,
+    },
+    data: {
+      status: OutboundProposalStatus.PROCESSING,
+    },
+  });
+
+  if (reserved.count === 0) {
+    return { status: "resolved" as const };
+  }
+
+  try {
+    if (
+      proposal.materializationMode === DraftMaterializationMode.MAILBOX_DRAFT &&
+      proposal.draftId
+    ) {
+      const emailProvider = await createEmailProvider({
+        emailAccountId: proposal.emailAccountId,
+        provider: proposal.emailAccount.account.provider,
+        logger,
+      });
+      const draft = await emailProvider.getDraft(proposal.draftId);
+      if (!draft) {
+        await closeOutboundProposal({
+          proposalId: proposal.id,
+          closeReason: OutboundProposalCloseReason.DRAFT_MISSING,
+        });
+        return { status: "draft-missing" as const };
+      }
+
+      await emailProvider.deleteDraft(proposal.draftId);
+    }
+
+    const updatedProposal = await prisma.outboundProposal.update({
+      where: { id: proposal.id },
+      data: {
+        status: OutboundProposalStatus.DISMISSED,
+        resolvedAt: new Date(),
+      },
+    });
+
+    await prisma.executedAction.update({
+      where: { id: proposal.executedAction.id },
+      data: {
+        wasDraftSent: false,
+      },
+    });
+
+    return {
+      status: "dismissed" as const,
+      proposal: updatedProposal,
+    };
+  } catch (error) {
+    await prisma.outboundProposal.update({
+      where: { id: proposal.id },
+      data: { status: OutboundProposalStatus.OPEN },
+    });
+    throw error;
+  }
+}
+
+export async function markOutboundProposalSentExternally({
+  draftId,
+}: {
+  draftId: string;
+}) {
+  await prisma.outboundProposal.updateMany({
+    where: {
+      draftId,
+      status: {
+        in: [OutboundProposalStatus.OPEN, OutboundProposalStatus.PROCESSING],
+      },
+    },
+    data: {
+      status: OutboundProposalStatus.CLOSED,
+      closeReason: OutboundProposalCloseReason.SENT_EXTERNALLY,
+      resolvedAt: new Date(),
+    },
+  });
+}
+
+async function findProposalForReview(proposalId: string) {
+  return prisma.outboundProposal.findUnique({
+    where: { id: proposalId },
+    include: {
+      messagingChannel: true,
+      emailAccount: {
+        select: {
+          id: true,
+          email: true,
+          userId: true,
+          account: { select: { provider: true } },
+        },
+      },
+      executedAction: {
+        select: {
+          id: true,
+          content: true,
+          staticAttachments: true,
+        },
+      },
+    },
+  });
+}
+
+async function closeOutboundProposal({
+  proposalId,
+  closeReason,
+}: {
+  proposalId: string;
+  closeReason: OutboundProposalCloseReason;
+}) {
+  await prisma.outboundProposal.update({
+    where: { id: proposalId },
+    data: {
+      status: OutboundProposalStatus.CLOSED,
+      closeReason,
+      resolvedAt: new Date(),
+    },
+  });
+}
+
+async function resolveOutboundProposalAttachments({
+  emailAccountId,
+  userId,
+  selectedAttachments,
+  staticAttachments,
+  logger,
+}: {
+  emailAccountId: string;
+  userId: string;
+  selectedAttachments: unknown;
+  staticAttachments: unknown;
+  logger: Logger;
+}) {
+  const parsedSelected =
+    selectedAttachmentsSchema.safeParse(selectedAttachments);
+  const parsedStatic = staticAttachmentsSchema.safeParse(staticAttachments);
+
+  const attachments = [
+    ...(parsedSelected.success ? parsedSelected.data : []),
+    ...(parsedStatic.success ? parsedStatic.data : [])
+      .filter((attachment) => attachment.type === AttachmentSourceType.FILE)
+      .map((attachment) => ({
+        driveConnectionId: attachment.driveConnectionId,
+        fileId: attachment.sourceId,
+        filename: attachment.name,
+        mimeType: "application/pdf",
+      })),
+  ];
+
+  const dedupedAttachments = [
+    ...new Map(
+      attachments.map((attachment) => [
+        `${attachment.driveConnectionId}:${attachment.fileId}`,
+        attachment,
+      ]),
+    ).values(),
+  ];
+
+  if (dedupedAttachments.length === 0) return [];
+
+  return resolveDraftAttachments({
+    emailAccountId,
+    userId,
+    selectedAttachments: dedupedAttachments,
+    logger,
+  });
+}
+
+async function recordMessagingOnlySendLog({
+  executedActionId,
+  originalContent,
+  sentContent,
+  sentMessageId,
+}: {
+  executedActionId: string;
+  originalContent: string | null;
+  sentContent: string;
+  sentMessageId: string;
+}) {
+  const similarityScore = calculateSimilarity(originalContent, sentContent);
+
+  const draftSendLog = await prisma.draftSendLog.upsert({
+    where: { executedActionId },
+    update: {
+      sentMessageId,
+      similarityScore,
+    },
+    create: {
+      executedActionId,
+      sentMessageId,
+      similarityScore,
+    },
+  });
+
+  await prisma.executedAction.update({
+    where: { id: executedActionId },
+    data: {
+      wasDraftSent: true,
+    },
+  });
+
+  if (
+    originalContent &&
+    isMeaningfulDraftEdit({
+      draftText: originalContent,
+      sentText: sentContent,
+      similarityScore,
+    })
+  ) {
+    await saveDraftSendLogReplyMemory({
+      draftSendLogId: draftSendLog.id,
+      sentText: sentContent,
+    });
+  }
+}
+
+function toProviderHtmlAttachments(attachments: Mail.Attachment[]) {
+  return attachments
+    .map((attachment) => {
+      if (!attachment.filename || !attachment.contentType) return null;
+
+      const content =
+        typeof attachment.content === "string"
+          ? attachment.content
+          : Buffer.isBuffer(attachment.content)
+            ? attachment.content.toString("base64")
+            : null;
+
+      if (!content) return null;
+
+      return {
+        filename: attachment.filename,
+        content,
+        contentType: attachment.contentType,
+      };
+    })
+    .filter((attachment): attachment is NonNullable<typeof attachment> =>
+      Boolean(attachment),
+    );
+}

--- a/apps/web/utils/outbound-proposals/rewrite-outbound-proposal.ts
+++ b/apps/web/utils/outbound-proposals/rewrite-outbound-proposal.ts
@@ -1,0 +1,56 @@
+import { createGenerateText } from "@/utils/llms";
+import { getModel } from "@/utils/llms/model";
+import type { EmailAccountWithAI } from "@/utils/llms/types";
+import { PROMPT_SECURITY_INSTRUCTIONS } from "@/utils/ai/security";
+import type { ParsedMessage } from "@/utils/types";
+
+const REWRITE_SYSTEM_PROMPT = `You revise draft email replies based on explicit user edit instructions.
+
+${PROMPT_SECURITY_INSTRUCTIONS}
+
+Return only the updated email body as an HTML fragment.
+Do not include a subject line.
+Preserve existing links when they still make sense.
+Do not add a signature unless one is already present in the current draft.
+Do not mention that you are an AI.
+Do not use em dashes unless the existing draft already uses them or the instruction explicitly asks for them.`;
+
+export async function aiRewriteOutboundProposal({
+  emailAccount,
+  originalMessage,
+  currentContent,
+  instructions,
+}: {
+  emailAccount: EmailAccountWithAI;
+  originalMessage: ParsedMessage;
+  currentContent: string;
+  instructions: string;
+}) {
+  const modelOptions = getModel(emailAccount.user, "chat");
+  const generateText = createGenerateText({
+    label: "Rewrite outbound proposal",
+    emailAccount,
+    modelOptions,
+  });
+
+  const response = await generateText({
+    ...modelOptions,
+    system: REWRITE_SYSTEM_PROMPT,
+    prompt: `Original email:
+From: ${originalMessage.headers.from || ""}
+Subject: ${originalMessage.headers.subject || ""}
+
+Latest message content:
+${originalMessage.textPlain || originalMessage.textHtml || ""}
+
+Current draft:
+${currentContent}
+
+User instructions:
+${instructions}
+
+Rewrite the current draft to satisfy the instructions. Return only the updated HTML body fragment.`,
+  });
+
+  return response.text.trim();
+}

--- a/apps/web/utils/outbound-proposals/rewrite-outbound-proposal.ts
+++ b/apps/web/utils/outbound-proposals/rewrite-outbound-proposal.ts
@@ -26,6 +26,8 @@ export async function aiRewriteOutboundProposal({
   currentContent: string;
   instructions: string;
 }) {
+  // Review-thread edits stay on a constrained one-shot rewrite path so we only
+  // revise the existing proposal content and avoid the broader assistant flow.
   const modelOptions = getModel(emailAccount.user, "chat");
   const generateText = createGenerateText({
     label: "Rewrite outbound proposal",

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -12,6 +12,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
+import { markOutboundProposalSentExternally } from "@/utils/outbound-proposals/review";
 import { logReplyTrackerError } from "./error-logging";
 
 /**
@@ -152,6 +153,16 @@ export async function trackSentDraftStatus({
     "Successfully created draft send log and updated action status via transaction",
     { executedActionId },
   );
+
+  await markOutboundProposalSentExternally({
+    draftId: executedAction.draftId,
+  }).catch((error) => {
+    logger.error("Failed to close outbound proposal after external send", {
+      error,
+      executedActionId,
+      draftId: executedAction.draftId,
+    });
+  });
 
   queueReplyMemoryLearning({
     emailAccountId,


### PR DESCRIPTION
# User description
This adds a draft review workflow for connected messaging channels, including configurable draft materialization modes and Slack delivery.

It persists outbound proposals and notification state, handles review edits, send, and dismiss actions in messaging threads, and adds account settings plus the required database migration.

Focused tests cover the new draft action behavior, proposal execution path, and settings action.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a draft review delivery settings surface that wires <code>DraftReviewDeliverySetting</code> and <code>saveDraftReviewSettingsAction</code> to persist Slack subscriptions and the <code>draftMaterializationMode</code> preference. Enable outbound proposal creation, notification, and dispatch by updating <code>runActionFunction</code>, <code>executeMessagingNotification</code>, and the outbound proposal helpers so Slack threads can edit, send, or dismiss drafts.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2010?tool=ast&topic=Draft+delivery+settings>Draft delivery settings</a>
        </td><td>Provide Slack delivery controls and persistence so <code>saveDraftReviewSettingsAction</code>, the draft settings API, and the schema keep subscriptions and <code>draftMaterializationMode</code> in sync.<details><summary>Modified files (9)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/settings/DraftReviewDeliverySetting.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx</li>
<li>apps/web/app/api/user/draft-review-settings/route.ts</li>
<li>apps/web/hooks/useDraftReviewSettings.ts</li>
<li>apps/web/prisma/migrations/20260325013530_draft_review_delivery/migration.sql</li>
<li>apps/web/prisma/schema.prisma</li>
<li>apps/web/utils/actions/draft-review-settings.test.ts</li>
<li>apps/web/utils/actions/draft-review-settings.ts</li>
<li>apps/web/utils/actions/draft-review-settings.validation.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add security setting t...</td><td>March 16, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Follow up reminders</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2010?tool=ast&topic=Outbound+proposal+flow>Outbound proposal flow</a>
        </td><td>Implement the outbound proposal lifecycle so <code>runActionFunction</code>, notification dispatch, Slack handlers, and the new proposal/review helpers can materialize drafts, send/dismiss them, and surface them in Slack threads.<details><summary>Modified files (16)</summary><ul><li>apps/web/app/api/messaging-notifications/execute/queue/route.ts</li>
<li>apps/web/app/api/messaging-notifications/execute/route.ts</li>
<li>apps/web/utils/ai/actions.test.ts</li>
<li>apps/web/utils/ai/actions.ts</li>
<li>apps/web/utils/ai/choose-rule/execute.test.ts</li>
<li>apps/web/utils/ai/choose-rule/execute.ts</li>
<li>apps/web/utils/messaging-notifications/dispatch.ts</li>
<li>apps/web/utils/messaging-notifications/execute.ts</li>
<li>apps/web/utils/messaging-notifications/validation.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li>
<li>apps/web/utils/messaging/providers/slack/messages/outbound-proposal-review.ts</li>
<li>apps/web/utils/messaging/providers/slack/send.ts</li>
<li>apps/web/utils/outbound-proposals/create-outbound-proposal.ts</li>
<li>apps/web/utils/outbound-proposals/review.ts</li>
<li>apps/web/utils/outbound-proposals/rewrite-outbound-proposal.ts</li>
<li>apps/web/utils/reply-tracker/draft-tracking.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add drive-backed rule ...</td><td>March 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2010?tool=ast>(Baz)</a>.