### PR TITLE
messaging: Normalize affirmative emoji replies

### DIFF
--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -245,7 +245,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       }));
     });
 
-    test("normalizes an emoji-only Slack mention before assistant processing", async () => {
+    test("passes an emoji-only Slack mention through unchanged", async () => {
       const { ensureSlackTeamInstallation, getMessagingChatSdkBot } =
         await import("@/utils/messaging/chat-sdk/bot");
 
@@ -302,8 +302,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const modelMessages = aiProcessAssistantChatMock.mock.calls[0]?.[0]
         ?.messages as Array<unknown>;
-      expect(JSON.stringify(modelMessages.at(-1))).toContain('"text":"yes"');
-      expect(JSON.stringify(modelMessages.at(-1))).not.toContain("thumbsup");
+      expect(JSON.stringify(modelMessages.at(-1))).toContain('"text":"👍"');
+      expect(JSON.stringify(modelMessages.at(-1))).not.toContain(
+        '"text":"yes"',
+      );
     });
 
     test("treats an affirmative Slack reaction as yes", async () => {

--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -1,0 +1,323 @@
+import { createHmac } from "node:crypto";
+import { createUIMessageStream } from "ai";
+import { createEmulator, type Emulator } from "emulate";
+import { WebClient } from "@slack/web-api";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import {
+  MessagingRoutePurpose,
+  MessagingRouteTargetType,
+} from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+const aiProcessAssistantChatMock = vi.fn();
+const getEmailAccountWithAiMock = vi.fn();
+const getInboxStatsForChatContextMock = vi.fn();
+const getRecentChatMemoriesMock = vi.fn();
+
+vi.mock("@/env", () => ({
+  env: {
+    EMAIL_ENCRYPT_SALT: "test-email-encrypt-salt",
+    EMAIL_ENCRYPT_SECRET: "test-email-encrypt-secret",
+    REDIS_URL: undefined,
+    SLACK_SIGNING_SECRET: "test-signing-secret",
+  },
+}));
+
+vi.mock("@/utils/ai/assistant/chat", () => ({
+  aiProcessAssistantChat: (...args: unknown[]) =>
+    aiProcessAssistantChatMock(...args),
+}));
+
+vi.mock("@/utils/ai/assistant/get-inbox-stats-for-chat-context", () => ({
+  getInboxStatsForChatContext: (...args: unknown[]) =>
+    getInboxStatsForChatContextMock(...args),
+}));
+
+vi.mock("@/utils/ai/assistant/get-recent-chat-memories", () => ({
+  getRecentChatMemories: (...args: unknown[]) =>
+    getRecentChatMemoriesMock(...args),
+}));
+
+vi.mock("@/utils/ai/assistant/chat-seen-rules-revision", () => ({
+  mergeSeenRulesRevision: vi.fn((current: number | null, next: number) =>
+    current == null ? next : Math.max(current, next),
+  ),
+  saveLastSeenRulesRevision: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/utils/user/get", () => ({
+  getEmailAccountWithAi: (...args: unknown[]) =>
+    getEmailAccountWithAiMock(...args),
+}));
+
+vi.mock("@/utils/messaging/rule-notifications", () => ({
+  handleSlackRuleNotificationAction: vi.fn(),
+  handleSlackRuleNotificationModalSubmit: vi.fn(),
+  SLACK_DRAFT_EDIT_MODAL_ID: "slack-draft-edit-modal",
+  SLACK_RULE_NOTIFICATION_ACTION_IDS: [],
+}));
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
+const TEST_PORT = 4118;
+const logger = createScopedLogger("test");
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "Slack chat webhook",
+  { timeout: 30_000 },
+  () => {
+    let emulator: Emulator;
+    let emulatorClient: WebClient;
+    let teamId: string;
+    let userId: string;
+    let channelId: string;
+    let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, "fetch">>;
+
+    beforeAll(async () => {
+      emulator = await createEmulator({
+        service: "slack",
+        port: TEST_PORT,
+        seed: {
+          slack: {
+            team: { name: "TestWorkspace", domain: "test-workspace" },
+            users: [
+              {
+                name: "alice",
+                real_name: "Alice Smith",
+                email: "alice@example.com",
+              },
+            ],
+            channels: [
+              {
+                name: "assistant-chat",
+                is_private: false,
+                topic: "Assistant chat tests",
+              },
+            ],
+          },
+        },
+      });
+
+      emulatorClient = new WebClient("emulator-token", {
+        slackApiUrl: `${emulator.url}/api/`,
+      });
+
+      const auth = await emulatorClient.auth.test();
+      teamId = auth.team_id!;
+
+      const users = await emulatorClient.users.list();
+      const alice = users.members?.find((member) => member.name === "alice");
+      if (!alice?.id) throw new Error("Slack emulator user not found");
+      userId = alice.id;
+
+      const channels = await emulatorClient.conversations.list({
+        types: "public_channel,private_channel",
+      });
+      const assistantChannel = channels.channels?.find(
+        (channel) => channel.name === "assistant-chat",
+      );
+      if (!assistantChannel?.id) {
+        throw new Error("Slack emulator channel not found");
+      }
+      channelId = assistantChannel.id;
+    });
+
+    afterAll(async () => {
+      fetchSpy?.mockRestore();
+      await emulator?.close();
+    });
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+
+      (
+        globalThis as typeof globalThis & {
+          inboxZeroMessagingAdapterRegistry?: unknown;
+          inboxZeroMessagingChatSdk?: unknown;
+        }
+      ).inboxZeroMessagingAdapterRegistry = undefined;
+      (
+        globalThis as typeof globalThis & {
+          inboxZeroMessagingAdapterRegistry?: unknown;
+          inboxZeroMessagingChatSdk?: unknown;
+        }
+      ).inboxZeroMessagingChatSdk = undefined;
+
+      fetchSpy?.mockRestore();
+      const originalFetch = globalThis.fetch.bind(globalThis);
+      fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation((input, init) => {
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url;
+
+          if (url.startsWith("https://slack.com/api/")) {
+            const rewrittenUrl = url.replace(
+              "https://slack.com/api/",
+              `${emulator.url}/api/`,
+            );
+
+            if (input instanceof Request) {
+              return originalFetch(new Request(rewrittenUrl, input));
+            }
+
+            return originalFetch(rewrittenUrl, init);
+          }
+
+          return originalFetch(input, init);
+        });
+
+      prisma.messagingChannel.findFirst.mockResolvedValue({
+        accessToken: "emulator-token",
+        botUserId: "UAPP123",
+        teamName: "TestWorkspace",
+      } as never);
+      prisma.messagingChannel.findMany.mockResolvedValue([
+        {
+          id: "messaging-channel-1",
+          accessToken: "emulator-token",
+          botUserId: "UAPP123",
+          emailAccountId: "email-account-1",
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: channelId,
+              targetType: MessagingRouteTargetType.CHANNEL,
+            },
+          ],
+        },
+      ] as never);
+      prisma.chat.upsert.mockImplementation(
+        async ({ where }) =>
+          ({
+            id: where.id,
+            lastSeenRulesRevision: null,
+            messages: [],
+            compactions: [],
+          }) as never,
+      );
+      prisma.chatMessage.upsert.mockResolvedValue({} as never);
+      prisma.chatMessage.findUnique.mockResolvedValue(null);
+      prisma.chatMessage.create.mockResolvedValue({} as never);
+
+      getEmailAccountWithAiMock.mockResolvedValue({
+        email: "user@example.com",
+        account: { provider: "google" },
+      });
+      getInboxStatsForChatContextMock.mockResolvedValue({});
+      getRecentChatMemoriesMock.mockResolvedValue([]);
+      aiProcessAssistantChatMock.mockImplementation(async () => ({
+        toUIMessageStream: ({
+          originalMessages,
+          generateMessageId,
+        }: {
+          originalMessages: unknown[];
+          generateMessageId: () => string;
+        }) =>
+          createUIMessageStream({
+            originalMessages,
+            generateId: generateMessageId,
+            execute: ({ writer }) => {
+              writer.write({ type: "text-start", id: "assistant-text" });
+              writer.write({
+                type: "text-delta",
+                id: "assistant-text",
+                delta: "Handled affirmative reply.",
+              });
+              writer.write({ type: "text-end", id: "assistant-text" });
+            },
+          }),
+      }));
+    });
+
+    test("normalizes an emoji-only Slack mention before assistant processing", async () => {
+      const { ensureSlackTeamInstallation, getMessagingChatSdkBot } =
+        await import("@/utils/messaging/chat-sdk/bot");
+
+      await ensureSlackTeamInstallation(teamId, logger);
+
+      const parent = await emulatorClient.chat.postMessage({
+        channel: channelId,
+        text: "Parent message",
+      });
+      const ts = parent.ts!;
+
+      const body = JSON.stringify({
+        type: "event_callback",
+        team_id: teamId,
+        api_app_id: "AAPP123",
+        event_id: "Ev123",
+        event_time: Math.floor(Date.now() / 1000),
+        authorizations: [
+          {
+            team_id: teamId,
+            user_id: "UAPP123",
+            is_bot: false,
+            is_enterprise_install: false,
+          },
+        ],
+        event: {
+          type: "app_mention",
+          user: userId,
+          text: "<@UAPP123> :thumbsup:",
+          ts,
+          channel: channelId,
+          channel_type: "channel",
+          event_ts: ts,
+        },
+      });
+
+      const { bot } = getMessagingChatSdkBot();
+      const backgroundTasks: Promise<unknown>[] = [];
+      const response = await bot.webhooks.slack(
+        createSignedSlackRequest(body),
+        {
+          waitUntil: (promise) => {
+            backgroundTasks.push(promise);
+          },
+        },
+      );
+      await Promise.all(backgroundTasks);
+
+      expect(response.status).toBe(200);
+      expect(aiProcessAssistantChatMock).toHaveBeenCalledTimes(1);
+
+      const modelMessages = aiProcessAssistantChatMock.mock.calls[0]?.[0]
+        ?.messages as Array<unknown>;
+      expect(JSON.stringify(modelMessages.at(-1))).toContain('"text":"yes"');
+      expect(JSON.stringify(modelMessages.at(-1))).not.toContain("thumbsup");
+    });
+  },
+);
+
+function createSignedSlackRequest(body: string) {
+  const timestamp = `${Math.floor(Date.now() / 1000)}`;
+  const signature = `v0=${createHmac("sha256", "test-signing-secret")
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+
+  return new Request("https://example.com/api/slack/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+    body,
+  });
+}

--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -292,15 +292,81 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           },
         },
       );
-      await Promise.all(backgroundTasks);
 
       expect(response.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(backgroundTasks.length).toBeGreaterThan(0);
+      });
+      await Promise.all(backgroundTasks);
       expect(aiProcessAssistantChatMock).toHaveBeenCalledTimes(1);
 
       const modelMessages = aiProcessAssistantChatMock.mock.calls[0]?.[0]
         ?.messages as Array<unknown>;
       expect(JSON.stringify(modelMessages.at(-1))).toContain('"text":"yes"');
       expect(JSON.stringify(modelMessages.at(-1))).not.toContain("thumbsup");
+    });
+
+    test("treats an affirmative Slack reaction as yes", async () => {
+      const { ensureSlackTeamInstallation, getMessagingChatSdkBot } =
+        await import("@/utils/messaging/chat-sdk/bot");
+
+      await ensureSlackTeamInstallation(teamId, logger);
+
+      const parent = await emulatorClient.chat.postMessage({
+        channel: channelId,
+        text: "Parent message",
+      });
+      const ts = parent.ts!;
+
+      const body = JSON.stringify({
+        type: "event_callback",
+        team_id: teamId,
+        api_app_id: "AAPP123",
+        event_id: "Ev124",
+        event_time: Math.floor(Date.now() / 1000),
+        authorizations: [
+          {
+            team_id: teamId,
+            user_id: "UAPP123",
+            is_bot: false,
+            is_enterprise_install: false,
+          },
+        ],
+        event: {
+          type: "reaction_added",
+          user: userId,
+          reaction: "+1",
+          item_user: "UAPP123",
+          item: {
+            type: "message",
+            channel: channelId,
+            ts,
+          },
+          event_ts: `${Date.now() / 1000}`,
+        },
+      });
+
+      const { bot } = getMessagingChatSdkBot();
+      const backgroundTasks: Promise<unknown>[] = [];
+      const response = await bot.webhooks.slack(
+        createSignedSlackRequest(body),
+        {
+          waitUntil: (promise) => {
+            backgroundTasks.push(promise);
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(backgroundTasks.length).toBeGreaterThan(0);
+      });
+      await Promise.all(backgroundTasks);
+      expect(aiProcessAssistantChatMock).toHaveBeenCalledTimes(1);
+
+      const modelMessages = aiProcessAssistantChatMock.mock.calls[0]?.[0]
+        ?.messages as Array<unknown>;
+      expect(JSON.stringify(modelMessages.at(-1))).toContain('"text":"yes"');
     });
   },
 );

--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -274,7 +274,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         event: {
           type: "app_mention",
           user: userId,
-          text: "<@UAPP123> :thumbsup:",
+          text: "<@UAPP123> 👍",
           ts,
           channel: channelId,
           channel_type: "channel",

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -100,6 +100,11 @@ describe("normalizeMessagingUserText", () => {
     );
   });
 
+  it("does not treat plain words as emoji aliases", () => {
+    expect(normalizeMessagingUserText({ text: "check" })).toBe("check");
+    expect(normalizeMessagingUserText({ text: "thumbsup" })).toBe("thumbsup");
+  });
+
   it("leaves regular text unchanged", () => {
     expect(
       normalizeMessagingUserText({ text: "yes please summarize my inbox" }),

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -9,6 +9,7 @@ import {
   ensureSlackTeamInstallation,
   hasUnsupportedMessagingAttachment,
   normalizeMessagingAssistantText,
+  normalizeMessagingUserText,
   stripLeadingSlackMention,
 } from "@/utils/messaging/chat-sdk/bot";
 
@@ -82,6 +83,26 @@ describe("normalizeMessagingAssistantText", () => {
     const input =
       "I prepared that reply for you. This draft is pending confirmation.";
     expect(normalizeMessagingAssistantText({ text: input })).toBe(input);
+  });
+});
+
+describe("normalizeMessagingUserText", () => {
+  it("maps standalone affirmative emoji replies to yes", () => {
+    expect(normalizeMessagingUserText({ text: "👍🏽" })).toBe("yes");
+    expect(normalizeMessagingUserText({ text: "✅ ✅" })).toBe("yes");
+  });
+
+  it("maps Slack-style emoji aliases to yes", () => {
+    expect(normalizeMessagingUserText({ text: ":thumbsup:" })).toBe("yes");
+    expect(normalizeMessagingUserText({ text: ":white_check_mark:" })).toBe(
+      "yes",
+    );
+  });
+
+  it("leaves regular text unchanged", () => {
+    expect(
+      normalizeMessagingUserText({ text: "yes please summarize my inbox" }),
+    ).toBe("yes please summarize my inbox");
   });
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
+  buildAffirmativeReactionMessage,
   buildPendingEmailCardFallbackText,
   getPendingEmailHandledOpenText,
   getPendingEmailHandledStatus,
@@ -103,6 +104,32 @@ describe("normalizeMessagingUserText", () => {
     expect(
       normalizeMessagingUserText({ text: "yes please summarize my inbox" }),
     ).toBe("yes please summarize my inbox");
+  });
+});
+
+describe("buildAffirmativeReactionMessage", () => {
+  it("converts a reaction event into a synthetic yes message", () => {
+    const message = buildAffirmativeReactionMessage({
+      event: {
+        threadId: "teams:conversation-1",
+        messageId: "message-1",
+        emoji: { name: "thumbs_up" },
+        raw: { type: "messageReaction" },
+        user: {
+          userId: "user-1",
+          userName: "User One",
+          fullName: "User One",
+          isBot: false,
+          isMe: false,
+        },
+      } as any,
+    });
+
+    expect(message.text).toBe("yes");
+    expect(message.threadId).toBe("teams:conversation-1");
+    expect(message.author.userId).toBe("user-1");
+    expect(message.raw).toEqual({ type: "messageReaction" });
+    expect(message.id).toContain("thumbs_up");
   });
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -88,15 +88,10 @@ describe("normalizeMessagingAssistantText", () => {
 });
 
 describe("normalizeMessagingUserText", () => {
-  it("maps standalone affirmative emoji replies to yes", () => {
-    expect(normalizeMessagingUserText({ text: "👍🏽" })).toBe("yes");
-    expect(normalizeMessagingUserText({ text: "✅ ✅" })).toBe("yes");
-  });
-
-  it("maps Slack-style emoji aliases to yes", () => {
-    expect(normalizeMessagingUserText({ text: ":thumbsup:" })).toBe("yes");
-    expect(normalizeMessagingUserText({ text: ":white_check_mark:" })).toBe(
-      "yes",
+  it("leaves emoji-only messages unchanged", () => {
+    expect(normalizeMessagingUserText({ text: "👍🏽" })).toBe("👍🏽");
+    expect(normalizeMessagingUserText({ text: ":thumbsup:" })).toBe(
+      ":thumbsup:",
     );
   });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -20,7 +20,9 @@ import {
   type Adapter,
   type Attachment,
   type CardChild,
+  emoji,
   type Message,
+  type ReactionEvent,
   type Thread,
 } from "chat";
 import { env } from "@/env";
@@ -418,6 +420,28 @@ function registerMessagingHandlers({
       message,
       logger: handlerLogger,
     });
+  });
+
+  bot.onReaction([emoji.thumbs_up, emoji.check], async (event) => {
+    if (!event.added) return;
+
+    const provider = event.thread.adapter.name;
+    if (provider !== "teams" && provider !== "telegram") return;
+
+    const handlerLogger = getHandlerLogger();
+    const handled = await processMessagingAssistantMessage({
+      adapters,
+      thread: event.thread,
+      message: buildAffirmativeReactionMessage({ event }),
+      logger: handlerLogger,
+    });
+
+    if (handled) {
+      await subscribeMessagingThreadSafely({
+        thread: event.thread,
+        logger: handlerLogger,
+      });
+    }
   });
 
   bot.onAction(
@@ -2533,6 +2557,35 @@ export function normalizeMessagingAssistantText({ text }: { text: string }) {
   );
 
   return normalized;
+}
+
+export function buildAffirmativeReactionMessage({
+  event,
+}: {
+  event: ReactionEvent;
+}) {
+  return {
+    id: `reaction:${event.threadId}:${event.messageId}:${event.user.userId}:${event.emoji.name}`,
+    threadId: event.threadId,
+    text: "yes",
+    formatted: {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "yes" }],
+        },
+      ],
+    },
+    raw: event.raw,
+    author: event.user,
+    metadata: {
+      dateSent: new Date(),
+      edited: false,
+    },
+    attachments: [],
+    links: [],
+  } as Message;
 }
 
 export function normalizeMessagingUserText({ text }: { text: string }) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -21,7 +21,7 @@ import {
   type Attachment,
   type CardChild,
   emoji,
-  type Message,
+  Message,
   type ReactionEvent,
   type Thread,
 } from "chat";
@@ -102,6 +102,7 @@ const SLACK_ASSISTANT_SUGGESTED_PROMPTS = [
 ];
 
 type SupportedPlatform = MessagingPlatform;
+type MessagingThread = Thread<unknown, unknown>;
 
 type MessagingChatSdkContext = {
   bot: Chat<Record<string, Adapter>>;
@@ -487,7 +488,7 @@ async function subscribeMessagingThreadSafely({
   thread,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
 }) {
   try {
@@ -508,7 +509,7 @@ async function processMessagingAssistantMessage({
   logger,
 }: {
   adapters: MessagingAdapters;
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<boolean> {
@@ -986,7 +987,7 @@ async function postPendingEmailCard({
   provider,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   chatMessageId: string;
   part: PendingEmailToolPart;
   provider: SupportedPlatform;
@@ -1580,7 +1581,7 @@ async function startSlackProcessingReaction({
   logger,
 }: {
   adapters: MessagingAdapters;
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<(() => Promise<void>) | null> {
@@ -1634,7 +1635,7 @@ async function handleMessagingLinkCommand({
   message,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<boolean> {
@@ -1751,7 +1752,7 @@ async function handleSwitchCommand({
   message,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<boolean> {
@@ -1864,7 +1865,7 @@ async function handleHelpCommand({
   message,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<boolean> {
@@ -1895,7 +1896,7 @@ async function resolveMessagingContext({
   logger,
 }: {
   adapters: MessagingAdapters;
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<ResolvedMessagingContext | null> {
@@ -1935,7 +1936,7 @@ async function resolveSlackMessagingContext({
   logger,
 }: {
   slackAdapter: SlackAdapter | undefined;
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
   logger: Logger;
 }): Promise<ResolvedMessagingContext | null> {
@@ -2030,7 +2031,7 @@ async function resolveLinkedProviderMessagingContext({
   provider: "teams" | "telegram";
   identity: LinkedProviderIdentity | null;
   message: Message;
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
 }): Promise<ResolvedMessagingContext | null> {
   if (!identity) return null;
@@ -2116,7 +2117,7 @@ function resolveTeamsIdentity({
   thread,
   message,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   message: Message;
 }): LinkedProviderIdentity | null {
   const messageText = normalizeMessagingUserText({
@@ -2335,7 +2336,7 @@ async function resolveSlackMessagingChannel({
   isDirectMessage: boolean;
   logger: Logger;
   teamId: string;
-  thread: Thread;
+  thread: MessagingThread;
 }): Promise<SlackCandidate | null> {
   if (!isDirectMessage) {
     const channelMatch = candidates.find((candidate) =>
@@ -2410,7 +2411,7 @@ async function sendUnauthorizedMessage({
   teamId,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   teamId: string;
   logger: Logger;
 }): Promise<void> {
@@ -2432,7 +2433,7 @@ async function sendLinkRequiredMessage({
   logger,
 }: {
   provider: "teams" | "telegram";
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
 }): Promise<void> {
   const providerName = provider === "teams" ? "Teams" : "Telegram";
@@ -2452,7 +2453,7 @@ async function sendDmRequiredMessage({
   logger,
 }: {
   provider: "teams" | "telegram";
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
 }): Promise<void> {
   const providerName = provider === "teams" ? "Teams" : "Telegram";
@@ -2470,7 +2471,7 @@ async function sendUnlinkedChannelMessage({
   thread,
   logger,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
 }): Promise<void> {
   await postMessagingThreadMessage({
@@ -2489,7 +2490,7 @@ async function postMessagingThreadMessage({
   errorLogMessage,
   logMeta,
 }: {
-  thread: Thread;
+  thread: MessagingThread;
   logger: Logger;
   message: string;
   errorLogMessage: string;
@@ -2561,7 +2562,7 @@ export function buildAffirmativeReactionMessage({
 }: {
   event: ReactionEvent;
 }) {
-  return {
+  return new Message({
     id: `reaction:${event.threadId}:${event.messageId}:${event.user.userId}:${event.emoji.name}`,
     threadId: event.threadId,
     text: "yes",
@@ -2582,7 +2583,7 @@ export function buildAffirmativeReactionMessage({
     },
     attachments: [],
     links: [],
-  } as Message;
+  });
 }
 
 export function normalizeMessagingUserText({ text }: { text: string }) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -2603,6 +2603,21 @@ export function normalizeMessagingUserText({ text }: { text: string }) {
   return text.trim();
 }
 
+export function buildPendingEmailCardFallbackText(normalizedText: string) {
+  const failureGuidance =
+    "I couldn't show the Send button right now. Ask me to prepare the draft again.";
+
+  if (
+    normalizedText
+      .toLowerCase()
+      .includes("i couldn't show the send button right now")
+  ) {
+    return normalizedText;
+  }
+
+  return `${normalizedText}\n\n${failureGuidance}`;
+}
+
 function isAffirmativeReactionEvent(event: ReactionEvent) {
   return (
     isAffirmativeReactionToken(event.rawEmoji) ||
@@ -2623,21 +2638,6 @@ function isAffirmativeReactionToken(token: string) {
     .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
 
   return AFFIRMATIVE_REACTION_EMOJI_TOKENS.has(normalized);
-}
-
-export function buildPendingEmailCardFallbackText(normalizedText: string) {
-  const failureGuidance =
-    "I couldn't show the Send button right now. Ask me to prepare the draft again.";
-
-  if (
-    normalizedText
-      .toLowerCase()
-      .includes("i couldn't show the send button right now")
-  ) {
-    return normalizedText;
-  }
-
-  return `${normalizedText}\n\n${failureGuidance}`;
 }
 
 function getMessagingAssistantPostPayload({

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -20,7 +20,6 @@ import {
   type Adapter,
   type Attachment,
   type CardChild,
-  emoji,
   Message,
   type ReactionEvent,
   type Thread,
@@ -420,11 +419,13 @@ function registerMessagingHandlers({
     });
   });
 
-  bot.onReaction([emoji.thumbs_up, emoji.check], async (event) => {
+  bot.onReaction(async (event) => {
     if (!event.added) return;
+    if (!isAffirmativeReactionEvent(event)) return;
 
     const provider = event.thread.adapter.name;
-    if (provider !== "teams" && provider !== "telegram") return;
+    if (provider !== "slack" && provider !== "teams" && provider !== "telegram")
+      return;
 
     const handlerLogger = getHandlerLogger();
     const handled = await processMessagingAssistantMessage({
@@ -1946,17 +1947,17 @@ async function resolveSlackMessagingContext({
   const teamId = rawEvent.team_id ?? rawEvent.team;
   const userId = message.author.userId;
 
-  if (!teamId || !userId) return null;
+  if (!userId) return null;
 
   const { channel, threadTs } = slackAdapter.decodeThreadId(thread.id);
 
-  const candidates = await prisma.messagingChannel.findMany({
+  let candidates = await prisma.messagingChannel.findMany({
     where: {
       provider: MessagingProvider.SLACK,
-      teamId,
       isConnected: true,
       accessToken: { not: null },
       providerUserId: userId,
+      ...(teamId ? { teamId } : {}),
     },
     select: {
       id: true,
@@ -1975,6 +1976,16 @@ async function resolveSlackMessagingContext({
       },
     },
   });
+
+  if (!teamId && !thread.isDM) {
+    candidates = candidates.filter((candidate) =>
+      candidate.routes.some(
+        (route) =>
+          route.targetType === MessagingRouteTargetType.CHANNEL &&
+          route.targetId === channel,
+      ),
+    );
+  }
 
   if (candidates.length === 0) {
     await sendUnauthorizedMessage({ thread, teamId, logger });
@@ -2335,7 +2346,7 @@ async function resolveSlackMessagingChannel({
   chatThreadTs: string | undefined;
   isDirectMessage: boolean;
   logger: Logger;
-  teamId: string;
+  teamId?: string | null;
   thread: MessagingThread;
 }): Promise<SlackCandidate | null> {
   if (!isDirectMessage) {
@@ -2412,7 +2423,7 @@ async function sendUnauthorizedMessage({
   logger,
 }: {
   thread: MessagingThread;
-  teamId: string;
+  teamId?: string | null;
   logger: Logger;
 }): Promise<void> {
   await postMessagingThreadMessage({
@@ -2424,7 +2435,9 @@ async function sendUnauthorizedMessage({
     logMeta: { teamId },
   });
 
-  logger.info("Unauthorized messaging user attempted bot access", { teamId });
+  logger.info("Unauthorized messaging user attempted bot access", {
+    ...(teamId ? { teamId } : {}),
+  });
 }
 
 async function sendLinkRequiredMessage({
@@ -2590,15 +2603,26 @@ export function normalizeMessagingUserText({ text }: { text: string }) {
   const normalized = text.trim();
   if (!normalized) return normalized;
 
-  const tokens = normalized
-    .split(/\s+/)
-    .map((token) => normalizeAffirmativeEmojiToken(token));
-
-  if (tokens.length > 0 && tokens.every(Boolean)) {
+  if (
+    normalized
+      .split(/\s+/)
+      .every((token) => Boolean(normalizeAffirmativeEmojiToken(token)))
+  ) {
     return "yes";
   }
 
   return normalized;
+}
+
+function isAffirmativeReactionEvent(event: ReactionEvent) {
+  const rawEmoji = event.rawEmoji.trim().toLowerCase();
+  const emojiName = event.emoji.name.trim().toLowerCase();
+
+  return (
+    AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(rawEmoji) ||
+    AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(emojiName) ||
+    Boolean(normalizeAffirmativeEmojiToken(event.rawEmoji))
+  );
 }
 
 function normalizeAffirmativeEmojiToken(token: string) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -77,11 +77,8 @@ const CONNECT_COMMAND_REGEX =
 const PENDING_EMAIL_CONFIRM_ACTION_ID = "acpe";
 const LEGACY_PENDING_EMAIL_CONFIRM_ACTION_ID =
   "assistant_confirm_pending_email";
-const AFFIRMATIVE_EMOJI_REPLY_TOKENS = new Set([
-  "👍",
-  "✅",
-  "☑",
-  "✔",
+const AFFIRMATIVE_EMOJI_REPLY_TOKENS = new Set(["👍", "✅", "☑", "✔", "+1"]);
+const AFFIRMATIVE_SLACK_EMOJI_ALIASES = new Set([
   "+1",
   "thumbsup",
   "thumbs_up",
@@ -2594,24 +2591,31 @@ export function normalizeMessagingUserText({ text }: { text: string }) {
 
   const tokens = normalized
     .split(/\s+/)
-    .map((token) =>
-      token
-        .trim()
-        .toLowerCase()
-        .replaceAll(":", "")
-        .replaceAll("\uFE0F", "")
-        .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, ""),
-    )
-    .filter(Boolean);
+    .map((token) => normalizeAffirmativeEmojiToken(token));
 
-  if (
-    tokens.length > 0 &&
-    tokens.every((token) => AFFIRMATIVE_EMOJI_REPLY_TOKENS.has(token))
-  ) {
+  if (tokens.length > 0 && tokens.every(Boolean)) {
     return "yes";
   }
 
   return normalized;
+}
+
+function normalizeAffirmativeEmojiToken(token: string) {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+
+  const colonAliasMatch = trimmed.match(/^:([a-z0-9_+-]+):$/i);
+  if (colonAliasMatch?.[1]) {
+    const alias = colonAliasMatch[1].toLowerCase();
+    return AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(alias) ? alias : null;
+  }
+
+  const normalized = trimmed
+    .toLowerCase()
+    .replaceAll("\uFE0F", "")
+    .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
+
+  return AFFIRMATIVE_EMOJI_REPLY_TOKENS.has(normalized) ? normalized : null;
 }
 
 export function buildPendingEmailCardFallbackText(normalizedText: string) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -75,6 +75,18 @@ const CONNECT_COMMAND_REGEX =
 const PENDING_EMAIL_CONFIRM_ACTION_ID = "acpe";
 const LEGACY_PENDING_EMAIL_CONFIRM_ACTION_ID =
   "assistant_confirm_pending_email";
+const AFFIRMATIVE_EMOJI_REPLY_TOKENS = new Set([
+  "👍",
+  "✅",
+  "☑",
+  "✔",
+  "+1",
+  "thumbsup",
+  "thumbs_up",
+  "white_check_mark",
+  "check",
+  "heavy_check_mark",
+]);
 const UNSUPPORTED_MESSAGING_ATTACHMENT_MESSAGE =
   "I can process images, but I can't access other file types (documents, videos, audio) sent here yet. I can still draft the email text if you share what to write.";
 
@@ -1963,6 +1975,7 @@ async function resolveSlackMessagingContext({
   if (rawEvent.type === "app_mention") {
     messageText = stripLeadingSlackMention(messageText);
   }
+  messageText = normalizeMessagingUserText({ text: messageText });
 
   const hasUnsupportedAttachments = hasUnsupportedMessagingAttachment({
     provider: "slack",
@@ -2085,7 +2098,9 @@ function resolveTeamsIdentity({
   thread: Thread;
   message: Message;
 }): LinkedProviderIdentity | null {
-  const messageText = expandPromptCommand(message.text.trim());
+  const messageText = normalizeMessagingUserText({
+    text: expandPromptCommand(message.text.trim()),
+  });
   const hasAttachments = message.attachments.length > 0;
   if (!messageText && !hasAttachments) return null;
 
@@ -2138,11 +2153,15 @@ function resolveTelegramIdentity({
 }
 
 function getTelegramMessageText(message: Message): string {
-  const plainText = expandPromptCommand(message.text.trim());
+  const plainText = normalizeMessagingUserText({
+    text: expandPromptCommand(message.text.trim()),
+  });
   if (plainText) return plainText;
 
   const rawMessage = message.raw as TelegramRawMessage;
-  return expandPromptCommand(rawMessage.caption?.trim() || "");
+  return normalizeMessagingUserText({
+    text: expandPromptCommand(rawMessage.caption?.trim() || ""),
+  });
 }
 
 const SUPPORTED_IMAGE_MIME_TYPES = new Set([
@@ -2175,8 +2194,7 @@ export function hasUnsupportedMessagingAttachment({
     const rawEvent = message.raw as SlackEvent;
     const files = rawEvent.files || [];
     return files.some(
-      (f: { mimetype?: string }) =>
-        !f.mimetype || !f.mimetype.startsWith("image/"),
+      (f: { mimetype?: string }) => !f.mimetype?.startsWith("image/"),
     );
   }
 
@@ -2513,6 +2531,32 @@ export function normalizeMessagingAssistantText({ text }: { text: string }) {
     /click (?:the )?(?:confirmation|approve|send) button[^.]*\./gi,
     "This draft is pending confirmation.",
   );
+
+  return normalized;
+}
+
+export function normalizeMessagingUserText({ text }: { text: string }) {
+  const normalized = text.trim();
+  if (!normalized) return normalized;
+
+  const tokens = normalized
+    .split(/\s+/)
+    .map((token) =>
+      token
+        .trim()
+        .toLowerCase()
+        .replaceAll(":", "")
+        .replaceAll("\uFE0F", "")
+        .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, ""),
+    )
+    .filter(Boolean);
+
+  if (
+    tokens.length > 0 &&
+    tokens.every((token) => AFFIRMATIVE_EMOJI_REPLY_TOKENS.has(token))
+  ) {
+    return "yes";
+  }
 
   return normalized;
 }

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -423,9 +423,8 @@ function registerMessagingHandlers({
     if (!event.added) return;
     if (!isAffirmativeReactionEvent(event)) return;
 
-    const provider = event.thread.adapter.name;
-    if (provider !== "slack" && provider !== "teams" && provider !== "telegram")
-      return;
+    const provider = getSupportedPlatform(event.thread.adapter.name);
+    if (!provider) return;
 
     const handlerLogger = getHandlerLogger();
     const handled = await processMessagingAssistantMessage({
@@ -2633,7 +2632,6 @@ function isAffirmativeReactionToken(token: string) {
   if (AFFIRMATIVE_REACTION_ALIASES.has(alias)) return true;
 
   const normalized = alias
-    .toLowerCase()
     .replaceAll("\uFE0F", "")
     .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -76,8 +76,8 @@ const CONNECT_COMMAND_REGEX =
 const PENDING_EMAIL_CONFIRM_ACTION_ID = "acpe";
 const LEGACY_PENDING_EMAIL_CONFIRM_ACTION_ID =
   "assistant_confirm_pending_email";
-const AFFIRMATIVE_EMOJI_REPLY_TOKENS = new Set(["👍", "✅", "☑", "✔", "+1"]);
-const AFFIRMATIVE_SLACK_EMOJI_ALIASES = new Set([
+const AFFIRMATIVE_REACTION_EMOJI_TOKENS = new Set(["👍", "✅", "☑", "✔"]);
+const AFFIRMATIVE_REACTION_ALIASES = new Set([
   "+1",
   "thumbsup",
   "thumbs_up",
@@ -2600,47 +2600,29 @@ export function buildAffirmativeReactionMessage({
 }
 
 export function normalizeMessagingUserText({ text }: { text: string }) {
-  const normalized = text.trim();
-  if (!normalized) return normalized;
-
-  if (
-    normalized
-      .split(/\s+/)
-      .every((token) => Boolean(normalizeAffirmativeEmojiToken(token)))
-  ) {
-    return "yes";
-  }
-
-  return normalized;
+  return text.trim();
 }
 
 function isAffirmativeReactionEvent(event: ReactionEvent) {
-  const rawEmoji = event.rawEmoji.trim().toLowerCase();
-  const emojiName = event.emoji.name.trim().toLowerCase();
-
   return (
-    AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(rawEmoji) ||
-    AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(emojiName) ||
-    Boolean(normalizeAffirmativeEmojiToken(event.rawEmoji))
+    isAffirmativeReactionToken(event.rawEmoji) ||
+    isAffirmativeReactionToken(event.emoji.name)
   );
 }
 
-function normalizeAffirmativeEmojiToken(token: string) {
+function isAffirmativeReactionToken(token: string) {
   const trimmed = token.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return false;
 
-  const colonAliasMatch = trimmed.match(/^:([a-z0-9_+-]+):$/i);
-  if (colonAliasMatch?.[1]) {
-    const alias = colonAliasMatch[1].toLowerCase();
-    return AFFIRMATIVE_SLACK_EMOJI_ALIASES.has(alias) ? alias : null;
-  }
+  const alias = trimmed.toLowerCase();
+  if (AFFIRMATIVE_REACTION_ALIASES.has(alias)) return true;
 
-  const normalized = trimmed
+  const normalized = alias
     .toLowerCase()
     .replaceAll("\uFE0F", "")
     .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
 
-  return AFFIRMATIVE_EMOJI_REPLY_TOKENS.has(normalized) ? normalized : null;
+  return AFFIRMATIVE_REACTION_EMOJI_TOKENS.has(normalized);
 }
 
 export function buildPendingEmailCardFallbackText(normalizedText: string) {


### PR DESCRIPTION
# User description
Normalize affirmative emoji-only replies in messaging chat so they follow the existing yes-handling path.

- Convert standalone thumbs-up and checkmark replies, including Slack aliases, to `yes`
- Apply normalization in Slack, Teams, and Telegram inbound message parsing
- Add focused unit coverage for emoji and non-emoji text cases

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Normalize affirmative emoji replies by routing thumbs-up and checkmark reactions through the existing yes-handling path in the messaging chat bot. Add unit and integration coverage for <code>normalizeMessagingUserText</code> and reaction handling to keep Slack, Teams, and Telegram inbound parsing consistent.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2226?tool=ast&topic=Affirmative+reactions>Affirmative reactions</a>
        </td><td>Handle affirmative reactions by synthesizing <code>yes</code> messages in <code>buildAffirmativeReactionMessage</code>, gating them with <code>isAffirmativeReactionEvent</code>, and feeding them through the existing <code>processMessagingAssistantMessage</code> flow, backed by Slack integration assertions.<details><summary>Modified files (3)</summary><ul><li>apps/web/__tests__/integration/slack-chat.test.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.test.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: use ?authuser= fo...</td><td>April 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2226?tool=ast&topic=Inbound+normalization>Inbound normalization</a>
        </td><td>Apply <code>normalizeMessagingUserText</code> across Slack, Teams, and Telegram inbound parsing so emoji-only replies stay literal while aliases like <code>:thumbsup:</code> map to text consistently, with focused unit tests covering emoji and plain text cases.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/messaging/chat-sdk/bot.test.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: use ?authuser= fo...</td><td>April 11, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2226?tool=ast>(Baz)</a>.