### PR TITLE
outlook: Refresh subscriptions sooner

### DIFF
--- a/apps/web/utils/outlook/subscription-manager.test.ts
+++ b/apps/web/utils/outlook/subscription-manager.test.ts
@@ -137,6 +137,66 @@ describe("OutlookSubscriptionManager", () => {
       // Assert
       expect(result).toBeNull();
     });
+
+    it("should renew a subscription once it is older than a day", async () => {
+      const now = new Date("2026-04-14T12:00:00Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue({
+        watchEmailsSubscriptionId: "aged-subscription-id",
+        watchEmailsExpirationDate: new Date("2026-04-15T11:00:00Z"),
+        watchEmailsSubscriptionHistory: null,
+        createdAt: new Date("2026-03-01T00:00:00Z"),
+      } as any);
+
+      const newSubscription = {
+        subscriptionId: "replacement-subscription-id",
+        expirationDate: new Date("2026-04-17T12:00:00Z"),
+      };
+      vi.mocked(mockProvider.watchEmails).mockResolvedValue(newSubscription);
+
+      const result = await manager.createSubscription();
+
+      expect(mockProvider.unwatchEmails).toHaveBeenCalledWith(
+        "aged-subscription-id",
+      );
+      expect(mockProvider.watchEmails).toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          subscriptionId: "replacement-subscription-id",
+          changed: true,
+        }),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("should reuse a subscription that is less than a day old", async () => {
+      const now = new Date("2026-04-14T12:00:00Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue({
+        watchEmailsSubscriptionId: "fresh-subscription-id",
+        watchEmailsExpirationDate: new Date("2026-04-17T06:00:00Z"),
+        watchEmailsSubscriptionHistory: null,
+        createdAt: new Date("2026-03-01T00:00:00Z"),
+      } as any);
+
+      const result = await manager.createSubscription();
+
+      expect(mockProvider.unwatchEmails).not.toHaveBeenCalled();
+      expect(mockProvider.watchEmails).not.toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          subscriptionId: "fresh-subscription-id",
+          changed: false,
+        }),
+      );
+
+      vi.useRealTimers();
+    });
   });
 
   describe("updateSubscriptionInDatabase", () => {

--- a/apps/web/utils/outlook/subscription-manager.ts
+++ b/apps/web/utils/outlook/subscription-manager.ts
@@ -9,6 +9,10 @@ import {
   addCurrentSubscriptionToHistory,
 } from "@/utils/outlook/subscription-history";
 
+const OUTLOOK_SUBSCRIPTION_RENEWAL_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+const OUTLOOK_MAX_REUSE_AGE_MS = 24 * 60 * 60 * 1000;
+const OUTLOOK_SUBSCRIPTION_LIFETIME_MS = 3 * 24 * 60 * 60 * 1000;
+
 /**
  * Manages Outlook subscriptions, ensuring only one active subscription per email account
  * by canceling old subscriptions before creating new ones.
@@ -35,11 +39,13 @@ export class OutlookSubscriptionManager {
 
       if (existing?.subscriptionId && existing.expirationDate) {
         const now = new Date();
-        const renewalThresholdMs = 24 * 60 * 60 * 1000; // 24 hours
         const timeUntilExpiry =
           new Date(existing.expirationDate).getTime() - now.getTime();
 
-        if (timeUntilExpiry > renewalThresholdMs) {
+        if (
+          timeUntilExpiry > OUTLOOK_SUBSCRIPTION_RENEWAL_THRESHOLD_MS &&
+          !shouldRenewAgedSubscription(existing.expirationDate, now)
+        ) {
           this.logger.info("Existing subscription is valid; reuse", {
             subscriptionId: existing.subscriptionId,
             expirationDate: existing.expirationDate,
@@ -51,10 +57,17 @@ export class OutlookSubscriptionManager {
           };
         }
 
-        this.logger.info("Existing subscription near expiry; renewing", {
-          subscriptionId: existing.subscriptionId,
-          expirationDate: existing.expirationDate,
-        });
+        if (timeUntilExpiry <= OUTLOOK_SUBSCRIPTION_RENEWAL_THRESHOLD_MS) {
+          this.logger.info("Existing subscription near expiry; renewing", {
+            subscriptionId: existing.subscriptionId,
+            expirationDate: existing.expirationDate,
+          });
+        } else {
+          this.logger.info("Existing subscription reached max age; renewing", {
+            subscriptionId: existing.subscriptionId,
+            expirationDate: existing.expirationDate,
+          });
+        }
       } else {
         this.logger.info("No existing subscription found; creating new");
       }
@@ -282,6 +295,15 @@ export class OutlookSubscriptionManager {
         )
     `;
   }
+}
+
+function shouldRenewAgedSubscription(expirationDate: Date, now: Date) {
+  const subscriptionStartedAt = new Date(
+    expirationDate.getTime() - OUTLOOK_SUBSCRIPTION_LIFETIME_MS,
+  );
+  const subscriptionAgeMs = now.getTime() - subscriptionStartedAt.getTime();
+
+  return subscriptionAgeMs >= OUTLOOK_MAX_REUSE_AGE_MS;
 }
 
 export async function createManagedOutlookSubscription({


### PR DESCRIPTION
# User description
Reduce how long Outlook webhook subscriptions are trusted before rotation.

- renew subscriptions once they are older than 24 hours instead of waiting for near-expiry rotation
- keep the change scoped to the Outlook subscription manager
- add focused tests for aged renewal and fresh reuse

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Renew Outlook webhook subscriptions proactively in <code>OutlookSubscriptionManager</code> once they exceed a day old instead of waiting for near-expiry rotation. Add focused tests for aged renewal and fresh reuse scenarios in the subscription manager suite.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2261?tool=ast&topic=Subscription+tests>Subscription tests</a>
        </td><td>Exercise the Outlook subscription-manager flow by confirming aged subscriptions trigger unwatch/watch and fresh subscriptions are retained without calls to the provider.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/subscription-manager.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2261?tool=ast&topic=Renewal+timing>Renewal timing</a>
        </td><td>Adjust Outlook subscription renewal timing to force replacement when the current subscription exceeds one day of age while still logging whether rotation occurred due to expiry proximity or max age.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/subscription-manager.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>outlook: fix race cond...</td><td>January 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2261?tool=ast>(Baz)</a>.