### PR TITLE
assistant: refresh rule state for legacy chats

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -846,6 +846,7 @@ describe("aiProcessAssistantChat", () => {
       emailAccountId: "email-account-id",
       user: getEmailAccount(),
       chatLastSeenRulesRevision: 1,
+      chatHasHistory: true,
       onRulesStateExposed,
       logger,
     });
@@ -965,6 +966,24 @@ describe("aiProcessAssistantChat", () => {
 
     expect(freshRuleContext).toBeUndefined();
     expect(mockPrisma.emailAccount.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit chatHasHistory when a rules cursor is provided", async () => {
+    const { aiProcessAssistantChat } = await loadAssistantChatModule({
+      emailSend: true,
+    });
+
+    await expect(
+      aiProcessAssistantChat({
+        messages: baseMessages,
+        emailAccountId: "email-account-id",
+        user: getEmailAccount(),
+        chatLastSeenRulesRevision: null,
+        logger,
+      }),
+    ).rejects.toThrow(
+      "chatHasHistory must be provided when chatLastSeenRulesRevision is set",
+    );
   });
 
   it("rejects stale rule reads when the rules revision changed", async () => {

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -278,14 +278,16 @@ describe("chat route rule freshness persistence", () => {
       return createAssistantStreamResult();
     });
 
-    await expect(POST(createRequest())).rejects.toThrow("db down");
-    expect(consoleErrorSpy.mock.calls.flat()).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("Failed to save rules revision"),
-      ]),
-    );
-
-    consoleErrorSpy.mockRestore();
+    try {
+      await expect(POST(createRequest())).rejects.toThrow("db down");
+      expect(consoleErrorSpy.mock.calls.flat()).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("Failed to save rules revision"),
+        ]),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -27,6 +27,10 @@ import {
   assistantInputSchema,
 } from "@/utils/actions/assistant-chat.validation";
 import { buildInlineEmailActionSystemMessage } from "@/utils/ai/assistant/inline-email-actions";
+import {
+  mergeSeenRulesRevision,
+  saveLastSeenRulesRevision,
+} from "@/utils/ai/assistant/chat-seen-rules-revision";
 import { getToolFailureWarning } from "@/utils/ai/assistant/chat-response-guard";
 
 export const maxDuration = 120;
@@ -213,10 +217,10 @@ export const POST = withEmailAccount("chat", async (request) => {
       memories,
       inboxStats,
       onRulesStateExposed: (rulesRevision) => {
-        seenRulesRevision =
-          seenRulesRevision == null
-            ? rulesRevision
-            : Math.max(seenRulesRevision, rulesRevision);
+        seenRulesRevision = mergeSeenRulesRevision(
+          seenRulesRevision,
+          rulesRevision,
+        );
       },
       logger: request.logger,
     });
@@ -250,11 +254,11 @@ export const POST = withEmailAccount("chat", async (request) => {
         await saveChatMessages(messages, chat.id, request.logger);
 
         if (seenRulesRevision != null) {
-          await saveLastSeenRulesRevision(
-            chat.id,
-            seenRulesRevision,
-            request.logger,
-          );
+          await saveLastSeenRulesRevision({
+            chatId: chat.id,
+            rulesRevision: seenRulesRevision,
+            logger: request.logger,
+          });
         }
       },
     });
@@ -321,30 +325,6 @@ async function saveChatMessages(
   } catch (error) {
     logger.error("Failed to save chat messages", { error, chatId });
     captureException(error, { extra: { chatId } });
-    throw error;
-  }
-}
-
-async function saveLastSeenRulesRevision(
-  chatId: string,
-  rulesRevision: number,
-  logger: Logger,
-) {
-  try {
-    await prisma.chat.updateMany({
-      where: {
-        id: chatId,
-        OR: [
-          { lastSeenRulesRevision: null },
-          { lastSeenRulesRevision: { lt: rulesRevision } },
-        ],
-      },
-      data: {
-        lastSeenRulesRevision: rulesRevision,
-      },
-    });
-  } catch (error) {
-    logger.error("Failed to save rules revision", { error, chatId });
     throw error;
   }
 }

--- a/apps/web/utils/ai/assistant/chat-seen-rules-revision.ts
+++ b/apps/web/utils/ai/assistant/chat-seen-rules-revision.ts
@@ -1,0 +1,39 @@
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+export function mergeSeenRulesRevision(
+  currentRulesRevision: number | null,
+  nextRulesRevision: number,
+) {
+  return currentRulesRevision == null
+    ? nextRulesRevision
+    : Math.max(currentRulesRevision, nextRulesRevision);
+}
+
+export async function saveLastSeenRulesRevision({
+  chatId,
+  rulesRevision,
+  logger,
+}: {
+  chatId: string;
+  rulesRevision: number;
+  logger: Logger;
+}) {
+  try {
+    await prisma.chat.updateMany({
+      where: {
+        id: chatId,
+        OR: [
+          { lastSeenRulesRevision: null },
+          { lastSeenRulesRevision: { lt: rulesRevision } },
+        ],
+      },
+      data: {
+        lastSeenRulesRevision: rulesRevision,
+      },
+    });
+  } catch (error) {
+    logger.error("Failed to save rules revision", { error, chatId });
+    throw error;
+  }
+}

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -97,7 +97,7 @@ export async function aiProcessAssistantChat({
   context,
   chatId,
   chatLastSeenRulesRevision,
-  chatHasHistory = false,
+  chatHasHistory,
   memories,
   inboxStats,
   responseSurface = "web",
@@ -121,6 +121,12 @@ export async function aiProcessAssistantChat({
   onStepFinish?: AssistantChatOnStepFinish;
   logger: Logger;
 }) {
+  if (chatLastSeenRulesRevision !== undefined && chatHasHistory === undefined) {
+    throw new Error(
+      "chatHasHistory must be provided when chatLastSeenRulesRevision is set",
+    );
+  }
+
   const emailSendToolsEnabled = env.NEXT_PUBLIC_EMAIL_SEND_ENABLED;
   let ruleReadState: RuleReadState | null = null;
 
@@ -325,7 +331,7 @@ Behavior anchors (minimal examples):
     const freshRuleState = await loadFreshRuleContext({
       emailAccountId,
       chatLastSeenRulesRevision,
-      chatHasHistory,
+      chatHasHistory: chatHasHistory ?? false,
     });
 
     if (freshRuleState) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -40,6 +40,10 @@ import type { AssistantPendingEmailActionType } from "@/utils/actions/assistant-
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import { getRecentChatMemories } from "@/utils/ai/assistant/get-recent-chat-memories";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
+import {
+  mergeSeenRulesRevision,
+  saveLastSeenRulesRevision,
+} from "@/utils/ai/assistant/chat-seen-rules-revision";
 import { createScopedLogger, type Logger } from "@/utils/logger";
 import { consumeMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code-consume";
 import type { MessagingPlatform } from "@/utils/messaging/platforms";
@@ -575,9 +579,15 @@ async function processMessagingAssistantMessage({
       update: {},
       select: {
         id: true,
+        lastSeenRulesRevision: true,
         messages: {
           orderBy: { createdAt: "desc" },
           take: MAX_CHAT_CONTEXT_MESSAGES,
+        },
+        compactions: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { id: true },
         },
       },
     });
@@ -649,6 +659,7 @@ async function processMessagingAssistantMessage({
       }
 
       const inboxStats = await inboxStatsPromise;
+      let seenRulesRevision: number | null = null;
       const result = await aiProcessAssistantChat({
         messages: await convertToModelMessages([
           ...existingMessages,
@@ -657,10 +668,19 @@ async function processMessagingAssistantMessage({
         emailAccountId: context.emailAccountId,
         user: emailAccountUser,
         chatId: chat.id,
+        chatLastSeenRulesRevision: chat.lastSeenRulesRevision,
+        chatHasHistory:
+          existingMessages.length > 0 || chat.compactions.length > 0,
         memories: await memoriesPromise,
         inboxStats,
         responseSurface: "messaging",
         messagingPlatform: context.provider,
+        onRulesStateExposed: (rulesRevision) => {
+          seenRulesRevision = mergeSeenRulesRevision(
+            seenRulesRevision,
+            rulesRevision,
+          );
+        },
         logger: threadLogger,
       });
 
@@ -705,6 +725,14 @@ async function processMessagingAssistantMessage({
           return true;
         }
         throw error;
+      }
+
+      if (seenRulesRevision != null) {
+        await saveLastSeenRulesRevision({
+          chatId: chat.id,
+          rulesRevision: seenRulesRevision,
+          logger: threadLogger,
+        });
       }
 
       if (pendingToolPart) {

--- a/apps/web/utils/messaging/providers/slack/slash-commands.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.ts
@@ -8,6 +8,10 @@ import { MessagingProvider } from "@/generated/prisma/enums";
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import { getRecentChatMemories } from "@/utils/ai/assistant/get-recent-chat-memories";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
+import {
+  mergeSeenRulesRevision,
+  saveLastSeenRulesRevision,
+} from "@/utils/ai/assistant/chat-seen-rules-revision";
 import type { Logger } from "@/utils/logger";
 import { normalizeMessagingAssistantText } from "@/utils/messaging/chat-sdk/bot";
 import { PROMPT_COMMANDS } from "@/utils/messaging/prompt-commands";
@@ -130,9 +134,15 @@ async function runSlackSlashCommandAi({
     update: {},
     select: {
       id: true,
+      lastSeenRulesRevision: true,
       messages: {
         orderBy: { createdAt: "desc" },
         take: MAX_CHAT_CONTEXT_MESSAGES,
+      },
+      compactions: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: { id: true },
       },
     },
   });
@@ -162,6 +172,7 @@ async function runSlackSlashCommandAi({
   });
 
   const assistantMessageId = `${userMessageId}-assistant`;
+  let seenRulesRevision: number | null = null;
 
   const [inboxStats, memories] = await Promise.all([
     getInboxStatsForChatContext({
@@ -184,10 +195,18 @@ async function runSlackSlashCommandAi({
     emailAccountId,
     user: emailAccountUser,
     chatId: chat.id,
+    chatLastSeenRulesRevision: chat.lastSeenRulesRevision,
+    chatHasHistory: existingMessages.length > 0 || chat.compactions.length > 0,
     memories,
     inboxStats,
     responseSurface: "messaging",
     messagingPlatform: "slack",
+    onRulesStateExposed: (rulesRevision) => {
+      seenRulesRevision = mergeSeenRulesRevision(
+        seenRulesRevision,
+        rulesRevision,
+      );
+    },
     logger,
   });
 
@@ -220,6 +239,14 @@ async function runSlackSlashCommandAi({
       parts: (assistantMessage.parts || []) as Prisma.InputJsonValue,
     },
   });
+
+  if (seenRulesRevision != null) {
+    await saveLastSeenRulesRevision({
+      chatId: chat.id,
+      rulesRevision: seenRulesRevision,
+      logger,
+    });
+  }
 
   return normalizeMessagingAssistantText({ text: fullText || "Done." });
 }


### PR DESCRIPTION
# User description
Handle legacy rule freshness follow-ups for continuing chats and route persistence.

- refresh rule state for chats with prior history but no stored revision cursor
- keep new chats opt-in so rules are not injected on first turn
- log and rethrow rule revision persistence failures in the chat route

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refresh rule state for legacy chats by injecting fresh rule context when prior history exists even without a cursor, flagging history in the chat route and threading it through <code>aiProcessAssistantChat</code> for accurate behavior. Wrap seen-revision merging and persistence into reusable helpers that log failures and reuse them across web, messaging bot, and Slack flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2059?tool=ast&topic=Legacy+rule+refresh>Legacy rule refresh</a>
        </td><td>Refresh rule state for chats with history by surfacing <code>chatHasHistory</code> in the chat route, updating <code>aiProcessAssistantChat</code> fresh-rule loading, and expanding web tests to cover the new behaviors.<details><summary>Modified files (4)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li>
<li>apps/web/app/api/chat/route.test.ts</li>
<li>apps/web/app/api/chat/route.ts</li>
<li>apps/web/utils/ai/assistant/chat.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chat: track fresh rule...</td><td>March 27, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix Anthropic System M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2059?tool=ast&topic=Revision+persistence>Revision persistence</a>
        </td><td>Ensure seen revisions are merged and stored with logging by introducing shared helpers and wiring them into the messaging bot, Slack, and chat route flows.<details><summary>Modified files (3)</summary><ul><li>apps/web/utils/ai/assistant/chat-seen-rules-revision.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li>
<li>apps/web/utils/messaging/providers/slack/slash-commands.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Show active account in...</td><td>March 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2059?tool=ast>(Baz)</a>.