### PR TITLE
rules: relax Gmail label validation

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting.tsx
@@ -51,7 +51,7 @@ export function MultiRuleSetting() {
           <span>Multi-rule selection</span>
           <TooltipExplanation
             side="top"
-            text="This only lets the AI return multiple custom rules from the AI selection step. More than one rule can still be applied in some other cases, such as learned-pattern matches, conversation-status rules, or when a deterministic match is combined with an AI match."
+            text="Turning this off stops the AI from intentionally choosing multiple custom rules for one email. Inbox Zero can still apply more than one rule in a few special cases."
           />
         </div>
       }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting.tsx
@@ -9,6 +9,7 @@ import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useAction } from "next-safe-action/hooks";
 import { Skeleton } from "@/components/ui/skeleton";
 import { LoadingContent } from "@/components/LoadingContent";
+import { TooltipExplanation } from "@/components/TooltipExplanation";
 
 export function MultiRuleSetting() {
   const { data, isLoading, error, mutate } = useEmailAccountFull();
@@ -45,7 +46,15 @@ export function MultiRuleSetting() {
 
   return (
     <SettingCard
-      title="Multi-rule selection"
+      title={
+        <div className="flex items-center gap-1.5">
+          <span>Multi-rule selection</span>
+          <TooltipExplanation
+            side="top"
+            text="This only lets the AI return multiple custom rules from the AI selection step. More than one rule can still be applied in some other cases, such as learned-pattern matches, conversation-status rules, or when a deterministic match is combined with an AI match."
+          />
+        </div>
+      }
       description="Allow the AI to select multiple rules for a single email when appropriate."
       right={
         <LoadingContent

--- a/apps/web/components/SettingCard.tsx
+++ b/apps/web/components/SettingCard.tsx
@@ -7,7 +7,7 @@ export function SettingCard({
   right,
   collapseOnMobile = false,
 }: {
-  title: string;
+  title: React.ReactNode;
   description: string;
   right: React.ReactNode;
   collapseOnMobile?: boolean;

--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -2844,7 +2844,7 @@ describe("findMatchingRules - Integration Tests", () => {
 
     // Ensure potentialAiMatches includes aiOnlyRule
     vi.mocked(aiChooseRule).mockResolvedValue({
-      rules: [aiOnlyRule as any],
+      rules: [{ rule: aiOnlyRule as any, isPrimary: true }],
       reason: "AI reasoning here",
     });
 

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -560,6 +560,8 @@ async function findMatchingRulesWithReasons(
       reason: fullResult.reason,
     };
 
+    // Build combined matches: update existing matches with AI reasons if AI also chose them,
+    // and append new AI-selected matches
     const aiRuleIds = new Set(result.rules.map((r) => r.id));
 
     const combinedMatches = [

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -560,8 +560,6 @@ async function findMatchingRulesWithReasons(
       reason: fullResult.reason,
     };
 
-    // Build combined matches: update existing matches with AI reasons if AI also chose them,
-    // and append new AI-selected matches
     const aiRuleIds = new Set(result.rules.map((r) => r.id));
 
     const combinedMatches = [

--- a/apps/web/utils/gmail/label-validation.test.ts
+++ b/apps/web/utils/gmail/label-validation.test.ts
@@ -14,6 +14,7 @@ describe("validateLabelNameBasic", () => {
         "Project Alpha",
         "2024 Taxes",
         "Follow Up",
+        "* Marketing",
         "a".repeat(225), // Max length
         // Nested labels with forward slash are valid
         "Inbox Zero/Archived",
@@ -87,12 +88,6 @@ describe("validateLabelNameBasic", () => {
       expect(result.error).toContain("\\");
     });
 
-    it("should reject labels with asterisk", () => {
-      const result = validateLabelNameBasic("Work*Items");
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("*");
-    });
-
     it("should reject labels with plus sign", () => {
       const result = validateLabelNameBasic("Work+Items");
       expect(result.valid).toBe(false);
@@ -116,6 +111,7 @@ describe("validateGmailLabelName", () => {
         "Project Alpha",
         "2024 Taxes",
         "Follow Up",
+        "* Marketing",
         "CATEGORY_PERSONAL",
       ];
 

--- a/apps/web/utils/gmail/label-validation.test.ts
+++ b/apps/web/utils/gmail/label-validation.test.ts
@@ -15,6 +15,9 @@ describe("validateLabelNameBasic", () => {
         "2024 Taxes",
         "Follow Up",
         "* Marketing",
+        "Work+Items",
+        "Work\\Items",
+        "Work`Items",
         "a".repeat(225), // Max length
         // Nested labels with forward slash are valid
         "Inbox Zero/Archived",
@@ -81,23 +84,23 @@ describe("validateLabelNameBasic", () => {
     });
   });
 
-  describe("invalid characters", () => {
-    it("should reject labels with backslash", () => {
+  describe("supported characters", () => {
+    it("should accept labels with backslash", () => {
       const result = validateLabelNameBasic("Work\\Items");
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("\\");
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
-    it("should reject labels with plus sign", () => {
+    it("should accept labels with plus sign", () => {
       const result = validateLabelNameBasic("Work+Items");
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("+");
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
-    it("should reject labels with backtick", () => {
+    it("should accept labels with backtick", () => {
       const result = validateLabelNameBasic("Work`Items");
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("`");
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
   });
 });
@@ -112,6 +115,9 @@ describe("validateGmailLabelName", () => {
         "2024 Taxes",
         "Follow Up",
         "* Marketing",
+        "Work+Items",
+        "Work\\Items",
+        "Work`Items",
         "CATEGORY_PERSONAL",
       ];
 

--- a/apps/web/utils/gmail/label-validation.ts
+++ b/apps/web/utils/gmail/label-validation.ts
@@ -6,8 +6,7 @@
  *
  * Sources:
  * - https://developers.google.com/workspace/gmail/api/guides/labels
- * - Observed errors in production (e.g., VOICEMAIL)
- * - Code analysis (e.g., CHAT labels filtered in report.ts)
+ * - Observed errors in production (e.g., reserved system labels)
  */
 
 /**
@@ -46,18 +45,6 @@ const GMAIL_RESERVED_LABELS = [
   "VOICEMAIL",
   "SCHEDULED",
   "MUTED",
-] as const;
-
-/**
- * Invalid characters that cannot be used in Gmail label names
- *
- * Note: Forward slash (/) is NOT included here because it's used to create
- * nested labels (e.g., "Inbox Zero/Archived")
- */
-const GMAIL_LABEL_INVALID_CHARS = [
-  "\\", // Backslash
-  "+", // Plus sign
-  "`", // Backtick
 ] as const;
 
 /**
@@ -105,16 +92,6 @@ export function validateLabelNameBasic(name: string): LabelValidationResult {
   // Check for double spaces
   if (name.includes("  ")) {
     return { valid: false, error: "Label name cannot contain double spaces" };
-  }
-
-  // Check for invalid characters
-  for (const char of GMAIL_LABEL_INVALID_CHARS) {
-    if (name.includes(char)) {
-      return {
-        valid: false,
-        error: `Label name cannot contain the character: ${char}`,
-      };
-    }
   }
 
   return { valid: true };

--- a/apps/web/utils/gmail/label-validation.ts
+++ b/apps/web/utils/gmail/label-validation.ts
@@ -56,7 +56,6 @@ const GMAIL_RESERVED_LABELS = [
  */
 const GMAIL_LABEL_INVALID_CHARS = [
   "\\", // Backslash
-  "*", // Asterisk
   "+", // Plus sign
   "`", // Backtick
 ] as const;
@@ -82,7 +81,7 @@ type LabelValidationResult = {
  */
 export function validateLabelNameBasic(name: string): LabelValidationResult {
   // Check if empty
-  if (!name || !name.trim()) {
+  if (!name?.trim()) {
     return { valid: false, error: "Label name cannot be empty" };
   }
 


### PR DESCRIPTION
# User description
This relaxes Gmail label validation so existing labels with supported special characters can still be saved and edited.

It also updates the related validation tests and clarifies the multi-rule setting copy.
A small matcher test mock was aligned with the current AI response shape.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Relax Gmail label validation so <code>validateLabelNameBasic</code> allows labels with legacy special characters and the tests cover these cases while keeping reserved label checks intact. Update <code>MultiRuleSetting</code>'s title rendering with <code>TooltipExplanation</code> and adjust the matcher test mock to match the current AI response shape.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2232?tool=ast&topic=Multi-rule+tooltip>Multi-rule tooltip</a>
        </td><td>Enhance <code>MultiRuleSetting</code> by embedding a <code>TooltipExplanation</code> into its title, adapt <code>SettingCard</code> to accept node-based titles, and align <code>match-rules.test.ts</code>’s mock shape with the AI response format that the UI now describes.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/settings/MultiRuleSetting.tsx</li>
<li>apps/web/components/SettingCard.tsx</li>
<li>apps/web/utils/ai/choose-rule/match-rules.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rules: fix label valid...</td><td>April 13, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Refactor getMessage to...</td><td>July 28, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2232?tool=ast&topic=Label+validation>Label validation</a>
        </td><td>Allow <code>validateLabelNameBasic</code> to accept Gmail labels containing special characters such as <code>\</code>, <code>*</code>, <code>+</code>, and <code></code> <code> </code><code>, remove the restrictive invalid-char guard, and refresh </code>label-validation.test.ts` expectations accordingly while preserving the reserved-label and length checks.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/gmail/label-validation.test.ts</li>
<li>apps/web/utils/gmail/label-validation.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rules: fix label valid...</td><td>April 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2232?tool=ast>(Baz)</a>.