### PR TITLE
docs: move dev env notes to bottom

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,8 +11,6 @@ DIRECT_URL="postgresql://postgres:password@localhost:5432/inboxzero?schema=publi
 # POSTGRES_PORT=5432
 # REDIS_PORT=6380
 # REDIS_HTTP_PORT=8079
-# GOOGLE_EMULATOR_PORT=4002
-# MICROSOFT_EMULATOR_PORT=4003
 
 UPSTASH_REDIS_URL="http://localhost:8079"
 UPSTASH_REDIS_TOKEN= # openssl rand -hex 32
@@ -24,19 +22,11 @@ QUEUE_BACKEND= # bullmq | qstash | internal
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-# To use the optional Docker Compose Google emulator instead of real Google OAuth:
-# GOOGLE_BASE_URL=http://localhost:4002
-# GOOGLE_CLIENT_ID=emulate-google-client.apps.googleusercontent.com
-# GOOGLE_CLIENT_SECRET=emulate-google-secret
 GOOGLE_PUBSUB_TOPIC_NAME="projects/abc/topics/xyz"
 GOOGLE_PUBSUB_VERIFICATION_TOKEN= # openssl rand -hex 32
 
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
-# To use the optional Docker Compose Microsoft emulator instead of real Microsoft OAuth/Graph:
-# MICROSOFT_BASE_URL=http://localhost:4003
-# MICROSOFT_CLIENT_ID=emulate-microsoft-client-id
-# MICROSOFT_CLIENT_SECRET=emulate-microsoft-secret
 MICROSOFT_WEBHOOK_CLIENT_STATE= # openssl rand -hex 32
 MICROSOFT_TENANT_ID= # leave empty for "common"
 
@@ -238,3 +228,13 @@ LOOPS_API_SECRET=
 # IS_OAUTH_PROXY_SERVER=false # Set to true on the server that acts as the OAuth proxy (e.g., staging)
 # ADDITIONAL_TRUSTED_ORIGINS=https://*.vercel.app # Comma-separated list of trusted origins for CORS (supports wildcards)
 # MOBILE_AUTH_ORIGIN=inboxzero:// # Mobile auth deep link origin
+
+# Local development emulators (optional)
+# GOOGLE_EMULATOR_PORT=4002
+# GOOGLE_BASE_URL=http://localhost:4002
+# GOOGLE_CLIENT_ID=emulate-google-client.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=emulate-google-secret
+# MICROSOFT_EMULATOR_PORT=4003
+# MICROSOFT_BASE_URL=http://localhost:4003
+# MICROSOFT_CLIENT_ID=emulate-microsoft-client-id
+# MICROSOFT_CLIENT_SECRET=emulate-microsoft-secret


### PR DESCRIPTION
# User description
Moves the emulator-only `.env.example` notes to the end of the file so the main self-hosting configuration stays focused on commonly needed settings.

- remove dev-only emulator overrides from the primary Google and Microsoft auth sections
- keep the same emulator values documented in a dedicated bottom-of-file section

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Move the emulator-focused <code>.env.example</code> notes below the standard configuration so Google and Microsoft auth sections highlight the shared self-hosted settings. Maintain the same local emulator host and credential examples in a dedicated bottom section for optional developer workflows.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>dev: add local Microso...</td><td>March 28, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add OpenAI-compatible ...</td><td>February 22, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2065?tool=ast>(Baz)</a>.