### PR TITLE
fix: make internal tool calls subtle in assistant chat

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -83,10 +83,33 @@ function getOutputField<T>(output: unknown, field: string): T | undefined {
 }
 
 export function BasicToolInfo({ text }: { text: string }) {
+  return <div className="text-xs text-muted-foreground">{text}</div>;
+}
+
+function SubtleToolCollapsible({
+  title,
+  children,
+}: {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <ToolCard>
-      <div className="text-sm">{text}</div>
-    </ToolCard>
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronRightIcon
+          className={cn(
+            "size-3 shrink-0 transition-transform duration-200",
+            open && "rotate-90",
+          )}
+        />
+        <span>{title}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 space-y-3 rounded-md border p-3">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -156,7 +179,7 @@ export function SearchInboxResult({ output }: { output: unknown }) {
   >(output, "messages");
 
   return (
-    <CollapsibleToolCard title="Search Inbox">
+    <SubtleToolCollapsible title="Search Inbox">
       {queryUsed && (
         <ToolDetailRow
           label="Query"
@@ -164,7 +187,7 @@ export function SearchInboxResult({ output }: { output: unknown }) {
         />
       )}
       {messages && messages.length > 0 && <ToolEmailRows emails={messages} />}
-    </CollapsibleToolCard>
+    </SubtleToolCollapsible>
   );
 }
 
@@ -317,7 +340,7 @@ export function ReadEmailResult({ output }: { output: unknown }) {
     : null;
 
   return (
-    <CollapsibleToolCard title="Read Email" initialOpen={false}>
+    <SubtleToolCollapsible title="Read Email">
       <div className="space-y-3 text-sm">
         {(subject || from || to || formattedDate) && (
           <div className="space-y-1">
@@ -346,7 +369,7 @@ export function ReadEmailResult({ output }: { output: unknown }) {
           </ToolExternalLink>
         )}
       </div>
-    </CollapsibleToolCard>
+    </SubtleToolCollapsible>
   );
 }
 


### PR DESCRIPTION
# User description
## Summary
- Internal/thinking tool calls (Search Inbox, Read Email) now render as subtle muted text instead of bordered cards, reducing visual noise in the chat
- New `SubtleToolCollapsible` component for tools users don't typically need to inspect — small text with a chevron, expandable on click
- `BasicToolInfo` (loading states like "Searching inbox...") also switched from card to muted inline text
- User-facing tool results like Manage Inbox keep the full card style

## Test plan
- [ ] Verify "Search Inbox" renders as subtle muted text, expandable on click
- [ ] Verify "Read Email" renders as subtle muted text, expandable on click
- [ ] Verify "Manage Inbox" (archive, etc.) still renders as a full card
- [ ] Verify loading states ("Searching inbox...") appear as small muted text
- [ ] Verify expanded content shows properly when clicking subtle tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Render <code>BasicToolInfo</code> as muted inline text and introduce <code>SubtleToolCollapsible</code> for internal tool interactions, keeping visible tool cards reserved for user-facing flows. Use <code>SubtleToolCollapsible</code> to wrap <code>SearchInboxResult</code> and <code>ReadEmailResult</code> so those entries start as small chevron-triggered text that expand for detailed content.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore: refine assistan...</td><td>April 12, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2220?tool=ast>(Baz)</a>.