### PR TITLE
fix: always show attachment options for supported actions (INB-147)

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.tsx
@@ -49,16 +49,12 @@ export function ActionAttachmentsField({
   value,
   onChange,
   emailAccountId,
-  contentSetManually,
-  allowAiSelectedSources = true,
   attachmentSources,
   onAttachmentSourcesChange,
 }: {
   value: AttachmentSourceInput[];
   onChange: (value: AttachmentSourceInput[]) => void;
   emailAccountId: string;
-  contentSetManually: boolean;
-  allowAiSelectedSources?: boolean;
   attachmentSources: AttachmentSourceInput[];
   onAttachmentSourcesChange: (value: AttachmentSourceInput[]) => void;
 }) {
@@ -70,9 +66,8 @@ export function ActionAttachmentsField({
 
   const isConnected = (connectionsData?.connections.length ?? 0) > 0;
   const hasAttachments = value.length > 0;
-  const aiSourceCount = allowAiSelectedSources ? attachmentSources.length : 0;
-  const hasAiSources = aiSourceCount > 0;
-  const totalCount = value.length + aiSourceCount;
+  const hasAiSources = attachmentSources.length > 0;
+  const totalCount = value.length + attachmentSources.length;
 
   const selectedKeys = useMemo(
     () => new Set(value.map((source) => getSourceKey(source))),
@@ -148,7 +143,7 @@ export function ActionAttachmentsField({
         </div>
       )}
 
-      {isConnected && contentSetManually && (
+      {isConnected && (
         <div className="mt-2">
           <button
             type="button"
@@ -200,7 +195,7 @@ export function ActionAttachmentsField({
         </div>
       )}
 
-      {isConnected && allowAiSelectedSources && (
+      {isConnected && (
         <div className="mt-2">
           <button
             type="button"

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -631,10 +631,6 @@ function ActionCard({
     isDraftReplyActionType(rawActionType) ||
     actionType === ActionType.REPLY ||
     actionType === ActionType.SEND_EMAIL;
-  const supportsAiSelectedSources = isDraftReplyActionType(rawActionType);
-  const canConfigureStaticAttachments = isDraftReplyActionType(rawActionType)
-    ? contentSetManually
-    : supportsAttachments;
 
   const staticAttachments = useWatch({
     control,
@@ -643,13 +639,11 @@ function ActionCard({
 
   const attachmentsField = supportsAttachments ? (
     <ActionAttachmentsField
-      value={canConfigureStaticAttachments ? (staticAttachments ?? []) : []}
+      value={staticAttachments ?? []}
       onChange={(newValue) =>
         setValue(`actions.${index}.staticAttachments`, newValue)
       }
       emailAccountId={emailAccountId}
-      contentSetManually={canConfigureStaticAttachments}
-      allowAiSelectedSources={supportsAiSelectedSources}
       attachmentSources={attachmentSources}
       onAttachmentSourcesChange={onAttachmentSourcesChange}
     />


### PR DESCRIPTION
## Summary

- The Attachments section in the rule editor now always renders BOTH "Always attach" and "AI-selected sources" sub-sections whenever the action type supports attachments (Draft reply, Reply, Send email).
- Previously, visibility depended on whether content was set manually and on `isDraftReplyActionType`, so users saw different options based on how the rule was created (e.g. file mentioned in prompt vs. not).
- Fixes INB-147.

## Root cause

`ActionSteps.tsx` computed `supportsAiSelectedSources` (Draft reply only) and `canConfigureStaticAttachments` (Draft reply AND `contentSetManually`) and passed them into `ActionAttachmentsField` as `allowAiSelectedSources` / `contentSetManually`, which gated the two sub-sections.

## Fix

- Removed the `allowAiSelectedSources` and `contentSetManually` props from `ActionAttachmentsField`; both sub-sections now render whenever the drive is connected.
- Simplified `ActionSteps.tsx` to only pass values and `supportsAttachments` as the gate for rendering `ActionAttachmentsField` at all.
- Stored `staticAttachments` are now always passed through; no longer masked to `[]` when the action is a draft reply without `setManually`.

## Test plan

- [ ] Create a new Draft reply rule without mentioning a file; confirm both "Always attach" and "AI-selected sources" are visible in the action.
- [ ] Create a new Reply rule; confirm both options are visible.
- [ ] Create a new Send email rule; confirm both options are visible.
- [ ] Create a rule via prompt mentioning a specific file; confirm pre-selected files show under "Always attach" and both sections remain visible.
- [ ] Switch an action type away from Draft reply / Reply / Send email and confirm the Attachments section disappears.

Generated with Claude Code