### PR TITLE
organization stats: consolidate route helpers

### DIFF
--- a/apps/web/app/api/organizations/[organizationId]/stats/email-buckets/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/stats/email-buckets/route.ts
@@ -1,44 +1,20 @@
-import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
-import { withAuth } from "@/utils/middleware";
-import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
 import { Prisma } from "@/generated/prisma/client";
-import { type OrgStatsParams, orgStatsParams } from "../types";
-
-const EMAIL_BUCKETS = [
-  { min: 500, label: "500+" },
-  { min: 200, max: 499, label: "200-499" },
-  { min: 100, max: 199, label: "100-199" },
-  { min: 50, max: 99, label: "50-99" },
-  { min: 0, max: 49, label: "<50" },
-];
+import {
+  bucketMemberCounts,
+  buildDateClause,
+  createOrgStatsRoute,
+  getOrgAnalyticsMemberFilter,
+} from "../utils";
+import type { OrgStatsParams } from "../types";
 
 export type OrgEmailBucketsResponse = Awaited<
   ReturnType<typeof getEmailVolumeBuckets>
 >;
 
-export const GET = withAuth(
+export const GET = createOrgStatsRoute(
   "organizations/stats/email-buckets",
-  async (request, { params }) => {
-    const { userId } = request.auth;
-    const { organizationId } = await params;
-
-    await fetchAndCheckIsAdmin({ organizationId, userId });
-
-    const { searchParams } = new URL(request.url);
-    const queryParams = orgStatsParams.parse({
-      fromDate: searchParams.get("fromDate"),
-      toDate: searchParams.get("toDate"),
-    });
-
-    const result = await getEmailVolumeBuckets({
-      organizationId,
-      fromDate: queryParams.fromDate ?? undefined,
-      toDate: queryParams.toDate ?? undefined,
-    });
-
-    return NextResponse.json(result);
-  },
+  getEmailVolumeBuckets,
 );
 
 async function getEmailVolumeBuckets({
@@ -46,49 +22,20 @@ async function getEmailVolumeBuckets({
   fromDate,
   toDate,
 }: OrgStatsParams & { organizationId: string }) {
-  // Get email count per member using raw SQL for efficiency
   type MemberEmailCount = { emailAccountId: string; email_count: bigint };
 
-  // Build date conditions
-  const dateConditions: Prisma.Sql[] = [];
-  if (fromDate) {
-    dateConditions.push(Prisma.sql`em.date >= ${new Date(fromDate)}`);
-  }
-  if (toDate) {
-    dateConditions.push(Prisma.sql`em.date <= ${new Date(toDate)}`);
-  }
-  const dateClause =
-    dateConditions.length > 0
-      ? Prisma.sql` AND ${Prisma.join(dateConditions, " AND ")}`
-      : Prisma.sql``;
+  const dateClause = buildDateClause(Prisma.sql`em.date`, { fromDate, toDate });
+  const memberFilter = getOrgAnalyticsMemberFilter(organizationId);
 
   const memberCounts = await prisma.$queryRaw<MemberEmailCount[]>`
     SELECT em."emailAccountId", COUNT(*) as email_count
     FROM "EmailMessage" em
     JOIN "Member" m ON m."emailAccountId" = em."emailAccountId"
-    WHERE m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true AND em.sent = false${dateClause}
+    WHERE ${memberFilter} AND em.sent = false${dateClause}
     GROUP BY em."emailAccountId"
   `;
 
-  // Bucket the results in JavaScript for flexibility
-  const bucketCounts = EMAIL_BUCKETS.map((bucket) => ({
-    label: bucket.label,
-    userCount: 0,
-  }));
-
-  for (const member of memberCounts) {
-    const count = Number(member.email_count);
-    for (let i = 0; i < EMAIL_BUCKETS.length; i++) {
-      const bucket = EMAIL_BUCKETS[i];
-      if (
-        count >= bucket.min &&
-        (bucket.max === undefined || count <= bucket.max)
-      ) {
-        bucketCounts[i].userCount++;
-        break;
-      }
-    }
-  }
-
-  return bucketCounts;
+  return bucketMemberCounts(memberCounts, (member) =>
+    Number(member.email_count),
+  );
 }

--- a/apps/web/app/api/organizations/[organizationId]/stats/rules-buckets/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/stats/rules-buckets/route.ts
@@ -1,44 +1,20 @@
-import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
-import { withAuth } from "@/utils/middleware";
-import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
 import { Prisma } from "@/generated/prisma/client";
-import { type OrgStatsParams, orgStatsParams } from "../types";
-
-const RULES_BUCKETS = [
-  { min: 500, label: "500+" },
-  { min: 200, max: 499, label: "200-499" },
-  { min: 100, max: 199, label: "100-199" },
-  { min: 50, max: 99, label: "50-99" },
-  { min: 0, max: 49, label: "<50" },
-];
+import {
+  bucketMemberCounts,
+  buildDateClause,
+  createOrgStatsRoute,
+  getOrgAnalyticsMemberFilter,
+} from "../utils";
+import type { OrgStatsParams } from "../types";
 
 export type OrgRulesBucketsResponse = Awaited<
   ReturnType<typeof getExecutedRulesBuckets>
 >;
 
-export const GET = withAuth(
+export const GET = createOrgStatsRoute(
   "organizations/stats/rules-buckets",
-  async (request, { params }) => {
-    const { userId } = request.auth;
-    const { organizationId } = await params;
-
-    await fetchAndCheckIsAdmin({ organizationId, userId });
-
-    const { searchParams } = new URL(request.url);
-    const queryParams = orgStatsParams.parse({
-      fromDate: searchParams.get("fromDate"),
-      toDate: searchParams.get("toDate"),
-    });
-
-    const result = await getExecutedRulesBuckets({
-      organizationId,
-      fromDate: queryParams.fromDate ?? undefined,
-      toDate: queryParams.toDate ?? undefined,
-    });
-
-    return NextResponse.json(result);
-  },
+  getExecutedRulesBuckets,
 );
 
 async function getExecutedRulesBuckets({
@@ -46,49 +22,23 @@ async function getExecutedRulesBuckets({
   fromDate,
   toDate,
 }: OrgStatsParams & { organizationId: string }) {
-  // Get executed rules count per member
   type MemberRulesCount = { emailAccountId: string; rules_count: bigint };
 
-  // Build date conditions
-  const dateConditions: Prisma.Sql[] = [];
-  if (fromDate) {
-    dateConditions.push(Prisma.sql`er."createdAt" >= ${new Date(fromDate)}`);
-  }
-  if (toDate) {
-    dateConditions.push(Prisma.sql`er."createdAt" <= ${new Date(toDate)}`);
-  }
-  const dateClause =
-    dateConditions.length > 0
-      ? Prisma.sql` AND ${Prisma.join(dateConditions, " AND ")}`
-      : Prisma.sql``;
+  const dateClause = buildDateClause(Prisma.sql`er."createdAt"`, {
+    fromDate,
+    toDate,
+  });
+  const memberFilter = getOrgAnalyticsMemberFilter(organizationId);
 
   const memberCounts = await prisma.$queryRaw<MemberRulesCount[]>`
     SELECT er."emailAccountId", COUNT(*) as rules_count
     FROM "ExecutedRule" er
     JOIN "Member" m ON m."emailAccountId" = er."emailAccountId"
-    WHERE m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true${dateClause}
+    WHERE ${memberFilter}${dateClause}
     GROUP BY er."emailAccountId"
   `;
 
-  // Bucket the results
-  const bucketCounts = RULES_BUCKETS.map((bucket) => ({
-    label: bucket.label,
-    userCount: 0,
-  }));
-
-  for (const member of memberCounts) {
-    const count = Number(member.rules_count);
-    for (let i = 0; i < RULES_BUCKETS.length; i++) {
-      const bucket = RULES_BUCKETS[i];
-      if (
-        count >= bucket.min &&
-        (bucket.max === undefined || count <= bucket.max)
-      ) {
-        bucketCounts[i].userCount++;
-        break;
-      }
-    }
-  }
-
-  return bucketCounts;
+  return bucketMemberCounts(memberCounts, (member) =>
+    Number(member.rules_count),
+  );
 }

--- a/apps/web/app/api/organizations/[organizationId]/stats/totals/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/stats/totals/route.ts
@@ -1,35 +1,15 @@
-import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
-import { withAuth } from "@/utils/middleware";
-import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
 import { Prisma } from "@/generated/prisma/client";
-import { type OrgStatsParams, orgStatsParams } from "../types";
+import {
+  buildDateClause,
+  createOrgStatsRoute,
+  getOrgAnalyticsMemberFilter,
+} from "../utils";
+import type { OrgStatsParams } from "../types";
 
 export type OrgTotalsResponse = Awaited<ReturnType<typeof getTotals>>;
 
-export const GET = withAuth(
-  "organizations/stats/totals",
-  async (request, { params }) => {
-    const { userId } = request.auth;
-    const { organizationId } = await params;
-
-    await fetchAndCheckIsAdmin({ organizationId, userId });
-
-    const { searchParams } = new URL(request.url);
-    const queryParams = orgStatsParams.parse({
-      fromDate: searchParams.get("fromDate"),
-      toDate: searchParams.get("toDate"),
-    });
-
-    const result = await getTotals({
-      organizationId,
-      fromDate: queryParams.fromDate ?? undefined,
-      toDate: queryParams.toDate ?? undefined,
-    });
-
-    return NextResponse.json(result);
-  },
-);
+export const GET = createOrgStatsRoute("organizations/stats/totals", getTotals);
 
 async function getTotals({
   organizationId,
@@ -42,33 +22,15 @@ async function getTotals({
     active_members: bigint;
   };
 
-  // Build date conditions for emails
-  const emailDateConditions: Prisma.Sql[] = [];
-  if (fromDate) {
-    emailDateConditions.push(Prisma.sql`em.date >= ${new Date(fromDate)}`);
-  }
-  if (toDate) {
-    emailDateConditions.push(Prisma.sql`em.date <= ${new Date(toDate)}`);
-  }
-  const emailDateClause =
-    emailDateConditions.length > 0
-      ? Prisma.sql` AND ${Prisma.join(emailDateConditions, " AND ")}`
-      : Prisma.sql``;
-
-  // Build date conditions for rules
-  const rulesDateConditions: Prisma.Sql[] = [];
-  if (fromDate) {
-    rulesDateConditions.push(
-      Prisma.sql`er."createdAt" >= ${new Date(fromDate)}`,
-    );
-  }
-  if (toDate) {
-    rulesDateConditions.push(Prisma.sql`er."createdAt" <= ${new Date(toDate)}`);
-  }
-  const rulesDateClause =
-    rulesDateConditions.length > 0
-      ? Prisma.sql` AND ${Prisma.join(rulesDateConditions, " AND ")}`
-      : Prisma.sql``;
+  const emailDateClause = buildDateClause(Prisma.sql`em.date`, {
+    fromDate,
+    toDate,
+  });
+  const rulesDateClause = buildDateClause(Prisma.sql`er."createdAt"`, {
+    fromDate,
+    toDate,
+  });
+  const memberFilter = getOrgAnalyticsMemberFilter(organizationId);
 
   const result = await prisma.$queryRaw<TotalsResult[]>`
     SELECT
@@ -76,18 +38,18 @@ async function getTotals({
         SELECT COUNT(*)
         FROM "EmailMessage" em
         JOIN "Member" m ON m."emailAccountId" = em."emailAccountId"
-        WHERE m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true AND em.sent = false${emailDateClause}
+        WHERE ${memberFilter} AND em.sent = false${emailDateClause}
       ) as total_emails,
       (
         SELECT COUNT(*)
         FROM "ExecutedRule" er
         JOIN "Member" m ON m."emailAccountId" = er."emailAccountId"
-        WHERE m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true${rulesDateClause}
+        WHERE ${memberFilter}${rulesDateClause}
       ) as total_rules,
       (
         SELECT COUNT(DISTINCT m."emailAccountId")
         FROM "Member" m
-        WHERE m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true
+        WHERE ${memberFilter}
       ) as active_members
   `;
 

--- a/apps/web/app/api/organizations/[organizationId]/stats/utils.ts
+++ b/apps/web/app/api/organizations/[organizationId]/stats/utils.ts
@@ -1,0 +1,102 @@
+import { Prisma } from "@/generated/prisma/client";
+import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
+import { withAuth } from "@/utils/middleware";
+import { type OrgStatsParams, orgStatsParams } from "./types";
+
+type OrgStatsRouteHandler<T> = (
+  params: OrgStatsParams & {
+    organizationId: string;
+  },
+) => Promise<T>;
+
+type OrgStatsBucket = {
+  label: string;
+  min: number;
+  max?: number;
+};
+
+export const ORG_STATS_BUCKETS: OrgStatsBucket[] = [
+  { min: 500, label: "500+" },
+  { min: 200, max: 499, label: "200-499" },
+  { min: 100, max: 199, label: "100-199" },
+  { min: 50, max: 99, label: "50-99" },
+  { min: 0, max: 49, label: "<50" },
+];
+
+export function createOrgStatsRoute<T>(
+  routeName: string,
+  getData: OrgStatsRouteHandler<T>,
+) {
+  return withAuth(routeName, async (request, { params }) => {
+    const { userId } = request.auth;
+    const { organizationId } = await params;
+
+    await fetchAndCheckIsAdmin({ organizationId, userId });
+
+    const { searchParams } = new URL(request.url);
+    const queryParams = orgStatsParams.parse({
+      fromDate: searchParams.get("fromDate"),
+      toDate: searchParams.get("toDate"),
+    });
+
+    return Response.json(
+      await getData({
+        organizationId,
+        fromDate: queryParams.fromDate ?? undefined,
+        toDate: queryParams.toDate ?? undefined,
+      }),
+    );
+  });
+}
+
+export function buildDateClause(
+  field: Prisma.Sql,
+  { fromDate, toDate }: OrgStatsParams,
+) {
+  const dateConditions: Prisma.Sql[] = [];
+
+  if (fromDate) {
+    dateConditions.push(Prisma.sql`${field} >= ${new Date(fromDate)}`);
+  }
+
+  if (toDate) {
+    dateConditions.push(Prisma.sql`${field} <= ${new Date(toDate)}`);
+  }
+
+  return dateConditions.length > 0
+    ? Prisma.sql` AND ${Prisma.join(dateConditions, " AND ")}`
+    : Prisma.sql``;
+}
+
+export function getOrgAnalyticsMemberFilter(organizationId: string) {
+  return Prisma.sql`m."organizationId" = ${organizationId} AND m."allowOrgAdminAnalytics" = true`;
+}
+
+export function bucketMemberCounts<T>(
+  rows: readonly T[],
+  getCount: (row: T) => number,
+  buckets: readonly OrgStatsBucket[] = ORG_STATS_BUCKETS,
+) {
+  const bucketCounts = buckets.map((bucket) => ({
+    label: bucket.label,
+    userCount: 0,
+  }));
+
+  for (const row of rows) {
+    const count = getCount(row);
+
+    for (let i = 0; i < buckets.length; i++) {
+      const bucket = buckets[i];
+
+      if (
+        count >= bucket.min &&
+        (bucket.max === undefined || count <= bucket.max)
+      ) {
+        bucketCounts[i].userCount++;
+        break;
+      }
+    }
+  }
+
+  return bucketCounts;
+}


### PR DESCRIPTION
# User description
Refactors the organization stats endpoints to share the repeated route setup and query helpers. This keeps the existing API responses intact while reducing duplicate SQL and bucketing logic.

- extract shared auth and query-param handling for organization stats routes
- centralize date-clause, member-filter, and bucket-count helpers
- keep each endpoint focused on its specific query and response shape

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refactor the organization stats flow to route through <code>createOrgStatsRoute</code>, which centralizes auth, admin checks, and parameter handling before delegating to each metric handler. Share <code>buildDateClause</code>, <code>getOrgAnalyticsMemberFilter</code>, and <code>bucketMemberCounts</code> across the email, rules, and totals queries so each handler can focus on its specific SQL and response formatting.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2045?tool=ast&topic=Analytics+helpers>Analytics helpers</a>
        </td><td>Factor date clauses, member filtering, and bucketization into <code>buildDateClause</code>, <code>getOrgAnalyticsMemberFilter</code>, and <code>bucketMemberCounts</code> so the shared helpers keep SQL repetition out of the endpoints.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/api/organizations/[organizationId]/stats/utils.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2045?tool=ast&topic=Stats+route+sharing>Stats route sharing</a>
        </td><td>Reuse <code>createOrgStatsRoute</code> across the email, rules, and totals endpoints to centralize auth/admin checks and parameter handling.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/api/organizations/[organizationId]/stats/email-buckets/route.ts</li>
<li>apps/web/app/api/organizations/[organizationId]/stats/rules-buckets/route.ts</li>
<li>apps/web/app/api/organizations/[organizationId]/stats/totals/route.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>Add team invite step t...</td><td>January 29, 2026</td></tr>
<tr><td>elie222</td><td>fix build</td><td>December 10, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2045?tool=ast>(Baz)</a>.