### PR TITLE
Add channels redirect page

### DIFF
--- a/apps/web/app/(redirects)/channels/page.tsx
+++ b/apps/web/app/(redirects)/channels/page.tsx
@@ -1,0 +1,9 @@
+import { redirectToEmailAccountPath } from "@/utils/account";
+
+export default async function ChannelsRedirectPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await redirectToEmailAccountPath("/channels", await searchParams);
+}


### PR DESCRIPTION
# User description
Adds the missing redirect page for the channels route so it follows the existing account-scoped redirect pattern.

- add `/channels` redirect page under the shared redirects route group
- forward existing search params to the account-scoped channels page

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add channels redirect page under shared redirects route so it recycles the <code>redirectToEmailAccountPath</code> helper for the account-scoped flow. Ensure existing search params flow through to the account-specific <code>/channels</code> landing page when users hit the generic route.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2079?tool=ast>(Baz)</a>.