### PR TITLE
landing: remove social proof layout experiment

### DIFF
--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -28,7 +28,6 @@ import {
   Badge,
   type BadgeVariant,
 } from "@/components/new-landing/common/Badge";
-import { useHeroLayoutVariant } from "@/hooks/useFeatureFlags";
 import { BrandScroller } from "@/components/new-landing/BrandScroller";
 
 interface HeroProps {
@@ -130,21 +129,10 @@ export function HeroVideoPlayer() {
 }
 
 export function HeroContent() {
-  const variant = useHeroLayoutVariant();
-
-  if (variant === "social-proof-first") {
-    return (
-      <>
-        <BrandScroller />
-        <HeroVideoPlayer />
-      </>
-    );
-  }
-
   return (
     <>
-      <HeroVideoPlayer />
       <BrandScroller />
+      <HeroVideoPlayer />
     </>
   );
 }

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -69,16 +69,6 @@ export function useTestimonialsVariant() {
   );
 }
 
-export type HeroLayoutVariant = "control" | "social-proof-first";
-
-export function useHeroLayoutVariant() {
-  return (
-    (useFeatureFlagVariantKey(
-      "hero-social-proof-position",
-    ) as HeroLayoutVariant) || "control"
-  );
-}
-
 export type WelcomePricingVariant = "control" | "two-tiers";
 
 export function useWelcomePricingVariant() {


### PR DESCRIPTION
# User description
Simplifies the landing page by removing a completed layout experiment and keeping the winning arrangement in place. It also deletes the unused feature flag hook for that experiment.

- remove the conditional hero layout variant
- keep the social proof content in the winning position
- delete the unused landing feature flag hook

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplify the landing hero by hardcoding the winning layout so <code>BrandScroller</code> precedes <code>HeroVideoPlayer</code> and removing the unused layout flag logic. Remove the orphaned hero layout feature flag hook since the experiment is complete.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>onboarding: add flow v...</td><td>March 28, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix: useCleanerEnabled...</td><td>December 30, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2068?tool=ast>(Baz)</a>.