### PR TITLE
assistant: improve rule fix handling

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -598,19 +598,18 @@ describe("aiProcessAssistantChat", () => {
         message.content.includes("Hidden context for the user's request"),
     );
 
-    expect(hiddenContext?.content).toContain("Structured match details:");
-    expect(hiddenContext?.content).toContain(
-      "Matched by static sender, recipient, or subject conditions.",
-    );
-    expect(hiddenContext?.content).toContain(
-      "Team Mail learned pattern exclude on FROM: store@company.example",
-    );
-    expect(hiddenContext?.content).toContain(
-      "create a new rule only if no existing rule can be safely updated without causing overlap.",
-    );
-    expect(hiddenContext?.content).toContain(
-      "Treat that selection as user intent about the desired behavior, not as an instruction to duplicate a matching rule.",
-    );
+    const content = hiddenContext?.content ?? "";
+
+    expect(content).toContain("Structured match details:");
+    expect(content).toContain("Team Mail");
+    expect(content).toContain("store@company.example");
+    expect(content).toContain("FROM");
+    expect(content).toMatch(/static/i);
+    expect(content).toMatch(/learned pattern/i);
+    expect(content).toMatch(/new rule/i);
+    expect(content).toMatch(/user intent/i);
+    expect(content).toMatch(/existing rule/i);
+    expect(content).toMatch(/overlap/i);
   });
 
   it("skips expected rule lookup when results already show conversation status", async () => {

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -607,7 +607,7 @@ describe("aiProcessAssistantChat", () => {
     expect(content).toMatch(/static/i);
     expect(content).toMatch(/learned pattern/i);
     expect(content).toMatch(/new rule/i);
-    expect(content).toMatch(/user intent/i);
+    expect(content).toMatch(/intent/i);
     expect(content).toMatch(/existing rule/i);
     expect(content).toMatch(/overlap/i);
   });

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelMessage } from "ai";
 import { getEmailAccount, getMockMessage } from "@/__tests__/helpers";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, GroupItemType } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
@@ -528,6 +528,88 @@ describe("aiProcessAssistantChat", () => {
 
     expect(hiddenContext?.content).toContain(
       "This fix is about conversation status classification",
+    );
+  });
+
+  it("includes structured match details in fix-rule hidden context", async () => {
+    const { aiProcessAssistantChat } = await loadAssistantChatModule({
+      emailSend: true,
+    });
+
+    mockToolCallAgentStream.mockResolvedValue({
+      toUIMessageStreamResponse: vi.fn(),
+    });
+
+    await aiProcessAssistantChat({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Create a new rule for emails like this: internal planning updates should be labeled Action.",
+        },
+      ],
+      emailAccountId: "email-account-id",
+      user: getEmailAccount(),
+      logger,
+      context: {
+        type: "fix-rule",
+        message: {
+          id: "message-1",
+          threadId: "thread-1",
+          snippet: "test snippet",
+          headers: {
+            from: "sender@example.com",
+            to: "user@example.com",
+            subject: "Subject",
+            date: new Date().toISOString(),
+          },
+        },
+        results: [
+          {
+            ruleName: "Team Mail",
+            systemType: null,
+            reason: "Matched existing team rule.",
+            matchMetadata: [
+              { type: "STATIC" },
+              {
+                type: "LEARNED_PATTERN",
+                group: {
+                  id: "group-1",
+                  name: "Team Mail",
+                },
+                groupItem: {
+                  id: "group-item-1",
+                  type: GroupItemType.FROM,
+                  value: "store@company.example",
+                  exclude: true,
+                },
+              },
+            ],
+          },
+        ],
+        expected: "new",
+      },
+    });
+
+    const args = mockToolCallAgentStream.mock.calls[0][0];
+    const hiddenContext = args.messages.find(
+      (message: { role: string; content: string }) =>
+        message.role === "user" &&
+        message.content.includes("Hidden context for the user's request"),
+    );
+
+    expect(hiddenContext?.content).toContain("Structured match details:");
+    expect(hiddenContext?.content).toContain(
+      "Matched by static sender, recipient, or subject conditions.",
+    );
+    expect(hiddenContext?.content).toContain(
+      "Team Mail learned pattern exclude on FROM: store@company.example",
+    );
+    expect(hiddenContext?.content).toContain(
+      "create a new rule only if no existing rule can be safely updated without causing overlap.",
+    );
+    expect(hiddenContext?.content).toContain(
+      "Treat that selection as user intent about the desired behavior, not as an instruction to duplicate a matching rule.",
     );
   });
 

--- a/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
@@ -1,11 +1,24 @@
 import type { ModelMessage } from "ai";
+import { ActionType } from "@/generated/prisma/enums";
 import type { getEmailAccount } from "@/__tests__/helpers";
+import type { MessageContext } from "@/app/api/chat/validation";
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import type { Logger } from "@/utils/logger";
 
 export type RecordedToolCall = {
   toolName: string;
   input: unknown;
+};
+
+export type UpdateRuleActionsInput = {
+  ruleName: string;
+  actions: Array<{
+    type: ActionType;
+    fields?: {
+      label?: string | null;
+    } | null;
+    delayInMinutes?: number | null;
+  }>;
 };
 
 export type AssistantChatTrace = {
@@ -18,11 +31,13 @@ export async function captureAssistantChatTrace({
   messages,
   logger,
   inboxStats,
+  context,
 }: {
   emailAccount: ReturnType<typeof getEmailAccount>;
   messages: ModelMessage[];
   logger: Logger;
   inboxStats?: { total: number; unread: number } | null;
+  context?: MessageContext;
 }) {
   const recordedToolCalls: RecordedToolCall[] = [];
   const stepTexts: string[] = [];
@@ -32,6 +47,7 @@ export async function captureAssistantChatTrace({
     emailAccountId: emailAccount.id,
     user: emailAccount,
     inboxStats,
+    context,
     logger,
     onStepFinish: async ({ text, toolCalls }) => {
       if (text?.trim()) {
@@ -107,4 +123,35 @@ export function getLastMatchingToolCall<TInput>(
   }
 
   return null;
+}
+
+export function isUpdateRuleActionsInput(
+  input: unknown,
+): input is UpdateRuleActionsInput {
+  if (!input || typeof input !== "object") return false;
+
+  const value = input as {
+    ruleName?: unknown;
+    actions?: unknown;
+  };
+
+  return typeof value.ruleName === "string" && Array.isArray(value.actions);
+}
+
+export function hasActionType(
+  actions: Array<{ type: ActionType }>,
+  expectedActionType: ActionType,
+) {
+  return actions.some((action) => action.type === expectedActionType);
+}
+
+export function hasLabelAction(
+  actions: UpdateRuleActionsInput["actions"],
+  expectedLabel: string,
+) {
+  return actions.some(
+    (action) =>
+      action.type === ActionType.LABEL &&
+      action.fields?.label === expectedLabel,
+  );
 }

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
@@ -2,6 +2,9 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
+  hasActionType,
+  hasLabelAction,
+  isUpdateRuleActionsInput,
   getLastMatchingToolCall,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
@@ -257,53 +260,6 @@ async function runAssistantChat({
       (toolCall) => toolCall.toolName,
     ),
   };
-}
-
-type UpdateRuleActionsInput = {
-  ruleName: string;
-  actions: Array<{
-    type: ActionType;
-    fields?: {
-      label?: string | null;
-    } | null;
-    delayInMinutes?: number | null;
-  }>;
-};
-
-function isUpdateRuleActionsInput(
-  input: unknown,
-): input is UpdateRuleActionsInput {
-  if (!input || typeof input !== "object") return false;
-
-  const value = input as {
-    ruleName?: unknown;
-    actions?: unknown;
-  };
-
-  return typeof value.ruleName === "string" && Array.isArray(value.actions);
-}
-
-function hasActionType(
-  actions: Array<{ type: ActionType }>,
-  expectedActionType: ActionType,
-) {
-  return actions.some((action) => action.type === expectedActionType);
-}
-
-function hasLabelAction(
-  actions: Array<{
-    type: ActionType;
-    fields?: {
-      label?: string | null;
-    } | null;
-  }>,
-  expectedLabel: string,
-) {
-  return actions.some(
-    (action) =>
-      action.type === ActionType.LABEL &&
-      action.fields?.label === expectedLabel,
-  );
 }
 
 function getLastToolCallIndex(toolCalls: RecordedToolCall[], toolName: string) {

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
@@ -2,6 +2,10 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
+  hasActionType,
+  hasLabelAction,
+  isUpdateRuleActionsInput,
+  getLastMatchingToolCall,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -17,7 +21,8 @@ import {
   configureRuleMutationMocks,
   senderListHasValue,
 } from "@/__tests__/eval/assistant-chat-rule-eval-test-utils";
-import type { getEmailAccount } from "@/__tests__/helpers";
+import { getMockMessage, type getEmailAccount } from "@/__tests__/helpers";
+import type { MessageContext } from "@/app/api/chat/validation";
 import {
   ActionType,
   GroupItemType,
@@ -68,7 +73,78 @@ const keepInInboxRule = {
   ],
 };
 
-const ruleRows = [...defaultRuleRows, keepInInboxRule];
+const teamMailRule = {
+  id: "team-mail-rule-id",
+  name: "Team Mail",
+  instructions:
+    "Apply this rule to internal company emails, but exclude store@company.example.",
+  updatedAt: ruleUpdatedAt,
+  from: "@company.example",
+  to: null,
+  subject: null,
+  conditionalOperator: LogicalOperator.AND,
+  enabled: true,
+  runOnThreads: true,
+  systemType: null as SystemType | null,
+  actions: [
+    {
+      type: ActionType.LABEL,
+      content: null,
+      label: "Team",
+      to: null,
+      cc: null,
+      bcc: null,
+      subject: null,
+      url: null,
+      folderName: null,
+    },
+  ],
+};
+
+const shippingUpdatesRule = {
+  id: "shipping-updates-rule-id",
+  name: "Shipping Updates",
+  instructions: "Apply this rule to store receipts and shipping updates.",
+  updatedAt: ruleUpdatedAt,
+  from: "store@company.example",
+  to: null,
+  subject: null,
+  conditionalOperator: LogicalOperator.AND,
+  enabled: true,
+  runOnThreads: true,
+  systemType: null as SystemType | null,
+  actions: [
+    {
+      type: ActionType.LABEL,
+      content: null,
+      label: "Receipts",
+      to: null,
+      cc: null,
+      bcc: null,
+      subject: null,
+      url: null,
+      folderName: null,
+    },
+    {
+      type: ActionType.ARCHIVE,
+      content: null,
+      label: null,
+      to: null,
+      cc: null,
+      bcc: null,
+      subject: null,
+      url: null,
+      folderName: null,
+    },
+  ],
+};
+
+const ruleRows = [
+  ...defaultRuleRows,
+  keepInInboxRule,
+  teamMailRule,
+  shippingUpdatesRule,
+];
 
 const {
   mockCreateRule,
@@ -172,6 +248,25 @@ describe.runIf(shouldRunEval)("Eval: assistant chat overlap exceptions", () => {
             exclude: false,
           },
         ],
+        "Team Mail": [
+          {
+            type: GroupItemType.FROM,
+            value: "no-reply@company.example",
+            exclude: false,
+          },
+          {
+            type: GroupItemType.FROM,
+            value: "store@company.example",
+            exclude: true,
+          },
+        ],
+        "Shipping Updates": [
+          {
+            type: GroupItemType.FROM,
+            value: "store@company.example",
+            exclude: false,
+          },
+        ],
       },
     });
 
@@ -231,6 +326,49 @@ describe.runIf(shouldRunEval)("Eval: assistant chat overlap exceptions", () => {
         },
         TIMEOUT,
       );
+
+      test(
+        "fix-rule avoids creating an overlapping broad domain rule",
+        async () => {
+          const { toolCalls, actual } = await runAssistantChat({
+            emailAccount,
+            messages: [
+              {
+                role: "user",
+                content:
+                  "Create a new rule for emails like this: emails from our company domain should be labeled Action and should stay out of archive flows.",
+              },
+            ],
+            context: buildFixRuleContext(),
+          });
+
+          const updateActionsCall = getLastMatchingToolCall(
+            toolCalls,
+            "updateRuleActions",
+            isUpdateRuleActionsInput,
+          )?.input;
+
+          const pass =
+            !!updateActionsCall &&
+            updateActionsCall.ruleName === "Team Mail" &&
+            hasLabelAction(updateActionsCall.actions, "Action") &&
+            !hasActionType(updateActionsCall.actions, ActionType.ARCHIVE) &&
+            !toolCalls.some((toolCall) => toolCall.toolName === "createRule") &&
+            !toolCalls.some(
+              (toolCall) => toolCall.toolName === "updateLearnedPatterns",
+            );
+
+          evalReporter.record({
+            testName: "fix-rule avoids overlapping broad domain rule",
+            model: model.label,
+            pass,
+            actual,
+          });
+
+          expect(pass).toBe(true);
+        },
+        TIMEOUT,
+      );
     },
   );
 
@@ -256,15 +394,18 @@ type UpdateLearnedPatternsInput = {
 async function runAssistantChat({
   emailAccount,
   messages,
+  context,
 }: {
   emailAccount: ReturnType<typeof getEmailAccount>;
   messages: ModelMessage[];
+  context?: MessageContext;
 }) {
   const saveLearnedPatternsCallsBefore =
     mockSaveLearnedPatterns.mock.calls.length;
   const toolCalls = await captureAssistantChatToolCalls({
     messages,
     emailAccount,
+    context,
     logger,
   });
   const saveLearnedPatternsCallsAfter =
@@ -351,6 +492,48 @@ function hasExcludedFrom(
       !!pattern.exclude?.from &&
       senderListHasValue(pattern.exclude.from, expectedFrom),
   );
+}
+
+function buildFixRuleContext(): MessageContext {
+  const message = getMockMessage({
+    id: "message-fix-overlap",
+    threadId: "thread-fix-overlap",
+    from: "ops@company.example",
+    to: "user@test.com",
+    subject: "Quarterly planning update",
+    snippet: "Sharing the latest internal planning notes.",
+    textPlain:
+      "Hi team,\n\nSharing the latest internal planning notes for next quarter.\n\nThanks.",
+    textHtml:
+      "<p>Hi team,</p><p>Sharing the latest internal planning notes for next quarter.</p><p>Thanks.</p>",
+  });
+
+  return {
+    type: "fix-rule",
+    message: {
+      id: message.id,
+      threadId: message.threadId,
+      snippet: message.snippet,
+      textPlain: message.textPlain,
+      textHtml: message.textHtml,
+      headers: {
+        from: message.headers.from,
+        to: message.headers.to,
+        subject: message.headers.subject,
+        date: message.headers.date,
+      },
+      internalDate: message.date,
+    },
+    results: [
+      {
+        ruleName: "Team Mail",
+        systemType: null,
+        reason:
+          "Matched the Team Mail rule because the sender domain matches @company.example.",
+      },
+    ],
+    expected: "new",
+  };
 }
 
 function summarizeToolCall(toolCall: RecordedToolCall) {

--- a/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
@@ -132,6 +132,30 @@ export function configureRuleEvalPrisma({
       },
     };
   });
+
+  prisma.rule.findMany.mockImplementation(async ({ select }) => {
+    if (
+      select?.name &&
+      select?.from &&
+      select?.to &&
+      select?.subject &&
+      select?.enabled
+    ) {
+      return ruleRows.map((rule) => ({
+        name: rule.name,
+        enabled: rule.enabled,
+        instructions: rule.instructions,
+        from: rule.from,
+        to: rule.to,
+        subject: rule.subject,
+        group: {
+          items: groupItemsByRuleName?.[rule.name] ?? [],
+        },
+      }));
+    }
+
+    return ruleRows;
+  });
 }
 
 export function configureRuleEvalProvider({

--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -234,7 +234,7 @@ function getMatchMetadataForContext(result: {
     return parsedMatchMetadata.data;
   }
 
-  return serializeMatchReasons(result.matchReasons) ?? undefined;
+  return serializeMatchReasons(result.matchReasons);
 }
 
 function RuleMismatch({

--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -27,7 +27,15 @@ import {
   NEW_RULE_ID as CONST_NEW_RULE_ID,
   NONE_RULE_ID as CONST_NONE_RULE_ID,
 } from "@/app/(app)/[emailAccountId]/assistant/consts";
-import type { MessageContext } from "@/app/api/chat/validation";
+import {
+  serializedMatchMetadataSchema,
+  type MessageContext,
+} from "@/app/api/chat/validation";
+import {
+  serializeMatchReasons,
+  type MatchReason,
+  type SerializedMatchReason,
+} from "@/utils/ai/choose-rule/types";
 
 export function FixWithChat({
   setInput,
@@ -103,6 +111,7 @@ export function FixWithChat({
         ruleName: r.rule?.name ?? null,
         systemType: r.rule?.systemType ?? null,
         reason: r.reason ?? "",
+        matchMetadata: getMatchMetadataForContext(r),
       })),
       expected:
         selectedRuleId === CONST_NEW_RULE_ID
@@ -211,6 +220,21 @@ export function FixWithChat({
       </DialogContent>
     </Dialog>
   );
+}
+
+function getMatchMetadataForContext(result: {
+  matchMetadata?: unknown;
+  matchReasons?: MatchReason[];
+}): SerializedMatchReason[] | undefined {
+  const parsedMatchMetadata = serializedMatchMetadataSchema.safeParse(
+    result.matchMetadata,
+  );
+
+  if (parsedMatchMetadata.success) {
+    return parsedMatchMetadata.data;
+  }
+
+  return serializeMatchReasons(result.matchReasons) ?? undefined;
 }
 
 function RuleMismatch({

--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -27,15 +27,15 @@ import {
   NEW_RULE_ID as CONST_NEW_RULE_ID,
   NONE_RULE_ID as CONST_NONE_RULE_ID,
 } from "@/app/(app)/[emailAccountId]/assistant/consts";
-import {
-  serializedMatchMetadataSchema,
-  type MessageContext,
-} from "@/app/api/chat/validation";
+import type { MessageContext } from "@/app/api/chat/validation";
 import {
   serializeMatchReasons,
-  type MatchReason,
   type SerializedMatchReason,
 } from "@/utils/ai/choose-rule/types";
+
+type FixWithChatResult = RunRulesResult & {
+  matchMetadata?: SerializedMatchReason[] | null;
+};
 
 export function FixWithChat({
   setInput,
@@ -44,7 +44,7 @@ export function FixWithChat({
 }: {
   setInput: (input: string) => void;
   message: ParsedMessage;
-  results: RunRulesResult[];
+  results: FixWithChatResult[];
 }) {
   const { data, isLoading, error } = useRules();
   const { isModalOpen, setIsModalOpen } = useModal();
@@ -111,7 +111,7 @@ export function FixWithChat({
         ruleName: r.rule?.name ?? null,
         systemType: r.rule?.systemType ?? null,
         reason: r.reason ?? "",
-        matchMetadata: getMatchMetadataForContext(r),
+        matchMetadata: r.matchMetadata ?? serializeMatchReasons(r.matchReasons),
       })),
       expected:
         selectedRuleId === CONST_NEW_RULE_ID
@@ -222,27 +222,12 @@ export function FixWithChat({
   );
 }
 
-function getMatchMetadataForContext(result: {
-  matchMetadata?: unknown;
-  matchReasons?: MatchReason[];
-}): SerializedMatchReason[] | undefined {
-  const parsedMatchMetadata = serializedMatchMetadataSchema.safeParse(
-    result.matchMetadata,
-  );
-
-  if (parsedMatchMetadata.success) {
-    return parsedMatchMetadata.data;
-  }
-
-  return serializeMatchReasons(result.matchReasons);
-}
-
 function RuleMismatch({
   results,
   rules,
   onSelectExpectedRuleId,
 }: {
-  results: RunRulesResult[];
+  results: FixWithChatResult[];
   rules: RulesResponse;
   onSelectExpectedRuleId: (ruleId: string | null) => void;
 }) {

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -27,7 +27,7 @@ export const messageContextSchema = z.object({
       ruleName: z.string().nullable(),
       systemType: z.nativeEnum(SystemType).nullable().optional(),
       reason: z.string(),
-      matchMetadata: z.custom<SerializedMatchReason[] | null>().nullish(),
+      matchMetadata: z.unknown().nullish(),
     }),
   ),
   expected: z.union([
@@ -44,4 +44,17 @@ export const messageContextSchema = z.object({
     ]),
   ]),
 });
-export type MessageContext = z.infer<typeof messageContextSchema>;
+
+type MessageContextResult = Omit<
+  z.infer<typeof messageContextSchema>["results"][number],
+  "matchMetadata"
+> & {
+  matchMetadata?: SerializedMatchReason[] | null;
+};
+
+export type MessageContext = Omit<
+  z.infer<typeof messageContextSchema>,
+  "results"
+> & {
+  results: MessageContextResult[];
+};

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { SystemType } from "@/generated/prisma/enums";
-import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
+import { GroupItemType, SystemType } from "@/generated/prisma/enums";
 
 const parsedMessageSchema = z.object({
   id: z.string(),
@@ -27,7 +26,35 @@ export const messageContextSchema = z.object({
       ruleName: z.string().nullable(),
       systemType: z.nativeEnum(SystemType).nullable().optional(),
       reason: z.string(),
-      matchMetadata: z.unknown().nullish(),
+      matchMetadata: z
+        .array(
+          z.union([
+            z.object({
+              type: z.literal("STATIC"),
+            }),
+            z.object({
+              type: z.literal("LEARNED_PATTERN"),
+              group: z.object({
+                id: z.string(),
+                name: z.string(),
+              }),
+              groupItem: z.object({
+                id: z.string(),
+                type: z.nativeEnum(GroupItemType),
+                value: z.string(),
+                exclude: z.boolean(),
+              }),
+            }),
+            z.object({
+              type: z.literal("AI"),
+            }),
+            z.object({
+              type: z.literal("PRESET"),
+              systemType: z.nativeEnum(SystemType),
+            }),
+          ]),
+        )
+        .nullish(),
     }),
   ),
   expected: z.union([
@@ -44,17 +71,4 @@ export const messageContextSchema = z.object({
     ]),
   ]),
 });
-
-type MessageContextResult = Omit<
-  z.infer<typeof messageContextSchema>["results"][number],
-  "matchMetadata"
-> & {
-  matchMetadata?: SerializedMatchReason[] | null;
-};
-
-export type MessageContext = Omit<
-  z.infer<typeof messageContextSchema>,
-  "results"
-> & {
-  results: MessageContextResult[];
-};
+export type MessageContext = z.infer<typeof messageContextSchema>;

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -18,6 +18,36 @@ const parsedMessageSchema = z.object({
   internalDate: z.string().optional().nullable(),
 });
 
+const serializedMatchReasonSchema = z.union([
+  z.object({
+    type: z.literal("STATIC"),
+  }),
+  z.object({
+    type: z.literal("LEARNED_PATTERN"),
+    group: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+    groupItem: z.object({
+      id: z.string(),
+      type: z.nativeEnum(GroupItemType),
+      value: z.string(),
+      exclude: z.boolean(),
+    }),
+  }),
+  z.object({
+    type: z.literal("AI"),
+  }),
+  z.object({
+    type: z.literal("PRESET"),
+    systemType: z.nativeEnum(SystemType),
+  }),
+]);
+
+export const serializedMatchMetadataSchema = z
+  .array(serializedMatchReasonSchema)
+  .nullish();
+
 export const messageContextSchema = z.object({
   type: z.literal("fix-rule"),
   message: parsedMessageSchema,
@@ -26,35 +56,7 @@ export const messageContextSchema = z.object({
       ruleName: z.string().nullable(),
       systemType: z.nativeEnum(SystemType).nullable().optional(),
       reason: z.string(),
-      matchMetadata: z
-        .array(
-          z.union([
-            z.object({
-              type: z.literal("STATIC"),
-            }),
-            z.object({
-              type: z.literal("LEARNED_PATTERN"),
-              group: z.object({
-                id: z.string(),
-                name: z.string(),
-              }),
-              groupItem: z.object({
-                id: z.string(),
-                type: z.nativeEnum(GroupItemType),
-                value: z.string(),
-                exclude: z.boolean(),
-              }),
-            }),
-            z.object({
-              type: z.literal("AI"),
-            }),
-            z.object({
-              type: z.literal("PRESET"),
-              systemType: z.nativeEnum(SystemType),
-            }),
-          ]),
-        )
-        .nullish(),
+      matchMetadata: serializedMatchMetadataSchema,
     }),
   ),
   expected: z.union([

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { GroupItemType } from "@/generated/prisma/enums";
 import { SystemType } from "@/generated/prisma/enums";
+import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
 
 const parsedMessageSchema = z.object({
   id: z.string(),
@@ -19,34 +19,6 @@ const parsedMessageSchema = z.object({
   internalDate: z.string().optional().nullable(),
 });
 
-const serializedMatchReasonSchema = z.union([
-  z.object({
-    type: z.literal("STATIC"),
-  }),
-  z.object({
-    type: z.literal("LEARNED_PATTERN"),
-    group: z.object({
-      id: z.string(),
-      name: z.string(),
-    }),
-    groupItem: z.object({
-      id: z.string(),
-      type: z.nativeEnum(GroupItemType),
-      value: z.string(),
-      exclude: z.boolean(),
-    }),
-  }),
-  z.object({
-    type: z.literal("AI"),
-  }),
-  z.object({
-    type: z.literal("PRESET"),
-    systemType: z.nativeEnum(SystemType),
-  }),
-]);
-
-const serializedMatchMetadataSchema = z.array(serializedMatchReasonSchema);
-
 export const messageContextSchema = z.object({
   type: z.literal("fix-rule"),
   message: parsedMessageSchema,
@@ -55,7 +27,7 @@ export const messageContextSchema = z.object({
       ruleName: z.string().nullable(),
       systemType: z.nativeEnum(SystemType).nullable().optional(),
       reason: z.string(),
-      matchMetadata: serializedMatchMetadataSchema.nullish(),
+      matchMetadata: z.custom<SerializedMatchReason[] | null>().nullish(),
     }),
   ),
   expected: z.union([

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { GroupItemType } from "@/generated/prisma/enums";
 import { SystemType } from "@/generated/prisma/enums";
 
 const parsedMessageSchema = z.object({
@@ -18,6 +19,36 @@ const parsedMessageSchema = z.object({
   internalDate: z.string().optional().nullable(),
 });
 
+export const serializedMatchReasonSchema = z.union([
+  z.object({
+    type: z.literal("STATIC"),
+  }),
+  z.object({
+    type: z.literal("LEARNED_PATTERN"),
+    group: z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+    groupItem: z.object({
+      id: z.string(),
+      type: z.nativeEnum(GroupItemType),
+      value: z.string(),
+      exclude: z.boolean(),
+    }),
+  }),
+  z.object({
+    type: z.literal("AI"),
+  }),
+  z.object({
+    type: z.literal("PRESET"),
+    systemType: z.nativeEnum(SystemType),
+  }),
+]);
+
+export const serializedMatchMetadataSchema = z.array(
+  serializedMatchReasonSchema,
+);
+
 export const messageContextSchema = z.object({
   type: z.literal("fix-rule"),
   message: parsedMessageSchema,
@@ -26,6 +57,7 @@ export const messageContextSchema = z.object({
       ruleName: z.string().nullable(),
       systemType: z.nativeEnum(SystemType).nullable().optional(),
       reason: z.string(),
+      matchMetadata: serializedMatchMetadataSchema.nullish(),
     }),
   ),
   expected: z.union([

--- a/apps/web/app/api/chat/validation.ts
+++ b/apps/web/app/api/chat/validation.ts
@@ -19,7 +19,7 @@ const parsedMessageSchema = z.object({
   internalDate: z.string().optional().nullable(),
 });
 
-export const serializedMatchReasonSchema = z.union([
+const serializedMatchReasonSchema = z.union([
   z.object({
     type: z.literal("STATIC"),
   }),
@@ -45,9 +45,7 @@ export const serializedMatchReasonSchema = z.union([
   }),
 ]);
 
-export const serializedMatchMetadataSchema = z.array(
-  serializedMatchReasonSchema,
-);
+const serializedMatchMetadataSchema = z.array(serializedMatchReasonSchema);
 
 export const messageContextSchema = z.object({
   type: z.literal("fix-rule"),

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import groupBy from "lodash/groupBy";
+import { serializedMatchMetadataSchema } from "@/app/api/chat/validation";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 import { ExecutedRuleStatus } from "@/generated/prisma/enums";
 import type { Prisma } from "@/generated/prisma/client";
-import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
 
 const LIMIT = 50;
 
@@ -95,9 +95,9 @@ async function getExecutedRules({
       threadId: groupedExecutedRules[0].threadId,
       executedRules: groupedExecutedRules.map((executedRule) => ({
         ...executedRule,
-        matchMetadata: executedRule.matchMetadata as
-          | SerializedMatchReason[]
-          | null,
+        matchMetadata:
+          serializedMatchMetadataSchema.safeParse(executedRule.matchMetadata)
+            .data ?? null,
       })),
     }));
 

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -62,6 +62,7 @@ async function getExecutedRules({
         actionItems: true,
         status: true,
         reason: true,
+        matchMetadata: true,
         automated: true,
         createdAt: true,
         rule: {

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -4,6 +4,7 @@ import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 import { ExecutedRuleStatus } from "@/generated/prisma/enums";
 import type { Prisma } from "@/generated/prisma/client";
+import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
 
 const LIMIT = 50;
 
@@ -92,7 +93,12 @@ async function getExecutedRules({
     .map(([messageId, groupedExecutedRules]) => ({
       messageId,
       threadId: groupedExecutedRules[0].threadId,
-      executedRules: groupedExecutedRules,
+      executedRules: groupedExecutedRules.map((executedRule) => ({
+        ...executedRule,
+        matchMetadata: executedRule.matchMetadata as
+          | SerializedMatchReason[]
+          | null,
+      })),
     }));
 
   return {

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionType, GroupItemType } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+import { createRuleTool } from "./chat-rule-tools";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockCreateRule,
+  mockOutboundActionsNeedChatRiskConfirmation,
+  mockPrisma,
+} = vi.hoisted(() => ({
+  mockCreateRule: vi.fn(),
+  mockOutboundActionsNeedChatRiskConfirmation: vi.fn(),
+  mockPrisma: {
+    rule: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: mockPrisma,
+}));
+
+vi.mock("@/utils/rule/rule", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/rule/rule")>();
+
+  return {
+    ...actual,
+    createRule: mockCreateRule,
+    outboundActionsNeedChatRiskConfirmation:
+      mockOutboundActionsNeedChatRiskConfirmation,
+  };
+});
+
+const logger = createScopedLogger("chat-rule-tools-test");
+
+const defaultActions = [
+  {
+    type: ActionType.LABEL,
+    fields: { label: "Action" },
+    delayInMinutes: null,
+  },
+];
+
+describe("createRuleTool overlap guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOutboundActionsNeedChatRiskConfirmation.mockReturnValue({
+      needsConfirmation: false,
+      riskMessages: [],
+    });
+    mockCreateRule.mockResolvedValue({ id: "new-rule-id" });
+    mockPrisma.rule.findMany.mockResolvedValue([
+      {
+        name: "Team Mail",
+        instructions: null,
+        from: "@company.example",
+        to: null,
+        subject: null,
+        group: {
+          items: [
+            {
+              value: "store@company.example",
+              exclude: true,
+              type: GroupItemType.FROM,
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("blocks overlapping sender-only rules", async () => {
+    const result = await createRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+    }).execute({
+      name: "Action Mail",
+      condition: {
+        aiInstructions: null,
+        static: { from: "@company.example" },
+        conditionalOperator: null,
+      },
+      actions: defaultActions,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('overlaps the existing "Team Mail"');
+    expect(mockCreateRule).not.toHaveBeenCalled();
+  });
+
+  it("allows sender rules narrowed by semantic instructions", async () => {
+    const result = await createRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+    }).execute({
+      name: "Urgent Action Mail",
+      condition: {
+        aiInstructions: "Only urgent requests from this sender domain.",
+        static: { from: "@company.example" },
+        conditionalOperator: null,
+      },
+      actions: defaultActions,
+    });
+
+    expect(result).toEqual({ success: true, ruleId: "new-rule-id" });
+    expect(mockCreateRule).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/utils/ai/assistant/chat-rule-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.ts
@@ -24,6 +24,7 @@ import { posthogCaptureEvent } from "@/utils/posthog";
 import { filterNullProperties } from "@/utils";
 import { updateRuleConditionSchema } from "@/utils/actions/rule.validation";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
+import { splitEmailPatterns } from "@/utils/rule/email-from-pattern";
 import {
   buildRuleReadState,
   getVisibleRulesFromSnapshot,
@@ -230,6 +231,20 @@ export const createRuleTool = ({
       trackToolCall({ tool: "create_rule", email, logger });
 
       try {
+        const overlapConflict = await findSenderOnlyOverlapConflict({
+          emailAccountId,
+          condition,
+        });
+
+        if (overlapConflict) {
+          return {
+            success: false,
+            error: `Cannot create this rule because it overlaps the existing "${overlapConflict.ruleName}" rule on sender scope ${overlapConflict.overlappingSenders.join(", ")}. Update the existing rule instead of creating a duplicate.`,
+            conflictingRuleName: overlapConflict.ruleName,
+            overlappingSenders: overlapConflict.overlappingSenders,
+          };
+        }
+
         const resultPayload = buildCreateRuleSchemaFromChatToolInput(
           { name, condition, actions },
           provider,
@@ -885,4 +900,211 @@ function validateRuleWasReadRecently({
   }
 
   return null;
+}
+
+async function findSenderOnlyOverlapConflict({
+  emailAccountId,
+  condition,
+}: {
+  emailAccountId: string;
+  condition: CreateOrUpdateRuleSchema["condition"];
+}) {
+  if (
+    condition.aiInstructions ||
+    condition.static?.to ||
+    condition.static?.subject ||
+    !condition.static?.from
+  ) {
+    return null;
+  }
+
+  const proposedPatterns = parseSenderScopePatterns(condition.static.from);
+  if (!proposedPatterns.length) return null;
+
+  const existingRules = await prisma.rule.findMany({
+    where: {
+      emailAccountId,
+      enabled: true,
+      from: { not: null },
+    },
+    select: {
+      name: true,
+      enabled: true,
+      instructions: true,
+      from: true,
+      to: true,
+      subject: true,
+      group: {
+        select: {
+          items: {
+            where: {
+              type: GroupItemType.FROM,
+            },
+            select: {
+              value: true,
+              exclude: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  for (const existingRule of existingRules) {
+    if (
+      !existingRule.enabled ||
+      existingRule.instructions ||
+      existingRule.to ||
+      existingRule.subject ||
+      !existingRule.from
+    ) {
+      continue;
+    }
+
+    const overlappingSenders = getOverlappingSenderScopes(
+      proposedPatterns,
+      parseSenderScopePatterns(existingRule.from),
+      getExcludedSenderScopePatterns(existingRule.group?.items ?? []),
+      getIncludedSenderScopePatterns(existingRule.group?.items ?? []),
+    );
+
+    if (!overlappingSenders.length) continue;
+
+    return {
+      ruleName: existingRule.name,
+      overlappingSenders,
+    };
+  }
+
+  return null;
+}
+
+function getOverlappingSenderScopes(
+  left: SenderScopePattern[],
+  right: SenderScopePattern[],
+  rightExcluded: SenderScopePattern[] = [],
+  rightIncluded: SenderScopePattern[] = [],
+) {
+  const overlaps = new Set<string>();
+
+  for (const leftPattern of left) {
+    if (
+      rightIncluded.some((includedPattern) =>
+        senderScopesOverlap(leftPattern, includedPattern),
+      )
+    ) {
+      overlaps.add(leftPattern.raw);
+      continue;
+    }
+
+    for (const rightPattern of right) {
+      if (!senderScopesOverlap(leftPattern, rightPattern)) continue;
+      if (isSenderScopeFullyExcluded(leftPattern, rightExcluded)) continue;
+      overlaps.add(leftPattern.raw);
+    }
+  }
+
+  return [...overlaps];
+}
+
+type SenderScopePattern =
+  | {
+      kind: "domain";
+      value: string;
+      raw: string;
+    }
+  | {
+      kind: "email";
+      value: string;
+      raw: string;
+    };
+
+function parseSenderScopePatterns(value: string) {
+  return splitEmailPatterns(value)
+    .map(normalizeSenderScopePattern)
+    .filter((pattern): pattern is SenderScopePattern => Boolean(pattern));
+}
+
+function normalizeSenderScopePattern(value: string): SenderScopePattern | null {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.startsWith("@")) {
+    const domain = normalized.slice(1);
+    return domain
+      ? {
+          kind: "domain",
+          value: domain,
+          raw: normalized,
+        }
+      : null;
+  }
+
+  if (normalized.includes("@")) {
+    return {
+      kind: "email",
+      value: normalized,
+      raw: normalized,
+    };
+  }
+
+  return {
+    kind: "domain",
+    value: normalized,
+    raw: normalized,
+  };
+}
+
+function senderScopesOverlap(
+  left: SenderScopePattern,
+  right: SenderScopePattern,
+) {
+  if (left.kind === "email" && right.kind === "email") {
+    return left.value === right.value;
+  }
+
+  if (left.kind === "domain" && right.kind === "domain") {
+    return left.value === right.value;
+  }
+
+  if (left.kind === "email" && right.kind === "domain") {
+    return left.value.endsWith(`@${right.value}`);
+  }
+
+  return right.value.endsWith(`@${left.value}`);
+}
+
+function isSenderScopeFullyExcluded(
+  pattern: SenderScopePattern,
+  excludedPatterns: SenderScopePattern[],
+) {
+  if (!excludedPatterns.length) return false;
+
+  if (pattern.kind === "email") {
+    return excludedPatterns.some((excludedPattern) =>
+      senderScopesOverlap(pattern, excludedPattern),
+    );
+  }
+
+  return excludedPatterns.some(
+    (excludedPattern) =>
+      excludedPattern.kind === "domain" &&
+      excludedPattern.value === pattern.value,
+  );
+}
+
+function getExcludedSenderScopePatterns(
+  items: Array<{ value: string; exclude: boolean }>,
+) {
+  return items
+    .filter((item) => item.exclude)
+    .flatMap((item) => parseSenderScopePatterns(item.value));
+}
+
+function getIncludedSenderScopePatterns(
+  items: Array<{ value: string; exclude: boolean }>,
+) {
+  return items
+    .filter((item) => !item.exclude)
+    .flatMap((item) => parseSenderScopePatterns(item.value));
 }

--- a/apps/web/utils/ai/assistant/chat-rule-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.ts
@@ -909,7 +909,12 @@ async function findSenderOnlyOverlapConflict({
   emailAccountId: string;
   condition: CreateOrUpdateRuleSchema["condition"];
 }) {
-  if (!condition.static?.from) {
+  if (
+    condition.aiInstructions ||
+    condition.static?.to ||
+    condition.static?.subject ||
+    !condition.static?.from
+  ) {
     return null;
   }
 

--- a/apps/web/utils/ai/assistant/chat-rule-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.ts
@@ -909,12 +909,7 @@ async function findSenderOnlyOverlapConflict({
   emailAccountId: string;
   condition: CreateOrUpdateRuleSchema["condition"];
 }) {
-  if (
-    condition.aiInstructions ||
-    condition.static?.to ||
-    condition.static?.subject ||
-    !condition.static?.from
-  ) {
+  if (!condition.static?.from) {
     return null;
   }
 
@@ -929,7 +924,6 @@ async function findSenderOnlyOverlapConflict({
     },
     select: {
       name: true,
-      enabled: true,
       instructions: true,
       from: true,
       to: true,
@@ -952,7 +946,6 @@ async function findSenderOnlyOverlapConflict({
 
   for (const existingRule of existingRules) {
     if (
-      !existingRule.enabled ||
       existingRule.instructions ||
       existingRule.to ||
       existingRule.subject ||

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -41,6 +41,7 @@ import { createOrGetLabelTool, listLabelsTool } from "./chat-label-tools";
 import { saveMemoryTool, searchMemoriesTool } from "./chat-memory-tools";
 import { getCalendarEventsTool } from "./chat-calendar-tools";
 import type { MessagingPlatform } from "@/utils/messaging/platforms";
+import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
 import {
   buildFreshRuleContextMessage,
   buildRuleReadState,
@@ -410,15 +411,15 @@ General handling patterns:
                 3000,
               )}\n</email>\n\n` +
               `Rules that were applied:\n${context.results
-                .map((r) => `- ${r.ruleName ?? "None"}: ${r.reason}`)
+                .map((r) =>
+                  formatFixRuleResultContext({
+                    ruleName: r.ruleName ?? "None",
+                    reason: r.reason,
+                    matchMetadata: r.matchMetadata ?? undefined,
+                  }),
+                )
                 .join("\n")}\n\n` +
-              `Expected outcome: ${
-                context.expected === "new"
-                  ? "Create a new rule"
-                  : context.expected === "none"
-                    ? "No rule should be applied"
-                    : `Should match the "${context.expected.name}" rule`
-              }` +
+              `Expected outcome: ${formatFixRuleExpectedOutcome(context)}` +
               (isConversationStatusFixContext(context, expectedFixSystemType)
                 ? "\n\nThis fix is about conversation status classification. Prefer updating conversation rule instructions with updateRuleConditions (for example, To Reply/FYI rules)."
                 : ""),
@@ -665,6 +666,66 @@ function addAnthropicCacheControl(
       },
     };
   });
+}
+
+function formatFixRuleResultContext({
+  ruleName,
+  reason,
+  matchMetadata,
+}: {
+  ruleName: string;
+  reason: string;
+  matchMetadata?: SerializedMatchReason[];
+}) {
+  const structuredDetails = formatSerializedMatchMetadata(matchMetadata);
+  if (!structuredDetails.length) {
+    return `- ${ruleName}: ${reason}`;
+  }
+
+  return `- ${ruleName}: ${reason}\n  Structured match details:\n${structuredDetails.map((detail) => `  - ${detail}`).join("\n")}`;
+}
+
+function formatSerializedMatchMetadata(
+  matchMetadata?: SerializedMatchReason[],
+) {
+  if (!matchMetadata?.length) return [];
+
+  return matchMetadata.map((matchReason) => {
+    switch (matchReason.type) {
+      case "STATIC":
+        return "Matched by static sender, recipient, or subject conditions.";
+      case "AI":
+        return "Matched by AI instructions.";
+      case "PRESET":
+        return `Matched preset classification ${matchReason.systemType}.`;
+      case "LEARNED_PATTERN": {
+        const qualifier = matchReason.groupItem.exclude ? "exclude" : "include";
+        return `${matchReason.group.name} learned pattern ${qualifier} on ${matchReason.groupItem.type}: ${matchReason.groupItem.value}`;
+      }
+    }
+  });
+}
+
+function formatFixRuleExpectedOutcome(context: MessageContext) {
+  if (context.type !== "fix-rule") return "";
+
+  if (context.expected === "none") {
+    return "No rule should be applied";
+  }
+
+  if (context.expected !== "new") {
+    return `Should match the "${context.expected.name}" rule`;
+  }
+
+  const matchedRuleNames = context.results
+    .map((result) => result.ruleName)
+    .filter((ruleName): ruleName is string => Boolean(ruleName));
+
+  if (!matchedRuleNames.length) {
+    return 'The user selected "New rule" in the fix UI because the current behavior was wrong. Create a new rule only if no existing rule can be safely updated without causing overlap.';
+  }
+
+  return `The user selected "New rule" in the fix UI because the desired behavior changed. This email already matched ${matchedRuleNames.map((name) => `"${name}"`).join(", ")}. Treat that selection as user intent about the desired behavior, not as an instruction to duplicate a matching rule. Prefer updating the matched rule when it already covers the sender or domain scope, and create a new rule only if no existing rule can be safely updated without causing overlap.`;
 }
 
 function getChatProviderOptionsForCaching({ chatId }: { chatId?: string }) {

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -722,10 +722,10 @@ function formatFixRuleExpectedOutcome(context: MessageContext) {
     .filter((ruleName): ruleName is string => Boolean(ruleName));
 
   if (!matchedRuleNames.length) {
-    return 'The user selected "New rule" in the fix UI because the current behavior was wrong. Create a new rule only if no existing rule can be safely updated without causing overlap.';
+    return "The user wants new rule behavior because the current behavior was wrong. Create a new rule only if no existing rule can be safely updated without causing overlap.";
   }
 
-  return `The user selected "New rule" in the fix UI because the desired behavior changed. This email already matched ${matchedRuleNames.map((name) => `"${name}"`).join(", ")}. Treat that selection as user intent about the desired behavior, not as an instruction to duplicate a matching rule. Prefer updating the matched rule when it already covers the sender or domain scope, and create a new rule only if no existing rule can be safely updated without causing overlap.`;
+  return `The user wants new rule behavior for this email. This email already matched ${matchedRuleNames.map((name) => `"${name}"`).join(", ")}. Treat that as intent about the desired behavior, not as an instruction to duplicate a matching rule. Prefer updating the matched rule when it already covers the sender or domain scope, and create a new rule only if no existing rule can be safely updated without causing overlap.`;
 }
 
 function getChatProviderOptionsForCaching({ chatId }: { chatId?: string }) {

--- a/apps/web/utils/ai/choose-rule/types.ts
+++ b/apps/web/utils/ai/choose-rule/types.ts
@@ -59,7 +59,7 @@ export type RuleSelectionMetadata = {
 /**
  * Serializable version of MatchReason for database storage
  */
-type SerializedMatchReason =
+export type SerializedMatchReason =
   | { type: "STATIC" }
   | {
       type: "LEARNED_PATTERN";

--- a/apps/web/utils/ai/choose-rule/types.ts
+++ b/apps/web/utils/ai/choose-rule/types.ts
@@ -66,13 +66,13 @@ export type SerializedMatchReason =
       group: { id: string; name: string };
       groupItem: {
         id: string;
-        type: string;
+        type: GroupItemType;
         value: string;
         exclude: boolean;
       };
     }
   | { type: "AI" }
-  | { type: "PRESET"; systemType: string };
+  | { type: "PRESET"; systemType: SystemType };
 
 /**
  * Serializes match reasons to a JSON-safe format for database storage

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,9 +1,11 @@
+import { existsSync } from "node:fs";
 import { config } from "dotenv";
 import { configDefaults, defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const isE2E = process.env.RUN_E2E_FLOW_TESTS === "true";
 const envFile = isE2E ? "./.env.e2e" : "./.env.test";
+const env = existsSync(envFile) ? config({ path: envFile }).parsed : undefined;
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -17,7 +19,7 @@ export default defineConfig({
     setupFiles: ["./__tests__/setup.ts"],
     exclude: [...configDefaults.exclude, "__tests__/playwright/**"],
     env: {
-      ...config({ path: envFile }).parsed,
+      ...env,
     },
   },
 });


### PR DESCRIPTION
# User description
Improve the assistant's rule-fix path so it gets better match context and avoids creating overlapping sender-scope rules.

- pass structured rule-match metadata through the fix workflow and tighten the hidden prompt guidance
- block overlapping sender-only rule creation in chat while respecting exclusions and disabled rules
- add eval coverage for the fix workflow repro and shared helper coverage for action assertions

Verification:
- pnpm exec vitest --run __tests__/ai-assistant-chat.test.ts
- RUN_AI_TESTS=true EVAL_MODELS=gemini-3-flash pnpm exec vitest --run __tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts

Note:
- One pre-existing eval in the overlap exceptions file still fails and is not addressed in this change.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Pass structured <code>matchMetadata</code> through the fix-rule validation, execution history, UI context, and hidden prompt guidance so assistant recommendations clearly document why each rule was matched and what follow-up behavior is expected. Tighten chat-driven rule creation by guarding <code>createRuleTool</code> against sender-only overlaps while expanding supporting eval helpers/tests and hardening the Vitest env loading logic.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2213?tool=ast&topic=Match+Context>Match Context</a>
        </td><td>Document the match reasons that feed the fix-rule flow by validating <code>matchMetadata</code>, surfacing it when collecting executed rules, converting run results to <code>SerializedMatchReason</code>, and adding hidden prompt expectations so the assistant can explain how existing rules or presets matched the user’s message.<details><summary>Modified files (6)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx</li>
<li>apps/web/app/api/chat/validation.ts</li>
<li>apps/web/app/api/user/executed-rules/history/route.ts</li>
<li>apps/web/utils/ai/assistant/chat.ts</li>
<li>apps/web/utils/ai/choose-rule/types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: append personal i...</td><td>April 10, 2026</td></tr>
<tr><td>jayhf614@gmail.com</td><td>Fix Anthropic System M...</td><td>February 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2213?tool=ast&topic=Overlap+Guard>Overlap Guard</a>
        </td><td>Protect against duplicate sender-only rules by extending <code>createRuleTool</code> with overlap detection (respecting excludes/disabled rules) and proving the guard with a focused suite that covers both the tool and the rule-overlap scenario.<details><summary>Modified files (4)</summary><ul><li>apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts</li>
<li>apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts</li>
<li>apps/web/utils/ai/assistant/chat-rule-tools.test.ts</li>
<li>apps/web/utils/ai/assistant/chat-rule-tools.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: deduplicate ass...</td><td>April 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2213?tool=ast&topic=Eval+Infra>Eval Infra</a>
        </td><td>Strengthen the evaluation harness by sharing helpers for detecting update-action calls, wiring fix-rule contexts into eval traces, and avoiding dotenv failures when env files are missing so overlap and action-update expectations stay reliable.<details><summary>Modified files (3)</summary><ul><li>apps/web/__tests__/eval/assistant-chat-eval-utils.ts</li>
<li>apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts</li>
<li>apps/web/vitest.config.mts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: deduplicate ass...</td><td>April 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2213?tool=ast>(Baz)</a>.