### PR TITLE
docker: align pnpm version pins

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -15,7 +15,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache openssl
-RUN npm install -g pnpm@10.27.0
+RUN npm install -g pnpm@10.32.1
 
 # Copy lockfiles/workspace manifests for better caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc* ./

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -4,7 +4,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache openssl
-RUN npm install -g pnpm@10.22.0
+RUN npm install -g pnpm@10.32.1
 
 # Copy lockfiles/workspace manifests for better caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc* ./


### PR DESCRIPTION
# User description
Align the Docker builder pnpm version with the root workspace packageManager version.

- update both Dockerfiles to install pnpm 10.32.1
- remove version drift between local and production Docker builds

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Docker builder scripts to align both local and production environments by installing <code>pnpm</code> 10.32.1, matching the workspace package manager version. Ensure the builder setup now consistently uses the same package manager release for caching and dependency installs across environments.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>docker: fix worker dep...</td><td>March 26, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix(docker): align pnp...</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2036?tool=ast>(Baz)</a>.