### PR TITLE
assistant-chat: harden confirmation state persistence

### DIFF
--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -34,9 +34,6 @@ describe("confirmAssistantEmailAction", () => {
     } as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "chat-message-1",
-    } as any);
 
     const sendEmailWithHtml = vi.fn().mockResolvedValue({
       messageId: "msg-1",
@@ -78,7 +75,7 @@ describe("confirmAssistantEmailAction", () => {
     ).data.parts as any[];
     expect(processingParts[0].output.confirmationState).toBe("processing");
 
-    const updatedParts = (prisma.chatMessage.update.mock.calls[0][0] as any)
+    const updatedParts = (prisma.chatMessage.updateMany.mock.calls[1][0] as any)
       .data.parts as any[];
     expect(updatedParts[0].output.confirmationState).toBe("confirmed");
     expect(updatedParts[0].output.confirmationResult.actionType).toBe(
@@ -100,9 +97,6 @@ describe("confirmAssistantEmailAction", () => {
     } as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "chat-message-1",
-    } as any);
 
     const sourceMessage = {
       id: "source-message-1",
@@ -158,9 +152,6 @@ describe("confirmAssistantEmailAction", () => {
     } as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "chat-message-1",
-    } as any);
 
     const sourceMessage = {
       id: "source-message-1",
@@ -259,7 +250,6 @@ describe("confirmAssistantEmailAction", () => {
 
     expect(createEmailProvider).not.toHaveBeenCalled();
     expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
-    expect(prisma.chatMessage.update).not.toHaveBeenCalled();
     expect(result?.data?.confirmationResult).toMatchObject({
       messageId: "msg-1",
       threadId: "thr-1",
@@ -321,9 +311,6 @@ describe("confirmAssistantEmailAction", () => {
     } as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "chat-message-1",
-    } as any);
 
     const sendEmailWithHtml = vi.fn().mockResolvedValue({
       messageId: "msg-1",
@@ -344,7 +331,7 @@ describe("confirmAssistantEmailAction", () => {
     );
 
     expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
-    expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(2);
     expect(result?.data?.confirmationState).toBe("confirmed");
   });
 
@@ -395,7 +382,14 @@ describe("confirmAssistantEmailAction", () => {
         email: "owner@example.com",
       });
 
-    prisma.chatMessage.findFirst.mockResolvedValue(null as any);
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({
+        id: "assistant-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [buildPendingSendPart()],
+      } as any);
     prisma.chatMessage.findMany.mockResolvedValue([
       {
         id: "assistant-message-1",
@@ -406,9 +400,6 @@ describe("confirmAssistantEmailAction", () => {
     ] as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "assistant-message-1",
-    } as any);
 
     const sendEmailWithHtml = vi.fn().mockResolvedValue({
       messageId: "msg-1",
@@ -517,9 +508,6 @@ describe("confirmAssistantEmailAction", () => {
       } as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update.mockResolvedValue({
-      id: "chat-message-1",
-    } as any);
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       sendEmailWithHtml: vi.fn().mockRejectedValue(new Error("send failed")),
@@ -543,6 +531,88 @@ describe("confirmAssistantEmailAction", () => {
     expect(revertedParts[0].output.confirmationState).toBe("pending");
   });
 
+  it("merges confirmation into the latest message state before persisting", async () => {
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    const processingPart = buildProcessingSendPart({
+      processingAt: "2026-02-23T00:01:00.000Z",
+    });
+    const latestTextPart = { type: "text", text: "new assistant note" };
+
+    let storedMessage = {
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildPendingSendPart()],
+    };
+
+    prisma.chatMessage.findFirst.mockImplementation(async () => {
+      return { ...storedMessage } as any;
+    });
+
+    prisma.chatMessage.updateMany.mockImplementation(async (args) => {
+      const where = args.where as { updatedAt?: Date };
+      const nextParts = (args.data as { parts: unknown[] }).parts;
+
+      if (where.updatedAt?.toISOString() === "2026-02-23T00:00:00.000Z") {
+        storedMessage = {
+          ...storedMessage,
+          updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+          parts: [processingPart],
+        };
+        return { count: 1 } as any;
+      }
+
+      storedMessage = {
+        ...storedMessage,
+        updatedAt: new Date("2026-02-23T00:03:00.000Z"),
+        parts: nextParts as any[],
+      };
+      return { count: 1 } as any;
+    });
+
+    const sendEmailWithHtml = vi.fn().mockImplementation(async () => {
+      storedMessage = {
+        ...storedMessage,
+        updatedAt: new Date("2026-02-23T00:02:00.000Z"),
+        parts: [processingPart, latestTextPart],
+      };
+
+      return {
+        messageId: "msg-1",
+        threadId: "thr-1",
+      };
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const result = await confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "send_email",
+      } as any,
+    );
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(storedMessage.parts).toHaveLength(2);
+    expect((storedMessage.parts[0] as any).output.confirmationState).toBe(
+      "confirmed",
+    );
+    expect((storedMessage.parts[1] as any).text).toBe("new assistant note");
+  });
+
   it("retries persisting confirmed state before succeeding", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
@@ -554,18 +624,42 @@ describe("confirmAssistantEmailAction", () => {
         email: "owner@example.com",
       });
 
-    prisma.chatMessage.findFirst.mockResolvedValue({
+    let storedMessage = {
       id: "chat-message-1",
       chatId: "chat-1",
       updatedAt: new Date("2026-02-23T00:00:00.000Z"),
       parts: [buildPendingSendPart()],
-    } as any);
+    };
 
-    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-    prisma.chatMessage.update
-      .mockRejectedValueOnce(new Error("transient-1"))
-      .mockRejectedValueOnce(new Error("transient-2"))
-      .mockResolvedValueOnce({ id: "chat-message-1" } as any);
+    prisma.chatMessage.findFirst.mockImplementation(async () => {
+      return { ...storedMessage } as any;
+    });
+
+    let persistAttempts = 0;
+    prisma.chatMessage.updateMany.mockImplementation(async (args) => {
+      const where = args.where as { updatedAt?: Date };
+
+      if (where.updatedAt?.toISOString() === "2026-02-23T00:00:00.000Z") {
+        storedMessage = {
+          ...storedMessage,
+          updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+          parts: (args.data as { parts: unknown[] }).parts as any[],
+        };
+        return { count: 1 } as any;
+      }
+
+      persistAttempts += 1;
+      if (persistAttempts < 3) {
+        return { count: 0 } as any;
+      }
+
+      storedMessage = {
+        ...storedMessage,
+        updatedAt: new Date("2026-02-23T00:02:00.000Z"),
+        parts: (args.data as { parts: unknown[] }).parts as any[],
+      };
+      return { count: 1 } as any;
+    });
 
     const sendEmailWithHtml = vi.fn().mockResolvedValue({
       messageId: "msg-1",
@@ -586,7 +680,7 @@ describe("confirmAssistantEmailAction", () => {
     );
 
     expect(result?.data?.confirmationState).toBe("confirmed");
-    expect(prisma.chatMessage.update).toHaveBeenCalledTimes(3);
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -174,17 +174,14 @@ export async function confirmAssistantEmailActionForAccount({
     throw new SafeError(getAssistantEmailActionErrorMessage(actionType));
   }
 
-  const updatedParts = updateAssistantEmailPartWithConfirmation({
-    parts: reservation.parts,
-    partIndex: reservation.partIndex,
-    confirmationResult,
-    contentOverride,
-  });
-
   try {
-    await persistConfirmedAssistantEmailPart({
+    await persistConfirmedAssistantEmailActionPart({
       chatMessageId: reservation.chatMessageId,
-      parts: updatedParts,
+      emailAccountId,
+      toolCallId,
+      actionType,
+      confirmationResult,
+      contentOverride,
     });
   } catch (error) {
     logger.error("Failed to persist confirmed assistant email action", {
@@ -946,6 +943,100 @@ async function persistConfirmedAssistantEmailPart({
         data: { parts: parts as Prisma.InputJsonValue },
       });
       return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+async function persistConfirmedAssistantEmailActionPart({
+  chatMessageId,
+  emailAccountId,
+  toolCallId,
+  actionType,
+  confirmationResult,
+  contentOverride,
+}: {
+  chatMessageId: string;
+  emailAccountId: string;
+  toolCallId: string;
+  actionType: AssistantPendingEmailActionType;
+  confirmationResult: AssistantEmailConfirmationResult;
+  contentOverride?: string;
+}) {
+  let lastError: unknown;
+
+  for (
+    let attempt = 1;
+    attempt <= CONFIRMATION_PERSIST_MAX_ATTEMPTS;
+    attempt++
+  ) {
+    try {
+      const latestMessage = await prisma.chatMessage.findFirst({
+        where: {
+          id: chatMessageId,
+          chat: { emailAccountId },
+        },
+        select: {
+          id: true,
+          chatId: true,
+          updatedAt: true,
+          parts: true,
+        },
+      });
+
+      if (!latestMessage) {
+        throw new Error(
+          "Assistant email confirmation chat message not found while persisting",
+        );
+      }
+
+      const latestLookup = findPendingAssistantEmailPart({
+        parts: latestMessage.parts,
+        toolCallId,
+        actionType,
+      });
+
+      if (!latestLookup) {
+        throw new Error(
+          "Assistant email confirmation part not found while persisting",
+        );
+      }
+
+      if (
+        latestLookup.output.confirmationState === "confirmed" &&
+        latestLookup.output.confirmationResult
+      ) {
+        return;
+      }
+
+      const reconciledParts = updateAssistantEmailPartWithConfirmation({
+        parts: latestLookup.parts,
+        partIndex: latestLookup.index,
+        confirmationResult,
+        contentOverride,
+      });
+
+      const updateResult = await prisma.chatMessage.updateMany({
+        where: {
+          id: latestMessage.id,
+          chatId: latestMessage.chatId,
+          updatedAt: latestMessage.updatedAt,
+        },
+        data: {
+          parts: reconciledParts as Prisma.InputJsonValue,
+        },
+      });
+
+      if (updateResult.count === 1) {
+        return;
+      }
+
+      lastError = new Error(
+        "Assistant email confirmation state changed before it could be saved",
+      );
     } catch (error) {
       lastError = error;
     }


### PR DESCRIPTION
# User description
Improves assistant confirmation persistence so final state updates do not overwrite newer message changes.

- replace blind confirmation overwrites with an optimistic read-merge-update flow
- add regression coverage for concurrent message edits and retry handling

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden assistant email confirmation persistence by introducing an optimistic read-merge-update flow through <code>confirmAssistantEmailActionForAccount</code> and the new <code>persistConfirmedAssistantEmailActionPart</code> helper to avoid overwriting concurrent edits. Add retries around the persistence logic and regression coverage that mirrors concurrent message edits and transient failures.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2043?tool=ast&topic=Test+coverage>Test coverage</a>
        </td><td>Expand regression tests to mock concurrent message edits, transient persistence failures, and retries so the optimistic merge behavior and retry logic stay covered enuring confirmed states survive newer message changes.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/actions/assistant-chat.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: Chat create...</td><td>March 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2043?tool=ast&topic=Confirm+persistence>Confirm persistence</a>
        </td><td>Apply an optimistic read-merge-update flow in <code>persistConfirmedAssistantEmailActionPart</code> so the latest pending confirmation part is reloaded, merged with the new confirmation state, and retried via <code>prisma.chatMessage.updateMany</code> until it succeeds without overwriting newer message edits.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/actions/assistant-chat.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: Chat create...</td><td>March 21, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2043?tool=ast>(Baz)</a>.