### PR TITLE
Add POST /api/threads/[id]/archive endpoint for mobile

### DIFF
--- a/apps/web/app/api/threads/[id]/archive/route.ts
+++ b/apps/web/app/api/threads/[id]/archive/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { withEmailProvider } from "@/utils/middleware";
+
+const paramsSchema = z.object({ id: z.string() });
+
+export const POST = withEmailProvider(
+  "threads/archive",
+  async (request, context) => {
+    const params = await context.params;
+    const { id: threadId } = paramsSchema.parse(params);
+
+    try {
+      await request.emailProvider.archiveThreadWithLabel(
+        threadId,
+        request.auth.email,
+      );
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      request.logger.error("Failed to archive thread", {
+        error,
+        threadId,
+        emailAccountId: request.auth.emailAccountId,
+      });
+      return NextResponse.json(
+        { error: "Failed to archive email" },
+        { status: 500 },
+      );
+    }
+  },
+);


### PR DESCRIPTION
# User description
## Summary
- Adds a `POST /api/threads/[id]/archive` endpoint so mobile clients can archive threads directly (web uses Next.js Server Actions which aren't callable from native)
- Uses `withEmailProvider` middleware for auth, calls `emailProvider.archiveThreadWithLabel`

## Test plan
- [ ] Send POST request to `/api/threads/{threadId}/archive` with valid auth headers
- [ ] Verify thread is archived in Gmail/Outlook
- [ ] Verify 401 returned without auth, 500 on invalid thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add POST <code>/api/threads/[id]/archive</code> endpoint that uses <code>withEmailProvider</code> to validate auth and parse params before calling <code>emailProvider.archiveThreadWithLabel</code> to archive the thread. Handle success responses and log errors so clients receive a 500 status when archiving fails.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2223?tool=ast>(Baz)</a>.