### PR TITLE
onboarding: restore draft preference step

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
@@ -43,6 +43,7 @@ describe("getVisibleOnboardingStepKeys", () => {
       STEP_KEYS.WHO,
       STEP_KEYS.COMPANY_SIZE,
       STEP_KEYS.LABELS,
+      STEP_KEYS.DRAFT,
       STEP_KEYS.INBOX_PROCESSED,
     ]);
   });
@@ -84,7 +85,7 @@ describe("getOnboardingStepIndex", () => {
   });
 
   it("clamps oversized numeric steps to the last visible step", () => {
-    expect(getOnboardingStepIndex("99", fastFlowKeys)).toBe(3);
+    expect(getOnboardingStepIndex("99", fastFlowKeys)).toBe(4);
   });
 
   it("falls back to the first visible fast-flow step for removed steps", () => {

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
@@ -43,6 +43,7 @@ const flowStepOrders: Record<OnboardingFlowVariant, readonly StepKey[]> = {
     STEP_KEYS.WHO,
     STEP_KEYS.COMPANY_SIZE,
     STEP_KEYS.LABELS,
+    STEP_KEYS.DRAFT,
     STEP_KEYS.INBOX_PROCESSED,
   ],
 };


### PR DESCRIPTION
# User description
Restore the draft preference step in the shortened onboarding flow so users can enable draft replies during setup.

- add the existing draft yes/no step back to the fast onboarding variant
- update onboarding flow coverage for the restored step order and last-step index

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Restore the draft preference step in the fast onboarding flow by updating <code>onboardingFlow</code> so the draft prompt appears before <code>INBOX_PROCESSED</code>. Adjust the corresponding <code>onboardingFlow.test</code> coverage to match the new step order and updated last-step index.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>onboarding: add flow v...</td><td>March 28, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2069?tool=ast>(Baz)</a>.