### PR TITLE
fix: draft formatting adapts to reply content complexity (INB-149)

### DIFF
--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -26,6 +26,7 @@ Don't mention that you're an AI.
 Don't reply with a Subject. Only reply with the body of the email.
 ${DRAFT_OUTPUT_INSTRUCTION}
 IMPORTANT: Format paragraphs using Unix newlines: use "\n\n" between paragraphs and "\n" for single line breaks.
+Choose formatting based on the complexity of your reply, not the sender's format. If the reply addresses multiple topics, questions, or points, split them into separate paragraphs (or a bulleted list for parallel items) even when the sender wrote a one-liner. If the reply makes a single point, keep it to one short paragraph even when the sender wrote long paragraphs.
 Write the reply in the same language as the latest message in the thread.
 
 IMPORTANT: Use placeholders sparingly! Only use them where you have limited information.
@@ -39,7 +40,7 @@ Your reply should aim to continue the conversation or provide new information ba
 `;
 
 const defaultWritingStyle = `Keep it concise, direct, and friendly.
-Keep the reply short. Aim for 2 sentences at most unless a brief answer to multiple questions needs more.
+Keep the reply short: aim for 2 sentences when a single point answers the email. When addressing multiple topics or questions, use enough paragraphs (or bullets) to cover each one clearly, even if that makes the reply longer.
 Don't be pushy.
 Write in a plainspoken, professional tone.
 Prefer short declarative sentences over polished or overly elaborate phrasing.`;


### PR DESCRIPTION
## Summary
- Drafts used to mirror the sender's format: a one-line question collapsed multi-point replies into one line, and long-paragraph senders produced verbose drafts.
- Updated the draft system prompt to explicitly instruct the model to choose formatting (paragraphs, bullets, length) based on the complexity of the reply content, not the sender's format.
- Softened the default writing style so the "aim for 2 sentences" guidance no longer pushes multi-topic replies into a single line.

## Root cause
`apps/web/utils/ai/reply/draft-reply.ts` had no guidance about reply-content-driven formatting. The `defaultWritingStyle` also strongly biased toward 2-sentence replies, which reinforced collapsing multi-point answers into one line when the sender wrote tersely.

## Test plan
- [x] Existing `draft-reply.formatting.test.ts` suite passes (21 tests)
- [ ] Manual QA: send one-liner requesting multiple items, verify draft uses paragraphs/bullets
- [ ] Manual QA: send long-paragraph email with a single-point answer, verify draft stays short
- [ ] Consider adding an AI eval case under `__tests__/ai-regression/reply/` for multi-topic reply formatting

Linear: INB-149