### PR TITLE
fix: guard webhook error metadata

### DIFF
--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -127,6 +127,37 @@ describe("captureException", () => {
       },
     });
   });
+
+  it("ignores LLM repair metadata for non-extensible errors", () => {
+    const error = Object.preventExtensions(new Error("generation failed"));
+
+    expect(() =>
+      attachLlmRepairMetadata(error, {
+        attempted: true,
+        successful: false,
+        label: "Categorize sender",
+        provider: "openai",
+        model: "gpt-test",
+        inputLength: 12,
+        inputFingerprint: "abc123",
+        startsWithQuote: true,
+        startsWithBrace: false,
+        startsWithBracket: false,
+        looksCodeFenced: false,
+        candidateKindsTried: ["trimmed", "original"],
+      }),
+    ).not.toThrow();
+
+    captureException(error, {
+      extra: { operation: "test" },
+    });
+
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(error, {
+      extra: {
+        operation: "test",
+      },
+    });
+  });
 });
 
 function createAPICallError({

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -76,7 +76,17 @@ export function attachLlmRepairMetadata(
 ) {
   if (!metadata || typeof error !== "object" || error === null) return;
 
-  (error as Record<string, unknown>)[LLM_REPAIR_METADATA_KEY] = metadata;
+  const target = error as Record<string, unknown>;
+
+  // Diagnostic metadata must never turn the original model error into a
+  // webhook-processing failure for frozen or otherwise immutable errors.
+  if (!Object.isExtensible(target)) return;
+
+  try {
+    target[LLM_REPAIR_METADATA_KEY] = metadata;
+  } catch {
+    return;
+  }
 }
 
 export function captureException(


### PR DESCRIPTION
# User description
Prevent immutable error objects from causing secondary webhook failures.

- make LLM repair metadata attachment best-effort for non-extensible errors
- add regression coverage for frozen error objects in the shared error helper
- verified with `cd apps/web && pnpm exec vitest run utils/error.test.ts`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Guard <code>attachLlmRepairMetadata</code> by skipping metadata attachment when an error is not extensible and catching assignment failures so frozen webhook errors no longer trigger secondary failures. Add regression coverage that creates a non-extensible error to ensure metadata attachment stays best-effort while <code>captureException</code> still reports original context.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2100?tool=ast&topic=Frozen+error+tests>Frozen error tests</a>
        </td><td>Verify <code>attachLlmRepairMetadata</code> leaves frozen errors untouched and <code>captureException</code> keeps reporting its extra context by exercising the helper with a non-extensible <code>Error</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/error.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix LLM object repair ...</td><td>March 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2100?tool=ast&topic=Metadata+guard>Metadata guard</a>
        </td><td>Prevent <code>attachLlmRepairMetadata</code> from mutating non-extensible errors by checking <code>Object.isExtensible</code> and swallowing assignment failures so immutable errors do not break webhook processing.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/error.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix LLM object repair ...</td><td>March 27, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2100?tool=ast>(Baz)</a>.