### PR TITLE
tests: refresh eval model matrix

### DIFF
--- a/.claude/skills/testing/eval.md
+++ b/.claude/skills/testing/eval.md
@@ -85,7 +85,7 @@ pnpm test-ai eval/your-feature
 EVAL_MODELS=all pnpm test-ai eval/your-feature
 
 # Specific models
-EVAL_MODELS=gemini-2.5-flash,grok-4.1-fast pnpm test-ai eval/your-feature
+EVAL_MODELS=gemini-2.5-flash,gpt-5.4-mini pnpm test-ai eval/your-feature
 
 # Save report to file
 EVAL_REPORT_PATH=eval-results/report.md EVAL_MODELS=all pnpm test-ai eval/your-feature

--- a/apps/web/__tests__/eval/models.ts
+++ b/apps/web/__tests__/eval/models.ts
@@ -25,15 +25,15 @@ const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
     model: "google/gemini-3.1-flash-lite-preview",
     label: "Gemini 3.1 Flash Lite",
   },
-  "grok-4.1-fast": {
+  "gpt-5.4-nano": {
     provider: "openrouter",
-    model: "x-ai/grok-4.1-fast",
-    label: "Grok 4.1 Fast",
+    model: "openai/gpt-5.4-nano",
+    label: "GPT-5.4 Nano",
   },
-  "gpt-5-nano": {
+  "gpt-5.4-mini": {
     provider: "openrouter",
-    model: "openai/gpt-5-nano",
-    label: "GPT-5 Nano",
+    model: "openai/gpt-5.4-mini",
+    label: "GPT-5.4 Mini",
   },
 };
 
@@ -43,7 +43,7 @@ const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
  * - Not set:                         single run with default env-configured model
  * - EVAL_MODELS=all                  every model in the catalog
  * - EVAL_MODELS=gemini-2.5-flash     single model by shorthand
- * - EVAL_MODELS=gemini-2.5-flash,grok-4.1-fast   comma-separated shorthand picks
+ * - EVAL_MODELS=gemini-2.5-flash,gpt-5.4-mini   comma-separated shorthand picks
  * - EVAL_MODELS=[{...}]             custom JSON array
  */
 export function getEvalModels(): EvalModel[] {


### PR DESCRIPTION
# User description
Refresh the shared eval model catalog to use the current OpenRouter GPT-5.4 presets and remove the deprecated models from the default matrix.

- replace the retired Grok and GPT-5 Nano eval presets with GPT-5.4 Nano and GPT-5.4 Mini
- update the local eval testing guide example to match the supported shorthand list
- re-run the eval model registry test and the memory eval suites against the updated matrix

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the shared eval model catalog in <code>getEvalModels</code> so it lists the current OpenRouter GPT-5.4 presets instead of the retired Grok and GPT-5 Nano entries. Document the supported shorthand list in the eval testing guide to match the refreshed catalog.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2210?tool=ast&topic=Eval+testing+guide>Eval testing guide</a>
        </td><td>Align the eval testing guide example with the refreshed shorthand list so the documented <code>EVAL_MODELS</code> invocation matches the supported presets.<details><summary>Modified files (1)</summary><ul><li>.claude/skills/testing/eval.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve learned writin...</td><td>March 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2210?tool=ast&topic=Eval+model+matrix>Eval model matrix</a>
        </td><td>Refresh <code>EVAL_MODEL_CATALOG</code> to replace the retired <code>grok-4.1-fast</code> and <code>gpt-5-nano</code> presets with <code>gpt-5.4-nano</code> and <code>gpt-5.4-mini</code>, and update the <code>getEvalModels</code> shorthand list to reference the new GPT-5.4 Mini option.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/eval/models.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add assistant chat inb...</td><td>March 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2210?tool=ast>(Baz)</a>.