### PR TITLE
fix: surface pagination to chat bulk email tools (INB-134)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -7,6 +7,7 @@ import {
   forwardEmailTool,
   manageInboxTool,
   replyEmailTool,
+  searchInboxTool,
   sendEmailTool,
 } from "./chat-inbox-tools";
 
@@ -489,5 +490,84 @@ describe("chat inbox tools", () => {
       requestedCount: 1,
       failedThreadIds: ["thread-1"],
     });
+  });
+
+  it("searchInbox surfaces hasMore and a pagination hint when more pages exist", async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "m1",
+          threadId: "t1",
+          labelIds: [],
+          headers: { from: "sender@example.com", subject: "Hi" },
+          snippet: "",
+        },
+      ],
+      nextPageToken: "token-abc",
+    });
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      searchMessages,
+      getLabels: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = (await (toolInstance.execute as any)({
+      query: "older_than:3y is:unread",
+      limit: 50,
+    })) as {
+      hasMore: boolean;
+      nextPageToken?: string | null;
+      paginationHint?: string;
+    };
+
+    expect(result.hasMore).toBe(true);
+    expect(result.nextPageToken).toBe("token-abc");
+    expect(result.paginationHint).toBeDefined();
+  });
+
+  it("searchInbox marks hasMore false and omits pagination hint when there are no more pages", async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "m1",
+          threadId: "t1",
+          labelIds: [],
+          headers: { from: "sender@example.com", subject: "Hi" },
+          snippet: "",
+        },
+      ],
+      nextPageToken: undefined,
+    });
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      searchMessages,
+      getLabels: vi.fn().mockResolvedValue([]),
+    } as any);
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = (await (toolInstance.execute as any)({
+      query: "older_than:3y is:unread",
+      limit: 50,
+    })) as {
+      hasMore: boolean;
+      nextPageToken?: string | null;
+      paginationHint?: string;
+    };
+
+    expect(result.hasMore).toBe(false);
+    expect(result.paginationHint).toBeUndefined();
   });
 });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -217,7 +217,9 @@ function searchInboxInputSchema(provider: string) {
     pageToken: z
       .string()
       .nullish()
-      .describe("Use the page token returned from a prior search to paginate."),
+      .describe(
+        "Page token from a prior search result's nextPageToken to fetch the next page. Required to retrieve results beyond the first page when hasMore is true.",
+      ),
   });
 }
 
@@ -234,7 +236,7 @@ export const searchInboxTool = ({
 }) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata for triage and summarization.",
+      'Search inbox messages and return concise message metadata for triage and summarization. Returns one page of results (up to `limit`, max 50). When the response includes `hasMore: true`, more matches exist — call this tool again with the returned `nextPageToken` to fetch subsequent pages. For any request to act on ALL matching emails (for example "archive all unread older than 3 years", "label everything from X"), keep paginating and running the action on each page until `hasMore` is false. Do not claim a bulk action is complete while `hasMore` is true; report the actual cumulative count processed across pages.',
     inputSchema: searchInboxInputSchema(provider),
     execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });
@@ -265,10 +267,17 @@ export const searchInboxTool = ({
           .slice(0, limit)
           .map((message) => mapMessageForSearchResult(message, labelsById));
 
+        const hasMore = Boolean(nextPageToken);
+
         return {
           queryUsed: query,
           totalReturned: items.length,
+          hasMore,
           nextPageToken,
+          ...(hasMore && {
+            paginationHint:
+              "There are more results matching this query. Call searchInbox again with this pageToken to fetch the next page. Do not claim the operation is complete while hasMore is true.",
+          }),
           summary: summarizeSearchResults(items),
           messages: items,
         };
@@ -533,7 +542,8 @@ export const manageInboxTool = ({
   const inputSchema = manageInboxInputSchema(provider);
 
   return tool({
-    description: "Run inbox actions on threads or senders.",
+    description:
+      "Run inbox actions on threads or senders. Accepts at most 100 threadIds per call. When the user wants to act on more than 100 matching threads, split them into multiple manageInbox calls across pages from searchInbox (see its pagination rules) and keep going until every matching thread has been processed.",
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "manage_inbox", email, logger });


### PR DESCRIPTION
## Summary
- Chat assistant reported success on large bulk actions (e.g. "mark as read and archive all unread older than 3 years") but only processed the first page of search results (~50 threads) and left older matches untouched.
- Root cause: `searchInbox` returned a `nextPageToken` but no explicit "more results exist" signal, and neither `searchInbox` nor `manageInbox` tool descriptions told the model to paginate and keep running the action until all pages were consumed. The model saw a finite set, processed it, and said "done".
- Fix: surface `hasMore` + a `paginationHint` in the `searchInbox` tool output whenever more pages exist, and update the `searchInbox` and `manageInbox` tool descriptions (per AGENTS.md: per-tool guidance belongs in the tool description, not the system prompt) to require paginating through every page, splitting work across multiple `manageInbox` calls (100-threadId cap), and reporting the cumulative count processed before claiming completion.

Stays AI-first: no hardcoded pagination loops or keyword heuristics; we just make the tool faithful and make the model aware.

Files:
- `apps/web/utils/ai/assistant/chat-inbox-tools.ts`
- `apps/web/utils/ai/assistant/chat-inbox-tools.test.ts`

## Test plan
- [x] `pnpm test utils/ai/assistant/chat-inbox-tools.test.ts` - new tests lock `hasMore` / `paginationHint` behavior for both paginated and terminal results
- [x] `pnpm test utils/ai/assistant/` - all 54 existing assistant unit tests still pass
- [x] Biome check on changed files
- [ ] Manual: ask the chat to archive a large old-mail set and confirm it keeps calling `searchInbox` with `pageToken` until `hasMore` is false, reporting the true cumulative count

🤖 Generated with [Claude Code](https://claude.com/claude-code)