### PR TITLE
rule: fix action mapper typing

### DIFF
--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -552,6 +552,7 @@ function validateLowTrustStaticFromOutboundActions({
 
 async function mapActionFields(
   actions: (CreateOrUpdateRuleSchema["actions"][number] & {
+    messagingChannelId?: string | null;
     labelId?: string | null;
     folderId?: string | null;
   })[],


### PR DESCRIPTION
# User description
This fixes a TypeScript mismatch in rule action mapping that blocked the build.

- allow optional messaging channel ids in the rule action mapper input
- align the mapper type with the persisted action shape used by the build path

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adjusts rule action mapping to permit optional messaging channel ids and match the persisted action shape consumed by the build flow, ensuring <code>mapActionFields</code> keeps alignment with downstream components. Verifies that <code>mapActionFields</code> input typing mirrors the stored rule action records so the build no longer fails type checking.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rules: preserve messag...</td><td>March 29, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix(move-folder): add ...</td><td>January 08, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2073?tool=ast>(Baz)</a>.