### PR TITLE
rules: preserve messaging channel ids

### DIFF
--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -227,3 +227,64 @@ describe("outbound action guardrails", () => {
     expect(prisma.rule.update).not.toHaveBeenCalled();
   });
 });
+
+describe("draft messaging actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves messagingChannelId when updating a draft messaging rule", async () => {
+    prisma.rule.update.mockResolvedValue({
+      id: "rule-id",
+      actions: [],
+      group: null,
+    } as any);
+
+    await updateRule({
+      ruleId: "rule-id",
+      result: {
+        name: "To Reply",
+        condition: {
+          aiInstructions: null,
+          conditionalOperator: null,
+          static: {
+            from: null,
+            to: null,
+            subject: null,
+          },
+        },
+        actions: [
+          {
+            type: ActionType.DRAFT_MESSAGING_CHANNEL,
+            messagingChannelId: "cmessagingchannel1234567890123",
+            fields: {
+              content: "",
+            } as any,
+            delayInMinutes: null,
+          },
+        ],
+      },
+      emailAccountId: "email-account-id",
+      provider: "gmail",
+      logger,
+    });
+
+    expect(prisma.rule.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          actions: {
+            deleteMany: {},
+            createMany: {
+              data: [
+                expect.objectContaining({
+                  type: ActionType.DRAFT_MESSAGING_CHANNEL,
+                  messagingChannelId: "cmessagingchannel1234567890123",
+                }),
+              ],
+            },
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -610,6 +610,7 @@ async function mapActionFields(
 
       return {
         type: a.type,
+        messagingChannelId: a.messagingChannelId ?? null,
         label,
         labelId,
         to,


### PR DESCRIPTION
# User description
This fixes rule persistence for draft messaging actions.

The save path now keeps messaging channel IDs when rules are created or updated. It also adds a regression test covering draft messaging rule updates. Tested with cd apps/web && pnpm test --run utils/rule/rule.test.ts.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure <code>mapActionFields</code> carries <code>messagingChannelId</code> through draft messaging rule saves so updates keep the intended channel references. Add a regression test around <code>updateRule</code> so Prisma updates continue to include the draft messaging channel identifier.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2071?tool=ast&topic=Channel+persistence>Channel persistence</a>
        </td><td>Ensure <code>mapActionFields</code> includes <code>messagingChannelId</code> when building draft messaging actions so rule updates preserve channel IDs.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/rule/rule.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: Chat create...</td><td>March 21, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix(move-folder): add ...</td><td>January 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2071?tool=ast&topic=Draft+action+test>Draft action test</a>
        </td><td>Verify <code>updateRule</code> continues to send <code>messagingChannelId</code> for draft actions by asserting the Prisma payload in the rule utils test.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/rule/rule.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2071?tool=ast>(Baz)</a>.