### PR TITLE
chore: update emulate package to 0.4.5

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -225,7 +225,7 @@
     "cross-env": "10.1.0",
     "dotenv": "17.3.1",
     "dotenv-cli": "11.0.0",
-    "emulate": "npm:@inbox-zero/emulate@0.4.0-inboxzero.0",
+    "emulate": "npm:@inbox-zero/emulate@0.4.5",
     "jsdom": "27.3.0",
     "postcss": "8.5.6",
     "serwist": "9.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,8 +635,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       emulate:
-        specifier: npm:@inbox-zero/emulate@0.4.0-inboxzero.0
-        version: '@inbox-zero/emulate@0.4.0-inboxzero.0(hono@4.11.4)'
+        specifier: npm:@inbox-zero/emulate@0.4.5
+        version: '@inbox-zero/emulate@0.4.5(hono@4.11.4)'
       jsdom:
         specifier: 27.3.0
         version: 27.3.0
@@ -2992,8 +2992,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inbox-zero/emulate@0.4.0-inboxzero.0':
-    resolution: {integrity: sha512-amgSJyZqvmSdHJ97T6npkpdYUKxf1yZ0Aa4WE6p9XxpcvzOSNPGXCV7VnCUW2gu6ABxSkkeVxKadn8HZlAiRqQ==}
+  '@inbox-zero/emulate@0.4.5':
+    resolution: {integrity: sha512-xd6HANmTYlx32wDGf6GI3DztfdsHC8zzwrtJtXeET7WDe1vfHOhTiyKrZl2BYh5nS71PTihqXx5nE+sYLu55qA==}
     hasBin: true
 
   '@inquirer/ansi@1.0.2':
@@ -14805,7 +14805,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inbox-zero/emulate@0.4.0-inboxzero.0(hono@4.11.4)':
+  '@inbox-zero/emulate@0.4.5(hono@4.11.4)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.4)
       commander: 14.0.3


### PR DESCRIPTION
# User description
Updates the local emulator dependency to the latest published release.

- bump `@inbox-zero/emulate` from `0.4.0-inboxzero.0` to `0.4.5`
- refresh `pnpm-lock.yaml` for the new package version

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the web app package manifest’s <code>emulate</code> dependency to <code>@inbox-zero/emulate@0.4.5</code> so the local emulator uses the latest published release. Refresh the pnpm lockfile resolution entries to align install metadata with the new emulator version.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>dev: add local Microso...</td><td>March 28, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Extract shared Gmail t...</td><td>March 25, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2067?tool=ast>(Baz)</a>.