### PR TITLE
fix: use ?authuser= for Gmail URLs

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -143,7 +143,7 @@ describe("pending email handled state helpers", () => {
         },
       }),
     ).toBe(
-      "Open in Gmail: https://mail.google.com/mail/u/user@example.com/#all/message-1",
+      "Open in Gmail: https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
     );
   });
 

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -151,7 +151,7 @@ describe("handleSlackRuleNotificationAction", () => {
     expect(cardText).toContain("Status: Reply sent.");
     expect(cardText).toContain("Open in Gmail");
     expect(cardText).toContain(
-      "https://mail.google.com/mail/u/user@example.com/#all/message-1",
+      "https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
     );
   });
 });
@@ -202,7 +202,7 @@ describe("sendMessagingRuleNotification", () => {
 
     expect(serializedBlocks).toContain("Open in Gmail");
     expect(serializedBlocks).toContain(
-      "https://mail.google.com/mail/u/user@example.com/#all/message-1",
+      "https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
     );
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -15,7 +15,7 @@ describe("getEmailUrl", () => {
     it("builds Gmail URL with email address", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "google");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
       );
     });
 
@@ -55,21 +55,21 @@ describe("getEmailUrl", () => {
     it("uses Gmail format when provider is undefined", () => {
       const result = getEmailUrl("msg123", "user@gmail.com");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
       );
     });
 
     it("falls back to default for unknown provider", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "unknown");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
       );
     });
 
     it("falls back to default for empty provider", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/user@gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
       );
     });
   });
@@ -164,7 +164,7 @@ describe("getGmailSearchUrl", () => {
   it("builds advanced search URL with from parameter", () => {
     const result = getGmailSearchUrl("sender@example.com", "user@gmail.com");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -190,7 +190,7 @@ describe("getEmailSearchUrl", () => {
       "google",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -212,7 +212,7 @@ describe("getEmailSearchUrl", () => {
       "",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -223,7 +223,7 @@ describe("getEmailSearchUrl", () => {
       "unknown-provider",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
     );
   });
 });
@@ -232,7 +232,7 @@ describe("getGmailBasicSearchUrl", () => {
   it("builds search URL with query", () => {
     const result = getGmailBasicSearchUrl("user@gmail.com", "is:unread");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#search/is%3Aunread",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#search/is%3Aunread",
     );
   });
 
@@ -259,7 +259,7 @@ describe("getGmailFilterSettingsUrl", () => {
   it("builds filter settings URL with email address", () => {
     const result = getGmailFilterSettingsUrl("user@gmail.com");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/user@gmail.com/#settings/filters",
+      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#settings/filters",
     );
   });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -1,5 +1,7 @@
 function getGmailBaseUrl(emailAddress?: string | null) {
-  return `https://mail.google.com/mail/u/${emailAddress || 0}`;
+  const base = "https://mail.google.com/mail/u/0";
+  if (!emailAddress) return base;
+  return `${base}/?authuser=${encodeURIComponent(emailAddress)}`;
 }
 
 function getOutlookBaseUrl() {


### PR DESCRIPTION
# User description
## Summary
- Gmail's undocumented `/u/{email}` URL path now returns 404 errors
- Switch to the official `?authuser=` query parameter for multi-account routing
- Fixes "Open in Gmail" links in Slack notifications, web UI, and chat bot

## Test plan
- [x] Unit tests updated and passing (`url.test.ts`, `rule-notifications.test.ts`, `bot.test.ts`)
- [ ] Manually verified new URL format opens correct Gmail account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>getGmailBaseUrl</code> to use Gmail’s <code>?authuser=</code> parameter so account-specific links route correctly without relying on the <code>/u/{email}</code> path. Adjust the messaging utilities’ notification and bot tests to validate the new Gmail URL format required for Slack, UI, and chat bot links.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve Slack draft no...</td><td>April 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2214?tool=ast>(Baz)</a>.