### PR TITLE
messaging: require Telegram webhook secret

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -42,6 +42,7 @@ TEAMS_BOT_APP_PASSWORD=
 TEAMS_BOT_APP_TENANT_ID=
 # TEAMS_BOT_APP_TYPE=MultiTenant
 TELEGRAM_BOT_TOKEN=
+# Required when Telegram webhooks are enabled. Used to verify x-telegram-bot-api-secret-token.
 TELEGRAM_BOT_SECRET_TOKEN=
 
 AUTH_SECRET= # openssl rand -hex 32

--- a/apps/web/app/api/telegram/events/route.test.ts
+++ b/apps/web/app/api/telegram/events/route.test.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { envMock, handleMessagingWebhookRouteMock } = vi.hoisted(() => ({
+  envMock: {
+    TELEGRAM_BOT_TOKEN: "test-telegram-token" as string | undefined,
+    TELEGRAM_BOT_SECRET_TOKEN: "test-telegram-secret" as string | undefined,
+  },
+  handleMessagingWebhookRouteMock: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withError: (
+    scopeOrHandler: string | ((request: Request) => Promise<Response>),
+    maybeHandler?: (request: Request) => Promise<Response>,
+  ) => {
+    if (typeof scopeOrHandler === "string") {
+      return maybeHandler as (request: Request) => Promise<Response>;
+    }
+    return scopeOrHandler;
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/messaging/chat-sdk/webhook-route", () => ({
+  handleMessagingWebhookRoute: (...args: unknown[]) =>
+    handleMessagingWebhookRouteMock(...args),
+}));
+
+import { POST } from "./route";
+
+function createRequest() {
+  const request = new Request("https://example.com/api/telegram/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-telegram-bot-api-secret-token": "test-telegram-secret",
+    },
+    body: JSON.stringify({ update_id: 1 }),
+  }) as Request & {
+    logger: {
+      warn: ReturnType<typeof vi.fn>;
+      error: ReturnType<typeof vi.fn>;
+      info: ReturnType<typeof vi.fn>;
+      trace: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  request.logger = {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+  };
+
+  return request;
+}
+
+describe("Telegram events route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    envMock.TELEGRAM_BOT_TOKEN = "test-telegram-token";
+    envMock.TELEGRAM_BOT_SECRET_TOKEN = "test-telegram-secret";
+    handleMessagingWebhookRouteMock.mockResolvedValue(
+      NextResponse.json({ ok: true }),
+    );
+  });
+
+  it("fails closed when the webhook secret token is missing", async () => {
+    envMock.TELEGRAM_BOT_SECRET_TOKEN = undefined;
+    const request = createRequest();
+
+    const response = await POST(request as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      error: "Telegram webhook secret token not configured",
+    });
+    expect(handleMessagingWebhookRouteMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the shared webhook handler when the secret token is configured", async () => {
+    const request = createRequest();
+
+    const response = await POST(request as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(handleMessagingWebhookRouteMock).toHaveBeenCalledTimes(1);
+    expect(handleMessagingWebhookRouteMock).toHaveBeenCalledWith({
+      request,
+      platform: "telegram",
+      isConfigured: true,
+      notConfiguredError: "Telegram not configured",
+      adapterUnavailableError: "Telegram adapter unavailable",
+      webhookUnavailableError: "Telegram webhook unavailable",
+    });
+  });
+});

--- a/apps/web/app/api/telegram/events/route.ts
+++ b/apps/web/app/api/telegram/events/route.ts
@@ -1,10 +1,18 @@
 import { env } from "@/env";
+import { NextResponse } from "next/server";
 import { withError } from "@/utils/middleware";
 import { handleMessagingWebhookRoute } from "@/utils/messaging/chat-sdk/webhook-route";
 
 export const maxDuration = 120;
 
 export const POST = withError("telegram/events", async (request) => {
+  if (!env.TELEGRAM_BOT_SECRET_TOKEN) {
+    return NextResponse.json(
+      { error: "Telegram webhook secret token not configured" },
+      { status: 503 },
+    );
+  }
+
   return handleMessagingWebhookRoute({
     request,
     platform: "telegram",


### PR DESCRIPTION
# User description
Require Telegram webhook endpoints to fail closed when the webhook secret is not configured. This hardens self-hosted setups against accidental unauthenticated webhook handling.

- return 503 from the Telegram webhook route when the secret token is missing
- add a route test that covers the fail-closed behavior and the configured path
- document the Telegram webhook secret requirement in the example env file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Guard the Telegram events <code>POST</code> route with a secret check so <code>handleMessagingWebhookRoute</code> only executes when <code>env.TELEGRAM_BOT_SECRET_TOKEN</code> exists, returning a 503 response otherwise. Document the required webhook secret in the example configuration and validate the fail-closed behavior plus successful delegation through new route tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2090?tool=ast&topic=Secret+docs>Secret docs</a>
        </td><td>Document the Telegram webhook secret requirement in the example env file to guide deployments that enable the integration.<details><summary>Modified files (1)</summary><ul><li>apps/web/.env.example</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add channels page for ...</td><td>March 30, 2026</td></tr>
<tr><td>msoukhomlinov@users.no...</td><td>Add OpenAI-compatible ...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2090?tool=ast&topic=Webhook+protection>Webhook protection</a>
        </td><td>Strengthen the Telegram events flow by returning a 503 with <code>NextResponse</code> when <code>env.TELEGRAM_BOT_SECRET_TOKEN</code> is missing and by ensuring <code>handleMessagingWebhookRoute</code> is only invoked when the secret is configured via targeted route tests.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/telegram/events/route.test.ts</li>
<li>apps/web/app/api/telegram/events/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Messaging: migrate to ...</td><td>March 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2090?tool=ast>(Baz)</a>.