### PR TITLE
Improve Slack draft notification formatting

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -455,6 +455,30 @@ describe("buildMessagingRuleNotificationText", () => {
     expect(text).toContain("details: https://example.com");
     expect(text).toContain("Slack-only");
   });
+
+  it("unescapes Slack entities for Teams fallback", async () => {
+    const { buildMessagingRuleNotificationText } = await import(
+      "./rule-notifications"
+    );
+
+    const text = buildMessagingRuleNotificationText({
+      actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
+      content: {
+        title: "Draft reply",
+        summary:
+          '📩 You got an email from *Tom &amp; Jerry* about "A &lt;B&gt;".',
+        details: ["💬 *They wrote:*\nHello &amp; welcome"],
+      },
+      provider: MessagingProvider.TEAMS,
+    });
+
+    expect(text).toContain("Tom & Jerry");
+    expect(text).toContain("A <B>");
+    expect(text).toContain("Hello & welcome");
+    expect(text).not.toContain("&amp;");
+    expect(text).not.toContain("&lt;");
+    expect(text).not.toContain("&gt;");
+  });
 });
 
 function getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -442,8 +442,10 @@ describe("buildMessagingRuleNotificationText", () => {
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
         title: "Draft reply",
-        summary:
-          'You got an email from *Sender* about "Test".\n\nI drafted a reply for you:\n>See <https://example.com|details>.',
+        summary: '📩 You got an email from *Sender* about "Test".',
+        details: [
+          "✍️ *I drafted a reply for you:*\nSee <https://example.com|details>.",
+        ],
       },
       provider: MessagingProvider.TELEGRAM,
     });

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1454,7 +1454,10 @@ function toCalendarPreviewMessage(
 function stripSlackFormatting(text: string) {
   return text
     .replace(/<([^|>]+)\|([^>]+)>/g, "$2: $1")
-    .replace(/\*([^*]+)\*/g, "$1");
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
 }
 
 function getLinkedProviderLimitationText({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -56,7 +56,7 @@ import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 
 const DRAFT_PREVIEW_MAX_CHARS = 900;
-const SUMMARY_PREVIEW_MAX_CHARS = 280;
+const SUMMARY_PREVIEW_MAX_CHARS = 2000;
 const SLACK_DRAFT_SEND_ACTION_ID = "rule_draft_send";
 const SLACK_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
 const SLACK_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
@@ -980,17 +980,18 @@ function buildNotificationContent({
     const emailPreview = buildEmailPreview(email);
     const draftPreview = buildDraftPreview(draftContent);
 
-    const parts = [`You got an email from *${senderName}* about "${subject}".`];
+    const summary = `📩 You got an email from *${senderName}* about "${subject}".`;
 
+    const details: string[] = [];
     if (emailPreview) {
-      parts.push(`They wrote:\n${blockquote(emailPreview)}`);
+      details.push(`💬 *They wrote:*\n${emailPreview}`);
     }
-
-    parts.push(`I drafted a reply for you:\n${blockquote(draftPreview)}`);
+    details.push(`✍️ *I drafted a reply for you:*\n${draftPreview}`);
 
     return {
       title: "Draft reply",
-      summary: parts.join("\n\n"),
+      summary,
+      details,
     };
   }
 
@@ -1176,7 +1177,9 @@ function buildEmailSummary(email: {
 
 function buildEmailPreview(email: { snippet: string; textPlain?: string }) {
   const rawPreview = email.snippet || email.textPlain || "";
-  const preview = removeExcessiveWhitespace(rawPreview).trim();
+  const preview = escapeSlackText(
+    removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
+  );
   if (!preview) return null;
 
   return truncate(preview, SUMMARY_PREVIEW_MAX_CHARS);
@@ -1446,13 +1449,6 @@ function toCalendarPreviewMessage(
     textPlain: email.textPlain,
     threadId: "",
   };
-}
-
-function blockquote(text: string): string {
-  return text
-    .split("\n")
-    .map((line) => `>${line}`)
-    .join("\n");
 }
 
 function stripSlackFormatting(text: string) {


### PR DESCRIPTION
# User description
## Summary
- Fix HTML entity encoding in email previews (e.g. `&#39;` now renders as `'`)
- Increase email preview limit from 280 to 2000 characters so full email context is visible in Slack
- Add emoji section markers (📩 💬 ✍️) and bold labels for clearer visual separation between email content and draft reply
- Split email preview and draft into separate Slack blocks instead of a single blockquoted text block
- Properly escape special characters in email previews for Slack mrkdwn

## Test plan
- [x] Unit tests pass (8/8)
- [ ] Verify Slack notification renders with decoded HTML entities
- [ ] Verify full email content is shown without truncation
- [ ] Verify emoji section headers display correctly in Slack
- [ ] Verify Teams/Telegram fallback still works with new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refresh the messaging rule notification builder so Slack drafts show emoji-labeled summary and detail sections with decoded, escaped previews and a larger snippet limit. Verify the update through the notification tests that assert the new formatting and entity handling, ensuring Teams fallback text strips HTML entities.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2204?tool=ast&topic=Slack+draft+formatting>Slack draft formatting</a>
        </td><td>Improve Slack draft formatting by adding emoji-labeled summary and detail sections while decoding/escaping text, expanding previews via <code>buildNotificationContent</code> and <code>buildEmailPreview</code>, and trimming unneeded blockquotes.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Disable Slack link unf...</td><td>April 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2204?tool=ast&topic=Notification+tests>Notification tests</a>
        </td><td>Update rule notification tests to expect the emoji summary/details layout and assert Teams fallback unescapes HTML entities when calling <code>buildMessagingRuleNotificationText</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/rule-notifications.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add mailbox links to S...</td><td>April 09, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2204?tool=ast>(Baz)</a>.