### PR TITLE
mail: restore queued archive progress

### DIFF
--- a/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
+++ b/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration test: queued Gmail bulk archive handler archives sender mail in the background
+ *
+ * Verifies that the internal bulk archive route executes against the Gmail emulator,
+ * removes the INBOX label for the targeted sender, and leaves unrelated mail untouched.
+ *
+ * Usage:
+ *   pnpm test-integration mail-bulk-archive-queue
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createEmulator, type Emulator } from "emulate";
+import { auth, gmail, type gmail_v1 } from "@googleapis/gmail";
+
+vi.mock("server-only", () => ({}));
+
+const mockUpdateEmailMessagesForSender = vi.fn().mockResolvedValue(undefined);
+const mockPublishBulkActionToTinybird = vi.fn().mockResolvedValue(undefined);
+
+let gmailClient: gmail_v1.Gmail;
+
+vi.mock("@/utils/account", () => ({
+  getGmailClientForEmail: vi.fn(async () => gmailClient),
+  getOutlookClientForEmail: vi.fn(),
+}));
+
+vi.mock("@/utils/email/bulk-action-tracking", () => ({
+  updateEmailMessagesForSender: (
+    ...args: Parameters<typeof mockUpdateEmailMessagesForSender>
+  ) => mockUpdateEmailMessagesForSender(...args),
+  publishBulkActionToTinybird: (
+    ...args: Parameters<typeof mockPublishBulkActionToTinybird>
+  ) => mockPublishBulkActionToTinybird(...args),
+}));
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
+const TEST_EMAIL = "bulk-archive-test@example.com";
+const TEST_PORT = 4101;
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "Mail bulk archive queue",
+  { timeout: 30_000 },
+  () => {
+    let emulator: Emulator;
+
+    beforeAll(async () => {
+      emulator = await createEmulator({
+        service: "google",
+        port: TEST_PORT,
+        seed: {
+          google: {
+            users: [{ email: TEST_EMAIL, name: "Bulk Archive Test" }],
+            oauth_clients: [
+              {
+                client_id: "test-client.apps.googleusercontent.com",
+                client_secret: "test-secret",
+                redirect_uris: ["http://localhost:3000/callback"],
+              },
+            ],
+            messages: [
+              {
+                id: "msg_1",
+                user_email: TEST_EMAIL,
+                from: "target@example.com",
+                to: TEST_EMAIL,
+                subject: "Archive me",
+                body_text: "First target message",
+                label_ids: ["INBOX", "UNREAD"],
+              },
+              {
+                id: "msg_2",
+                user_email: TEST_EMAIL,
+                from: "target@example.com",
+                to: TEST_EMAIL,
+                subject: "Archive me too",
+                body_text: "Second target message",
+                label_ids: ["INBOX"],
+              },
+              {
+                id: "msg_3",
+                user_email: TEST_EMAIL,
+                from: "other@example.com",
+                to: TEST_EMAIL,
+                subject: "Leave me alone",
+                body_text: "Other sender message",
+                label_ids: ["INBOX"],
+              },
+            ],
+          },
+        },
+      });
+
+      const oauth2Client = new auth.OAuth2(
+        "test-client.apps.googleusercontent.com",
+        "test-secret",
+      );
+      oauth2Client.setCredentials({ access_token: "emulator-token" });
+
+      gmailClient = gmail({
+        version: "v1",
+        auth: oauth2Client,
+        rootUrl: emulator.url,
+      });
+    });
+
+    afterAll(async () => {
+      await emulator?.close();
+    });
+
+    beforeEach(async () => {
+      await emulator.reset();
+      mockUpdateEmailMessagesForSender.mockClear();
+      mockPublishBulkActionToTinybird.mockClear();
+      vi.resetModules();
+    });
+
+    it("archives only the targeted sender when the queued handler runs", async () => {
+      const { POST } = await import("@/app/api/mail/bulk-archive/route");
+
+      const response = await POST(
+        new Request("http://localhost/api/mail/bulk-archive", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": process.env.INTERNAL_API_KEY!,
+          },
+          body: JSON.stringify({
+            emailAccountId: "account-1",
+            ownerEmail: TEST_EMAIL,
+            provider: "google",
+            sender: "target@example.com",
+          }),
+        }) as any,
+      );
+
+      expect(response.status).toBe(200);
+
+      const [targetMessageOne, targetMessageTwo, otherMessage] =
+        await Promise.all([
+          gmailClient.users.messages.get({
+            userId: "me",
+            id: "msg_1",
+            format: "metadata",
+          }),
+          gmailClient.users.messages.get({
+            userId: "me",
+            id: "msg_2",
+            format: "metadata",
+          }),
+          gmailClient.users.messages.get({
+            userId: "me",
+            id: "msg_3",
+            format: "metadata",
+          }),
+        ]);
+
+      expect(targetMessageOne.data.labelIds).not.toContain("INBOX");
+      expect(targetMessageTwo.data.labelIds).not.toContain("INBOX");
+      expect(otherMessage.data.labelIds).toContain("INBOX");
+
+      expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledTimes(1);
+      expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledWith({
+        sender: "target@example.com",
+        messageIds: ["msg_1", "msg_2"],
+        emailAccountId: "account-1",
+        action: "archive",
+      });
+      expect(mockPublishBulkActionToTinybird).toHaveBeenCalledTimes(1);
+      expect(mockPublishBulkActionToTinybird).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "archive",
+          ownerEmail: TEST_EMAIL,
+        }),
+      );
+    });
+  },
+);

--- a/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
+++ b/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
@@ -182,10 +182,13 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledTimes(1);
       expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledWith({
         sender: "target@example.com",
-        messageIds: ["msg_1", "msg_2"],
+        messageIds: expect.arrayContaining(["msg_1", "msg_2"]),
         emailAccountId: "account-1",
         action: "archive",
       });
+      expect(
+        mockUpdateEmailMessagesForSender.mock.calls[0]?.[0]?.messageIds,
+      ).toHaveLength(2);
       expect(mockPublishBulkActionToTinybird).toHaveBeenCalledTimes(1);
       expect(mockPublishBulkActionToTinybird).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
+++ b/apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts
@@ -24,6 +24,8 @@ vi.mock("server-only", () => ({}));
 
 const mockUpdateEmailMessagesForSender = vi.fn().mockResolvedValue(undefined);
 const mockPublishBulkActionToTinybird = vi.fn().mockResolvedValue(undefined);
+const mockSaveBulkArchiveProgress = vi.fn().mockResolvedValue(undefined);
+const mockSaveBulkArchiveTotalItems = vi.fn().mockResolvedValue(undefined);
 
 let gmailClient: gmail_v1.Gmail;
 
@@ -39,6 +41,15 @@ vi.mock("@/utils/email/bulk-action-tracking", () => ({
   publishBulkActionToTinybird: (
     ...args: Parameters<typeof mockPublishBulkActionToTinybird>
   ) => mockPublishBulkActionToTinybird(...args),
+}));
+
+vi.mock("@/utils/redis/bulk-archive-progress", () => ({
+  saveBulkArchiveProgress: (
+    ...args: Parameters<typeof mockSaveBulkArchiveProgress>
+  ) => mockSaveBulkArchiveProgress(...args),
+  saveBulkArchiveTotalItems: (
+    ...args: Parameters<typeof mockSaveBulkArchiveTotalItems>
+  ) => mockSaveBulkArchiveTotalItems(...args),
 }));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
@@ -119,6 +130,8 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       await emulator.reset();
       mockUpdateEmailMessagesForSender.mockClear();
       mockPublishBulkActionToTinybird.mockClear();
+      mockSaveBulkArchiveProgress.mockClear();
+      mockSaveBulkArchiveTotalItems.mockClear();
       vi.resetModules();
     });
 
@@ -180,6 +193,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           ownerEmail: TEST_EMAIL,
         }),
       );
+      expect(mockSaveBulkArchiveProgress).toHaveBeenCalledWith({
+        emailAccountId: "account-1",
+        incrementCompleted: 1,
+      });
     });
   },
 );

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/utils/messaging/providers/slack/client", () => ({
   createSlackClient: () => emulatorClient,
 }));
 
-const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
 const TEST_PORT = 4098;
 
 describe.skipIf(!RUN_INTEGRATION_TESTS)(

--- a/apps/web/__tests__/integration/stats-reuse-messages.test.ts
+++ b/apps/web/__tests__/integration/stats-reuse-messages.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
 const TEST_EMAIL = "stats-test@example.com";
 const TEST_PORT = 4099;
 

--- a/apps/web/__tests__/integration/worker-queue.test.ts
+++ b/apps/web/__tests__/integration/worker-queue.test.ts
@@ -155,7 +155,7 @@ vi.mock("ioredis", () => ({
   },
 }));
 
-const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
 const TEST_ENV_KEYS = [
   "INTERNAL_API_KEY",
   "INTERNAL_API_URL",
@@ -256,6 +256,47 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         body: { emailAccountId: "account-2", message: { id: "msg-1" } },
         method: "POST",
         url: "/api/ai/digest",
+      });
+    });
+
+    it("processes mail bulk archive jobs with the default worker queues", async () => {
+      const serverInfo = await startTestServer(capturedRequests);
+      server = serverInfo.server;
+      setWorkerTestEnv(serverInfo.port);
+
+      const { startWorkerRuntime } = await import(
+        "../../../worker/src/runtime.mjs"
+      );
+      runtime = await startWorkerRuntime();
+
+      const { enqueueBackgroundJob } = await import("@/utils/queue/dispatch");
+
+      await enqueueBackgroundJob({
+        topic: "mail-bulk-archive",
+        body: {
+          emailAccountId: "account-3",
+          ownerEmail: "owner@example.com",
+          provider: "google",
+          sender: "sender@example.com",
+        },
+        qstash: {
+          queueName: "mail-bulk-archive",
+          parallelism: 1,
+          path: "/api/mail/bulk-archive",
+        },
+        logger: createScopedLogger("test"),
+      });
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0]).toMatchObject({
+        body: {
+          emailAccountId: "account-3",
+          ownerEmail: "owner@example.com",
+          provider: "google",
+          sender: "sender@example.com",
+        },
+        method: "POST",
+        url: "/api/mail/bulk-archive",
       });
     });
 

--- a/apps/web/__tests__/integration/worker-queue.test.ts
+++ b/apps/web/__tests__/integration/worker-queue.test.ts
@@ -284,7 +284,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           parallelism: 1,
           path: "/api/mail/bulk-archive",
         },
-        logger: createScopedLogger("test"),
+        logger: createTestLogger(),
       });
 
       expect(capturedRequests).toHaveLength(1);

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -109,7 +109,7 @@ describe("AutoCategorizationSetup", () => {
 
   it("dismisses the setup dialog after setup starts successfully", async () => {
     mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 12, hasSyncedMessages: true },
+      data: { totalUncategorizedSenders: 12 },
     });
 
     const onOpenChange = vi.fn();
@@ -129,27 +129,7 @@ describe("AutoCategorizationSetup", () => {
 
   it("dismisses the setup dialog when all senders are already categorized", async () => {
     mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 0, hasSyncedMessages: true },
-    });
-
-    const onOpenChange = vi.fn();
-
-    const { AutoCategorizationSetup } = await import(
-      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
-    );
-
-    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
-
-    await waitFor(() => {
-      expect(onOpenChange).toHaveBeenCalledWith(false);
-    });
-  });
-
-  it("dismisses the setup dialog when no emails have synced yet", async () => {
-    mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 0, hasSyncedMessages: false },
+      data: { totalUncategorizedSenders: 0 },
     });
 
     const onOpenChange = vi.fn();

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -1,19 +1,30 @@
 /** @vitest-environment jsdom */
 
 import React, { type ReactNode } from "react";
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 (globalThis as { React?: typeof React }).React = React;
 
 const mockSetupDialog = vi.fn();
 const mockUseAccount = vi.fn();
 const mockUseCategorizeProgress = vi.fn();
+const mockBulkCategorizeSendersAction = vi.fn();
 
 vi.mock("@/components/SetupCard", () => ({
-  SetupDialog: (props: { children: ReactNode }) => {
+  SetupDialog: (props: {
+    children: ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
     mockSetupDialog(props);
-    return <div>{props.children}</div>;
+    return props.open ? <div>{props.children}</div> : null;
   },
 }));
 
@@ -21,18 +32,27 @@ vi.mock("@/providers/EmailAccountProvider", () => ({
   useAccount: () => mockUseAccount(),
 }));
 
-vi.mock("@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress", () => ({
-  useCategorizeProgress: () => mockUseCategorizeProgress(),
-}));
+vi.mock(
+  "@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress",
+  () => ({
+    useCategorizeProgress: () => mockUseCategorizeProgress(),
+  }),
+);
 
 vi.mock("@/utils/actions/categorize", () => ({
-  bulkCategorizeSendersAction: vi.fn(),
+  bulkCategorizeSendersAction: (
+    ...args: Parameters<typeof mockBulkCategorizeSendersAction>
+  ) => mockBulkCategorizeSendersAction(...args),
 }));
 
 vi.mock("@/components/Toast", () => ({
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
 }));
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("AutoCategorizationSetup", () => {
   beforeEach(() => {
@@ -47,7 +67,7 @@ describe("AutoCategorizationSetup", () => {
     });
   });
 
-  it("prevents accidental dismissal from the backdrop or escape key", async () => {
+  it("allows the setup dialog to be dismissed", async () => {
     const { AutoCategorizationSetup } = await import(
       "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
     );
@@ -56,16 +76,26 @@ describe("AutoCategorizationSetup", () => {
 
     const setupDialogProps = mockSetupDialog.mock.calls[0]?.[0];
 
-    expect(setupDialogProps.dialogContentProps.hideCloseButton).toBe(true);
+    expect(setupDialogProps.dialogContentProps).toBeUndefined();
+  });
 
-    const interactOutsideEvent = { preventDefault: vi.fn() };
-    setupDialogProps.dialogContentProps.onInteractOutside(
-      interactOutsideEvent,
+  it("dismisses the setup dialog after a premium access error", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      serverError: "Please upgrade for AI access",
+    });
+
+    const onOpenChange = vi.fn();
+
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
     );
-    expect(interactOutsideEvent.preventDefault).toHaveBeenCalledTimes(1);
 
-    const escapeKeyEvent = { preventDefault: vi.fn() };
-    setupDialogProps.dialogContentProps.onEscapeKeyDown(escapeKeyEvent);
-    expect(escapeKeyEvent.preventDefault).toHaveBeenCalledTimes(1);
+    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -106,4 +106,44 @@ describe("AutoCategorizationSetup", () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it("dismisses the setup dialog after setup starts successfully", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      data: { totalUncategorizedSenders: 12 },
+    });
+
+    const onOpenChange = vi.fn();
+
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
+    );
+
+    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("dismisses the setup dialog when no work needs to run", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      data: { totalUncategorizedSenders: 0 },
+    });
+
+    const onOpenChange = vi.fn();
+
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
+    );
+
+    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -146,4 +146,22 @@ describe("AutoCategorizationSetup", () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it("dismisses the setup dialog when the action resolves without data", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({});
+
+    const onOpenChange = vi.fn();
+
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
+    );
+
+    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -67,7 +67,7 @@ describe("AutoCategorizationSetup", () => {
     });
   });
 
-  it("allows the setup dialog to be dismissed", async () => {
+  it("prevents dismissal before setup starts", async () => {
     const { AutoCategorizationSetup } = await import(
       "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
     );
@@ -76,7 +76,15 @@ describe("AutoCategorizationSetup", () => {
 
     const setupDialogProps = mockSetupDialog.mock.calls[0]?.[0];
 
-    expect(setupDialogProps.dialogContentProps).toBeUndefined();
+    expect(setupDialogProps.dialogContentProps.hideCloseButton).toBe(true);
+
+    const interactOutsideEvent = { preventDefault: vi.fn() };
+    setupDialogProps.dialogContentProps.onInteractOutside(interactOutsideEvent);
+    expect(interactOutsideEvent.preventDefault).toHaveBeenCalledTimes(1);
+
+    const escapeKeyEvent = { preventDefault: vi.fn() };
+    setupDialogProps.dialogContentProps.onEscapeKeyDown(escapeKeyEvent);
+    expect(escapeKeyEvent.preventDefault).toHaveBeenCalledTimes(1);
   });
 
   it("dismisses the setup dialog after a premium access error", async () => {

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx
@@ -109,7 +109,7 @@ describe("AutoCategorizationSetup", () => {
 
   it("dismisses the setup dialog after setup starts successfully", async () => {
     mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 12 },
+      data: { totalUncategorizedSenders: 12, hasSyncedMessages: true },
     });
 
     const onOpenChange = vi.fn();
@@ -127,9 +127,29 @@ describe("AutoCategorizationSetup", () => {
     });
   });
 
-  it("dismisses the setup dialog when no work needs to run", async () => {
+  it("dismisses the setup dialog when all senders are already categorized", async () => {
     mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 0 },
+      data: { totalUncategorizedSenders: 0, hasSyncedMessages: true },
+    });
+
+    const onOpenChange = vi.fn();
+
+    const { AutoCategorizationSetup } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup"
+    );
+
+    render(<AutoCategorizationSetup open onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("dismisses the setup dialog when no emails have synced yet", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      data: { totalUncategorizedSenders: 0, hasSyncedMessages: false },
     });
 
     const onOpenChange = vi.fn();

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -52,20 +52,14 @@ export function AutoCategorizationSetup({
         throw new Error(result.serverError);
       }
 
-      if (!result?.data?.hasSyncedMessages) {
-        toastSuccess({
-          description: "No emails have been synced yet.",
-        });
-        setIsBulkCategorizing(false);
-        onOpenChange?.(false);
-      } else if (result.data.totalUncategorizedSenders) {
+      if (result?.data?.totalUncategorizedSenders) {
         toastSuccess({
           description: `Categorizing ${result.data.totalUncategorizedSenders} senders... This may take a few minutes.`,
         });
         onOpenChange?.(false);
       } else {
         toastSuccess({
-          description: "All current senders are already categorized.",
+          description: "No more senders to categorize right now.",
         });
         setIsBulkCategorizing(false);
         onOpenChange?.(false);

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -78,6 +78,11 @@ export function AutoCategorizationSetup({
     <SetupDialog
       open={open}
       onOpenChange={onOpenChange}
+      dialogContentProps={{
+        hideCloseButton: true,
+        onInteractOutside: (event) => event.preventDefault(),
+        onEscapeKeyDown: (event) => event.preventDefault(),
+      }}
       imageSrc="/images/illustrations/working-vacation.svg"
       imageAlt="Bulk Archive"
       title="Bulk Archive"

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -56,9 +56,11 @@ export function AutoCategorizationSetup({
         toastSuccess({
           description: `Categorizing ${result.data.totalUncategorizedSenders} senders... This may take a few minutes.`,
         });
+        onOpenChange?.(false);
       } else {
         toastSuccess({ description: "No uncategorized senders found." });
         setIsBulkCategorizing(false);
+        onOpenChange?.(false);
       }
     } catch (error) {
       toastError({

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -65,20 +65,19 @@ export function AutoCategorizationSetup({
         description: `Failed to enable feature: ${error instanceof Error ? error.message : "Unknown error"}`,
       });
       setIsBulkCategorizing(false);
+
+      if (isUpgradeError(error)) {
+        onOpenChange?.(false);
+      }
     } finally {
       setIsEnabling(false);
     }
-  }, [emailAccountId, setIsBulkCategorizing]);
+  }, [emailAccountId, onOpenChange, setIsBulkCategorizing]);
 
   return (
     <SetupDialog
       open={open}
       onOpenChange={onOpenChange}
-      dialogContentProps={{
-        hideCloseButton: true,
-        onInteractOutside: (event) => event.preventDefault(),
-        onEscapeKeyDown: (event) => event.preventDefault(),
-      }}
       imageSrc="/images/illustrations/working-vacation.svg"
       imageAlt="Bulk Archive"
       title="Bulk Archive"
@@ -90,4 +89,8 @@ export function AutoCategorizationSetup({
       </Button>
     </SetupDialog>
   );
+}
+
+function isUpgradeError(error: unknown) {
+  return error instanceof Error && error.message.includes("Please upgrade");
 }

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -52,7 +52,12 @@ export function AutoCategorizationSetup({
         throw new Error(result.serverError);
       }
 
-      if (result?.data?.totalUncategorizedSenders) {
+      if (!result?.data) {
+        toastSuccess({
+          description: "Categorization started.",
+        });
+        onOpenChange?.(false);
+      } else if (result.data.totalUncategorizedSenders) {
         toastSuccess({
           description: `Categorizing ${result.data.totalUncategorizedSenders} senders... This may take a few minutes.`,
         });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx
@@ -52,13 +52,21 @@ export function AutoCategorizationSetup({
         throw new Error(result.serverError);
       }
 
-      if (result?.data?.totalUncategorizedSenders) {
+      if (!result?.data?.hasSyncedMessages) {
+        toastSuccess({
+          description: "No emails have been synced yet.",
+        });
+        setIsBulkCategorizing(false);
+        onOpenChange?.(false);
+      } else if (result.data.totalUncategorizedSenders) {
         toastSuccess({
           description: `Categorizing ${result.data.totalUncategorizedSenders} senders... This may take a few minutes.`,
         });
         onOpenChange?.(false);
       } else {
-        toastSuccess({ description: "No uncategorized senders found." });
+        toastSuccess({
+          description: "All current senders are already categorized.",
+        });
         setIsBulkCategorizing(false);
         onOpenChange?.(false);
       }

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
@@ -17,6 +17,7 @@ import { PageWrapper } from "@/components/PageWrapper";
 import { LoadingContent } from "@/components/LoadingContent";
 import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { PageHeading } from "@/components/Typography";
+import { EmailStatsPreloader } from "@/components/EmailStatsPreloader";
 
 export function BulkArchive() {
   const { isBulkCategorizing } = useCategorizeProgress();
@@ -58,6 +59,7 @@ export function BulkArchive() {
 
   return (
     <LoadingContent loading={isLoading} error={error}>
+      <EmailStatsPreloader />
       <PageWrapper>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
@@ -18,8 +18,11 @@ import { LoadingContent } from "@/components/LoadingContent";
 import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { PageHeading } from "@/components/Typography";
 import { EmailStatsPreloader } from "@/components/EmailStatsPreloader";
+import { clearArchiveSenderStatuses } from "@/store/archive-sender-queue";
+import { useAccount } from "@/providers/EmailAccountProvider";
 
 export function BulkArchive() {
+  const { emailAccountId } = useAccount();
   const { isBulkCategorizing } = useCategorizeProgress();
   const [onboarding] = useQueryState("onboarding", parseAsBoolean);
   const [bulkAction, setBulkAction] = useState<BulkActionType>("archive");
@@ -47,8 +50,9 @@ export function BulkArchive() {
   );
 
   const handleProgressComplete = useCallback(() => {
+    clearArchiveSenderStatuses(emailAccountId);
     mutate();
-  }, [mutate]);
+  }, [emailAccountId, mutate]);
 
   const [setupDismissed, setSetupDismissed] = useState(false);
 

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSWR = vi.fn();
+const mockProgressPanel = vi.fn();
+const mockUseCategorizeProgress = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("swr", () => ({
+  default: (...args: Parameters<typeof mockUseSWR>) => mockUseSWR(...args),
+}));
+
+vi.mock("@/components/ProgressPanel", () => ({
+  ProgressPanel: (props: {
+    totalItems: number;
+    remainingItems: number;
+    completedText: string;
+  }) => {
+    mockProgressPanel(props);
+    return (
+      <div>
+        {props.remainingItems} remaining / {props.totalItems} total
+      </div>
+    );
+  },
+}));
+
+vi.mock(
+  "@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress",
+  () => ({
+    useCategorizeProgress: () => mockUseCategorizeProgress(),
+  }),
+);
+
+describe("BulkArchiveProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseCategorizeProgress.mockReturnValue({
+      isBulkCategorizing: false,
+      setIsBulkCategorizing: vi.fn(),
+    });
+  });
+
+  it("shows completed backend progress after a refresh", async () => {
+    mockUseSWR.mockReturnValue({
+      data: { totalItems: 8, completedItems: 8 },
+    });
+
+    const { BulkArchiveProgress } = await import(
+      "@/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress"
+    );
+
+    render(<BulkArchiveProgress />);
+
+    expect(screen.getByText("0 remaining / 8 total")).toBeTruthy();
+    expect(mockProgressPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalItems: 8,
+        remainingItems: 0,
+        completedText: "Categorization complete! 8 senders categorized!",
+      }),
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import useSWR from "swr";
 import { ProgressPanel } from "@/components/ProgressPanel";
 import type { CategorizeProgress } from "@/app/api/user/categorize/senders/progress/route";
 import { useCategorizeProgress } from "@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress";
-import { useInterval } from "@/hooks/useInterval";
 
 export function BulkArchiveProgress({
   onComplete,
@@ -13,7 +12,6 @@ export function BulkArchiveProgress({
   onComplete?: () => void;
 }) {
   const { isBulkCategorizing, setIsBulkCategorizing } = useCategorizeProgress();
-  const [fakeProgress, setFakeProgress] = useState(0);
 
   // Check if there's active progress (categorization in progress from server)
   const { data } = useSWR<CategorizeProgress>(
@@ -26,7 +24,10 @@ export function BulkArchiveProgress({
   // Categorization is active if explicitly set OR if server shows incomplete progress
   const hasActiveProgress =
     data?.totalItems && data.completedItems < data.totalItems;
-  const isCategorizationActive = isBulkCategorizing || hasActiveProgress;
+  const hasCompletedProgress =
+    !!data?.totalItems && data.completedItems === data.totalItems;
+  const isCategorizationVisible =
+    isBulkCategorizing || hasActiveProgress || hasCompletedProgress;
 
   // Sync local state with server state
   useEffect(() => {
@@ -34,25 +35,6 @@ export function BulkArchiveProgress({
       setIsBulkCategorizing(true);
     }
   }, [hasActiveProgress, isBulkCategorizing, setIsBulkCategorizing]);
-
-  // Fake progress animation to make it feel responsive
-  useInterval(
-    () => {
-      if (!data?.totalItems) return;
-
-      setFakeProgress((prev) => {
-        const realCompleted = data.completedItems || 0;
-        if (realCompleted > prev) return realCompleted;
-
-        const maxProgress = Math.min(
-          Math.floor(data.totalItems * 0.9),
-          realCompleted + 30,
-        );
-        return prev < maxProgress ? prev + 1 : prev;
-      });
-    },
-    isCategorizationActive ? 1500 : null,
-  );
 
   // Handle completion
   useEffect(() => {
@@ -64,7 +46,6 @@ export function BulkArchiveProgress({
     ) {
       timeoutId = setTimeout(() => {
         setIsBulkCategorizing(false);
-        setFakeProgress(0);
         onComplete?.();
       }, 3000);
     }
@@ -78,19 +59,19 @@ export function BulkArchiveProgress({
     onComplete,
   ]);
 
-  if (!isCategorizationActive || !data?.totalItems) {
+  if (!isCategorizationVisible || !data?.totalItems) {
     return null;
   }
 
   const totalItems = data.totalItems || 0;
-  const displayedProgress = Math.max(data.completedItems || 0, fakeProgress);
+  const completedItems = data.completedItems || 0;
 
   return (
     <ProgressPanel
       totalItems={totalItems}
-      remainingItems={totalItems - displayedProgress}
+      remainingItems={totalItems - completedItems}
       inProgressText="Categorizing senders..."
-      completedText={`Categorization complete! ${displayedProgress} senders categorized!`}
+      completedText={`Categorization complete! ${completedItems} senders categorized!`}
       itemLabel="senders"
     />
   );

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ArchiveProgress } from "./ArchiveProgress";
+
+const mockUseSWR = vi.fn();
+const mockUseQueueState = vi.fn();
+const mockResetTotalThreads = vi.fn();
+
+vi.mock("swr", () => ({
+  default: (...args: Parameters<typeof mockUseSWR>) => mockUseSWR(...args),
+}));
+
+vi.mock("@/store/archive-queue", () => ({
+  useQueueState: (...args: Parameters<typeof mockUseQueueState>) =>
+    mockUseQueueState(...args),
+  resetTotalThreads: (...args: Parameters<typeof mockResetTotalThreads>) =>
+    mockResetTotalThreads(...args),
+}));
+
+describe("ArchiveProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefers backend bulk archive progress when present", () => {
+    mockUseSWR.mockReturnValue({
+      data: {
+        totalItems: 3,
+        completedItems: 1,
+      },
+    });
+    mockUseQueueState.mockReturnValue({
+      totalThreads: 4,
+      activeThreads: {
+        "archive-thread-1": { threadId: "thread-1", actionType: "archive" },
+      },
+    });
+
+    render(<ArchiveProgress />);
+
+    expect(screen.getByText("Archiving senders...")).toBeTruthy();
+    expect(screen.getByText("1 of 3 senders processed")).toBeTruthy();
+    expect(screen.queryByText("3 of 4 emails processed")).toBeNull();
+  });
+
+  it("falls back to the local archive queue progress", () => {
+    mockUseSWR.mockReturnValue({ data: null });
+    mockUseQueueState.mockReturnValue({
+      totalThreads: 4,
+      activeThreads: {
+        "archive-thread-1": { threadId: "thread-1", actionType: "archive" },
+      },
+    });
+
+    render(<ArchiveProgress />);
+
+    expect(screen.getByText("Archiving emails...")).toBeTruthy();
+    expect(screen.getByText("3 of 4 emails processed")).toBeTruthy();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.tsx
@@ -1,25 +1,49 @@
 "use client";
 
 import { memo, useEffect } from "react";
+import useSWR from "swr";
+import type { BulkArchiveProgress } from "@/app/api/user/bulk-archive/progress/route";
 import { resetTotalThreads, useQueueState } from "@/store/archive-queue";
 import { ProgressPanel } from "@/components/ProgressPanel";
 
 export const ArchiveProgress = memo(() => {
   const { totalThreads, activeThreads } = useQueueState();
+  const { data: bulkArchiveProgress } = useSWR<BulkArchiveProgress>(
+    "/api/user/bulk-archive/progress",
+    {
+      refreshInterval: 1000,
+    },
+  );
 
-  // Make sure activeThreads is an object as this was causing an error.
+  const hasBackendProgress = Boolean(bulkArchiveProgress?.totalItems);
   const threadsRemaining = Object.values(activeThreads || {}).length;
   const totalProcessed = totalThreads - threadsRemaining;
-  const progress = (totalProcessed / totalThreads) * 100;
-  const isCompleted = progress === 100;
+  const localProgress =
+    totalThreads > 0 ? (totalProcessed / totalThreads) * 100 : 0;
+  const isLocalCompleted = localProgress === 100;
 
   useEffect(() => {
-    if (isCompleted) {
+    if (isLocalCompleted) {
       setTimeout(() => {
         resetTotalThreads();
       }, 5000);
     }
-  }, [isCompleted]);
+  }, [isLocalCompleted]);
+
+  if (hasBackendProgress) {
+    return (
+      <ProgressPanel
+        totalItems={bulkArchiveProgress?.totalItems || 0}
+        remainingItems={
+          (bulkArchiveProgress?.totalItems || 0) -
+          (bulkArchiveProgress?.completedItems || 0)
+        }
+        inProgressText="Archiving senders..."
+        completedText="Archiving complete!"
+        itemLabel="senders"
+      />
+    );
+  }
 
   return (
     <ProgressPanel

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkActions.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkActions.tsx
@@ -130,7 +130,6 @@ export function BulkActions({
   });
 
   const { onBulkArchive, isBulkArchiving } = useBulkArchive({
-    mutate,
     posthog,
     emailAccountId,
   });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -140,10 +140,10 @@ export function BulkUnsubscribeRowDesktop({
         </div>
       </TableCell>
       <TableCell>
-        <span className="text-muted-foreground">{item.value}</span>
+        <span className="font-medium text-foreground/80">{item.value}</span>
       </TableCell>
       <TableCell>
-        <span className="text-muted-foreground">
+        <span className="font-medium text-foreground/80">
           {Math.round(readPercentage)}%
         </span>
       </TableCell>

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -117,15 +117,25 @@ export function BulkUnsubscribeRowDesktop({
       <TableCell className="max-w-[250px] py-3 pl-8">
         <div className="flex items-center gap-2">
           <DomainIcon domain={domain} size={32} variant="circular" />
-          <div className="flex flex-col min-w-0">
-            <span className="font-medium truncate">
-              {item.fromName || item.name}
-            </span>
-            {item.fromName && (
-              <span className="text-xs text-muted-foreground truncate">
-                {item.name}
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="truncate font-medium">
+                {item.fromName || item.name}
               </span>
-            )}
+              {item.fromName && (
+                <span
+                  aria-hidden="true"
+                  className="shrink-0 text-muted-foreground"
+                >
+                  ·
+                </span>
+              )}
+              {item.fromName && (
+                <span className="truncate text-sm text-muted-foreground">
+                  {item.name}
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </TableCell>

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeMobile.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeMobile.tsx
@@ -75,7 +75,6 @@ export function BulkUnsubscribeRowMobile({
     },
   );
   const { onBulkArchive, isBulkArchiving } = useBulkArchive({
-    mutate,
     posthog,
     emailAccountId,
   });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
@@ -263,7 +263,6 @@ export function MoreDropdown<T extends Row>({
   const { provider } = useAccount();
   const terminology = getEmailTerminology(provider);
   const { onBulkArchive, isBulkArchiving } = useBulkArchive({
-    mutate,
     posthog,
     emailAccountId,
   });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
@@ -50,6 +50,7 @@ import type { EmailLabel } from "@/providers/EmailProvider";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { getEmailTerminology } from "@/utils/terminology";
+import { Tooltip } from "@/components/Tooltip";
 
 export function ActionCell<T extends Row>({
   item,
@@ -232,14 +233,24 @@ function ApproveButton<T extends Row>({
   });
 
   return (
-    <Button
-      size="sm"
-      variant={isApproved ? "green" : "ghost"}
-      onClick={onApprove}
-      disabled={!hasUnsubscribeAccess}
+    <Tooltip
+      content={
+        isApproved
+          ? "Approved sender. Keep these emails in your inbox."
+          : "Approve sender to keep these emails in your inbox."
+      }
     >
-      <ThumbsUpIcon className={`size-5 ${isApproved ? "" : "text-gray-400"}`} />
-    </Button>
+      <Button
+        size="sm"
+        variant={isApproved ? "green" : "ghost"}
+        onClick={onApprove}
+        disabled={!hasUnsubscribeAccess}
+      >
+        <ThumbsUpIcon
+          className={`size-5 ${isApproved ? "" : "text-gray-400"}`}
+        />
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -12,7 +12,10 @@ import {
 import { decrementUnsubscribeCreditAction } from "@/utils/actions/premium";
 import { NewsletterStatus } from "@/generated/prisma/enums";
 import { captureException } from "@/utils/error";
-import { addToArchiveSenderQueue } from "@/store/archive-sender-queue";
+import {
+  addToArchiveSenderThreadQueue,
+  useArchiveSenderQueueActions,
+} from "@/store/archive-sender-queue";
 import { deleteEmails } from "@/store/archive-queue";
 import type { Row } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
 import type { GetThreadsResponse } from "@/app/api/threads/basic/route";
@@ -41,6 +44,10 @@ type MutateFn = (
   data?: any,
   opts?: { revalidate?: boolean },
 ) => Promise<void>;
+
+type QueueArchiveSendersFn = (params: {
+  senders: string[];
+}) => Promise<unknown>;
 
 function pluralize(count: number, singular: string): string {
   return count === 1 ? singular : `${singular}s`;
@@ -181,12 +188,14 @@ async function unsubscribeAndArchive({
   mutate,
   refetchPremium,
   emailAccountId,
+  queueArchiveSenders,
 }: {
   newsletterEmail: string;
   unsubscribeLink?: string | null;
   mutate: () => Promise<void>;
   refetchPremium: () => Promise<UserResponse | null | undefined>;
   emailAccountId: string;
+  queueArchiveSenders: QueueArchiveSendersFn;
 }) {
   const unsubscribed = await performAutomaticUnsubscribe({
     emailAccountId,
@@ -198,10 +207,7 @@ async function unsubscribeAndArchive({
   await mutate();
   await decrementUnsubscribeCreditAction();
   await refetchPremium();
-  await addToArchiveSenderQueue({
-    sender: newsletterEmail,
-    emailAccountId,
-  });
+  await queueArchiveSenders({ senders: [newsletterEmail] });
 
   return true;
 }
@@ -211,11 +217,13 @@ async function blockSender({
   emailAccountId,
   labelId,
   labelName,
+  queueArchiveSenders,
 }: {
   sender: string;
   emailAccountId: string;
   labelId?: string;
   labelName?: string;
+  queueArchiveSenders: QueueArchiveSendersFn;
 }) {
   await onAutoArchive({
     emailAccountId,
@@ -228,11 +236,17 @@ async function blockSender({
     status: NewsletterStatus.AUTO_ARCHIVED,
   });
   await decrementUnsubscribeCreditAction();
-  await addToArchiveSenderQueue({
-    sender,
-    labelId,
-    emailAccountId,
-  });
+
+  if (labelId) {
+    await addToArchiveSenderThreadQueue({
+      sender,
+      labelId,
+      emailAccountId,
+    });
+    return;
+  }
+
+  await queueArchiveSenders({ senders: [sender] });
 }
 
 export function useUnsubscribe<T extends Row>({
@@ -251,6 +265,7 @@ export function useUnsubscribe<T extends Row>({
   refetchPremium: () => Promise<UserResponse | null | undefined>;
 }) {
   const [unsubscribeLoading, setUnsubscribeLoading] = useState(false);
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
   const automaticUnsubscribeLink = getAutomaticUnsubscribeLink(
     item.unsubscribeLink,
   );
@@ -277,6 +292,7 @@ export function useUnsubscribe<T extends Row>({
           await blockSender({
             sender: item.name,
             emailAccountId,
+            queueArchiveSenders,
           });
           await mutate();
           await refetchPremium();
@@ -291,6 +307,7 @@ export function useUnsubscribe<T extends Row>({
           mutate,
           refetchPremium,
           emailAccountId,
+          queueArchiveSenders,
         });
         if (!unsubscribed) {
           toast.error(`Could not automatically unsubscribe from ${item.name}`);
@@ -312,6 +329,7 @@ export function useUnsubscribe<T extends Row>({
     posthog,
     emailAccountId,
     userFacingUnsubscribeLink,
+    queueArchiveSenders,
   ]);
 
   return {
@@ -341,6 +359,8 @@ export function useBulkUnsubscribe<T extends Row>({
   onDeselectItem?: (id: string) => void;
   filter: NewsletterFilterType;
 }) {
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
+
   const onBulkUnsubscribe = useCallback(
     async (items: T[]) => {
       if (!hasUnsubscribeAccess) return;
@@ -364,6 +384,7 @@ export function useBulkUnsubscribe<T extends Row>({
             await blockSender({
               sender: item.name,
               emailAccountId,
+              queueArchiveSenders,
             });
             return;
           }
@@ -378,10 +399,7 @@ export function useBulkUnsubscribe<T extends Row>({
           }
 
           await decrementUnsubscribeCreditAction();
-          await addToArchiveSenderQueue({
-            sender: item.name,
-            emailAccountId,
-          });
+          await queueArchiveSenders({ senders: [item.name] });
         },
         onComplete: async () => {
           await mutate();
@@ -397,6 +415,7 @@ export function useBulkUnsubscribe<T extends Row>({
       emailAccountId,
       onDeselectItem,
       filter,
+      queueArchiveSenders,
     ],
   );
 
@@ -410,6 +429,7 @@ async function autoArchive({
   mutate,
   refetchPremium,
   emailAccountId,
+  queueArchiveSenders,
 }: {
   name: string;
   labelId: string | undefined;
@@ -417,12 +437,14 @@ async function autoArchive({
   mutate: () => Promise<void>;
   refetchPremium: () => Promise<UserResponse | null | undefined>;
   emailAccountId: string;
+  queueArchiveSenders: QueueArchiveSendersFn;
 }) {
   await blockSender({
     sender: name,
     emailAccountId,
     labelId,
     labelName,
+    queueArchiveSenders,
   });
   await mutate();
   await refetchPremium();
@@ -444,6 +466,7 @@ export function useAutoArchive<T extends Row>({
   emailAccountId: string;
 }) {
   const [autoArchiveLoading, setAutoArchiveLoading] = useState(false);
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
 
   const onAutoArchiveClick = useCallback(async () => {
     if (!hasUnsubscribeAccess) return;
@@ -457,6 +480,7 @@ export function useAutoArchive<T extends Row>({
       mutate,
       refetchPremium,
       emailAccountId,
+      queueArchiveSenders,
     });
 
     posthog.capture("Clicked Auto Archive");
@@ -469,6 +493,7 @@ export function useAutoArchive<T extends Row>({
     hasUnsubscribeAccess,
     posthog,
     emailAccountId,
+    queueArchiveSenders,
   ]);
 
   const onDisableAutoArchive = useCallback(async () => {
@@ -502,11 +527,19 @@ export function useAutoArchive<T extends Row>({
         mutate,
         refetchPremium,
         emailAccountId,
+        queueArchiveSenders,
       });
 
       setAutoArchiveLoading(false);
     },
-    [item.name, mutate, refetchPremium, hasUnsubscribeAccess, emailAccountId],
+    [
+      item.name,
+      mutate,
+      refetchPremium,
+      hasUnsubscribeAccess,
+      emailAccountId,
+      queueArchiveSenders,
+    ],
   );
 
   return {
@@ -532,6 +565,8 @@ export function useBulkAutoArchive<T extends Row>({
   onDeselectItem?: (id: string) => void;
   filter: NewsletterFilterType;
 }) {
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
+
   const onBulkAutoArchive = useCallback(
     async (items: T[]) => {
       if (!hasUnsubscribeAccess) return;
@@ -557,11 +592,7 @@ export function useBulkAutoArchive<T extends Row>({
             status: NewsletterStatus.AUTO_ARCHIVED,
           });
           await decrementUnsubscribeCreditAction();
-          await addToArchiveSenderQueue({
-            sender: item.name,
-            labelId: undefined,
-            emailAccountId,
-          });
+          await queueArchiveSenders({ senders: [item.name] });
         },
         onComplete: refetchPremium,
       });
@@ -573,6 +604,7 @@ export function useBulkAutoArchive<T extends Row>({
       emailAccountId,
       onDeselectItem,
       filter,
+      queueArchiveSenders,
     ],
   );
 
@@ -731,36 +763,41 @@ export function useBulkApprove<T extends Row>({
 }
 
 export function useBulkArchive<T extends Row>({
-  mutate,
   posthog,
   emailAccountId,
 }: {
-  mutate: () => Promise<unknown>;
   posthog: PostHog;
   emailAccountId: string;
 }) {
   const { executeAsync: executeBulkArchive, isExecuting } = useAction(
     bulkArchiveAction.bind(null, emailAccountId),
-    {
-      onSuccess: () => {
-        mutate();
-      },
-    },
   );
 
   const onBulkArchive = (items: T[]) => {
     posthog.capture("Clicked Bulk Archive");
     const promise = executeBulkArchive({
       froms: items.map((item) => item.name),
+    }).then((result) => {
+      if (result?.serverError) {
+        throw new Error(result.serverError);
+      }
+
+      return result;
     });
 
     const displayNames = formatSenderNames(items);
 
     toast.promise(promise, {
       loading: `Archiving emails from ${displayNames}...`,
-      success: `Archived emails from ${displayNames}`,
+      success: (result) =>
+        result?.data?.mode === "queued"
+          ? `Queued archive for ${displayNames}`
+          : `Archived emails from ${displayNames}`,
       error: (error) =>
-        error?.error?.serverError || "There was an error archiving the emails",
+        error instanceof Error
+          ? error.message
+          : error?.error?.serverError ||
+            "There was an error archiving the emails",
     });
   };
 
@@ -900,6 +937,8 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
   emailAccountId: string;
   userEmail: string;
 }) {
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
+
   // perform actions using keyboard shortcuts
   // TODO make this available to command-K dialog too
   useEffect(() => {
@@ -960,6 +999,7 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
             await blockSender({
               sender: item.name,
               emailAccountId,
+              queueArchiveSenders,
             });
             await mutate();
             await refetchPremium();
@@ -981,6 +1021,7 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
             mutate,
             refetchPremium,
             emailAccountId,
+            queueArchiveSenders,
           });
           if (!unsubscribed) return;
           return;
@@ -1010,6 +1051,7 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
     setSelectedRow,
     onOpenNewsletter,
     emailAccountId,
+    queueArchiveSenders,
   ]);
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
@@ -26,8 +26,8 @@ import { EmailCell } from "@/components/EmailCell";
 import { LoadingContent } from "@/components/LoadingContent";
 import { cn } from "@/utils";
 import {
-  addToArchiveSenderQueue,
   useArchiveSenderStatus,
+  useArchiveSenderQueueActions,
 } from "@/store/archive-sender-queue";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useThreads } from "@/hooks/useThreads";
@@ -75,6 +75,7 @@ const confidenceConfig = {
 
 export function BulkArchiveTab() {
   const { emailAccountId, userEmail } = useAccount();
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
 
   const { data, error, isLoading } = useSWR<CategorizedSendersResponse>(
     "/api/user/categorize/senders/categorized",
@@ -195,12 +196,9 @@ export function BulkArchiveTab() {
     const toArchive = candidates.filter((c) => selectedSenders[c.address]);
 
     try {
-      for (const candidate of toArchive) {
-        await addToArchiveSenderQueue({
-          sender: candidate.address,
-          emailAccountId,
-        });
-      }
+      await queueArchiveSenders({
+        senders: toArchive.map((candidate) => candidate.address),
+      });
       setArchiveComplete(true);
     } catch {
       toast.error("Failed to archive some senders. Please try again.");
@@ -440,6 +438,7 @@ export function BulkArchiveTab() {
                   {senders.map((candidate) => (
                     <SenderRow
                       key={candidate.address}
+                      emailAccountId={emailAccountId}
                       candidate={candidate}
                       isSelected={!!selectedSenders[candidate.address]}
                       isExpanded={!!expandedSenders[candidate.address]}
@@ -463,6 +462,7 @@ export function BulkArchiveTab() {
 }
 
 function SenderRow({
+  emailAccountId,
   candidate,
   isSelected,
   isExpanded,
@@ -470,6 +470,7 @@ function SenderRow({
   onToggleExpanded,
   userEmail,
 }: {
+  emailAccountId: string;
   candidate: ArchiveCandidate;
   isSelected: boolean;
   isExpanded: boolean;
@@ -477,7 +478,7 @@ function SenderRow({
   onToggleExpanded: () => void;
   userEmail: string;
 }) {
-  const status = useArchiveSenderStatus(candidate.address);
+  const status = useArchiveSenderStatus(emailAccountId, candidate.address);
 
   return (
     <div className={cn(!isSelected && "opacity-50")}>
@@ -538,21 +539,10 @@ function ArchiveStatus({
 }) {
   switch (status?.status) {
     case "completed":
-      if (status.threadsTotal) {
-        return (
-          <span className="text-sm text-green-600">
-            Archived {status.threadsTotal}!
-          </span>
-        );
+      if (status.queued) {
+        return <span className="text-sm text-blue-600">Queued</span>;
       }
       return <span className="text-sm text-muted-foreground">Archived</span>;
-    case "processing":
-      return (
-        <span className="text-sm text-blue-600">
-          {status.threadsTotal - status.threadIds.length} /{" "}
-          {status.threadsTotal}
-        </span>
-      );
     case "pending":
       return <span className="text-sm text-muted-foreground">Pending...</span>;
     default:

--- a/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
@@ -506,9 +506,10 @@ function SenderRow({
           <EmailCell
             emailAddress={candidate.address}
             className={cn(
-              "flex flex-col",
+              "min-w-0",
               !isSelected && "text-muted-foreground line-through",
             )}
+            singleLine
           />
         </div>
         <div className="flex items-center gap-3">

--- a/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
@@ -543,7 +543,13 @@ function ArchiveStatus({
       if (status.queued) {
         return <span className="text-sm text-blue-600">Queued</span>;
       }
-      return <span className="text-sm text-muted-foreground">Archived</span>;
+      return (
+        <span className="text-sm text-muted-foreground">
+          {status.archivedCount
+            ? `Archived ${status.archivedCount}`
+            : "Archived"}
+        </span>
+      );
     case "pending":
       return <span className="text-sm text-muted-foreground">Pending...</span>;
     default:

--- a/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx
@@ -483,7 +483,7 @@ function SenderRow({
   return (
     <div className={cn(!isSelected && "opacity-50")}>
       <div
-        className="flex cursor-pointer items-center gap-3 p-4 transition-colors hover:bg-muted/50"
+        className="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50"
         onClick={onToggleExpanded}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { ArchiveProgress } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress";
 import { BulkArchiveTab } from "@/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab";
+import { EmailStatsPreloader } from "@/components/EmailStatsPreloader";
 
 export default function QuickBulkArchivePage() {
   return (
@@ -18,6 +19,7 @@ export default function QuickBulkArchivePage() {
         <PageHeader title="Quick Bulk Archive" />
 
         <ClientOnly>
+          <EmailStatsPreloader />
           <BulkArchiveTab />
         </ClientOnly>
       </PageWrapper>

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.test.tsx
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSWR = vi.fn();
+const mockProgressPanel = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("swr", () => ({
+  default: (...args: Parameters<typeof mockUseSWR>) => mockUseSWR(...args),
+}));
+
+vi.mock("@/components/ProgressPanel", () => ({
+  ProgressPanel: (props: {
+    totalItems: number;
+    remainingItems: number;
+    completedText: string;
+  }) => {
+    mockProgressPanel(props);
+    return (
+      <div>
+        {props.remainingItems} remaining / {props.totalItems} total
+      </div>
+    );
+  },
+}));
+
+describe("CategorizeSendersProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the real backend progress without faking additional completed items", async () => {
+    mockUseSWR.mockReturnValue({
+      data: { totalItems: 10, completedItems: 4 },
+    });
+
+    const { CategorizeSendersProgress } = await import(
+      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress"
+    );
+
+    render(<CategorizeSendersProgress refresh />);
+
+    expect(screen.getByText("6 remaining / 10 total")).toBeTruthy();
+    expect(mockProgressPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalItems: 10,
+        remainingItems: 6,
+        completedText: "Categorization complete! 4 categorized!",
+      }),
+    );
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { atom, useAtom } from "jotai";
 import useSWR from "swr";
 import { ProgressPanel } from "@/components/ProgressPanel";
 import type { CategorizeProgress } from "@/app/api/user/categorize/senders/progress/route";
-import { useInterval } from "@/hooks/useInterval";
 
 const isCategorizeInProgressAtom = atom(false);
 
@@ -22,7 +21,6 @@ export function CategorizeSendersProgress({
   refresh: boolean;
 }) {
   const { isBulkCategorizing } = useCategorizeProgress();
-  const [fakeProgress, setFakeProgress] = useState(0);
 
   const { data } = useSWR<CategorizeProgress>(
     "/api/user/categorize/senders/progress",
@@ -31,31 +29,12 @@ export function CategorizeSendersProgress({
     },
   );
 
-  useInterval(
-    () => {
-      if (!data?.totalItems) return;
-
-      setFakeProgress((prev) => {
-        const realCompleted = data.completedItems || 0;
-        if (realCompleted > prev) return realCompleted;
-
-        const maxProgress = Math.min(
-          Math.floor(data.totalItems * 0.9),
-          realCompleted + 30,
-        );
-        return prev < maxProgress ? prev + 1 : prev;
-      });
-    },
-    isBulkCategorizing ? 1500 : null,
-  );
-
   const { setIsBulkCategorizing } = useCategorizeProgress();
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined;
     if (data?.completedItems === data?.totalItems) {
       timeoutId = setTimeout(() => {
         setIsBulkCategorizing(false);
-        setFakeProgress(0);
       }, 3000);
     }
     return () => {
@@ -63,17 +42,17 @@ export function CategorizeSendersProgress({
     };
   }, [data?.completedItems, data?.totalItems, setIsBulkCategorizing]);
 
-  if (!data) return null;
+  if (!data?.totalItems) return null;
 
   const totalItems = data.totalItems || 0;
-  const displayedProgress = Math.max(data.completedItems || 0, fakeProgress);
+  const completedItems = data.completedItems || 0;
 
   return (
     <ProgressPanel
       totalItems={totalItems}
-      remainingItems={totalItems - displayedProgress}
+      remainingItems={totalItems - completedItems}
       inProgressText="Categorizing senders..."
-      completedText={`Categorization complete! ${displayedProgress} categorized!`}
+      completedText={`Categorization complete! ${completedItems} categorized!`}
       itemLabel="senders"
     />
   );

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
@@ -88,9 +88,14 @@ describe("CategorizeWithAiButton", () => {
     vi.clearAllMocks();
 
     mockToastPromise.mockImplementation(async (runner, messages) => {
-      const result = await runner();
-      messages?.success?.(result);
-      return result;
+      try {
+        const result = await runner();
+        messages?.success?.(result);
+        return result;
+      } catch (error) {
+        messages?.error?.(error);
+        throw error;
+      }
     });
   });
 
@@ -138,5 +143,29 @@ describe("CategorizeWithAiButton", () => {
 
     const [, toastMessages] = mockToastPromise.mock.calls[0];
     expect(toastMessages.success(undefined)).toBe("Categorization started.");
+  });
+
+  it("stops bulk categorizing when the action throws", async () => {
+    mockBulkCategorizeSendersAction.mockRejectedValue(
+      new Error("Queue publish failed"),
+    );
+
+    const { CategorizeWithAiButton } = await import(
+      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton"
+    );
+
+    render(<CategorizeWithAiButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Categorize" }));
+
+    await waitFor(() => {
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(1, true);
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(2, false);
+    });
+
+    const [, toastMessages] = mockToastPromise.mock.calls[0];
+    expect(toastMessages.error(new Error("Queue publish failed"))).toBe(
+      "Error categorizing senders: Queue publish failed",
+    );
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
@@ -119,4 +119,24 @@ describe("CategorizeWithAiButton", () => {
       }),
     ).toBe("No more senders to categorize right now.");
   });
+
+  it("shows a fallback success message when the action resolves without data", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({});
+
+    const { CategorizeWithAiButton } = await import(
+      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton"
+    );
+
+    render(<CategorizeWithAiButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Categorize" }));
+
+    await waitFor(() => {
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(1, true);
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(2, false);
+    });
+
+    const [, toastMessages] = mockToastPromise.mock.calls[0];
+    expect(toastMessages.success(undefined)).toBe("Categorization started.");
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
@@ -94,36 +94,9 @@ describe("CategorizeWithAiButton", () => {
     });
   });
 
-  it("stops bulk categorizing and shows an empty-sync message when no emails have synced yet", async () => {
-    mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 0, hasSyncedMessages: false },
-    });
-
-    const { CategorizeWithAiButton } = await import(
-      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton"
-    );
-
-    render(<CategorizeWithAiButton />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Categorize" }));
-
-    await waitFor(() => {
-      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(1, true);
-      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(2, false);
-    });
-
-    const [, toastMessages] = mockToastPromise.mock.calls[0];
-    expect(
-      toastMessages.success({
-        totalUncategorizedSenders: 0,
-        hasSyncedMessages: false,
-      }),
-    ).toBe("No emails have been synced yet.");
-  });
-
   it("stops bulk categorizing and shows an already-categorized message when no work is left", async () => {
     mockBulkCategorizeSendersAction.mockResolvedValue({
-      data: { totalUncategorizedSenders: 0, hasSyncedMessages: true },
+      data: { totalUncategorizedSenders: 0 },
     });
 
     const { CategorizeWithAiButton } = await import(
@@ -143,8 +116,7 @@ describe("CategorizeWithAiButton", () => {
     expect(
       toastMessages.success({
         totalUncategorizedSenders: 0,
-        hasSyncedMessages: true,
       }),
-    ).toBe("All current senders are already categorized.");
+    ).toBe("No more senders to categorize right now.");
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+
+import React, { createElement, type ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockBulkCategorizeSendersAction = vi.fn();
+const mockSetIsBulkCategorizing = vi.fn();
+const mockToastPromise = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: ReactNode;
+    onClick?: () => void | Promise<void>;
+    disabled?: boolean;
+  }) =>
+    createElement(
+      "button",
+      {
+        type: "button",
+        onClick,
+        disabled,
+      },
+      children,
+    ),
+}));
+
+vi.mock("@/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/components/PremiumAlert", () => ({
+  PremiumTooltip: ({ children }: { children: ReactNode }) => children,
+  usePremium: () => ({ hasAiAccess: true }),
+}));
+
+vi.mock("@/app/(app)/premium/PremiumModal", () => ({
+  usePremiumModal: () => ({
+    PremiumModal: () => null,
+    openModal: vi.fn(),
+  }),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => ({ emailAccountId: "account-1" }),
+}));
+
+vi.mock(
+  "@/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress",
+  () => ({
+    useCategorizeProgress: () => ({
+      setIsBulkCategorizing: mockSetIsBulkCategorizing,
+    }),
+  }),
+);
+
+vi.mock("@/utils/actions/categorize", () => ({
+  bulkCategorizeSendersAction: (
+    ...args: Parameters<typeof mockBulkCategorizeSendersAction>
+  ) => mockBulkCategorizeSendersAction(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    promise: (...args: Parameters<typeof mockToastPromise>) =>
+      mockToastPromise(...args),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CategorizeWithAiButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockToastPromise.mockImplementation(async (runner, messages) => {
+      const result = await runner();
+      messages?.success?.(result);
+      return result;
+    });
+  });
+
+  it("stops bulk categorizing and shows an empty-sync message when no emails have synced yet", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      data: { totalUncategorizedSenders: 0, hasSyncedMessages: false },
+    });
+
+    const { CategorizeWithAiButton } = await import(
+      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton"
+    );
+
+    render(<CategorizeWithAiButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Categorize" }));
+
+    await waitFor(() => {
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(1, true);
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(2, false);
+    });
+
+    const [, toastMessages] = mockToastPromise.mock.calls[0];
+    expect(
+      toastMessages.success({
+        totalUncategorizedSenders: 0,
+        hasSyncedMessages: false,
+      }),
+    ).toBe("No emails have been synced yet.");
+  });
+
+  it("stops bulk categorizing and shows an already-categorized message when no work is left", async () => {
+    mockBulkCategorizeSendersAction.mockResolvedValue({
+      data: { totalUncategorizedSenders: 0, hasSyncedMessages: true },
+    });
+
+    const { CategorizeWithAiButton } = await import(
+      "@/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton"
+    );
+
+    render(<CategorizeWithAiButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Categorize" }));
+
+    await waitFor(() => {
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(1, true);
+      expect(mockSetIsBulkCategorizing).toHaveBeenNthCalledWith(2, false);
+    });
+
+    const [, toastMessages] = mockToastPromise.mock.calls[0];
+    expect(
+      toastMessages.success({
+        totalUncategorizedSenders: 0,
+        hasSyncedMessages: true,
+      }),
+    ).toBe("All current senders are already categorized.");
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
@@ -40,25 +40,28 @@ export function CategorizeWithAiButton({
               async () => {
                 setIsCategorizing(true);
                 setIsBulkCategorizing(true);
-                const result =
-                  await bulkCategorizeSendersAction(emailAccountId);
+                try {
+                  const result =
+                    await bulkCategorizeSendersAction(emailAccountId);
 
-                if (result?.serverError) {
+                  if (result?.serverError) {
+                    throw new Error(result.serverError);
+                  }
+
+                  const totalUncategorizedSenders =
+                    result?.data?.totalUncategorizedSenders || 0;
+
+                  if (totalUncategorizedSenders === 0) {
+                    setIsBulkCategorizing(false);
+                  }
+
+                  return result?.data;
+                } catch (error) {
+                  setIsBulkCategorizing(false);
+                  throw error;
+                } finally {
                   setIsCategorizing(false);
-                  setIsBulkCategorizing(false);
-                  throw new Error(result.serverError);
                 }
-
-                const totalUncategorizedSenders =
-                  result?.data?.totalUncategorizedSenders || 0;
-
-                if (totalUncategorizedSenders === 0) {
-                  setIsBulkCategorizing(false);
-                }
-
-                setIsCategorizing(false);
-
-                return result?.data;
               },
               {
                 loading: "Categorizing senders... This might take a while.",

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactElement } from "react";
 import { SparklesIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -45,19 +45,31 @@ export function CategorizeWithAiButton({
 
                 if (result?.serverError) {
                   setIsCategorizing(false);
+                  setIsBulkCategorizing(false);
                   throw new Error(result.serverError);
+                }
+
+                const totalUncategorizedSenders =
+                  result?.data?.totalUncategorizedSenders || 0;
+
+                if (totalUncategorizedSenders === 0) {
+                  setIsBulkCategorizing(false);
                 }
 
                 setIsCategorizing(false);
 
-                return result?.data?.totalUncategorizedSenders || 0;
+                return result?.data;
               },
               {
                 loading: "Categorizing senders... This might take a while.",
-                success: (totalUncategorizedSenders) => {
-                  return totalUncategorizedSenders
-                    ? `Categorizing ${totalUncategorizedSenders} senders...`
-                    : "There are no more senders to categorize.";
+                success: (data) => {
+                  if (!data?.hasSyncedMessages) {
+                    return "No emails have been synced yet.";
+                  }
+
+                  return data.totalUncategorizedSenders
+                    ? `Categorizing ${data.totalUncategorizedSenders} senders...`
+                    : "All current senders are already categorized.";
                 },
                 error: (err) => {
                   return `Error categorizing senders: ${err.message}`;
@@ -85,7 +97,7 @@ function CategorizeWithAiButtonTooltip({
   hasAiAccess,
   openPremiumModal,
 }: {
-  children: React.ReactElement<any>;
+  children: ReactElement;
   hasAiAccess: boolean;
   openPremiumModal: () => void;
 }) {

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
@@ -63,12 +63,20 @@ export function CategorizeWithAiButton({
               {
                 loading: "Categorizing senders... This might take a while.",
                 success: (data) => {
+                  if (!data) {
+                    return "Categorization started.";
+                  }
+
                   return data.totalUncategorizedSenders
                     ? `Categorizing ${data.totalUncategorizedSenders} senders...`
                     : "No more senders to categorize right now.";
                 },
                 error: (err) => {
-                  return `Error categorizing senders: ${err.message}`;
+                  const message =
+                    err instanceof Error
+                      ? err.message
+                      : "An unknown error occurred.";
+                  return `Error categorizing senders: ${message}`;
                 },
               },
             );

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx
@@ -63,13 +63,9 @@ export function CategorizeWithAiButton({
               {
                 loading: "Categorizing senders... This might take a while.",
                 success: (data) => {
-                  if (!data?.hasSyncedMessages) {
-                    return "No emails have been synced yet.";
-                  }
-
                   return data.totalUncategorizedSenders
                     ? `Categorizing ${data.totalUncategorizedSenders} senders...`
-                    : "All current senders are already categorized.";
+                    : "No more senders to categorize right now.";
                 },
                 error: (err) => {
                   return `Error categorizing senders: ${err.message}`;

--- a/apps/web/app/(app)/[emailAccountId]/smart-categories/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/smart-categories/page.tsx
@@ -27,6 +27,7 @@ import { CategorizeSendersProgress } from "@/app/(app)/[emailAccountId]/smart-ca
 import { getCategorizationProgress } from "@/utils/redis/categorization-progress";
 import { prefixPath } from "@/utils/path";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
+import { EmailStatsPreloader } from "@/components/EmailStatsPreloader";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -65,6 +66,7 @@ export default async function CategoriesPage({
 
       <ClientOnly>
         <ArchiveProgress />
+        <EmailStatsPreloader />
         <CategorizeSendersProgress refresh={!!progress} />
       </ClientOnly>
 

--- a/apps/web/app/(landing)/login/LoginForm.test.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.test.tsx
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSearchParams = vi.fn();
+const mockSignInWithOauth2 = vi.fn();
+const mockSignInSocial = vi.fn();
+const mockToastError = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { unoptimized?: boolean }) => (
+    // biome-ignore lint/performance/noImgElement: test-only mock
+    <img
+      {...props}
+      alt={props.alt || ""}
+      width={Number(props.width) || 1}
+      height={Number(props.height) || 1}
+    />
+  ),
+}));
+
+vi.mock("@/utils/auth-client", () => ({
+  signInWithOauth2: (...args: Parameters<typeof mockSignInWithOauth2>) =>
+    mockSignInWithOauth2(...args),
+  signIn: {
+    social: (...args: Parameters<typeof mockSignInSocial>) =>
+      mockSignInSocial(...args),
+  },
+}));
+
+vi.mock("@/components/Toast", () => ({
+  toastError: (...args: Parameters<typeof mockToastError>) =>
+    mockToastError(...args),
+}));
+
+import { LoginForm } from "@/app/(landing)/login/LoginForm";
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSearchParams.mockReturnValue({
+      get: () => null,
+    });
+  });
+
+  it("shows an inline error when emulator sign-in fails", async () => {
+    mockSignInWithOauth2.mockRejectedValue(
+      new Error("Failed to connect to Google sign-in."),
+    );
+
+    render(<LoginForm useGoogleOauthEmulator />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign in with google/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "I agree" }));
+
+    expect(
+      await screen.findByText("Failed to start Google sign-in"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Failed to connect to Google sign-in."),
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith({
+        title: "Error signing in with Google",
+        description: "Failed to connect to Google sign-in.",
+      });
+    });
+  });
+});

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -19,6 +19,7 @@ import { WELCOME_PATH } from "@/utils/config";
 import { toastError } from "@/components/Toast";
 import { isInternalPath } from "@/utils/path";
 import { getPossessiveBrandName } from "@/utils/branding";
+import { AlertBasic } from "@/components/Alert";
 
 export function LoginForm({
   useGoogleOauthEmulator,
@@ -31,16 +32,19 @@ export function LoginForm({
 
   const [loadingGoogle, setLoadingGoogle] = useState(false);
   const [loadingMicrosoft, setLoadingMicrosoft] = useState(false);
+  const [googleError, setGoogleError] = useState<string | null>(null);
 
   const handleGoogleSignIn = async () => {
     setLoadingGoogle(true);
+    setGoogleError(null);
     try {
       if (useGoogleOauthEmulator) {
-        await signInWithOauth2({
+        const result = await signInWithOauth2({
           providerId: "google",
           errorCallbackURL,
           callbackURL,
         });
+        window.location.href = result.url;
       } else {
         await signIn.social({
           provider: "google",
@@ -49,10 +53,12 @@ export function LoginForm({
         });
       }
     } catch (error) {
+      const description = getSocialSignInErrorMessage(error);
       console.error("Error signing in with Google:", error);
+      setGoogleError(description);
       toastError({
         title: "Error signing in with Google",
-        description: "Please try again or contact support",
+        description,
       });
     } finally {
       setLoadingGoogle(false);
@@ -101,6 +107,13 @@ export function LoginForm({
             </a>{" "}
             Policy, including the Limited Use requirements.
           </DialogDescription>
+          {googleError ? (
+            <AlertBasic
+              variant="destructive"
+              title="Failed to start Google sign-in"
+              description={googleError}
+            />
+          ) : null}
           <div>
             <Button loading={loadingGoogle} onClick={handleGoogleSignIn}>
               I agree
@@ -173,12 +186,21 @@ async function handleSocialSignIn({
       callbackURL,
     });
   } catch (error) {
+    const description = getSocialSignInErrorMessage(error);
     console.error(`Error signing in with ${providerName}:`, error);
     toastError({
       title: `Error signing in with ${providerName}`,
-      description: "Please try again or contact support",
+      description,
     });
   } finally {
     setLoading(false);
   }
+}
+
+function getSocialSignInErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Please try again or contact support.";
 }

--- a/apps/web/app/api/mail/bulk-archive/queue/route.ts
+++ b/apps/web/app/api/mail/bulk-archive/queue/route.ts
@@ -1,0 +1,19 @@
+import { createForwardingQueueHandler } from "@/utils/queue/create-forwarding-queue-handler";
+import { bulkArchiveSenderJobSchema } from "@/utils/actions/mail-bulk-action.validation";
+import { MAIL_BULK_ARCHIVE_PATH } from "@/utils/email/bulk-archive-queue";
+
+export const maxDuration = 300;
+
+export const POST = createForwardingQueueHandler({
+  loggerScope: "mail/bulk-archive/queue",
+  schema: bulkArchiveSenderJobSchema,
+  path: MAIL_BULK_ARCHIVE_PATH,
+  invalidPayloadMessage: "Invalid bulk archive queue payload",
+  visibilityTimeoutSeconds: 295,
+  getLoggerContext: (payload) => ({
+    emailAccountId: payload.emailAccountId,
+  }),
+  getTraceContext: (payload) => ({
+    sender: payload.sender,
+  }),
+});

--- a/apps/web/app/api/mail/bulk-archive/route.ts
+++ b/apps/web/app/api/mail/bulk-archive/route.ts
@@ -1,0 +1,20 @@
+import { withError, type RequestWithLogger } from "@/utils/middleware";
+import { withQstashOrInternal } from "@/utils/qstash";
+import { bulkArchiveSenderJobSchema } from "@/utils/actions/mail-bulk-action.validation";
+import { executeBulkArchiveSenderJob } from "@/utils/email/bulk-archive-queue";
+
+export const maxDuration = 300;
+
+export const POST = withError(
+  "mail/bulk-archive",
+  withQstashOrInternal(async (request: RequestWithLogger) => {
+    const body = bulkArchiveSenderJobSchema.parse(await request.json());
+
+    await executeBulkArchiveSenderJob({
+      ...body,
+      logger: request.logger,
+    });
+
+    return Response.json({ success: true });
+  }),
+);

--- a/apps/web/app/api/user/bulk-archive/progress/route.ts
+++ b/apps/web/app/api/user/bulk-archive/progress/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import { getBulkArchiveProgress } from "@/utils/redis/bulk-archive-progress";
+
+export type BulkArchiveProgress = Awaited<
+  ReturnType<typeof getArchiveProgress>
+>;
+
+async function getArchiveProgress({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  return getBulkArchiveProgress({ emailAccountId });
+}
+
+export const GET = withEmailAccount(
+  "user/bulk-archive/progress",
+  async (request) => {
+    const emailAccountId = request.auth.emailAccountId;
+    const result = await getArchiveProgress({ emailAccountId });
+    return NextResponse.json(result);
+  },
+);

--- a/apps/web/app/api/user/bulk-archive/sender-status/route.ts
+++ b/apps/web/app/api/user/bulk-archive/sender-status/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import { getBulkArchiveSenderStatuses } from "@/utils/redis/bulk-archive-sender-status";
+
+export type BulkArchiveSenderStatuses = Awaited<
+  ReturnType<typeof getArchiveSenderStatuses>
+>;
+
+async function getArchiveSenderStatuses({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  return getBulkArchiveSenderStatuses(emailAccountId);
+}
+
+export const GET = withEmailAccount(
+  "user/bulk-archive/sender-status",
+  async (request) => {
+    const result = await getArchiveSenderStatuses({
+      emailAccountId: request.auth.emailAccountId,
+    });
+    return NextResponse.json(result);
+  },
+);

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -461,7 +461,8 @@ function SenderRow({
           <EmailCell
             emailAddress={sender.address}
             name={sender.name}
-            className="flex flex-col"
+            className="min-w-0"
+            singleLine
           />
         </div>
         <div className="mr-2 text-right">

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -319,9 +319,6 @@ export function BulkArchiveCards({
                     <p className="text-sm text-muted-foreground">
                       {senders.length} senders
                       {isArchived && " archived"}
-                      {!isArchived &&
-                        (category?.description || defaultCat?.description) &&
-                        ` · ${category?.description || defaultCat?.description}`}
                     </p>
                   </div>
                 </div>

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -442,7 +442,7 @@ function SenderRow({
     <div>
       {/* Sender row */}
       <div
-        className="flex cursor-pointer items-center gap-3 p-4 transition-colors hover:bg-muted/50"
+        className="flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50"
         onClick={onToggle}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -30,8 +30,8 @@ import { useThreads } from "@/hooks/useThreads";
 import { formatShortDate } from "@/utils/date";
 import { cn } from "@/utils";
 import {
-  addToArchiveSenderQueue,
   useArchiveSenderStatus,
+  useArchiveSenderQueueActions,
 } from "@/store/archive-sender-queue";
 import {
   addToMarkReadSenderQueue,
@@ -60,6 +60,7 @@ export function BulkArchiveCards({
   onCategoryChange?: () => Promise<unknown>;
 }) {
   const { emailAccountId, userEmail } = useAccount();
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
   const [expandedCategory, setExpandedCategory] = useQueryState("expanded");
   const [expandedSenders, setExpandedSenders] = useState<
     Record<string, boolean>
@@ -230,14 +231,18 @@ export function BulkArchiveCards({
             sender: sender.address,
             emailAccountId,
           });
-        } else {
-          await addToArchiveSenderQueue({
-            sender: sender.address,
-            emailAccountId,
-          });
         }
       }
-      setArchivedCategories((prev) => ({ ...prev, [categoryName]: true }));
+
+      if (bulkAction === "archive") {
+        await queueArchiveSenders({
+          senders: selectedToProcess.map((sender) => sender.address),
+        });
+      }
+
+      if (bulkAction === "markRead") {
+        setArchivedCategories((prev) => ({ ...prev, [categoryName]: true }));
+      }
     } catch (_error) {
       toastError({
         description: `Failed to ${bulkAction === "markRead" ? "mark as read" : "archive"} some senders. Please try again.`,
@@ -432,7 +437,7 @@ function SenderRow({
   emailAccountId: string;
   onCategoryChange?: () => Promise<unknown>;
 }) {
-  const archiveStatus = useArchiveSenderStatus(sender.address);
+  const archiveStatus = useArchiveSenderStatus(emailAccountId, sender.address);
   const markReadStatus = useMarkReadSenderStatus(sender.address);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
 
@@ -605,20 +610,10 @@ function SenderStatus({
   if (archiveStatus?.status) {
     switch (archiveStatus.status) {
       case "completed":
-        return (
-          <span className="text-sm text-green-600">
-            {archiveStatus.threadsTotal
-              ? `Archived ${archiveStatus.threadsTotal}!`
-              : "Archived"}
-          </span>
-        );
-      case "processing":
-        return (
-          <span className="text-sm text-blue-600">
-            {archiveStatus.threadsTotal - archiveStatus.threadIds.length} /{" "}
-            {archiveStatus.threadsTotal}
-          </span>
-        );
+        if (archiveStatus.queued) {
+          return <span className="text-sm text-blue-600">Queued</span>;
+        }
+        return <span className="text-sm text-green-600">Archived</span>;
       case "pending":
         return (
           <span className="text-sm text-muted-foreground">Pending...</span>

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -611,7 +611,13 @@ function SenderStatus({
         if (archiveStatus.queued) {
           return <span className="text-sm text-blue-600">Queued</span>;
         }
-        return <span className="text-sm text-green-600">Archived</span>;
+        return (
+          <span className="text-sm text-green-600">
+            {archiveStatus.archivedCount
+              ? `Archived ${archiveStatus.archivedCount}`
+              : "Archived"}
+          </span>
+        );
       case "pending":
         return (
           <span className="text-sm text-muted-foreground">Pending...</span>

--- a/apps/web/components/EmailCell.tsx
+++ b/apps/web/components/EmailCell.tsx
@@ -5,14 +5,39 @@ export const EmailCell = memo(function EmailCell({
   emailAddress,
   name,
   className,
+  singleLine = false,
 }: {
   emailAddress: string;
   name?: string | null;
   className?: string;
+  singleLine?: boolean;
 }) {
   const displayName = name || extractNameFromEmail(emailAddress);
   const email = extractEmailAddress(emailAddress) || emailAddress;
   const showEmail = displayName !== email;
+
+  if (singleLine) {
+    return (
+      <div className={className}>
+        <div className="flex min-w-0 items-baseline gap-2">
+          <span className="truncate">{displayName}</span>
+          {showEmail && (
+            <>
+              <span
+                aria-hidden="true"
+                className="shrink-0 text-muted-foreground"
+              >
+                ·
+              </span>
+              <span className="truncate text-sm text-muted-foreground">
+                {email}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={className}>

--- a/apps/web/components/EmailStatsPreloader.tsx
+++ b/apps/web/components/EmailStatsPreloader.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { useStatLoader } from "@/providers/StatLoaderProvider";
+
+export function EmailStatsPreloader({
+  loadBefore = false,
+}: {
+  loadBefore?: boolean;
+}) {
+  const { emailAccountId } = useAccount();
+  const { onLoad } = useStatLoader();
+  const lastPreloadedAccountId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (lastPreloadedAccountId.current === emailAccountId) return;
+
+    lastPreloadedAccountId.current = emailAccountId;
+
+    async function preload() {
+      await onLoad({ loadBefore, showToast: false });
+    }
+
+    preload().catch(() => undefined);
+  }, [emailAccountId, loadBefore, onLoad]);
+
+  return null;
+}

--- a/apps/web/components/GroupedTable.tsx
+++ b/apps/web/components/GroupedTable.tsx
@@ -39,8 +39,8 @@ import {
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Button } from "@/components/ui/button";
 import {
-  addToArchiveSenderQueue,
   useArchiveSenderStatus,
+  useArchiveSenderQueueActions,
 } from "@/store/archive-sender-queue";
 import { getEmailUrl, getGmailSearchUrl } from "@/utils/url";
 import { MessageText } from "@/components/Typography";
@@ -73,6 +73,7 @@ export function GroupedTable({
   categories: CategoryWithRules[];
 }) {
   const { emailAccountId, userEmail } = useAccount();
+  const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
 
   const categoryMap = useMemo(() => {
     return categories.reduce<Record<string, CategoryWithRules>>(
@@ -148,7 +149,12 @@ export function GroupedTable({
       {
         accessorKey: "preview",
         cell: ({ row }) => {
-          return <ArchiveStatusCell sender={row.original.address} />;
+          return (
+            <ArchiveStatusCell
+              emailAccountId={emailAccountId}
+              sender={row.original.address}
+            />
+          );
         },
       },
       {
@@ -205,12 +211,9 @@ export function GroupedTable({
             const isCategoryExpanded = expanded?.includes(categoryName);
 
             const onArchiveAll = async () => {
-              for (const sender of senders) {
-                await addToArchiveSenderQueue({
-                  sender: sender.address,
-                  emailAccountId,
-                });
-              }
+              await queueArchiveSenders({
+                senders: senders.map((sender) => sender.address),
+              });
             };
 
             const onEditCategory = () => {
@@ -462,7 +465,9 @@ function SenderRows({
             <TableCell
               key={cell.id}
               style={{
-                width: (cell.column.columnDef.meta as any)?.size || "auto",
+                width:
+                  (cell.column.columnDef.meta as { size?: string } | undefined)
+                    ?.size || "auto",
               }}
               className="py-1"
             >
@@ -553,26 +558,21 @@ function ExpandedRows({
   );
 }
 
-function ArchiveStatusCell({ sender }: { sender: string }) {
-  const status = useArchiveSenderStatus(sender);
+function ArchiveStatusCell({
+  emailAccountId,
+  sender,
+}: {
+  emailAccountId: string;
+  sender: string;
+}) {
+  const status = useArchiveSenderStatus(emailAccountId, sender);
 
   switch (status?.status) {
     case "completed":
-      if (status.threadsTotal) {
-        return (
-          <span className="text-green-500">
-            Archived {status.threadsTotal} emails!
-          </span>
-        );
+      if (status.queued) {
+        return <span className="text-blue-500">Queued</span>;
       }
       return <span className="text-muted-foreground">Archived</span>;
-    case "processing":
-      return (
-        <span className="text-blue-500">
-          Archiving... {status.threadsTotal - status.threadIds.length} /{" "}
-          {status.threadsTotal}
-        </span>
-      );
     case "pending":
       return <span className="text-muted-foreground">Pending...</span>;
     default:

--- a/apps/web/store/archive-sender-queue.test.tsx
+++ b/apps/web/store/archive-sender-queue.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "jotai";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecuteAsync = vi.fn();
+
+vi.mock("@/utils/actions/mail-bulk-action", () => ({
+  bulkArchiveAction: vi.fn(),
+}));
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({
+    executeAsync: mockExecuteAsync,
+    isExecuting: false,
+  }),
+}));
+
+vi.mock("./archive-queue", () => ({
+  archiveEmails: vi.fn(),
+}));
+
+vi.mock("./sender-queue", () => ({
+  createSenderQueue: () => ({
+    addToQueue: vi.fn(),
+  }),
+}));
+
+describe("archive sender queue", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.runOnlyPendingTimers();
+    }
+    vi.useRealTimers();
+  });
+
+  it("keeps sender status scoped to the email account", async () => {
+    vi.useFakeTimers();
+    mockExecuteAsync.mockResolvedValue({ data: { mode: "queued" } });
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderQueueActions, useArchiveSenderStatus } =
+      await import("./archive-sender-queue");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result: actionResult } = renderHook(
+      () => useArchiveSenderQueueActions("account-1"),
+      { wrapper },
+    );
+    const { result: firstAccountStatus } = renderHook(
+      () => useArchiveSenderStatus("account-1", "sender@example.com"),
+      { wrapper },
+    );
+    const { result: secondAccountStatus } = renderHook(
+      () => useArchiveSenderStatus("account-2", "sender@example.com"),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await actionResult.current.queueArchiveSenders({
+        senders: ["sender@example.com"],
+      });
+    });
+
+    expect(firstAccountStatus.current).toMatchObject({
+      status: "completed",
+      queued: true,
+    });
+    expect(secondAccountStatus.current).toBeUndefined();
+  });
+
+  it("clears queued sender status after a short delay", async () => {
+    vi.useFakeTimers();
+    mockExecuteAsync.mockResolvedValue({ data: { mode: "queued" } });
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderQueueActions, useArchiveSenderStatus } =
+      await import("./archive-sender-queue");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result: actionResult } = renderHook(
+      () => useArchiveSenderQueueActions("account-cleanup"),
+      { wrapper },
+    );
+    const { result: statusResult } = renderHook(
+      () => useArchiveSenderStatus("account-cleanup", "cleanup@example.com"),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await actionResult.current.queueArchiveSenders({
+        senders: ["cleanup@example.com"],
+      });
+    });
+
+    expect(statusResult.current).toMatchObject({
+      status: "completed",
+      queued: true,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(statusResult.current).toBeUndefined();
+  });
+
+  it("clears pending sender state when the action rejects", async () => {
+    mockExecuteAsync.mockRejectedValue(new Error("queue failed"));
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderQueueActions, useArchiveSenderStatus } =
+      await import("./archive-sender-queue");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result: actionResult } = renderHook(
+      () => useArchiveSenderQueueActions("account-1"),
+      { wrapper },
+    );
+    const { result: statusResult } = renderHook(
+      () => useArchiveSenderStatus("account-1", "sender@example.com"),
+      { wrapper },
+    );
+
+    await expect(
+      actionResult.current.queueArchiveSenders({
+        senders: ["sender@example.com"],
+      }),
+    ).rejects.toThrow("queue failed");
+
+    expect(statusResult.current).toBeUndefined();
+  });
+
+  it("dedupes sender queue requests case-insensitively", async () => {
+    mockExecuteAsync.mockResolvedValue({ data: { mode: "queued" } });
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderQueueActions } = await import(
+      "./archive-sender-queue"
+    );
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result: actionResult } = renderHook(
+      () => useArchiveSenderQueueActions("account-1"),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await actionResult.current.queueArchiveSenders({
+        senders: ["Sender@example.com", " sender@example.com "],
+      });
+    });
+
+    expect(mockExecuteAsync).toHaveBeenCalledWith({
+      froms: ["Sender@example.com"],
+    });
+  });
+
+  it("does not enqueue senders that are already queued", async () => {
+    vi.useFakeTimers();
+    mockExecuteAsync.mockResolvedValue({ data: { mode: "queued" } });
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderQueueActions, useArchiveSenderStatus } =
+      await import("./archive-sender-queue");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result: actionResult } = renderHook(
+      () => useArchiveSenderQueueActions("account-1"),
+      { wrapper },
+    );
+    const { result: statusResult } = renderHook(
+      () => useArchiveSenderStatus("account-1", "sender@example.com"),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await actionResult.current.queueArchiveSenders({
+        senders: ["sender@example.com"],
+      });
+    });
+
+    await act(async () => {
+      await actionResult.current.queueArchiveSenders({
+        senders: ["sender@example.com"],
+      });
+    });
+
+    expect(mockExecuteAsync).toHaveBeenCalledTimes(1);
+    expect(statusResult.current).toMatchObject({
+      status: "completed",
+      queued: true,
+    });
+  });
+});

--- a/apps/web/store/archive-sender-queue.test.tsx
+++ b/apps/web/store/archive-sender-queue.test.tsx
@@ -80,13 +80,15 @@ describe("archive sender queue", () => {
     expect(secondAccountStatus.current).toBeUndefined();
   });
 
-  it("clears queued sender status after a short delay", async () => {
-    vi.useFakeTimers();
+  it("clears queued sender status when the account run completes", async () => {
     mockExecuteAsync.mockResolvedValue({ data: { mode: "queued" } });
 
     const { jotaiStore } = await import("@/store");
-    const { useArchiveSenderQueueActions, useArchiveSenderStatus } =
-      await import("./archive-sender-queue");
+    const {
+      clearArchiveSenderStatuses,
+      useArchiveSenderQueueActions,
+      useArchiveSenderStatus,
+    } = await import("./archive-sender-queue");
 
     const wrapper = ({ children }: { children: ReactNode }) => (
       <Provider store={jotaiStore}>{children}</Provider>
@@ -113,7 +115,7 @@ describe("archive sender queue", () => {
     });
 
     act(() => {
-      vi.advanceTimersByTime(30_000);
+      clearArchiveSenderStatuses("account-cleanup");
     });
 
     expect(statusResult.current).toBeUndefined();

--- a/apps/web/store/archive-sender-queue.test.tsx
+++ b/apps/web/store/archive-sender-queue.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecuteAsync = vi.fn();
+const mockUseSWR = vi.fn();
 
 vi.mock("@/utils/actions/mail-bulk-action", () => ({
   bulkArchiveAction: vi.fn(),
@@ -28,11 +29,16 @@ vi.mock("./sender-queue", () => ({
   }),
 }));
 
+vi.mock("swr", () => ({
+  default: (...args: Parameters<typeof mockUseSWR>) => mockUseSWR(...args),
+}));
+
 describe("archive sender queue", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.useRealTimers();
+    mockUseSWR.mockReturnValue({ data: undefined });
   });
 
   afterEach(() => {
@@ -215,6 +221,36 @@ describe("archive sender queue", () => {
     expect(statusResult.current).toMatchObject({
       status: "completed",
       queued: true,
+    });
+  });
+
+  it("prefers backend sender status when available", async () => {
+    mockUseSWR.mockReturnValue({
+      data: {
+        "sender@example.com": {
+          status: "completed",
+          queued: false,
+          archivedCount: 9,
+        },
+      },
+    });
+
+    const { jotaiStore } = await import("@/store");
+    const { useArchiveSenderStatus } = await import("./archive-sender-queue");
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={jotaiStore}>{children}</Provider>
+    );
+
+    const { result } = renderHook(
+      () => useArchiveSenderStatus("account-1", "sender@example.com"),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual({
+      status: "completed",
+      queued: false,
+      archivedCount: 9,
     });
   });
 });

--- a/apps/web/store/archive-sender-queue.ts
+++ b/apps/web/store/archive-sender-queue.ts
@@ -1,7 +1,192 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { atom, useAtomValue } from "jotai";
+import { useAction } from "next-safe-action/hooks";
+import { jotaiStore } from "@/store";
+import { bulkArchiveAction } from "@/utils/actions/mail-bulk-action";
 import { archiveEmails } from "./archive-queue";
 import { createSenderQueue } from "./sender-queue";
 
-const { addToQueue, useSenderStatus } = createSenderQueue(archiveEmails);
+type QueueStatus = "pending" | "completed";
 
-export const addToArchiveSenderQueue = addToQueue;
-export const useArchiveSenderStatus = useSenderStatus;
+type QueueItem = {
+  status: QueueStatus;
+  queued?: boolean;
+};
+
+const QUEUED_STATUS_TTL_MS = 30_000;
+
+const queueAtom = atom<Map<string, QueueItem>>(new Map());
+const statusAtom = atom((get) => {
+  const queue = get(queueAtom);
+  return (emailAccountId: string, sender: string) =>
+    queue.get(getQueueKey(emailAccountId, sender));
+});
+const queueCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const { addToQueue: addToArchiveSenderThreadQueue } =
+  createSenderQueue(archiveEmails);
+
+export { addToArchiveSenderThreadQueue };
+
+export function useArchiveSenderQueueActions(emailAccountId: string) {
+  const { executeAsync, isExecuting } = useAction(
+    bulkArchiveAction.bind(null, emailAccountId),
+  );
+
+  const queueArchiveSenders = useCallback(
+    async ({ senders }: { senders: string[] }) => {
+      const uniqueSenders = getUniqueSenders(senders);
+      const sendersToQueue = getQueueableSenders({
+        emailAccountId,
+        senders: uniqueSenders,
+        queue: jotaiStore.get(queueAtom),
+      });
+      if (!sendersToQueue.length) return;
+
+      jotaiStore.set(queueAtom, (prev) => {
+        const next = new Map(prev);
+
+        for (const sender of sendersToQueue) {
+          const queueKey = getQueueKey(emailAccountId, sender);
+
+          clearQueueCleanupTimer(queueKey);
+          next.set(queueKey, { status: "pending" });
+        }
+
+        return next;
+      });
+
+      let result: Awaited<ReturnType<typeof executeAsync>>;
+
+      try {
+        result = await executeAsync({ froms: sendersToQueue });
+      } catch (error) {
+        clearQueueEntries(emailAccountId, sendersToQueue);
+        throw error;
+      }
+
+      if (result?.serverError) {
+        clearQueueEntries(emailAccountId, sendersToQueue);
+        throw new Error(result.serverError);
+      }
+
+      jotaiStore.set(queueAtom, (prev) => {
+        const next = new Map(prev);
+        const queued = result?.data?.mode === "queued";
+
+        for (const sender of sendersToQueue) {
+          const queueKey = getQueueKey(emailAccountId, sender);
+
+          next.set(queueKey, { status: "completed", queued });
+
+          if (queued) {
+            scheduleQueuedStatusCleanup(queueKey);
+          } else {
+            clearQueueCleanupTimer(queueKey);
+          }
+        }
+
+        return next;
+      });
+
+      return result?.data;
+    },
+    [emailAccountId, executeAsync],
+  );
+
+  return useMemo(
+    () => ({
+      queueArchiveSenders,
+      isQueueArchiving: isExecuting,
+    }),
+    [isExecuting, queueArchiveSenders],
+  );
+}
+
+export function useArchiveSenderStatus(emailAccountId: string, sender: string) {
+  const getStatus = useAtomValue(statusAtom);
+  return useMemo(
+    () => getStatus(emailAccountId, sender),
+    [emailAccountId, getStatus, sender],
+  );
+}
+
+function getUniqueSenders(senders: string[]) {
+  const uniqueSenders = new Map<string, string>();
+
+  for (const sender of senders) {
+    const normalizedSender = normalizeSender(sender);
+    if (!normalizedSender || uniqueSenders.has(normalizedSender)) continue;
+
+    uniqueSenders.set(normalizedSender, sender.trim());
+  }
+
+  return Array.from(uniqueSenders.values());
+}
+
+function getQueueKey(emailAccountId: string, sender: string) {
+  return `${emailAccountId}:${normalizeSender(sender)}`;
+}
+
+function getQueueableSenders({
+  emailAccountId,
+  senders,
+  queue,
+}: {
+  emailAccountId: string;
+  senders: string[];
+  queue: Map<string, QueueItem>;
+}) {
+  return senders.filter((sender) => {
+    const queueItem = queue.get(getQueueKey(emailAccountId, sender));
+    return !isActiveQueueItem(queueItem);
+  });
+}
+
+function clearQueueCleanupTimer(queueKey: string) {
+  const timer = queueCleanupTimers.get(queueKey);
+  if (timer) {
+    clearTimeout(timer);
+    queueCleanupTimers.delete(queueKey);
+  }
+}
+
+function scheduleQueuedStatusCleanup(queueKey: string) {
+  clearQueueCleanupTimer(queueKey);
+
+  queueCleanupTimers.set(
+    queueKey,
+    setTimeout(() => {
+      jotaiStore.set(queueAtom, (prev) => {
+        const next = new Map(prev);
+        next.delete(queueKey);
+        return next;
+      });
+      queueCleanupTimers.delete(queueKey);
+    }, QUEUED_STATUS_TTL_MS),
+  );
+}
+
+function clearQueueEntries(emailAccountId: string, senders: string[]) {
+  jotaiStore.set(queueAtom, (prev) => {
+    const next = new Map(prev);
+
+    for (const sender of senders) {
+      const queueKey = getQueueKey(emailAccountId, sender);
+      clearQueueCleanupTimer(queueKey);
+      next.delete(queueKey);
+    }
+
+    return next;
+  });
+}
+
+function normalizeSender(sender: string) {
+  return sender.trim().toLowerCase();
+}
+
+function isActiveQueueItem(queueItem?: QueueItem) {
+  return queueItem?.status === "pending" || queueItem?.queued === true;
+}

--- a/apps/web/store/archive-sender-queue.ts
+++ b/apps/web/store/archive-sender-queue.ts
@@ -15,15 +15,12 @@ type QueueItem = {
   queued?: boolean;
 };
 
-const QUEUED_STATUS_TTL_MS = 30_000;
-
 const queueAtom = atom<Map<string, QueueItem>>(new Map());
 const statusAtom = atom((get) => {
   const queue = get(queueAtom);
   return (emailAccountId: string, sender: string) =>
     queue.get(getQueueKey(emailAccountId, sender));
 });
-const queueCleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 const { addToQueue: addToArchiveSenderThreadQueue } =
   createSenderQueue(archiveEmails);
@@ -50,8 +47,6 @@ export function useArchiveSenderQueueActions(emailAccountId: string) {
 
         for (const sender of sendersToQueue) {
           const queueKey = getQueueKey(emailAccountId, sender);
-
-          clearQueueCleanupTimer(queueKey);
           next.set(queueKey, { status: "pending" });
         }
 
@@ -80,12 +75,6 @@ export function useArchiveSenderQueueActions(emailAccountId: string) {
           const queueKey = getQueueKey(emailAccountId, sender);
 
           next.set(queueKey, { status: "completed", queued });
-
-          if (queued) {
-            scheduleQueuedStatusCleanup(queueKey);
-          } else {
-            clearQueueCleanupTimer(queueKey);
-          }
         }
 
         return next;
@@ -111,6 +100,19 @@ export function useArchiveSenderStatus(emailAccountId: string, sender: string) {
     () => getStatus(emailAccountId, sender),
     [emailAccountId, getStatus, sender],
   );
+}
+
+export function clearArchiveSenderStatuses(emailAccountId: string) {
+  jotaiStore.set(queueAtom, (prev) => {
+    const next = new Map(prev);
+
+    for (const queueKey of next.keys()) {
+      if (!queueKey.startsWith(`${emailAccountId}:`)) continue;
+      next.delete(queueKey);
+    }
+
+    return next;
+  });
 }
 
 function getUniqueSenders(senders: string[]) {
@@ -145,37 +147,12 @@ function getQueueableSenders({
   });
 }
 
-function clearQueueCleanupTimer(queueKey: string) {
-  const timer = queueCleanupTimers.get(queueKey);
-  if (timer) {
-    clearTimeout(timer);
-    queueCleanupTimers.delete(queueKey);
-  }
-}
-
-function scheduleQueuedStatusCleanup(queueKey: string) {
-  clearQueueCleanupTimer(queueKey);
-
-  queueCleanupTimers.set(
-    queueKey,
-    setTimeout(() => {
-      jotaiStore.set(queueAtom, (prev) => {
-        const next = new Map(prev);
-        next.delete(queueKey);
-        return next;
-      });
-      queueCleanupTimers.delete(queueKey);
-    }, QUEUED_STATUS_TTL_MS),
-  );
-}
-
 function clearQueueEntries(emailAccountId: string, senders: string[]) {
   jotaiStore.set(queueAtom, (prev) => {
     const next = new Map(prev);
 
     for (const sender of senders) {
       const queueKey = getQueueKey(emailAccountId, sender);
-      clearQueueCleanupTimer(queueKey);
       next.delete(queueKey);
     }
 

--- a/apps/web/store/archive-sender-queue.ts
+++ b/apps/web/store/archive-sender-queue.ts
@@ -2,17 +2,20 @@
 
 import { useCallback, useMemo } from "react";
 import { atom, useAtomValue } from "jotai";
+import useSWR from "swr";
 import { useAction } from "next-safe-action/hooks";
 import { jotaiStore } from "@/store";
 import { bulkArchiveAction } from "@/utils/actions/mail-bulk-action";
 import { archiveEmails } from "./archive-queue";
 import { createSenderQueue } from "./sender-queue";
+import type { BulkArchiveSenderStatuses } from "@/app/api/user/bulk-archive/sender-status/route";
 
 type QueueStatus = "pending" | "completed";
 
 type QueueItem = {
   status: QueueStatus;
   queued?: boolean;
+  archivedCount?: number;
 };
 
 const queueAtom = atom<Map<string, QueueItem>>(new Map());
@@ -96,9 +99,15 @@ export function useArchiveSenderQueueActions(emailAccountId: string) {
 
 export function useArchiveSenderStatus(emailAccountId: string, sender: string) {
   const getStatus = useAtomValue(statusAtom);
+  const { data } = useSWR<BulkArchiveSenderStatuses>(
+    "/api/user/bulk-archive/sender-status",
+    {
+      refreshInterval: 1000,
+    },
+  );
   return useMemo(
-    () => getStatus(emailAccountId, sender),
-    [emailAccountId, getStatus, sender],
+    () => data?.[normalizeSender(sender)] || getStatus(emailAccountId, sender),
+    [data, emailAccountId, getStatus, sender],
   );
 }
 

--- a/apps/web/utils/actions/categorize.test.ts
+++ b/apps/web/utils/actions/categorize.test.ts
@@ -91,17 +91,83 @@ describe("bulkCategorizeSendersAction", () => {
     mockSaveCategorizationTotalItems.mockResolvedValue(undefined);
     mockPublishToAiCategorizeSendersQueue.mockResolvedValue(undefined);
     mockCreateEmailProvider.mockResolvedValue({} as never);
-    mockLoadEmails.mockResolvedValue({ pages: 1 });
+    mockLoadEmails.mockResolvedValue({
+      pages: 1,
+      loadedAfterMessages: 0,
+      loadedBeforeMessages: 0,
+      hasMoreAfter: false,
+      hasMoreBefore: false,
+    });
   });
 
-  it("bootstraps recent emails before categorizing when no local messages exist", async () => {
-    prisma.emailMessage.findFirst
-      .mockResolvedValueOnce(null as never)
-      .mockResolvedValueOnce({ id: "message-1" } as never);
+  it("loads more email history and only queues newly discovered senders", async () => {
+    mockGetUncategorizedSenders
+      .mockResolvedValueOnce({
+        uncategorizedSenders: [{ email: "first@example.com", name: "First" }],
+      })
+      .mockResolvedValueOnce({
+        uncategorizedSenders: [
+          { email: "first@example.com", name: "First" },
+          { email: "second@example.com", name: "Second" },
+        ],
+      });
 
-    mockGetUncategorizedSenders.mockResolvedValueOnce({
-      uncategorizedSenders: [{ email: "sender@example.com", name: "Sender" }],
+    mockLoadEmails
+      .mockResolvedValueOnce({
+        pages: 1,
+        loadedAfterMessages: 0,
+        loadedBeforeMessages: 20,
+        hasMoreAfter: false,
+        hasMoreBefore: true,
+      })
+      .mockResolvedValueOnce({
+        pages: 1,
+        loadedAfterMessages: 0,
+        loadedBeforeMessages: 0,
+        hasMoreAfter: false,
+        hasMoreBefore: false,
+      });
+
+    const result = await bulkCategorizeSendersAction("account-1");
+
+    expect(mockLoadEmails).toHaveBeenCalledTimes(2);
+    expect(mockPublishToAiCategorizeSendersQueue).toHaveBeenNthCalledWith(1, {
+      emailAccountId: "account-1",
+      senders: [{ email: "first@example.com", name: "First" }],
     });
+    expect(mockPublishToAiCategorizeSendersQueue).toHaveBeenNthCalledWith(2, {
+      emailAccountId: "account-1",
+      senders: [{ email: "second@example.com", name: "Second" }],
+    });
+    expect(result?.data).toEqual({
+      totalUncategorizedSenders: 2,
+    });
+  });
+
+  it("loads more email history before categorizing when the first pass finds no senders", async () => {
+    mockGetUncategorizedSenders
+      .mockResolvedValueOnce({
+        uncategorizedSenders: [],
+      })
+      .mockResolvedValueOnce({
+        uncategorizedSenders: [{ email: "sender@example.com", name: "Sender" }],
+      });
+
+    mockLoadEmails
+      .mockResolvedValueOnce({
+        pages: 1,
+        loadedAfterMessages: 20,
+        loadedBeforeMessages: 0,
+        hasMoreAfter: true,
+        hasMoreBefore: false,
+      })
+      .mockResolvedValueOnce({
+        pages: 1,
+        loadedAfterMessages: 0,
+        loadedBeforeMessages: 0,
+        hasMoreAfter: false,
+        hasMoreBefore: false,
+      });
 
     const result = await bulkCategorizeSendersAction("account-1");
 
@@ -111,7 +177,7 @@ describe("bulkCategorizeSendersAction", () => {
         emailProvider: expect.anything(),
         logger: expect.anything(),
       },
-      { loadBefore: false, maxPages: 5 },
+      { loadBefore: true, maxPages: 5 },
     );
     expect(mockPublishToAiCategorizeSendersQueue).toHaveBeenCalledWith({
       emailAccountId: "account-1",
@@ -119,16 +185,11 @@ describe("bulkCategorizeSendersAction", () => {
     });
     expect(result?.data).toEqual({
       totalUncategorizedSenders: 1,
-      hasSyncedMessages: true,
     });
   });
 
-  it("returns no-synced-messages when bootstrap sync still finds nothing", async () => {
-    prisma.emailMessage.findFirst
-      .mockResolvedValueOnce(null as never)
-      .mockResolvedValueOnce(null as never);
-
-    mockGetUncategorizedSenders.mockResolvedValueOnce({
+  it("returns zero when categorization exhausts the available email history", async () => {
+    mockGetUncategorizedSenders.mockResolvedValue({
       uncategorizedSenders: [],
     });
 
@@ -138,7 +199,6 @@ describe("bulkCategorizeSendersAction", () => {
     expect(mockPublishToAiCategorizeSendersQueue).not.toHaveBeenCalled();
     expect(result?.data).toEqual({
       totalUncategorizedSenders: 0,
-      hasSyncedMessages: false,
     });
   });
 });

--- a/apps/web/utils/actions/categorize.test.ts
+++ b/apps/web/utils/actions/categorize.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { bulkCategorizeSendersAction } from "@/utils/actions/categorize";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+const {
+  mockValidateUserAndAiAccess,
+  mockDeleteEmptyCategorizeSendersQueues,
+  mockPublishToAiCategorizeSendersQueue,
+  mockSaveCategorizationTotalItems,
+  mockGetUncategorizedSenders,
+  mockLoadEmails,
+  mockCreateEmailProvider,
+} = vi.hoisted(() => ({
+  mockValidateUserAndAiAccess: vi.fn(),
+  mockDeleteEmptyCategorizeSendersQueues: vi.fn(),
+  mockPublishToAiCategorizeSendersQueue: vi.fn(),
+  mockSaveCategorizationTotalItems: vi.fn(),
+  mockGetUncategorizedSenders: vi.fn(),
+  mockLoadEmails: vi.fn(),
+  mockCreateEmailProvider: vi.fn(),
+}));
+
+vi.mock("@/utils/user/validate", () => ({
+  validateUserAndAiAccess: (
+    ...args: Parameters<typeof mockValidateUserAndAiAccess>
+  ) => mockValidateUserAndAiAccess(...args),
+}));
+
+vi.mock("@/utils/upstash/categorize-senders", () => ({
+  deleteEmptyCategorizeSendersQueues: (
+    ...args: Parameters<typeof mockDeleteEmptyCategorizeSendersQueues>
+  ) => mockDeleteEmptyCategorizeSendersQueues(...args),
+  publishToAiCategorizeSendersQueue: (
+    ...args: Parameters<typeof mockPublishToAiCategorizeSendersQueue>
+  ) => mockPublishToAiCategorizeSendersQueue(...args),
+}));
+
+vi.mock("@/utils/redis/categorization-progress", () => ({
+  saveCategorizationTotalItems: (
+    ...args: Parameters<typeof mockSaveCategorizationTotalItems>
+  ) => mockSaveCategorizationTotalItems(...args),
+}));
+
+vi.mock(
+  "@/app/api/user/categorize/senders/uncategorized/get-uncategorized-senders",
+  () => ({
+    getUncategorizedSenders: (
+      ...args: Parameters<typeof mockGetUncategorizedSenders>
+    ) => mockGetUncategorizedSenders(...args),
+  }),
+);
+
+vi.mock("@/utils/actions/stats", () => ({
+  loadEmails: (...args: Parameters<typeof mockLoadEmails>) =>
+    mockLoadEmails(...args),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: Parameters<typeof mockCreateEmailProvider>) =>
+    mockCreateEmailProvider(...args),
+}));
+
+describe("bulkCategorizeSendersAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockValidateUserAndAiAccess.mockResolvedValue({
+      emailAccount: { id: "account-1" },
+    });
+
+    prisma.category.createMany.mockResolvedValue({ count: 0 } as never);
+    prisma.emailAccount.update.mockResolvedValue({ id: "account-1" } as never);
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        id: "account-1",
+        userId: "user-1",
+        provider: "google",
+      }) as never,
+    );
+
+    mockDeleteEmptyCategorizeSendersQueues.mockResolvedValue(undefined);
+    mockSaveCategorizationTotalItems.mockResolvedValue(undefined);
+    mockPublishToAiCategorizeSendersQueue.mockResolvedValue(undefined);
+    mockCreateEmailProvider.mockResolvedValue({} as never);
+    mockLoadEmails.mockResolvedValue({ pages: 1 });
+  });
+
+  it("bootstraps recent emails before categorizing when no local messages exist", async () => {
+    prisma.emailMessage.findFirst
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce({ id: "message-1" } as never);
+
+    mockGetUncategorizedSenders.mockResolvedValueOnce({
+      uncategorizedSenders: [{ email: "sender@example.com", name: "Sender" }],
+    });
+
+    const result = await bulkCategorizeSendersAction("account-1");
+
+    expect(mockLoadEmails).toHaveBeenCalledWith(
+      {
+        emailAccountId: "account-1",
+        emailProvider: expect.anything(),
+        logger: expect.anything(),
+      },
+      { loadBefore: false, maxPages: 5 },
+    );
+    expect(mockPublishToAiCategorizeSendersQueue).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      senders: [{ email: "sender@example.com", name: "Sender" }],
+    });
+    expect(result?.data).toEqual({
+      totalUncategorizedSenders: 1,
+      hasSyncedMessages: true,
+    });
+  });
+
+  it("returns no-synced-messages when bootstrap sync still finds nothing", async () => {
+    prisma.emailMessage.findFirst
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(null as never);
+
+    mockGetUncategorizedSenders.mockResolvedValueOnce({
+      uncategorizedSenders: [],
+    });
+
+    const result = await bulkCategorizeSendersAction("account-1");
+
+    expect(mockLoadEmails).toHaveBeenCalledOnce();
+    expect(mockPublishToAiCategorizeSendersQueue).not.toHaveBeenCalled();
+    expect(result?.data).toEqual({
+      totalUncategorizedSenders: 0,
+      hasSyncedMessages: false,
+    });
+  });
+});

--- a/apps/web/utils/actions/categorize.ts
+++ b/apps/web/utils/actions/categorize.ts
@@ -26,63 +26,32 @@ import { actionClient } from "@/utils/actions/safe-action";
 import { prefixPath } from "@/utils/path";
 import { loadEmails } from "@/utils/actions/stats";
 
+const CATEGORIZE_SYNC_CHUNK_PAGES = 5;
+const MAX_SYNC_PASSES = 20;
+
 export const bulkCategorizeSendersAction = actionClient
   .metadata({ name: "bulkCategorizeSenders" })
   .action(async ({ ctx: { emailAccountId, logger } }) => {
     await validateUserAndAiAccess({ emailAccountId });
 
-    let hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
-      where: {
-        emailAccountId,
-        sent: false,
+    const emailAccount = await prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: {
+        account: {
+          select: { provider: true },
+        },
       },
-      select: { id: true },
-    }));
+    });
 
-    if (!hasSyncedMessages) {
-      const emailAccount = await prisma.emailAccount.findUnique({
-        where: { id: emailAccountId },
-        select: {
-          account: {
-            select: { provider: true },
-          },
-        },
-      });
-
-      if (!emailAccount?.account?.provider) {
-        throw new SafeError("Email account or provider not found");
-      }
-
-      logger.info("Bootstrapping recent emails before categorization", {
-        maxPages: 5,
-      });
-
-      const emailProvider = await createEmailProvider({
-        emailAccountId,
-        provider: emailAccount.account.provider,
-        logger,
-      });
-
-      await loadEmails(
-        {
-          emailAccountId,
-          emailProvider,
-          logger,
-        },
-        {
-          loadBefore: false,
-          maxPages: 5,
-        },
-      );
-
-      hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
-        where: {
-          emailAccountId,
-          sent: false,
-        },
-        select: { id: true },
-      }));
+    if (!emailAccount?.account?.provider) {
+      throw new SafeError("Email account or provider not found");
     }
+
+    const emailProvider = await createEmailProvider({
+      emailAccountId,
+      provider: emailAccount.account.provider,
+      logger,
+    });
 
     // Ensure default categories exist before categorizing
     const categoriesToCreate = Object.values(defaultCategory)
@@ -116,46 +85,97 @@ export const bulkCategorizeSendersAction = actionClient
     const MAX_SENDERS = 2000;
 
     let totalUncategorizedSenders = 0;
-    let currentOffset: number | undefined = 0;
+    let syncPasses = 0;
+    let shouldLoadMoreMessages = true;
+    const queuedSenderEmails = new Set<string>();
 
-    while (currentOffset !== undefined) {
-      const result = await getUncategorizedSenders({
-        emailAccountId,
-        limit: LIMIT,
-        offset: currentOffset,
-      });
+    while (
+      totalUncategorizedSenders < MAX_SENDERS &&
+      shouldLoadMoreMessages &&
+      syncPasses < MAX_SYNC_PASSES
+    ) {
+      let currentOffset: number | undefined = 0;
 
-      logger.trace("Got uncategorized senders", {
-        uncategorizedSenders: result.uncategorizedSenders.length,
-      });
-
-      if (result.uncategorizedSenders.length > 0) {
-        totalUncategorizedSenders += result.uncategorizedSenders.length;
-
-        await saveCategorizationTotalItems({
+      while (currentOffset !== undefined) {
+        const result = await getUncategorizedSenders({
           emailAccountId,
-          totalItems: totalUncategorizedSenders,
+          limit: LIMIT,
+          offset: currentOffset,
         });
 
-        await publishToAiCategorizeSendersQueue({
-          emailAccountId,
-          senders: result.uncategorizedSenders,
+        logger.trace("Got uncategorized senders", {
+          uncategorizedSenders: result.uncategorizedSenders.length,
         });
+
+        const sendersToQueue = result.uncategorizedSenders.filter((sender) => {
+          if (queuedSenderEmails.has(sender.email)) return false;
+          queuedSenderEmails.add(sender.email);
+          return true;
+        });
+
+        if (sendersToQueue.length > 0) {
+          totalUncategorizedSenders += sendersToQueue.length;
+
+          await saveCategorizationTotalItems({
+            emailAccountId,
+            totalItems: totalUncategorizedSenders,
+          });
+
+          await publishToAiCategorizeSendersQueue({
+            emailAccountId,
+            senders: sendersToQueue,
+          });
+        }
+
+        if (totalUncategorizedSenders >= MAX_SENDERS) {
+          logger.info("Reached max senders limit", { MAX_SENDERS });
+          break;
+        }
+
+        currentOffset = result.nextOffset;
       }
 
       if (totalUncategorizedSenders >= MAX_SENDERS) {
-        logger.info("Reached max senders limit", { MAX_SENDERS });
         break;
       }
 
-      currentOffset = result.nextOffset;
+      const syncResult = await loadEmails(
+        {
+          emailAccountId,
+          emailProvider,
+          logger,
+        },
+        {
+          loadBefore: true,
+          maxPages: CATEGORIZE_SYNC_CHUNK_PAGES,
+        },
+      );
+
+      const loadedMoreMessages =
+        syncResult.loadedAfterMessages > 0 ||
+        syncResult.loadedBeforeMessages > 0;
+
+      logger.info("Categorize sync pass completed", {
+        syncPasses,
+        loadedAfterMessages: syncResult.loadedAfterMessages,
+        loadedBeforeMessages: syncResult.loadedBeforeMessages,
+        hasMoreAfter: syncResult.hasMoreAfter,
+        hasMoreBefore: syncResult.hasMoreBefore,
+        totalUncategorizedSenders,
+      });
+
+      shouldLoadMoreMessages = loadedMoreMessages;
+
+      syncPasses++;
     }
 
     logger.info("Queued senders for categorization", {
       totalUncategorizedSenders,
+      syncPasses,
+      shouldLoadMoreMessages,
     });
 
-    return { totalUncategorizedSenders, hasSyncedMessages };
+    return { totalUncategorizedSenders };
   });
 
 export const categorizeSenderAction = actionClient

--- a/apps/web/utils/actions/categorize.ts
+++ b/apps/web/utils/actions/categorize.ts
@@ -30,6 +30,14 @@ export const bulkCategorizeSendersAction = actionClient
   .action(async ({ ctx: { emailAccountId, logger } }) => {
     await validateUserAndAiAccess({ emailAccountId });
 
+    const hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
+      where: {
+        emailAccountId,
+        sent: false,
+      },
+      select: { id: true },
+    }));
+
     // Ensure default categories exist before categorizing
     const categoriesToCreate = Object.values(defaultCategory)
       .filter((c) => c.enabled)
@@ -101,7 +109,7 @@ export const bulkCategorizeSendersAction = actionClient
       totalUncategorizedSenders,
     });
 
-    return { totalUncategorizedSenders };
+    return { totalUncategorizedSenders, hasSyncedMessages };
   });
 
 export const categorizeSenderAction = actionClient

--- a/apps/web/utils/actions/categorize.ts
+++ b/apps/web/utils/actions/categorize.ts
@@ -24,19 +24,65 @@ import { saveCategorizationTotalItems } from "@/utils/redis/categorization-progr
 import { getUncategorizedSenders } from "@/app/api/user/categorize/senders/uncategorized/get-uncategorized-senders";
 import { actionClient } from "@/utils/actions/safe-action";
 import { prefixPath } from "@/utils/path";
+import { loadEmails } from "@/utils/actions/stats";
 
 export const bulkCategorizeSendersAction = actionClient
   .metadata({ name: "bulkCategorizeSenders" })
   .action(async ({ ctx: { emailAccountId, logger } }) => {
     await validateUserAndAiAccess({ emailAccountId });
 
-    const hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
+    let hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
       where: {
         emailAccountId,
         sent: false,
       },
       select: { id: true },
     }));
+
+    if (!hasSyncedMessages) {
+      const emailAccount = await prisma.emailAccount.findUnique({
+        where: { id: emailAccountId },
+        select: {
+          account: {
+            select: { provider: true },
+          },
+        },
+      });
+
+      if (!emailAccount?.account?.provider) {
+        throw new SafeError("Email account or provider not found");
+      }
+
+      logger.info("Bootstrapping recent emails before categorization", {
+        maxPages: 5,
+      });
+
+      const emailProvider = await createEmailProvider({
+        emailAccountId,
+        provider: emailAccount.account.provider,
+        logger,
+      });
+
+      await loadEmails(
+        {
+          emailAccountId,
+          emailProvider,
+          logger,
+        },
+        {
+          loadBefore: false,
+          maxPages: 5,
+        },
+      );
+
+      hasSyncedMessages = !!(await prisma.emailMessage.findFirst({
+        where: {
+          emailAccountId,
+          sent: false,
+        },
+        select: { id: true },
+      }));
+    }
 
     // Ensure default categories exist before categorizing
     const categoriesToCreate = Object.values(defaultCategory)

--- a/apps/web/utils/actions/mail-bulk-action.test.ts
+++ b/apps/web/utils/actions/mail-bulk-action.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { bulkArchiveAction } from "@/utils/actions/mail-bulk-action";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+const { envMock, mockEnqueueBulkArchiveSenderJobs, mockCreateEmailProvider } =
+  vi.hoisted(() => ({
+    envMock: {
+      NODE_ENV: "test",
+    },
+    mockEnqueueBulkArchiveSenderJobs: vi.fn(),
+    mockCreateEmailProvider: vi.fn(),
+  }));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/email/bulk-archive-queue", () => ({
+  enqueueBulkArchiveSenderJobs: (
+    ...args: Parameters<typeof mockEnqueueBulkArchiveSenderJobs>
+  ) => mockEnqueueBulkArchiveSenderJobs(...args),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: Parameters<typeof mockCreateEmailProvider>) =>
+    mockCreateEmailProvider(...args),
+}));
+
+describe("bulkArchiveAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        email: "owner@example.com",
+        userId: "user-1",
+        provider: "google",
+      }),
+    );
+    mockEnqueueBulkArchiveSenderJobs.mockResolvedValue(2);
+  });
+
+  it("queues Gmail sender archives through the backend queue", async () => {
+    const result = await bulkArchiveAction("account-1", {
+      froms: ["first@example.com", "second@example.com"],
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(result?.data).toEqual({
+      mode: "queued",
+      queuedSenders: 2,
+    });
+    expect(mockEnqueueBulkArchiveSenderJobs).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "google",
+      froms: ["first@example.com", "second@example.com"],
+      logger: expect.anything(),
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("queues Outlook sender archives through the backend queue", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountWithAccount({
+        email: "owner@example.com",
+        userId: "user-1",
+        provider: "microsoft",
+      }),
+    );
+
+    const result = await bulkArchiveAction("account-1", {
+      froms: ["sender@example.com"],
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(result?.data).toEqual({
+      mode: "queued",
+      queuedSenders: 2,
+    });
+    expect(mockEnqueueBulkArchiveSenderJobs).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "microsoft",
+      froms: ["sender@example.com"],
+      logger: expect.anything(),
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/mail-bulk-action.ts
+++ b/apps/web/utils/actions/mail-bulk-action.ts
@@ -1,42 +1,47 @@
 "use server";
 
-import { z } from "zod";
 import { actionClient } from "@/utils/actions/safe-action";
+import { bulkSenderActionSchema } from "@/utils/actions/mail-bulk-action.validation";
 import { createEmailProvider } from "@/utils/email/provider";
+import { enqueueBulkArchiveSenderJobs } from "@/utils/email/bulk-archive-queue";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
+import { SafeError } from "@/utils/error";
 
 export const bulkArchiveAction = actionClient
   .metadata({ name: "bulkArchive" })
-  .inputSchema(
-    z.object({
-      froms: z.array(z.string()),
-    }),
-  )
+  .inputSchema(bulkSenderActionSchema)
   .action(
     async ({
       ctx: { emailAccountId, provider, emailAccount, logger },
       parsedInput: { froms },
     }) => {
-      const emailProvider = await createEmailProvider({
+      if (!isGoogleProvider(provider) && !isMicrosoftProvider(provider)) {
+        throw new SafeError(
+          "Bulk archive is only supported for email providers",
+        );
+      }
+
+      const queuedSenders = await enqueueBulkArchiveSenderJobs({
         emailAccountId,
+        ownerEmail: emailAccount.email,
         provider,
+        froms,
         logger,
       });
 
-      await emailProvider.bulkArchiveFromSenders(
-        froms,
-        emailAccount.email,
-        emailAccountId,
-      );
+      return {
+        mode: "queued" as const,
+        queuedSenders,
+      };
     },
   );
 
 export const bulkTrashAction = actionClient
   .metadata({ name: "bulkTrash" })
-  .inputSchema(
-    z.object({
-      froms: z.array(z.string()),
-    }),
-  )
+  .inputSchema(bulkSenderActionSchema)
   .action(
     async ({
       ctx: { emailAccountId, provider, emailAccount, logger },

--- a/apps/web/utils/actions/mail-bulk-action.validation.ts
+++ b/apps/web/utils/actions/mail-bulk-action.validation.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const bulkSenderActionSchema = z.object({
+  froms: z.array(z.string().trim().min(1)).min(1),
+});
+
+export const bulkArchiveSenderJobSchema = z.object({
+  emailAccountId: z.string().min(1),
+  ownerEmail: z.string().email(),
+  provider: z.enum(["google", "microsoft"]),
+  sender: z.string().trim().min(1),
+});
+
+export type BulkArchiveSenderJob = z.infer<typeof bulkArchiveSenderJobSchema>;

--- a/apps/web/utils/actions/stats.ts
+++ b/apps/web/utils/actions/stats.ts
@@ -65,7 +65,7 @@ export const loadEmailStatsAction = actionClient
     },
   );
 
-async function loadEmails(
+export async function loadEmails(
   {
     emailAccountId,
     emailProvider,
@@ -75,7 +75,10 @@ async function loadEmails(
     emailProvider: EmailProvider;
     logger: Logger;
   },
-  { loadBefore }: { loadBefore: boolean },
+  {
+    loadBefore,
+    maxPages = MAX_PAGES,
+  }: { loadBefore: boolean; maxPages?: number },
 ) {
   let pages = 0;
 
@@ -89,7 +92,7 @@ async function loadEmails(
 
   // First pagination loop - load emails after the newest saved email
   let nextPageToken: string | undefined;
-  while (pages < MAX_PAGES) {
+  while (pages < maxPages) {
     logger.info("After Page", { pages, nextPageToken });
     const res = await saveBatch({
       emailAccountId,
@@ -127,7 +130,7 @@ async function loadEmails(
   // Second pagination loop - load emails before the oldest saved email
   // Reset nextPageToken for this new pagination sequence
   nextPageToken = undefined;
-  while (pages < MAX_PAGES) {
+  while (pages < maxPages) {
     logger.info("Before Page", { pages, nextPageToken });
     const res = await saveBatch({
       emailAccountId,

--- a/apps/web/utils/actions/stats.ts
+++ b/apps/web/utils/actions/stats.ts
@@ -81,6 +81,10 @@ export async function loadEmails(
   }: { loadBefore: boolean; maxPages?: number },
 ) {
   let pages = 0;
+  let loadedAfterMessages = 0;
+  let loadedBeforeMessages = 0;
+  let hasMoreAfter = false;
+  let hasMoreBefore = false;
 
   const newestEmailSaved = await prisma.emailMessage.findFirst({
     where: { emailAccountId },
@@ -104,17 +108,34 @@ export async function loadEmails(
     });
 
     nextPageToken = res.data.nextPageToken ?? undefined;
+    loadedAfterMessages += res.data.messages?.length || 0;
 
-    if (!res.data.messages || res.data.messages.length < PAGE_SIZE) break;
+    if (!res.data.messages || res.data.messages.length < PAGE_SIZE) {
+      hasMoreAfter = false;
+      break;
+    }
 
     pages++;
 
-    if (!nextPageToken) break;
+    if (!nextPageToken) {
+      hasMoreAfter = false;
+      break;
+    }
+
+    hasMoreAfter = true;
   }
 
   logger.info("Completed emails after", { after, pages });
 
-  if (!loadBefore || !newestEmailSaved) return { pages };
+  if (!loadBefore || !newestEmailSaved) {
+    return {
+      pages,
+      loadedAfterMessages,
+      loadedBeforeMessages,
+      hasMoreAfter,
+      hasMoreBefore,
+    };
+  }
 
   const oldestEmailSaved = await prisma.emailMessage.findFirst({
     where: { emailAccountId },
@@ -142,17 +163,32 @@ export async function loadEmails(
     });
 
     nextPageToken = res.data.nextPageToken ?? undefined;
+    loadedBeforeMessages += res.data.messages?.length || 0;
 
-    if (!res.data.messages || res.data.messages.length < PAGE_SIZE) break;
+    if (!res.data.messages || res.data.messages.length < PAGE_SIZE) {
+      hasMoreBefore = false;
+      break;
+    }
 
     pages++;
 
-    if (!nextPageToken) break;
+    if (!nextPageToken) {
+      hasMoreBefore = false;
+      break;
+    }
+
+    hasMoreBefore = true;
   }
 
   logger.info("Completed emails before", { before, pages });
 
-  return { pages };
+  return {
+    pages,
+    loadedAfterMessages,
+    loadedBeforeMessages,
+    hasMoreAfter,
+    hasMoreBefore,
+  };
 }
 
 export async function saveBatch({

--- a/apps/web/utils/auth-client.ts
+++ b/apps/web/utils/auth-client.ts
@@ -24,7 +24,40 @@ export async function signInWithOauth2(
     ReturnType<typeof createGenericOauthAuthClient>["signIn"]["oauth2"]
   >[0],
 ) {
-  const { signIn } = createGenericOauthAuthClient();
+  const response = await fetch("/api/auth/sign-in/oauth2", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(options),
+  });
 
-  return signIn.oauth2(options);
+  const payload = await parseOauth2Response(response);
+  if (!response.ok) {
+    throw new Error(payload.error);
+  }
+
+  return payload;
+}
+
+async function parseOauth2Response(response: Response) {
+  try {
+    const data = (await response.json()) as {
+      url?: string;
+      message?: string;
+      error?: string;
+    };
+
+    return {
+      url: data.url,
+      error:
+        data.error ||
+        data.message ||
+        `Request failed with status ${response.status}`,
+    };
+  } catch {
+    return {
+      error: `Request failed with status ${response.status}`,
+    };
+  }
 }

--- a/apps/web/utils/email/bulk-archive-queue.test.ts
+++ b/apps/web/utils/email/bulk-archive-queue.test.ts
@@ -115,6 +115,9 @@ describe("enqueueBulkArchiveSenderJobs", () => {
       emailAccountId: "account-1",
       totalItems: 2,
     });
+    expect(
+      mockSaveBulkArchiveTotalItems.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockEnqueueBackgroundJob.mock.invocationCallOrder[0]);
   });
 
   it("queues Outlook sender archives with the real provider", async () => {

--- a/apps/web/utils/email/bulk-archive-queue.test.ts
+++ b/apps/web/utils/email/bulk-archive-queue.test.ts
@@ -16,6 +16,8 @@ const mockBulkArchiveFromSenders = vi.fn();
 const mockBulkArchiveSenderOrThrow = vi.fn();
 const mockSaveBulkArchiveTotalItems = vi.fn();
 const mockSaveBulkArchiveProgress = vi.fn();
+const mockSaveQueuedBulkArchiveSenderStatuses = vi.fn();
+const mockSaveCompletedBulkArchiveSenderStatus = vi.fn();
 
 vi.mock("@/utils/email/provider", () => ({
   createEmailProvider: (...args: Parameters<typeof mockCreateEmailProvider>) =>
@@ -51,6 +53,15 @@ vi.mock("@/utils/redis/bulk-archive-progress", () => ({
   ) => mockSaveBulkArchiveProgress(...args),
 }));
 
+vi.mock("@/utils/redis/bulk-archive-sender-status", () => ({
+  saveQueuedBulkArchiveSenderStatuses: (
+    ...args: Parameters<typeof mockSaveQueuedBulkArchiveSenderStatuses>
+  ) => mockSaveQueuedBulkArchiveSenderStatuses(...args),
+  saveCompletedBulkArchiveSenderStatus: (
+    ...args: Parameters<typeof mockSaveCompletedBulkArchiveSenderStatus>
+  ) => mockSaveCompletedBulkArchiveSenderStatus(...args),
+}));
+
 describe("enqueueBulkArchiveSenderJobs", () => {
   beforeEach(() => {
     mockEnqueueBackgroundJob.mockReset();
@@ -60,6 +71,8 @@ describe("enqueueBulkArchiveSenderJobs", () => {
     mockBulkArchiveSenderOrThrow.mockReset();
     mockSaveBulkArchiveTotalItems.mockReset();
     mockSaveBulkArchiveProgress.mockReset();
+    mockSaveQueuedBulkArchiveSenderStatuses.mockReset();
+    mockSaveCompletedBulkArchiveSenderStatus.mockReset();
   });
 
   it("queues one background job per unique sender", async () => {
@@ -115,6 +128,10 @@ describe("enqueueBulkArchiveSenderJobs", () => {
       emailAccountId: "account-1",
       totalItems: 2,
     });
+    expect(mockSaveQueuedBulkArchiveSenderStatuses).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      senders: ["Sender@example.com", "other@example.com"],
+    });
     expect(
       mockSaveBulkArchiveTotalItems.mock.invocationCallOrder[0],
     ).toBeLessThan(mockEnqueueBackgroundJob.mock.invocationCallOrder[0]);
@@ -155,12 +172,14 @@ describe("executeBulkArchiveSenderJob", () => {
     mockBulkArchiveFromSenders.mockReset();
     mockBulkArchiveSenderOrThrow.mockReset();
     mockSaveBulkArchiveProgress.mockReset();
+    mockSaveCompletedBulkArchiveSenderStatus.mockReset();
   });
 
   it("uses the Gmail-specific archive path for Google jobs", async () => {
     const logger = createScopedLogger("bulk-archive-queue-test");
     const { GmailProvider } = await import("@/utils/email/google");
 
+    mockBulkArchiveSenderOrThrow.mockResolvedValue(7);
     mockCreateEmailProvider.mockResolvedValue(new GmailProvider());
 
     await executeBulkArchiveSenderJob({
@@ -181,12 +200,18 @@ describe("executeBulkArchiveSenderJob", () => {
       emailAccountId: "account-1",
       incrementCompleted: 1,
     });
+    expect(mockSaveCompletedBulkArchiveSenderStatus).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      sender: "sender@example.com",
+      archivedCount: 7,
+    });
   });
 
   it("uses the Outlook sender archive path for Outlook jobs", async () => {
     const logger = createScopedLogger("bulk-archive-queue-test");
     const { OutlookProvider } = await import("@/utils/email/microsoft");
 
+    mockBulkArchiveSenderOrThrow.mockResolvedValue(3);
     mockCreateEmailProvider.mockResolvedValue(new OutlookProvider());
 
     await executeBulkArchiveSenderJob({
@@ -206,6 +231,11 @@ describe("executeBulkArchiveSenderJob", () => {
     expect(mockSaveBulkArchiveProgress).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       incrementCompleted: 1,
+    });
+    expect(mockSaveCompletedBulkArchiveSenderStatus).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      sender: "sender@example.com",
+      archivedCount: 3,
     });
   });
 });

--- a/apps/web/utils/email/bulk-archive-queue.test.ts
+++ b/apps/web/utils/email/bulk-archive-queue.test.ts
@@ -14,6 +14,8 @@ const mockEnqueueBackgroundJob = vi.fn();
 const mockCreateEmailProvider = vi.fn();
 const mockBulkArchiveFromSenders = vi.fn();
 const mockBulkArchiveSenderOrThrow = vi.fn();
+const mockSaveBulkArchiveTotalItems = vi.fn();
+const mockSaveBulkArchiveProgress = vi.fn();
 
 vi.mock("@/utils/email/provider", () => ({
   createEmailProvider: (...args: Parameters<typeof mockCreateEmailProvider>) =>
@@ -40,6 +42,15 @@ vi.mock("@/utils/queue/dispatch", () => ({
   ) => mockEnqueueBackgroundJob(...args),
 }));
 
+vi.mock("@/utils/redis/bulk-archive-progress", () => ({
+  saveBulkArchiveTotalItems: (
+    ...args: Parameters<typeof mockSaveBulkArchiveTotalItems>
+  ) => mockSaveBulkArchiveTotalItems(...args),
+  saveBulkArchiveProgress: (
+    ...args: Parameters<typeof mockSaveBulkArchiveProgress>
+  ) => mockSaveBulkArchiveProgress(...args),
+}));
+
 describe("enqueueBulkArchiveSenderJobs", () => {
   beforeEach(() => {
     mockEnqueueBackgroundJob.mockReset();
@@ -47,6 +58,8 @@ describe("enqueueBulkArchiveSenderJobs", () => {
     mockCreateEmailProvider.mockReset();
     mockBulkArchiveFromSenders.mockReset();
     mockBulkArchiveSenderOrThrow.mockReset();
+    mockSaveBulkArchiveTotalItems.mockReset();
+    mockSaveBulkArchiveProgress.mockReset();
   });
 
   it("queues one background job per unique sender", async () => {
@@ -98,6 +111,10 @@ describe("enqueueBulkArchiveSenderJobs", () => {
       },
       logger,
     });
+    expect(mockSaveBulkArchiveTotalItems).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      totalItems: 2,
+    });
   });
 
   it("queues Outlook sender archives with the real provider", async () => {
@@ -134,6 +151,7 @@ describe("executeBulkArchiveSenderJob", () => {
     mockCreateEmailProvider.mockReset();
     mockBulkArchiveFromSenders.mockReset();
     mockBulkArchiveSenderOrThrow.mockReset();
+    mockSaveBulkArchiveProgress.mockReset();
   });
 
   it("uses the Gmail-specific archive path for Google jobs", async () => {
@@ -156,6 +174,10 @@ describe("executeBulkArchiveSenderJob", () => {
       "account-1",
     );
     expect(mockBulkArchiveFromSenders).not.toHaveBeenCalled();
+    expect(mockSaveBulkArchiveProgress).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      incrementCompleted: 1,
+    });
   });
 
   it("uses the Outlook sender archive path for Outlook jobs", async () => {
@@ -178,5 +200,9 @@ describe("executeBulkArchiveSenderJob", () => {
       "account-1",
     );
     expect(mockBulkArchiveFromSenders).not.toHaveBeenCalled();
+    expect(mockSaveBulkArchiveProgress).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      incrementCompleted: 1,
+    });
   });
 });

--- a/apps/web/utils/email/bulk-archive-queue.test.ts
+++ b/apps/web/utils/email/bulk-archive-queue.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createScopedLogger } from "@/utils/logger";
+import {
+  executeBulkArchiveSenderJob,
+  enqueueBulkArchiveSenderJobs,
+  MAIL_BULK_ARCHIVE_PATH,
+  MAIL_BULK_ARCHIVE_QUEUE_NAME,
+  MAIL_BULK_ARCHIVE_TOPIC,
+} from "./bulk-archive-queue";
+
+vi.mock("server-only", () => ({}));
+
+const mockEnqueueBackgroundJob = vi.fn();
+const mockCreateEmailProvider = vi.fn();
+const mockBulkArchiveFromSenders = vi.fn();
+const mockBulkArchiveSenderOrThrow = vi.fn();
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: Parameters<typeof mockCreateEmailProvider>) =>
+    mockCreateEmailProvider(...args),
+}));
+
+vi.mock("@/utils/email/google", () => ({
+  GmailProvider: class MockGmailProvider {
+    bulkArchiveFromSenders = mockBulkArchiveFromSenders;
+    bulkArchiveSenderOrThrow = mockBulkArchiveSenderOrThrow;
+  },
+}));
+
+vi.mock("@/utils/email/microsoft", () => ({
+  OutlookProvider: class MockOutlookProvider {
+    bulkArchiveFromSenders = mockBulkArchiveFromSenders;
+    bulkArchiveSenderOrThrow = mockBulkArchiveSenderOrThrow;
+  },
+}));
+
+vi.mock("@/utils/queue/dispatch", () => ({
+  enqueueBackgroundJob: (
+    ...args: Parameters<typeof mockEnqueueBackgroundJob>
+  ) => mockEnqueueBackgroundJob(...args),
+}));
+
+describe("enqueueBulkArchiveSenderJobs", () => {
+  beforeEach(() => {
+    mockEnqueueBackgroundJob.mockReset();
+    mockEnqueueBackgroundJob.mockResolvedValue("bullmq");
+    mockCreateEmailProvider.mockReset();
+    mockBulkArchiveFromSenders.mockReset();
+    mockBulkArchiveSenderOrThrow.mockReset();
+  });
+
+  it("queues one background job per unique sender", async () => {
+    const logger = createScopedLogger("bulk-archive-queue-test");
+
+    const queuedSenders = await enqueueBulkArchiveSenderJobs({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "google",
+      froms: [
+        " Sender@example.com ",
+        "sender@example.com",
+        "sender@example.com",
+        "other@example.com",
+        "",
+      ],
+      logger,
+    });
+
+    expect(queuedSenders).toBe(2);
+    expect(mockEnqueueBackgroundJob).toHaveBeenCalledTimes(2);
+    expect(mockEnqueueBackgroundJob).toHaveBeenNthCalledWith(1, {
+      topic: MAIL_BULK_ARCHIVE_TOPIC,
+      body: {
+        emailAccountId: "account-1",
+        ownerEmail: "owner@example.com",
+        provider: "google",
+        sender: "Sender@example.com",
+      },
+      qstash: {
+        queueName: MAIL_BULK_ARCHIVE_QUEUE_NAME,
+        parallelism: 1,
+        path: MAIL_BULK_ARCHIVE_PATH,
+      },
+      logger,
+    });
+    expect(mockEnqueueBackgroundJob).toHaveBeenNthCalledWith(2, {
+      topic: MAIL_BULK_ARCHIVE_TOPIC,
+      body: {
+        emailAccountId: "account-1",
+        ownerEmail: "owner@example.com",
+        provider: "google",
+        sender: "other@example.com",
+      },
+      qstash: {
+        queueName: MAIL_BULK_ARCHIVE_QUEUE_NAME,
+        parallelism: 1,
+        path: MAIL_BULK_ARCHIVE_PATH,
+      },
+      logger,
+    });
+  });
+
+  it("queues Outlook sender archives with the real provider", async () => {
+    const logger = createScopedLogger("bulk-archive-queue-test");
+
+    await enqueueBulkArchiveSenderJobs({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "microsoft",
+      froms: ["sender@example.com"],
+      logger,
+    });
+
+    expect(mockEnqueueBackgroundJob).toHaveBeenCalledWith({
+      topic: MAIL_BULK_ARCHIVE_TOPIC,
+      body: {
+        emailAccountId: "account-1",
+        ownerEmail: "owner@example.com",
+        provider: "microsoft",
+        sender: "sender@example.com",
+      },
+      qstash: {
+        queueName: MAIL_BULK_ARCHIVE_QUEUE_NAME,
+        parallelism: 1,
+        path: MAIL_BULK_ARCHIVE_PATH,
+      },
+      logger,
+    });
+  });
+});
+
+describe("executeBulkArchiveSenderJob", () => {
+  beforeEach(() => {
+    mockCreateEmailProvider.mockReset();
+    mockBulkArchiveFromSenders.mockReset();
+    mockBulkArchiveSenderOrThrow.mockReset();
+  });
+
+  it("uses the Gmail-specific archive path for Google jobs", async () => {
+    const logger = createScopedLogger("bulk-archive-queue-test");
+    const { GmailProvider } = await import("@/utils/email/google");
+
+    mockCreateEmailProvider.mockResolvedValue(new GmailProvider());
+
+    await executeBulkArchiveSenderJob({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "google",
+      sender: "sender@example.com",
+      logger,
+    });
+
+    expect(mockBulkArchiveSenderOrThrow).toHaveBeenCalledWith(
+      "sender@example.com",
+      "owner@example.com",
+      "account-1",
+    );
+    expect(mockBulkArchiveFromSenders).not.toHaveBeenCalled();
+  });
+
+  it("uses the Outlook sender archive path for Outlook jobs", async () => {
+    const logger = createScopedLogger("bulk-archive-queue-test");
+    const { OutlookProvider } = await import("@/utils/email/microsoft");
+
+    mockCreateEmailProvider.mockResolvedValue(new OutlookProvider());
+
+    await executeBulkArchiveSenderJob({
+      emailAccountId: "account-1",
+      ownerEmail: "owner@example.com",
+      provider: "microsoft",
+      sender: "sender@example.com",
+      logger,
+    });
+
+    expect(mockBulkArchiveSenderOrThrow).toHaveBeenCalledWith(
+      "sender@example.com",
+      "owner@example.com",
+      "account-1",
+    );
+    expect(mockBulkArchiveFromSenders).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/email/bulk-archive-queue.ts
+++ b/apps/web/utils/email/bulk-archive-queue.ts
@@ -1,0 +1,115 @@
+import type { Logger } from "@/utils/logger";
+import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
+import { bulkArchiveSenderJobSchema } from "@/utils/actions/mail-bulk-action.validation";
+import { createEmailProvider } from "@/utils/email/provider";
+import { isGoogleProvider } from "@/utils/email/provider-types";
+import { GmailProvider } from "@/utils/email/google";
+import { OutlookProvider } from "@/utils/email/microsoft";
+import { SafeError } from "@/utils/error";
+
+export const MAIL_BULK_ARCHIVE_TOPIC = "mail-bulk-archive";
+export const MAIL_BULK_ARCHIVE_QUEUE_NAME = "mail-bulk-archive";
+export const MAIL_BULK_ARCHIVE_PATH = "/api/mail/bulk-archive";
+
+export async function enqueueBulkArchiveSenderJobs({
+  emailAccountId,
+  ownerEmail,
+  provider,
+  froms,
+  logger,
+}: {
+  emailAccountId: string;
+  ownerEmail: string;
+  provider: "google" | "microsoft";
+  froms: string[];
+  logger: Logger;
+}) {
+  const senders = getUniqueSenders(froms);
+
+  await Promise.all(
+    senders.map((sender) =>
+      enqueueBackgroundJob({
+        topic: MAIL_BULK_ARCHIVE_TOPIC,
+        body: bulkArchiveSenderJobSchema.parse({
+          emailAccountId,
+          ownerEmail,
+          provider,
+          sender,
+        }),
+        qstash: {
+          queueName: MAIL_BULK_ARCHIVE_QUEUE_NAME,
+          parallelism: 1,
+          path: MAIL_BULK_ARCHIVE_PATH,
+        },
+        logger,
+      }),
+    ),
+  );
+
+  return senders.length;
+}
+
+export async function executeBulkArchiveSenderJob({
+  emailAccountId,
+  ownerEmail,
+  provider,
+  sender,
+  logger,
+}: {
+  emailAccountId: string;
+  ownerEmail: string;
+  provider: "google" | "microsoft";
+  sender: string;
+  logger: Logger;
+}) {
+  const emailProvider = await createEmailProvider({
+    emailAccountId,
+    provider,
+    logger,
+  });
+
+  if (isGoogleProvider(provider)) {
+    if (!(emailProvider instanceof GmailProvider)) {
+      throw new SafeError(
+        "Failed to initialize Gmail provider for bulk archive",
+      );
+    }
+
+    await emailProvider.bulkArchiveSenderOrThrow(
+      sender,
+      ownerEmail,
+      emailAccountId,
+    );
+
+    return;
+  }
+
+  if (!(emailProvider instanceof OutlookProvider)) {
+    throw new SafeError(
+      "Failed to initialize Outlook provider for bulk archive",
+    );
+  }
+
+  await emailProvider.bulkArchiveSenderOrThrow(
+    sender,
+    ownerEmail,
+    emailAccountId,
+  );
+}
+
+function getUniqueSenders(froms: string[]) {
+  const uniqueSenders = new Map<string, string>();
+
+  for (const from of froms) {
+    const normalizedSender = normalizeSender(from);
+    if (!normalizedSender || uniqueSenders.has(normalizedSender)) continue;
+
+    uniqueSenders.set(normalizedSender, from.trim());
+  }
+
+  return Array.from(uniqueSenders.values());
+}
+
+function normalizeSender(sender: string) {
+  return sender.trim().toLowerCase();
+}

--- a/apps/web/utils/email/bulk-archive-queue.ts
+++ b/apps/web/utils/email/bulk-archive-queue.ts
@@ -6,6 +6,10 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { GmailProvider } from "@/utils/email/google";
 import { OutlookProvider } from "@/utils/email/microsoft";
 import { SafeError } from "@/utils/error";
+import {
+  saveBulkArchiveProgress,
+  saveBulkArchiveTotalItems,
+} from "@/utils/redis/bulk-archive-progress";
 
 export const MAIL_BULK_ARCHIVE_TOPIC = "mail-bulk-archive";
 export const MAIL_BULK_ARCHIVE_QUEUE_NAME = "mail-bulk-archive";
@@ -46,6 +50,11 @@ export async function enqueueBulkArchiveSenderJobs({
     ),
   );
 
+  await saveBulkArchiveTotalItems({
+    emailAccountId,
+    totalItems: senders.length,
+  });
+
   return senders.length;
 }
 
@@ -80,21 +89,24 @@ export async function executeBulkArchiveSenderJob({
       ownerEmail,
       emailAccountId,
     );
+  } else {
+    if (!(emailProvider instanceof OutlookProvider)) {
+      throw new SafeError(
+        "Failed to initialize Outlook provider for bulk archive",
+      );
+    }
 
-    return;
-  }
-
-  if (!(emailProvider instanceof OutlookProvider)) {
-    throw new SafeError(
-      "Failed to initialize Outlook provider for bulk archive",
+    await emailProvider.bulkArchiveSenderOrThrow(
+      sender,
+      ownerEmail,
+      emailAccountId,
     );
   }
 
-  await emailProvider.bulkArchiveSenderOrThrow(
-    sender,
-    ownerEmail,
+  await saveBulkArchiveProgress({
     emailAccountId,
-  );
+    incrementCompleted: 1,
+  });
 }
 
 function getUniqueSenders(froms: string[]) {

--- a/apps/web/utils/email/bulk-archive-queue.ts
+++ b/apps/web/utils/email/bulk-archive-queue.ts
@@ -7,6 +7,10 @@ import { GmailProvider } from "@/utils/email/google";
 import { OutlookProvider } from "@/utils/email/microsoft";
 import { SafeError } from "@/utils/error";
 import {
+  saveCompletedBulkArchiveSenderStatus,
+  saveQueuedBulkArchiveSenderStatuses,
+} from "@/utils/redis/bulk-archive-sender-status";
+import {
   saveBulkArchiveProgress,
   saveBulkArchiveTotalItems,
 } from "@/utils/redis/bulk-archive-progress";
@@ -33,6 +37,10 @@ export async function enqueueBulkArchiveSenderJobs({
   await saveBulkArchiveTotalItems({
     emailAccountId,
     totalItems: senders.length,
+  });
+  await saveQueuedBulkArchiveSenderStatuses({
+    emailAccountId,
+    senders,
   });
 
   await Promise.all(
@@ -71,6 +79,8 @@ export async function executeBulkArchiveSenderJob({
   sender: string;
   logger: Logger;
 }) {
+  let archivedCount = 0;
+
   const emailProvider = await createEmailProvider({
     emailAccountId,
     provider,
@@ -84,7 +94,7 @@ export async function executeBulkArchiveSenderJob({
       );
     }
 
-    await emailProvider.bulkArchiveSenderOrThrow(
+    archivedCount = await emailProvider.bulkArchiveSenderOrThrow(
       sender,
       ownerEmail,
       emailAccountId,
@@ -96,12 +106,18 @@ export async function executeBulkArchiveSenderJob({
       );
     }
 
-    await emailProvider.bulkArchiveSenderOrThrow(
+    archivedCount = await emailProvider.bulkArchiveSenderOrThrow(
       sender,
       ownerEmail,
       emailAccountId,
     );
   }
+
+  await saveCompletedBulkArchiveSenderStatus({
+    emailAccountId,
+    sender,
+    archivedCount,
+  });
 
   await saveBulkArchiveProgress({
     emailAccountId,

--- a/apps/web/utils/email/bulk-archive-queue.ts
+++ b/apps/web/utils/email/bulk-archive-queue.ts
@@ -30,6 +30,11 @@ export async function enqueueBulkArchiveSenderJobs({
 }) {
   const senders = getUniqueSenders(froms);
 
+  await saveBulkArchiveTotalItems({
+    emailAccountId,
+    totalItems: senders.length,
+  });
+
   await Promise.all(
     senders.map((sender) =>
       enqueueBackgroundJob({
@@ -49,11 +54,6 @@ export async function enqueueBulkArchiveSenderJobs({
       }),
     ),
   );
-
-  await saveBulkArchiveTotalItems({
-    emailAccountId,
-    totalItems: senders.length,
-  });
 
   return senders.length;
 }

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -361,7 +361,7 @@ export class GmailProvider implements EmailProvider {
     ownerEmail: string,
     emailAccountId: string,
     options?: { continueOnError?: boolean },
-  ): Promise<void> {
+  ): Promise<number> {
     const log = this.logger.with({
       action: "archiveMessagesFromSenders",
       emailAccountId,
@@ -371,6 +371,8 @@ export class GmailProvider implements EmailProvider {
     const continueOnError = options?.continueOnError ?? true;
 
     if (senders.length === 0) return;
+
+    let archivedMessagesCount = 0;
 
     for (const sender of senders) {
       if (!sender) continue;
@@ -394,6 +396,7 @@ export class GmailProvider implements EmailProvider {
 
           if (batchMessageIds.length > 0) {
             await this.archiveMessagesBulk(batchMessageIds);
+            archivedMessagesCount += batchMessageIds.length;
 
             const newThreadIds = Array.from(batchThreadIds).filter(
               (threadId) => !publishedThreadIds.has(threadId),
@@ -441,6 +444,7 @@ export class GmailProvider implements EmailProvider {
     }
 
     log.info("Completed bulk archive from senders");
+    return archivedMessagesCount;
   }
 
   private async trashThreadsFromSenders(
@@ -572,9 +576,9 @@ export class GmailProvider implements EmailProvider {
     fromEmail: string,
     ownerEmail: string,
     emailAccountId: string,
-  ): Promise<void> {
-    await this.withRateLimitTracking("bulk-archive-sender", async () => {
-      await this.archiveMessagesFromSenders(
+  ): Promise<number> {
+    return this.withRateLimitTracking("bulk-archive-sender", async () => {
+      return await this.archiveMessagesFromSenders(
         [fromEmail],
         ownerEmail,
         emailAccountId,

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -360,6 +360,7 @@ export class GmailProvider implements EmailProvider {
     senders: string[],
     ownerEmail: string,
     emailAccountId: string,
+    options?: { continueOnError?: boolean },
   ): Promise<void> {
     const log = this.logger.with({
       action: "archiveMessagesFromSenders",
@@ -367,6 +368,7 @@ export class GmailProvider implements EmailProvider {
       email: ownerEmail,
       sendersCount: senders.length,
     });
+    const continueOnError = options?.continueOnError ?? true;
 
     if (senders.length === 0) return;
 
@@ -429,6 +431,9 @@ export class GmailProvider implements EmailProvider {
             sender,
             error,
           });
+          if (!continueOnError) {
+            throw error;
+          }
           // continue processing remaining pages
           nextPageToken = undefined;
         }
@@ -561,6 +566,21 @@ export class GmailProvider implements EmailProvider {
       ownerEmail,
       emailAccountId,
     );
+  }
+
+  async bulkArchiveSenderOrThrow(
+    fromEmail: string,
+    ownerEmail: string,
+    emailAccountId: string,
+  ): Promise<void> {
+    await this.withRateLimitTracking("bulk-archive-sender", async () => {
+      await this.archiveMessagesFromSenders(
+        [fromEmail],
+        ownerEmail,
+        emailAccountId,
+        { continueOnError: false },
+      );
+    });
   }
 
   async bulkTrashFromSenders(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1933,6 +1933,23 @@ export class OutlookProvider implements EmailProvider {
     });
   }
 
+  async bulkArchiveSenderOrThrow(
+    fromEmail: string,
+    ownerEmail: string,
+    emailAccountId: string,
+  ): Promise<void> {
+    await moveMessagesForSenders({
+      client: this.client,
+      senders: [fromEmail],
+      destinationId: "archive",
+      action: "archive",
+      ownerEmail,
+      emailAccountId,
+      logger: this.logger,
+      continueOnError: false,
+    });
+  }
+
   async bulkTrashFromSenders(
     fromEmails: string[],
     ownerEmail: string,

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1937,8 +1937,8 @@ export class OutlookProvider implements EmailProvider {
     fromEmail: string,
     ownerEmail: string,
     emailAccountId: string,
-  ): Promise<void> {
-    await moveMessagesForSenders({
+  ): Promise<number> {
+    return moveMessagesForSenders({
       client: this.client,
       senders: [fromEmail],
       destinationId: "archive",

--- a/apps/web/utils/email/provider-types.ts
+++ b/apps/web/utils/email/provider-types.ts
@@ -1,7 +1,11 @@
-export function isGoogleProvider(provider: string | null | undefined) {
+export function isGoogleProvider(
+  provider: string | null | undefined,
+): provider is "google" {
   return provider === "google";
 }
 
-export function isMicrosoftProvider(provider: string | null | undefined) {
+export function isMicrosoftProvider(
+  provider: string | null | undefined,
+): provider is "microsoft" {
   return provider === "microsoft";
 }

--- a/apps/web/utils/outlook/batch.test.ts
+++ b/apps/web/utils/outlook/batch.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OutlookClient } from "@/utils/outlook/client";
+import { createScopedLogger } from "@/utils/logger";
+import { moveMessagesForSenders } from "./batch";
+
+const mockGetFolderIds = vi.fn();
+const mockUpdateEmailMessagesForSender = vi.fn();
+const mockPublishBulkActionToTinybird = vi.fn();
+
+vi.mock("@/utils/outlook/message", () => ({
+  getFolderIds: (...args: Parameters<typeof mockGetFolderIds>) =>
+    mockGetFolderIds(...args),
+}));
+
+vi.mock("@/utils/email/bulk-action-tracking", () => ({
+  updateEmailMessagesForSender: (
+    ...args: Parameters<typeof mockUpdateEmailMessagesForSender>
+  ) => mockUpdateEmailMessagesForSender(...args),
+  publishBulkActionToTinybird: (
+    ...args: Parameters<typeof mockPublishBulkActionToTinybird>
+  ) => mockPublishBulkActionToTinybird(...args),
+}));
+
+describe("moveMessagesForSenders", () => {
+  beforeEach(() => {
+    mockGetFolderIds.mockReset();
+    mockUpdateEmailMessagesForSender.mockReset();
+    mockPublishBulkActionToTinybird.mockReset();
+  });
+
+  it("tracks successful Outlook message moves before surfacing a partial batch failure", async () => {
+    mockGetFolderIds.mockResolvedValue({
+      inbox: "inbox-folder-id",
+    });
+
+    const client = createMockOutlookClient({
+      listMessages: async () => ({
+        value: [
+          { id: "message-1", conversationId: "thread-1" },
+          { id: "message-2", conversationId: "thread-2" },
+        ],
+      }),
+      batchPost: async () => ({
+        responses: [
+          { id: "archive-0", status: 201, body: {} },
+          {
+            id: "archive-1",
+            status: 429,
+            body: { error: { message: "Rate limited" } },
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      moveMessagesForSenders({
+        client,
+        senders: ["sender@example.com"],
+        destinationId: "archive",
+        action: "archive",
+        ownerEmail: "owner@example.com",
+        emailAccountId: "account-1",
+        continueOnError: false,
+        logger: createScopedLogger("outlook-batch-test"),
+      }),
+    ).rejects.toThrow("Graph batch returned one or more error responses.");
+
+    expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledWith({
+      sender: "sender@example.com",
+      messageIds: ["message-1"],
+      emailAccountId: "account-1",
+      action: "archive",
+    });
+    expect(mockPublishBulkActionToTinybird).toHaveBeenCalledWith({
+      threadIds: ["thread-1"],
+      action: "archive",
+      ownerEmail: "owner@example.com",
+    });
+  });
+});
+
+function createMockOutlookClient({
+  listMessages,
+  batchPost,
+}: {
+  listMessages: () => Promise<{
+    value: Array<{ id?: string | null; conversationId?: string | null }>;
+    "@odata.nextLink"?: string;
+  }>;
+  batchPost: (body: unknown) => Promise<{
+    responses: Array<{ id: string; status: number; body?: unknown }>;
+  }>;
+}): OutlookClient {
+  const api = vi.fn((path: string) => {
+    if (path === "/me/messages") {
+      return {
+        filter: () => ({
+          top: () => ({
+            select: () => ({
+              get: listMessages,
+            }),
+          }),
+        }),
+      };
+    }
+
+    if (path === "/$batch") {
+      return {
+        post: batchPost,
+      };
+    }
+
+    throw new Error(`Unexpected API path: ${path}`);
+  });
+
+  return {
+    getClient: vi.fn(() => ({ api })),
+  } as unknown as OutlookClient;
+}

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -202,8 +202,8 @@ export async function moveMessagesForSenders({
   emailAccountId: string;
   continueOnError?: boolean;
   logger: Logger;
-}): Promise<void> {
-  if (senders.length === 0) return;
+}): Promise<number> {
+  if (senders.length === 0) return 0;
 
   // Resolve the actual inbox folder ID for archive filtering
   // parentFolderId on messages is the real folder ID (a GUID), not the well-known name
@@ -220,9 +220,11 @@ export async function moveMessagesForSenders({
       if (!continueOnError) {
         throw new Error("Could not resolve inbox folder ID for bulk archive");
       }
-      return;
+      return 0;
     }
   }
+
+  let movedMessagesCount = 0;
 
   for (const sender of senders) {
     if (!sender) continue;
@@ -297,6 +299,7 @@ export async function moveMessagesForSenders({
             const promises: Promise<unknown>[] = [];
 
             if (movedMessageIds.length > 0) {
+              movedMessagesCount += movedMessageIds.length;
               promises.push(
                 updateEmailMessagesForSender({
                   sender,
@@ -359,4 +362,6 @@ export async function moveMessagesForSenders({
       }
     } while (nextLink);
   }
+
+  return movedMessagesCount;
 }

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -28,17 +28,20 @@ type GraphBatchResponse<TBody = unknown> = {
   responses?: GraphBatchResponseItem<TBody>[];
 };
 
+type MoveMessagesBatchResult = {
+  movedMessageIds: string[];
+  hasErrors: boolean;
+};
+
 async function batch<TRequestBody = unknown, TResponseBody = unknown>({
   client,
   requests,
-  stopOnError = false,
   onFailure,
   context,
   logger,
 }: {
   client: OutlookClient;
   requests: GraphBatchRequestItem<TRequestBody>[];
-  stopOnError?: boolean;
   onFailure?: (params: {
     request?: GraphBatchRequestItem<TRequestBody>;
     response: GraphBatchResponseItem<TResponseBody>;
@@ -77,18 +80,6 @@ async function batch<TRequestBody = unknown, TResponseBody = unknown>({
           });
         }
       });
-
-      if (stopOnError) {
-        const errors = responses.filter((res) => res.status >= 400);
-        if (errors.length > 0) {
-          logger.error("Graph batch responses contain errors", {
-            ...context,
-            errorCount: errors.length,
-            statuses: errors.map((res) => res.status),
-          });
-          throw new Error("Graph batch returned one or more error responses.");
-        }
-      }
     } catch (error) {
       logger.error("Graph batch request failed", {
         ...context,
@@ -107,15 +98,19 @@ async function moveMessagesInBatches({
   messageIds,
   destinationId,
   action,
+  stopOnError = false,
   logger,
 }: {
   client: OutlookClient;
   messageIds: string[];
   destinationId: string;
   action: "archive" | "trash";
+  stopOnError?: boolean;
   logger: Logger;
-}): Promise<void> {
-  if (messageIds.length === 0) return;
+}): Promise<MoveMessagesBatchResult> {
+  if (messageIds.length === 0) {
+    return { movedMessageIds: [], hasErrors: false };
+  }
 
   const requestIdToMessageId = new Map<string, string>();
   const requests = messageIds.map((messageId, index) => {
@@ -135,10 +130,9 @@ async function moveMessagesInBatches({
     };
   });
 
-  await batch({
+  const responses = await batch({
     client,
     requests,
-    stopOnError: false,
     context: {
       action,
       destinationId,
@@ -163,6 +157,31 @@ async function moveMessagesInBatches({
       });
     },
   });
+
+  const movedMessageIds = responses.flatMap((response) => {
+    if (response.status >= 400) return [];
+
+    const messageId = requestIdToMessageId.get(response.id);
+    return messageId ? [messageId] : [];
+  });
+  const hasErrors = responses.some((response) => response.status >= 400);
+
+  if (hasErrors && stopOnError) {
+    logger.error("Graph batch responses contain errors", {
+      action,
+      destinationId,
+      errorCount: responses.filter((response) => response.status >= 400).length,
+      messageCount: messageIds.length,
+      statuses: responses
+        .filter((response) => response.status >= 400)
+        .map((response) => response.status),
+    });
+  }
+
+  return {
+    movedMessageIds,
+    hasErrors,
+  };
 }
 
 export async function moveMessagesForSenders({
@@ -172,6 +191,7 @@ export async function moveMessagesForSenders({
   action,
   ownerEmail,
   emailAccountId,
+  continueOnError = true,
   logger,
 }: {
   client: OutlookClient;
@@ -180,6 +200,7 @@ export async function moveMessagesForSenders({
   action: "archive" | "trash";
   ownerEmail: string;
   emailAccountId: string;
+  continueOnError?: boolean;
   logger: Logger;
 }): Promise<void> {
   if (senders.length === 0) return;
@@ -196,6 +217,9 @@ export async function moveMessagesForSenders({
       logger.error(
         "Could not resolve inbox folder ID — aborting bulk archive to avoid archiving from all folders",
       );
+      if (!continueOnError) {
+        throw new Error("Could not resolve inbox folder ID for bulk archive");
+      }
       return;
     }
   }
@@ -250,30 +274,38 @@ export async function moveMessagesForSenders({
 
         if (messageIds.length > 0) {
           try {
-            await moveMessagesInBatches({
+            const { movedMessageIds, hasErrors } = await moveMessagesInBatches({
               client,
               messageIds,
               destinationId,
               action,
+              stopOnError: !continueOnError,
               logger,
             });
 
+            const movedMessageIdSet = new Set(movedMessageIds);
             const batchThreadIds = new Set(
-              allMessages.map((msg) => msg.conversationId),
+              allMessages
+                .filter((message) => movedMessageIdSet.has(message.id))
+                .map((message) => message.conversationId),
             );
 
             const newThreadIds = Array.from(batchThreadIds).filter(
               (threadId) => !publishedThreadIds.has(threadId),
             );
 
-            const promises = [
-              updateEmailMessagesForSender({
-                sender,
-                messageIds,
-                emailAccountId,
-                action,
-              }),
-            ];
+            const promises: Promise<unknown>[] = [];
+
+            if (movedMessageIds.length > 0) {
+              promises.push(
+                updateEmailMessagesForSender({
+                  sender,
+                  messageIds: movedMessageIds,
+                  emailAccountId,
+                  action,
+                }),
+              );
+            }
 
             if (newThreadIds.length > 0) {
               promises.push(
@@ -290,6 +322,12 @@ export async function moveMessagesForSenders({
             newThreadIds.forEach((threadId) =>
               publishedThreadIds.add(threadId),
             );
+
+            if (hasErrors && !continueOnError) {
+              throw new Error(
+                "Graph batch returned one or more error responses.",
+              );
+            }
           } catch (error) {
             logger.error("Failed to move or track messages", {
               action,
@@ -299,6 +337,7 @@ export async function moveMessagesForSenders({
               messageIds,
               error,
             });
+            if (!continueOnError) throw error;
           } finally {
             messageIds.forEach((id) => processedMessageIds.add(id));
           }
@@ -315,6 +354,7 @@ export async function moveMessagesForSenders({
           action,
           error,
         });
+        if (!continueOnError) throw error;
         nextLink = undefined;
       }
     } while (nextLink);

--- a/apps/web/utils/queue/create-forwarding-queue-handler.ts
+++ b/apps/web/utils/queue/create-forwarding-queue-handler.ts
@@ -16,6 +16,7 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
   invalidPayloadMessage,
   visibilityTimeoutSeconds,
   getLoggerContext,
+  getTraceContext,
 }: {
   loggerScope: string;
   schema: TSchema;
@@ -23,6 +24,10 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
   invalidPayloadMessage: string;
   visibilityTimeoutSeconds: number;
   getLoggerContext?: (
+    payload: z.infer<TSchema>,
+    metadata: QueueMetadata,
+  ) => Record<string, unknown>;
+  getTraceContext?: (
     payload: z.infer<TSchema>,
     metadata: QueueMetadata,
   ) => Record<string, unknown>;
@@ -45,6 +50,11 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
         queueMessageId: metadata.messageId,
         deliveryCount: metadata.deliveryCount,
       });
+
+      const traceContext = getTraceContext?.(parseResult.data, metadata);
+      if (traceContext) {
+        runLogger.trace("Forwarding queue message", traceContext);
+      }
 
       await forwardQueueMessageToInternalApi({
         path,

--- a/apps/web/utils/redis/bulk-archive-progress.test.ts
+++ b/apps/web/utils/redis/bulk-archive-progress.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import {
+  getBulkArchiveProgress,
+  saveBulkArchiveProgress,
+  saveBulkArchiveTotalItems,
+} from "@/utils/redis/bulk-archive-progress";
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+describe("bulk archive progress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores queued sender totals for a fresh archive run", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce(null);
+
+    await saveBulkArchiveTotalItems({
+      emailAccountId: "account-1",
+      totalItems: 3,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      { totalItems: 3, completedItems: 0 },
+      { ex: 300 },
+    );
+  });
+
+  it("resets completed progress when a new run starts", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce({
+      totalItems: 2,
+      completedItems: 2,
+    });
+
+    await saveBulkArchiveTotalItems({
+      emailAccountId: "account-1",
+      totalItems: 4,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      { totalItems: 4, completedItems: 0 },
+      { ex: 300 },
+    );
+  });
+
+  it("increments completed items and shortens ttl when progress is done", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce({
+      totalItems: 3,
+      completedItems: 2,
+    });
+
+    await saveBulkArchiveProgress({
+      emailAccountId: "account-1",
+      incrementCompleted: 1,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      { totalItems: 3, completedItems: 3 },
+      { ex: 5 },
+    );
+  });
+
+  it("returns null when no stored progress exists", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce(null);
+
+    const progress = await getBulkArchiveProgress({
+      emailAccountId: "account-1",
+    });
+
+    expect(progress).toBeNull();
+  });
+});

--- a/apps/web/utils/redis/bulk-archive-progress.test.ts
+++ b/apps/web/utils/redis/bulk-archive-progress.test.ts
@@ -8,8 +8,10 @@ import {
 
 vi.mock("@/utils/redis", () => ({
   redis: {
-    get: vi.fn(),
-    set: vi.fn(),
+    hgetall: vi.fn(),
+    hset: vi.fn(),
+    hincrby: vi.fn(),
+    expire: vi.fn(),
   },
 }));
 
@@ -19,22 +21,25 @@ describe("bulk archive progress", () => {
   });
 
   it("stores queued sender totals for a fresh archive run", async () => {
-    vi.mocked(redis.get).mockResolvedValueOnce(null);
+    vi.mocked(redis.hgetall).mockResolvedValueOnce(null);
 
     await saveBulkArchiveTotalItems({
       emailAccountId: "account-1",
       totalItems: 3,
     });
 
-    expect(redis.set).toHaveBeenCalledWith(
+    expect(redis.hset).toHaveBeenCalledWith("bulk-archive-progress:account-1", {
+      totalItems: 3,
+      completedItems: 0,
+    });
+    expect(redis.expire).toHaveBeenCalledWith(
       "bulk-archive-progress:account-1",
-      { totalItems: 3, completedItems: 0 },
-      { ex: 300 },
+      300,
     );
   });
 
   it("resets completed progress when a new run starts", async () => {
-    vi.mocked(redis.get).mockResolvedValueOnce({
+    vi.mocked(redis.hgetall).mockResolvedValueOnce({
       totalItems: 2,
       completedItems: 2,
     });
@@ -44,33 +49,64 @@ describe("bulk archive progress", () => {
       totalItems: 4,
     });
 
-    expect(redis.set).toHaveBeenCalledWith(
+    expect(redis.hset).toHaveBeenCalledWith("bulk-archive-progress:account-1", {
+      totalItems: 4,
+      completedItems: 0,
+    });
+    expect(redis.expire).toHaveBeenCalledWith(
       "bulk-archive-progress:account-1",
-      { totalItems: 4, completedItems: 0 },
-      { ex: 300 },
+      300,
     );
   });
 
-  it("increments completed items and shortens ttl when progress is done", async () => {
-    vi.mocked(redis.get).mockResolvedValueOnce({
+  it("adds totals onto an in-flight archive run", async () => {
+    vi.mocked(redis.hgetall).mockResolvedValueOnce({
+      totalItems: 2,
+      completedItems: 1,
+    });
+    vi.mocked(redis.hincrby).mockResolvedValueOnce(4);
+
+    await saveBulkArchiveTotalItems({
+      emailAccountId: "account-1",
+      totalItems: 2,
+    });
+
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      "totalItems",
+      2,
+    );
+    expect(redis.expire).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      300,
+    );
+  });
+
+  it("increments completed items atomically and shortens ttl when progress is done", async () => {
+    vi.mocked(redis.hgetall).mockResolvedValueOnce({
       totalItems: 3,
       completedItems: 2,
     });
+    vi.mocked(redis.hincrby).mockResolvedValueOnce(3);
 
     await saveBulkArchiveProgress({
       emailAccountId: "account-1",
       incrementCompleted: 1,
     });
 
-    expect(redis.set).toHaveBeenCalledWith(
+    expect(redis.hincrby).toHaveBeenCalledWith(
       "bulk-archive-progress:account-1",
-      { totalItems: 3, completedItems: 3 },
-      { ex: 5 },
+      "completedItems",
+      1,
+    );
+    expect(redis.expire).toHaveBeenCalledWith(
+      "bulk-archive-progress:account-1",
+      30,
     );
   });
 
   it("returns null when no stored progress exists", async () => {
-    vi.mocked(redis.get).mockResolvedValueOnce(null);
+    vi.mocked(redis.hgetall).mockResolvedValueOnce(null);
 
     const progress = await getBulkArchiveProgress({
       emailAccountId: "account-1",

--- a/apps/web/utils/redis/bulk-archive-progress.ts
+++ b/apps/web/utils/redis/bulk-archive-progress.ts
@@ -2,14 +2,14 @@ import { z } from "zod";
 import { redis } from "@/utils/redis";
 
 const bulkArchiveProgressSchema = z.object({
-  totalItems: z.number().int().min(0),
-  completedItems: z.number().int().min(0),
+  totalItems: z.coerce.number().int().min(0),
+  completedItems: z.coerce.number().int().min(0),
 });
 
 type RedisBulkArchiveProgress = z.infer<typeof bulkArchiveProgressSchema>;
 
 const IN_PROGRESS_TTL_SECONDS = 5 * 60;
-const COMPLETED_TTL_SECONDS = 5;
+const COMPLETED_TTL_SECONDS = 30;
 
 function getKey({ emailAccountId }: { emailAccountId: string }) {
   return `bulk-archive-progress:${emailAccountId}`;
@@ -20,11 +20,15 @@ export async function getBulkArchiveProgress({
 }: {
   emailAccountId: string;
 }) {
-  const progress = await redis.get<RedisBulkArchiveProgress>(
+  const progress = await redis.hgetall<RedisBulkArchiveProgress>(
     getKey({ emailAccountId }),
   );
   if (!progress) return null;
-  return progress;
+
+  const parsedProgress = bulkArchiveProgressSchema.safeParse(progress);
+  if (!parsedProgress.success) return null;
+
+  return parsedProgress.data;
 }
 
 export async function saveBulkArchiveTotalItems({
@@ -51,9 +55,13 @@ export async function saveBulkArchiveTotalItems({
         completedItems: existingProgress.completedItems,
       };
 
-  await redis.set(getKey({ emailAccountId }), nextProgress, {
-    ex: IN_PROGRESS_TTL_SECONDS,
-  });
+  if (shouldResetProgress) {
+    await redis.hset(getKey({ emailAccountId }), nextProgress);
+  } else {
+    await redis.hincrby(getKey({ emailAccountId }), "totalItems", totalItems);
+  }
+
+  await redis.expire(getKey({ emailAccountId }), IN_PROGRESS_TTL_SECONDS);
 
   return nextProgress;
 }
@@ -71,20 +79,29 @@ export async function saveBulkArchiveProgress({
   if (!existingProgress) return null;
 
   const completedItems = Math.min(
-    existingProgress.completedItems + incrementCompleted,
+    await redis.hincrby(
+      getKey({ emailAccountId }),
+      "completedItems",
+      incrementCompleted,
+    ),
     existingProgress.totalItems,
   );
-  const nextProgress: RedisBulkArchiveProgress = {
+
+  if (completedItems < existingProgress.completedItems + incrementCompleted) {
+    await redis.hset(getKey({ emailAccountId }), {
+      completedItems,
+    });
+  }
+
+  await redis.expire(
+    getKey({ emailAccountId }),
+    completedItems >= existingProgress.totalItems
+      ? COMPLETED_TTL_SECONDS
+      : IN_PROGRESS_TTL_SECONDS,
+  );
+
+  return {
     totalItems: existingProgress.totalItems,
     completedItems,
   };
-
-  await redis.set(getKey({ emailAccountId }), nextProgress, {
-    ex:
-      completedItems >= existingProgress.totalItems
-        ? COMPLETED_TTL_SECONDS
-        : IN_PROGRESS_TTL_SECONDS,
-  });
-
-  return nextProgress;
 }

--- a/apps/web/utils/redis/bulk-archive-progress.ts
+++ b/apps/web/utils/redis/bulk-archive-progress.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import { redis } from "@/utils/redis";
+
+const bulkArchiveProgressSchema = z.object({
+  totalItems: z.number().int().min(0),
+  completedItems: z.number().int().min(0),
+});
+
+type RedisBulkArchiveProgress = z.infer<typeof bulkArchiveProgressSchema>;
+
+const IN_PROGRESS_TTL_SECONDS = 5 * 60;
+const COMPLETED_TTL_SECONDS = 5;
+
+function getKey({ emailAccountId }: { emailAccountId: string }) {
+  return `bulk-archive-progress:${emailAccountId}`;
+}
+
+export async function getBulkArchiveProgress({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  const progress = await redis.get<RedisBulkArchiveProgress>(
+    getKey({ emailAccountId }),
+  );
+  if (!progress) return null;
+  return progress;
+}
+
+export async function saveBulkArchiveTotalItems({
+  emailAccountId,
+  totalItems,
+}: {
+  emailAccountId: string;
+  totalItems: number;
+}) {
+  if (totalItems <= 0) return null;
+
+  const existingProgress = await getBulkArchiveProgress({ emailAccountId });
+  const shouldResetProgress =
+    !existingProgress ||
+    existingProgress.completedItems >= existingProgress.totalItems;
+
+  const nextProgress: RedisBulkArchiveProgress = shouldResetProgress
+    ? {
+        totalItems,
+        completedItems: 0,
+      }
+    : {
+        totalItems: existingProgress.totalItems + totalItems,
+        completedItems: existingProgress.completedItems,
+      };
+
+  await redis.set(getKey({ emailAccountId }), nextProgress, {
+    ex: IN_PROGRESS_TTL_SECONDS,
+  });
+
+  return nextProgress;
+}
+
+export async function saveBulkArchiveProgress({
+  emailAccountId,
+  incrementCompleted,
+}: {
+  emailAccountId: string;
+  incrementCompleted: number;
+}) {
+  if (incrementCompleted <= 0) return null;
+
+  const existingProgress = await getBulkArchiveProgress({ emailAccountId });
+  if (!existingProgress) return null;
+
+  const completedItems = Math.min(
+    existingProgress.completedItems + incrementCompleted,
+    existingProgress.totalItems,
+  );
+  const nextProgress: RedisBulkArchiveProgress = {
+    totalItems: existingProgress.totalItems,
+    completedItems,
+  };
+
+  await redis.set(getKey({ emailAccountId }), nextProgress, {
+    ex:
+      completedItems >= existingProgress.totalItems
+        ? COMPLETED_TTL_SECONDS
+        : IN_PROGRESS_TTL_SECONDS,
+  });
+
+  return nextProgress;
+}

--- a/apps/web/utils/redis/bulk-archive-sender-status.test.ts
+++ b/apps/web/utils/redis/bulk-archive-sender-status.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import {
+  getBulkArchiveSenderStatuses,
+  saveCompletedBulkArchiveSenderStatus,
+  saveQueuedBulkArchiveSenderStatuses,
+} from "@/utils/redis/bulk-archive-sender-status";
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+describe("bulk archive sender status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores queued sender statuses by normalized sender", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce(null);
+
+    await saveQueuedBulkArchiveSenderStatuses({
+      emailAccountId: "account-1",
+      senders: [" Sender@Example.com "],
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "bulk-archive-sender-status:account-1",
+      {
+        "sender@example.com": {
+          status: "completed",
+          queued: true,
+        },
+      },
+      { ex: 300 },
+    );
+  });
+
+  it("stores completed sender statuses with archived counts", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce({
+      "sender@example.com": {
+        status: "completed",
+        queued: true,
+      },
+    });
+
+    await saveCompletedBulkArchiveSenderStatus({
+      emailAccountId: "account-1",
+      sender: "sender@example.com",
+      archivedCount: 12,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "bulk-archive-sender-status:account-1",
+      {
+        "sender@example.com": {
+          status: "completed",
+          queued: false,
+          archivedCount: 12,
+        },
+      },
+      { ex: 300 },
+    );
+  });
+
+  it("returns an empty object for invalid stored state", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce("invalid");
+
+    const statuses = await getBulkArchiveSenderStatuses("account-1");
+
+    expect(statuses).toEqual({});
+  });
+});

--- a/apps/web/utils/redis/bulk-archive-sender-status.ts
+++ b/apps/web/utils/redis/bulk-archive-sender-status.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { redis } from "@/utils/redis";
+
+const bulkArchiveSenderStatusSchema = z.object({
+  status: z.enum(["completed"]),
+  queued: z.boolean(),
+  archivedCount: z.number().int().min(0).optional(),
+});
+
+const bulkArchiveSenderStatusesSchema = z.record(
+  z.string(),
+  bulkArchiveSenderStatusSchema,
+);
+
+export type BulkArchiveSenderStatus = z.infer<
+  typeof bulkArchiveSenderStatusSchema
+>;
+
+const TTL_SECONDS = 5 * 60;
+
+function getKey(emailAccountId: string) {
+  return `bulk-archive-sender-status:${emailAccountId}`;
+}
+
+export async function getBulkArchiveSenderStatuses(emailAccountId: string) {
+  const raw = await redis.get(getKey(emailAccountId));
+  const parsed = bulkArchiveSenderStatusesSchema.safeParse(raw);
+  if (!parsed.success) return {};
+  return parsed.data;
+}
+
+export async function saveQueuedBulkArchiveSenderStatuses({
+  emailAccountId,
+  senders,
+}: {
+  emailAccountId: string;
+  senders: string[];
+}) {
+  if (!senders.length) return {};
+
+  const existing = await getBulkArchiveSenderStatuses(emailAccountId);
+  const next = { ...existing };
+
+  for (const sender of senders) {
+    next[normalizeSender(sender)] = {
+      status: "completed",
+      queued: true,
+    };
+  }
+
+  await redis.set(getKey(emailAccountId), next, { ex: TTL_SECONDS });
+  return next;
+}
+
+export async function saveCompletedBulkArchiveSenderStatus({
+  emailAccountId,
+  sender,
+  archivedCount,
+}: {
+  emailAccountId: string;
+  sender: string;
+  archivedCount: number;
+}) {
+  const existing = await getBulkArchiveSenderStatuses(emailAccountId);
+  const next = {
+    ...existing,
+    [normalizeSender(sender)]: {
+      status: "completed" as const,
+      queued: false,
+      archivedCount,
+    },
+  };
+
+  await redis.set(getKey(emailAccountId), next, { ex: TTL_SECONDS });
+  return next;
+}
+
+function normalizeSender(sender: string) {
+  return sender.trim().toLowerCase();
+}

--- a/apps/web/utils/redis/categorization-progress.test.ts
+++ b/apps/web/utils/redis/categorization-progress.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import {
+  getCategorizationProgress,
+  saveCategorizationProgress,
+  saveCategorizationTotalItems,
+} from "@/utils/redis/categorization-progress";
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+describe("categorization progress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("overwrites total items while preserving completed progress", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce({
+      totalItems: 2,
+      completedItems: 1,
+    });
+
+    await saveCategorizationTotalItems({
+      emailAccountId: "account-1",
+      totalItems: 4,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "categorization-progress:account-1",
+      {
+        totalItems: 4,
+        completedItems: 1,
+      },
+      { ex: 120 },
+    );
+  });
+
+  it("increments completed items from stored progress", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce({
+      totalItems: 4,
+      completedItems: 1,
+    });
+
+    const progress = await saveCategorizationProgress({
+      emailAccountId: "account-1",
+      incrementCompleted: 2,
+    });
+
+    expect(progress).toEqual({
+      totalItems: 4,
+      completedItems: 3,
+    });
+    expect(redis.set).toHaveBeenCalledWith(
+      "categorization-progress:account-1",
+      {
+        totalItems: 4,
+        completedItems: 3,
+      },
+      { ex: 120 },
+    );
+  });
+
+  it("returns null when no progress exists", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce(null);
+
+    const progress = await getCategorizationProgress({
+      emailAccountId: "account-1",
+    });
+
+    expect(progress).toBeNull();
+  });
+});

--- a/apps/web/utils/redis/categorization-progress.ts
+++ b/apps/web/utils/redis/categorization-progress.ts
@@ -35,7 +35,8 @@ export async function saveCategorizationTotalItems({
     key,
     {
       ...existingProgress,
-      totalItems: (existingProgress?.totalItems || 0) + totalItems,
+      totalItems,
+      completedItems: existingProgress?.completedItems || 0,
     },
     { ex: 2 * 60 },
   );

--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -16,7 +16,7 @@ function setupFetchMock() {
 async function loadUpstashModule({
   qstashToken,
   nextPublicBaseUrl = "https://public.example.com",
-  internalApiUrl = "http://web:3000",
+  internalApiUrl = "https://worker.example.com",
 }: {
   qstashToken?: string;
   nextPublicBaseUrl?: string;
@@ -75,7 +75,7 @@ describe("publishToQstash", () => {
 
     expect(mockPublishJSON).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "http://web:3000/api/process",
+        url: "https://worker.example.com/api/process",
       }),
     );
     expect(fetchMock).not.toHaveBeenCalled();
@@ -90,7 +90,23 @@ describe("publishToQstash", () => {
     expect(mockPublishJSON).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://web:3000/api/process",
+      "https://worker.example.com/api/process",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("falls back when the QStash callback URL resolves to loopback", async () => {
+    const fetchMock = setupFetchMock();
+    const upstash = await loadUpstashModule({
+      qstashToken: "token",
+      internalApiUrl: "http://localhost:3000",
+    });
+
+    await upstash.publishToQstash("/api/process", { id: 1 });
+
+    expect(mockPublishJSON).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/api/process",
       expect.objectContaining({ method: "POST" }),
     );
   });
@@ -98,7 +114,7 @@ describe("publishToQstash", () => {
   it("handles trailing slash on INTERNAL_API_URL", async () => {
     const upstash = await loadUpstashModule({
       qstashToken: "token",
-      internalApiUrl: "http://web:3000/",
+      internalApiUrl: "https://worker.example.com/",
     });
     setupFetchMock();
 
@@ -106,7 +122,7 @@ describe("publishToQstash", () => {
 
     expect(mockPublishJSON).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "http://web:3000/api/process",
+        url: "https://worker.example.com/api/process",
       }),
     );
   });
@@ -131,8 +147,8 @@ describe("bulkPublishToQstash", () => {
     expect(mockBatchJSON).toHaveBeenCalledTimes(1);
     const [batchItems] = mockBatchJSON.mock.calls[0];
     expect(batchItems).toHaveLength(2);
-    expect(batchItems[0].url).toBe("http://web:3000/api/task-one");
-    expect(batchItems[1].url).toBe("http://web:3000/api/task-two");
+    expect(batchItems[0].url).toBe("https://worker.example.com/api/task-one");
+    expect(batchItems[1].url).toBe("https://worker.example.com/api/task-two");
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -151,11 +167,11 @@ describe("bulkPublishToQstash", () => {
     expect(mockBatchJSON).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://web:3000/api/task-one",
+      "https://worker.example.com/api/task-one",
       expect.objectContaining({ method: "POST" }),
     );
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://web:3000/api/task-two",
+      "https://worker.example.com/api/task-two",
       expect.objectContaining({ method: "POST" }),
     );
   });
@@ -178,9 +194,31 @@ describe("publishToQstashQueue", () => {
     });
 
     expect(mockQueueEnqueueJSON).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "http://web:3000/api/task" }),
+      expect.objectContaining({ url: "https://worker.example.com/api/task" }),
     );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back for queue publishing when callback URL resolves to loopback", async () => {
+    const fetchMock = setupFetchMock();
+    const upstash = await loadUpstashModule({
+      qstashToken: "token",
+      internalApiUrl: "http://localhost:3000",
+    });
+
+    await upstash.publishToQstashQueue({
+      queueName: "test",
+      parallelism: 1,
+      path: "/api/task",
+      body: { id: "a" },
+    });
+
+    expect(mockQueueUpsert).not.toHaveBeenCalled();
+    expect(mockQueueEnqueueJSON).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/api/task",
+      expect.objectContaining({ method: "POST" }),
+    );
   });
 
   it("falls back to internal URL when QStash client is unavailable", async () => {
@@ -198,7 +236,7 @@ describe("publishToQstashQueue", () => {
     expect(mockQueueEnqueueJSON).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://web:3000/api/task",
+      "https://worker.example.com/api/task",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -6,11 +6,21 @@ import {
   getInternalApiUrl,
 } from "@/utils/internal-api";
 import { createScopedLogger } from "@/utils/logger";
+import { isSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
 
 const logger = createScopedLogger("upstash");
 
 function getQstashClient() {
   if (!env.QSTASH_TOKEN) return null;
+  if (!isSafeExternalHttpUrl(getQstashCallbackBaseUrl())) {
+    logger.warn(
+      "Qstash callback URL is not externally reachable; using fallback",
+      {
+        qstashCallbackBaseUrl: getQstashCallbackBaseUrl(),
+      },
+    );
+    return null;
+  }
   return new Client({ token: env.QSTASH_TOKEN });
 }
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -47,6 +47,15 @@
           "retryAfterSeconds": 60
         }
       ]
+    },
+    "app/api/mail/bulk-archive/queue/route.ts": {
+      "experimentalTriggers": [
+        {
+          "type": "queue/v2beta",
+          "topic": "mail-bulk-archive",
+          "retryAfterSeconds": 60
+        }
+      ]
     }
   },
   "rewrites": [

--- a/apps/worker/src/runtime.mjs
+++ b/apps/worker/src/runtime.mjs
@@ -8,6 +8,7 @@ const DEFAULT_QUEUES = [
   { name: "digest-item-summarize", concurrency: 3 },
   { name: "email-summary-all", concurrency: 3 },
   { name: "email-digest-all", concurrency: 3 },
+  { name: "mail-bulk-archive", concurrency: 1 },
 ];
 
 export async function startWorkerRuntime({


### PR DESCRIPTION
# User description
Restore visible progress for queued bulk archive runs and update the local Google emulator package.

- update emulate to 0.4.3 for local QA parity
- initialize bulk archive progress before queue dispatch
- use atomic Redis progress counters so concurrent sender jobs do not lose updates

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Restore visibility into queued bulk archive work by routing sender jobs through the new queue handler, Redis-backed progress/sender-status APIs, and queue-launching helpers so every run initializes totals, tracks completions atomically, and feeds the worker runtime. Surface that backend state throughout the archive and categorize UI flows while tightening login error handling, Upstash routing, and supporting integration tests to keep client experiences aligned with the worker/queue behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2039?tool=ast&topic=Infra+%26+Auth>Infra & Auth</a>
        </td><td>Harden the surrounding infrastructure and developer experience by surfacing OAuth errors, keeping QStash callbacks safe, and tightening integration regression suites so queue-related flags and login flows stay aligned with the new backend behavior.<details><summary>Modified files (5)</summary><ul><li>apps/web/__tests__/integration/slack-notifications.test.ts</li>
<li>apps/web/__tests__/integration/stats-reuse-messages.test.ts</li>
<li>apps/web/app/(landing)/login/LoginForm.test.tsx</li>
<li>apps/web/app/(landing)/login/LoginForm.tsx</li>
<li>apps/web/utils/auth-client.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Extract shared Gmail t...</td><td>March 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2039?tool=ast&topic=Archive+UI+Flow>Archive UI Flow</a>
        </td><td>Refresh the bulk archive/categorization UI flow so progress feeds, preloaders, and dialog interactions react to backend counts while bulk unsubscribe, quick archive, and grouped sender tables all route through the new queue action and surface queued/completed sender statuses.<details><summary>Modified files (23)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-archive/AutoCategorizationSetup.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchiveProgress.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkActions.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeMobile.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts</li>
<li>apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/BulkArchiveTab.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/quick-bulk-archive/page.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeProgress.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/smart-categories/CategorizeWithAiButton.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/smart-categories/page.tsx</li>
<li>apps/web/components/BulkArchiveCards.tsx</li>
<li>apps/web/components/EmailCell.tsx</li>
<li>apps/web/components/EmailStatsPreloader.tsx</li>
<li>apps/web/components/GroupedTable.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix setup modal dismis...</td><td>March 12, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Editing the category o...</td><td>January 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2039?tool=ast&topic=Bulk+Archive+Queue>Bulk Archive Queue</a>
        </td><td>Coordinate queued bulk archive execution through the new queue routes, enqueue helpers, Redis progress/status persistence, and provider-specific job runners so <code>bulkArchiveAction</code> always publishes unique sender jobs, tracks completion counts atomically, and surfaces per-sender states to clients.<details><summary>Modified files (31)</summary><ul><li>apps/web/__tests__/integration/mail-bulk-archive-queue.test.ts</li>
<li>apps/web/__tests__/integration/worker-queue.test.ts</li>
<li>apps/web/app/api/mail/bulk-archive/queue/route.ts</li>
<li>apps/web/app/api/mail/bulk-archive/route.ts</li>
<li>apps/web/app/api/user/bulk-archive/progress/route.ts</li>
<li>apps/web/app/api/user/bulk-archive/sender-status/route.ts</li>
<li>apps/web/store/archive-sender-queue.ts</li>
<li>apps/web/utils/actions/categorize.test.ts</li>
<li>apps/web/utils/actions/categorize.ts</li>
<li>apps/web/utils/actions/mail-bulk-action.test.ts</li>
<li>apps/web/utils/actions/mail-bulk-action.ts</li>
<li>apps/web/utils/actions/mail-bulk-action.validation.ts</li>
<li>apps/web/utils/actions/stats.ts</li>
<li>apps/web/utils/email/bulk-archive-queue.test.ts</li>
<li>apps/web/utils/email/bulk-archive-queue.ts</li>
<li>apps/web/utils/email/google.ts</li>
<li>apps/web/utils/email/microsoft.ts</li>
<li>apps/web/utils/email/provider-types.ts</li>
<li>apps/web/utils/outlook/batch.test.ts</li>
<li>apps/web/utils/outlook/batch.ts</li>
<li>apps/web/utils/queue/create-forwarding-queue-handler.ts</li>
<li>apps/web/utils/redis/bulk-archive-progress.test.ts</li>
<li>apps/web/utils/redis/bulk-archive-progress.ts</li>
<li>apps/web/utils/redis/bulk-archive-sender-status.test.ts</li>
<li>apps/web/utils/redis/bulk-archive-sender-status.ts</li>
<li>apps/web/utils/redis/categorization-progress.test.ts</li>
<li>apps/web/utils/redis/categorization-progress.ts</li>
<li>apps/web/utils/upstash/index.test.ts</li>
<li>apps/web/utils/upstash/index.ts</li>
<li>apps/web/vercel.json</li>
<li>apps/worker/src/runtime.mjs</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2039?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>apps/web/store/archive-sender-queue.test.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Revert "queue: move bu...</td><td>March 26, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2039?tool=ast>(Baz)</a>.