### PR TITLE
fix: improve draft reply notification format

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -307,7 +307,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const postArgs = postMessageSpy.mock.calls[0]?.[0];
 
       expect(message).toBeDefined();
-      expect(message?.text).toContain("Draft reply");
+      expect(message?.text).toContain("New email — reply drafted");
       expect(message?.text).toContain("*sender@example.com*");
       expect(message?.text).toContain(`about "${subject}"`);
       expect(message?.text).toContain("They wrote:");
@@ -942,7 +942,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       });
 
       expect(message).toBeDefined();
-      expect(message?.text).toContain("Draft reply");
+      expect(message?.text).toContain("New email — reply drafted");
       expect(prisma.executedAction.update).toHaveBeenCalledWith({
         where: { id: executedActionId },
         data: {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -138,7 +138,7 @@ describe("handleSlackRuleNotificationAction", () => {
     const [, , card] = editMessage.mock.calls[0];
     const cardText = JSON.stringify(card);
 
-    expect(cardText).toContain("Draft reply");
+    expect(cardText).toContain("New email — reply drafted");
     expect(cardText).toContain("*sender@example.com*");
     expect(cardText).toContain('about \\"Test subject\\"');
     expect(cardText).toContain("They wrote:");
@@ -441,7 +441,7 @@ describe("buildMessagingRuleNotificationText", () => {
     const text = buildMessagingRuleNotificationText({
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
-        title: "Draft reply",
+        title: "New email — reply drafted",
         summary: '📩 You got an email from *Sender* about "Test".',
         details: [
           "✍️ *I drafted a reply for you:*\nSee <https://example.com|details>.",
@@ -450,7 +450,7 @@ describe("buildMessagingRuleNotificationText", () => {
       provider: MessagingProvider.TELEGRAM,
     });
 
-    expect(text).toContain("Draft reply");
+    expect(text).toContain("New email — reply drafted");
     expect(text).toContain('You got an email from Sender about "Test".');
     expect(text).toContain("details: https://example.com");
     expect(text).toContain("Slack-only");
@@ -464,7 +464,7 @@ describe("buildMessagingRuleNotificationText", () => {
     const text = buildMessagingRuleNotificationText({
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
-        title: "Draft reply",
+        title: "New email — reply drafted",
         summary:
           '📩 You got an email from *Tom &amp; Jerry* about "A &lt;B&gt;".',
         details: ["💬 *They wrote:*\nHello &amp; welcome"],

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -47,7 +47,7 @@ import { extractDraftPlainText } from "@/utils/ai/choose-rule/draft-management";
 import type { ParsedMessage } from "@/utils/types";
 import he from "he";
 import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
-import { extractNameFromEmail } from "@/utils/email";
+import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 import {
   isGoogleProvider,
   isMicrosoftProvider,
@@ -973,6 +973,13 @@ function buildNotificationContent({
     const senderName = escapeSlackText(
       extractNameFromEmail(email.headers.from),
     );
+    const senderEmail = escapeSlackText(
+      extractEmailAddress(email.headers.from),
+    );
+    const senderDisplay =
+      senderEmail && senderName !== senderEmail
+        ? `${senderName} (${senderEmail})`
+        : senderName;
     const subject = escapeSlackText(
       truncate(he.decode(email.headers.subject), 80),
     );
@@ -980,16 +987,20 @@ function buildNotificationContent({
     const emailPreview = buildEmailPreview(email);
     const draftPreview = buildDraftPreview(draftContent);
 
-    const summary = `📩 You got an email from *${senderName}* about "${subject}".`;
+    const summary = `📩 You got an email from *${senderDisplay}* about "${subject}".`;
 
     const details: string[] = [];
     if (emailPreview) {
-      details.push(`💬 *They wrote:*\n${emailPreview}`);
+      const quotedPreview = emailPreview
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      details.push(`💬 *They wrote:*\n${quotedPreview}`);
     }
     details.push(`✍️ *I drafted a reply for you:*\n${draftPreview}`);
 
     return {
-      title: "Draft reply",
+      title: "New email — reply drafted",
       summary,
       details,
     };


### PR DESCRIPTION
# User description
## Summary
- Rename title from "Draft reply" to "New email — reply drafted" for clarity
- Show sender email address alongside display name (e.g., `Leonard (leonard@acme.com)`)
- Blockquote original email with `>` prefix to visually separate it from the drafted reply

## Test plan
- [x] Unit tests updated and passing (`rule-notifications.test.ts`)
- [x] Integration test assertions updated (`slack-notifications.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the rule notification builder to rename the draft reply title to "New email — reply drafted", include the sender’s display name with email, and blockquote the quoted original message. Align the Slack integration and messaging rule tests with the updated wording so the notification helpers stay consistent.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2215?tool=ast&topic=Notification+tests>Notification tests</a>
        </td><td>Verify the Slack integration and rule notification helpers emit the new title and sender formatting so the updated copy is covered by tests.<details><summary>Modified files (2)</summary><ul><li>apps/web/__tests__/integration/slack-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: use ?authuser= fo...</td><td>April 11, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Add Slack integration ...</td><td>March 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2215?tool=ast&topic=Notification+format>Notification format</a>
        </td><td>Adjust messaging notifications to rename the draft reply title, show the sender as <code>Name (email)</code>, and prefix each line of the quoted original email with <code>></code> for better readability.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve Slack draft no...</td><td>April 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2215?tool=ast>(Baz)</a>.