### PR TITLE
Improve mobile sign-in logging

### DIFF
--- a/apps/web/app/api/mobile-review/sign-in/route.test.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.test.ts
@@ -62,6 +62,7 @@ describe("mobile review sign-in route", () => {
 
     expect(createMobileReviewSessionMock).toHaveBeenCalledWith({
       code: "review-code",
+      logger: request.logger,
     });
     expect(body).toEqual({ success: true });
     expect(body.setCookie).toBeUndefined();

--- a/apps/web/app/api/mobile-review/sign-in/route.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.ts
@@ -15,6 +15,7 @@ export const POST = withError("mobile-review/sign-in", async (request) => {
   });
 
   request.logger.info("Created mobile review session", {
+    reviewUserEmail: result.userEmail,
     reviewUserId: result.userId,
     reviewEmailAccountId: result.emailAccountId,
   });

--- a/apps/web/app/api/mobile-review/sign-in/route.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.ts
@@ -11,10 +11,10 @@ export const POST = withError("mobile-review/sign-in", async (request) => {
   const body = signInSchema.parse(await request.json());
   const result = await createMobileReviewSession({
     code: body.code,
+    logger: request.logger,
   });
 
   request.logger.info("Created mobile review session", {
-    reviewUserEmail: result.userEmail,
     reviewUserId: result.userId,
     reviewEmailAccountId: result.emailAccountId,
   });

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -1,8 +1,8 @@
 vi.mock("server-only", () => ({}));
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
 
 const { mockAuthContext, mockMakeSignature } = vi.hoisted(() => ({
   mockAuthContext: {
@@ -65,7 +65,7 @@ describe("createMobileReviewSession", () => {
 
   it("creates a signed Better Auth session cookie", async () => {
     const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createScopedLogger("mobile-review-test");
+    const logger = createTestLogger();
 
     const result = await createMobileReviewSession({
       code: "review-code",
@@ -104,7 +104,7 @@ describe("createMobileReviewSession", () => {
 
   it("logs a warning when the review code is invalid", async () => {
     const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createScopedLogger("mobile-review-test");
+    const logger = createTestLogger();
     const warnSpy = vi.spyOn(logger, "warn");
 
     await expect(
@@ -130,7 +130,7 @@ describe("createMobileReviewSession", () => {
     } as never);
 
     const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createScopedLogger("mobile-review-test");
+    const logger = createTestLogger();
     const warnSpy = vi.spyOn(logger, "warn");
 
     await expect(

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -2,6 +2,7 @@ vi.mock("server-only", () => ({}));
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
 
 const { mockAuthContext, mockMakeSignature } = vi.hoisted(() => ({
   mockAuthContext: {
@@ -64,9 +65,11 @@ describe("createMobileReviewSession", () => {
 
   it("creates a signed Better Auth session cookie", async () => {
     const { createMobileReviewSession } = await import("./mobile-review");
+    const logger = createScopedLogger("mobile-review-test");
 
     const result = await createMobileReviewSession({
       code: "review-code",
+      logger,
     });
 
     expect(mockAuthContext.internalAdapter.createSession).toHaveBeenCalledWith(
@@ -96,6 +99,52 @@ describe("createMobileReviewSession", () => {
       },
       userEmail: "demo@example.com",
       userId: "user-1",
+    });
+  });
+
+  it("logs a warning when the review code is invalid", async () => {
+    const { createMobileReviewSession } = await import("./mobile-review");
+    const logger = createScopedLogger("mobile-review-test");
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    await expect(
+      createMobileReviewSession({
+        code: "wrong-code",
+        logger,
+      }),
+    ).rejects.toMatchObject({
+      message: "Invalid review access code",
+      statusCode: 401,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("Mobile review sign-in rejected", {
+      reason: "invalid_review_demo_code",
+    });
+  });
+
+  it("logs a warning when the review user has no email account", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      email: "demo@example.com",
+      id: "user-1",
+      emailAccounts: [],
+    } as never);
+
+    const { createMobileReviewSession } = await import("./mobile-review");
+    const logger = createScopedLogger("mobile-review-test");
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    await expect(
+      createMobileReviewSession({
+        code: "review-code",
+        logger,
+      }),
+    ).rejects.toMatchObject({
+      message: "Review access is unavailable",
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("Mobile review sign-in unavailable", {
+      hasUser: true,
+      reason: "review_user_missing_email_account",
     });
   });
 });

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -3,6 +3,7 @@ import { makeSignature } from "better-auth/crypto";
 import { env } from "@/env";
 import { betterAuthConfig } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
+import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 
 export function isMobileReviewEnabled(): boolean {
@@ -13,8 +14,14 @@ export function isMobileReviewEnabled(): boolean {
   );
 }
 
-export async function createMobileReviewSession(input: { code: string }) {
-  if (!isMobileReviewEnabled()) {
+export async function createMobileReviewSession(input: {
+  code: string;
+  logger: Logger;
+}) {
+  if (!env.APP_REVIEW_DEMO_ENABLED) {
+    input.logger.warn("Mobile review sign-in unavailable", {
+      reason: "review_demo_disabled",
+    });
     throw new SafeError("Review access is unavailable");
   }
 
@@ -22,10 +29,18 @@ export async function createMobileReviewSession(input: { code: string }) {
   const reviewDemoEmail = env.APP_REVIEW_DEMO_EMAIL?.trim().toLowerCase();
 
   if (!reviewDemoCode || !reviewDemoEmail) {
+    input.logger.warn("Mobile review sign-in unavailable", {
+      hasReviewDemoCode: Boolean(reviewDemoCode),
+      hasReviewDemoEmail: Boolean(reviewDemoEmail),
+      reason: "review_demo_misconfigured",
+    });
     throw new SafeError("Review access is unavailable");
   }
 
   if (!codesMatch(input.code, reviewDemoCode)) {
+    input.logger.warn("Mobile review sign-in rejected", {
+      reason: "invalid_review_demo_code",
+    });
     throw new SafeError("Invalid review access code", 401);
   }
 
@@ -47,6 +62,10 @@ export async function createMobileReviewSession(input: { code: string }) {
   });
 
   if (!user?.emailAccounts.length) {
+    input.logger.warn("Mobile review sign-in unavailable", {
+      hasUser: Boolean(user),
+      reason: "review_user_missing_email_account",
+    });
     throw new SafeError("Review access is unavailable");
   }
 


### PR DESCRIPTION
# User description
Adds targeted logging around mobile sign-in failures and trims sensitive success logging.

- pass the request-scoped logger into mobile review session creation
- emit structured warning reasons for disabled, misconfigured, invalid-code, and missing-account failures
- add focused unit coverage for the new logging paths and session creation flow

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Pass <code>request.logger</code> through the mobile review sign-in route and use it inside <code>createMobileReviewSession</code> to emit structured warnings for disabled, misconfigured, invalid-code, and missing-account scenarios while keeping success logs minimal. Add focused unit tests that inject a test logger to cover the new logging paths and ensure the sign-in route forwards the scoped logger.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2235?tool=ast&topic=Logging+tests>Logging tests</a>
        </td><td>Add test coverage that injects the scoped logger into <code>createMobileReviewSession</code>, asserting warnings for invalid codes and missing email accounts while ensuring the route supplies the logger.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/mobile-review/sign-in/route.test.ts</li>
<li>apps/web/utils/mobile-review.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>mobile review: add inv...</td><td>April 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2235?tool=ast&topic=Session+logging>Session logging</a>
        </td><td>Add structured <code>logger</code> usage in <code>createMobileReviewSession</code> to warn when the demo flow is disabled, misconfigured, the code is wrong, or the user lacks an email account while keeping success logs minimal.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/mobile-review/sign-in/route.ts</li>
<li>apps/web/utils/mobile-review.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>mobile review: add inv...</td><td>April 06, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2235?tool=ast>(Baz)</a>.