### PR TITLE
Rename /support use case page, add /support contact page

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from "react";
 import Link from "next/link";
 import { env } from "@/env";
 import { EXTENSION_URL } from "@/utils/config";
-import { BRAND_NAME, SUPPORT_EMAIL } from "@/utils/branding";
+import { BRAND_NAME } from "@/utils/branding";
 
 export const footerNavigation = {
   main: [
@@ -30,7 +30,7 @@ export const footerNavigation = {
     { name: "Small Business", href: "/small-business" },
     { name: "Content Creator", href: "/creator" },
     { name: "Realtor", href: "/real-estate" },
-    { name: "Customer Support", href: "/support" },
+    { name: "Customer Support", href: "/customer-support" },
     { name: "E-commerce", href: "/ecommerce" },
   ],
   industries: [
@@ -61,11 +61,7 @@ export const footerNavigation = {
   ],
   support: [
     { name: "Pricing", href: "/pricing" },
-    {
-      name: "Contact",
-      href: `mailto:${SUPPORT_EMAIL}`,
-      target: "_blank",
-    },
+    { name: "Support", href: "/support" },
     {
       name: "Documentation",
       href: "https://docs.getinboxzero.com",

--- a/apps/web/components/new-landing/HeaderLinks.tsx
+++ b/apps/web/components/new-landing/HeaderLinks.tsx
@@ -68,7 +68,7 @@ const useCases = [
   },
   {
     title: "Customer Support",
-    href: "/support",
+    href: "/customer-support",
     description: "Deliver faster support with AI-powered responses",
     icon: HeadphonesIcon,
     iconColor: "text-new-orange-600",


### PR DESCRIPTION
# User description
Rename /support use case to /customer-support, add /support contact page

Moved the existing customer support use case page to `/customer-support` and repurposed `/support` as a simple contact/support page (previously at `/contact`).

- Renamed use case page route from `/support` to `/customer-support`
- Moved contact page from `/contact` to `/support`
- Updated all navigation links (header, footer, sitemap, case studies)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the landing navigation so the header tiles and footer sections now reference the renamed <code>customer-support</code> use case route while exposing the refreshed <code>/support</code> contact page. Coordinate these navigation endpoints with the marketing flow to keep the support story consistent for visitors across the site.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2030?tool=ast&topic=Marketing+routing>Marketing routing</a>
        </td><td>Align the marketing landing entry flow with the new support routes so any marketing-specific references to support content surface the <code>/support</code> contact page and the <code>/customer-support</code> use case consistently.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(marketing)</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Revert the sitemap rou...</td><td>March 26, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Fix mobile version of ...</td><td>November 30, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2030?tool=ast&topic=Support+navigation>Support navigation</a>
        </td><td>Reroute the header <code>HeaderLinks</code> tiles and footer <code>footerNavigation</code> entries so the customer support use case links target <code>/customer-support</code> and the simpler contact/support page lives at <code>/support</code> instead of <code>/contact</code>.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(landing)/home/Footer.tsx</li>
<li>apps/web/components/new-landing/HeaderLinks.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve SEO: structure...</td><td>March 24, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Move colors into tailwind</td><td>November 23, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2030?tool=ast>(Baz)</a>.