### PR TITLE
landing: update displayed user count

### DIFF
--- a/apps/web/utils/config.ts
+++ b/apps/web/utils/config.ts
@@ -5,7 +5,7 @@ export const EMAIL_ACCOUNT_HEADER = "X-Email-Account-ID";
 export const NO_REFRESH_TOKEN_ERROR_CODE = "NO_REFRESH_TOKEN";
 export const MICROSOFT_AUTH_EXPIRED_ERROR_CODE = "MICROSOFT_AUTH_EXPIRED";
 
-export const userMinCount = "15,000";
+export const userMinCount = "20,000";
 export const userCount = `${userMinCount}+`;
 
 export const KNOWLEDGE_BASIC_MAX_ITEMS = 1;


### PR DESCRIPTION
# User description
Updates the shared landing-page user count value.

- changes the centralized config value from 15,000 to 20,000
- updates all landing views that read the shared user count
- keeps the change scoped to the existing config source of truth

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the centralized landing-page count configuration so the shared <code>userMinCount</code> and its derived <code>userCount</code> reflect the new milestone. Ensure the landing flow continues to read this single source of truth for displayed user tallies.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add Slack, Telegram, a...</td><td>March 18, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Use user count from co...</td><td>November 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2084?tool=ast>(Baz)</a>.