### PR TITLE
logging: add action flow observability

### DIFF
--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -31,24 +31,51 @@ export const runRulesAction = actionClient
     }): Promise<RunRulesResult[]> => {
       const logger = ctxLogger.with({ messageId, threadId });
 
+      logger.info("runRulesAction started", { isTest, rerun });
+
+      logger.info("Loading email account for rule execution");
       const emailAccount = await getEmailAccountForRuleExecution({
         emailAccountId,
+      }).catch((error) => {
+        logger.error("Failed to load email account for rule execution", {
+          error,
+        });
+        throw error;
+      });
+      logger.info("Loaded email account for rule execution", {
+        emailAccountFound: Boolean(emailAccount),
       });
 
       if (!emailAccount) throw new SafeError("Email account not found");
       if (!provider) throw new SafeError("Provider not found");
 
+      logger.info("Creating email provider");
       const emailProvider = await createEmailProvider({
         emailAccountId,
         provider,
         logger,
+      }).catch((error) => {
+        logger.error("Failed to create email provider", { error });
+        throw error;
       });
-      const message = await emailProvider.getMessage(messageId);
+      logger.info("Created email provider");
+
+      logger.info("Fetching message for rule execution");
+      const message = await emailProvider
+        .getMessage(messageId)
+        .catch((error) => {
+          logger.error("Failed to fetch message for rule execution", { error });
+          throw error;
+        });
+      logger.info("Fetched message for rule execution", {
+        fetchedThreadId: message.threadId,
+      });
 
       const fetchExecutedRule = !isTest && !rerun;
 
-      const executedRules = fetchExecutedRule
-        ? await prisma.executedRule.findMany({
+      logger.info("Loading existing executed rules", { fetchExecutedRule });
+      const executedRules = await (fetchExecutedRule
+        ? prisma.executedRule.findMany({
             where: {
               emailAccountId,
               threadId,
@@ -63,7 +90,14 @@ export const runRulesAction = actionClient
               status: true,
             },
           })
-        : [];
+        : Promise.resolve([])
+      ).catch((error) => {
+        logger.error("Failed to load existing executed rules", { error });
+        throw error;
+      });
+      logger.info("Loaded existing executed rules", {
+        executedRuleCount: executedRules.length,
+      });
 
       if (executedRules.length > 0) {
         logger.info("Skipping. Rule already exists.");
@@ -78,14 +112,24 @@ export const runRulesAction = actionClient
         }));
       }
 
-      const rules = await prisma.rule.findMany({
-        where: {
-          emailAccountId,
-          enabled: true,
-        },
-        include: { actions: true },
+      logger.info("Loading enabled rules for execution");
+      const rules = await prisma.rule
+        .findMany({
+          where: {
+            emailAccountId,
+            enabled: true,
+          },
+          include: { actions: true },
+        })
+        .catch((error) => {
+          logger.error("Failed to load enabled rules for execution", { error });
+          throw error;
+        });
+      logger.info("Loaded enabled rules for execution", {
+        ruleCount: rules.length,
       });
 
+      logger.info("Invoking runRules");
       const result = await runRules({
         isTest,
         provider: emailProvider,
@@ -94,6 +138,9 @@ export const runRulesAction = actionClient
         emailAccount,
         logger,
         modelType: "chat",
+      }).catch((error) => {
+        logger.error("runRules failed", { error });
+        throw error;
       });
 
       logger.info("runRules completed", {


### PR DESCRIPTION
# User description
Add step-level logging to the rule test action so production failures can be traced without guessing.

- log each major action step before rule matching begins
- emit explicit failure logs for account, provider, message, and rule loading steps
- preserve the existing completion and test-mode flush behavior

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add step-aware logging around <code>runRulesAction</code> so production executions emit context for account, provider, message loading and rule matching while invoking <code>runRules</code>. Preserve existing completion and test-mode behaviors while reporting result counts and keeping flush semantics.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: improve rule choo...</td><td>March 27, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Add provider to filter...</td><td>August 13, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2055?tool=ast>(Baz)</a>.