### PR TITLE
fix: recover chat email confirmation lookup

### DIFF
--- a/apps/web/app/api/chat/confirm-email-action/route.test.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.test.ts
@@ -86,6 +86,7 @@ describe("confirm email action route", () => {
     await expect(response.json()).resolves.toEqual({ success: true });
     expect(mockConfirmAssistantEmailActionForAccount).toHaveBeenCalledWith({
       ...body,
+      waitForPersistence: true,
       emailAccountId: "email-account-1",
       logger: request.logger,
       provider: "google",

--- a/apps/web/app/api/chat/confirm-email-action/route.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.ts
@@ -35,6 +35,7 @@ export const POST = withEmailAccount(
       toolCallId: data.toolCallId,
       actionType: data.actionType,
       contentOverride: data.contentOverride,
+      waitForPersistence: true,
       emailAccountId,
       provider: user.account.provider,
       logger: request.logger,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -361,7 +361,6 @@ async function saveChatMessages(
     logger.info("Persisted chat messages", {
       chatId,
       insertedCount: result.count,
-      assistantMessageIds: assistantMessages.map((message) => message.id),
     });
 
     return result;

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -339,10 +339,32 @@ async function saveChatMessages(
   logger: Logger,
 ) {
   try {
-    return prisma.chatMessage.createMany({
-      data: mapUiMessagesToChatMessageRows(messages, chatId),
+    const rows = mapUiMessagesToChatMessageRows(messages, chatId);
+    const assistantMessages = messages.filter(
+      (message) => message.role === "assistant",
+    );
+
+    logger.info("Persisting chat messages", {
+      chatId,
+      messageCount: messages.length,
+      assistantMessageIds: assistantMessages.map((message) => message.id),
+      assistantToolCallIds: assistantMessages.flatMap((message) =>
+        getToolCallIdsFromUiParts(message.parts),
+      ),
+    });
+
+    const result = await prisma.chatMessage.createMany({
+      data: rows,
       skipDuplicates: true,
     });
+
+    logger.info("Persisted chat messages", {
+      chatId,
+      insertedCount: result.count,
+      assistantMessageIds: assistantMessages.map((message) => message.id),
+    });
+
+    return result;
   } catch (error) {
     logger.error("Failed to save chat messages", { error, chatId });
     captureException(error, { extra: { chatId } });
@@ -379,4 +401,11 @@ function hasRenderableAssistantResponse(
     if (part.type !== "text") return true;
     return part.text.trim().length > 0;
   });
+}
+
+function getToolCallIdsFromUiParts(parts: UIMessage["parts"] | undefined) {
+  return (
+    parts?.flatMap((part) => ("toolCallId" in part ? [part.toolCallId] : [])) ||
+    []
+  );
 }

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -48,6 +48,7 @@ export function Chat({ open }: { open: boolean }) {
     chat,
     chatId,
     input,
+    persistedMessageIds,
     setInput,
     handleSubmit,
     setNewChat,
@@ -275,6 +276,7 @@ export function Chat({ open }: { open: boolean }) {
         <ChatMessagesView
           status={status}
           messages={messages}
+          persistedMessageIds={persistedMessageIds}
           setMessages={setMessages}
           setInput={setInput}
           regenerate={regenerate}
@@ -302,6 +304,7 @@ export function Chat({ open }: { open: boolean }) {
 function ChatMessagesView({
   status,
   messages,
+  persistedMessageIds,
   setMessages,
   setInput,
   regenerate,
@@ -311,6 +314,7 @@ function ChatMessagesView({
 }: {
   status: UseChatHelpers<ChatMessage>["status"];
   messages: ChatMessage[];
+  persistedMessageIds: Set<string>;
   setMessages: UseChatHelpers<ChatMessage>["setMessages"];
   setInput: (input: string) => void;
   regenerate: UseChatHelpers<ChatMessage>["regenerate"];
@@ -324,6 +328,7 @@ function ChatMessagesView({
       <Messages
         status={status}
         messages={messages}
+        persistedMessageIds={persistedMessageIds}
         setMessages={setMessages}
         setInput={setInput}
         regenerate={regenerate}

--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -34,6 +34,7 @@ import { requiresThreadIds } from "@/utils/ai/assistant/manage-inbox-actions";
 interface MessagePartProps {
   disableConfirm: boolean;
   hideInlineEmailCards: boolean;
+  isPersistedMessage: boolean;
   isStreaming: boolean;
   messageId: string;
   part: ChatMessage["parts"][0];
@@ -61,6 +62,7 @@ export function MessagePart({
   isStreaming,
   disableConfirm,
   hideInlineEmailCards,
+  isPersistedMessage,
   messageId,
   partIndex,
   threadLookup,
@@ -251,6 +253,7 @@ export function MessagePart({
     return renderPendingEmailAction({
       part,
       disableConfirm,
+      isPersistedMessage,
       messageId,
       preparingText: "Preparing email...",
       ResultComponent: SendEmailResult,
@@ -261,6 +264,7 @@ export function MessagePart({
     return renderPendingEmailAction({
       part,
       disableConfirm,
+      isPersistedMessage,
       messageId,
       preparingText: "Preparing reply...",
       ResultComponent: ReplyEmailResult,
@@ -271,6 +275,7 @@ export function MessagePart({
     return renderPendingEmailAction({
       part,
       disableConfirm,
+      isPersistedMessage,
       messageId,
       preparingText: "Preparing forward...",
       ResultComponent: ForwardEmailResult,
@@ -328,7 +333,7 @@ export function MessagePart({
             output={output}
             chatMessageId={messageId}
             toolCallId={toolCallId}
-            disableConfirm={disableConfirm}
+            disableConfirm={disableConfirm || !isPersistedMessage}
           />
         );
       }
@@ -499,7 +504,7 @@ export function MessagePart({
             output={output}
             chatMessageId={messageId}
             toolCallId={toolCallId}
-            disableConfirm={disableConfirm}
+            disableConfirm={disableConfirm || !isPersistedMessage}
           />
         );
       }
@@ -603,6 +608,7 @@ function renderToolStatus({
 function renderPendingEmailAction({
   part,
   disableConfirm,
+  isPersistedMessage,
   messageId,
   preparingText,
   ResultComponent,
@@ -613,6 +619,7 @@ function renderPendingEmailAction({
     output?: unknown;
   };
   disableConfirm: boolean;
+  isPersistedMessage: boolean;
   messageId: string;
   preparingText: string;
   ResultComponent: (props: {
@@ -639,7 +646,7 @@ function renderPendingEmailAction({
         output={part.output}
         chatMessageId={messageId}
         toolCallId={toolCallId}
-        disableConfirm={disableConfirm}
+        disableConfirm={disableConfirm || !isPersistedMessage}
       />
     );
   }

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -15,12 +15,12 @@ import {
 } from "@/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Loader } from "@/components/ai-elements/loader";
-import { useChat } from "@/providers/ChatProvider";
 
 interface MessagesProps {
   footer?: ReactNode;
   isArtifactVisible: boolean;
   messages: Array<ChatMessage>;
+  persistedMessageIds: Set<string>;
   regenerate: UseChatHelpers<ChatMessage>["regenerate"];
   setInput: (input: string) => void;
   setMessages: UseChatHelpers<ChatMessage>["setMessages"];
@@ -30,10 +30,10 @@ interface MessagesProps {
 export function Messages({
   status,
   messages,
+  persistedMessageIds,
   setInput,
   footer,
 }: MessagesProps) {
-  const { persistedMessageIds } = useChat();
   const disableConfirm = status === "streaming" || status === "submitted";
   const emailLookup = useMemo(() => buildEmailLookup(messages), [messages]);
   const firstAssistantIndex = useMemo(

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ai-elements/conversation";
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Loader } from "@/components/ai-elements/loader";
+import { useChat } from "@/providers/ChatProvider";
 
 interface MessagesProps {
   footer?: ReactNode;
@@ -32,6 +33,7 @@ export function Messages({
   setInput,
   footer,
 }: MessagesProps) {
+  const { persistedMessageIds } = useChat();
   const disableConfirm = status === "streaming" || status === "submitted";
   const emailLookup = useMemo(() => buildEmailLookup(messages), [messages]);
   const firstAssistantIndex = useMemo(
@@ -66,6 +68,9 @@ export function Messages({
                           }
                           disableConfirm={disableConfirm}
                           hideInlineEmailCards={hideInlineEmailCards}
+                          isPersistedMessage={persistedMessageIds.has(
+                            message.id,
+                          )}
                           messageId={message.id}
                           partIndex={partIndex}
                           threadLookup={emailLookup}

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -455,7 +455,7 @@ function EmailActionResult({
   disableConfirm: boolean;
 }) {
   const { emailAccountId, provider, userEmail } = useAccount();
-  const { chatId } = useChat();
+  const { chatId, persistedMessageIds } = useChat();
   const [isConfirming, setIsConfirming] = useState(false);
   const [confirmationResultOverride, setConfirmationResultOverride] =
     useState<EmailConfirmationResult | null>(null);
@@ -481,6 +481,7 @@ function EmailActionResult({
     confirmationResultOverride || parsedConfirmationResult;
   const isProcessing = confirmationState === "processing";
   const isChatBusy = disableConfirm;
+  const isPersistedMessage = persistedMessageIds.has(chatMessageId);
   const isConfirmed =
     confirmationState === "confirmed" ||
     Boolean(confirmationResult) ||
@@ -543,7 +544,6 @@ function EmailActionResult({
       const hasEdits = editedBody && editedBody !== body;
       const input = {
         chatId,
-        chatMessageId,
         toolCallId,
         actionType,
         ...(hasEdits ? { contentOverride: editedBody } : {}),
@@ -710,6 +710,8 @@ function EmailActionResult({
                   <Loader2 className="size-4 animate-spin" />
                   Sending...
                 </>
+              ) : !isPersistedMessage ? (
+                "Saving..."
               ) : (
                 <>
                   <SendIcon className="hidden size-3.5 sm:inline" />

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -1410,10 +1410,6 @@ function LearnedPatternsActions({ ruleId }: { ruleId: string }) {
   );
 }
 
-function _ToolCard({ children }: { children: React.ReactNode }) {
-  return <Card className="space-y-3 p-4">{children}</Card>;
-}
-
 function RuleToolCardHeader({
   title,
   actions,

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -549,14 +549,7 @@ function EmailActionResult({
         ...(hasEdits ? { contentOverride: editedBody } : {}),
       };
 
-      let result = await confirmAssistantEmailAction(emailAccountId, input);
-
-      // Message may not be persisted yet if clicked right after
-      // streaming finished. Retry once after a short wait.
-      if (result?.serverError === "Chat message not found") {
-        await new Promise((r) => setTimeout(r, 2000));
-        result = await confirmAssistantEmailAction(emailAccountId, input);
-      }
+      const result = await confirmAssistantEmailAction(emailAccountId, input);
 
       if (result?.serverError) {
         toastError({ description: result.serverError });
@@ -1415,7 +1408,7 @@ function LearnedPatternsActions({ ruleId }: { ruleId: string }) {
   );
 }
 
-function ToolCard({ children }: { children: React.ReactNode }) {
+function _ToolCard({ children }: { children: React.ReactNode }) {
   return <Card className="space-y-3 p-4">{children}</Card>;
 }
 

--- a/apps/web/providers/ChatProvider.tsx
+++ b/apps/web/providers/ChatProvider.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -39,6 +40,7 @@ type ChatContextType = {
   chat: Chat;
   input: string;
   chatId: string | null;
+  persistedMessageIds: Set<string>;
   setInput: (input: string) => void;
   setChatId: (chatId: string | null) => void;
   setNewChat: () => void;
@@ -65,6 +67,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const previousChatIdRef = useRef(chatId);
 
   const { data } = useChatMessages(chatId);
+  const persistedMessageIds = useMemo(
+    () => new Set(data?.messages.map((message) => message.id) ?? []),
+    [data?.messages],
+  );
 
   const setNewChat = useCallback(() => {
     setChatId(generateUUID());
@@ -101,9 +107,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     // messages: initialMessages, // NOTE: couldn't get this to work
     experimental_throttle: 100,
     generateId: generateUUID,
-    onFinish: () => {
+    onFinish: async () => {
       pendingInlineActionsRef.current = null;
-      mutate("/api/user/rules");
+      await Promise.all([
+        mutate("/api/user/rules"),
+        chatId ? mutate(`/api/chats/${chatId}`) : Promise.resolve(),
+      ]);
     },
     onError: (error) => {
       const pendingInlineActions = pendingInlineActionsRef.current;
@@ -178,6 +187,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         chat,
         chatId,
         input,
+        persistedMessageIds,
         setInput,
         setChatId,
         setNewChat,

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -794,6 +794,130 @@ describe("confirmAssistantEmailAction", () => {
     expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for pending email persistence in the web confirmation action", async () => {
+    vi.useFakeTimers();
+
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingSendPart()],
+        },
+      ] as any);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildProcessingSendPart()],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const resultPromise = confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        toolCallId: "tool-1",
+        actionType: "send_email",
+      } as any,
+    );
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits when the reservation race fallback re-reads the pending action", async () => {
+    vi.useFakeTimers();
+
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce({
+        id: "chat-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [buildPendingSendPart()],
+      } as any)
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({
+        id: "chat-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:01.000Z"),
+        parts: [
+          {
+            ...buildPendingSendPart(),
+            output: {
+              ...buildPendingSendPart().output,
+              confirmationState: "confirmed",
+              confirmationResult: {
+                actionType: "send_email",
+                messageId: "msg-1",
+                threadId: "thr-1",
+                to: "recipient@example.com",
+                subject: "Hello",
+                confirmedAt: "2026-02-23T00:00:01.000Z",
+              },
+            },
+          },
+        ],
+      } as any);
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 0 } as any);
+
+    const resultPromise = confirmAssistantEmailActionForAccount({
+      chatId: "chat-1",
+      chatMessageId: "chat-message-1",
+      toolCallId: "tool-1",
+      actionType: "send_email",
+      waitForPersistence: true,
+      emailAccountId: "ea_1",
+      provider: "google",
+      logger: createScopedLogger("test/assistant-email-confirmation"),
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.confirmationState).toBe("confirmed");
+    expect(result.confirmationResult).toMatchObject({
+      actionType: "send_email",
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    expect(prisma.chatMessage.findFirst).toHaveBeenCalledTimes(4);
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(2);
+    expect(createEmailProvider).not.toHaveBeenCalled();
+  });
+
   it("returns not found when chat message id is stale and no fallback candidate matches", async () => {
     (prisma.emailAccount.findUnique as any).mockResolvedValue({
       email: "owner@example.com",

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -684,9 +684,7 @@ describe("confirmAssistantEmailAction", () => {
     );
   });
 
-  it("waits for pending action persistence before confirming", async () => {
-    vi.useFakeTimers();
-
+  it("confirms using tool lookup when chat message id is omitted", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
         email: "owner@example.com",
@@ -706,16 +704,14 @@ describe("confirmAssistantEmailAction", () => {
         updatedAt: new Date("2026-02-23T00:00:01.000Z"),
         parts: [buildProcessingSendPart()],
       } as any);
-    prisma.chatMessage.findMany
-      .mockResolvedValueOnce([] as any)
-      .mockResolvedValueOnce([
-        {
-          id: "assistant-message-1",
-          chatId: "chat-1",
-          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
-          parts: [buildPendingSendPart()],
-        },
-      ] as any);
+    prisma.chatMessage.findMany.mockResolvedValue([
+      {
+        id: "assistant-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [buildPendingSendPart()],
+      },
+    ] as any);
 
     prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
 
@@ -727,22 +723,17 @@ describe("confirmAssistantEmailAction", () => {
       sendEmailWithHtml,
     } as any);
 
-    const resultPromise = confirmAssistantEmailAction(
+    const result = await confirmAssistantEmailAction(
       "ea_1" as any,
       {
         chatId: "chat-1",
-        chatMessageId: "chat-message-1",
         toolCallId: "tool-1",
         actionType: "send_email",
       } as any,
     );
 
-    await vi.runAllTimersAsync();
-
-    const result = await resultPromise;
-
     expect(result?.data?.confirmationState).toBe("confirmed");
-    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(2);
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(1);
     expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -609,6 +609,82 @@ describe("confirmAssistantEmailAction", () => {
     );
   });
 
+  it("falls back when the provided chat message exists but does not contain the pending action", async () => {
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce({
+        id: "wrong-message-id",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+        parts: [{ type: "text", text: "Different assistant message" }],
+      } as any)
+      .mockResolvedValueOnce({
+        id: "assistant-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+        parts: [buildProcessingSendPart()],
+      } as any);
+    prisma.chatMessage.findMany.mockResolvedValue([
+      {
+        id: "assistant-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:01:00.000Z"),
+        parts: [buildPendingSendPart()],
+      },
+    ] as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const result = await confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "wrong-message-id",
+        toolCallId: "tool-1",
+        actionType: "send_email",
+      } as any,
+    );
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          role: "assistant",
+          chat: {
+            id: "chat-1",
+            emailAccountId: "ea_1",
+          },
+        }),
+        take: 50,
+      }),
+    );
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "assistant-message-1",
+        }),
+      }),
+    );
+  });
+
   it("returns not found when chat message id is stale and no fallback candidate matches", async () => {
     (prisma.emailAccount.findUnique as any).mockResolvedValue({
       email: "owner@example.com",

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -673,7 +673,6 @@ describe("confirmAssistantEmailAction", () => {
             emailAccountId: "ea_1",
           },
         }),
-        take: 50,
       }),
     );
     expect(prisma.chatMessage.updateMany).toHaveBeenCalledWith(
@@ -683,6 +682,68 @@ describe("confirmAssistantEmailAction", () => {
         }),
       }),
     );
+  });
+
+  it("waits for pending action persistence before confirming", async () => {
+    vi.useFakeTimers();
+
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findFirst
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({
+        id: "assistant-message-1",
+        chatId: "chat-1",
+        updatedAt: new Date("2026-02-23T00:00:01.000Z"),
+        parts: [buildProcessingSendPart()],
+      } as any);
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingSendPart()],
+        },
+      ] as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const resultPromise = confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "send_email",
+      } as any,
+    );
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(2);
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
   });
 
   it("returns not found when chat message id is stale and no fallback candidate matches", async () => {

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -3,8 +3,10 @@ import prisma from "@/utils/__mocks__/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import {
   confirmAssistantEmailAction,
+  confirmAssistantEmailActionForAccount,
   confirmAssistantSaveMemory,
 } from "@/utils/actions/assistant-chat";
+import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
@@ -734,6 +736,61 @@ describe("confirmAssistantEmailAction", () => {
 
     expect(result?.data?.confirmationState).toBe("confirmed");
     expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(1);
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for pending email persistence for direct confirmations", async () => {
+    vi.useFakeTimers();
+
+    (prisma.emailAccount.findUnique as any).mockResolvedValueOnce({
+      name: "Owner",
+      email: "owner@example.com",
+    });
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingSendPart()],
+        },
+      ] as any);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildProcessingSendPart()],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const resultPromise = confirmAssistantEmailActionForAccount({
+      chatId: "chat-1",
+      toolCallId: "tool-1",
+      actionType: "send_email",
+      waitForPersistence: true,
+      emailAccountId: "ea_1",
+      provider: "google",
+      logger: createScopedLogger("test/assistant-email-confirmation"),
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
     expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -88,6 +88,7 @@ export const confirmAssistantEmailAction = actionClient
         toolCallId,
         actionType,
         contentOverride,
+        waitForPersistence: true,
         emailAccountId,
         provider,
         logger,
@@ -939,6 +940,9 @@ async function reservePendingAssistantEmailAction({
 }) {
   const matchEmailParts = (parts: unknown) =>
     !!findPendingAssistantEmailPart({ parts, toolCallId, actionType });
+  const waitForPersistenceMs = waitForPersistence
+    ? PENDING_ACTION_PERSIST_WAIT_MS
+    : undefined;
 
   const chatMessage = await findChatMessageForPendingAction({
     chatId,
@@ -947,9 +951,7 @@ async function reservePendingAssistantEmailAction({
     logger,
     matchParts: matchEmailParts,
     logPrefix: "Assistant email confirmation",
-    waitForPersistenceMs: waitForPersistence
-      ? PENDING_ACTION_PERSIST_WAIT_MS
-      : undefined,
+    waitForPersistenceMs,
   });
 
   if (!chatMessage) {
@@ -1032,6 +1034,7 @@ async function reservePendingAssistantEmailAction({
     logger,
     matchParts: matchEmailParts,
     logPrefix: "Assistant email confirmation",
+    waitForPersistenceMs,
   });
 
   if (!latestMessage) {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -1763,7 +1763,7 @@ function warnAndThrowAssistantEmailConfirmationError({
   logger: Logger;
   logMessage: string;
   safeMessage: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
 }): never {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -36,8 +36,6 @@ const CONFIRMATION_IN_PROGRESS_ERROR =
 const SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR =
   "Memory save confirmation already in progress";
 const CONFIRMATION_PROCESSING_LEASE_MS = 5 * 60 * 1000;
-const PENDING_ACTION_LOOKUP_MAX_ATTEMPTS = 5;
-const PENDING_ACTION_LOOKUP_RETRY_MS = 500;
 const CONFIRMATION_PERSIST_MAX_ATTEMPTS = 3;
 const SENT_MESSAGE_RESOLVE_MAX_ATTEMPTS = 5;
 const SENT_MESSAGE_RESOLVE_RETRY_MS = 500;
@@ -711,109 +709,70 @@ async function findChatMessageForPendingAction({
   matchParts: (parts: unknown) => boolean;
   logPrefix: string;
 }) {
-  for (
-    let attempt = 1;
-    attempt <= PENDING_ACTION_LOOKUP_MAX_ATTEMPTS;
-    attempt++
-  ) {
-    const hintedChatMessage = chatMessageId
-      ? await prisma.chatMessage.findFirst({
-          where: {
-            id: chatMessageId,
-            chat: { id: chatId, emailAccountId },
-          },
-          select: {
-            id: true,
-            chatId: true,
-            updatedAt: true,
-            parts: true,
-          },
-        })
-      : null;
-
-    const hintedMatch =
-      hintedChatMessage && matchParts(hintedChatMessage.parts)
-        ? hintedChatMessage
-        : null;
-
-    if (hintedMatch) {
-      if (attempt > 1) {
-        logger.info(`${logPrefix} resolved pending action after waiting`, {
-          chatId,
-          requestedChatMessageId: chatMessageId,
-          resolvedChatMessageId: hintedMatch.id,
-          attempt,
-        });
-      }
-      return hintedMatch;
-    }
-
-    const assistantMessages =
-      (await prisma.chatMessage.findMany({
+  const hintedChatMessage = chatMessageId
+    ? await prisma.chatMessage.findFirst({
         where: {
-          role: "assistant",
+          id: chatMessageId,
           chat: { id: chatId, emailAccountId },
         },
-        orderBy: { updatedAt: "desc" },
         select: {
           id: true,
           chatId: true,
           updatedAt: true,
           parts: true,
         },
-      })) ?? [];
+      })
+    : null;
 
-    const matchingMessages = assistantMessages.filter((message) =>
-      matchParts(message.parts),
-    );
+  if (hintedChatMessage && matchParts(hintedChatMessage.parts)) {
+    return hintedChatMessage;
+  }
 
-    if (matchingMessages.length === 1) {
+  const assistantMessages =
+    (await prisma.chatMessage.findMany({
+      where: {
+        role: "assistant",
+        chat: { id: chatId, emailAccountId },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        chatId: true,
+        updatedAt: true,
+        parts: true,
+      },
+    })) ?? [];
+
+  const matchingMessages = assistantMessages.filter((message) =>
+    matchParts(message.parts),
+  );
+
+  if (matchingMessages.length === 1) {
+    if (chatMessageId && matchingMessages[0].id !== chatMessageId) {
       logger.warn(`${logPrefix} resolved pending action by tool lookup`, {
         chatId,
         requestedChatMessageId: chatMessageId,
         resolvedChatMessageId: matchingMessages[0].id,
-        attempt,
-      });
-      return matchingMessages[0];
-    }
-
-    if (matchingMessages.length > 1) {
-      logger.warn(`${logPrefix} found multiple pending action matches`, {
-        chatId,
-        requestedChatMessageId: chatMessageId,
-        matchedChatMessageIds: matchingMessages.map((message) => message.id),
-        attempt,
-      });
-      return matchingMessages[0];
-    }
-
-    if (attempt < PENDING_ACTION_LOOKUP_MAX_ATTEMPTS) {
-      logger.info(`${logPrefix} waiting for pending action persistence`, {
-        chatId,
-        requestedChatMessageId: chatMessageId,
-        attempt,
-        hintedMessageFound: Boolean(hintedChatMessage),
-        assistantMessageCount: assistantMessages.length,
-        recentAssistantToolCallIds: assistantMessages
-          .slice(0, 5)
-          .flatMap((message) => getToolCallIdsFromParts(message.parts)),
-      });
-      await wait(PENDING_ACTION_LOOKUP_RETRY_MS);
-    } else {
-      logger.warn(`${logPrefix} pending action not found`, {
-        chatId,
-        requestedChatMessageId: chatMessageId,
-        hintedMessageFound: Boolean(hintedChatMessage),
-        assistantMessageCount: assistantMessages.length,
-        recentAssistantMessageIds: assistantMessages
-          .slice(0, 5)
-          .map((message) => message.id),
-        recentAssistantToolCallIds: assistantMessages
-          .slice(0, 5)
-          .flatMap((message) => getToolCallIdsFromParts(message.parts)),
       });
     }
+    return matchingMessages[0];
   }
+
+  if (matchingMessages.length > 1) {
+    logger.warn(`${logPrefix} found multiple pending action matches`, {
+      chatId,
+      requestedChatMessageId: chatMessageId,
+      matchedChatMessageIds: matchingMessages.map((message) => message.id),
+    });
+    return matchingMessages[0];
+  }
+
+  logger.warn(`${logPrefix} pending action not found`, {
+    chatId,
+    requestedChatMessageId: chatMessageId,
+    hintedMessageFound: Boolean(hintedChatMessage),
+    assistantMessageCount: assistantMessages.length,
+  });
 
   return null;
 }
@@ -1808,15 +1767,6 @@ function getPendingActionContentPatch(
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function getToolCallIdsFromParts(parts: unknown): string[] {
-  if (!Array.isArray(parts)) return [];
-
-  return parts.flatMap((part) => {
-    if (!isRecord(part) || typeof part.toolCallId !== "string") return [];
-    return [part.toolCallId];
-  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -37,6 +37,8 @@ const SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR =
   "Memory save confirmation already in progress";
 const CONFIRMATION_PROCESSING_LEASE_MS = 5 * 60 * 1000;
 const CONFIRMATION_PERSIST_MAX_ATTEMPTS = 3;
+const PENDING_ACTION_PERSIST_WAIT_MS = 2000;
+const PENDING_ACTION_POLL_INTERVAL_MS = 250;
 const SENT_MESSAGE_RESOLVE_MAX_ATTEMPTS = 5;
 const SENT_MESSAGE_RESOLVE_RETRY_MS = 500;
 const SENT_MESSAGE_RESOLVE_LOOKBACK_MS = 60 * 1000;
@@ -133,6 +135,7 @@ export async function confirmAssistantEmailActionForAccount({
   toolCallId,
   actionType,
   contentOverride,
+  waitForPersistence,
   emailAccountId,
   provider,
   logger,
@@ -142,6 +145,7 @@ export async function confirmAssistantEmailActionForAccount({
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
   contentOverride?: string;
+  waitForPersistence?: boolean;
   emailAccountId: string;
   provider: string;
   logger: Logger;
@@ -152,6 +156,7 @@ export async function confirmAssistantEmailActionForAccount({
     toolCallId,
     actionType,
     emailAccountId,
+    waitForPersistence,
     logger,
   });
 
@@ -701,6 +706,7 @@ async function findChatMessageForPendingAction({
   logger,
   matchParts,
   logPrefix,
+  waitForPersistenceMs,
 }: {
   chatId: string;
   chatMessageId?: string;
@@ -708,72 +714,110 @@ async function findChatMessageForPendingAction({
   logger: Logger;
   matchParts: (parts: unknown) => boolean;
   logPrefix: string;
+  waitForPersistenceMs?: number;
 }) {
-  const hintedChatMessage = chatMessageId
-    ? await prisma.chatMessage.findFirst({
-        where: {
-          id: chatMessageId,
-          chat: { id: chatId, emailAccountId },
-        },
-        select: {
-          id: true,
-          chatId: true,
-          updatedAt: true,
-          parts: true,
-        },
-      })
-    : null;
+  const startedAt = Date.now();
+  let attemptCount = 0;
 
-  if (hintedChatMessage && matchParts(hintedChatMessage.parts)) {
-    return hintedChatMessage;
-  }
+  while (true) {
+    attemptCount += 1;
 
-  const assistantMessages = await prisma.chatMessage.findMany({
-    where: {
-      role: "assistant",
-      chat: { id: chatId, emailAccountId },
-    },
-    orderBy: { updatedAt: "desc" },
-    select: {
-      id: true,
-      chatId: true,
-      updatedAt: true,
-      parts: true,
-    },
-  });
+    const hintedChatMessage = chatMessageId
+      ? await prisma.chatMessage.findFirst({
+          where: {
+            id: chatMessageId,
+            chat: { id: chatId, emailAccountId },
+          },
+          select: {
+            id: true,
+            chatId: true,
+            updatedAt: true,
+            parts: true,
+          },
+        })
+      : null;
 
-  const matchingMessages = assistantMessages.filter((message) =>
-    matchParts(message.parts),
-  );
+    if (hintedChatMessage && matchParts(hintedChatMessage.parts)) {
+      if (attemptCount > 1) {
+        logger.info(`${logPrefix} resolved after persistence wait`, {
+          chatId,
+          requestedChatMessageId: chatMessageId,
+          resolvedChatMessageId: hintedChatMessage.id,
+          waitedMs: Date.now() - startedAt,
+          lookupAttempts: attemptCount,
+        });
+      }
+      return hintedChatMessage;
+    }
 
-  if (matchingMessages.length === 1) {
-    if (chatMessageId && matchingMessages[0].id !== chatMessageId) {
-      logger.warn(`${logPrefix} resolved pending action by tool lookup`, {
+    const assistantMessages = await prisma.chatMessage.findMany({
+      where: {
+        role: "assistant",
+        chat: { id: chatId, emailAccountId },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        chatId: true,
+        updatedAt: true,
+        parts: true,
+      },
+    });
+
+    const matchingMessages = assistantMessages.filter((message) =>
+      matchParts(message.parts),
+    );
+
+    if (matchingMessages.length === 1) {
+      if (attemptCount > 1) {
+        logger.info(`${logPrefix} resolved after persistence wait`, {
+          chatId,
+          requestedChatMessageId: chatMessageId,
+          resolvedChatMessageId: matchingMessages[0].id,
+          waitedMs: Date.now() - startedAt,
+          lookupAttempts: attemptCount,
+        });
+      } else if (chatMessageId && matchingMessages[0].id !== chatMessageId) {
+        logger.warn(`${logPrefix} resolved pending action by tool lookup`, {
+          chatId,
+          requestedChatMessageId: chatMessageId,
+          resolvedChatMessageId: matchingMessages[0].id,
+        });
+      }
+      return matchingMessages[0];
+    }
+
+    if (matchingMessages.length > 1) {
+      logger.warn(`${logPrefix} found multiple pending action matches`, {
         chatId,
         requestedChatMessageId: chatMessageId,
-        resolvedChatMessageId: matchingMessages[0].id,
+        matchedChatMessageIds: matchingMessages.map((message) => message.id),
       });
+      return matchingMessages[0];
     }
-    return matchingMessages[0];
-  }
 
-  if (matchingMessages.length > 1) {
-    logger.warn(`${logPrefix} found multiple pending action matches`, {
+    const waitedMs = Date.now() - startedAt;
+    if (waitForPersistenceMs && waitedMs < waitForPersistenceMs) {
+      await wait(
+        Math.min(
+          PENDING_ACTION_POLL_INTERVAL_MS,
+          waitForPersistenceMs - waitedMs,
+        ),
+      );
+      continue;
+    }
+
+    logger.warn(`${logPrefix} pending action not found`, {
       chatId,
       requestedChatMessageId: chatMessageId,
-      matchedChatMessageIds: matchingMessages.map((message) => message.id),
+      hintedMessageFound: Boolean(hintedChatMessage),
+      assistantMessageCount: assistantMessages.length,
+      waitedMs,
+      lookupAttempts: attemptCount,
     });
-    return matchingMessages[0];
+
+    return null;
   }
-
-  logger.warn(`${logPrefix} pending action not found`, {
-    chatId,
-    requestedChatMessageId: chatMessageId,
-    hintedMessageFound: Boolean(hintedChatMessage),
-    assistantMessageCount: assistantMessages.length,
-  });
-
-  return null;
 }
 
 function findPendingAssistantEmailPart({
@@ -882,6 +926,7 @@ async function reservePendingAssistantEmailAction({
   toolCallId,
   actionType,
   emailAccountId,
+  waitForPersistence,
   logger,
 }: {
   chatId: string;
@@ -889,6 +934,7 @@ async function reservePendingAssistantEmailAction({
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
   emailAccountId: string;
+  waitForPersistence?: boolean;
   logger: Logger;
 }) {
   const matchEmailParts = (parts: unknown) =>
@@ -901,6 +947,9 @@ async function reservePendingAssistantEmailAction({
     logger,
     matchParts: matchEmailParts,
     logPrefix: "Assistant email confirmation",
+    waitForPersistenceMs: waitForPersistence
+      ? PENDING_ACTION_PERSIST_WAIT_MS
+      : undefined,
   });
 
   if (!chatMessage) {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -728,20 +728,19 @@ async function findChatMessageForPendingAction({
     return hintedChatMessage;
   }
 
-  const assistantMessages =
-    (await prisma.chatMessage.findMany({
-      where: {
-        role: "assistant",
-        chat: { id: chatId, emailAccountId },
-      },
-      orderBy: { updatedAt: "desc" },
-      select: {
-        id: true,
-        chatId: true,
-        updatedAt: true,
-        parts: true,
-      },
-    })) ?? [];
+  const assistantMessages = await prisma.chatMessage.findMany({
+    where: {
+      role: "assistant",
+      chat: { id: chatId, emailAccountId },
+    },
+    orderBy: { updatedAt: "desc" },
+    select: {
+      id: true,
+      chatId: true,
+      updatedAt: true,
+      parts: true,
+    },
+  });
 
   const matchingMessages = assistantMessages.filter((message) =>
     matchParts(message.parts),

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -36,6 +36,8 @@ const CONFIRMATION_IN_PROGRESS_ERROR =
 const SAVE_MEMORY_CONFIRMATION_IN_PROGRESS_ERROR =
   "Memory save confirmation already in progress";
 const CONFIRMATION_PROCESSING_LEASE_MS = 5 * 60 * 1000;
+const PENDING_ACTION_LOOKUP_MAX_ATTEMPTS = 5;
+const PENDING_ACTION_LOOKUP_RETRY_MS = 500;
 const CONFIRMATION_PERSIST_MAX_ATTEMPTS = 3;
 const SENT_MESSAGE_RESOLVE_MAX_ATTEMPTS = 5;
 const SENT_MESSAGE_RESOLVE_RETRY_MS = 500;
@@ -138,7 +140,7 @@ export async function confirmAssistantEmailActionForAccount({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
   contentOverride?: string;
@@ -235,7 +237,7 @@ export async function confirmAssistantCreateRuleForAccount({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
   provider: string;
@@ -369,7 +371,7 @@ export async function confirmAssistantSaveMemoryForAccount({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
   logger: Logger;
@@ -703,59 +705,114 @@ async function findChatMessageForPendingAction({
   logPrefix,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   emailAccountId: string;
   logger: Logger;
   matchParts: (parts: unknown) => boolean;
   logPrefix: string;
 }) {
-  const chatMessage = await prisma.chatMessage.findFirst({
-    where: {
-      id: chatMessageId,
-      chat: { id: chatId, emailAccountId },
-    },
-    select: {
-      id: true,
-      chatId: true,
-      updatedAt: true,
-      parts: true,
-    },
-  });
+  for (
+    let attempt = 1;
+    attempt <= PENDING_ACTION_LOOKUP_MAX_ATTEMPTS;
+    attempt++
+  ) {
+    const hintedChatMessage = chatMessageId
+      ? await prisma.chatMessage.findFirst({
+          where: {
+            id: chatMessageId,
+            chat: { id: chatId, emailAccountId },
+          },
+          select: {
+            id: true,
+            chatId: true,
+            updatedAt: true,
+            parts: true,
+          },
+        })
+      : null;
 
-  if (chatMessage && matchParts(chatMessage.parts)) return chatMessage;
+    const hintedMatch =
+      hintedChatMessage && matchParts(hintedChatMessage.parts)
+        ? hintedChatMessage
+        : null;
 
-  if (chatMessage) {
-    logger.warn(`${logPrefix} exact chat message missing pending action`, {
-      chatId,
-      chatMessageId,
-      resolvedChatMessageId: chatMessage.id,
-    });
-  }
+    if (hintedMatch) {
+      if (attempt > 1) {
+        logger.info(`${logPrefix} resolved pending action after waiting`, {
+          chatId,
+          requestedChatMessageId: chatMessageId,
+          resolvedChatMessageId: hintedMatch.id,
+          attempt,
+        });
+      }
+      return hintedMatch;
+    }
 
-  const fallbackCandidates = await prisma.chatMessage.findMany({
-    where: {
-      role: "assistant",
-      chat: { id: chatId, emailAccountId },
-    },
-    orderBy: { updatedAt: "desc" },
-    take: 50,
-    select: {
-      id: true,
-      chatId: true,
-      updatedAt: true,
-      parts: true,
-    },
-  });
+    const assistantMessages =
+      (await prisma.chatMessage.findMany({
+        where: {
+          role: "assistant",
+          chat: { id: chatId, emailAccountId },
+        },
+        orderBy: { updatedAt: "desc" },
+        select: {
+          id: true,
+          chatId: true,
+          updatedAt: true,
+          parts: true,
+        },
+      })) ?? [];
 
-  for (const candidate of fallbackCandidates) {
-    if (!matchParts(candidate.parts)) continue;
+    const matchingMessages = assistantMessages.filter((message) =>
+      matchParts(message.parts),
+    );
 
-    logger.warn(`${logPrefix} recovered using fallback message lookup`, {
-      chatId,
-      chatMessageId,
-      resolvedChatMessageId: candidate.id,
-    });
-    return candidate;
+    if (matchingMessages.length === 1) {
+      logger.warn(`${logPrefix} resolved pending action by tool lookup`, {
+        chatId,
+        requestedChatMessageId: chatMessageId,
+        resolvedChatMessageId: matchingMessages[0].id,
+        attempt,
+      });
+      return matchingMessages[0];
+    }
+
+    if (matchingMessages.length > 1) {
+      logger.warn(`${logPrefix} found multiple pending action matches`, {
+        chatId,
+        requestedChatMessageId: chatMessageId,
+        matchedChatMessageIds: matchingMessages.map((message) => message.id),
+        attempt,
+      });
+      return matchingMessages[0];
+    }
+
+    if (attempt < PENDING_ACTION_LOOKUP_MAX_ATTEMPTS) {
+      logger.info(`${logPrefix} waiting for pending action persistence`, {
+        chatId,
+        requestedChatMessageId: chatMessageId,
+        attempt,
+        hintedMessageFound: Boolean(hintedChatMessage),
+        assistantMessageCount: assistantMessages.length,
+        recentAssistantToolCallIds: assistantMessages
+          .slice(0, 5)
+          .flatMap((message) => getToolCallIdsFromParts(message.parts)),
+      });
+      await wait(PENDING_ACTION_LOOKUP_RETRY_MS);
+    } else {
+      logger.warn(`${logPrefix} pending action not found`, {
+        chatId,
+        requestedChatMessageId: chatMessageId,
+        hintedMessageFound: Boolean(hintedChatMessage),
+        assistantMessageCount: assistantMessages.length,
+        recentAssistantMessageIds: assistantMessages
+          .slice(0, 5)
+          .map((message) => message.id),
+        recentAssistantToolCallIds: assistantMessages
+          .slice(0, 5)
+          .flatMap((message) => getToolCallIdsFromParts(message.parts)),
+      });
+    }
   }
 
   return null;
@@ -870,7 +927,7 @@ async function reservePendingAssistantEmailAction({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   actionType: AssistantPendingEmailActionType;
   emailAccountId: string;
@@ -1006,7 +1063,7 @@ async function clearPendingPartProcessing({
   emailAccountId,
   findPart,
 }: {
-  chatMessageId: string;
+  chatMessageId?: string;
   emailAccountId: string;
   findPart: (parts: unknown) => {
     index: number;
@@ -1210,7 +1267,7 @@ async function reservePendingAssistantSaveMemory({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
   logger: Logger;
@@ -1335,7 +1392,7 @@ async function reservePendingAssistantCreateRule({
   logger,
 }: {
   chatId: string;
-  chatMessageId: string;
+  chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
   logger: Logger;
@@ -1751,6 +1808,15 @@ function getPendingActionContentPatch(
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getToolCallIdsFromParts(parts: unknown): string[] {
+  if (!Array.isArray(parts)) return [];
+
+  return parts.flatMap((part) => {
+    if (!isRecord(part) || typeof part.toolCallId !== "string") return [];
+    return [part.toolCallId];
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -722,7 +722,15 @@ async function findChatMessageForPendingAction({
     },
   });
 
-  if (chatMessage) return chatMessage;
+  if (chatMessage && matchParts(chatMessage.parts)) return chatMessage;
+
+  if (chatMessage) {
+    logger.warn(`${logPrefix} exact chat message missing pending action`, {
+      chatId,
+      chatMessageId,
+      resolvedChatMessageId: chatMessage.id,
+    });
+  }
 
   const fallbackCandidates = await prisma.chatMessage.findMany({
     where: {
@@ -730,7 +738,7 @@ async function findChatMessageForPendingAction({
       chat: { id: chatId, emailAccountId },
     },
     orderBy: { updatedAt: "desc" },
-    take: 10,
+    take: 50,
     select: {
       id: true,
       chatId: true,

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -102,7 +102,7 @@ export type AssistantPendingEmailToolOutput =
 
 const confirmAssistantActionBaseBody = z.object({
   chatId: z.string().trim().min(1),
-  chatMessageId: z.string().trim().min(1),
+  chatMessageId: z.string().trim().min(1).optional(),
   toolCallId: z.string().trim().min(1),
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -934,6 +934,7 @@ async function handlePendingEmailConfirmAction({
       chatMessageId: pendingAction.chatMessageId,
       toolCallId: pendingAction.toolCallId,
       actionType: pendingAction.actionType,
+      waitForPersistence: true,
       emailAccountId: chat.emailAccountId,
       provider: emailAccount.account.provider,
       logger,


### PR DESCRIPTION
# User description
This hardens pending chat email confirmation when the provided message id no longer points at the correct assistant message. It verifies the matched message still contains the pending action before using it, widens fallback recovery across recent assistant messages, and adds regression coverage for mismatched message ids.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Strengthen email confirmation by waiting for the assistant message to persist, verifying the pending action still lives on the hinted message, and broadening fallback lookups before returning success. Track persisted assistant message ids through the chat provider/UI and log their creation so email actions can disable their controls until the data is durable.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2239?tool=ast&topic=Persisted+message+gating>Persisted message gating</a>
        </td><td>Log assistant tool call ids when saving chats, memoize persisted message ids in <code>ChatProvider</code>, and surface that set to chat UI components so email action controls stay disabled until the relevant message exists in storage.<details><summary>Modified files (6)</summary><ul><li>apps/web/app/api/chat/route.ts</li>
<li>apps/web/components/assistant-chat/chat.tsx</li>
<li>apps/web/components/assistant-chat/message-part.tsx</li>
<li>apps/web/components/assistant-chat/messages.tsx</li>
<li>apps/web/components/assistant-chat/tools.tsx</li>
<li>apps/web/providers/ChatProvider.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix empty assistant ch...</td><td>April 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Assistant chat UI/UX i...</td><td>February 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2239?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/chat/confirm-email-action/route.test.ts</li>
<li>apps/web/app/api/chat/confirm-email-action/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>josh@jshwrnr.com</td><td>assistant-chat: add mo...</td><td>March 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2239?tool=ast&topic=Email+confirmation+recovery>Email confirmation recovery</a>
        </td><td>Harden <code>confirmAssistantEmailActionForAccount</code> and the confirmation route so they wait for inserted assistant messages, verify that the hinted chat message still contains the pending email action before acting, and broaden fallback lookups, with regression tests capturing mismatched ids and persistence races.<details><summary>Modified files (4)</summary><ul><li>apps/web/utils/actions/assistant-chat.test.ts</li>
<li>apps/web/utils/actions/assistant-chat.ts</li>
<li>apps/web/utils/actions/assistant-chat.validation.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore: refine assistan...</td><td>April 12, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2239?tool=ast>(Baz)</a>.