### PR TITLE
auth: recover stale account linking sessions

### DIFF
--- a/apps/web/app/api/google/linking/auth-url/route.ts
+++ b/apps/web/app/api/google/linking/auth-url/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/utils/middleware";
 import { getLinkingOAuth2Client } from "@/utils/gmail/client";
 import { GOOGLE_LINKING_STATE_COOKIE_NAME } from "@/utils/gmail/constants";
 import { SCOPES } from "@/utils/gmail/scopes";
+import { hasActiveAccountLinkingUser } from "@/utils/oauth/account-linking";
 import {
   generateOAuthState,
   oauthStateCookieOptions,
@@ -27,6 +28,18 @@ const getAuthUrl = ({ userId }: { userId: string }) => {
 
 export const GET = withAuth("google/linking/auth-url", async (request) => {
   const userId = request.auth.userId;
+  const hasActiveUser = await hasActiveAccountLinkingUser({
+    targetUserId: userId,
+    logger: request.logger,
+  });
+
+  if (!hasActiveUser) {
+    return NextResponse.json(
+      { error: "Unauthorized", isKnownError: true, redirectTo: "/logout" },
+      { status: 401 },
+    );
+  }
+
   const { url: authUrl, state } = getAuthUrl({ userId });
 
   const response = NextResponse.json({ url: authUrl });

--- a/apps/web/app/api/outlook/linking/auth-url/route.ts
+++ b/apps/web/app/api/outlook/linking/auth-url/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/utils/middleware";
 import { getLinkingOAuth2Url } from "@/utils/outlook/client";
 import { OUTLOOK_LINKING_STATE_COOKIE_NAME } from "@/utils/outlook/constants";
 import { SCOPES as OUTLOOK_SCOPES } from "@/utils/outlook/scopes";
+import { hasActiveAccountLinkingUser } from "@/utils/oauth/account-linking";
 import {
   generateOAuthState,
   oauthStateCookieOptions,
@@ -21,6 +22,18 @@ const getAuthUrl = ({ userId }: { userId: string }) => {
 
 export const GET = withAuth("outlook/linking/auth-url", async (request) => {
   const userId = request.auth.userId;
+  const hasActiveUser = await hasActiveAccountLinkingUser({
+    targetUserId: userId,
+    logger: request.logger,
+  });
+
+  if (!hasActiveUser) {
+    return NextResponse.json(
+      { error: "Unauthorized", isKnownError: true, redirectTo: "/logout" },
+      { status: 401 },
+    );
+  }
+
   const { url: authUrl, state } = getAuthUrl({ userId });
   const parsedAuthUrl = new URL(authUrl);
 

--- a/apps/web/utils/account-linking.test.ts
+++ b/apps/web/utils/account-linking.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAccountLinkingUrl } from "./account-linking";
+
+describe("getAccountLinkingUrl", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the OAuth URL on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          url: "https://accounts.google.com/o/oauth2/v2/auth",
+        }),
+      }),
+    );
+
+    await expect(getAccountLinkingUrl("google")).resolves.toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+  });
+
+  it("returns the redirect URL when the server asks the client to log out", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ redirectTo: "/logout" }),
+      }),
+    );
+
+    await expect(getAccountLinkingUrl("google")).resolves.toBe("/logout");
+  });
+});

--- a/apps/web/utils/account-linking.ts
+++ b/apps/web/utils/account-linking.ts
@@ -4,8 +4,9 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 
 /**
  * Initiates the OAuth account linking flow for Google or Microsoft.
- * Returns the OAuth URL to redirect the user to.
- * @throws Error if the request fails
+ * Returns a URL to redirect the user to (OAuth provider, or /logout if
+ * the session is stale).
+ * @throws Error if the request fails for a non-recoverable reason
  */
 export async function getAccountLinkingUrl(
   provider: "google" | "microsoft",
@@ -18,6 +19,14 @@ export async function getAccountLinkingUrl(
   });
 
   if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as {
+      redirectTo?: string;
+    } | null;
+
+    if (response.status === 401 && errorBody?.redirectTo) {
+      return errorBody.redirectTo;
+    }
+
     throw new Error(
       `Failed to initiate ${isGoogleProvider(provider) ? "Google" : "Microsoft"} account linking`,
     );

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/utils/user/orphaned-account");
 describe("handleAccountLinking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.user.findUnique.mockResolvedValue({ id: "target-user-id" } as any);
   });
 
   it("should cleanup orphaned account and continue create", async () => {
@@ -118,5 +119,27 @@ describe("handleAccountLinking", () => {
         "account_already_exists_use_merge",
       );
     }
+  });
+
+  it("redirects to logout when the linking session user no longer exists", async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    const result = await handleAccountLinking({
+      existingAccountId: null,
+      hasEmailAccount: false,
+      existingUserId: null,
+      targetUserId: "deleted-user-id",
+      provider: "google",
+      providerEmail: "new@gmail.com",
+      logger,
+    });
+
+    expect(result.type).toBe("redirect");
+    if (result.type === "redirect") {
+      expect(result.response.headers.get("location")).toBe(
+        "http://localhost:3000/logout",
+      );
+    }
+    expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/oauth/account-linking.ts
+++ b/apps/web/utils/oauth/account-linking.ts
@@ -29,6 +29,19 @@ export async function handleAccountLinking({
   | { type: "update_tokens"; existingAccountId: string }
 > {
   const redirectUrl = new URL("/accounts", env.NEXT_PUBLIC_BASE_URL);
+  const hasActiveTargetUser = await hasActiveAccountLinkingUser({
+    targetUserId,
+    logger,
+  });
+
+  if (!hasActiveTargetUser) {
+    return {
+      type: "redirect",
+      response: NextResponse.redirect(
+        new URL("/logout", env.NEXT_PUBLIC_BASE_URL),
+      ),
+    };
+  }
 
   if (existingAccountId && !hasEmailAccount) {
     logger.warn("Found orphaned Account, cleaning up", {
@@ -99,4 +112,25 @@ export async function handleAccountLinking({
     sourceAccountId: existingAccountId,
     sourceUserId: existingUserId,
   };
+}
+
+export async function hasActiveAccountLinkingUser({
+  targetUserId,
+  logger,
+}: {
+  targetUserId: string;
+  logger: Logger;
+}) {
+  const user = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { id: true },
+  });
+
+  if (user) return true;
+
+  logger.warn("Account linking attempted with deleted user in session", {
+    targetUserId,
+  });
+
+  return false;
 }


### PR DESCRIPTION
# User description
Prevent stale account-linking sessions from falling into a broken OAuth flow.

- Validate the current user before starting or continuing Google and Microsoft account linking.
- Send stale sessions through /logout instead of letting linking fail deeper in the flow.
- Add regression tests for the logout recovery path.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the Google and Outlook linking auth-url routes verify the session user via <code>hasActiveAccountLinkingUser</code> before generating OAuth states so stale sessions redirect to <code>/logout</code>. Update <code>getAccountLinkingUrl</code> and <code>handleAccountLinking</code> to surface those redirects, keeping <code>hasActiveAccountLinkingUser</code> as the reusable guard for account-linking recovery flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2097?tool=ast&topic=Linking+recovery>Linking recovery</a>
        </td><td>Recover account-linking sessions by letting <code>handleAccountLinking</code> redirect to <code>/logout</code> when <code>hasActiveAccountLinkingUser</code> reports no target user, adding helper/logging coverage so deleted-user sessions exit early.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/oauth/account-linking.test.ts</li>
<li>apps/web/utils/oauth/account-linking.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2097?tool=ast&topic=Link+auth+guard>Link auth guard</a>
        </td><td>Validate OAuth entry points by calling <code>hasActiveAccountLinkingUser</code> in the Google and Outlook linking routes so stale sessions immediately return a 401 with a <code>/logout</code> redirect, and let <code>getAccountLinkingUrl</code> surface that redirect instead of throwing on fetch failures.<details><summary>Modified files (4)</summary><ul><li>apps/web/app/api/google/linking/auth-url/route.ts</li>
<li>apps/web/app/api/outlook/linking/auth-url/route.ts</li>
<li>apps/web/utils/account-linking.test.ts</li>
<li>apps/web/utils/account-linking.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>auth: improve microsof...</td><td>March 17, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Fix account link not a...</td><td>August 29, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2097?tool=ast>(Baz)</a>.