### PR TITLE
messaging: disable Slack link unfurls

### DIFF
--- a/apps/web/utils/automation-jobs/slack.test.ts
+++ b/apps/web/utils/automation-jobs/slack.test.ts
@@ -71,6 +71,8 @@ describe("sendAutomationMessageToSlack", () => {
       expect.objectContaining({
         channel: "C123",
         text: expect.stringContaining("_Reply with <@UAPP123>"),
+        unfurl_links: false,
+        unfurl_media: false,
       }),
     );
   });
@@ -91,9 +93,13 @@ describe("sendAutomationMessageToSlack", () => {
       logger,
     });
 
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      channel: "D123",
-      text: "Your inbox looks clear right now. Want me to keep monitoring and ping again later?",
-    });
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "D123",
+        text: "Your inbox looks clear right now. Want me to keep monitoring and ping again later?",
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
   });
 });

--- a/apps/web/utils/automation-jobs/slack.ts
+++ b/apps/web/utils/automation-jobs/slack.ts
@@ -5,6 +5,7 @@ import {
 import type { Logger } from "@/utils/logger";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 import {
+  disableSlackLinkUnfurls,
   formatSlackAppMention,
   resolveSlackRouteDestination,
 } from "@/utils/messaging/providers/slack/send";
@@ -85,10 +86,12 @@ export async function sendAutomationMessageToSlack({
   }
 
   try {
-    const response = await client.chat.postMessage({
-      channel: destinationChannelId,
-      text: formattedText,
-    });
+    const response = await client.chat.postMessage(
+      disableSlackLinkUnfurls({
+        channel: destinationChannelId,
+        text: formattedText,
+      }),
+    );
     slackLogger.info("Slack automation message sent");
 
     return {
@@ -107,10 +110,12 @@ export async function sendAutomationMessageToSlack({
 
       slackLogger.info("Joining Slack channel before retrying message");
       await client.conversations.join({ channel: route.targetId });
-      const response = await client.chat.postMessage({
-        channel: route.targetId,
-        text: formattedText,
-      });
+      const response = await client.chat.postMessage(
+        disableSlackLinkUnfurls({
+          channel: route.targetId,
+          text: formattedText,
+        }),
+      );
       slackLogger.info("Slack automation message sent after joining channel");
 
       return {

--- a/apps/web/utils/messaging/providers/slack/send.test.ts
+++ b/apps/web/utils/messaging/providers/slack/send.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateSlackClient, mockPostMessage, mockJoinConversation } =
+  vi.hoisted(() => ({
+    mockCreateSlackClient: vi.fn(),
+    mockPostMessage: vi.fn(),
+    mockJoinConversation: vi.fn(),
+  }));
+
+vi.mock("./client", () => ({
+  createSlackClient: mockCreateSlackClient,
+}));
+
+import {
+  sendChannelConfirmation,
+  sendConnectionOnboardingDirectMessage,
+} from "./send";
+
+describe("slack send helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCreateSlackClient.mockReturnValue({
+      chat: {
+        postMessage: mockPostMessage,
+      },
+      conversations: {
+        join: mockJoinConversation,
+      },
+    });
+    mockPostMessage.mockResolvedValue({ ts: "123.456" });
+    mockJoinConversation.mockResolvedValue({});
+  });
+
+  it("disables link unfurls for channel confirmation messages", async () => {
+    await sendChannelConfirmation({
+      accessToken: "xoxb-token",
+      channelId: "C123",
+      botUserId: "UAPP123",
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
+  });
+
+  it("keeps link unfurls disabled after joining a channel and retrying", async () => {
+    mockPostMessage
+      .mockRejectedValueOnce(
+        Object.assign(new Error("not in channel"), {
+          data: { error: "not_in_channel" },
+        }),
+      )
+      .mockResolvedValueOnce({ ts: "123.456" });
+
+    await sendChannelConfirmation({
+      accessToken: "xoxb-token",
+      channelId: "C123",
+      botUserId: "UAPP123",
+    });
+
+    expect(mockJoinConversation).toHaveBeenCalledWith({ channel: "C123" });
+    expect(mockPostMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        channel: "C123",
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
+  });
+
+  it("disables link unfurls for onboarding direct messages", async () => {
+    await sendConnectionOnboardingDirectMessage({
+      accessToken: "xoxb-token",
+      userId: "U123",
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "U123",
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
+  });
+});

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -68,10 +68,12 @@ export async function sendConnectionOnboardingDirectMessage({
 }): Promise<void> {
   const client = createSlackClient(accessToken);
 
-  await client.chat.postMessage({
-    channel: userId,
-    text: "Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite @InboxZero there. You can also DM me anytime to chat about your emails.",
-  });
+  await client.chat.postMessage(
+    disableSlackLinkUnfurls({
+      channel: userId,
+      text: "Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite @InboxZero there. You can also DM me anytime to chat about your emails.",
+    }),
+  );
 }
 
 export type SlackDocumentFiledParams = DocumentFiledBlocksParams & {
@@ -186,6 +188,14 @@ export function formatSlackAppMention(botUserId: string | null | undefined) {
   return botUserId ? `<@${botUserId}>` : "@Inbox Zero";
 }
 
+export function disableSlackLinkUnfurls<T extends object>(message: T) {
+  return {
+    ...message,
+    unfurl_links: false,
+    unfurl_media: false,
+  };
+}
+
 type Blocks = (KnownBlock | Block)[];
 
 async function postMessageWithJoin(
@@ -193,9 +203,11 @@ async function postMessageWithJoin(
   channelId: string,
   message: { text: string; blocks?: Blocks },
 ): Promise<void> {
-  const args = message.blocks
-    ? { channel: channelId, blocks: message.blocks, text: message.text }
-    : { channel: channelId, text: message.text };
+  const args = disableSlackLinkUnfurls(
+    message.blocks
+      ? { channel: channelId, blocks: message.blocks, text: message.text }
+      : { channel: channelId, text: message.text },
+  );
 
   try {
     await client.chat.postMessage(args);

--- a/apps/web/utils/messaging/providers/slack/slash-commands.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.ts
@@ -15,6 +15,7 @@ import {
 import type { Logger } from "@/utils/logger";
 import { normalizeMessagingAssistantText } from "@/utils/messaging/chat-sdk/bot";
 import { PROMPT_COMMANDS } from "@/utils/messaging/prompt-commands";
+import { disableSlackLinkUnfurls } from "@/utils/messaging/providers/slack/send";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 
@@ -263,7 +264,7 @@ async function postToSlackResponseUrl(
   const response = await fetch(responseUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    body: JSON.stringify(disableSlackLinkUnfurls(body)),
   });
 
   if (!response.ok) {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -14,7 +14,10 @@ import {
 import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import prisma from "@/utils/prisma";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
-import { resolveSlackRouteDestination } from "@/utils/messaging/providers/slack/send";
+import {
+  disableSlackLinkUnfurls,
+  resolveSlackRouteDestination,
+} from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 import {
   escapeSlackText,
@@ -1281,12 +1284,12 @@ async function postSlackCard({
 }) {
   const client = createSlackClient(accessToken);
 
-  const args = {
+  const args = disableSlackLinkUnfurls({
     channel: destinationChannelId,
     text: cardToFallbackText(card),
     blocks: cardToBlockKit(card),
     ...(rootMessageId ? { thread_ts: rootMessageId } : {}),
-  };
+  });
 
   try {
     const response = await client.chat.postMessage(args);


### PR DESCRIPTION
Disable Slack link unfurls across direct messaging paths and add focused regression coverage.

- disable unfurls for direct Slack API messages and response payloads
- cover the Slack send helpers and automation sender with tests
- include the latest main changes in this branch