### PR TITLE
assistant: fix chat label_threads removing existing labels (INB-137)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -413,14 +413,22 @@ describe("chat inbox tools", () => {
     expect(maxInFlight).toBeLessThanOrEqual(3);
   });
 
-  it("returns a descriptive error when label_threads receives an unknown labelName", async () => {
-    const getThreadMessages = vi.fn();
+  it("auto-creates a missing label when label_threads receives an unknown labelName", async () => {
+    const getThreadMessages = vi
+      .fn()
+      .mockResolvedValue([{ id: "thread-1-message-1", threadId: "thread-1" }]);
     const getLabelByName = vi.fn().mockResolvedValue(null);
-    const labelMessage = vi.fn();
+    const createLabel = vi.fn().mockResolvedValue({
+      id: "Label_new",
+      name: "Finance",
+      type: "user",
+    });
+    const labelMessage = vi.fn().mockResolvedValue(undefined);
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       getThreadMessages,
       getLabelByName,
+      createLabel,
       labelMessage,
     } as any);
 
@@ -437,14 +445,19 @@ describe("chat inbox tools", () => {
       threadIds: ["thread-1"],
     });
 
-    expect(result).toEqual({
-      error:
-        'Label "Finance" does not exist. Use createOrGetLabel first if you want to create it.',
-    });
     expect(getLabelByName).toHaveBeenCalledWith("Finance");
-    expect(getLabelByName).toHaveBeenCalledTimes(1);
-    expect(getThreadMessages).not.toHaveBeenCalled();
-    expect(labelMessage).not.toHaveBeenCalled();
+    expect(createLabel).toHaveBeenCalledWith("Finance");
+    expect(labelMessage).toHaveBeenCalledWith({
+      messageId: "thread-1-message-1",
+      labelId: "Label_new",
+      labelName: "Finance",
+    });
+    expect(result).toMatchObject({
+      action: "label_threads",
+      success: true,
+      labelId: "Label_new",
+      labelName: "Finance",
+    });
   });
 
   it("marks a thread labeling action as failed when any message label call fails", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -486,7 +486,7 @@ function manageInboxInputSchema(provider: string) {
     action: z
       .enum(manageInboxActions)
       .describe(
-        "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: apply a label (requires labelName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
+        'archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: add a label to threads without archiving, marking read, or removing any existing labels (requires labelName; auto-creates the label if missing). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests). For "label X as Y" requests, use label_threads — do not fall back to archive_threads or mark_read_threads.',
       ),
     threadIds: threadIdsSchema
       .nullish()
@@ -533,7 +533,8 @@ export const manageInboxTool = ({
   const inputSchema = manageInboxInputSchema(provider);
 
   return tool({
-    description: "Run inbox actions on threads or senders.",
+    description:
+      "Run inbox actions on threads or senders: archive, trash, add a label (label_threads, non-destructive), mark read/unread, bulk archive by sender, or unsubscribe.",
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "manage_inbox", email, logger });
@@ -1147,15 +1148,17 @@ async function resolveThreadLabel({
 }) {
   const existingLabel = await emailProvider.getLabelByName(labelName);
 
-  if (!existingLabel) {
-    throw new Error(
-      `Label "${labelName}" does not exist. Use createOrGetLabel first if you want to create it.`,
-    );
+  if (existingLabel) {
+    return {
+      labelId: existingLabel.id,
+      labelName: existingLabel.name,
+    };
   }
 
+  const createdLabel = await emailProvider.createLabel(labelName);
   return {
-    labelId: existingLabel.id,
-    labelName: existingLabel.name,
+    labelId: createdLabel.id,
+    labelName: createdLabel.name,
   };
 }
 

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -633,7 +633,7 @@ export function buildResolvedSystemPrompt({
     "You are the Inbox Zero assistant. You help users understand their inbox, take inbox actions, update account features, and manage automation rules.",
     `Core responsibilities:
 1. Search and summarize inbox activity, especially what is new and what needs attention
-2. Take inbox actions such as archive, trash/delete, mark read, bulk archive by sender, and sender unsubscribe
+2. Take inbox actions such as archive, trash/delete, add labels, mark read, bulk archive by sender, and sender unsubscribe
 3. Update account features such as meeting briefs and auto-file attachments
 4. Create and update rules`,
     `Tool usage strategy:


### PR DESCRIPTION
## Summary

Fixes INB-137: asking the assistant to "label all emails from X as Y" previously resulted in emails losing their existing label and being marked read, with no new label applied.

Root cause: when the requested label didn't exist, `manageInbox`'s `label_threads` action threw an error pointing at `createOrGetLabel`. The model would then fall back to `archive_threads` / `mark_read_threads` to "clean up" instead of chaining `createOrGetLabel` + `label_threads`. System prompt also omitted labeling from core responsibilities, which made this fallback more likely.

- `label_threads` now auto-creates a missing label (same pattern used by `archive_threads` via `resolveLabelNameAndId`), so a single tool call suffices.
- Clarified the `manageInbox` tool and action descriptions so the model treats `label_threads` as a non-destructive add-only action and uses it for "label X as Y" requests.
- Added labeling to the assistant's listed core responsibilities.

No change to the underlying email-provider `labelMessage` implementations — both Gmail and Outlook were already additive.

## Test plan

- [x] `pnpm test chat-inbox-tools` (10 passed) — updated the "unknown labelName" test to assert auto-create behavior.
- [x] `pnpm test chat-label-tools` (4 passed) — no behavioral change to `createOrGetLabel` tool.
- [ ] Manual QA: ask chat "label all emails from X as 'NewLabel'" and verify (1) the new label is created, (2) it is applied to matching threads, (3) existing labels remain, (4) threads are not archived or marked read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)