### PR TITLE
fix: re-run AI attachment selection on draft cache miss (INB-146)

### DIFF
--- a/apps/web/utils/ai/action-attachments.ts
+++ b/apps/web/utils/ai/action-attachments.ts
@@ -4,10 +4,17 @@ import {
   type SelectedAttachment,
   attachmentSourceInputSchema,
 } from "@/utils/attachments/source-schema";
-import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
+import {
+  resolveDraftAttachments,
+  selectDraftAttachmentsForRule,
+} from "@/utils/attachments/draft-attachments";
 import type { ActionItem, EmailForAction } from "@/utils/ai/types";
 import type { Logger } from "@/utils/logger";
 import { getReplyWithConfidence } from "@/utils/redis/reply";
+import { getEmailAccountWithAi } from "@/utils/user/get";
+import { stringifyEmail } from "@/utils/stringify-email";
+import { getEmailForLLM } from "@/utils/get-email-from-message";
+import type { ParsedMessage } from "@/utils/types";
 
 export async function resolveActionAttachments({
   email,
@@ -79,22 +86,47 @@ async function getDraftSelectedAttachments({
   logger: Logger;
 }): Promise<SelectedAttachment[]> {
   if (!executedRule.ruleId) return [];
+  const ruleId = executedRule.ruleId;
 
   const cachedDraft = await getReplyWithConfidence({
     emailAccountId,
     messageId: email.id,
-    ruleId: executedRule.ruleId,
+    ruleId,
   });
 
   if (cachedDraft) {
     return cachedDraft.attachments ?? [];
   }
 
-  logger.warn("Draft attachment cache missing, skipping attachments", {
+  logger.info("Draft attachment cache missing, re-running selection", {
     messageId: email.id,
-    ruleId: executedRule.ruleId,
+    ruleId,
   });
-  return [];
+
+  const emailAccount = await getEmailAccountWithAi({ emailAccountId });
+  if (!emailAccount) return [];
+
+  const emailContent = stringifyEmail(
+    getEmailForLLM(email as ParsedMessage),
+    10_000,
+  );
+
+  try {
+    const { selectedAttachments } = await selectDraftAttachmentsForRule({
+      emailAccount,
+      ruleId,
+      emailContent,
+      logger,
+    });
+    return selectedAttachments;
+  } catch (error) {
+    logger.error("Failed to select draft attachments on cache miss", {
+      messageId: email.id,
+      ruleId,
+      error,
+    });
+    return [];
+  }
 }
 
 function parseStaticAttachments(raw: unknown): SelectedAttachment[] {

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -31,6 +31,14 @@ vi.mock("@/utils/attachments/draft-attachments", () => ({
   }),
 }));
 
+vi.mock("@/utils/user/get", () => ({
+  getEmailAccountWithAi: vi.fn().mockResolvedValue({
+    id: "account-1",
+    userId: "user-1",
+    email: "user@example.com",
+  }),
+}));
+
 vi.mock("@/utils/messaging/rule-notifications", () => ({
   getMessagingRuleNotificationResult: vi.fn().mockResolvedValue({
     delivered: true,
@@ -147,10 +155,29 @@ describe("runActionFunction", () => {
     );
   });
 
-  it("skips draft attachments when the rule cache is missing", async () => {
+  it("re-runs AI attachment selection when the rule cache is missing", async () => {
     const client = createMockEmailProvider();
 
     vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
+    vi.mocked(selectDraftAttachmentsForRule).mockResolvedValue({
+      selectedAttachments: [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-1",
+          filename: "lease.pdf",
+          mimeType: "application/pdf",
+          reason: "Matched the requested property",
+        },
+      ],
+      attachmentContext: null,
+    });
+    vi.mocked(resolveDraftAttachments).mockResolvedValue([
+      {
+        filename: "lease.pdf",
+        content: Buffer.from("pdf"),
+        contentType: "application/pdf",
+      },
+    ]);
 
     await runActionFunction({
       client,
@@ -172,13 +199,35 @@ describe("runActionFunction", () => {
       logger,
     });
 
-    expect(selectDraftAttachmentsForRule).not.toHaveBeenCalled();
-    expect(resolveDraftAttachments).not.toHaveBeenCalled();
+    expect(selectDraftAttachmentsForRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleId: "rule-1",
+        emailAccount: expect.objectContaining({ id: "account-1" }),
+      }),
+    );
+    expect(resolveDraftAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        userId: "user-1",
+        selectedAttachments: [
+          expect.objectContaining({
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+            filename: "lease.pdf",
+          }),
+        ],
+      }),
+    );
     expect(client.draftEmail).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         content: "Attached the requested PDF.",
-        attachments: [],
+        attachments: [
+          expect.objectContaining({
+            filename: "lease.pdf",
+            contentType: "application/pdf",
+          }),
+        ],
       }),
       "user@example.com",
       expect.objectContaining({ id: "executed-rule-1" }),


### PR DESCRIPTION
## Summary
- Fixes INB-146: rules configured with AI-selected Drive sources generated drafts with no attachments whenever the Redis draft cache was missing (cache expiry, replay after restart, etc.).
- `getDraftSelectedAttachments` now falls back to `selectDraftAttachmentsForRule` on cache miss instead of silently returning `[]`.
- The fallback is cost-conscious: `selectDraftAttachmentsForRule` already short-circuits with a cheap DB check when the rule has no attachment sources, so there is no extra LLM call for rules without Drive sources. Only rules that genuinely have AI-selected sources incur the selection call.

## Test plan
- [x] `pnpm --filter inbox-zero-ai test utils/ai/actions.test.ts` — inverted existing wrong test ("skips draft attachments when the rule cache is missing") into "re-runs AI attachment selection when the rule cache is missing"; now passes.
- [x] `pnpm --filter inbox-zero-ai test utils/reply-tracker/generate-draft.test.ts utils/attachments/` — 17 tests pass (no regressions).
- [ ] Manual: verify that a reply-tracker rule with a Drive folder source attaches the relevant PDF on a fresh draft when the Redis cache has expired.

Follow-ups
- Consider passing the already-loaded `emailAccount` through the action pipeline to avoid the extra DB read on cache miss.