### PR TITLE
fix: include all enabled calendars in assistant event lookup (INB-151)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-calendar-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-calendar-tools.ts
@@ -32,7 +32,8 @@ export const getCalendarEventsTool = ({
   logger: Logger;
 }) =>
   tool({
-    description: "Fetch calendar events for a date range.",
+    description:
+      "Fetch calendar events for a date range across all the user's connected and enabled calendars (Google and Microsoft). Use this when the user asks about their schedule, meetings, or calendar.",
     inputSchema: getCalendarEventsInputSchema,
     execute: async ({ startDate, endDate, maxResults }) => {
       trackToolCall({ tool: "get_calendar_events", email, logger });

--- a/apps/web/utils/calendar/event-provider.ts
+++ b/apps/web/utils/calendar/event-provider.ts
@@ -24,6 +24,13 @@ export async function createCalendarEventProviders(
       accessToken: true,
       refreshToken: true,
       expiresAt: true,
+      calendars: {
+        where: { isEnabled: true },
+        select: {
+          calendarId: true,
+          primary: true,
+        },
+      },
     },
   });
 
@@ -37,6 +44,15 @@ export async function createCalendarEventProviders(
   for (const connection of connections) {
     if (!connection.refreshToken) continue;
 
+    const calendarIds = connection.calendars.map((cal) => cal.calendarId);
+    if (calendarIds.length === 0) {
+      logger.info("No enabled calendars for connection", {
+        connectionId: connection.id,
+        provider: connection.provider,
+      });
+      continue;
+    }
+
     try {
       if (isGoogleProvider(connection.provider)) {
         providers.push(
@@ -46,6 +62,7 @@ export async function createCalendarEventProviders(
               refreshToken: connection.refreshToken,
               expiresAt: connection.expiresAt?.getTime() ?? null,
               emailAccountId,
+              calendarIds,
             },
             logger,
           ),
@@ -58,6 +75,7 @@ export async function createCalendarEventProviders(
               refreshToken: connection.refreshToken,
               expiresAt: connection.expiresAt?.getTime() ?? null,
               emailAccountId,
+              calendarIds,
             },
             logger,
           ),

--- a/apps/web/utils/calendar/providers/google-events.ts
+++ b/apps/web/utils/calendar/providers/google-events.ts
@@ -8,6 +8,7 @@ import type { Logger } from "@/utils/logger";
 
 export interface GoogleCalendarConnectionParams {
   accessToken: string | null;
+  calendarIds: string[];
   emailAccountId: string;
   expiresAt: number | null;
   refreshToken: string | null;
@@ -45,17 +46,30 @@ export class GoogleCalendarEventProvider implements CalendarEventProvider {
   }): Promise<CalendarEvent[]> {
     const client = await this.getClient();
 
-    const response = await client.events.list({
-      calendarId: "primary",
-      timeMin: timeMin.toISOString(),
-      timeMax: timeMax.toISOString(),
-      maxResults,
-      singleEvents: true,
-      orderBy: "startTime",
-      q: attendeeEmail,
-    });
+    const results = await Promise.allSettled(
+      this.connection.calendarIds.map((calendarId) =>
+        client.events.list({
+          calendarId,
+          timeMin: timeMin.toISOString(),
+          timeMax: timeMax.toISOString(),
+          maxResults,
+          singleEvents: true,
+          orderBy: "startTime",
+          q: attendeeEmail,
+        }),
+      ),
+    );
 
-    const events = response.data.items || [];
+    const events = results.flatMap((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.warn("Failed to fetch events for calendar", {
+          calendarId: this.connection.calendarIds[index],
+          error: result.reason,
+        });
+        return [];
+      }
+      return result.value.data.items || [];
+    });
 
     // Filter to events that actually have this attendee
     return events
@@ -64,6 +78,7 @@ export class GoogleCalendarEventProvider implements CalendarEventProvider {
           (a) => a.email?.toLowerCase() === attendeeEmail.toLowerCase(),
         ),
       )
+      .slice(0, maxResults)
       .map((event) => this.parseEvent(event));
   }
 
@@ -77,19 +92,36 @@ export class GoogleCalendarEventProvider implements CalendarEventProvider {
     maxResults?: number;
   }): Promise<CalendarEvent[]> {
     const client = await this.getClient();
+    const perCalendarLimit = maxResults || 10;
 
-    const response = await client.events.list({
-      calendarId: "primary",
-      timeMin: timeMin?.toISOString(),
-      timeMax: timeMax?.toISOString(),
-      maxResults: maxResults || 10,
-      singleEvents: true,
-      orderBy: "startTime",
+    const results = await Promise.allSettled(
+      this.connection.calendarIds.map((calendarId) =>
+        client.events.list({
+          calendarId,
+          timeMin: timeMin?.toISOString(),
+          timeMax: timeMax?.toISOString(),
+          maxResults: perCalendarLimit,
+          singleEvents: true,
+          orderBy: "startTime",
+        }),
+      ),
+    );
+
+    const events = results.flatMap((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.warn("Failed to fetch events for calendar", {
+          calendarId: this.connection.calendarIds[index],
+          error: result.reason,
+        });
+        return [];
+      }
+      return result.value.data.items || [];
     });
 
-    const events = response.data.items || [];
-
-    return events.map((event) => this.parseEvent(event));
+    return events
+      .map((event) => this.parseEvent(event))
+      .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+      .slice(0, perCalendarLimit);
   }
 
   private parseEvent(event: calendar_v3.Schema$Event) {

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -8,6 +8,7 @@ import type { Logger } from "@/utils/logger";
 
 export interface MicrosoftCalendarConnectionParams {
   accessToken: string | null;
+  calendarIds: string[];
   emailAccountId: string;
   expiresAt: number | null;
   refreshToken: string | null;
@@ -60,18 +61,30 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
   }): Promise<CalendarEvent[]> {
     const client = await this.getClient();
 
-    // Use calendarView endpoint which correctly returns events overlapping the time range
-    const response = await client
-      .api("/me/calendar/calendarView")
-      .query({
-        startDateTime: timeMin.toISOString(),
-        endDateTime: timeMax.toISOString(),
-      })
-      .top(maxResults * 3) // Fetch more to filter by attendee
-      .orderby("start/dateTime")
-      .get();
+    const results = await Promise.allSettled(
+      this.connection.calendarIds.map((calendarId) =>
+        client
+          .api(`/me/calendars/${calendarId}/calendarView`)
+          .query({
+            startDateTime: timeMin.toISOString(),
+            endDateTime: timeMax.toISOString(),
+          })
+          .top(maxResults * 3) // Fetch more to filter by attendee
+          .orderby("start/dateTime")
+          .get(),
+      ),
+    );
 
-    const events: MicrosoftEvent[] = response.value || [];
+    const events: MicrosoftEvent[] = results.flatMap((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.warn("Failed to fetch events for calendar", {
+          calendarId: this.connection.calendarIds[index],
+          error: result.reason,
+        });
+        return [];
+      }
+      return result.value.value || [];
+    });
 
     // Filter to events that have this attendee
     return events
@@ -100,21 +113,37 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
     // calendarView requires both start and end times, default to 30 days from timeMin
     const effectiveTimeMax =
       timeMax ?? new Date(timeMin.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const perCalendarLimit = maxResults || 100;
 
-    // Use calendarView endpoint which correctly returns events overlapping the time range
-    const response = await client
-      .api("/me/calendar/calendarView")
-      .query({
-        startDateTime: timeMin.toISOString(),
-        endDateTime: effectiveTimeMax.toISOString(),
-      })
-      .top(maxResults || 100)
-      .orderby("start/dateTime")
-      .get();
+    const results = await Promise.allSettled(
+      this.connection.calendarIds.map((calendarId) =>
+        client
+          .api(`/me/calendars/${calendarId}/calendarView`)
+          .query({
+            startDateTime: timeMin.toISOString(),
+            endDateTime: effectiveTimeMax.toISOString(),
+          })
+          .top(perCalendarLimit)
+          .orderby("start/dateTime")
+          .get(),
+      ),
+    );
 
-    const events: MicrosoftEvent[] = response.value || [];
+    const events: MicrosoftEvent[] = results.flatMap((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.warn("Failed to fetch events for calendar", {
+          calendarId: this.connection.calendarIds[index],
+          error: result.reason,
+        });
+        return [];
+      }
+      return result.value.value || [];
+    });
 
-    return events.map((event) => this.parseEvent(event));
+    return events
+      .map((event) => this.parseEvent(event))
+      .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
+      .slice(0, perCalendarLimit);
   }
 
   private parseEvent(event: MicrosoftEvent) {


### PR DESCRIPTION
## Summary
- Chat assistant's `getCalendarEvents` tool now fetches events from every enabled calendar on each connected calendar account, not just the primary one.
- `GoogleCalendarEventProvider` and `MicrosoftCalendarEventProvider` accept `calendarIds` from `createCalendarEventProviders` (sourced from `Calendar` rows where `isEnabled = true`) and iterate them via `events.list({ calendarId })` / `/me/calendars/{id}/calendarView`, merging and sorting results.
- Connections with no enabled calendars are skipped. Tool description updated to reflect multi-calendar behavior.

## Root cause
Both event providers hardcoded `calendarId: "primary"` (Google) and `/me/calendar/calendarView` (Microsoft default), so secondary calendars that users had toggled ON in settings were ignored by the assistant even though the availability pipeline already respected them.

## Test plan
- [ ] Connect a Google account with a primary + one secondary calendar, toggle both ON in Calendars settings, ask the assistant "what's on my calendar tomorrow" and confirm events from both calendars appear.
- [ ] Disable the secondary calendar and confirm its events are excluded.
- [ ] Repeat with a Microsoft account (default + additional calendar).
- [ ] Verify a connection with all calendars disabled is silently skipped.

Closes INB-151.

Generated with [Claude Code](https://claude.com/claude-code)