### PR TITLE
Add /contact -> /support permanent redirect

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -127,6 +127,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/contact",
+        destination: "/support",
+        permanent: true,
+      },
+      {
         source: "/waitlist",
         destination: "https://go.getinboxzero.com/waitlist",
         permanent: true,


### PR DESCRIPTION
# User description
Add permanent redirect from /contact to /support

The contact page was moved to /support. This adds a 301 redirect so old links still work.

- Adds permanent redirect in next.config.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Configure Next's redirect rules to map /contact to /support so the relocated help page is always reached efficiently. Update the redirects array in <code>nextConfig</code> to return a permanent 301 response from the legacy contact path.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore: update Next.js ...</td><td>March 18, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add fallback icons fro...</td><td>November 19, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2031?tool=ast>(Baz)</a>.