### PR TITLE
fix: align channel control toggles

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -703,19 +703,6 @@ function RuleToggle({
       </ItemContent>
       <ItemActions>
         <div className="flex items-center gap-1">
-          <Toggle
-            name={`rule-${rule.id}-${channelId}`}
-            enabled={enabled}
-            disabled={isExecuting}
-            onChange={(value) =>
-              execute({
-                ruleId: rule.id,
-                messagingChannelId: channelId,
-                enabled: value,
-                actionType: value ? defaultActionType : undefined,
-              })
-            }
-          />
           {enabled && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -748,6 +735,19 @@ function RuleToggle({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
+          <Toggle
+            name={`rule-${rule.id}-${channelId}`}
+            enabled={enabled}
+            disabled={isExecuting}
+            onChange={(value) =>
+              execute({
+                ruleId: rule.id,
+                messagingChannelId: channelId,
+                enabled: value,
+                actionType: value ? defaultActionType : undefined,
+              })
+            }
+          />
         </div>
       </ItemActions>
     </Item>


### PR DESCRIPTION
# User description
This updates the channel rule action layout so the switch stays aligned even when the overflow menu is present.

It reorders the menu and toggle within the rule row without changing the underlying behavior.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Aligns the channel rule controls so the toggle remains flush even when the overflow menu is shown, maintaining the existing action behavior. Keeps the rule toggle interaction with <code>execute</code> intact while repositioning it after the menu within the rule row layout.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix channel page order...</td><td>March 30, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2085?tool=ast>(Baz)</a>.