### PR TITLE
fix: retry Microsoft OAuth requests over IPv4

### DIFF
--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 vi.mock("server-only", () => ({}));
 
 import { NextRequest } from "next/server";
@@ -14,7 +13,6 @@ const {
   mockClearOAuthCode,
   mockCaptureException,
   mockAuth,
-  mockHttpsRequest,
 } = vi.hoisted(() => ({
   mockValidateOAuthCallback: vi.fn(),
   mockHandleAccountLinking: vi.fn(),
@@ -24,7 +22,6 @@ const {
   mockClearOAuthCode: vi.fn(),
   mockCaptureException: vi.fn(),
   mockAuth: vi.fn(),
-  mockHttpsRequest: vi.fn(),
 }));
 
 vi.mock("@/env", () => ({
@@ -96,10 +93,6 @@ vi.mock("@/utils/prisma-helpers", () => ({
 
 vi.mock("@/utils/auth", () => ({
   auth: mockAuth,
-}));
-
-vi.mock("node:https", () => ({
-  request: mockHttpsRequest,
 }));
 
 vi.mock("@/utils/outlook/scopes", () => ({
@@ -355,6 +348,16 @@ describe("outlook linking callback route", () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => ({
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            scope: "Mail.ReadWrite Mail.Send MailboxSettings.ReadWrite",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
             id: "provider-account-id",
             userPrincipalName: "user@example.com",
           }),
@@ -362,15 +365,6 @@ describe("outlook linking callback route", () => {
         .mockResolvedValueOnce({
           ok: false,
         }),
-    );
-    mockHttpsRequest.mockImplementation(
-      createHttpsJsonResponse({
-        access_token: "access-token",
-        refresh_token: "refresh-token",
-        scope: "Mail.ReadWrite Mail.Send MailboxSettings.ReadWrite",
-        token_type: "Bearer",
-        expires_in: 3600,
-      }),
     );
 
     const response = await GET(
@@ -475,36 +469,4 @@ function createFetchFailedError(code: string) {
   error.cause = new AggregateError([connectError], `connect ${code}`);
 
   return error;
-}
-
-function createHttpsJsonResponse(payload: unknown, statusCode = 200) {
-  return (
-    _options: unknown,
-    callback: (
-      response: EventEmitter & {
-        statusCode: number;
-        headers: Record<string, string>;
-      },
-    ) => void,
-  ) => {
-    const response = new EventEmitter() as EventEmitter & {
-      statusCode: number;
-      headers: Record<string, string>;
-    };
-    response.statusCode = statusCode;
-    response.headers = { "content-type": "application/json" };
-
-    const request = new EventEmitter() as EventEmitter & {
-      write: (chunk: string | Buffer) => void;
-      end: () => void;
-    };
-    request.write = vi.fn();
-    request.end = () => {
-      callback(response);
-      response.emit("data", Buffer.from(JSON.stringify(payload)));
-      response.emit("end");
-    };
-
-    return request;
-  };
 }

--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 vi.mock("server-only", () => ({}));
 
 import { NextRequest } from "next/server";
@@ -13,6 +14,7 @@ const {
   mockClearOAuthCode,
   mockCaptureException,
   mockAuth,
+  mockHttpsRequest,
 } = vi.hoisted(() => ({
   mockValidateOAuthCallback: vi.fn(),
   mockHandleAccountLinking: vi.fn(),
@@ -22,6 +24,7 @@ const {
   mockClearOAuthCode: vi.fn(),
   mockCaptureException: vi.fn(),
   mockAuth: vi.fn(),
+  mockHttpsRequest: vi.fn(),
 }));
 
 vi.mock("@/env", () => ({
@@ -93,6 +96,10 @@ vi.mock("@/utils/prisma-helpers", () => ({
 
 vi.mock("@/utils/auth", () => ({
   auth: mockAuth,
+}));
+
+vi.mock("node:https", () => ({
+  request: mockHttpsRequest,
 }));
 
 vi.mock("@/utils/outlook/scopes", () => ({
@@ -333,6 +340,50 @@ describe("outlook linking callback route", () => {
     expect(mockClearOAuthCode).toHaveBeenCalledWith("valid-auth-code");
   });
 
+  it("retries Microsoft token exchange with IPv4 when the first request fails with ENETUNREACH", async () => {
+    mockHandleAccountLinking.mockResolvedValue({
+      type: "continue_create",
+    });
+    prisma.account.create.mockResolvedValue({
+      id: "account-123",
+    } as Awaited<ReturnType<typeof prisma.account.create>>);
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValueOnce(createFetchFailedError("ENETUNREACH"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: "provider-account-id",
+            userPrincipalName: "user@example.com",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+        }),
+    );
+    mockHttpsRequest.mockImplementation(
+      createHttpsJsonResponse({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        scope: "Mail.ReadWrite Mail.Send MailboxSettings.ReadWrite",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    );
+
+    const response = await GET(
+      createRequest("http://localhost:3000/api/outlook/linking/callback"),
+    );
+
+    expect(response.headers.get("location")).toContain(
+      "success=account_created_and_linked",
+    );
+    expect(mockHandleAccountLinking).toHaveBeenCalled();
+    expect(prisma.account.create).toHaveBeenCalled();
+  });
+
   it("sanitizes unmapped Microsoft token errors before redirecting", async () => {
     vi.stubGlobal(
       "fetch",
@@ -414,3 +465,46 @@ describe("outlook linking callback route", () => {
     consoleWarn.mockRestore();
   });
 });
+
+function createFetchFailedError(code: string) {
+  const connectError = Object.assign(new Error(`connect ${code}`), { code });
+  const error = new TypeError("fetch failed") as TypeError & {
+    cause: AggregateError;
+  };
+
+  error.cause = new AggregateError([connectError], `connect ${code}`);
+
+  return error;
+}
+
+function createHttpsJsonResponse(payload: unknown, statusCode = 200) {
+  return (
+    _options: unknown,
+    callback: (
+      response: EventEmitter & {
+        statusCode: number;
+        headers: Record<string, string>;
+      },
+    ) => void,
+  ) => {
+    const response = new EventEmitter() as EventEmitter & {
+      statusCode: number;
+      headers: Record<string, string>;
+    };
+    response.statusCode = statusCode;
+    response.headers = { "content-type": "application/json" };
+
+    const request = new EventEmitter() as EventEmitter & {
+      write: (chunk: string | Buffer) => void;
+      end: () => void;
+    };
+    request.write = vi.fn();
+    request.end = () => {
+      callback(response);
+      response.emit("data", Buffer.from(JSON.stringify(payload)));
+      response.emit("end");
+    };
+
+    return request;
+  };
+}

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -165,18 +165,13 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       profile = result.profile;
       providerEmail = result.email;
     } catch (error) {
-      if (
-        error instanceof MicrosoftUserProfileError &&
-        typeof error.status === "number"
-      ) {
-        logger.error("Failed to fetch Microsoft user profile", {
-          targetUserId,
-          status: error.status,
-        });
-        throw new SafeError("Failed to fetch user profile");
-      }
-
       if (error instanceof MicrosoftUserProfileError) {
+        if (error.status) {
+          logger.error("Failed to fetch Microsoft user profile", {
+            targetUserId,
+            status: error.status,
+          });
+        }
         throw new SafeError(error.message);
       }
 
@@ -237,16 +232,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
         },
       );
 
-      let expiresAt: Date | null = null;
-      if (tokens.expires_at) {
-        expiresAt = new Date(tokens.expires_at * 1000);
-      } else if (tokens.expires_in) {
-        const expiresInSeconds =
-          typeof tokens.expires_in === "string"
-            ? Number.parseInt(tokens.expires_in, 10)
-            : tokens.expires_in;
-        expiresAt = new Date(Date.now() + expiresInSeconds * 1000);
-      }
+      const expiresAt = parseMicrosoftExpiresAt(tokens);
 
       let profileImage = null;
       try {

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -186,7 +186,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
     const providerAccountId = profile.id;
 
     if (!providerAccountId) {
-      throw new SafeError("Profile missing required id or email");
+      throw new SafeError("Profile missing required id");
     }
 
     const existingAccount = await prisma.account.findUnique({

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -23,7 +23,7 @@ import {
   parseMicrosoftScopes,
 } from "@/utils/oauth/microsoft-oauth";
 import {
-  getMicrosoftGraphUrl,
+  fetchMicrosoftGraph,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import {
@@ -154,7 +154,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
     }
 
     // Get user profile using the access token
-    const profileResponse = await fetch(getMicrosoftGraphUrl("/me"), {
+    const profileResponse = await fetchMicrosoftGraph("/me", {
       headers: {
         Authorization: `Bearer ${tokens.access_token}`,
       },
@@ -237,14 +237,11 @@ export const GET = withError("outlook/linking/callback", async (request) => {
 
       let profileImage = null;
       try {
-        const photoResponse = await fetch(
-          getMicrosoftGraphUrl("/me/photo/$value"),
-          {
-            headers: {
-              Authorization: `Bearer ${tokens.access_token}`,
-            },
+        const photoResponse = await fetchMicrosoftGraph("/me/photo/$value", {
+          headers: {
+            Authorization: `Bearer ${tokens.access_token}`,
           },
-        );
+        });
 
         if (photoResponse.ok) {
           const photoBuffer = await photoResponse.arrayBuffer();

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -24,6 +24,8 @@ import {
 } from "@/utils/oauth/microsoft-oauth";
 import {
   fetchMicrosoftGraph,
+  fetchMicrosoftUserProfile,
+  MicrosoftUserProfileError,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import {
@@ -153,26 +155,37 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       throw new SafeError(errorDescription);
     }
 
-    // Get user profile using the access token
-    const profileResponse = await fetchMicrosoftGraph("/me", {
-      headers: {
-        Authorization: `Bearer ${tokens.access_token}`,
-      },
-    });
+    let profile: Awaited<
+      ReturnType<typeof fetchMicrosoftUserProfile>
+    >["profile"];
+    let providerEmail: string;
 
-    if (!profileResponse.ok) {
-      logger.error("Failed to fetch Microsoft user profile", {
-        targetUserId,
-        status: profileResponse.status,
-      });
-      throw new SafeError("Failed to fetch user profile");
+    try {
+      const result = await fetchMicrosoftUserProfile(tokens.access_token);
+      profile = result.profile;
+      providerEmail = result.email;
+    } catch (error) {
+      if (
+        error instanceof MicrosoftUserProfileError &&
+        typeof error.status === "number"
+      ) {
+        logger.error("Failed to fetch Microsoft user profile", {
+          targetUserId,
+          status: error.status,
+        });
+        throw new SafeError("Failed to fetch user profile");
+      }
+
+      if (error instanceof MicrosoftUserProfileError) {
+        throw new SafeError(error.message);
+      }
+
+      throw error;
     }
 
-    const profile = await profileResponse.json();
     const providerAccountId = profile.id;
-    const providerEmail = profile.mail || profile.userPrincipalName;
 
-    if (!providerAccountId || !providerEmail) {
+    if (!providerAccountId) {
       throw new SafeError("Profile missing required id or email");
     }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -195,6 +195,7 @@
     "tailwindcss-animate": "1.0.7",
     "tiptap-markdown": "0.8.10",
     "tldts": "7.0.28",
+    "undici": "8.0.2",
     "unpdf": "1.4.0",
     "use-stick-to-bottom": "1.1.3",
     "usehooks-ts": "3.1.1",

--- a/apps/web/utils/calendar/providers/microsoft.ts
+++ b/apps/web/utils/calendar/providers/microsoft.ts
@@ -2,7 +2,7 @@ import { env } from "@/env";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import {
-  fetchMicrosoftGraph,
+  fetchMicrosoftUserProfile,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import {
@@ -40,23 +40,9 @@ export function createMicrosoftCalendarProvider(
         );
       }
 
-      // Get user profile using the access token
-      const profileResponse = await fetchMicrosoftGraph("/me", {
-        headers: {
-          Authorization: `Bearer ${tokens.access_token}`,
-        },
-      });
-
-      if (!profileResponse.ok) {
-        throw new Error("Failed to fetch user profile");
-      }
-
-      const profile = await profileResponse.json();
-      const microsoftEmail = profile.mail || profile.userPrincipalName;
-
-      if (!microsoftEmail) {
-        throw new Error("Profile missing required email");
-      }
+      const { email: microsoftEmail } = await fetchMicrosoftUserProfile(
+        tokens.access_token,
+      );
 
       if (!tokens.refresh_token) {
         throw new Error(

--- a/apps/web/utils/calendar/providers/microsoft.ts
+++ b/apps/web/utils/calendar/providers/microsoft.ts
@@ -2,7 +2,7 @@ import { env } from "@/env";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import {
-  getMicrosoftGraphUrl,
+  fetchMicrosoftGraph,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import {
@@ -41,7 +41,7 @@ export function createMicrosoftCalendarProvider(
       }
 
       // Get user profile using the access token
-      const profileResponse = await fetch(getMicrosoftGraphUrl("/me"), {
+      const profileResponse = await fetchMicrosoftGraph("/me", {
         headers: {
           Authorization: `Bearer ${tokens.access_token}`,
         },

--- a/apps/web/utils/drive/client.ts
+++ b/apps/web/utils/drive/client.ts
@@ -6,7 +6,7 @@ import {
   isGoogleOauthEmulationEnabled,
 } from "@/utils/google/oauth";
 import {
-  getMicrosoftGraphUrl,
+  fetchMicrosoftGraph,
   getMicrosoftOauthAuthorizeUrl,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
@@ -153,7 +153,7 @@ export async function exchangeMicrosoftDriveCode(code: string) {
   }
 
   // Get user email from Microsoft Graph
-  const profileResponse = await fetch(getMicrosoftGraphUrl("/me"), {
+  const profileResponse = await fetchMicrosoftGraph("/me", {
     headers: {
       Authorization: `Bearer ${tokens.access_token}`,
     },

--- a/apps/web/utils/drive/client.ts
+++ b/apps/web/utils/drive/client.ts
@@ -160,6 +160,6 @@ export async function exchangeMicrosoftDriveCode(code: string) {
     expiresAt: tokens.expires_in
       ? new Date(Date.now() + tokens.expires_in * 1000)
       : null,
-    email: email as string,
+    email,
   };
 }

--- a/apps/web/utils/drive/client.ts
+++ b/apps/web/utils/drive/client.ts
@@ -6,7 +6,7 @@ import {
   isGoogleOauthEmulationEnabled,
 } from "@/utils/google/oauth";
 import {
-  fetchMicrosoftGraph,
+  fetchMicrosoftUserProfile,
   getMicrosoftOauthAuthorizeUrl,
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
@@ -152,23 +152,7 @@ export async function exchangeMicrosoftDriveCode(code: string) {
     throw new Error("No access or refresh token returned from Microsoft");
   }
 
-  // Get user email from Microsoft Graph
-  const profileResponse = await fetchMicrosoftGraph("/me", {
-    headers: {
-      Authorization: `Bearer ${tokens.access_token}`,
-    },
-  });
-
-  if (!profileResponse.ok) {
-    throw new Error("Failed to get user profile from Microsoft");
-  }
-
-  const profile = await profileResponse.json();
-  const email = profile.mail || profile.userPrincipalName;
-
-  if (!email) {
-    throw new Error("Could not get email from Microsoft profile");
-  }
+  const { email } = await fetchMicrosoftUserProfile(tokens.access_token);
 
   return {
     accessToken: tokens.access_token as string,

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -3,8 +3,8 @@ import type { DriveItem } from "@microsoft/microsoft-graph-types";
 import type { Logger } from "@/utils/logger";
 import { createScopedLogger } from "@/utils/logger";
 import {
+  fetchMicrosoftGraph,
   getMicrosoftGraphClientOptions,
-  getMicrosoftGraphUrl,
 } from "@/utils/microsoft/oauth";
 import { isNotFoundError } from "@/utils/outlook/errors";
 import type {
@@ -236,8 +236,8 @@ export class OneDriveProvider implements DriveProvider {
     const file = await this.getFile(fileId);
     if (!file) return null;
 
-    const response = await fetch(
-      getMicrosoftGraphUrl(`/me/drive/items/${fileId}/content`),
+    const response = await fetchMicrosoftGraph(
+      `/me/drive/items/${fileId}/content`,
       {
         headers: {
           Authorization: `Bearer ${this.accessToken}`,

--- a/apps/web/utils/microsoft/oauth.test.ts
+++ b/apps/web/utils/microsoft/oauth.test.ts
@@ -1,11 +1,4 @@
-import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const mockHttpsRequest = vi.hoisted(() => vi.fn());
-
-vi.mock("node:https", () => ({
-  request: mockHttpsRequest,
-}));
 
 describe("microsoft oauth helpers", () => {
   beforeEach(() => {
@@ -109,30 +102,61 @@ describe("microsoft oauth helpers", () => {
     const fetchMock = vi
       .fn()
       .mockRejectedValueOnce(createFetchFailedError("ENETUNREACH"))
-      .mockResolvedValueOnce({ ok: true });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
     vi.stubGlobal("fetch", fetchMock);
-    mockHttpsRequest.mockImplementation(
-      createHttpsJsonResponse({
-        access_token: "access-token",
-      }),
-    );
 
     const response = await oauth.requestMicrosoftToken({
       client_id: "client-id",
       grant_type: "refresh_token",
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
-    expect(mockHttpsRequest.mock.calls[0]?.[0]).toEqual(
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
       expect.objectContaining({
-        hostname: "login.microsoftonline.com",
-        family: 4,
+        dispatcher: expect.any(Object),
         method: "POST",
       }),
     );
-    await expect(response.json()).resolves.toEqual({
-      access_token: "access-token",
+    await expect(response.json()).resolves.toEqual({});
+  });
+
+  it("returns the Microsoft user profile and derived email", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "user-id",
+        userPrincipalName: "user@example.com",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      oauth.fetchMicrosoftUserProfile("access-token"),
+    ).resolves.toEqual({
+      profile: {
+        id: "user-id",
+        userPrincipalName: "user@example.com",
+      },
+      email: "user@example.com",
+    });
+  });
+
+  it("throws a typed error when the Microsoft profile request fails", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(
+      oauth.fetchMicrosoftUserProfile("access-token"),
+    ).rejects.toMatchObject({
+      message: "Failed to fetch Microsoft user profile",
+      status: 503,
     });
   });
 });
@@ -163,36 +187,4 @@ function createFetchFailedError(code: string) {
   error.cause = new AggregateError([connectError], `connect ${code}`);
 
   return error;
-}
-
-function createHttpsJsonResponse(payload: unknown, statusCode = 200) {
-  return (
-    _options: unknown,
-    callback: (
-      response: EventEmitter & {
-        statusCode: number;
-        headers: Record<string, string>;
-      },
-    ) => void,
-  ) => {
-    const response = new EventEmitter() as EventEmitter & {
-      statusCode: number;
-      headers: Record<string, string>;
-    };
-    response.statusCode = statusCode;
-    response.headers = { "content-type": "application/json" };
-
-    const request = new EventEmitter() as EventEmitter & {
-      write: (chunk: string | Buffer) => void;
-      end: () => void;
-    };
-    request.write = vi.fn();
-    request.end = () => {
-      callback(response);
-      response.emit("data", Buffer.from(JSON.stringify(payload)));
-      response.emit("end");
-    };
-
-    return request;
-  };
 }

--- a/apps/web/utils/microsoft/oauth.test.ts
+++ b/apps/web/utils/microsoft/oauth.test.ts
@@ -1,4 +1,11 @@
+import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHttpsRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("node:https", () => ({
+  request: mockHttpsRequest,
+}));
 
 describe("microsoft oauth helpers", () => {
   beforeEach(() => {
@@ -96,6 +103,38 @@ describe("microsoft oauth helpers", () => {
       },
     );
   });
+
+  it("retries Microsoft token requests with IPv4 after an IPv6 reachability failure", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(createFetchFailedError("ENETUNREACH"))
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    mockHttpsRequest.mockImplementation(
+      createHttpsJsonResponse({
+        access_token: "access-token",
+      }),
+    );
+
+    const response = await oauth.requestMicrosoftToken({
+      client_id: "client-id",
+      grant_type: "refresh_token",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(1);
+    expect(mockHttpsRequest.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        hostname: "login.microsoftonline.com",
+        family: 4,
+        method: "POST",
+      }),
+    );
+    await expect(response.json()).resolves.toEqual({
+      access_token: "access-token",
+    });
+  });
 });
 
 async function importMicrosoftOauthModule(
@@ -113,4 +152,47 @@ async function importMicrosoftOauthModule(
   }));
 
   return import("./oauth");
+}
+
+function createFetchFailedError(code: string) {
+  const connectError = Object.assign(new Error(`connect ${code}`), { code });
+  const error = new TypeError("fetch failed") as TypeError & {
+    cause: AggregateError;
+  };
+
+  error.cause = new AggregateError([connectError], `connect ${code}`);
+
+  return error;
+}
+
+function createHttpsJsonResponse(payload: unknown, statusCode = 200) {
+  return (
+    _options: unknown,
+    callback: (
+      response: EventEmitter & {
+        statusCode: number;
+        headers: Record<string, string>;
+      },
+    ) => void,
+  ) => {
+    const response = new EventEmitter() as EventEmitter & {
+      statusCode: number;
+      headers: Record<string, string>;
+    };
+    response.statusCode = statusCode;
+    response.headers = { "content-type": "application/json" };
+
+    const request = new EventEmitter() as EventEmitter & {
+      write: (chunk: string | Buffer) => void;
+      end: () => void;
+    };
+    request.write = vi.fn();
+    request.end = () => {
+      callback(response);
+      response.emit("data", Buffer.from(JSON.stringify(payload)));
+      response.emit("end");
+    };
+
+    return request;
+  };
 }

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -155,7 +155,7 @@ async function fetchMicrosoftUrl(url: string, init?: RequestInit) {
     }
 
     return fetch(url, {
-      ...(init || {}),
+      ...init,
       dispatcher: microsoftIpv4Dispatcher,
     } as RequestInit & { dispatcher: Dispatcher });
   }
@@ -176,14 +176,11 @@ function shouldRetryWithIpv4(url: string, error: unknown) {
   return false;
 }
 
-function extractErrorCodes(error: unknown): Set<string> {
-  const codes = new Set<string>();
-  collectErrorCodes(error, codes);
-  return codes;
-}
-
-function collectErrorCodes(error: unknown, codes: Set<string>) {
-  if (!error || typeof error !== "object") return;
+function extractErrorCodes(
+  error: unknown,
+  codes = new Set<string>(),
+): Set<string> {
+  if (!error || typeof error !== "object") return codes;
 
   const code =
     "code" in error && typeof error.code === "string" ? error.code : null;
@@ -193,11 +190,13 @@ function collectErrorCodes(error: unknown, codes: Set<string>) {
 
   if ("errors" in error && Array.isArray(error.errors)) {
     for (const nestedError of error.errors) {
-      collectErrorCodes(nestedError, codes);
+      extractErrorCodes(nestedError, codes);
     }
   }
 
   if ("cause" in error) {
-    collectErrorCodes(error.cause, codes);
+    extractErrorCodes(error.cause, codes);
   }
+
+  return codes;
 }

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -1,8 +1,14 @@
 import { env } from "@/env";
+import { request as httpsRequest } from "node:https";
 
 const MICROSOFT_LOGIN_BASE_URL = "https://login.microsoftonline.com";
 const MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com";
 const MICROSOFT_GRAPH_API_VERSION = "v1.0";
+const MICROSOFT_IPV4_RETRY_HOSTS = new Set([
+  new URL(MICROSOFT_LOGIN_BASE_URL).hostname,
+  new URL(MICROSOFT_GRAPH_BASE_URL).hostname,
+]);
+const IPV6_UNREACHABLE_ERROR_CODES = new Set(["ENETUNREACH", "EHOSTUNREACH"]);
 
 type MicrosoftGraphClientOptions = {
   baseUrl?: string;
@@ -48,7 +54,7 @@ export function getMicrosoftOauthTokenUrl() {
 }
 
 export function requestMicrosoftToken(form: Record<string, string>) {
-  return fetch(getMicrosoftOauthTokenUrl(), {
+  return fetchMicrosoftUrl(getMicrosoftOauthTokenUrl(), {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
@@ -66,6 +72,10 @@ export function getMicrosoftGraphApiRootUrl() {
 
 export function getMicrosoftGraphUrl(path: string) {
   return `${getMicrosoftGraphApiRootUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function fetchMicrosoftGraph(path: string, init?: RequestInit) {
+  return fetchMicrosoftUrl(getMicrosoftGraphUrl(path), init);
 }
 
 export function getMicrosoftGraphClientOptions(
@@ -88,4 +98,136 @@ export function getMicrosoftGraphClientOptions(
 
 function getMicrosoftBaseUrl() {
   return env.MICROSOFT_BASE_URL?.replace(/\/+$/, "") || null;
+}
+
+async function fetchMicrosoftUrl(url: string, init?: RequestInit) {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    if (!shouldRetryWithIpv4(url, error)) {
+      throw error;
+    }
+
+    return fetchMicrosoftUrlOverIpv4(url, init);
+  }
+}
+
+function shouldRetryWithIpv4(url: string, error: unknown) {
+  if (getMicrosoftBaseUrl()) return false;
+
+  const hostname = new URL(url).hostname;
+  if (!MICROSOFT_IPV4_RETRY_HOSTS.has(hostname)) return false;
+
+  for (const code of extractErrorCodes(error)) {
+    if (IPV6_UNREACHABLE_ERROR_CODES.has(code)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractErrorCodes(error: unknown): Set<string> {
+  const codes = new Set<string>();
+  collectErrorCodes(error, codes);
+  return codes;
+}
+
+function collectErrorCodes(error: unknown, codes: Set<string>) {
+  if (!error || typeof error !== "object") return;
+
+  const code =
+    "code" in error && typeof error.code === "string" ? error.code : null;
+  if (code) {
+    codes.add(code);
+  }
+
+  if ("errors" in error && Array.isArray(error.errors)) {
+    for (const nestedError of error.errors) {
+      collectErrorCodes(nestedError, codes);
+    }
+  }
+
+  if ("cause" in error) {
+    collectErrorCodes(error.cause, codes);
+  }
+}
+
+async function fetchMicrosoftUrlOverIpv4(url: string, init?: RequestInit) {
+  const parsedUrl = new URL(url);
+  const body = await serializeRequestBody(init?.body);
+  const headers = Object.fromEntries(new Headers(init?.headers).entries());
+
+  return new Promise<Response>((resolve, reject) => {
+    const request = httpsRequest(
+      {
+        protocol: parsedUrl.protocol,
+        hostname: parsedUrl.hostname,
+        port: parsedUrl.port || undefined,
+        path: `${parsedUrl.pathname}${parsedUrl.search}`,
+        method: init?.method ?? "GET",
+        headers,
+        family: 4,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+
+        response.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+
+        response.on("end", () => {
+          resolve(
+            new Response(Buffer.concat(chunks), {
+              status: response.statusCode ?? 500,
+              headers: toHeaders(response.headers),
+            }),
+          );
+        });
+      },
+    );
+
+    request.on("error", reject);
+
+    if (body) {
+      request.write(body);
+    }
+
+    request.end();
+  });
+}
+
+function toHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): Headers {
+  const normalizedHeaders = new Headers();
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      for (const headerValue of value) {
+        normalizedHeaders.append(key, headerValue);
+      }
+      continue;
+    }
+
+    if (value != null) {
+      normalizedHeaders.append(key, value);
+    }
+  }
+
+  return normalizedHeaders;
+}
+
+async function serializeRequestBody(body: RequestInit["body"]) {
+  if (!body) return null;
+  if (typeof body === "string") return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof ArrayBuffer) return Buffer.from(body);
+  if (ArrayBuffer.isView(body))
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  if (body instanceof Blob) {
+    return Buffer.from(await body.arrayBuffer());
+  }
+
+  throw new TypeError("Unsupported Microsoft fallback request body");
 }

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -24,7 +24,7 @@ type MicrosoftGraphClientOptions = {
   };
 };
 
-export type MicrosoftUserProfile = {
+type MicrosoftUserProfile = {
   id?: string | null;
   mail?: string | null;
   userPrincipalName?: string | null;

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -1,5 +1,5 @@
 import { env } from "@/env";
-import { request as httpsRequest } from "node:https";
+import { Agent, type Dispatcher } from "undici";
 
 const MICROSOFT_LOGIN_BASE_URL = "https://login.microsoftonline.com";
 const MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com";
@@ -9,6 +9,9 @@ const MICROSOFT_IPV4_RETRY_HOSTS = new Set([
   new URL(MICROSOFT_GRAPH_BASE_URL).hostname,
 ]);
 const IPV6_UNREACHABLE_ERROR_CODES = new Set(["ENETUNREACH", "EHOSTUNREACH"]);
+const microsoftIpv4Dispatcher = new Agent({
+  connect: { family: 4 },
+});
 
 type MicrosoftGraphClientOptions = {
   baseUrl?: string;
@@ -20,6 +23,25 @@ type MicrosoftGraphClientOptions = {
     };
   };
 };
+
+export type MicrosoftUserProfile = {
+  id?: string | null;
+  mail?: string | null;
+  userPrincipalName?: string | null;
+  displayName?: string | null;
+  givenName?: string | null;
+  surname?: string | null;
+};
+
+export class MicrosoftUserProfileError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "MicrosoftUserProfileError";
+    this.status = status;
+  }
+}
 
 export function isMicrosoftEmulationEnabled() {
   return !!getMicrosoftBaseUrl();
@@ -78,6 +100,30 @@ export function fetchMicrosoftGraph(path: string, init?: RequestInit) {
   return fetchMicrosoftUrl(getMicrosoftGraphUrl(path), init);
 }
 
+export async function fetchMicrosoftUserProfile(accessToken: string) {
+  const response = await fetchMicrosoftGraph("/me", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new MicrosoftUserProfileError(
+      "Failed to fetch Microsoft user profile",
+      response.status,
+    );
+  }
+
+  const profile = (await response.json()) as MicrosoftUserProfile;
+  const email = profile.mail || profile.userPrincipalName;
+
+  if (!email) {
+    throw new MicrosoftUserProfileError("Profile missing required email");
+  }
+
+  return { profile, email };
+}
+
 export function getMicrosoftGraphClientOptions(
   accessToken: string,
 ): MicrosoftGraphClientOptions {
@@ -108,7 +154,10 @@ async function fetchMicrosoftUrl(url: string, init?: RequestInit) {
       throw error;
     }
 
-    return fetchMicrosoftUrlOverIpv4(url, init);
+    return fetch(url, {
+      ...(init || {}),
+      dispatcher: microsoftIpv4Dispatcher,
+    } as RequestInit & { dispatcher: Dispatcher });
   }
 }
 
@@ -151,85 +200,4 @@ function collectErrorCodes(error: unknown, codes: Set<string>) {
   if ("cause" in error) {
     collectErrorCodes(error.cause, codes);
   }
-}
-
-async function fetchMicrosoftUrlOverIpv4(url: string, init?: RequestInit) {
-  const parsedUrl = new URL(url);
-  const body = await serializeRequestBody(init?.body);
-  const headers = Object.fromEntries(new Headers(init?.headers).entries());
-
-  return new Promise<Response>((resolve, reject) => {
-    const request = httpsRequest(
-      {
-        protocol: parsedUrl.protocol,
-        hostname: parsedUrl.hostname,
-        port: parsedUrl.port || undefined,
-        path: `${parsedUrl.pathname}${parsedUrl.search}`,
-        method: init?.method ?? "GET",
-        headers,
-        family: 4,
-      },
-      (response) => {
-        const chunks: Buffer[] = [];
-
-        response.on("error", reject);
-
-        response.on("data", (chunk) => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        });
-
-        response.on("end", () => {
-          resolve(
-            new Response(Buffer.concat(chunks), {
-              status: response.statusCode ?? 500,
-              headers: toHeaders(response.headers),
-            }),
-          );
-        });
-      },
-    );
-
-    request.on("error", reject);
-
-    if (body) {
-      request.write(body);
-    }
-
-    request.end();
-  });
-}
-
-function toHeaders(
-  headers: Record<string, string | string[] | undefined>,
-): Headers {
-  const normalizedHeaders = new Headers();
-
-  for (const [key, value] of Object.entries(headers)) {
-    if (Array.isArray(value)) {
-      for (const headerValue of value) {
-        normalizedHeaders.append(key, headerValue);
-      }
-      continue;
-    }
-
-    if (value != null) {
-      normalizedHeaders.append(key, value);
-    }
-  }
-
-  return normalizedHeaders;
-}
-
-async function serializeRequestBody(body: RequestInit["body"]) {
-  if (!body) return null;
-  if (typeof body === "string") return body;
-  if (body instanceof URLSearchParams) return body.toString();
-  if (body instanceof ArrayBuffer) return Buffer.from(body);
-  if (ArrayBuffer.isView(body))
-    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
-  if (body instanceof Blob) {
-    return Buffer.from(await body.arrayBuffer());
-  }
-
-  throw new TypeError("Unsupported Microsoft fallback request body");
 }

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -172,6 +172,8 @@ async function fetchMicrosoftUrlOverIpv4(url: string, init?: RequestInit) {
       (response) => {
         const chunks: Buffer[] = [];
 
+        response.on("error", reject);
+
         response.on("data", (chunk) => {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,9 @@ importers:
       tldts:
         specifier: 7.0.28
         version: 7.0.28
+      undici:
+        specifier: 8.0.2
+        version: 8.0.2
       unpdf:
         specifier: 1.4.0
         version: 1.4.0
@@ -12581,10 +12584,6 @@ packages:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
 
-  undici@7.21.0:
-    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
@@ -12592,6 +12591,10 @@ packages:
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.0.2:
+    resolution: {integrity: sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -21126,7 +21129,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.21.0
+      undici: 7.24.7
       whatwg-mimetype: 4.0.0
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
@@ -23324,7 +23327,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.21.0
+      undici: 7.24.7
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -26911,11 +26914,11 @@ snapshots:
 
   undici@6.23.0: {}
 
-  undici@7.21.0: {}
-
   undici@7.24.4: {}
 
   undici@7.24.7: {}
+
+  undici@8.0.2: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
# User description
This adds a narrow IPv4 retry path for Microsoft OAuth and direct Microsoft Graph requests when the first request fails because IPv6 is unreachable.

- add a shared Microsoft fetch helper for token and direct Graph requests
- apply the helper to linking, calendar, and drive flows
- add regression tests for the fallback behavior and callback flow

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a shared Microsoft fetch helper that retries requests over IPv4 when IPv6 reachability errors occur, enabling <code>requestMicrosoftToken</code>, <code>fetchMicrosoftGraph</code>, and <code>fetchMicrosoftUserProfile</code> to reuse the same behavior. Apply the helper to the Outlook linking callback, calendar provider, and drive flows while extending the regression suite for the IPv4 fallback and profile-fetching errors.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2206?tool=ast&topic=Flow+coverage>Flow coverage</a>
        </td><td>Update Outlook linking callback, calendar provider, drive client/provider, and related tests to use the helper-backed profile fetching and assert the IPv4 fallback behavior.<details><summary>Modified files (5)</summary><ul><li>apps/web/app/api/outlook/linking/callback/route.test.ts</li>
<li>apps/web/app/api/outlook/linking/callback/route.ts</li>
<li>apps/web/utils/calendar/providers/microsoft.ts</li>
<li>apps/web/utils/drive/client.ts</li>
<li>apps/web/utils/drive/providers/microsoft.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Pass request headers i...</td><td>April 10, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>PR feedback</td><td>August 29, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2206?tool=ast&topic=Microsoft+OAuth+helper>Microsoft OAuth helper</a>
        </td><td>Wrap Microsoft token, Graph, and profile requests with <code>fetchMicrosoftUrl</code> so they retry over IPv4 when IPv6 errors happen and surface typed <code>MicrosoftUserProfileError</code> information.<details><summary>Modified files (4)</summary><ul><li>apps/web/package.json</li>
<li>apps/web/utils/microsoft/oauth.test.ts</li>
<li>apps/web/utils/microsoft/oauth.ts</li>
<li>pnpm-lock.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore: update app depe...</td><td>April 09, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Extract shared Gmail t...</td><td>March 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2206?tool=ast>(Baz)</a>.