### PR TITLE
fix: align compose env loading

### DIFF
--- a/docs/hosting/quick-start.mdx
+++ b/docs/hosting/quick-start.mdx
@@ -21,7 +21,7 @@ The CLI will walk you through configuring [Google OAuth](/hosting/google-oauth) 
 <Info>
   **CLI is optional:** The setup command is a convenience wrapper that helps prepare your `.env` and run Docker Compose with sensible defaults.
 
-  Prefer manual setup? Clone the repo, copy `apps/web/.env.example` to `apps/web/.env`, and run the Docker/Node commands that match your environment.
+  Prefer manual setup? Clone the repo, copy `apps/web/.env.example` to `apps/web/.env`, then link it for Compose once with `ln -sf apps/web/.env .env`, and run the Docker/Node commands that match your environment.
 </Info>
 
 ## Install Options

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -87,7 +87,7 @@ NEXT_PUBLIC_BASE_URL=https://yourdomain.com docker compose --profile all up -d
 
 The pre-built Docker image is hosted at `ghcr.io/elie222/inbox-zero:latest` and will be automatically pulled.
 
-**Important**: `docker compose` reads `NEXT_PUBLIC_BASE_URL` from your shell environment or from a root `.env` file next to `docker-compose.yml`. Setting it only in `apps/web/.env` will not work because Compose resolves that override before the container loads `apps/web/.env`. If you use a custom port, set `WEB_PORT` the same way.
+**Important**: Compose-time `${...}` values are resolved before service-level `env_file` entries are loaded. If you're running from a cloned repo, make sure Compose can see the same values as the app by linking or copying `apps/web/.env` to the repo root as `.env`. The CLI setup does this automatically. For manual setup, run `ln -sf apps/web/.env .env` once before `docker compose up`.
 
 #### Using External Database Services (Optional)
 

--- a/docs/hosting/troubleshooting.mdx
+++ b/docs/hosting/troubleshooting.mdx
@@ -32,6 +32,8 @@ Check logs for errors using the commands above.
   - Solution: Increase VPS RAM or add swap space
 - **Missing environment variables**: Check `.env` file exists and has required values
   - Solution: Run `inbox-zero setup` again
+- **Slow page loads with `validate-email-account` or `Unable to parse response body` Redis warnings**: `docker compose` may have started `serverless-redis-http` without the token from `apps/web/.env`
+  - Solution: make sure repo-root `.env` matches `apps/web/.env` before starting Docker, for example: `ln -sf apps/web/.env .env`
 
 ## Database Connection Errors
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { basename, resolve } from "node:path";
+import { basename, relative, resolve } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { program } from "commander";
 import * as p from "@clack/prompts";
@@ -55,6 +62,22 @@ const STANDALONE_COMPOSE_FILE = resolve(
 function ensureConfigDir(configDir: string) {
   if (!existsSync(configDir)) {
     mkdirSync(configDir, { recursive: true });
+  }
+}
+
+function ensureRepoComposeEnvLink(envFile: string) {
+  if (!REPO_ROOT) return;
+  if (basename(envFile) !== ".env") return;
+
+  const rootEnvFile = resolve(REPO_ROOT, ".env");
+  if (existsSync(rootEnvFile)) return;
+
+  const linkTarget = relative(REPO_ROOT, envFile);
+
+  try {
+    symlinkSync(linkTarget, rootEnvFile);
+  } catch {
+    copyFileSync(envFile, rootEnvFile);
   }
 }
 
@@ -666,6 +689,7 @@ async function runSetupQuick(options: { name?: string }) {
     template,
   });
   writeFileSync(envFile, envContent);
+  ensureRepoComposeEnvLink(envFile);
 
   spinner.stop("Configuration ready");
 
@@ -1200,6 +1224,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
     template,
   });
   writeFileSync(envFile, envContent);
+  ensureRepoComposeEnvLink(envFile);
 
   spinner.stop(".env file created");
 
@@ -1236,8 +1261,10 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
 
   // For standalone installs, include -f flag to point to the compose file
   const composeCmd = REPO_ROOT
-    ? "docker compose"
-    : `docker compose -f ${composeFile}`;
+    ? envFileName === ".env"
+      ? "docker compose"
+      : `docker compose --env-file apps/web/${envFileName}`
+    : `docker compose --env-file ${envFile} -f ${composeFile}`;
 
   if (runWebInDocker) {
     // Web app runs in Docker with database & Redis

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,15 +1,8 @@
 #!/usr/bin/env node
 
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, relative, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { program } from "commander";
 import * as p from "@clack/prompts";
@@ -19,6 +12,7 @@ import {
   isSensitiveKey,
   parseEnvFile,
   parsePortConflict,
+  syncManagedComposeEnv,
   updateEnvValue,
   redactValue,
   type EnvConfig,
@@ -62,22 +56,6 @@ const STANDALONE_COMPOSE_FILE = resolve(
 function ensureConfigDir(configDir: string) {
   if (!existsSync(configDir)) {
     mkdirSync(configDir, { recursive: true });
-  }
-}
-
-function ensureRepoComposeEnvLink(envFile: string) {
-  if (!REPO_ROOT) return;
-  if (basename(envFile) !== ".env") return;
-
-  const rootEnvFile = resolve(REPO_ROOT, ".env");
-  if (existsSync(rootEnvFile)) return;
-
-  const linkTarget = relative(REPO_ROOT, envFile);
-
-  try {
-    symlinkSync(linkTarget, rootEnvFile);
-  } catch {
-    copyFileSync(envFile, rootEnvFile);
   }
 }
 
@@ -689,7 +667,7 @@ async function runSetupQuick(options: { name?: string }) {
     template,
   });
   writeFileSync(envFile, envContent);
-  ensureRepoComposeEnvLink(envFile);
+  syncManagedComposeEnv({ envFile, repoRoot: REPO_ROOT });
 
   spinner.stop("Configuration ready");
 
@@ -1224,7 +1202,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
     template,
   });
   writeFileSync(envFile, envContent);
-  ensureRepoComposeEnvLink(envFile);
+  syncManagedComposeEnv({ envFile, repoRoot: REPO_ROOT });
 
   spinner.stop(".env file created");
 
@@ -1263,7 +1241,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
   const composeCmd = REPO_ROOT
     ? envFileName === ".env"
       ? "docker compose"
-      : `docker compose --env-file apps/web/${envFileName}`
+      : `docker compose --env-file ${envFile}`
     : `docker compose --env-file ${envFile} -f ${composeFile}`;
 
   if (runWebInDocker) {
@@ -1703,6 +1681,7 @@ async function runConfigInteractive(name?: string) {
 
   const updated = updateEnvValue(content, keyToUpdate, newValue);
   writeFileSync(envFile, updated);
+  syncManagedComposeEnv({ envFile, repoRoot: REPO_ROOT });
 
   p.log.success(`Updated ${keyToUpdate}`);
   p.note(
@@ -1727,6 +1706,7 @@ async function runConfigSet(key: string, value: string, name?: string) {
   const { envFile, content } = requireEnvFile(name);
   const updated = updateEnvValue(content, key, value);
   writeFileSync(envFile, updated);
+  syncManagedComposeEnv({ envFile, repoRoot: REPO_ROOT });
   p.log.success(`Set ${key}`);
 }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -694,7 +694,11 @@ async function runSetupQuick(options: { name?: string }) {
   }
 
   // Check if already running
-  const composeArgs = REPO_ROOT ? ["compose"] : ["compose", "-f", composeFile];
+  const composeArgs = REPO_ROOT
+    ? envFileName === ".env"
+      ? ["compose"]
+      : ["compose", "--env-file", envFile]
+    : ["compose", "--env-file", envFile, "-f", composeFile];
 
   if (checkContainersRunning(composeArgs)) {
     const restart = await p.confirm({
@@ -1241,8 +1245,8 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
   const composeCmd = REPO_ROOT
     ? envFileName === ".env"
       ? "docker compose"
-      : `docker compose --env-file ${envFile}`
-    : `docker compose --env-file ${envFile} -f ${composeFile}`;
+      : `docker compose --env-file "${envFile}"`
+    : `docker compose --env-file "${envFile}" -f "${composeFile}"`;
 
   if (runWebInDocker) {
     // Web app runs in Docker with database & Redis

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   generateSecret,
@@ -5,6 +8,7 @@ import {
   isSensitiveKey,
   parseEnvFile,
   parsePortConflict,
+  syncManagedComposeEnv,
   updateEnvValue,
   redactValue,
   type EnvConfig,
@@ -628,5 +632,68 @@ describe("parsePortConflict", () => {
     expect(parsePortConflict("image not found")).toBeNull();
     expect(parsePortConflict("network timeout")).toBeNull();
     expect(parsePortConflict("")).toBeNull();
+  });
+});
+
+describe("syncManagedComposeEnv", () => {
+  it("creates a managed root env for the default repo config", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const appEnv = join(appDir, ".env");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(appEnv, "FOO=bar\n");
+
+    syncManagedComposeEnv({ envFile: appEnv, repoRoot });
+
+    expect(readFileSync(join(repoRoot, ".env"), "utf-8")).toBe("FOO=bar\n");
+    expect(
+      readFileSync(join(repoRoot, ".env.inbox-zero-managed"), "utf-8"),
+    ).toBe("apps/web/.env");
+  });
+
+  it("refreshes a managed copied root env after later updates", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const appEnv = join(appDir, ".env");
+    const rootEnv = join(repoRoot, ".env");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(appEnv, "FOO=one\n");
+    writeFileSync(rootEnv, "FOO=one\n");
+    writeFileSync(join(repoRoot, ".env.inbox-zero-managed"), "apps/web/.env");
+    writeFileSync(appEnv, "FOO=two\n");
+
+    syncManagedComposeEnv({ envFile: appEnv, repoRoot });
+
+    expect(readFileSync(rootEnv, "utf-8")).toBe("FOO=two\n");
+  });
+
+  it("does not overwrite an unmanaged root env file", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const appEnv = join(appDir, ".env");
+    const rootEnv = join(repoRoot, ".env");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(appEnv, "FOO=managed\n");
+    writeFileSync(rootEnv, "FOO=manual\n");
+
+    syncManagedComposeEnv({ envFile: appEnv, repoRoot });
+
+    expect(readFileSync(rootEnv, "utf-8")).toBe("FOO=manual\n");
+  });
+
+  it("skips named env files because they use explicit compose env-file flags", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const namedEnv = join(appDir, ".env.staging");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(namedEnv, "FOO=bar\n");
+
+    syncManagedComposeEnv({ envFile: namedEnv, repoRoot });
+
+    expect(() => readFileSync(join(repoRoot, ".env"), "utf-8")).toThrow();
   });
 });

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect } from "vitest";
@@ -682,6 +688,39 @@ describe("syncManagedComposeEnv", () => {
     syncManagedComposeEnv({ envFile: appEnv, repoRoot });
 
     expect(readFileSync(rootEnv, "utf-8")).toBe("FOO=manual\n");
+  });
+
+  it("does not overwrite an unmanaged root env symlink", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const appEnv = join(appDir, ".env");
+    const manualEnv = join(repoRoot, ".env.manual");
+    const rootEnv = join(repoRoot, ".env");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(appEnv, "FOO=managed\n");
+    writeFileSync(manualEnv, "FOO=manual\n");
+    symlinkSync(".env.manual", rootEnv);
+
+    syncManagedComposeEnv({ envFile: appEnv, repoRoot });
+
+    expect(readFileSync(rootEnv, "utf-8")).toBe("FOO=manual\n");
+  });
+
+  it("relinks a managed root env symlink when it points to the wrong target", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "inbox-zero-cli-"));
+    const appDir = join(repoRoot, "apps", "web");
+    const appEnv = join(appDir, ".env");
+    const rootEnv = join(repoRoot, ".env");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(appEnv, "FOO=managed\n");
+    writeFileSync(join(repoRoot, ".env.inbox-zero-managed"), "apps/web/.env");
+    symlinkSync(".env.previous", rootEnv);
+
+    syncManagedComposeEnv({ envFile: appEnv, repoRoot });
+
+    expect(readFileSync(rootEnv, "utf-8")).toBe("FOO=managed\n");
   });
 
   it("skips named env files because they use explicit compose env-file flags", () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,15 @@
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { randomBytes } from "node:crypto";
+import { basename, relative, resolve } from "node:path";
 
 // Environment variable builder
 export type EnvConfig = Record<string, string | undefined>;
@@ -262,4 +273,79 @@ export function parsePortConflict(stderr: string): string | null {
   }
 
   return null;
+}
+
+const MANAGED_COMPOSE_ENV_MARKER_SUFFIX = ".inbox-zero-managed";
+
+export function syncManagedComposeEnv({
+  envFile,
+  repoRoot,
+}: {
+  envFile: string;
+  repoRoot: string | null;
+}) {
+  if (!repoRoot) return;
+  if (basename(envFile) !== ".env") return;
+
+  const rootEnvFile = resolve(repoRoot, ".env");
+  const markerFile = `${rootEnvFile}${MANAGED_COMPOSE_ENV_MARKER_SUFFIX}`;
+  const linkTarget = relative(repoRoot, envFile);
+  const sourceContent = readFileSync(envFile, "utf-8");
+
+  if (!existsSync(rootEnvFile)) {
+    createManagedComposeEnv({
+      linkTarget,
+      markerFile,
+      rootEnvFile,
+      sourceContent,
+    });
+    return;
+  }
+
+  const rootEnvStat = lstatSync(rootEnvFile);
+  if (rootEnvStat.isSymbolicLink()) {
+    const currentTarget = readlinkSync(rootEnvFile);
+    if (currentTarget !== linkTarget) {
+      rmSync(rootEnvFile, { force: true });
+      symlinkSync(linkTarget, rootEnvFile);
+    }
+    writeFileSync(markerFile, linkTarget);
+    return;
+  }
+
+  const isManaged = existsSync(markerFile);
+  if (!isManaged) {
+    const currentContent = readFileSync(rootEnvFile, "utf-8");
+    if (currentContent !== sourceContent) return;
+
+    writeFileSync(markerFile, linkTarget);
+    return;
+  }
+
+  const currentContent = readFileSync(rootEnvFile, "utf-8");
+  if (currentContent !== sourceContent) {
+    copyFileSync(envFile, rootEnvFile);
+  }
+
+  writeFileSync(markerFile, linkTarget);
+}
+
+function createManagedComposeEnv({
+  linkTarget,
+  markerFile,
+  rootEnvFile,
+  sourceContent,
+}: {
+  linkTarget: string;
+  markerFile: string;
+  rootEnvFile: string;
+  sourceContent: string;
+}) {
+  try {
+    symlinkSync(linkTarget, rootEnvFile);
+  } catch {
+    writeFileSync(rootEnvFile, sourceContent);
+  }
+
+  writeFileSync(markerFile, linkTarget);
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -303,17 +303,28 @@ export function syncManagedComposeEnv({
   }
 
   const rootEnvStat = lstatSync(rootEnvFile);
+  const isManaged = existsSync(markerFile);
   if (rootEnvStat.isSymbolicLink()) {
     const currentTarget = readlinkSync(rootEnvFile);
     if (currentTarget !== linkTarget) {
+      if (!isManaged) return;
+
       rmSync(rootEnvFile, { force: true });
-      symlinkSync(linkTarget, rootEnvFile);
+      createManagedComposeEnv({
+        linkTarget,
+        markerFile,
+        rootEnvFile,
+        sourceContent,
+      });
+      return;
     }
-    writeFileSync(markerFile, linkTarget);
+
+    if (isManaged) {
+      writeFileSync(markerFile, linkTarget);
+    }
     return;
   }
 
-  const isManaged = existsSync(markerFile);
   if (!isManaged) {
     const currentContent = readFileSync(rootEnvFile, "utf-8");
     if (currentContent !== sourceContent) return;


### PR DESCRIPTION
This original proposal aligns self-hosted Docker Compose interpolation with the app's environment file by managing a repo-root `.env` link/copy and adding explicit env-file flags for named setups.

Updated implementation: #3659. The replacement is based on current main and fixes dangling-symlink ownership, named container env selection, and command quoting, with expanded regression and Compose configuration validation. Please review the replacement PR for the current implementation.
