### PR TITLE
CI: run integration tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,19 @@ jobs:
           EMAIL_ENCRYPT_SALT: "salt"
           INTERNAL_API_KEY: "secret"
           NEXT_PUBLIC_BASE_URL: "http://localhost:3000"
+
+      - name: Run integration tests
+        run: pnpm -F inbox-zero-ai test-integration
+        env:
+          RUN_INTEGRATION_TESTS: true
+          DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
+          AUTH_SECRET: "secret"
+          GOOGLE_CLIENT_ID: "client_id"
+          GOOGLE_CLIENT_SECRET: "client_secret"
+          MICROSOFT_CLIENT_ID: "client_id"
+          MICROSOFT_CLIENT_SECRET: "client_secret"
+          GOOGLE_PUBSUB_TOPIC_NAME: "topic"
+          EMAIL_ENCRYPT_SECRET: "secret"
+          EMAIL_ENCRYPT_SALT: "salt"
+          INTERNAL_API_KEY: "secret"
+          NEXT_PUBLIC_BASE_URL: "http://localhost:3000"


### PR DESCRIPTION
## Summary
- Add integration test step to the existing test workflow
- Runs `pnpm test-integration` after unit tests on every PR
- Uses the in-process emulator — no Docker, no credentials, no external services

## Test plan
- [ ] Workflow runs and integration tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)