### PR TITLE
drive: sanitize Microsoft item names

### DIFF
--- a/apps/web/utils/drive/folder-utils.test.ts
+++ b/apps/web/utils/drive/folder-utils.test.ts
@@ -16,13 +16,14 @@ function createMockFolder(id: string, name: string): DriveFolder {
 
 function createMockProvider(
   existingFolders: Map<string | undefined, DriveFolder[]> = new Map(),
+  providerName: DriveProvider["name"] = "google",
 ): DriveProvider {
   const createdFolders: DriveFolder[] = [];
   let folderId = 1;
 
   return {
-    name: "google",
-    toJSON: () => ({ name: "google", type: "drive" }),
+    name: providerName,
+    toJSON: () => ({ name: providerName, type: "drive" }),
     getAccessToken: () => "mock-token",
     listFolders: vi.fn(async (parentId?: string) => {
       const existing = existingFolders.get(parentId) || [];
@@ -148,5 +149,19 @@ describe("createFolderPath", () => {
     await expect(createFolderPath(provider, "", logger)).rejects.toThrow(
       "Failed to create folder path",
     );
+  });
+
+  it("should match existing normalized microsoft folders", async () => {
+    const existingFolders = new Map<string | undefined, DriveFolder[]>([
+      [undefined, [createMockFolder("existing-1", "Plans-2026")]],
+    ]);
+    const provider = createMockProvider(existingFolders, "microsoft");
+
+    const result = await createFolderPath(provider, "Plans:2026", logger);
+
+    expect(result.folder.id).toBe("existing-1");
+    expect(result.folder.name).toBe("Plans-2026");
+    expect(result.allFolders[0].path).toBe("Plans-2026");
+    expect(provider.createFolder).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/drive/folder-utils.ts
+++ b/apps/web/utils/drive/folder-utils.ts
@@ -20,26 +20,28 @@ export async function createFolderPath(
   let parentId: string | undefined;
   let currentFolder: DriveFolder | null = null;
   const allFolders: { folder: DriveFolder; path: string }[] = [];
+  const resolvedPathParts: string[] = [];
 
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+  for (const part of parts) {
+    const normalizedPart = normalizeFolderPathPart(provider, part);
     const existingFolders = await provider.listFolders(parentId);
     const existing = existingFolders.find(
-      (f) => f.name.toLowerCase() === part.toLowerCase(),
+      (f) => f.name.toLowerCase() === normalizedPart.toLowerCase(),
     );
 
     if (existing) {
       currentFolder = existing;
       parentId = existing.id;
     } else {
-      logger.info("Creating folder", { name: part, parentId });
-      currentFolder = await provider.createFolder(part, parentId);
+      logger.info("Creating folder", { name: normalizedPart, parentId });
+      currentFolder = await provider.createFolder(normalizedPart, parentId);
       parentId = currentFolder.id;
     }
 
+    resolvedPathParts.push(currentFolder.name);
     allFolders.push({
       folder: currentFolder,
-      path: parts.slice(0, i + 1).join("/"),
+      path: resolvedPathParts.join("/"),
     });
   }
 
@@ -94,4 +96,19 @@ export async function createAndSaveFilingFolder({
   });
 
   return folder;
+}
+
+const INVALID_ONEDRIVE_NAME_CHARS = /[\\/:*?"<>|]/g;
+
+function normalizeFolderPathPart(provider: DriveProvider, part: string) {
+  if (provider.name !== "microsoft") {
+    return part;
+  }
+
+  const normalizedPart = part
+    .replace(INVALID_ONEDRIVE_NAME_CHARS, "-")
+    .trim()
+    .replace(/[. ]+$/g, "");
+
+  return normalizedPart || "untitled";
 }

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@microsoft/microsoft-graph-client";
+import { createScopedLogger } from "@/utils/logger";
+import { OneDriveProvider } from "./microsoft";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    init: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  fetchMicrosoftGraph: vi.fn(),
+  getMicrosoftGraphClientOptions: vi.fn(() => ({})),
+}));
+
+describe("OneDriveProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sanitizes invalid folder names before creating them", async () => {
+    const post = vi.fn(async () => ({
+      id: "folder-1",
+      name: "Plans-2026",
+      folder: {},
+      parentReference: { id: "parent-1", path: "/drive/root:" },
+    }));
+    const api = vi.fn(() => ({ post }));
+
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider(
+      "token",
+      createScopedLogger("onedrive-provider-test"),
+    );
+
+    await provider.createFolder("Plans:2026", "parent-1");
+
+    expect(api).toHaveBeenCalledWith("/me/drive/items/parent-1/children");
+    expect(post).toHaveBeenCalledWith({
+      name: "Plans-2026",
+      folder: {},
+      "@microsoft.graph.conflictBehavior": "rename",
+    });
+  });
+
+  it("sanitizes invalid file names before uploading them", async () => {
+    const content = Buffer.from("pdf-binary");
+    const put = vi.fn(async () => ({
+      id: "file-1",
+      name: "Agenda - Plans 2025-2026.pdf",
+      file: { mimeType: "application/pdf" },
+      parentReference: { id: "folder-1" },
+      size: content.length,
+    }));
+    const header = vi.fn(() => ({ put }));
+    const api = vi.fn(() => ({ header }));
+
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider(
+      "token",
+      createScopedLogger("onedrive-provider-test"),
+    );
+
+    await provider.uploadFile({
+      filename: "Agenda - Plans 2025:2026.pdf",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      "/me/drive/items/folder-1:/Agenda%20-%20Plans%202025-2026.pdf:/content",
+    );
+    expect(header).toHaveBeenCalledWith("Content-Type", "application/pdf");
+    expect(put).toHaveBeenCalledWith(content);
+  });
+});

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -77,4 +77,37 @@ describe("OneDriveProvider", () => {
     expect(header).toHaveBeenCalledWith("Content-Type", "application/pdf");
     expect(put).toHaveBeenCalledWith(content);
   });
+
+  it("uses a fallback name when uploading a blank filename", async () => {
+    const content = Buffer.from("pdf-binary");
+    const put = vi.fn(async () => ({
+      id: "file-1",
+      name: "untitled",
+      file: { mimeType: "application/pdf" },
+      parentReference: { id: "folder-1" },
+      size: content.length,
+    }));
+    const header = vi.fn(() => ({ put }));
+    const api = vi.fn(() => ({ header }));
+
+    vi.mocked(Client.init).mockReturnValue({ api } as any);
+
+    const provider = new OneDriveProvider(
+      "token",
+      createScopedLogger("onedrive-provider-test"),
+    );
+
+    await provider.uploadFile({
+      filename: "   ",
+      mimeType: "application/pdf",
+      content,
+      folderId: "folder-1",
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      "/me/drive/items/folder-1:/untitled:/content",
+    );
+    expect(header).toHaveBeenCalledWith("Content-Type", "application/pdf");
+    expect(put).toHaveBeenCalledWith(content);
+  });
 });

--- a/apps/web/utils/drive/providers/microsoft.ts
+++ b/apps/web/utils/drive/providers/microsoft.ts
@@ -112,12 +112,13 @@ export class OneDriveProvider implements DriveProvider {
     this.logger.info("Creating folder", { name, parentId });
 
     try {
+      const normalizedName = normalizeOneDriveItemName(name);
       const endpoint = parentId
         ? `/me/drive/items/${parentId}/children`
         : "/me/drive/root/children";
 
       const item: DriveItem = await this.client.api(endpoint).post({
-        name,
+        name: normalizedName,
         folder: {},
         "@microsoft.graph.conflictBehavior": "rename", // Rename if exists
       });
@@ -161,9 +162,10 @@ export class OneDriveProvider implements DriveProvider {
 
       // Use the PUT endpoint for simple upload
       // Path: /me/drive/items/{parent-id}:/{filename}:/content
+      const normalizedFilename = normalizeOneDriveItemName(filename);
       const item: DriveItem = await this.client
         .api(
-          `/me/drive/items/${folderId}:/${encodeURIComponent(filename)}:/content`,
+          `/me/drive/items/${folderId}:/${encodeURIComponent(normalizedFilename)}:/content`,
         )
         .header("Content-Type", mimeType)
         .put(content);
@@ -338,4 +340,15 @@ export class OneDriveProvider implements DriveProvider {
 
     return items;
   }
+}
+
+const INVALID_ONEDRIVE_NAME_CHARS = /[\\/:*?"<>|]/g;
+
+function normalizeOneDriveItemName(name: string) {
+  const normalizedName = name
+    .replace(INVALID_ONEDRIVE_NAME_CHARS, "-")
+    .trim()
+    .replace(/[. ]+$/g, "");
+
+  return normalizedName || "untitled";
 }


### PR DESCRIPTION
# User description
Normalizes unsupported Microsoft Drive item names before folder creation and file upload.

Adds regression coverage for invalid folder and file names in the Microsoft drive provider.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Stabilize Microsoft Drive folder and file flows by normalizing invalid item names in the folder path resolver and <code>OneDriveProvider</code> before API calls. Add regression tests covering Microsoft folders and uploads with unsupported names to guard the sanitization behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2262?tool=ast&topic=Path+normalization>Path normalization</a>
        </td><td>Normalize path segments in <code>createFolderPath</code> with <code>normalizeFolderPathPart</code>, preserve the resolved names, and add regression coverage to match existing normalized Microsoft folders instead of creating duplicates.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/drive/folder-utils.test.ts</li>
<li>apps/web/utils/drive/folder-utils.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>tests: share common te...</td><td>March 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2262?tool=ast&topic=OneDrive+sanitization>OneDrive sanitization</a>
        </td><td>Normalize Microsoft Drive folder and file names via <code>normalizeOneDriveItemName</code> before calling the OneDrive API so invalid characters are replaced, blank names become <code>untitled</code>, and uploads use sanitized paths.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/drive/providers/microsoft.test.ts</li>
<li>apps/web/utils/drive/providers/microsoft.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: retry Microsoft O...</td><td>April 10, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>fix(drive): preserve O...</td><td>March 01, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2262?tool=ast>(Baz)</a>.