### PR TITLE
Fix invalid Link-inside-button nesting on settings page

### DIFF
--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -203,10 +203,17 @@ function EmailAccountSettingsCard({
 
   return (
     <ItemCard>
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left"
         onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
       >
         <Avatar className="size-8 rounded-full">
           <AvatarImage
@@ -248,7 +255,7 @@ function EmailAccountSettingsCard({
             expanded && "rotate-90",
           )}
         />
-      </button>
+      </div>
 
       {expanded && (
         <>


### PR DESCRIPTION
# User description
## Summary
- Changed `<button>` wrapper to `<div role="button">` in the email account settings card to avoid invalid HTML nesting with the "Connect Apps" `<Link>` inside it
- Preserves keyboard accessibility with `onKeyDown` handler

## Test plan
- [ ] Verify settings page expand/collapse still works
- [ ] Verify "Connect Apps" badge link navigates to channels page
- [ ] Verify keyboard navigation (Enter/Space to toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Replace the outer wrapper in <code>EmailAccountSettingsCard</code> with a <code>div role="button"</code> so the card can include the <code>Connect Apps</code> link without invalid nesting. Preserve keyboard accessibility by handling Enter and Space on the new wrapper to keep expand/collapse controls functional.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add channels page for ...</td><td>March 30, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Globalize settings rou...</td><td>February 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2078?tool=ast>(Baz)</a>.