### PR TITLE
dev: allow loopback origin for local QA

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,6 +13,7 @@ const withMDX = nextMdx({
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  allowedDevOrigins: ["127.0.0.1"],
   logging: {
     browserToTerminal: true,
   },


### PR DESCRIPTION
# User description
Allow the local dev server to serve assets to the loopback host used by browser automation.

- add 127.0.0.1 to Next.js allowed dev origins
- restore local browser automation flows that hit the app via loopback

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable Next.js dev server to accept loopback requests by updating the dev config so automated browser flows can reach the local app. Document and highlight the config adjustment to restore local QA flows that depend on loopback access.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add /contact -> /suppo...</td><td>March 26, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Add fallback icons fro...</td><td>November 19, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2033?tool=ast>(Baz)</a>.