### PR TITLE
fix: allow closing chat panel and auto-reset on navigation (INB-135)

### DIFF
--- a/apps/web/components/SidebarRight.tsx
+++ b/apps/web/components/SidebarRight.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCallback, useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Chat } from "@/components/assistant-chat/chat";
 import { cn } from "@/utils";
@@ -11,8 +13,37 @@ export function SidebarRight({
   name: string;
   className?: string;
 }) {
-  const { state, openMobile, isMobile } = useSidebar();
+  const { state, setOpen, openMobile, isMobile, closeMobileSidebar } =
+    useSidebar();
   const isOpen = isMobile ? openMobile.includes(name) : state.includes(name);
+
+  const handleClose = useCallback(() => {
+    if (isMobile) {
+      closeMobileSidebar(name);
+    } else {
+      setOpen((prev) => prev.filter((n) => n !== name));
+    }
+  }, [isMobile, name, setOpen, closeMobileSidebar]);
+
+  // Auto-close the chat panel when navigating to a new page so it doesn't
+  // persist across unrelated routes (including when remounting after
+  // visiting a route that does not render this sidebar).
+  const pathname = usePathname();
+  const handleCloseRef = useRef(handleClose);
+  handleCloseRef.current = handleClose;
+  const previousPathnameRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (previousPathnameRef.current !== pathname) {
+      if (previousPathnameRef.current !== null) handleCloseRef.current();
+      previousPathnameRef.current = pathname;
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    return () => {
+      handleCloseRef.current();
+    };
+  }, []);
 
   return (
     <div
@@ -24,7 +55,7 @@ export function SidebarRight({
       )}
     >
       <div className="flex h-full w-full flex-col overflow-hidden">
-        <Chat open={isOpen} />
+        <Chat open={isOpen} onClose={handleClose} />
       </div>
     </div>
   );

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -8,6 +8,7 @@ import {
   PaperclipIcon,
   PlusIcon,
   SquareIcon,
+  XIcon,
 } from "lucide-react";
 import { Messages } from "./messages";
 import { PreviewAttachment } from "./preview-attachment";
@@ -43,7 +44,13 @@ const ACCEPTED_IMAGE_TYPES = [
   "image/gif",
 ];
 
-export function Chat({ open }: { open: boolean }) {
+export function Chat({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose?: () => void;
+}) {
   const {
     chat,
     chatId,
@@ -270,7 +277,7 @@ export function Chat({ open }: { open: boolean }) {
         } as React.CSSProperties
       }
     >
-      <ChatTopBar hasMessages={hasMessages} />
+      <ChatTopBar hasMessages={hasMessages} onClose={onClose} />
       {hasMessages ? (
         <ChatMessagesView
           status={status}
@@ -395,7 +402,13 @@ function NewChatView({
   );
 }
 
-function ChatTopBar({ hasMessages }: { hasMessages: boolean }) {
+function ChatTopBar({
+  hasMessages,
+  onClose,
+}: {
+  hasMessages: boolean;
+  onClose?: () => void;
+}) {
   return (
     <div className="relative mx-auto w-full max-w-[calc(var(--chat-max-w)+var(--chat-px)*2)] px-[var(--chat-px)] pt-2">
       <div className="flex items-center justify-end gap-1">
@@ -407,8 +420,20 @@ function ChatTopBar({ hasMessages }: { hasMessages: boolean }) {
         ) : (
           <ChatHistoryDropdown />
         )}
+        {onClose ? <CloseChatButton onClose={onClose} /> : null}
       </div>
     </div>
+  );
+}
+
+function CloseChatButton({ onClose }: { onClose: () => void }) {
+  return (
+    <Tooltip content="Close chat">
+      <Button variant="ghost" size="icon" onClick={onClose}>
+        <XIcon className="size-5" />
+        <span className="sr-only">Close chat</span>
+      </Button>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds a visible close (X) button to the AI Chat sidebar header
- Auto-closes the chat panel when the route changes so it no longer persists across unrelated pages
- Ensures the close action clears the sidebar state (used by the shared layout to shift content)

## Root cause
`SidebarRight` rendered `Chat` inside a right sidebar whose open state lives in the shared `SidebarProvider` context (persisted via cookie). There was no close affordance in the chat header, and nothing reset the sidebar state on navigation, so once opened from `/automation` it stayed open on every other app route.

## Fix
- `components/SidebarRight.tsx`: wire a `handleClose` callback that removes the sidebar from the provider's open state (or closes the mobile sheet), close on pathname change, and close on unmount so remounting on another route starts fresh.
- `components/assistant-chat/chat.tsx`: accept an optional `onClose` prop and render an X button in `ChatTopBar` when provided. The full-page assistant (`/assistant`) does not pass `onClose`, so the X only appears when the chat is in the dismissible side panel.

## Test plan
- [ ] Open `/automation`, click `AI Chat`: panel opens, content shifts, X button visible in header
- [ ] Click X: panel closes and content reflows
- [ ] Open panel, navigate to another app route: panel auto-closes
- [ ] Navigate to `/assistant`: full-page chat renders without an X button (expected)
- [ ] On mobile, open via toggle then close via X: mobile sheet closes