### PR TITLE
email: fix outlook thread label filtering

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -494,7 +494,7 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     vi.spyOn(outlookLabelModule, "getLabelById").mockResolvedValue({
       id: "label-to-reply",
       displayName: "To Reply",
-    } as any);
+    } as Awaited<ReturnType<typeof outlookLabelModule.getLabelById>>);
 
     const provider = new OutlookProvider(
       createMockOutlookClient([
@@ -509,6 +509,54 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
 
     const result = await provider.getThreadsWithQuery({
       query: { labelIds: ["label-to-reply"] },
+    });
+
+    expect(result.threads.map((thread) => thread.id)).toEqual([
+      "thread-with-category",
+    ]);
+  });
+
+  it("ignores unresolved required category labelIds when only some IDs can be resolved", async () => {
+    getFolderIdsMock.mockResolvedValue({
+      inbox: "folder-inbox",
+      archive: "folder-archive",
+      drafts: "folder-drafts",
+      deleteditems: "folder-trash",
+      junkemail: "folder-spam",
+      sentitems: "folder-sent",
+    });
+    vi.spyOn(outlookMessageModule, "getCategoryMap").mockResolvedValue(
+      new Map(),
+    );
+    vi.spyOn(outlookLabelModule, "getLabelById").mockImplementation(
+      async ({ id }) => {
+        if (id === "label-to-reply") {
+          return {
+            id,
+            displayName: "To Reply",
+          } as Awaited<ReturnType<typeof outlookLabelModule.getLabelById>>;
+        }
+
+        return {
+          id,
+          displayName: undefined,
+        } as Awaited<ReturnType<typeof outlookLabelModule.getLabelById>>;
+      },
+    );
+
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({
+          id: "message-with-category",
+          conversationId: "thread-with-category",
+          categories: ["To Reply"],
+          parentFolderId: "folder-inbox",
+        }),
+      ]),
+    );
+
+    const result = await provider.getThreadsWithQuery({
+      query: { labelIds: ["label-to-reply", "label-without-name"] },
     });
 
     expect(result.threads.map((thread) => thread.id)).toEqual([

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1486,19 +1486,26 @@ export class OutlookProvider implements EmailProvider {
     let categoryMap = needsCategoryMapForFiltering
       ? await getCategoryMap(this.client, this.logger)
       : cachedCategoryMap;
-    categoryMap = await ensureOutlookRequiredCategoryMap({
-      client: this.client,
-      logger: this.logger,
-      requiredLabelIds: requiredLabelIdsForLocalFiltering,
-      folderIds: resolvedFolderIds,
-      categoryMap,
-    });
+    const { categoryMap: ensuredCategoryMap, unresolvedRequiredLabelIds } =
+      await ensureOutlookRequiredCategoryMap({
+        client: this.client,
+        logger: this.logger,
+        requiredLabelIds: requiredLabelIdsForLocalFiltering,
+        folderIds: resolvedFolderIds,
+        categoryMap,
+      });
+    categoryMap = ensuredCategoryMap;
+    const effectiveRequiredLabelIdsForLocalFiltering =
+      requiredLabelIdsForLocalFiltering?.filter(
+        (labelId) => !unresolvedRequiredLabelIds.includes(labelId),
+      );
     const excludedLabelIds = getExcludedOutlookThreadLabelIds(
       excludeLabelNames,
       categoryMap,
     );
     const requiresLocalLabelFiltering = Boolean(
-      excludedLabelIds.size || requiredLabelIdsForLocalFiltering?.length,
+      excludedLabelIds.size ||
+        effectiveRequiredLabelIdsForLocalFiltering?.length,
     );
     const maxResults = options.maxResults || 50;
 
@@ -1606,7 +1613,7 @@ export class OutlookProvider implements EmailProvider {
         folderIds: resolvedFolderIds,
         categoryMap,
         excludedLabelIds,
-        requiredLabelIds: requiredLabelIdsForLocalFiltering,
+        requiredLabelIds: effectiveRequiredLabelIdsForLocalFiltering,
         logger: this.logger,
       });
 
@@ -1621,7 +1628,7 @@ export class OutlookProvider implements EmailProvider {
       folderIds: resolvedFolderIds,
       categoryMap,
       excludedLabelIds,
-      requiredLabelIds: requiredLabelIdsForLocalFiltering,
+      requiredLabelIds: effectiveRequiredLabelIdsForLocalFiltering,
       logger: this.logger,
     });
 
@@ -2312,8 +2319,16 @@ async function ensureOutlookRequiredCategoryMap({
   requiredLabelIds?: string[];
   folderIds: Record<string, string>;
   categoryMap?: Map<string, string>;
-}): Promise<Map<string, string> | undefined> {
-  if (!requiredLabelIds?.length) return categoryMap;
+}): Promise<{
+  categoryMap?: Map<string, string>;
+  unresolvedRequiredLabelIds: string[];
+}> {
+  if (!requiredLabelIds?.length) {
+    return {
+      categoryMap,
+      unresolvedRequiredLabelIds: [],
+    };
+  }
 
   const missingCategoryIds = requiredLabelIds.filter(
     (labelId) =>
@@ -2321,25 +2336,41 @@ async function ensureOutlookRequiredCategoryMap({
       !Array.from(categoryMap?.values() || []).includes(labelId),
   );
 
-  if (!missingCategoryIds.length) return categoryMap;
+  if (!missingCategoryIds.length) {
+    return {
+      categoryMap,
+      unresolvedRequiredLabelIds: [],
+    };
+  }
 
   const resolvedCategoryMap = new Map(categoryMap?.entries() || []);
+  const unresolvedRequiredLabelIds: string[] = [];
 
   for (const labelId of missingCategoryIds) {
     try {
       const label = await getLabelById({ client, id: labelId });
       if (label.displayName) {
         resolvedCategoryMap.set(label.displayName, labelId);
+      } else {
+        logger.warn("Outlook required category has no displayName", {
+          labelId,
+        });
+        unresolvedRequiredLabelIds.push(labelId);
       }
     } catch (error) {
       logger.warn("Failed to resolve Outlook required category", {
         labelId,
         error,
       });
+      unresolvedRequiredLabelIds.push(labelId);
     }
   }
 
-  return resolvedCategoryMap.size > 0 ? resolvedCategoryMap : categoryMap;
+  return {
+    categoryMap:
+      resolvedCategoryMap.size > 0 ? resolvedCategoryMap : categoryMap,
+    unresolvedRequiredLabelIds,
+  };
 }
 
 const OUTLOOK_THREAD_PAGE_TOKEN_PREFIX = "outlook-threads:";


### PR DESCRIPTION
# User description
Align Outlook thread queries with the shared provider contract so label-based filters do not silently return broader results. This resolves incorrect thread selection when callers use shared query filters across providers.

- resolve explicit thread labels as folders or Outlook categories
- apply required and excluded label filtering before returning Outlook threads
- add focused regression coverage for explicit and excluded label filters

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjust OutlookProvider thread queries to resolve folder-backed and category labels via the shared helpers so required and excluded label filters are applied locally before returning threads and pagination tokens surface consistent results. Add regression coverage in the Outlook provider suite for explicit/excluded label handling, pagination buffering, and category lookup fallbacks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2046?tool=ast&topic=Thread+filtering>Thread filtering</a>
        </td><td>Enforce Outlook thread filtering by fetching folder IDs, resolving required/excluded label IDs, and running local filtering/pagination helpers so explicit label queries and shared provider contracts return the expected threads.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/email/microsoft.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix Outlook parsed mes...</td><td>March 27, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Fix auto-filer reply s...</td><td>February 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2046?tool=ast&topic=Provider+tests>Provider tests</a>
        </td><td>Exercise OutlookProvider thread queries with explicit/excluded labels, paging behavior, and category lookup fallbacks to prevent regressions in how label filters interact with cached maps and shared filters.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/email/microsoft.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix Outlook parsed mes...</td><td>March 27, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2046?tool=ast>(Baz)</a>.