### PR TITLE
logging: preserve server action error context

### DIFF
--- a/apps/web/utils/actions/safe-action.ts
+++ b/apps/web/utils/actions/safe-action.ts
@@ -20,20 +20,35 @@ const baseClient = createSafeActionClient({
   },
   defaultValidationErrorsShape: "flattened",
   handleServerError(error, { metadata, ctx, bindArgsClientInputs }) {
-    const context = ctx as {
-      userId?: string;
-      userEmail?: string;
-      emailAccountId?: string;
-    };
+    const context = ctx as
+      | {
+          logger: ReturnType<typeof createScopedLogger>;
+          requestId: string;
+          userId?: string;
+          userEmail?: string;
+          emailAccountId?: string;
+        }
+      | undefined;
 
-    const logger = createScopedLogger("safe-action");
+    const logger =
+      context?.logger ??
+      createScopedLogger(metadata?.name || "safe-action").with({
+        requestId: context?.requestId,
+        userId: context?.userId,
+        userEmail: context?.userEmail,
+        emailAccountId: context?.emailAccountId,
+      });
     logger.error("Server action error:", {
       metadata,
-      userId: context?.userId,
-      userEmail: context?.userEmail,
-      emailAccountId: context?.emailAccountId,
       bindArgsClientInputs,
       error,
+    });
+    after(async () => {
+      await flushLoggerSafely(logger, {
+        action: metadata?.name,
+        flushReason: "server-action-error",
+        requestId: context?.requestId,
+      });
     });
 
     if (env.NODE_ENV !== "production") {
@@ -66,7 +81,7 @@ const baseClient = createSafeActionClient({
     });
   });
 
-  const result = await next({ ctx: { logger } });
+  const result = await next({ ctx: { logger, requestId } });
 
   if (result.validationErrors) {
     logger.warn("Action validation error", {
@@ -122,6 +137,7 @@ export const actionClient = baseClient
     return withServerActionInstrumentation(metadata.name, async () => {
       return next({
         ctx: {
+          ...ctx,
           logger,
           userId,
           userEmail,
@@ -155,7 +171,7 @@ export const actionClientUser = baseClient.use(
 
     return withServerActionInstrumentation(metadata?.name, async () => {
       return next({
-        ctx: { userId, userEmail, logger },
+        ctx: { ...ctx, userId, userEmail, logger },
       });
     });
   },
@@ -171,7 +187,7 @@ export const adminActionClient = baseClient.use(
     const logger = ctx.logger.with({ admin: true });
 
     return withServerActionInstrumentation(metadata?.name, async () => {
-      return next({ ctx: { logger } });
+      return next({ ctx: { ...ctx, logger } });
     });
   },
 );


### PR DESCRIPTION
# User description
Preserve request-scoped logging context for server action failures so hidden action errors remain traceable in production.

- reuse the existing request-scoped logger in the shared server action error handler
- flush the logger on the server action error path
- preserve inherited action context across shared middleware layers

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the shared <code>safe-action</code> server action error handler reuses request-scoped logger data so production failures retain contextual metadata. Propagate this context through middleware layers and flush the logger on server action errors to keep inherited tracing details alive.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve async logger f...</td><td>February 15, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Major better-auth refa...</td><td>August 06, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2054?tool=ast>(Baz)</a>.