### PR TITLE
fix: chat label_threads auto-creates missing labels (INB-137)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -413,14 +413,24 @@ describe("chat inbox tools", () => {
     expect(maxInFlight).toBeLessThanOrEqual(3);
   });
 
-  it("returns a descriptive error when label_threads receives an unknown labelName", async () => {
-    const getThreadMessages = vi.fn();
+  it("auto-creates a missing label when label_threads is called with an unknown labelName", async () => {
+    const getThreadMessages = vi
+      .fn()
+      .mockImplementation(async (threadId) => [
+        { id: `${threadId}-message-1`, threadId },
+      ]);
     const getLabelByName = vi.fn().mockResolvedValue(null);
-    const labelMessage = vi.fn();
+    const createLabel = vi.fn().mockResolvedValue({
+      id: "Label_new",
+      name: "Finance",
+      type: "user",
+    });
+    const labelMessage = vi.fn().mockResolvedValue(undefined);
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       getThreadMessages,
       getLabelByName,
+      createLabel,
       labelMessage,
     } as any);
 
@@ -437,14 +447,40 @@ describe("chat inbox tools", () => {
       threadIds: ["thread-1"],
     });
 
-    expect(result).toEqual({
-      error:
-        'Label "Finance" does not exist. Use createOrGetLabel first if you want to create it.',
-    });
     expect(getLabelByName).toHaveBeenCalledWith("Finance");
-    expect(getLabelByName).toHaveBeenCalledTimes(1);
-    expect(getThreadMessages).not.toHaveBeenCalled();
-    expect(labelMessage).not.toHaveBeenCalled();
+    expect(createLabel).toHaveBeenCalledWith("Finance");
+    expect(labelMessage).toHaveBeenCalledWith({
+      messageId: "thread-1-message-1",
+      labelId: "Label_new",
+      labelName: "Finance",
+    });
+    expect(result).toMatchObject({
+      action: "label_threads",
+      success: true,
+      failedCount: 0,
+      successCount: 1,
+      requestedCount: 1,
+      labelId: "Label_new",
+      labelName: "Finance",
+    });
+  });
+
+  it("documents label_threads as add-only in the manageInbox action description", () => {
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const actionDescription = (
+      toolInstance.inputSchema as any
+    ).shape.action.description.toLowerCase();
+
+    expect(actionDescription).toContain("label_threads");
+    expect(actionDescription).toMatch(
+      /add[- ]?only|does not archive|never archive/,
+    );
   });
 
   it("marks a thread labeling action as failed when any message label call fails", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -486,7 +486,7 @@ function manageInboxInputSchema(provider: string) {
     action: z
       .enum(manageInboxActions)
       .describe(
-        "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: apply a label (requires labelName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
+        "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: add-only — apply a label to the given threads (requires labelName; auto-creates the label if it does not exist; does not archive, trash, or mark read). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
       ),
     threadIds: threadIdsSchema
       .nullish()
@@ -1147,15 +1147,17 @@ async function resolveThreadLabel({
 }) {
   const existingLabel = await emailProvider.getLabelByName(labelName);
 
-  if (!existingLabel) {
-    throw new Error(
-      `Label "${labelName}" does not exist. Use createOrGetLabel first if you want to create it.`,
-    );
+  if (existingLabel) {
+    return {
+      labelId: existingLabel.id,
+      labelName: existingLabel.name,
+    };
   }
 
+  const createdLabel = await emailProvider.createLabel(labelName);
   return {
-    labelId: existingLabel.id,
-    labelName: existingLabel.name,
+    labelId: createdLabel.id,
+    labelName: createdLabel.name,
   };
 }
 


### PR DESCRIPTION
## Summary
- Chat's `label_threads` action threw when the requested label did not exist, and the model fell back to archiving / marking read, so existing labels were removed instead of the new one being added (INB-137).
- `resolveThreadLabel` in `chat-inbox-tools.ts` now auto-creates a missing label via `emailProvider.createLabel`, matching the existing behavior of `resolveLabelNameAndId`.
- Tightened the `manageInbox` action enum description so the model understands `label_threads` is add-only (does not archive, trash, or mark read) and that missing labels are auto-created.

## Test plan
- [x] `pnpm --filter inbox-zero-ai test utils/ai/assistant/chat-inbox-tools.test.ts` (11 pass)
- [x] Added unit test: `label_threads` auto-creates a missing label and applies it to the thread's messages.
- [x] Added unit test: the `manageInbox` action description documents `label_threads` as add-only.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Fixes INB-137.