### PR TITLE
fix: append personal instructions by default

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1669,6 +1669,29 @@ describe("aiProcessAssistantChat", () => {
     );
   });
 
+  it("updatePersonalInstructions defaults to append mode", async () => {
+    const tools = await captureToolSet();
+
+    mockPrisma.emailAccount.findUnique.mockResolvedValue({
+      about: "Existing instructions",
+    });
+    mockPrisma.emailAccount.update.mockResolvedValue({});
+
+    const result = await tools.updatePersonalInstructions.execute({
+      about: "Additional preference",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.updatedAbout).toBe(
+      "Existing instructions\nAdditional preference",
+    );
+    expect(mockPrisma.emailAccount.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { about: "Existing instructions\nAdditional preference" },
+      }),
+    );
+  });
+
   it("updatePersonalInstructions in append mode with no existing about sets new content", async () => {
     const tools = await captureToolSet();
 

--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -461,7 +461,7 @@ export function MessagePart({
                 updatedAbout ??
                 part.input?.about ??
                 "Personal instructions updated.",
-              mode: part.input?.mode ?? "replace",
+              mode: part.input?.mode ?? "append",
             }}
           />
         );

--- a/apps/web/utils/ai/assistant/chat-rule-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.ts
@@ -742,12 +742,12 @@ export const updatePersonalInstructionsTool = ({
       about: z.string(),
       mode: z
         .enum(["replace", "append"])
-        .default("replace")
+        .default("append")
         .describe(
           "Use 'append' to add to existing instructions, 'replace' to overwrite entirely.",
         ),
     }),
-    execute: async ({ about, mode }) => {
+    execute: async ({ about, mode = "append" }) => {
       trackToolCall({ tool: "update_personal_instructions", email, logger });
       try {
         const existing = await prisma.emailAccount.findUnique({


### PR DESCRIPTION
# User description
Align the personal instructions tool with the intended append-first behavior and cover it with a regression test.

- default updatePersonalInstructions to append instead of replace
- make the executor honor append when mode is omitted
- add a chat-tool regression test for the default behavior

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align the personal instructions tool configuration, executor, and message handling to append new content by default rather than replacing existing instructions. Cover the default append flow with a regression test that ensures <code>tools.updatePersonalInstructions.execute</code> adds new text to stored <code>about</code> content when no mode is provided.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2212?tool=ast&topic=Append+regression>Append regression</a>
        </td><td>Cover the default append behavior with a regression test that verifies <code>tools.updatePersonalInstructions.execute</code> appends to the existing <code>about</code> instructions when no mode is specified.<details><summary>Modified files (1)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-chat: tighte...</td><td>April 10, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix Anthropic System M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2212?tool=ast&topic=Append+defaults>Append defaults</a>
        </td><td>Align <code>updatePersonalInstructionsTool</code> and the <code>MessagePart</code> handling so they default to append mode and make the executor honor append when the caller omits the <code>mode</code> parameter.<details><summary>Modified files (2)</summary><ul><li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/utils/ai/assistant/chat-rule-tools.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant-chat: tighte...</td><td>April 10, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>fix: LLM rule creation...</td><td>March 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2212?tool=ast>(Baz)</a>.