### PR TITLE
fix: make internal tool calls subtle and remove nested cards

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -275,7 +275,9 @@ export function ManageInboxResult({
       )}
 
       {resolvedThreads && resolvedThreads.length > 0 && (
-        <ToolEmailRows emails={resolvedThreads} />
+        <div className="-mx-4">
+          <ToolEmailRows emails={resolvedThreads} />
+        </div>
       )}
 
       {senders && senders.length > 0 && (
@@ -1859,7 +1861,7 @@ function ToolEmailRows({ emails }: { emails: ToolEmailRow[] }) {
 
   return (
     <EmailLookupProvider value={lookup}>
-      <div className="overflow-hidden rounded-md border bg-background">
+      <div className="overflow-hidden">
         {uniqueEmails.map((email) => (
           <InlineEmailCard
             key={email.threadId}

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -83,10 +83,33 @@ function getOutputField<T>(output: unknown, field: string): T | undefined {
 }
 
 export function BasicToolInfo({ text }: { text: string }) {
+  return <div className="text-xs text-muted-foreground">{text}</div>;
+}
+
+function SubtleToolCollapsible({
+  title,
+  children,
+}: {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <ToolCard>
-      <div className="text-sm">{text}</div>
-    </ToolCard>
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronRightIcon
+          className={cn(
+            "size-3 shrink-0 transition-transform duration-200",
+            open && "rotate-90",
+          )}
+        />
+        <span>{title}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 space-y-3 rounded-md border p-3">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -156,7 +179,7 @@ export function SearchInboxResult({ output }: { output: unknown }) {
   >(output, "messages");
 
   return (
-    <CollapsibleToolCard title="Search Inbox">
+    <SubtleToolCollapsible title="Search Inbox">
       {queryUsed && (
         <ToolDetailRow
           label="Query"
@@ -164,7 +187,7 @@ export function SearchInboxResult({ output }: { output: unknown }) {
         />
       )}
       {messages && messages.length > 0 && <ToolEmailRows emails={messages} />}
-    </CollapsibleToolCard>
+    </SubtleToolCollapsible>
   );
 }
 
@@ -317,7 +340,7 @@ export function ReadEmailResult({ output }: { output: unknown }) {
     : null;
 
   return (
-    <CollapsibleToolCard title="Read Email" initialOpen={false}>
+    <SubtleToolCollapsible title="Read Email">
       <div className="space-y-3 text-sm">
         {(subject || from || to || formattedDate) && (
           <div className="space-y-1">
@@ -346,7 +369,7 @@ export function ReadEmailResult({ output }: { output: unknown }) {
           </ToolExternalLink>
         )}
       </div>
-    </CollapsibleToolCard>
+    </SubtleToolCollapsible>
   );
 }
 


### PR DESCRIPTION
# User description
## Summary
- Internal tool calls (Search Inbox, Read Email) now render as subtle muted text lines instead of bordered cards, reducing visual noise
- Loading/completed states (BasicToolInfo) also use muted inline text instead of cards
- User-facing tool results (Manage Inbox) keep the full card style
- Removed nested card borders from email rows inside tool result cards, making rows edge-to-edge

## Test plan
- [ ] Search Inbox result renders as subtle collapsible text
- [ ] Read Email result renders as subtle collapsible text
- [ ] Manage Inbox results still render as full cards
- [ ] Email rows inside Manage Inbox cards have no inner border, sit edge-to-edge
- [ ] Loading states appear as small muted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Simplify internal tool flows by replacing <code>CollapsibleToolCard</code> wrappers in <code>SearchInboxResult</code> and <code>ReadEmailResult</code> with the new <code>SubtleToolCollapsible</code>, which uses muted inline <code>BasicToolInfo</code> text for the loading/completed states to keep the callouts subtle. Adjust <code>ManageInboxResult</code> so <code>ToolEmailRows</code> render edge-to-edge without internal borders while leaving the user-facing cards intact.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2222?tool=ast&topic=Manage+inbox+layout>Manage inbox layout</a>
        </td><td>Remove nested borders around <code>ToolEmailRows</code> inside <code>ManageInboxResult</code>, keeping the outer cards while allowing the thread rows to stretch edge-to-edge for a cleaner inbox layout.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: make internal too...</td><td>April 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2222?tool=ast&topic=Subtle+tool+flows>Subtle tool flows</a>
        </td><td>Replace <code>CollapsibleToolCard</code> wrappers in the internal tool results with <code>SubtleToolCollapsible</code>, showing muted inline triggers plus the updated <code>BasicToolInfo</code> so Search and Read flows feel less heavy.<details><summary>Modified files (1)</summary><ul><li>apps/web/components/assistant-chat/tools.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: make internal too...</td><td>April 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2222?tool=ast>(Baz)</a>.