### PR TITLE
stats: reuse loaded messages

### DIFF
--- a/apps/web/utils/actions/stats.ts
+++ b/apps/web/utils/actions/stats.ts
@@ -176,9 +176,7 @@ async function saveBatch({
     after,
   });
 
-  const messages = await emailProvider.getMessagesBatch(
-    res.messages?.map((m) => m.id).filter(isDefined) || [],
-  );
+  const messages = res.messages ?? [];
 
   const emailsToSave = messages
     .map((m) => {


### PR DESCRIPTION
# User description
Reuse the messages already returned during stats pagination instead of fetching the same records a second time.

- remove the extra batch fetch in stats loading
- reduce provider API calls during stats backfills

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reuse previously loaded message batches in stats pagination by passing the <code>res.messages</code> array into <code>saveBatch</code> instead of calling <code>emailProvider.getMessagesBatch</code> again. Reduce provider API calls during stats backfills by routing the same <code>messages</code> array through the pagination response.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>security: harden unsub...</td><td>March 16, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>add bulk unsubscribe s...</td><td>June 23, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2013?tool=ast>(Baz)</a>.