### PR TITLE
automation: align default rule deletion behavior

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -627,7 +627,7 @@ export function RuleForm({
                   </div>
                 )}
 
-                {rule.id && (
+                {rule.id && !rule.systemType && (
                   <Button
                     size="sm"
                     variant="outline"
@@ -677,6 +677,12 @@ export function RuleForm({
                   >
                     Delete rule
                   </Button>
+                )}
+
+                {rule.id && rule.systemType && (
+                  <p className="text-sm text-muted-foreground">
+                    Default rules can be disabled from the rules list.
+                  </p>
                 )}
               </div>
             </DialogContent>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
@@ -1,0 +1,187 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SystemType } from "@/generated/prisma/enums";
+
+const mockUseRules = vi.fn();
+const mockUseAccount = vi.fn();
+const mockUseLabels = vi.fn();
+const mockUseDialogState = vi.fn();
+const mockSetOpen = vi.fn();
+const mockSetInput = vi.fn();
+const mockExecuteAsync = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/hooks/useRules", () => ({
+  useRules: () => mockUseRules(),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/hooks/useLabels", () => ({
+  useLabels: () => mockUseLabels(),
+}));
+
+vi.mock("@/hooks/useDialogState", () => ({
+  useDialogState: () => mockUseDialogState(),
+}));
+
+vi.mock("@/providers/ChatProvider", () => ({
+  useChat: () => ({ setInput: mockSetInput }),
+}));
+
+vi.mock("@/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get: () => "",
+    },
+  ),
+}));
+
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  useSidebar: () => ({ setOpen: mockSetOpen }),
+}));
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({ executeAsync: mockExecuteAsync }),
+}));
+
+vi.mock("./RuleDialog", () => ({
+  RuleDialog: () => null,
+}));
+
+import { Rules } from "./Rules";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Rules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseRules.mockReturnValue({
+      data: [
+        {
+          id: "system-rule-1",
+          name: "Newsletter",
+          instructions: "Auto-organize newsletters",
+          enabled: true,
+          runOnThreads: false,
+          automate: true,
+          actions: [],
+          group: null,
+          emailAccountId: "ea_1",
+          createdAt: new Date("2026-03-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+          categoryFilterType: null,
+          conditionalOperator: "OR",
+          groupId: null,
+          systemType: SystemType.NEWSLETTER,
+          to: null,
+          from: null,
+          subject: null,
+          body: null,
+          promptText: null,
+        },
+        {
+          id: "custom-rule-1",
+          name: "Custom rule",
+          instructions: "Handle a specific sender",
+          enabled: true,
+          runOnThreads: true,
+          automate: true,
+          actions: [],
+          group: null,
+          emailAccountId: "ea_1",
+          createdAt: new Date("2026-03-02T00:00:00.000Z"),
+          updatedAt: new Date("2026-03-02T00:00:00.000Z"),
+          categoryFilterType: null,
+          conditionalOperator: "OR",
+          groupId: null,
+          systemType: null,
+          to: null,
+          from: null,
+          subject: null,
+          body: null,
+          promptText: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "ea_1",
+      provider: "google",
+    });
+    mockUseLabels.mockReturnValue({ userLabels: [] });
+    mockUseDialogState.mockReturnValue({
+      data: undefined,
+      isOpen: false,
+      onOpen: vi.fn(),
+      onClose: vi.fn(),
+    });
+  });
+
+  it("hides delete for default rules", () => {
+    render(<Rules />);
+
+    const newsletterRow = screen.getByText("Newsletter").closest("tr");
+    expect(newsletterRow).toBeTruthy();
+
+    fireEvent.pointerDown(
+      within(newsletterRow as HTMLElement).getByRole("button", {
+        name: "Toggle menu",
+      }),
+      { button: 0, ctrlKey: false },
+    );
+
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  it("still shows delete for custom rules", () => {
+    render(<Rules />);
+
+    const customRuleRow = screen.getByText("Custom rule").closest("tr");
+    expect(customRuleRow).toBeTruthy();
+
+    fireEvent.pointerDown(
+      within(customRuleRow as HTMLElement).getByRole("button", {
+        name: "Toggle menu",
+      }),
+      { button: 0, ctrlKey: false },
+    );
+
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -293,57 +293,61 @@ export function Rules({
                                   History
                                 </Link>
                               </DropdownMenuItem>
-                              <DropdownMenuSeparator />
+                              {!rule.systemType && (
+                                <>
+                                  <DropdownMenuSeparator />
 
-                              <DropdownMenuItem
-                                onClick={async () => {
-                                  const yes = confirm(
-                                    `Are you sure you want to delete the rule "${rule.name}"?`,
-                                  );
-                                  if (yes) {
-                                    toast.promise(
-                                      async () => {
-                                        const res = await deleteRuleAction(
-                                          emailAccountId,
-                                          { id: rule.id },
+                                  <DropdownMenuItem
+                                    onClick={async () => {
+                                      const yes = confirm(
+                                        `Are you sure you want to delete the rule "${rule.name}"?`,
+                                      );
+                                      if (yes) {
+                                        toast.promise(
+                                          async () => {
+                                            const res = await deleteRuleAction(
+                                              emailAccountId,
+                                              { id: rule.id },
+                                            );
+
+                                            if (
+                                              res?.serverError ||
+                                              res?.validationErrors
+                                            ) {
+                                              throw new Error(
+                                                res?.serverError ||
+                                                  "There was an error deleting your rule",
+                                              );
+                                            }
+
+                                            mutate(
+                                              (currentRules) =>
+                                                currentRules?.filter(
+                                                  (currentRule) =>
+                                                    currentRule.id !== rule.id,
+                                                ),
+                                              { revalidate: false },
+                                            );
+                                            mutate();
+                                          },
+                                          {
+                                            loading: "Deleting rule...",
+                                            success: "Rule deleted",
+                                            error: (error) =>
+                                              `Error deleting rule. ${error.message}`,
+                                            finally: () => {
+                                              mutate();
+                                            },
+                                          },
                                         );
-
-                                        if (
-                                          res?.serverError ||
-                                          res?.validationErrors
-                                        ) {
-                                          throw new Error(
-                                            res?.serverError ||
-                                              "There was an error deleting your rule",
-                                          );
-                                        }
-
-                                        mutate(
-                                          (currentRules) =>
-                                            currentRules?.filter(
-                                              (currentRule) =>
-                                                currentRule.id !== rule.id,
-                                            ),
-                                          { revalidate: false },
-                                        );
-                                        mutate();
-                                      },
-                                      {
-                                        loading: "Deleting rule...",
-                                        success: "Rule deleted",
-                                        error: (error) =>
-                                          `Error deleting rule. ${error.message}`,
-                                        finally: () => {
-                                          mutate();
-                                        },
-                                      },
-                                    );
-                                  }
-                                }}
-                              >
-                                <Trash2Icon className="mr-2 size-4" />
-                                Delete
-                              </DropdownMenuItem>
+                                      }
+                                    }}
+                                  >
+                                    <Trash2Icon className="mr-2 size-4" />
+                                    Delete
+                                  </DropdownMenuItem>
+                                </>
+                              )}
                             </DropdownMenuContent>
                           </DropdownMenu>
                         )}

--- a/apps/web/utils/actions/rule.test.ts
+++ b/apps/web/utils/actions/rule.test.ts
@@ -19,7 +19,10 @@ vi.mock("@/utils/auth", () => ({
 }));
 
 import prisma from "@/utils/__mocks__/prisma";
-import { enableDraftRepliesAction } from "@/utils/actions/rule";
+import {
+  deleteRuleAction,
+  enableDraftRepliesAction,
+} from "@/utils/actions/rule";
 
 describe("enableDraftRepliesAction", () => {
   beforeEach(() => {
@@ -96,5 +99,40 @@ describe("enableDraftRepliesAction", () => {
         type: ActionType.DRAFT_EMAIL,
       },
     });
+  });
+});
+
+describe("deleteRuleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects deleting default rules", async () => {
+    (
+      prisma.emailAccount.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      email: "owner@example.com",
+      account: { userId: "u1", provider: "google" },
+    });
+
+    prisma.rule.findUnique.mockResolvedValue({
+      id: "rule-1",
+      emailAccountId: "ea_1",
+      systemType: SystemType.NEWSLETTER,
+      groupId: null,
+    } as never);
+
+    const result = await deleteRuleAction(
+      "ea_1" as never,
+      {
+        id: "rule-1",
+      } as never,
+    );
+
+    expect(result?.serverError).toBe(
+      "Default rules cannot be deleted. Disable them instead.",
+    );
+    expect(prisma.rule.delete).not.toHaveBeenCalled();
+    expect(prisma.group.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -276,6 +276,11 @@ export const deleteRuleAction = actionClient
     if (!rule) return; // already deleted
     if (rule.emailAccountId !== emailAccountId)
       throw new SafeError("You don't have permission to delete this rule");
+    if (rule.systemType) {
+      throw new SafeError(
+        "Default rules cannot be deleted. Disable them instead.",
+      );
+    }
 
     try {
       await deleteRule({


### PR DESCRIPTION
# User description
Default rules are built-in rule slots, so exposing delete created inconsistent behavior in the automation UI. This change keeps default rules disable-only and leaves true deletion for custom rules.

- block deletion of default rules on the server
- hide delete controls for default rules in the automation UI
- add tests for default and custom rule behavior

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reconcile the default rule experience so the <code>RuleForm</code> and rules list only allow disabling built-in flows, surface messaging when editing defaults, and keep the UI menu consistent with that intent. Harden the backend <code>deleteRuleAction</code> while expanding coverage so deletion attempts for system rules fail safely and accompanying tests verify both default and custom behaviors.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2096?tool=ast&topic=Default+rule+UI>Default rule UI</a>
        </td><td>Limit default rule controls by hiding the delete option in <code>Rules</code>, showing a note in <code>RuleForm</code>, and adding Vitest coverage that exercises both default and custom rows to ensure the UI reflects disable-only behavior.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: improve rul...</td><td>March 30, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove conditional tit...</td><td>December 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2096?tool=ast&topic=Rule+deletion+guard>Rule deletion guard</a>
        </td><td>Guard <code>deleteRuleAction</code> against removing <code>systemType</code> rules by throwing a <code>SafeError</code> and add regression tests that assert default rules cannot be deleted while custom ones still can.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/actions/rule.test.ts</li>
<li>apps/web/utils/actions/rule.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: add messagi...</td><td>March 29, 2026</td></tr>
<tr><td>rsnodgrass@gmail.com</td><td>fix(move-folder): add ...</td><td>January 08, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2096?tool=ast>(Baz)</a>.