### PR TITLE
Extract shared Gmail test harness, update emulate to 0.4.0

### DIFF
--- a/apps/web/__tests__/integration/draft-creation.test.ts
+++ b/apps/web/__tests__/integration/draft-creation.test.ts
@@ -10,12 +10,9 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
-import { GmailProvider } from "@/utils/email/google";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { draftEmail } from "@/utils/gmail/mail";
 import { sendDraft } from "@/utils/gmail/draft";
-import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
 
@@ -50,47 +47,22 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Draft creation & sending",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let provider: GmailProvider;
+    let harness: GmailTestHarness;
+    let gmailClient: GmailTestHarness["gmailClient"];
+    let provider: GmailTestHarness["provider"];
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Draft Test User" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      const logger = createScopedLogger("test");
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
+      gmailClient = harness.gmailClient;
+      provider = harness.provider;
     });
 
     afterAll(async () => {
-      await emulator?.close();
+      await harness?.emulator?.close();
     });
 
     test("draftEmail creates a reply draft on a thread", async () => {

--- a/apps/web/__tests__/integration/helpers.ts
+++ b/apps/web/__tests__/integration/helpers.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared helpers for Gmail integration tests using @inbox-zero/emulate.
+ *
+ * Eliminates boilerplate: emulator creation, OAuth setup, GmailProvider
+ * instantiation, and thread ID resolution.
+ */
+
+import { createEmulator, type Emulator } from "emulate";
+import { gmail, auth } from "@googleapis/gmail";
+import { GmailProvider } from "@/utils/email/google";
+import { createScopedLogger } from "@/utils/logger";
+
+type SeedMessage = {
+  id: string;
+  user_email: string;
+  from: string;
+  to: string;
+  subject: string;
+  body_text: string;
+  body_html?: string;
+  label_ids: string[];
+  internal_date: string;
+};
+
+export type GmailTestHarness = {
+  emulator: Emulator;
+  gmailClient: ReturnType<typeof gmail>;
+  provider: GmailProvider;
+  /** Map of seed message ID → emulator-assigned thread ID */
+  threadIds: Record<string, string>;
+};
+
+/**
+ * Creates a fully wired Gmail test environment:
+ * emulator + OAuth client + Gmail client + GmailProvider + thread ID map.
+ *
+ * Call `harness.emulator.close()` in afterAll to clean up.
+ */
+export async function createGmailTestHarness({
+  port,
+  email,
+  messages,
+}: {
+  port: number;
+  email: string;
+  messages: SeedMessage[];
+}): Promise<GmailTestHarness> {
+  const emulator = await createEmulator({
+    service: "google",
+    port,
+    seed: {
+      google: {
+        users: [{ email, name: "Test User" }],
+        oauth_clients: [
+          {
+            client_id: "test-client.apps.googleusercontent.com",
+            client_secret: "test-secret",
+            redirect_uris: ["http://localhost:3000/callback"],
+          },
+        ],
+        messages,
+      },
+    },
+  });
+
+  const oauth2Client = new auth.OAuth2(
+    "test-client.apps.googleusercontent.com",
+    "test-secret",
+  );
+  oauth2Client.setCredentials({ access_token: "emulator-token" });
+
+  const gmailClient = gmail({
+    version: "v1",
+    auth: oauth2Client,
+    rootUrl: emulator.url,
+  });
+
+  const logger = createScopedLogger("test");
+  const provider = new GmailProvider(gmailClient, logger, "test-account-id");
+
+  // Resolve thread IDs in parallel
+  const entries = await Promise.all(
+    messages.map(async (seed) => {
+      const msg = await gmailClient.users.messages.get({
+        userId: "me",
+        id: seed.id,
+      });
+      return [seed.id, msg.data.threadId!] as const;
+    }),
+  );
+  const threadIds = Object.fromEntries(entries);
+
+  return { emulator, gmailClient, provider, threadIds };
+}

--- a/apps/web/__tests__/integration/labeling-archiving.test.ts
+++ b/apps/web/__tests__/integration/labeling-archiving.test.ts
@@ -10,8 +10,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import {
   labelThread,
   archiveThread,
@@ -71,50 +70,19 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Labeling & archiving operations",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let threadIds: Record<string, string>;
+    let emulator: GmailTestHarness["emulator"];
+    let gmailClient: GmailTestHarness["gmailClient"];
+    let threadIds: GmailTestHarness["threadIds"];
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      const harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Label Test User" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      // Resolve thread IDs for seeded messages
-      threadIds = {};
-      for (const seed of SEED_MESSAGES) {
-        const msg = await gmailClient.users.messages.get({
-          userId: "me",
-          id: seed.id,
-        });
-        threadIds[seed.id] = msg.data.threadId!;
-      }
+      emulator = harness.emulator;
+      gmailClient = harness.gmailClient;
+      threadIds = harness.threadIds;
     });
 
     afterAll(async () => {

--- a/apps/web/__tests__/integration/rule-execution.test.ts
+++ b/apps/web/__tests__/integration/rule-execution.test.ts
@@ -11,9 +11,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
-import { GmailProvider } from "@/utils/email/google";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
@@ -104,58 +102,22 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Rule execution (executeAct)",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let provider: GmailProvider;
-    let threadIds: Record<string, string>;
+    let harness: GmailTestHarness;
+    let gmailClient: GmailTestHarness["gmailClient"];
+    let provider: GmailTestHarness["provider"];
+    let threadIds: GmailTestHarness["threadIds"];
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Rules Test User" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      const logger = createScopedLogger("test");
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
-
-      // Resolve thread IDs
-      threadIds = {};
-      for (const seed of SEED_MESSAGES) {
-        const msg = await gmailClient.users.messages.get({
-          userId: "me",
-          id: seed.id,
-        });
-        threadIds[seed.id] = msg.data.threadId!;
-      }
+      ({ gmailClient, provider, threadIds } = harness);
     });
 
     afterAll(async () => {
-      await emulator?.close();
+      await harness?.emulator.close();
     });
 
     function buildExecutedRule(

--- a/apps/web/__tests__/integration/stats-reuse-messages.test.ts
+++ b/apps/web/__tests__/integration/stats-reuse-messages.test.ts
@@ -11,9 +11,8 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
-import { GmailProvider } from "@/utils/email/google";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
+import type { GmailProvider } from "@/utils/email/google";
 import { saveBatch } from "@/utils/actions/stats";
 import { createScopedLogger } from "@/utils/logger";
 
@@ -72,50 +71,24 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Stats: reuse messages from pagination",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
+    let harness: GmailTestHarness;
     let provider: GmailProvider;
     let fetchSpy: ReturnType<typeof vi.spyOn>;
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Stats Test" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      const gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      const logger = createScopedLogger("test");
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
+      provider = harness.provider;
 
       fetchSpy = vi.spyOn(globalThis, "fetch");
     });
 
     afterAll(async () => {
       fetchSpy?.mockRestore();
-      await emulator?.close();
+      await harness?.emulator.close();
     });
 
     test("saveBatch processes emulator messages and saves to DB", async () => {

--- a/apps/web/__tests__/integration/thread-fetching.test.ts
+++ b/apps/web/__tests__/integration/thread-fetching.test.ts
@@ -9,11 +9,8 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { getThread, getThreadsWithNextPageToken } from "@/utils/gmail/thread";
-import { GmailProvider } from "@/utils/email/google";
-import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
 
@@ -79,47 +76,22 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Thread fetching & pagination",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let provider: GmailProvider;
+    let harness: GmailTestHarness;
+    let gmailClient: GmailTestHarness["gmailClient"];
+    let provider: GmailTestHarness["provider"];
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Thread Test User" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      const logger = createScopedLogger("test");
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
+      gmailClient = harness.gmailClient;
+      provider = harness.provider;
     });
 
     afterAll(async () => {
-      await emulator?.close();
+      await harness?.emulator.close();
     });
 
     test("getThread returns full thread with messages", async () => {

--- a/apps/web/__tests__/integration/webhook-action.test.ts
+++ b/apps/web/__tests__/integration/webhook-action.test.ts
@@ -11,9 +11,7 @@
 
 import http from "node:http";
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
-import { GmailProvider } from "@/utils/email/google";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
@@ -86,9 +84,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "CALL_WEBHOOK action",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let provider: GmailProvider;
+    let harness: GmailTestHarness;
     let threadId: string;
 
     // Local HTTP server to receive webhook calls
@@ -116,53 +112,21 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         webhookServer.listen(WEBHOOK_PORT, resolve),
       );
 
-      // Start Gmail emulator
-      emulator = await createEmulator({
-        service: "google",
+      // Start Gmail emulator via shared harness
+      harness = await createGmailTestHarness({
         port: EMULATOR_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Webhook Test User" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
 
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      const logger = createScopedLogger("test");
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
-
-      // Resolve thread ID
-      const msg = await gmailClient.users.messages.get({
-        userId: "me",
-        id: "msg_webhook",
-      });
-      threadId = msg.data.threadId!;
+      threadId = harness.threadIds.msg_webhook;
     });
 
     afterAll(async () => {
       await new Promise<void>((resolve) =>
         webhookServer?.close(() => resolve()),
       );
-      await emulator?.close();
+      await harness?.emulator.close();
     });
 
     test("CALL_WEBHOOK delivers payload with correct structure and secret", async () => {
@@ -230,7 +194,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       };
 
       await executeAct({
-        client: provider,
+        client: harness.provider,
         executedRule,
         message,
         userEmail: TEST_EMAIL,
@@ -348,7 +312,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       };
 
       await executeAct({
-        client: provider,
+        client: harness.provider,
         executedRule,
         message,
         userEmail: TEST_EMAIL,
@@ -361,13 +325,15 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(receivedRequests).toHaveLength(1);
 
       // Label was created and applied in Gmail
-      const labels = await gmailClient.users.labels.list({ userId: "me" });
+      const labels = await harness.gmailClient.users.labels.list({
+        userId: "me",
+      });
       const webhookLabel = labels.data.labels?.find(
         (l) => l.name === "Webhooks",
       );
       expect(webhookLabel).toBeDefined();
 
-      const msg = await gmailClient.users.messages.get({
+      const msg = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_webhook",
       });

--- a/apps/web/__tests__/integration/webhook-flow.test.ts
+++ b/apps/web/__tests__/integration/webhook-flow.test.ts
@@ -17,9 +17,7 @@ import {
   afterAll,
   vi,
 } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
-import { gmail, auth } from "@googleapis/gmail";
-import { GmailProvider } from "@/utils/email/google";
+import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { processHistoryItem } from "@/utils/webhook/process-history-item";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import {
@@ -206,10 +204,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Webhook → processHistoryItem → action execution",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
-    let gmailClient: ReturnType<typeof gmail>;
-    let provider: GmailProvider;
-    let threadIds: Record<string, string>;
+    let harness: GmailTestHarness;
 
     const logger = createScopedLogger("test");
 
@@ -227,9 +222,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       overrides?: Partial<Parameters<typeof processHistoryItem>[1]>,
     ) {
       return processHistoryItem(
-        { messageId, threadId: threadIds[messageId] },
+        { messageId, threadId: harness.threadIds[messageId] },
         {
-          provider,
+          provider: harness.provider,
           rules: [],
           hasAutomationRules: true,
           hasAiAccess: true,
@@ -241,49 +236,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     }
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "google",
+      harness = await createGmailTestHarness({
         port: TEST_PORT,
-        seed: {
-          google: {
-            users: [{ email: TEST_EMAIL, name: "Webhook Flow Test" }],
-            oauth_clients: [
-              {
-                client_id: "test-client.apps.googleusercontent.com",
-                client_secret: "test-secret",
-                redirect_uris: ["http://localhost:3000/callback"],
-              },
-            ],
-            messages: SEED_MESSAGES,
-          },
-        },
+        email: TEST_EMAIL,
+        messages: SEED_MESSAGES,
       });
-
-      const oauth2Client = new auth.OAuth2(
-        "test-client.apps.googleusercontent.com",
-        "test-secret",
-      );
-      oauth2Client.setCredentials({ access_token: "emulator-token" });
-
-      gmailClient = gmail({
-        version: "v1",
-        auth: oauth2Client,
-        rootUrl: emulator.url,
-      });
-
-      provider = new GmailProvider(gmailClient, logger, "test-account-id");
-
-      // Resolve thread IDs in parallel
-      const entries = await Promise.all(
-        SEED_MESSAGES.map(async (seed) => {
-          const msg = await gmailClient.users.messages.get({
-            userId: "me",
-            id: seed.id,
-          });
-          return [seed.id, msg.data.threadId!] as const;
-        }),
-      );
-      threadIds = Object.fromEntries(entries);
     });
 
     beforeEach(async () => {
@@ -300,7 +257,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     });
 
     afterAll(async () => {
-      await emulator?.close();
+      await harness?.emulator?.close();
     });
 
     test("inbound message: fetches from emulator, runs rules, applies LABEL + ARCHIVE", async () => {
@@ -309,7 +266,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         { type: ActionType.ARCHIVE },
       ];
 
-      const before = await gmailClient.users.messages.get({
+      const before = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_inbound",
       });
@@ -325,13 +282,15 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(capturedMessage.headers.from).toContain("customer@external.com");
       expect(capturedMessage.headers.subject).toBe("Support request #1234");
 
-      const after = await gmailClient.users.messages.get({
+      const after = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_inbound",
       });
       expect(after.data.labelIds).not.toContain("INBOX");
 
-      const labels = await gmailClient.users.labels.list({ userId: "me" });
+      const labels = await harness.gmailClient.users.labels.list({
+        userId: "me",
+      });
       const supportLabel = labels.data.labels?.find(
         (l) => l.name === "Support",
       );
@@ -360,7 +319,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       expect(capturedRunRulesCall).toBeNull();
 
-      const msg = await gmailClient.users.messages.get({
+      const msg = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_second_inbound",
       });
@@ -376,7 +335,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       expect(capturedRunRulesCall).toBeNull();
 
-      const labels = await gmailClient.users.labels.list({ userId: "me" });
+      const labels = await harness.gmailClient.users.labels.list({
+        userId: "me",
+      });
       const badLabel = labels.data.labels?.find(
         (l) => l.name === "ShouldNotApply",
       );
@@ -386,7 +347,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     test("MARK_READ action: processes and marks message as read", async () => {
       runRulesActions = [{ type: ActionType.MARK_READ }];
 
-      const before = await gmailClient.users.messages.get({
+      const before = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_second_inbound",
       });
@@ -394,7 +355,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       await callProcessHistoryItem("msg_second_inbound");
 
-      const after = await gmailClient.users.messages.get({
+      const after = await harness.gmailClient.users.messages.get({
         userId: "me",
         id: "msg_second_inbound",
       });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -224,7 +224,7 @@
     "cross-env": "10.1.0",
     "dotenv": "17.3.1",
     "dotenv-cli": "11.0.0",
-    "emulate": "npm:@inbox-zero/emulate@0.3.0-inboxzero.0",
+    "emulate": "npm:@inbox-zero/emulate@0.4.0-inboxzero.0",
     "jsdom": "27.3.0",
     "postcss": "8.5.6",
     "serwist": "9.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,7 +509,7 @@ importers:
         version: 4.0.1
       sanity-plugin-markdown:
         specifier: 8.0.5
-        version: 8.0.5(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 8.0.5(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       schema-dts:
         specifier: 1.1.5
         version: 1.1.5
@@ -635,8 +635,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       emulate:
-        specifier: npm:@inbox-zero/emulate@0.3.0-inboxzero.0
-        version: '@inbox-zero/emulate@0.3.0-inboxzero.0(hono@4.11.4)'
+        specifier: npm:@inbox-zero/emulate@0.4.0-inboxzero.0
+        version: '@inbox-zero/emulate@0.4.0-inboxzero.0(hono@4.11.4)'
       jsdom:
         specifier: 27.3.0
         version: 27.3.0
@@ -657,10 +657,10 @@ importers:
         version: 5.9.3
       vite-tsconfig-paths:
         specifier: 6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest-mock-extended:
         specifier: 3.1.0
         version: 3.1.0(typescript@5.9.3)(vitest@4.1.0)
@@ -676,13 +676,13 @@ importers:
         version: 2.0.2
       '@sanity/vision':
         specifier: '5'
-        version: 5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       next-sanity:
         specifier: '12'
-        version: 12.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.17.0)(@sanity/types@5.16.0(@types/react@19.0.10))(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(svelte@5.38.6)(typescript@5.9.3)
+        version: 12.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.17.0)(@sanity/types@5.16.0(@types/react@19.0.10))(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(svelte@5.38.6)(typescript@5.9.3)
       sanity:
         specifier: 5.16.0
-        version: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
+        version: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
 
   apps/worker:
     dependencies:
@@ -2992,8 +2992,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inbox-zero/emulate@0.3.0-inboxzero.0':
-    resolution: {integrity: sha512-R0XjJC4tpo8gkdkh4BNRoWhlYolijmces/c+AiQXkq4oxlANWrikE04NP/hVcU2JSrQtM/A9eZPo/1nrdqzCeA==}
+  '@inbox-zero/emulate@0.4.0-inboxzero.0':
+    resolution: {integrity: sha512-amgSJyZqvmSdHJ97T6npkpdYUKxf1yZ0Aa4WE6p9XxpcvzOSNPGXCV7VnCUW2gu6ABxSkkeVxKadn8HZlAiRqQ==}
     hasBin: true
 
   '@inquirer/ansi@1.0.2':
@@ -14805,7 +14805,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inbox-zero/emulate@0.3.0-inboxzero.0(hono@4.11.4)':
+  '@inbox-zero/emulate@0.4.0-inboxzero.0(hono@4.11.4)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.4)
       commander: 14.0.3
@@ -17125,7 +17125,7 @@ snapshots:
 
   '@sanity/blueprints@0.13.1': {}
 
-  '@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)':
+  '@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)':
     dependencies:
       '@inquirer/prompts': 8.3.0(@types/node@24.10.1)
       '@oclif/core': 4.9.0
@@ -17146,8 +17146,8 @@ snapshots:
       read-package-up: 12.0.0
       rxjs: 7.8.2
       tsx: 4.21.0
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 5.3.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -17169,16 +17169,16 @@ snapshots:
       '@oclif/core': 4.9.0
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.75(@types/node@24.10.1)
-      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
       '@sanity/client': 7.17.0(debug@4.4.3)
-      '@sanity/codegen': 6.0.1(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@sanity/telemetry@0.8.1(react@19.2.4))
+      '@sanity/codegen': 6.0.1(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@sanity/telemetry@0.8.1(react@19.2.4))
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.1.0
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
       '@sanity/import': 5.0.1(@sanity/client@7.17.0)(@types/react@19.0.10)
-      '@sanity/migrate': 6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/react@19.0.10)(xstate@5.28.0)
-      '@sanity/runtime-cli': 14.5.0(@types/node@24.10.1)(debug@4.4.3)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      '@sanity/migrate': 6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/react@19.0.10)(xstate@5.28.0)
+      '@sanity/runtime-cli': 14.5.0(@types/node@24.10.1)(debug@4.4.3)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       '@sanity/schema': 5.16.0(@types/react@19.0.10)(debug@4.4.3)
       '@sanity/telemetry': 0.8.1(react@19.2.4)
       '@sanity/template-validator': 3.0.0
@@ -17186,7 +17186,7 @@ snapshots:
       '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.8.4
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       chokidar: 5.0.0
       console-table-printer: 2.15.0
       date-fns: 4.1.0
@@ -17230,9 +17230,9 @@ snapshots:
       tinyglobby: 0.2.15
       tsx: 4.21.0
       typeid-js: 1.2.0
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       which: 6.0.1
-      yaml: 2.8.2
+      yaml: 2.8.3
       zod: 4.3.6
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -17265,7 +17265,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/codegen@6.0.1(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@sanity/telemetry@0.8.1(react@19.2.4))':
+  '@sanity/codegen@6.0.1(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@sanity/telemetry@0.8.1(react@19.2.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17276,7 +17276,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@oclif/core': 4.9.0
-      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
       '@sanity/telemetry': 0.8.1(react@19.2.4)
       '@sanity/worker-channels': 2.0.0
       chokidar: 3.6.0
@@ -17420,10 +17420,10 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
-  '@sanity/migrate@6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/react@19.0.10)(xstate@5.28.0)':
+  '@sanity/migrate@6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/react@19.0.10)(xstate@5.28.0)':
     dependencies:
       '@oclif/core': 4.9.0
-      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      '@sanity/cli-core': 1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
       '@sanity/client': 7.17.0(debug@4.4.3)
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.28.0)
       '@sanity/types': 5.16.0(@types/react@19.0.10)(debug@4.4.3)
@@ -17492,7 +17492,7 @@ snapshots:
       '@sanity/client': 7.17.0(debug@4.4.3)
       '@sanity/uuid': 3.0.2
 
-  '@sanity/runtime-cli@14.5.0(@types/node@24.10.1)(debug@4.4.3)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)':
+  '@sanity/runtime-cli@14.5.0(@types/node@24.10.1)(debug@4.4.3)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@architect/hydrate': 5.0.2
       '@architect/inventory': 5.0.0
@@ -17512,8 +17512,8 @@ snapshots:
       mime-types: 3.0.2
       ora: 9.3.0
       tar-stream: 3.1.7
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.19.0
       xdg-basedir: 5.1.0
     transitivePeerDependencies:
@@ -17594,7 +17594,7 @@ snapshots:
     dependencies:
       '@actions/core': 3.0.0
       '@actions/github': 9.0.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   '@sanity/types@3.99.0(@types/react@19.0.10)(debug@4.4.3)':
     dependencies:
@@ -17683,7 +17683,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vision@5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/vision@5.13.0(@babel/runtime@7.28.6)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/commands': 6.10.1
@@ -17708,7 +17708,7 @@ snapshots:
       react: 19.2.4
       react-rx: 4.2.2(react@19.2.4)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
+      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
       styled-components: 6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -19063,7 +19063,7 @@ snapshots:
 
   '@vercel/stega@1.0.0': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -19071,7 +19071,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -19087,7 +19087,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -19097,14 +19097,6 @@ snapshots:
       '@vitest/utils': 4.1.0
       chai: 6.2.2
       tinyrainbow: 3.0.3
-
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -19141,7 +19133,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -19608,7 +19600,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.38.6
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       vue: 3.5.20(typescript@5.9.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -23035,7 +23027,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next-sanity@12.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.17.0)(@sanity/types@5.16.0(@types/react@19.0.10))(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(svelte@5.38.6)(typescript@5.9.3):
+  next-sanity@12.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.17.0)(@sanity/types@5.16.0(@types/react@19.0.10))(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(svelte@5.38.6)(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.0.3(react@19.2.4)
       '@sanity/client': 7.17.0(debug@4.4.3)
@@ -23050,7 +23042,7 @@ snapshots:
       next: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
+      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
       server-only: 0.0.1
       styled-components: 6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -24505,20 +24497,20 @@ snapshots:
       xml-escape: 1.1.0
       xpath: 0.0.32
 
-  sanity-plugin-markdown@8.0.5(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  sanity-plugin-markdown@8.0.5(@emotion/is-prop-valid@1.2.2)(easymde@2.20.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3))(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       easymde: 2.20.0
       react: 19.2.4
       react-simplemde-editor: 5.2.0(easymde@2.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
+      sanity: 5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3)
       styled-components: 6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-dom
       - react-is
 
-  sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3):
+  sanity@5.16.0(@emotion/is-prop-valid@1.2.2)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/node@24.10.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(immer@11.0.1)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.1.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(typescript@5.9.3):
     dependencies:
       '@algorithm.ts/lcs': 4.0.5
       '@date-fns/tz': 1.4.1
@@ -24558,7 +24550,7 @@ snapshots:
       '@sanity/logos': 2.2.2(react@19.2.4)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
-      '@sanity/migrate': 6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(@types/react@19.0.10)(xstate@5.28.0)
+      '@sanity/migrate': 6.0.0(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))(@types/react@19.0.10)(xstate@5.28.0)
       '@sanity/mutator': 5.16.0(@types/react@19.0.10)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.17.0)(@sanity/types@5.16.0(@types/react@19.0.10))
       '@sanity/preview-url-secret': 4.0.3(@sanity/client@7.17.0)
@@ -25729,13 +25721,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@5.3.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@5.3.0(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -25749,31 +25741,15 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.8.2
 
   vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -25795,12 +25771,12 @@ snapshots:
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.1.0)(jsdom@27.3.0)(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -25817,7 +25793,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary
- **New shared helper** (`__tests__/integration/helpers.ts`): `createGmailTestHarness()` handles emulator creation, OAuth setup, Gmail client, GmailProvider, and thread ID resolution in a single call
- **Refactored all 7 Gmail integration tests** to use the shared harness, eliminating ~20 lines of duplicated setup from each file
- **Updated `@inbox-zero/emulate` from 0.3.0 to 0.4.0** — adds Outlook emulator support for future integration tests

Net change: **-156 lines** across 10 files.

## Test plan
- [x] All tests pass: `pnpm test-integration` → 9 files, 41 tests
- [x] No behavioral changes — purely a refactor + dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)