### PR TITLE
assistant: fix rule dialog crash for multi-condition rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 - Infer types from Zod schemas using `z.infer<typeof schema>` instead of duplicating as separate interfaces
 - Avoid premature abstraction. Duplicating 2-3 times is fine; extract when a stable pattern emerges.
 - Don't extract single-use helper functions that just rename and forward parameters; inline the logic at the call site.
+- Avoid large nested ternaries. Prefer a small helper or other straightforward control flow when it improves readability.
 - No barrel files. Import directly from source files.
 - Colocate page components next to their `page.tsx`. No nested `components/` subfolders in route directories.
 - Reusable components shared across pages go in `apps/web/components/`

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
@@ -1,5 +1,4 @@
 import type {
-  Control,
   UseFormRegister,
   UseFormSetValue,
   UseFormWatch,
@@ -22,7 +21,7 @@ import {
   SelectValue,
   SelectTrigger,
 } from "@/components/ui/select";
-import { FormControl, FormField, FormItem } from "@/components/ui/form";
+import { FormControl, FormItem } from "@/components/ui/form";
 import { RuleStep } from "@/app/(app)/[emailAccountId]/assistant/RuleStep";
 import { SystemType } from "@/generated/prisma/enums";
 import TextareaAutosize from "react-textarea-autosize";
@@ -129,7 +128,6 @@ export function ConditionSteps({
   conditionFields,
   conditionalOperator,
   removeCondition,
-  control,
   watch,
   setValue,
   register,
@@ -141,7 +139,6 @@ export function ConditionSteps({
   conditionFields: Array<{ id: string }>;
   conditionalOperator: LogicalOperator | null | undefined;
   removeCondition: (index: number) => void;
-  control: Control<CreateRuleBody>;
   watch: UseFormWatch<CreateRuleBody>;
   setValue: UseFormSetValue<CreateRuleBody>;
   register: UseFormRegister<CreateRuleBody>;
@@ -196,172 +193,131 @@ export function ConditionSteps({
         const uiType = getUIConditionType(currentCondition);
         const isFirstCondition = index === 0;
         const isFirstConditionPrompt = isFirstCondition && uiType === "prompt";
+        const conditionTypeLabel = getConditionTypeLabel(uiType);
+        const usedUITypes = new Set(
+          conditions
+            .map((c, idx) =>
+              idx === index ? undefined : getUIConditionType(c),
+            )
+            .filter(
+              (type): type is UIConditionType =>
+                type !== undefined && type !== null,
+            ),
+        );
+        const previousConditionType =
+          index > 0 ? getUIConditionType(conditions[index - 1]) : undefined;
+        const isStaticFollowingStatic =
+          uiType !== "prompt" && previousConditionType !== "prompt";
+        const showOperatorSelector =
+          index === 1 && previousConditionType === "prompt";
 
         // Hide leftContent only for first condition when it's a prompt type
         // Static conditions always need the label shown
         const leftContent = isFirstConditionPrompt ? null : (
-          <FormField
-            control={control}
-            name={`conditions.${index}`}
-            render={({ field }) => {
-              const currentCondition = field.value;
-              const uiType = getUIConditionType(currentCondition);
+          <FormItem>
+            <Select
+              onValueChange={(value: UIConditionType) => {
+                // Check if we have duplicate UI condition types
+                const prospectiveUITypes = conditions.map((c, idx) =>
+                  idx === index ? value : getUIConditionType(c),
+                );
+                const configuredTypes = prospectiveUITypes.filter(
+                  (type): type is UIConditionType =>
+                    type !== undefined && type !== null,
+                );
+                const uniqueUITypes = new Set(configuredTypes);
 
-              const conditionTypeLabel =
-                uiType === "prompt"
-                  ? "AI Prompt"
-                  : uiType === "from"
-                    ? "From"
-                    : uiType === "to"
-                      ? "To"
-                      : uiType === "subject"
-                        ? "Subject"
-                        : "Select";
+                if (uniqueUITypes.size !== configuredTypes.length) {
+                  toastError({
+                    description:
+                      "You can only have one condition of each type.",
+                  });
+                  return;
+                }
 
-              // Get UI types already used in other conditions (excluding current)
-              const usedUITypes = new Set(
-                conditions
-                  .map((c, idx) =>
-                    idx === index ? undefined : getUIConditionType(c),
-                  )
-                  .filter(
-                    (type): type is UIConditionType =>
-                      type !== undefined && type !== null,
-                  ),
-              );
+                const newCondition = getConditionFromUIType(value);
 
-              // Determine operator display logic:
-              // - AND/OR selector only between AI condition and first static condition
-              // - Static conditions always show "and" between each other
-              const previousConditionType =
-                index > 0
-                  ? getUIConditionType(conditions[index - 1])
-                  : undefined;
+                // If AI Prompt is selected at a non-first position,
+                // insert it at position 0 and shift other conditions
+                if (value === "prompt" && index !== 0) {
+                  const currentConditionAtIndex = conditions[index];
+                  const currentConditionType = getUIConditionType(
+                    currentConditionAtIndex,
+                  );
 
-              // Static following static: both current and previous are not prompt
-              // (includes undefined/empty conditions as they will become static)
-              const isStaticFollowingStatic =
-                uiType !== "prompt" && previousConditionType !== "prompt";
+                  const newConditions = [newCondition];
 
-              // Show AND/OR selector only at boundary between AI (prompt) and static conditions
-              const showOperatorSelector =
-                index === 1 && previousConditionType === "prompt";
+                  for (let i = 0; i < conditions.length; i++) {
+                    if (i !== index) {
+                      newConditions.push(conditions[i]);
+                    } else if (currentConditionType !== undefined) {
+                      newConditions.push(currentConditionAtIndex);
+                    }
+                  }
 
-              return (
-                <FormItem>
+                  setValue("conditions", newConditions);
+                } else {
+                  setValue(`conditions.${index}`, newCondition);
+                }
+              }}
+              value={uiType || undefined}
+            >
+              <div className="flex items-center gap-2">
+                {index === 0 ? null : showOperatorSelector ? (
                   <Select
-                    onValueChange={(value: UIConditionType) => {
-                      // Check if we have duplicate UI condition types
-                      const prospectiveUITypes = conditions.map((c, idx) =>
-                        idx === index ? value : getUIConditionType(c),
+                    value={
+                      conditionalOperator === LogicalOperator.OR ? "or" : "and"
+                    }
+                    onValueChange={(value) => {
+                      setValue(
+                        "conditionalOperator",
+                        value === "or"
+                          ? LogicalOperator.OR
+                          : LogicalOperator.AND,
                       );
-                      const configuredTypes = prospectiveUITypes.filter(
-                        (type): type is UIConditionType =>
-                          type !== undefined && type !== null,
-                      );
-                      const uniqueUITypes = new Set(configuredTypes);
-
-                      if (uniqueUITypes.size !== configuredTypes.length) {
-                        toastError({
-                          description:
-                            "You can only have one condition of each type.",
-                        });
-                        return; // abort update
-                      }
-
-                      const newCondition = getConditionFromUIType(value);
-
-                      // If AI Prompt is selected at a non-first position,
-                      // insert it at position 0 and shift other conditions
-                      if (value === "prompt" && index !== 0) {
-                        const currentConditionAtIndex = conditions[index];
-                        const currentConditionType = getUIConditionType(
-                          currentConditionAtIndex,
-                        );
-
-                        // Build new conditions array with AI Prompt at position 0
-                        const newConditions = [newCondition];
-
-                        // Add all existing conditions except the one being changed
-                        for (let i = 0; i < conditions.length; i++) {
-                          if (i !== index) {
-                            newConditions.push(conditions[i]);
-                          } else if (currentConditionType !== undefined) {
-                            // If the condition being changed had data, keep it
-                            newConditions.push(currentConditionAtIndex);
-                          }
-                          // If it was empty (undefined type), just skip it
-                        }
-
-                        setValue("conditions", newConditions);
-                      } else {
-                        setValue(`conditions.${index}`, newCondition);
-                      }
                     }}
-                    value={uiType || undefined}
                   >
-                    <div className="flex items-center gap-2">
-                      {index === 0 ? null : showOperatorSelector ? (
-                        <Select
-                          value={
-                            conditionalOperator === LogicalOperator.OR
-                              ? "or"
-                              : "and"
-                          }
-                          onValueChange={(value) => {
-                            setValue(
-                              "conditionalOperator",
-                              value === "or"
-                                ? LogicalOperator.OR
-                                : LogicalOperator.AND,
-                            );
-                          }}
-                        >
-                          <FormControl>
-                            <SelectTrigger className="w-[80px]">
-                              <SelectValue />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value="and">and</SelectItem>
-                            <SelectItem value="or">or</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <p className="text-muted-foreground">
-                          {isStaticFollowingStatic
-                            ? "and"
-                            : conditionalOperator === LogicalOperator.OR
-                              ? "or"
-                              : "and"}
-                        </p>
-                      )}
-                      <FormControl>
-                        <SelectTrigger className="w-[120px]">
-                          {uiType ? (
-                            conditionTypeLabel
-                          ) : (
-                            <SelectValue placeholder="Choose" />
-                          )}
-                        </SelectTrigger>
-                      </FormControl>
-                    </div>
+                    <FormControl>
+                      <SelectTrigger className="w-[80px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
                     <SelectContent>
-                      {CONDITION_TYPE_OPTIONS.filter(
-                        (option) =>
-                          !usedUITypes.has(option.value) ||
-                          option.value === uiType,
-                      ).map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
+                      <SelectItem value="and">and</SelectItem>
+                      <SelectItem value="or">or</SelectItem>
                     </SelectContent>
                   </Select>
-                </FormItem>
-              );
-            }}
-          />
+                ) : (
+                  <p className="text-muted-foreground">
+                    {isStaticFollowingStatic
+                      ? "and"
+                      : conditionalOperator === LogicalOperator.OR
+                        ? "or"
+                        : "and"}
+                  </p>
+                )}
+                <FormControl>
+                  <SelectTrigger className="w-[120px]">
+                    {uiType ? (
+                      conditionTypeLabel
+                    ) : (
+                      <SelectValue placeholder="Choose" />
+                    )}
+                  </SelectTrigger>
+                </FormControl>
+              </div>
+              <SelectContent>
+                {CONDITION_TYPE_OPTIONS.filter(
+                  (option) =>
+                    !usedUITypes.has(option.value) || option.value === uiType,
+                ).map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormItem>
         );
 
         // Check if this static condition should be indented
@@ -527,3 +483,18 @@ export function ConditionSteps({
 
 const getFilterTooltipText = (filterType: "from" | "to") =>
   `Only apply this rule ${filterType} emails from this address. Supports multiple addresses separated by comma, pipe, or OR. e.g. "@company.com", "hello@example.com OR support@test.com"`;
+
+function getConditionTypeLabel(uiType: UIConditionType | undefined): string {
+  switch (uiType) {
+    case "prompt":
+      return "AI Prompt";
+    case "from":
+      return "From";
+    case "to":
+      return "To";
+    case "subject":
+      return "Subject";
+    default:
+      return "Select";
+  }
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleDialog.tsx
@@ -15,6 +15,7 @@ import { useDialogState } from "@/hooks/useDialogState";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import { ConditionType } from "@/utils/config";
 import type { RulesResponse } from "@/app/api/user/rules/route";
+import { SUPPORT_EMAIL } from "@/utils/branding";
 import { RuleLoader } from "./RuleLoader";
 
 interface RuleDialogProps {
@@ -135,8 +136,11 @@ function RuleDialogErrorState({ onClose }: { onClose: () => void }) {
   return (
     <div className="space-y-4 py-4">
       <p className="text-sm text-muted-foreground">
-        We couldn&apos;t open this rule. Close the dialog and try again without
-        losing the rest of the page.
+        An error occurred while opening this rule. Please contact support at{" "}
+        <a href={`mailto:${SUPPORT_EMAIL}`} className="underline">
+          {SUPPORT_EMAIL}
+        </a>{" "}
+        if the problem persists.
       </p>
       <div className="flex justify-end">
         <Button type="button" onClick={onClose}>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -1,0 +1,173 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { ConditionType } from "@/utils/config";
+
+const mockUseAccount = vi.fn();
+const mockUseLabels = vi.fn();
+const mockUseMessagingChannels = vi.fn();
+const mockUseFolders = vi.fn();
+const mockUseRouter = vi.fn();
+const mockUsePostHog = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockUseRouter(),
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => mockUsePostHog(),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/hooks/useLabels", () => ({
+  useLabels: () => mockUseLabels(),
+}));
+
+vi.mock("@/hooks/useMessagingChannels", () => ({
+  useMessagingChannels: () => mockUseMessagingChannels(),
+}));
+
+vi.mock("@/hooks/useFolders", () => ({
+  useFolders: () => mockUseFolders(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+    NEXT_PUBLIC_DIGEST_ENABLED: true,
+    NEXT_PUBLIC_EMAIL_SEND_ENABLED: true,
+    NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: true,
+    NEXT_PUBLIC_IS_RESEND_CONFIGURED: true,
+    NEXT_PUBLIC_SUPPORT_EMAIL: "support@example.com",
+    EMAIL_ENCRYPT_SECRET: "test-secret",
+    EMAIL_ENCRYPT_SALT: "test-salt",
+  },
+}));
+
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/actions/rule", () => ({
+  createRuleAction: vi.fn(),
+  deleteRuleAction: vi.fn(),
+  updateRuleAction: vi.fn(),
+}));
+
+vi.mock("@/utils/attachments/rule", () => ({
+  handleRuleAttachmentSourceSave: vi.fn(),
+}));
+
+vi.mock("@/app/(app)/[emailAccountId]/assistant/group/LearnedPatterns", () => ({
+  LearnedPatternsDialog: () => null,
+}));
+
+import { RuleForm } from "./RuleForm";
+
+describe("RuleForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "18d9553a-5182-4347-8cfa-75c76c72f51e",
+      provider: "google",
+    });
+    mockUseLabels.mockReturnValue({
+      userLabels: [],
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+    mockUseMessagingChannels.mockReturnValue({
+      data: {
+        channels: [],
+        availableProviders: [],
+      },
+    });
+    mockUseFolders.mockReturnValue({
+      folders: [],
+      isLoading: false,
+    });
+    mockUseRouter.mockReturnValue({
+      push: vi.fn(),
+      replace: vi.fn(),
+    });
+    mockUsePostHog.mockReturnValue({
+      capture: vi.fn(),
+    });
+  });
+
+  it("renders a rule with multiple forward actions and split static conditions", () => {
+    render(
+      <RuleForm
+        alwaysEditMode
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Claude",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "@mail.anthropic.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+            {
+              type: ConditionType.STATIC,
+              from: null,
+              to: null,
+              subject: "Secure link to log in to Claude.ai",
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-1",
+              type: ActionType.FORWARD,
+              to: { value: "one@example.com" },
+            },
+            {
+              id: "action-2",
+              type: ActionType.FORWARD,
+              to: { value: "two@example.com" },
+            },
+            {
+              id: "action-3",
+              type: ActionType.FORWARD,
+              to: { value: "three@example.com" },
+            },
+            {
+              id: "action-4",
+              type: ActionType.FORWARD,
+              to: { value: "four@example.com" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Claude")).toBeTruthy();
+    expect(
+      screen.getByDisplayValue("Secure link to log in to Claude.ai"),
+    ).toBeTruthy();
+    expect(screen.getAllByDisplayValue(/@?example\.com/)).toHaveLength(4);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -435,7 +435,6 @@ export function RuleForm({
             conditionFields={conditionFields}
             conditionalOperator={conditionalOperator}
             removeCondition={removeCondition}
-            control={control}
             watch={watch}
             setValue={setValue}
             register={register}


### PR DESCRIPTION
# User description
This PR fixes a recent rule editor regression where rules with multiple conditions could crash when opened. It removes the broken condition field wrapper, updates the fallback error copy to use the configured support email, and adds a focused regression test for the affected rule shape. It also adds a short repo note to prefer helpers over large nested ternaries.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix ConditionSteps so multi-condition rule dialogs load without crashing by recalculating labels via a helper, keeping operator logic intact, and covering the regression with a focused RuleForm test. Update RuleDialog error copy to point to <code>SUPPORT_EMAIL</code> and reinforce the repo note preferring helpers over large nested ternaries.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2240?tool=ast&topic=Error+fallback+copy>Error fallback copy</a>
        </td><td>Update RuleDialog error fallback to surface <code>SUPPORT_EMAIL</code> for users and add the AGENTS note steering developers away from large nested ternaries in favor of clearer helpers.<details><summary>Modified files (2)</summary><ul><li>AGENTS.md</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/RuleDialog.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: contain rul...</td><td>April 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>assistant-chat: add mo...</td><td>March 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2240?tool=ast&topic=Multi-condition+flow>Multi-condition flow</a>
        </td><td>Refactor ConditionSteps to derive condition labels via <code>getConditionTypeLabel</code>, adjust operator handling without the broken wrapper, and keep the multi-condition UI stable while a regression test in <code>RuleForm.render.test.tsx</code> verifies rules with split static filters and four forward actions.<details><summary>Modified files (3)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx</li>
<li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix rule editor action...</td><td>April 14, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove conditional tit...</td><td>December 10, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2240?tool=ast>(Baz)</a>.