### PR TITLE
rules: preserve action order on save

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -1,7 +1,13 @@
 /** @vitest-environment jsdom */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import { ConditionType } from "@/utils/config";
@@ -12,6 +18,9 @@ const mockUseMessagingChannels = vi.fn();
 const mockUseFolders = vi.fn();
 const mockUseRouter = vi.fn();
 const mockUsePostHog = vi.fn();
+const { mockUpdateRuleAction } = vi.hoisted(() => ({
+  mockUpdateRuleAction: vi.fn(),
+}));
 
 (globalThis as { React?: typeof React }).React = React;
 
@@ -72,7 +81,7 @@ vi.mock("@/utils/prisma");
 vi.mock("@/utils/actions/rule", () => ({
   createRuleAction: vi.fn(),
   deleteRuleAction: vi.fn(),
-  updateRuleAction: vi.fn(),
+  updateRuleAction: mockUpdateRuleAction,
 }));
 
 vi.mock("@/utils/attachments/rule", () => ({
@@ -114,6 +123,13 @@ describe("RuleForm", () => {
     });
     mockUsePostHog.mockReturnValue({
       capture: vi.fn(),
+    });
+    mockUpdateRuleAction.mockResolvedValue({
+      data: {
+        rule: {
+          id: "cmjzoasfv000004ld2qar07t3",
+        },
+      },
     });
   });
 
@@ -295,5 +311,64 @@ describe("RuleForm", () => {
     expect(screen.getByText("Email")).toBeTruthy();
     expect(screen.getByText("Slack DM")).toBeTruthy();
     expect(screen.getByText("Telegram DM")).toBeTruthy();
+  });
+
+  it("preserves the original action order when saving an unchanged rule", async () => {
+    const view = render(
+      <RuleForm
+        alwaysEditMode
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Sorted for display",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-reply",
+              type: ActionType.REPLY,
+              content: { value: "Thanks" },
+            },
+            {
+              id: "action-label",
+              type: ActionType.LABEL,
+              labelId: { value: "label-1", name: "Follow up" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      within(view.container).getByRole("button", { name: "Save" }),
+    );
+
+    await waitFor(() => expect(mockUpdateRuleAction).toHaveBeenCalledTimes(1));
+
+    expect(mockUpdateRuleAction.mock.calls.at(-1)?.[1]).toMatchObject({
+      id: "cmjzoasfv000004ld2qar07t3",
+      actions: [
+        expect.objectContaining({
+          id: "action-reply",
+          type: ActionType.REPLY,
+        }),
+        expect.objectContaining({
+          id: "action-label",
+          type: ActionType.LABEL,
+        }),
+      ],
+    });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -695,7 +695,9 @@ function restorePersistedActionSequence({
   if (existing.length === 0) return actions;
 
   existing.sort(
-    (a, b) => originalIndexById.get(a.id!)! - originalIndexById.get(b.id!)!,
+    (a, b) =>
+      ((a.id && originalIndexById.get(a.id)) ?? 0) -
+      ((b.id && originalIndexById.get(b.id)) ?? 0),
   );
 
   return [...existing, ...added];

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -214,7 +214,7 @@ export function RuleForm({
       }
 
       if (data.id) {
-        const orderedActionsToSubmit = preserveOriginalActionOrder({
+        const orderedActionsToSubmit = restorePersistedActionSequence({
           actions: actionsToSubmit,
           originalActions: rule.actions,
         });
@@ -666,7 +666,7 @@ function allowMultipleConditions(systemType: SystemType | null | undefined) {
   );
 }
 
-function preserveOriginalActionOrder({
+function restorePersistedActionSequence({
   actions,
   originalActions,
 }: {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -203,10 +203,22 @@ export function RuleForm({
       // Add DIGEST action if digest is enabled
       const actionsToSubmit = [...normalizedActions];
       if (data.digest) {
-        actionsToSubmit.push({ type: ActionType.DIGEST });
+        const existingDigestAction = rule.actions.find(
+          (action) => action.type === ActionType.DIGEST,
+        );
+
+        actionsToSubmit.push({
+          id: existingDigestAction?.id,
+          type: ActionType.DIGEST,
+        });
       }
 
       if (data.id) {
+        const orderedActionsToSubmit = preserveOriginalActionOrder({
+          actions: actionsToSubmit,
+          originalActions: rule.actions,
+        });
+
         if (mutate) {
           // mutate delayInMinutes optimistically to keep the UI consistent
           // in case the modal is reopened immediately after saving
@@ -224,7 +236,7 @@ export function RuleForm({
 
         const res = await updateRuleAction(emailAccountId, {
           ...data,
-          actions: actionsToSubmit,
+          actions: orderedActionsToSubmit,
           id: data.id,
         });
 
@@ -252,7 +264,7 @@ export function RuleForm({
           if (mutate) mutate();
           posthog.capture("User updated AI rule", {
             conditions: data.conditions.map((condition) => condition.type),
-            actions: actionsToSubmit.map((action) => action.type),
+            actions: orderedActionsToSubmit.map((action) => action.type),
             runOnThreads: data.runOnThreads,
             digest: data.digest,
           });
@@ -652,6 +664,43 @@ function allowMultipleConditions(systemType: SystemType | null | undefined) {
     systemType !== SystemType.COLD_EMAIL &&
     !isConversationStatusType(systemType)
   );
+}
+
+function preserveOriginalActionOrder({
+  actions,
+  originalActions,
+}: {
+  actions: CreateRuleBody["actions"];
+  originalActions: CreateRuleBody["actions"];
+}) {
+  const originalActionIndexes = new Map(
+    originalActions.flatMap((action, index) =>
+      action.id ? [[action.id, index] as const] : [],
+    ),
+  );
+
+  if (originalActionIndexes.size === 0) return actions;
+
+  const existingActions: CreateRuleBody["actions"] = [];
+  const newActions: CreateRuleBody["actions"] = [];
+
+  for (const action of actions) {
+    if (action.id && originalActionIndexes.has(action.id)) {
+      existingActions.push(action);
+    } else {
+      newActions.push(action);
+    }
+  }
+
+  if (existingActions.length === 0) return actions;
+
+  existingActions.sort(
+    (left, right) =>
+      originalActionIndexes.get(left.id!)! -
+      originalActionIndexes.get(right.id!)!,
+  );
+
+  return [...existingActions, ...newActions];
 }
 
 type ActionTypeOption = {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -681,26 +681,35 @@ function restorePersistedActionSequence({
 
   if (originalActionIndexes.size === 0) return actions;
 
-  const existingActions: CreateRuleBody["actions"] = [];
+  const existingActionsWithIndexes: Array<{
+    action: CreateRuleBody["actions"][number];
+    originalIndex: number;
+  }> = [];
   const newActions: CreateRuleBody["actions"] = [];
 
   for (const action of actions) {
-    if (action.id && originalActionIndexes.has(action.id)) {
-      existingActions.push(action);
-    } else {
-      newActions.push(action);
+    const originalIndex = action.id
+      ? originalActionIndexes.get(action.id)
+      : undefined;
+
+    if (originalIndex !== undefined) {
+      existingActionsWithIndexes.push({ action, originalIndex });
+      continue;
     }
+
+    newActions.push(action);
   }
 
-  if (existingActions.length === 0) return actions;
+  if (existingActionsWithIndexes.length === 0) return actions;
 
-  existingActions.sort(
-    (left, right) =>
-      originalActionIndexes.get(left.id!)! -
-      originalActionIndexes.get(right.id!)!,
+  existingActionsWithIndexes.sort(
+    (left, right) => left.originalIndex - right.originalIndex,
   );
 
-  return [...existingActions, ...newActions];
+  return [
+    ...existingActionsWithIndexes.map(({ action }) => action),
+    ...newActions,
+  ];
 }
 
 type ActionTypeOption = {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -696,8 +696,8 @@ function restorePersistedActionSequence({
 
   existing.sort(
     (a, b) =>
-      ((a.id && originalIndexById.get(a.id)) ?? 0) -
-      ((b.id && originalIndexById.get(b.id)) ?? 0),
+      (originalIndexById.get(a.id ?? "") ?? 0) -
+      (originalIndexById.get(b.id ?? "") ?? 0),
   );
 
   return [...existing, ...added];

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -673,43 +673,32 @@ function restorePersistedActionSequence({
   actions: CreateRuleBody["actions"];
   originalActions: CreateRuleBody["actions"];
 }) {
-  const originalActionIndexes = new Map(
+  const originalIndexById = new Map(
     originalActions.flatMap((action, index) =>
       action.id ? [[action.id, index] as const] : [],
     ),
   );
 
-  if (originalActionIndexes.size === 0) return actions;
+  if (originalIndexById.size === 0) return actions;
 
-  const existingActionsWithIndexes: Array<{
-    action: CreateRuleBody["actions"][number];
-    originalIndex: number;
-  }> = [];
-  const newActions: CreateRuleBody["actions"] = [];
+  const existing: CreateRuleBody["actions"] = [];
+  const added: CreateRuleBody["actions"] = [];
 
   for (const action of actions) {
-    const originalIndex = action.id
-      ? originalActionIndexes.get(action.id)
-      : undefined;
-
-    if (originalIndex !== undefined) {
-      existingActionsWithIndexes.push({ action, originalIndex });
-      continue;
+    if (action.id && originalIndexById.has(action.id)) {
+      existing.push(action);
+    } else {
+      added.push(action);
     }
-
-    newActions.push(action);
   }
 
-  if (existingActionsWithIndexes.length === 0) return actions;
+  if (existing.length === 0) return actions;
 
-  existingActionsWithIndexes.sort(
-    (left, right) => left.originalIndex - right.originalIndex,
+  existing.sort(
+    (a, b) => originalIndexById.get(a.id!)! - originalIndexById.get(b.id!)!,
   );
 
-  return [
-    ...existingActionsWithIndexes.map(({ action }) => action),
-    ...newActions,
-  ];
+  return [...existing, ...added];
 }
 
 type ActionTypeOption = {


### PR DESCRIPTION
# User description
Preserves stored rule action order when saving unchanged rules from the editor.

- restore existing action order before update submissions
- keep existing digest actions stable when resubmitting
- add regression coverage for unchanged saves and draft grouping

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Preserve stored rule action order when submitting the form by reordering the payload with <code>restorePersistedActionSequence</code> and reusing existing digest action IDs so resubmissions remain stable. Add regression coverage in <code>RuleForm.render.test.tsx</code> that verifies saving an unchanged rule keeps the original action order.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2250?tool=ast&topic=Action+order>Action order</a>
        </td><td>Preserve existing action sequence inside <code>RuleForm</code> before calling <code>updateRuleAction</code>, including reusing digest action IDs and sorting via <code>restorePersistedActionSequence</code> so saved rules keep their stored order.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: stabilize draft r...</td><td>April 14, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove conditional tit...</td><td>December 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2250?tool=ast&topic=Rule+form+tests>Rule form tests</a>
        </td><td>Add regression coverage in <code>RuleForm.render.test.tsx</code> to assert that saving an unchanged rule keeps the previously stored action order.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: stabilize draft r...</td><td>April 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2250?tool=ast>(Baz)</a>.