### PR TITLE
Pass request headers into auth session resolution

### DIFF
--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -28,7 +28,7 @@ import { isDuplicateError } from "@/utils/prisma-helpers";
 import { SafeError } from "@/utils/error";
 
 export const GET = withError("google/linking/callback", async (request) => {
-  const actorUserId = (await auth())?.user.id ?? null;
+  const actorUserId = (await auth(request.headers))?.user.id ?? null;
   let logger = request.logger.with({
     actorUserId,
     auditType: "oauth_linking",

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -37,7 +37,7 @@ import { SCOPES as OUTLOOK_SCOPES } from "@/utils/outlook/scopes";
 import type { Logger } from "@/utils/logger";
 
 export const GET = withError("outlook/linking/callback", async (request) => {
-  const actorUserId = (await auth())?.user.id ?? null;
+  const actorUserId = (await auth(request.headers))?.user.id ?? null;
   let logger = request.logger.with({
     actorUserId,
     auditType: "oauth_linking",

--- a/apps/web/app/api/user/complete-registration/route.ts
+++ b/apps/web/app/api/user/complete-registration/route.ts
@@ -11,7 +11,7 @@ import type { Logger } from "@/utils/logger";
 
 export const POST = withError("complete-registration", async (request) => {
   const logger = request.logger;
-  const session = await auth();
+  const session = await auth(request.headers);
   if (!session?.user.email)
     return NextResponse.json({ error: "Not authenticated" });
 

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -96,7 +96,7 @@ async function getUser({
 // Not using withAuth — unauthenticated requests return 401 with isKnownError
 // so the client can distinguish "not logged in" from real errors without Sentry noise
 export const GET = withError("user/me", async (request) => {
-  const session = await auth();
+  const session = await auth(request.headers);
   const userId = session?.user.id;
   if (!userId)
     return NextResponse.json(

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -660,8 +660,12 @@ export async function handleLinkAccount(account: Account) {
   }
 }
 
-export const auth = async () =>
-  betterAuthConfig.api.getSession({ headers: await headers() });
+export const auth = async (
+  requestHeaders?: Headers | Awaited<ReturnType<typeof headers>>,
+) =>
+  betterAuthConfig.api.getSession({
+    headers: requestHeaders ?? (await headers()),
+  });
 
 async function autoJoinOrganization(emailAccountId: string) {
   const orgs = await prisma.organization.findMany({

--- a/apps/web/utils/middleware.ts
+++ b/apps/web/utils/middleware.ts
@@ -224,7 +224,7 @@ function withMiddleware<T extends NextRequest>(
 async function authMiddleware(
   req: NextRequest,
 ): Promise<RequestWithAuth | Response> {
-  const session = await auth();
+  const session = await auth(req.headers);
   if (!session?.user) {
     return NextResponse.json(
       { error: "Unauthorized", isKnownError: true },
@@ -308,7 +308,7 @@ async function emailAccountMiddleware(
           }),
       });
 
-      if (!targetMember || !targetMember.allowOrgAdminAnalytics) {
+      if (!targetMember?.allowOrgAdminAnalytics) {
         emailAccountLogger.error(
           "Member has not enabled org admin analytics access",
         );


### PR DESCRIPTION
# User description
## Summary
- pass route request headers into auth session resolution instead of relying on ambient headers
- update mobile-sensitive API and linking routes to resolve sessions from the incoming request
- align middleware auth checks with the same request-header based session handling

## Testing
- cd apps/web && pnpm exec vitest run 'app/api/user/me/route.test.ts' 'utils/webhook/validate-webhook-account.test.ts'

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update session resolution to pass incoming headers into the <code>auth</code> helper so downstream components derive user context from the specific request instead of ambient state. Ensure linking callbacks, user lifecycle endpoints, and middleware gates call <code>auth(request.headers)</code> so every flow checks authorization based on the request at hand.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>oauth: dedupe account ...</td><td>April 01, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Backend fixes for mobi...</td><td>March 09, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2203?tool=ast>(Baz)</a>.