### PR TITLE
assistant: Fix draft reply grouping in rule editor

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -15,6 +15,15 @@ const mockUsePostHog = vi.fn();
 
 (globalThis as { React?: typeof React }).React = React;
 
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(globalThis as { ResizeObserver?: typeof MockResizeObserver }).ResizeObserver =
+  MockResizeObserver;
+
 vi.mock("server-only", () => ({}));
 
 vi.mock("next/navigation", () => ({
@@ -169,5 +178,122 @@ describe("RuleForm", () => {
       screen.getByDisplayValue("Secure link to log in to Claude.ai"),
     ).toBeTruthy();
     expect(screen.getAllByDisplayValue(/@?example\.com/)).toHaveLength(4);
+  });
+
+  it("keeps draft reply destinations grouped when persisted actions arrive out of order", () => {
+    mockUseMessagingChannels.mockReturnValue({
+      data: {
+        channels: [
+          {
+            id: "cmessagingchannel1234567890123",
+            provider: "SLACK",
+            teamName: "Workspace",
+            teamId: "team-1",
+            isConnected: true,
+            canSendAsDm: true,
+            actions: [],
+            destinations: {
+              ruleNotifications: {
+                enabled: true,
+                targetId: "U123",
+                targetLabel: "Direct message",
+                isDm: true,
+              },
+              meetingBriefs: {
+                enabled: false,
+                targetId: null,
+                targetLabel: null,
+                isDm: false,
+              },
+              documentFilings: {
+                enabled: false,
+                targetId: null,
+                targetLabel: null,
+                isDm: false,
+              },
+            },
+          },
+          {
+            id: "cmessagingchannel1234567890456",
+            provider: "TELEGRAM",
+            teamName: "Telegram DM",
+            teamId: "chat-1",
+            isConnected: true,
+            canSendAsDm: false,
+            actions: [],
+            destinations: {
+              ruleNotifications: {
+                enabled: true,
+                targetId: "chat-1",
+                targetLabel: "Direct message",
+                isDm: true,
+              },
+              meetingBriefs: {
+                enabled: false,
+                targetId: null,
+                targetLabel: null,
+                isDm: false,
+              },
+              documentFilings: {
+                enabled: false,
+                targetId: null,
+                targetLabel: null,
+                isDm: false,
+              },
+            },
+          },
+        ],
+        availableProviders: ["SLACK", "TELEGRAM"],
+      },
+    });
+
+    render(
+      <RuleForm
+        alwaysEditMode
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Draft reply rule",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-telegram",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: "cmessagingchannel1234567890456",
+              content: { value: "" },
+            },
+            {
+              id: "action-email",
+              type: ActionType.DRAFT_EMAIL,
+              content: { value: "" },
+            },
+            {
+              id: "action-slack",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: "cmessagingchannel1234567890123",
+              content: { value: "" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("Draft to")).toHaveLength(1);
+    expect(screen.getByText("Email")).toBeTruthy();
+    expect(screen.getByText("Slack DM")).toBeTruthy();
+    expect(screen.getByText("Telegram DM")).toBeTruthy();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -58,6 +58,7 @@ import {
 import { handleRuleAttachmentSourceSave } from "@/utils/attachments/rule";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
+import { sortActionsByPriority } from "@/utils/action-sort";
 import {
   denormalizeDraftReplyActions,
   normalizeDraftReplyActions,
@@ -117,18 +118,20 @@ export function RuleForm({
           ),
           actions: [
             ...normalizeDraftReplyActions(
-              rule.actions
-                .filter((action) => action.type !== ActionType.DIGEST)
-                .map((action) => ({
-                  ...action,
-                  delayInMinutes: action.delayInMinutes,
-                  content: {
-                    ...action.content,
-                    setManually: !!action.content?.value,
-                  },
-                  folderName: action.folderName,
-                  folderId: action.folderId,
-                })),
+              sortActionsByPriority(
+                rule.actions
+                  .filter((action) => action.type !== ActionType.DIGEST)
+                  .map((action) => ({
+                    ...action,
+                    delayInMinutes: action.delayInMinutes,
+                    content: {
+                      ...action.content,
+                      setManually: !!action.content?.value,
+                    },
+                    folderName: action.folderName,
+                    folderId: action.folderId,
+                  })),
+              ),
             ),
           ],
         }


### PR DESCRIPTION
# User description
Stabilize draft reply rendering in the rule editor when persisted actions load out of order.

- sort persisted rule actions before draft-reply normalization so email and chat draft actions stay grouped
- add a render regression covering mixed email, Slack, and Telegram draft destinations
- verified with `pnpm test -- "app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx"`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Stabilize RuleForm draft reply rendering by sorting persisted actions via <code>sortActionsByPriority</code> before <code>normalizeDraftReplyActions</code> so grouped destinations stay intact. Add RuleForm.render regression coverage to verify mixed email, Slack DM, and Telegram DM draft replies remain grouped when persisted actions load out of order.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2241?tool=ast&topic=RuleForm+draft+flow>RuleForm draft flow</a>
        </td><td>Ensure RuleForm sorts persisted rule actions via <code>sortActionsByPriority</code> before <code>normalizeDraftReplyActions</code> so email and messaging draft replies group regardless of load order.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: fix rule di...</td><td>April 14, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove conditional tit...</td><td>December 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2241?tool=ast&topic=Draft+reply+test>Draft reply test</a>
        </td><td>Verify RuleForm.render keeps mixed email, Slack DM, and Telegram DM draft destinations grouped when persisted actions arrive out of order.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: fix rule di...</td><td>April 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2241?tool=ast>(Baz)</a>.