### PR TITLE
auth: Fix dialog accessibility warning

### DIFF
--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -6,10 +6,10 @@ import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/Button";
 import { Button as UIButton } from "@/components/ui/button";
-import { SectionDescription } from "@/components/Typography";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -127,7 +127,7 @@ export function LoginForm({
           <DialogHeader>
             <DialogTitle>Sign in</DialogTitle>
           </DialogHeader>
-          <SectionDescription>
+          <DialogDescription className="mt-1 text-sm leading-6 text-slate-700 dark:text-foreground">
             {getPossessiveBrandName()} use and transfer of information received
             from Google APIs to any other app will adhere to{" "}
             <a
@@ -137,7 +137,7 @@ export function LoginForm({
               Google API Services User Data
             </a>{" "}
             Policy, including the Limited Use requirements.
-          </SectionDescription>
+          </DialogDescription>
           <div>
             <Button loading={loadingGoogle} onClick={handleGoogleSignIn}>
               I agree


### PR DESCRIPTION
# User description
Adds the missing accessibility description metadata for the sign-in consent dialog.

- switch the dialog body to use the Radix description element
- preserve the existing visual styling while removing the dev warning

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add accessibility metadata to the sign-in consent dialog by switching its explanatory copy to <code>DialogDescription</code> so the dialog exposes the required Radix description hook. Maintain the costent copy’s existing styling and wording while eliminating the developer warning about missing descriptive metadata.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>auth: narrow emulator ...</td><td>March 25, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>PR feedback. Add migra...</td><td>September 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2015?tool=ast>(Baz)</a>.