### PR TITLE
Fix client error log redaction

### DIFF
--- a/apps/web/components/AppErrorBoundary.tsx
+++ b/apps/web/components/AppErrorBoundary.tsx
@@ -14,6 +14,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
+import { getAppErrorBoundaryLogContext } from "@/components/app-error-boundary-log-context";
 import { createClientLogger } from "@/utils/logger-client";
 
 export function AppErrorBoundary({
@@ -33,19 +34,17 @@ export function AppErrorBoundary({
   // biome-ignore lint/correctness/useExhaustiveDependencies: log each boundary error once with the route context captured at that time
   useEffect(() => {
     const logger = createClientLogger("app-error-boundary");
-    const search = searchParams.toString();
 
-    logger.error("App error boundary triggered", {
-      digest: error.digest,
-      emailAccountId: params.emailAccountId,
-      errorMessage: error.message,
-      errorName: error.name,
-      errorStack: error.stack,
-      pathname,
-      ruleId: params.ruleId,
-      search,
-    });
-    void logger.flush();
+    logger.error(
+      "App error boundary triggered",
+      getAppErrorBoundaryLogContext({
+        error,
+        params,
+        pathname,
+        searchParams,
+      }),
+    );
+    logger.flush().catch(() => undefined);
     Sentry.captureException(error);
   }, [error]);
 

--- a/apps/web/components/app-error-boundary-log-context.test.ts
+++ b/apps/web/components/app-error-boundary-log-context.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getAppErrorBoundaryLogContext } from "./app-error-boundary-log-context";
+
+describe("getAppErrorBoundaryLogContext", () => {
+  it("returns only allowlisted route context for client logs", () => {
+    const context = getAppErrorBoundaryLogContext({
+      error: {
+        digest: "digest-123",
+        message: "token=secret-value",
+        name: "TypeError",
+        stack: "stack with secret-value",
+      },
+      params: {
+        emailAccountId: "account-123",
+        ruleId: "rule-456",
+      },
+      pathname: "/mail",
+      searchParams: new URLSearchParams(
+        "token=secret-value&code=oauth-code&tab=history&ruleId=query-rule-id",
+      ),
+    });
+
+    expect(context).toEqual({
+      digest: "digest-123",
+      emailAccountId: "account-123",
+      errorName: "TypeError",
+      pathname: "/mail",
+      ruleId: "rule-456",
+      safeSearchParams: {
+        ruleId: "query-rule-id",
+        tab: "history",
+      },
+      searchParamKeys: ["token", "code", "tab", "ruleId"],
+    });
+    expect(context).not.toHaveProperty("errorMessage");
+    expect(context).not.toHaveProperty("errorStack");
+    expect(context).not.toHaveProperty("search");
+  });
+
+  it("omits unsupported route params and empty search state", () => {
+    const context = getAppErrorBoundaryLogContext({
+      error: {
+        name: "Error",
+      },
+      params: {
+        emailAccountId: ["account-123", "account-456"],
+        ruleId: "",
+      },
+      pathname: "/mail",
+      searchParams: new URLSearchParams(),
+    });
+
+    expect(context).toEqual({
+      errorName: "Error",
+      pathname: "/mail",
+    });
+  });
+});

--- a/apps/web/components/app-error-boundary-log-context.ts
+++ b/apps/web/components/app-error-boundary-log-context.ts
@@ -1,0 +1,55 @@
+type AppErrorBoundaryLogContextInput = {
+  error: Pick<Error & { digest?: string }, "digest" | "name">;
+  params: {
+    emailAccountId?: string | string[];
+    ruleId?: string | string[];
+  };
+  pathname: string;
+  searchParams: Iterable<[string, string]>;
+};
+
+const SAFE_SEARCH_PARAM_KEYS = new Set(["ruleId", "tab"]);
+
+export function getAppErrorBoundaryLogContext({
+  error,
+  params,
+  pathname,
+  searchParams,
+}: AppErrorBoundaryLogContextInput) {
+  const emailAccountId = getSingleRouteParam(params.emailAccountId);
+  const ruleId = getSingleRouteParam(params.ruleId);
+  const { safeSearchParams, searchParamKeys } =
+    getSearchParamContext(searchParams);
+
+  return {
+    ...(error.digest ? { digest: error.digest } : {}),
+    errorName: error.name,
+    ...(emailAccountId ? { emailAccountId } : {}),
+    pathname,
+    ...(ruleId ? { ruleId } : {}),
+    ...(Object.keys(safeSearchParams).length > 0 ? { safeSearchParams } : {}),
+    ...(searchParamKeys.length > 0 ? { searchParamKeys } : {}),
+  };
+}
+
+function getSingleRouteParam(value?: string | string[]) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getSearchParamContext(searchParams: Iterable<[string, string]>) {
+  const safeSearchParams: Record<string, string> = {};
+  const searchParamKeys = new Set<string>();
+
+  for (const [key, value] of searchParams) {
+    searchParamKeys.add(key);
+
+    if (SAFE_SEARCH_PARAM_KEYS.has(key) && !(key in safeSearchParams)) {
+      safeSearchParams[key] = value;
+    }
+  }
+
+  return {
+    safeSearchParams,
+    searchParamKeys: Array.from(searchParamKeys),
+  };
+}


### PR DESCRIPTION
Tighten client-side error boundary logging so raw search strings and exception details are not sent in broad client log events.

- move boundary log payload construction into a small helper
- keep route context plus allowlisted query values for debugging
- add a focused regression test for allowed and redacted fields