### PR TITLE
feat: warn when rule uses Drive attachments but Drive is disconnected (INB-143)

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
@@ -25,10 +25,15 @@ vi.mock("next/link", () => ({
   default: ({
     children,
     href,
+    ...rest
   }: {
     children: React.ReactNode;
     href: string;
-  }) => <a href={href}>{children}</a>,
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -183,5 +188,49 @@ describe("Rules", () => {
     );
 
     expect(screen.getByText("Delete")).toBeTruthy();
+  });
+
+  it("shows a warning badge when Drive attachments are disconnected", () => {
+    mockUseRules.mockReturnValue({
+      data: [
+        {
+          id: "rule-with-disconnected-drive",
+          name: "Send brochure",
+          instructions: "Reply with brochure",
+          enabled: true,
+          runOnThreads: false,
+          automate: true,
+          actions: [],
+          group: null,
+          emailAccountId: "ea_1",
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          categoryFilterType: null,
+          conditionalOperator: "OR",
+          groupId: null,
+          systemType: null,
+          to: null,
+          from: null,
+          subject: null,
+          body: null,
+          promptText: null,
+          attachmentSources: [],
+          hasDisconnectedDriveAttachments: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      mutate: vi.fn(),
+    });
+
+    render(<Rules />);
+
+    const row = screen.getByText("Send brochure").closest("tr");
+    expect(row).toBeTruthy();
+    expect(
+      within(row as HTMLElement).getByLabelText(
+        "Drive disconnected: attachments will be skipped",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -10,6 +10,7 @@ import {
   Trash2Icon,
   SparklesIcon,
   CopyIcon,
+  AlertTriangleIcon,
 } from "lucide-react";
 import { useMemo } from "react";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -30,6 +31,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
 import { deleteRuleAction, toggleRuleAction } from "@/utils/actions/rule";
 import { Badge } from "@/components/Badge";
@@ -120,6 +127,8 @@ export function Rules({
         subject: null,
         body: null,
         promptText: null,
+        attachmentSources: [],
+        hasDisconnectedDriveAttachments: false,
       };
     });
 
@@ -220,7 +229,14 @@ export function Rules({
                         />
                       </TableCell>
                       <TableCell className="font-medium p-2 sm:p-4">
-                        {rule.name}
+                        <div className="flex items-center gap-2">
+                          {rule.name}
+                          {rule.hasDisconnectedDriveAttachments && (
+                            <DriveDisconnectedWarning
+                              emailAccountId={emailAccountId}
+                            />
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="hidden sm:table-cell p-2 sm:p-4">
                         <TruncatedTooltipText
@@ -429,6 +445,33 @@ function getVisibleActions<T extends { type: ActionType }>(actions: T[]): T[] {
 
   return sortedActions.filter(
     (action) => !(action.type === "DRAFT_MESSAGING_CHANNEL" && hasEmailDraft),
+  );
+}
+
+function DriveDisconnectedWarning({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href={prefixPath(emailAccountId, "/drive")}
+            onClick={(e) => e.stopPropagation()}
+            className="text-amber-600 dark:text-amber-500"
+            aria-label="Drive disconnected: attachments will be skipped"
+          >
+            <AlertTriangleIcon className="size-4" />
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent>
+          Drive is disconnected. Attachments configured for this rule will be
+          skipped until you reconnect.
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/apps/web/app/api/user/rules/route.ts
+++ b/apps/web/app/api/user/rules/route.ts
@@ -1,17 +1,57 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
+import { attachmentSourceInputSchema } from "@/utils/attachments/source-schema";
 
 export type RulesResponse = Awaited<ReturnType<typeof getRules>>;
 
 async function getRules({ emailAccountId }: { emailAccountId: string }) {
-  return await prisma.rule.findMany({
-    where: { emailAccountId },
-    include: {
-      actions: true,
-      group: { select: { name: true } },
-    },
-    orderBy: { createdAt: "asc" },
+  const [rules, driveConnections] = await Promise.all([
+    prisma.rule.findMany({
+      where: { emailAccountId },
+      include: {
+        actions: true,
+        group: { select: { name: true } },
+        attachmentSources: {
+          select: {
+            id: true,
+            driveConnection: { select: { id: true, isConnected: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.driveConnection.findMany({
+      where: { emailAccountId },
+      select: { id: true, isConnected: true },
+    }),
+  ]);
+
+  const connectedDriveIds = new Set(
+    driveConnections.filter((c) => c.isConnected).map((c) => c.id),
+  );
+
+  return rules.map((rule) => {
+    const hasDisconnectedSourceAttachments = rule.attachmentSources.some(
+      (source) => !source.driveConnection?.isConnected,
+    );
+
+    const hasDisconnectedStaticAttachments = rule.actions.some((action) => {
+      if (!action.staticAttachments) return false;
+      const parsed = attachmentSourceInputSchema
+        .array()
+        .safeParse(action.staticAttachments);
+      if (!parsed.success) return false;
+      return parsed.data.some(
+        (attachment) => !connectedDriveIds.has(attachment.driveConnectionId),
+      );
+    });
+
+    return {
+      ...rule,
+      hasDisconnectedDriveAttachments:
+        hasDisconnectedSourceAttachments || hasDisconnectedStaticAttachments,
+    };
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes INB-143. When a rule is configured with Drive-backed attachments (AttachmentSource rows or staticAttachments on Actions) and the Drive connection is later disconnected, the rule keeps firing and replies are sent with no attachments, silently. This adds a warning surface on the rules list.

- `GET /api/user/rules` now computes `hasDisconnectedDriveAttachments` per rule. A rule is flagged if any `AttachmentSource.driveConnection.isConnected` is false, or if any `Action.staticAttachments[].driveConnectionId` does not match a currently connected `DriveConnection`.
- The Rules table renders a warning icon next to the rule name that links to the Drive settings page, with a tooltip explaining the attachments will be skipped until the Drive connection is restored.

## Test plan

- [x] Existing `Rules.test.tsx` cases still pass.
- [x] New test verifies the warning badge appears when `hasDisconnectedDriveAttachments` is true.
- [ ] Manually disconnect a Drive and confirm the warning appears on any rule that references it (both AttachmentSource and staticAttachments paths).
- [ ] Follow-up (not in this PR): inline alert inside the rule editor; execution-history entry noting the skipped attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)