### PR TITLE
reply: use model-based memory matching

### DIFF
--- a/apps/web/__tests__/eval/reply-memory-merge.test.ts
+++ b/apps/web/__tests__/eval/reply-memory-merge.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, describe, expect, test, vi } from "vitest";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import {
+  ReplyMemoryKind,
+  ReplyMemoryScopeType,
+} from "@/generated/prisma/enums";
+import { aiFindMatchingReplyMemoryId } from "@/utils/ai/reply/match-reply-memory";
+
+// pnpm test-ai eval/reply-memory-merge
+// Multi-model: EVAL_MODELS=all pnpm test-ai eval/reply-memory-merge
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 45_000;
+const evalReporter = createEvalReporter();
+
+const testCases = [
+  {
+    name: "matches a paraphrased demo qualification procedure",
+    memory: {
+      content:
+        "Before booking a demo, first ask how large the team is and which workflow they want to see.",
+      kind: ReplyMemoryKind.PROCEDURE,
+      scopeType: ReplyMemoryScopeType.TOPIC,
+    },
+    normalizedScopeValue: "demos",
+    candidates: [
+      {
+        id: "demo-qualification",
+        content:
+          "For demo requests, ask for team size and the main workflow before suggesting times.",
+      },
+      {
+        id: "demo-calendar-link",
+        content: "For demo requests, send the calendar link immediately.",
+      },
+    ],
+    expected: "demo-qualification",
+  },
+  {
+    name: "matches a cross-language pricing fact",
+    memory: {
+      content:
+        "El precio enterprise depende del numero de asientos y de si el cliente quiere facturacion anual.",
+      kind: ReplyMemoryKind.FACT,
+      scopeType: ReplyMemoryScopeType.TOPIC,
+    },
+    normalizedScopeValue: "pricing",
+    candidates: [
+      {
+        id: "pricing-annual-billing",
+        content:
+          "Enterprise pricing depends on seat count and whether the customer wants annual billing.",
+      },
+      {
+        id: "pricing-free-trial",
+        content: "Offer a free trial before discussing paid pricing.",
+      },
+    ],
+    expected: "pricing-annual-billing",
+  },
+  {
+    name: "keeps related but distinct pricing facts separate",
+    memory: {
+      content:
+        "When asked about enterprise pricing, mention that implementation fees are quoted separately from the subscription.",
+      kind: ReplyMemoryKind.FACT,
+      scopeType: ReplyMemoryScopeType.TOPIC,
+    },
+    normalizedScopeValue: "pricing",
+    candidates: [
+      {
+        id: "pricing-annual-billing",
+        content:
+          "Enterprise pricing depends on seat count and whether the customer wants annual billing.",
+      },
+      {
+        id: "pricing-procurement",
+        content:
+          "Procurement review starts only after the customer confirms budget and timeline.",
+      },
+    ],
+    expected: null,
+  },
+] as const;
+
+describe.runIf(shouldRunEval)("reply memory merge eval", () => {
+  describeEvalMatrix("reply memory merge", (model, emailAccount) => {
+    const replyMemoryEmailAccount = emailAccount as Parameters<
+      typeof aiFindMatchingReplyMemoryId
+    >[0]["emailAccount"];
+
+    for (const testCase of testCases) {
+      test(
+        testCase.name,
+        async () => {
+          const result = await aiFindMatchingReplyMemoryId({
+            emailAccount: replyMemoryEmailAccount,
+            memory: testCase.memory,
+            normalizedScopeValue: testCase.normalizedScopeValue,
+            candidates: [...testCase.candidates],
+          });
+
+          const pass = result === testCase.expected;
+
+          evalReporter.record({
+            testName: testCase.name,
+            model: model.label,
+            pass,
+            expected: testCase.expected ?? "null",
+            actual: result ?? "null",
+          });
+
+          expect(result).toBe(testCase.expected);
+        },
+        TIMEOUT,
+      );
+    }
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});

--- a/apps/web/utils/ai/reply/match-reply-memory.ts
+++ b/apps/web/utils/ai/reply/match-reply-memory.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import type { ReplyMemory } from "@/generated/prisma/client";
+import { PROMPT_SECURITY_INSTRUCTIONS } from "@/utils/ai/security";
+import { createGenerateObject } from "@/utils/llms";
+import { getModel } from "@/utils/llms/model";
+import type { getEmailAccountWithAi } from "@/utils/user/get";
+
+const replyMemoryMatchSchema = z.object({
+  matchingExistingMemoryId: z.string().trim().nullable(),
+});
+
+export async function aiFindMatchingReplyMemoryId({
+  emailAccount,
+  memory,
+  normalizedScopeValue,
+  candidates,
+}: {
+  emailAccount: NonNullable<Awaited<ReturnType<typeof getEmailAccountWithAi>>>;
+  memory: Pick<ReplyMemory, "content" | "kind" | "scopeType">;
+  normalizedScopeValue: string;
+  candidates: Pick<ReplyMemory, "id" | "content">[];
+}) {
+  if (!candidates.length) return null;
+
+  const modelOptions = getModel(emailAccount.user, "economy");
+  const generateObject = createGenerateObject({
+    emailAccount,
+    label: "Reply memory merge matching",
+    modelOptions,
+  });
+
+  const result = await generateObject({
+    ...modelOptions,
+    system: `You decide whether a newly extracted reply memory should attach to an existing reply memory instead of creating a new one.
+
+${PROMPT_SECURITY_INSTRUCTIONS}
+
+Work language-agnostically. The memories may be written in any language.
+
+Match an existing memory when:
+- it captures the same durable instruction, fact, or procedure
+- differences are only phrasing, wording, examples, or minor emphasis
+- the new memory would be redundant if stored separately
+
+Return null when:
+- the new memory adds a meaningfully different rule, fact, or workflow
+- two memories are related but should still remain separate
+- no candidate is a strong semantic match
+
+Rules:
+- Only return an id from the provided candidate list.
+- Be conservative: pick an id only when the match is clearly the same memory.
+- Ignore exact wording; focus on semantic equivalence.
+- Do not invent or rewrite memory text.`,
+    prompt: `<new_memory>
+kind: ${memory.kind}
+scope_type: ${memory.scopeType}
+scope_value: ${normalizedScopeValue || "(global)"}
+content: ${memory.content}
+</new_memory>
+
+<existing_memories>
+${candidates
+  .map(
+    (candidate, index) =>
+      `${index + 1}. id=${candidate.id}\ncontent: ${candidate.content}`,
+  )
+  .join("\n\n")}
+</existing_memories>
+
+Choose the existing memory id if one existing memory already captures the same durable idea as the new memory. Otherwise return null.`,
+    schema: replyMemoryMatchSchema,
+  });
+
+  const matchingId = result.object.matchingExistingMemoryId;
+  if (!matchingId) return null;
+
+  return candidates.some((candidate) => candidate.id === matchingId)
+    ? matchingId
+    : null;
+}

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -64,6 +64,7 @@ describe("reply-memory", () => {
     vi.mocked(prisma.emailAccount.update).mockResolvedValue({} as any);
     vi.mocked(prisma.replyMemory.findMany).mockResolvedValue([] as any);
     vi.mocked(prisma.replyMemory.count).mockResolvedValue(0 as any);
+    vi.mocked(prisma.replyMemory.update).mockResolvedValue({} as any);
     vi.mocked(prisma.replyMemory.updateMany).mockResolvedValue({
       count: 0,
     } as any);
@@ -406,6 +407,102 @@ describe("reply-memory", () => {
       data: {
         replyMemoryProcessedAt: expect.any(Date),
       },
+    });
+  });
+
+  it("attaches new evidence to an existing semantically equivalent memory", async () => {
+    vi.mocked(prisma.draftSendLog.updateMany).mockResolvedValue({
+      count: 0,
+    });
+    vi.mocked(prisma.draftSendLog.findMany).mockResolvedValue([
+      createDraftSendLog({
+        replyMemorySentText:
+          "Thanks for reaching out. Please complete the Recruit Questionnaire, keep us posted on your schedule, and let us know if you can attend camp.",
+      }),
+    ] as any);
+    vi.mocked(prisma.replyMemory.findMany)
+      .mockResolvedValueOnce([
+        createReplyMemory({
+          id: "existing-procedure-memory",
+          content:
+            "For initial recruit inquiries, ask them to complete the Recruit Questionnaire, keep staff updated on their schedule, mention camps, and sign as Coach Schmid.",
+          kind: ReplyMemoryKind.PROCEDURE,
+          scopeType: ReplyMemoryScopeType.GLOBAL,
+          createdAt: new Date("2026-03-10T09:00:00.000Z"),
+          updatedAt: new Date("2026-03-10T09:00:00.000Z"),
+        }),
+      ] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        createReplyMemory({
+          id: "existing-procedure-memory",
+          content:
+            "For initial recruit inquiries, ask them to complete the Recruit Questionnaire, keep staff updated on their schedule, mention camps, and sign as Coach Schmid.",
+          kind: ReplyMemoryKind.PROCEDURE,
+          scopeType: ReplyMemoryScopeType.GLOBAL,
+          createdAt: new Date("2026-03-10T09:00:00.000Z"),
+          updatedAt: new Date("2026-03-10T09:00:00.000Z"),
+        }),
+      ] as any);
+    vi.mocked(prisma.replyMemory.update).mockResolvedValue(
+      createReplyMemory({
+        id: "existing-procedure-memory",
+        content:
+          "For initial recruit inquiries, ask them to complete the Recruit Questionnaire, keep staff updated on their schedule, mention camps, and sign as Coach Schmid.",
+        kind: ReplyMemoryKind.PROCEDURE,
+        scopeType: ReplyMemoryScopeType.GLOBAL,
+      }) as any,
+    );
+    vi.mocked(prisma.draftSendLog.update).mockResolvedValue({} as any);
+    mockGenerateObject
+      .mockResolvedValueOnce({
+        object: {
+          memories: [
+            {
+              content:
+                "When replying to an initial recruit inquiry, ask the prospect to complete the Recruit Questionnaire, keep you updated on their schedule, mention upcoming camps, and close as Coach Schmid.",
+              kind: ReplyMemoryKind.PROCEDURE,
+              scopeType: ReplyMemoryScopeType.GLOBAL,
+              scopeValue: "",
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        object: {
+          matchingExistingMemoryId: "existing-procedure-memory",
+        },
+      });
+
+    const provider = {
+      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
+    };
+
+    await syncReplyMemoriesFromDraftSendLogs({
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+    });
+
+    expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
+    expect(prisma.replyMemory.update).toHaveBeenCalledWith({
+      where: { id: "existing-procedure-memory" },
+      data: {
+        isLearnedStyleEvidence: false,
+      },
+    });
+    expect(prisma.replyMemorySource.upsert).toHaveBeenCalledWith({
+      where: {
+        replyMemoryId_draftSendLogId: {
+          replyMemoryId: "existing-procedure-memory",
+          draftSendLogId: "draft-send-log-1",
+        },
+      },
+      create: {
+        replyMemoryId: "existing-procedure-memory",
+        draftSendLogId: "draft-send-log-1",
+      },
+      update: {},
     });
   });
 

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -3,17 +3,14 @@ import {
   ReplyMemoryScopeType,
 } from "@/generated/prisma/enums";
 import type { Prisma, ReplyMemory } from "@/generated/prisma/client";
-import { z } from "zod";
-import { PROMPT_SECURITY_INSTRUCTIONS } from "@/utils/ai/security";
 import { extractDomainFromEmail, extractEmailAddress } from "@/utils/email";
 import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
-import { createGenerateObject } from "@/utils/llms";
-import { getModel } from "@/utils/llms/model";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { aiExtractReplyMemoriesFromDraftEdit } from "./extract-reply-memories";
+import { aiFindMatchingReplyMemoryId } from "./match-reply-memory";
 import { aiSummarizeLearnedWritingStyle } from "./summarize-learned-writing-style";
 
 const REPLY_MEMORY_RETENTION_DAYS = 7;
@@ -30,9 +27,6 @@ const PROMPTABLE_REPLY_MEMORY_KINDS = [
 const MIN_PREFERENCE_EVIDENCE_FOR_LEARNED_STYLE = 10;
 const PREFERENCE_EVIDENCE_PER_LEARNED_STYLE_REFRESH = 5;
 const MAX_PREFERENCE_EVIDENCE_FOR_LEARNED_STYLE = 25;
-const replyMemoryMatchSchema = z.object({
-  matchingExistingMemoryId: z.string().trim().nullable(),
-});
 
 export async function saveDraftSendLogReplyMemory({
   draftSendLogId,
@@ -842,64 +836,19 @@ async function findMatchingExistingReplyMemory({
 
   if (!candidates.length) return null;
 
-  const modelOptions = getModel(emailAccount.user, "economy");
-  const generateObject = createGenerateObject({
-    emailAccount,
-    label: "Reply memory merge matching",
-    modelOptions,
-  });
-
   try {
-    const prompt = `<new_memory>
-kind: ${memory.kind}
-scope_type: ${memory.scopeType}
-scope_value: ${normalizedScopeValue || "(global)"}
-content: ${memory.content}
-</new_memory>
-
-<existing_memories>
-${candidates
-  .map(
-    (candidate, index) =>
-      `${index + 1}. id=${candidate.id}\ncontent: ${candidate.content}`,
-  )
-  .join("\n\n")}
-</existing_memories>
-
-Choose the existing memory id if one existing memory already captures the same durable idea as the new memory. Otherwise return null.`;
-    const system = `You decide whether a newly extracted reply memory should attach to an existing reply memory instead of creating a new one.
-
-${PROMPT_SECURITY_INSTRUCTIONS}
-
-Work language-agnostically. The memories may be written in any language.
-
-Match an existing memory when:
-- it captures the same durable instruction, fact, or procedure
-- differences are only phrasing, wording, examples, or minor emphasis
-- the new memory would be redundant if stored separately
-
-Return null when:
-- the new memory adds a meaningfully different rule, fact, or workflow
-- two memories are related but should still remain separate
-- no candidate is a strong semantic match
-
-Rules:
-- Only return an id from the provided candidate list.
-- Be conservative: pick an id only when the match is clearly the same memory.
-- Ignore exact wording; focus on semantic equivalence.
-- Do not invent or rewrite memory text.`;
-
-    const result = await generateObject({
-      ...modelOptions,
-      system,
-      prompt,
-      schema: replyMemoryMatchSchema,
+    const matchingExistingMemoryId = await aiFindMatchingReplyMemoryId({
+      emailAccount,
+      memory,
+      normalizedScopeValue,
+      candidates,
     });
-
-    const matchingId = result.object.matchingExistingMemoryId;
-    if (!matchingId) return null;
-
-    return candidates.find((candidate) => candidate.id === matchingId) ?? null;
+    if (!matchingExistingMemoryId) return null;
+    return (
+      candidates.find(
+        (candidate) => candidate.id === matchingExistingMemoryId,
+      ) ?? null
+    );
   } catch (error) {
     logger.warn("Failed to match reply memory against existing memories", {
       error,

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -850,42 +850,7 @@ async function findMatchingExistingReplyMemory({
   });
 
   try {
-    const result = await generateObject({
-      ...modelOptions,
-      system: getReplyMemoryMatchSystemPrompt(),
-      prompt: getReplyMemoryMatchPrompt({
-        memory,
-        normalizedScopeValue,
-        candidates,
-      }),
-      schema: replyMemoryMatchSchema,
-    });
-
-    const matchingId = result.object.matchingExistingMemoryId;
-    if (!matchingId) return null;
-
-    return candidates.find((candidate) => candidate.id === matchingId) ?? null;
-  } catch (error) {
-    logger.warn("Failed to match reply memory against existing memories", {
-      error,
-      emailAccountId,
-      replyMemoryKind: memory.kind,
-      replyMemoryScopeType: memory.scopeType,
-    });
-    return null;
-  }
-}
-
-function getReplyMemoryMatchPrompt({
-  memory,
-  normalizedScopeValue,
-  candidates,
-}: {
-  memory: Pick<ReplyMemory, "content" | "kind" | "scopeType">;
-  normalizedScopeValue: string;
-  candidates: ReplyMemory[];
-}) {
-  return `<new_memory>
+    const prompt = `<new_memory>
 kind: ${memory.kind}
 scope_type: ${memory.scopeType}
 scope_value: ${normalizedScopeValue || "(global)"}
@@ -902,10 +867,7 @@ ${candidates
 </existing_memories>
 
 Choose the existing memory id if one existing memory already captures the same durable idea as the new memory. Otherwise return null.`;
-}
-
-function getReplyMemoryMatchSystemPrompt() {
-  return `You decide whether a newly extracted reply memory should attach to an existing reply memory instead of creating a new one.
+    const system = `You decide whether a newly extracted reply memory should attach to an existing reply memory instead of creating a new one.
 
 ${PROMPT_SECURITY_INSTRUCTIONS}
 
@@ -926,4 +888,25 @@ Rules:
 - Be conservative: pick an id only when the match is clearly the same memory.
 - Ignore exact wording; focus on semantic equivalence.
 - Do not invent or rewrite memory text.`;
+
+    const result = await generateObject({
+      ...modelOptions,
+      system,
+      prompt,
+      schema: replyMemoryMatchSchema,
+    });
+
+    const matchingId = result.object.matchingExistingMemoryId;
+    if (!matchingId) return null;
+
+    return candidates.find((candidate) => candidate.id === matchingId) ?? null;
+  } catch (error) {
+    logger.warn("Failed to match reply memory against existing memories", {
+      error,
+      emailAccountId,
+      replyMemoryKind: memory.kind,
+      replyMemoryScopeType: memory.scopeType,
+    });
+    return null;
+  }
 }

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -3,9 +3,13 @@ import {
   ReplyMemoryScopeType,
 } from "@/generated/prisma/enums";
 import type { Prisma, ReplyMemory } from "@/generated/prisma/client";
+import { z } from "zod";
+import { PROMPT_SECURITY_INSTRUCTIONS } from "@/utils/ai/security";
 import { extractDomainFromEmail, extractEmailAddress } from "@/utils/email";
 import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
+import { createGenerateObject } from "@/utils/llms";
+import { getModel } from "@/utils/llms/model";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
@@ -18,6 +22,7 @@ const MAX_EXISTING_MEMORIES_IN_PROMPT = 12;
 const MAX_EXISTING_PREFERENCE_MEMORIES_IN_PROMPT = 4;
 const MAX_RETRIEVED_REPLY_MEMORIES = 6;
 const MAX_RETRIEVED_TOPIC_REPLY_MEMORIES = 3;
+const MAX_REPLY_MEMORY_MATCH_CANDIDATES = 20;
 const PROMPTABLE_REPLY_MEMORY_KINDS = [
   ReplyMemoryKind.FACT,
   ReplyMemoryKind.PROCEDURE,
@@ -25,6 +30,9 @@ const PROMPTABLE_REPLY_MEMORY_KINDS = [
 const MIN_PREFERENCE_EVIDENCE_FOR_LEARNED_STYLE = 10;
 const PREFERENCE_EVIDENCE_PER_LEARNED_STYLE_REFRESH = 5;
 const MAX_PREFERENCE_EVIDENCE_FOR_LEARNED_STYLE = 25;
+const replyMemoryMatchSchema = z.object({
+  matchingExistingMemoryId: z.string().trim().nullable(),
+});
 
 export async function saveDraftSendLogReplyMemory({
   draftSendLogId,
@@ -427,21 +435,36 @@ async function processReplyMemoryDraftSendLog({
     const isLearnedStyleEvidence =
       normalizedMemory.kind === ReplyMemoryKind.PREFERENCE;
 
-    const persistedMemory = await prisma.replyMemory.upsert({
-      where,
-      create: {
-        emailAccountId,
-        content: normalizedMemory.content,
-        kind: normalizedMemory.kind,
-        scopeType: normalizedMemory.scopeType,
-        scopeValue: normalizedScopeValue,
-        isLearnedStyleEvidence,
-      },
-      update: {
-        content: normalizedMemory.content,
-        isLearnedStyleEvidence,
-      },
+    const matchingExistingMemory = await findMatchingExistingReplyMemory({
+      emailAccount,
+      emailAccountId,
+      logger,
+      memory: normalizedMemory,
+      normalizedScopeValue,
     });
+
+    const persistedMemory = matchingExistingMemory
+      ? await prisma.replyMemory.update({
+          where: { id: matchingExistingMemory.id },
+          data: {
+            isLearnedStyleEvidence,
+          },
+        })
+      : await prisma.replyMemory.upsert({
+          where,
+          create: {
+            emailAccountId,
+            content: normalizedMemory.content,
+            kind: normalizedMemory.kind,
+            scopeType: normalizedMemory.scopeType,
+            scopeValue: normalizedScopeValue,
+            isLearnedStyleEvidence,
+          },
+          update: {
+            content: normalizedMemory.content,
+            isLearnedStyleEvidence,
+          },
+        });
 
     await prisma.replyMemorySource.upsert({
       where: {
@@ -791,4 +814,116 @@ function truncatePreferenceEvidenceText(value: string) {
   return normalized.length > 280
     ? `${normalized.slice(0, 277).trimEnd()}...`
     : normalized;
+}
+
+async function findMatchingExistingReplyMemory({
+  emailAccount,
+  emailAccountId,
+  logger,
+  memory,
+  normalizedScopeValue,
+}: {
+  emailAccount: NonNullable<Awaited<ReturnType<typeof getEmailAccountWithAi>>>;
+  emailAccountId: string;
+  logger: Logger;
+  memory: Pick<ReplyMemory, "content" | "kind" | "scopeType">;
+  normalizedScopeValue: string;
+}) {
+  const candidates = await prisma.replyMemory.findMany({
+    where: {
+      emailAccountId,
+      kind: memory.kind,
+      scopeType: memory.scopeType,
+      scopeValue: normalizedScopeValue,
+    },
+    orderBy: { updatedAt: "desc" },
+    take: MAX_REPLY_MEMORY_MATCH_CANDIDATES,
+  });
+
+  if (!candidates.length) return null;
+
+  const modelOptions = getModel(emailAccount.user, "economy");
+  const generateObject = createGenerateObject({
+    emailAccount,
+    label: "Reply memory merge matching",
+    modelOptions,
+  });
+
+  try {
+    const result = await generateObject({
+      ...modelOptions,
+      system: getReplyMemoryMatchSystemPrompt(),
+      prompt: getReplyMemoryMatchPrompt({
+        memory,
+        normalizedScopeValue,
+        candidates,
+      }),
+      schema: replyMemoryMatchSchema,
+    });
+
+    const matchingId = result.object.matchingExistingMemoryId;
+    if (!matchingId) return null;
+
+    return candidates.find((candidate) => candidate.id === matchingId) ?? null;
+  } catch (error) {
+    logger.warn("Failed to match reply memory against existing memories", {
+      error,
+      emailAccountId,
+      replyMemoryKind: memory.kind,
+      replyMemoryScopeType: memory.scopeType,
+    });
+    return null;
+  }
+}
+
+function getReplyMemoryMatchPrompt({
+  memory,
+  normalizedScopeValue,
+  candidates,
+}: {
+  memory: Pick<ReplyMemory, "content" | "kind" | "scopeType">;
+  normalizedScopeValue: string;
+  candidates: ReplyMemory[];
+}) {
+  return `<new_memory>
+kind: ${memory.kind}
+scope_type: ${memory.scopeType}
+scope_value: ${normalizedScopeValue || "(global)"}
+content: ${memory.content}
+</new_memory>
+
+<existing_memories>
+${candidates
+  .map(
+    (candidate, index) =>
+      `${index + 1}. id=${candidate.id}\ncontent: ${candidate.content}`,
+  )
+  .join("\n\n")}
+</existing_memories>
+
+Choose the existing memory id if one existing memory already captures the same durable idea as the new memory. Otherwise return null.`;
+}
+
+function getReplyMemoryMatchSystemPrompt() {
+  return `You decide whether a newly extracted reply memory should attach to an existing reply memory instead of creating a new one.
+
+${PROMPT_SECURITY_INSTRUCTIONS}
+
+Work language-agnostically. The memories may be written in any language.
+
+Match an existing memory when:
+- it captures the same durable instruction, fact, or procedure
+- differences are only phrasing, wording, examples, or minor emphasis
+- the new memory would be redundant if stored separately
+
+Return null when:
+- the new memory adds a meaningfully different rule, fact, or workflow
+- two memories are related but should still remain separate
+- no candidate is a strong semantic match
+
+Rules:
+- Only return an id from the provided candidate list.
+- Be conservative: pick an id only when the match is clearly the same memory.
+- Ignore exact wording; focus on semantic equivalence.
+- Do not invent or rewrite memory text.`;
 }


### PR DESCRIPTION
# User description
Adds an AI-based merge step for reply memories so semantically equivalent memories can reuse existing rows instead of creating duplicates.

- ask the model to choose an existing same-scope memory id before creating a new reply memory
- fall back to normal memory creation if the match call does not succeed
- add regression coverage for paraphrased duplicate memories attaching new source evidence

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable AI-guided reply memory merge by routing <code>syncReplyMemoriesFromDraftSendLogs</code> through <code>findMatchingExistingReplyMemory</code>, which uses <code>aiFindMatchingReplyMemoryId</code> to reuse semantically equivalent memories before creating new rows. Add eval and unit coverage for paraphrased duplicates so that new source evidence attaches to the reused memory when matches occur.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2050?tool=ast&topic=Memory+Matching>Memory Matching</a>
        </td><td>Add AI-driven matching via <code>aiFindMatchingReplyMemoryId</code> and <code>findMatchingExistingReplyMemory</code> to compare new memories against recent same-scope candidates, update existing rows when duplicates are found, and fall back to the previous upsert flow otherwise.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/ai/reply/match-reply-memory.ts</li>
<li>apps/web/utils/ai/reply/reply-memory.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve learned writin...</td><td>March 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2050?tool=ast&topic=Merge+Tests>Merge Tests</a>
        </td><td>Add regression coverage that runs the match evaluator across paraphrased and cross-language scenarios plus a unit test that ensures new evidence attaches to an existing memory when the merge succeeds.<details><summary>Modified files (2)</summary><ul><li>apps/web/__tests__/eval/reply-memory-merge.test.ts</li>
<li>apps/web/utils/ai/reply/reply-memory.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve learned writin...</td><td>March 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2050?tool=ast>(Baz)</a>.