### PR TITLE
fix: re-run AI attachment selection on draft cache miss

### DIFF
--- a/apps/web/utils/ai/action-attachments.ts
+++ b/apps/web/utils/ai/action-attachments.ts
@@ -4,10 +4,15 @@ import {
   type SelectedAttachment,
   attachmentSourceInputSchema,
 } from "@/utils/attachments/source-schema";
-import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
+import {
+  resolveDraftAttachments,
+  selectDraftAttachmentsForRule,
+} from "@/utils/attachments/draft-attachments";
 import type { ActionItem, EmailForAction } from "@/utils/ai/types";
 import type { Logger } from "@/utils/logger";
 import { getReplyWithConfidence } from "@/utils/redis/reply";
+import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
+import { getEmailAccountWithAiAndTokens } from "@/utils/user/get";
 
 export async function resolveActionAttachments({
   email,
@@ -79,22 +84,51 @@ async function getDraftSelectedAttachments({
   logger: Logger;
 }): Promise<SelectedAttachment[]> {
   if (!executedRule.ruleId) return [];
+  const ruleId = executedRule.ruleId;
 
   const cachedDraft = await getReplyWithConfidence({
     emailAccountId,
     messageId: email.id,
-    ruleId: executedRule.ruleId,
+    ruleId,
   });
 
   if (cachedDraft) {
     return cachedDraft.attachments ?? [];
   }
 
-  logger.warn("Draft attachment cache missing, skipping attachments", {
-    messageId: email.id,
-    ruleId: executedRule.ruleId,
+  // Cache-miss fallback: re-run attachment selection so drafts created outside
+  // the normal draft-generation flow (e.g. scheduled/delayed actions, expired
+  // cache, a rule whose draft was generated before attachment sources were
+  // configured) still get their AI-selected attachments. This costs an extra
+  // LLM call but is scoped to rules that actually have attachment sources
+  // configured (selectDraftAttachmentsForRule short-circuits otherwise).
+  logger.info(
+    "Draft attachment cache miss, running attachment selection inline",
+    {
+      messageId: email.id,
+      ruleId,
+    },
+  );
+
+  const emailAccount = await getEmailAccountWithAiAndTokens({ emailAccountId });
+  if (!emailAccount) {
+    logger.warn("Email account not found during attachment selection", {
+      messageId: email.id,
+      ruleId,
+    });
+    return [];
+  }
+
+  const emailContent = emailToContentForAI(email);
+
+  const { selectedAttachments } = await selectDraftAttachmentsForRule({
+    emailAccount,
+    ruleId,
+    emailContent,
+    logger,
   });
-  return [];
+
+  return selectedAttachments;
 }
 
 function parseStaticAttachments(raw: unknown): SelectedAttachment[] {

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -23,6 +23,15 @@ vi.mock("@/utils/redis/reply", () => ({
   getReplyWithConfidence: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/utils/user/get", () => ({
+  getEmailAccountWithAiAndTokens: vi.fn().mockResolvedValue({
+    id: "account-1",
+    userId: "user-1",
+    email: "user@example.com",
+    user: { aiProvider: null, aiModel: null, aiApiKey: null },
+  }),
+}));
+
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   resolveDraftAttachments: vi.fn().mockResolvedValue([]),
   selectDraftAttachmentsForRule: vi.fn().mockResolvedValue({
@@ -116,6 +125,9 @@ describe("runActionFunction", () => {
       ruleId: "rule-1",
     });
 
+    // On cache hit we must not re-run the selection LLM call.
+    expect(selectDraftAttachmentsForRule).not.toHaveBeenCalled();
+
     expect(resolveDraftAttachments).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       userId: "user-1",
@@ -147,10 +159,29 @@ describe("runActionFunction", () => {
     );
   });
 
-  it("skips draft attachments when the rule cache is missing", async () => {
+  it("re-runs attachment selection when the rule cache is missing", async () => {
     const client = createMockEmailProvider();
 
     vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
+    vi.mocked(selectDraftAttachmentsForRule).mockResolvedValue({
+      selectedAttachments: [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-1",
+          filename: "lease.pdf",
+          mimeType: "application/pdf",
+          reason: "Matched the requested property",
+        },
+      ],
+      attachmentContext: "<attachment>lease.pdf</attachment>",
+    });
+    vi.mocked(resolveDraftAttachments).mockResolvedValue([
+      {
+        filename: "lease.pdf",
+        content: Buffer.from("pdf"),
+        contentType: "application/pdf",
+      },
+    ]);
 
     await runActionFunction({
       client,
@@ -172,13 +203,28 @@ describe("runActionFunction", () => {
       logger,
     });
 
-    expect(selectDraftAttachmentsForRule).not.toHaveBeenCalled();
-    expect(resolveDraftAttachments).not.toHaveBeenCalled();
+    expect(selectDraftAttachmentsForRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleId: "rule-1",
+      }),
+    );
+    expect(resolveDraftAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedAttachments: [
+          expect.objectContaining({ fileId: "file-1", filename: "lease.pdf" }),
+        ],
+      }),
+    );
     expect(client.draftEmail).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         content: "Attached the requested PDF.",
-        attachments: [],
+        attachments: [
+          expect.objectContaining({
+            filename: "lease.pdf",
+            contentType: "application/pdf",
+          }),
+        ],
       }),
       "user@example.com",
       expect.objectContaining({ id: "executed-rule-1" }),


### PR DESCRIPTION
## Summary

Fixes INB-146. When a `DRAFT_EMAIL` action runs for a rule with AI-selected attachment sources configured (Drive folder / file) and the Redis-cached draft is missing, the action silently dropped all attachments even if the source was fully indexed and the email explicitly requested a matching file.

The two-step design stores the AI-selected attachments alongside the draft during generation (`selectDraftAttachmentsForRule` -> Redis), then re-reads them when the action executes. On cache miss (scheduled/delayed actions, expired cache, rules configured after draft generation, etc.) `getDraftSelectedAttachments` returned `[]`, so users with unindexed/recently-changed folders - or any timing-skew between draft generation and action execution - silently got no attachments.

## Change

- On cache miss in `apps/web/utils/ai/action-attachments.ts`, fall back to running `selectDraftAttachmentsForRule` inline using the current email content.
- The selection function already short-circuits when the rule has no attachment sources configured, so the extra LLM call only happens for rules that actually expect attachments.
- Updated the existing "cache miss" unit test to assert the new fallback behavior (attachments are still selected and resolved) and added a guard on the cache-hit path to ensure we don't double-run selection.

## Test plan

- [x] `pnpm test utils/ai/actions.test.ts` - 11/11 passing
- [x] `pnpm test utils/attachments utils/reply-tracker/generate-draft.test.ts` - 17/17 passing
- [ ] Manual: configure a rule with a Drive folder source, trigger a scheduled/delayed DRAFT_EMAIL action after the cache has expired, confirm the matching PDF is attached.

Refs INB-146.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>