### PR TITLE
docker: fix worker deploy for pnpm v10

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -88,7 +88,7 @@ RUN --mount=type=cache,target=/app/apps/web/.next/cache \
     cd apps/web && \
     ../../node_modules/.bin/next build --webpack && \
     cd ../.. && \
-    pnpm --filter @inboxzero/worker deploy --prod /tmp/apps/worker
+    pnpm --filter @inboxzero/worker deploy --legacy --prod /tmp/apps/worker
 
 # === Production image ===
 FROM node:24-alpine AS runner

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -75,7 +75,7 @@ RUN npx prisma generate --schema=apps/web/prisma/schema.prisma \
  && cd apps/web \
  && pnpm exec next build \
  && cd ../.. \
- && pnpm --filter @inboxzero/worker deploy --prod /tmp/apps/worker \
+ && pnpm --filter @inboxzero/worker deploy --legacy --prod /tmp/apps/worker \
  && cd /app \
  && rm -rf apps/web/.next/cache
 


### PR DESCRIPTION
# User description
Use pnpm's legacy deploy mode for the worker packaging step in both Dockerfiles.

- add --legacy to the worker deploy command in production and local Docker builds
- preserve current workspace install behavior while avoiding pnpm v10 deploy failures

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable pnpm's legacy deploy mode when packaging the worker in both local and production Docker builds to sidestep pnpm v10 deploy failures. Preserve the existing workspace install behavior while keeping the worker deploy command consistent across Docker contexts.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>self-hosting: add opti...</td><td>March 25, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix(docker): align pnp...</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2035?tool=ast>(Baz)</a>.