### PR TITLE
fix: surface pagination to chat bulk email tools (INB-134)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -7,6 +7,7 @@ import {
   forwardEmailTool,
   manageInboxTool,
   replyEmailTool,
+  searchInboxTool,
   sendEmailTool,
 } from "./chat-inbox-tools";
 
@@ -489,5 +490,105 @@ describe("chat inbox tools", () => {
       requestedCount: 1,
       failedThreadIds: ["thread-1"],
     });
+  });
+});
+
+describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("searchInbox description tells the model to paginate for bulk 'all matching' requests", () => {
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const description = toolInstance.description ?? "";
+    expect(description.toLowerCase()).toMatch(/paginat|nextpagetoken/);
+    expect(description.toLowerCase()).toMatch(/all/);
+  });
+
+  it("searchInbox result signals when more pages remain (hasMore)", async () => {
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages: vi.fn().mockResolvedValue({
+        messages: [
+          {
+            id: "m1",
+            threadId: "t1",
+            snippet: "",
+            historyId: "",
+            inline: [],
+            headers: {
+              from: "a@b.com",
+              to: TEST_EMAIL,
+              subject: "hi",
+              date: "2026-01-01T00:00:00.000Z",
+            },
+            subject: "hi",
+            textPlain: "",
+            textHtml: "",
+            labelIds: [],
+            internalDate: "0",
+          },
+        ],
+        nextPageToken: "PAGE_TOKEN_2",
+      }),
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result: any = await (toolInstance.execute as any)({
+      query: "older_than:3y is:unread",
+      limit: 20,
+    });
+
+    expect(result.nextPageToken).toBe("PAGE_TOKEN_2");
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("searchInbox result reports hasMore=false when no more pages", async () => {
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages: vi.fn().mockResolvedValue({
+        messages: [],
+        nextPageToken: undefined,
+      }),
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result: any = await (toolInstance.execute as any)({
+      query: "older_than:10y",
+      limit: 20,
+    });
+
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("manageInbox description calls out the 100-threadId cap per call", () => {
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const description = toolInstance.description ?? "";
+    expect(description).toMatch(/100/);
+    expect(description.toLowerCase()).toMatch(/thread/);
   });
 });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -234,7 +234,7 @@ export const searchInboxTool = ({
 }) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata for triage and summarization.",
+      "Search inbox messages and return concise message metadata for triage and summarization. Results are paginated: when the response includes hasMore=true (and a nextPageToken), there are more matching messages that were not returned. For bulk or 'all matching' requests (e.g. 'archive all unread older than 3 years'), keep calling searchInbox with the returned nextPageToken until hasMore=false before reporting completion. Do not claim an action covers all matches based on a single page.",
     inputSchema: searchInboxInputSchema(provider),
     execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });
@@ -269,6 +269,7 @@ export const searchInboxTool = ({
           queryUsed: query,
           totalReturned: items.length,
           nextPageToken,
+          hasMore: Boolean(nextPageToken),
           summary: summarizeSearchResults(items),
           messages: items,
         };
@@ -533,7 +534,8 @@ export const manageInboxTool = ({
   const inputSchema = manageInboxInputSchema(provider);
 
   return tool({
-    description: "Run inbox actions on threads or senders.",
+    description:
+      "Run inbox actions on threads or senders. Thread-level actions (archive_threads, trash_threads, label_threads, mark_read_threads) accept at most 100 threadIds per call, so bulk requests that match more than 100 threads require repeated calls: paginate searchInbox until hasMore=false and invoke manageInbox once per batch of up to 100 IDs before reporting completion. For server-wide cleanup from specific senders, prefer bulk_archive_senders or unsubscribe_senders with fromEmails instead of enumerating threadIds.",
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "manage_inbox", email, logger });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -234,7 +234,7 @@ export const searchInboxTool = ({
 }) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata for triage and summarization. Results are paginated: when the response includes hasMore=true (and a nextPageToken), there are more matching messages that were not returned. For bulk or 'all matching' requests (e.g. 'archive all unread older than 3 years'), keep calling searchInbox with the returned nextPageToken until hasMore=false before reporting completion. Do not claim an action covers all matches based on a single page.",
+      "Search inbox messages and return concise message metadata. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion.",
     inputSchema: searchInboxInputSchema(provider),
     execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });
@@ -535,7 +535,7 @@ export const manageInboxTool = ({
 
   return tool({
     description:
-      "Run inbox actions on threads or senders. Thread-level actions (archive_threads, trash_threads, label_threads, mark_read_threads) accept at most 100 threadIds per call, so bulk requests that match more than 100 threads require repeated calls: paginate searchInbox until hasMore=false and invoke manageInbox once per batch of up to 100 IDs before reporting completion. For server-wide cleanup from specific senders, prefer bulk_archive_senders or unsubscribe_senders with fromEmails instead of enumerating threadIds.",
+      "Run inbox actions on threads or senders. Thread actions accept up to 100 threadIds per call, so bulk requests require repeated manageInbox calls over paginated searchInbox results. For sender-wide cleanup, prefer bulk_archive_senders or unsubscribe_senders with fromEmails.",
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "manage_inbox", email, logger });


### PR DESCRIPTION
## Summary
Fixes [INB-134](https://linear.app/inbox-zero/issue/INB-134): for bulk requests like "mark as read + archive all unread older than 3 years", the assistant saw only the first page of `searchInbox` results, ran one `manageInbox` call (capped at 100 threadIds), and claimed success while the rest were untouched.

Fix is AI-first, applied at the tool surface (per `AGENTS.md`):

- `searchInbox` result now includes `hasMore` alongside `nextPageToken`, and the tool description tells the model to keep paginating until `hasMore=false` before reporting completion on "all matching" requests.
- `manageInbox` description calls out the 100-threadId-per-call cap, so the model fans out across batches (or routes to `bulk_archive_senders` / `unsubscribe_senders` for whole-sender cleanups).

## TDD
Followed failing-test-first workflow:
1. Added 4 tests in `apps/web/utils/ai/assistant/chat-inbox-tools.test.ts` covering the `hasMore` signal and the description guidance.
2. Confirmed all 4 failed on main.
3. Minimal fix in `chat-inbox-tools.ts` (two description strings + one extra field in the tool return value).
4. Full `chat-inbox-tools.test.ts` file now passes (14/14).

## Test plan
- [x] `pnpm --filter inbox-zero-ai test utils/ai/assistant/chat-inbox-tools.test.ts`
- [ ] Manual smoke: ask the chat "archive all unread older than 3 years" and confirm it paginates