### PR TITLE
Improve mobile review auth visibility

### DIFF
--- a/apps/web/app/api/mobile-review/status/route.test.ts
+++ b/apps/web/app/api/mobile-review/status/route.test.ts
@@ -1,0 +1,55 @@
+vi.mock("server-only", () => ({}));
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getMobileReviewAccessStatusMock } = vi.hoisted(() => ({
+  getMobileReviewAccessStatusMock: vi.fn(),
+}));
+
+vi.mock("@/utils/mobile-review", () => ({
+  getMobileReviewAccessStatus: (...args: unknown[]) =>
+    getMobileReviewAccessStatusMock(...args),
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withError:
+    (
+      _scope: string,
+      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
+    ) =>
+    (request: NextRequest, ...args: unknown[]) =>
+      handler(request, ...args),
+}));
+
+import { GET } from "./route";
+
+describe("mobile review status route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the validated review access status without caching", async () => {
+    getMobileReviewAccessStatusMock.mockResolvedValueOnce({ enabled: false });
+
+    const request = new NextRequest(
+      "http://localhost/api/mobile-review/status",
+    ) as NextRequest & {
+      logger: {
+        warn: ReturnType<typeof vi.fn>;
+      };
+    };
+    request.logger = {
+      warn: vi.fn(),
+    };
+
+    const response = await GET(request, {} as never);
+    const body = await response.json();
+
+    expect(getMobileReviewAccessStatusMock).toHaveBeenCalledWith({
+      logger: request.logger,
+    });
+    expect(body).toEqual({ enabled: false });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/apps/web/app/api/mobile-review/status/route.test.ts
+++ b/apps/web/app/api/mobile-review/status/route.test.ts
@@ -29,7 +29,7 @@ describe("mobile review status route", () => {
     vi.clearAllMocks();
   });
 
-  it("returns the validated review access status without caching", async () => {
+  it("returns the validated review access status", async () => {
     getMobileReviewAccessStatusMock.mockResolvedValueOnce({ enabled: false });
 
     const request = new NextRequest(
@@ -50,6 +50,5 @@ describe("mobile review status route", () => {
       logger: request.logger,
     });
     expect(body).toEqual({ enabled: false });
-    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 });

--- a/apps/web/app/api/mobile-review/status/route.ts
+++ b/apps/web/app/api/mobile-review/status/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from "next/server";
 import { withError } from "@/utils/middleware";
-import { isMobileReviewEnabled } from "@/utils/mobile-review";
+import { getMobileReviewAccessStatus } from "@/utils/mobile-review";
 
-export const GET = withError("mobile-review/status", async () => {
-  return NextResponse.json({ enabled: isMobileReviewEnabled() });
+export const GET = withError("mobile-review/status", async (request) => {
+  const { enabled } = await getMobileReviewAccessStatus({
+    logger: request.logger,
+  });
+
+  const response = NextResponse.json({ enabled });
+  response.headers.set("Cache-Control", "no-store");
+
+  return response;
 });

--- a/apps/web/app/api/mobile-review/status/route.ts
+++ b/apps/web/app/api/mobile-review/status/route.ts
@@ -6,9 +6,5 @@ export const GET = withError("mobile-review/status", async (request) => {
   const { enabled } = await getMobileReviewAccessStatus({
     logger: request.logger,
   });
-
-  const response = NextResponse.json({ enabled });
-  response.headers.set("Cache-Control", "no-store");
-
-  return response;
+  return NextResponse.json({ enabled });
 });

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -1,150 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 vi.mock("server-only", () => ({}));
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestLogger } from "@/__tests__/helpers";
-import prisma from "@/utils/__mocks__/prisma";
+const { createSessionMock, makeSignatureMock, mockedEnv, userFindUniqueMock } =
+  vi.hoisted(() => ({
+    createSessionMock: vi.fn(),
+    makeSignatureMock: vi.fn(),
+    mockedEnv: {
+      APP_REVIEW_DEMO_CODE: "review-code",
+      APP_REVIEW_DEMO_EMAIL: "review@example.com",
+      APP_REVIEW_DEMO_ENABLED: true,
+    },
+    userFindUniqueMock: vi.fn(),
+  }));
 
-const { mockAuthContext, mockMakeSignature } = vi.hoisted(() => ({
-  mockAuthContext: {
-    authCookies: {
-      sessionToken: {
-        name: "__Secure-better-auth.session_token",
-        attributes: {
-          domain: "example.com",
-          httpOnly: true,
-          maxAge: 60 * 60,
-          path: "/",
-          sameSite: "lax" as const,
-          secure: true,
-        },
-      },
-    },
-    internalAdapter: {
-      createSession: vi.fn(),
-    },
-    secret: "test-secret",
-  },
-  mockMakeSignature: vi.fn(),
+vi.mock("better-auth/crypto", () => ({
+  makeSignature: (...args: unknown[]) => makeSignatureMock(...args),
 }));
 
 vi.mock("@/env", () => ({
-  env: {
-    APP_REVIEW_DEMO_ENABLED: true,
-    APP_REVIEW_DEMO_CODE: "review-code",
-    APP_REVIEW_DEMO_EMAIL: "demo@example.com",
-    UPSTASH_REDIS_URL: "https://redis.example.com",
-    UPSTASH_REDIS_TOKEN: "redis-token",
-  },
+  env: mockedEnv,
 }));
 
 vi.mock("@/utils/auth", () => ({
   betterAuthConfig: {
-    $context: Promise.resolve(mockAuthContext),
+    $context: Promise.resolve({
+      authCookies: {
+        sessionToken: {
+          attributes: {
+            domain: undefined,
+            httpOnly: true,
+            maxAge: undefined,
+            partitioned: false,
+            path: "/",
+            sameSite: "lax",
+            secure: true,
+          },
+          name: "__Secure-better-auth.session_token",
+        },
+      },
+      internalAdapter: {
+        createSession: (...args: unknown[]) => createSessionMock(...args),
+      },
+      secret: "test-secret",
+    }),
   },
 }));
 
-vi.mock("@/utils/prisma");
-vi.mock("better-auth/crypto", () => ({
-  makeSignature: mockMakeSignature,
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    user: {
+      findUnique: (...args: unknown[]) => userFindUniqueMock(...args),
+    },
+  },
 }));
 
-describe("createMobileReviewSession", () => {
+import {
+  createMobileReviewSession,
+  getMobileReviewAccessStatus,
+} from "./mobile-review";
+
+function createLogger() {
+  const logger = {
+    error: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    with: vi.fn(),
+  };
+
+  logger.with.mockReturnValue(logger);
+
+  return logger;
+}
+
+describe("mobile review access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prisma.user.findUnique.mockResolvedValue({
-      email: "demo@example.com",
-      id: "user-1",
-      emailAccounts: [{ id: "account-1" }],
-    } as never);
-    mockAuthContext.internalAdapter.createSession.mockResolvedValue({
+    mockedEnv.APP_REVIEW_DEMO_ENABLED = true;
+    mockedEnv.APP_REVIEW_DEMO_CODE = "review-code";
+    mockedEnv.APP_REVIEW_DEMO_EMAIL = "review@example.com";
+    makeSignatureMock.mockResolvedValue("signed-token");
+    createSessionMock.mockResolvedValue({
       expiresAt: new Date("2026-05-01T00:00:00.000Z"),
       token: "session-token",
     });
-    mockMakeSignature.mockResolvedValue("cookie-signature");
   });
 
-  it("creates a signed Better Auth session cookie", async () => {
-    const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createTestLogger();
-
-    const result = await createMobileReviewSession({
-      code: "review-code",
-      logger,
+  it("reports disabled status when the configured review account has no email account", async () => {
+    const logger = createLogger();
+    userFindUniqueMock.mockResolvedValueOnce({
+      email: "review@example.com",
+      emailAccounts: [],
+      id: "user-1",
     });
 
-    expect(mockAuthContext.internalAdapter.createSession).toHaveBeenCalledWith(
-      "user-1",
-      false,
-      {},
+    const result = await getMobileReviewAccessStatus({ logger } as never);
+
+    expect(result).toEqual({ enabled: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Mobile review access unavailable",
+      expect.objectContaining({
+        hasUser: true,
+        ok: false,
+        reason: "review_user_missing_email_account",
+      }),
     );
-    expect(mockMakeSignature).toHaveBeenCalledWith(
-      "session-token",
-      "test-secret",
-    );
-    expect(result).toEqual({
-      emailAccountId: "account-1",
-      sessionCookie: {
-        name: "__Secure-better-auth.session_token",
-        options: {
-          domain: "example.com",
-          expires: new Date("2026-05-01T00:00:00.000Z"),
-          httpOnly: true,
-          maxAge: 60 * 60,
-          partitioned: undefined,
-          path: "/",
-          sameSite: "lax",
-          secure: true,
-        },
-        value: "session-token.cookie-signature",
-      },
-      userEmail: "demo@example.com",
-      userId: "user-1",
-    });
   });
 
-  it("logs a warning when the review code is invalid", async () => {
-    const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createTestLogger();
-    const warnSpy = vi.spyOn(logger, "warn");
+  it("reports enabled status when the configured review account is usable", async () => {
+    const logger = createLogger();
+    userFindUniqueMock.mockResolvedValueOnce({
+      email: "review@example.com",
+      emailAccounts: [{ id: "account-1" }],
+      id: "user-1",
+    });
+
+    const result = await getMobileReviewAccessStatus({ logger } as never);
+
+    expect(result).toEqual({ enabled: true });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid review codes before querying the database", async () => {
+    const logger = createLogger();
 
     await expect(
-      createMobileReviewSession({
-        code: "wrong-code",
-        logger,
-      }),
+      createMobileReviewSession({ code: "wrong-code", logger } as never),
     ).rejects.toMatchObject({
       message: "Invalid review access code",
+      safeMessage: "Invalid review access code",
       statusCode: 401,
     });
 
-    expect(warnSpy).toHaveBeenCalledWith("Mobile review sign-in rejected", {
+    expect(userFindUniqueMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith("Mobile review sign-in rejected", {
       reason: "invalid_review_demo_code",
     });
   });
 
-  it("logs a warning when the review user has no email account", async () => {
-    prisma.user.findUnique.mockResolvedValue({
-      email: "demo@example.com",
-      id: "user-1",
+  it("rejects valid review codes when the configured review account cannot create a session", async () => {
+    const logger = createLogger();
+    userFindUniqueMock.mockResolvedValueOnce({
+      email: "review@example.com",
       emailAccounts: [],
-    } as never);
-
-    const { createMobileReviewSession } = await import("./mobile-review");
-    const logger = createTestLogger();
-    const warnSpy = vi.spyOn(logger, "warn");
+      id: "user-1",
+    });
 
     await expect(
-      createMobileReviewSession({
-        code: "review-code",
-        logger,
-      }),
+      createMobileReviewSession({ code: "review-code", logger } as never),
     ).rejects.toMatchObject({
       message: "Review access is unavailable",
+      safeMessage: "Review access is unavailable",
     });
 
-    expect(warnSpy).toHaveBeenCalledWith("Mobile review sign-in unavailable", {
-      hasUser: true,
-      reason: "review_user_missing_email_account",
-    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Mobile review sign-in unavailable",
+      expect.objectContaining({
+        hasUser: true,
+        ok: false,
+        reason: "review_user_missing_email_account",
+      }),
+    );
   });
 });

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -123,6 +123,23 @@ describe("mobile review access", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it("reports disabled status when the review user lookup fails", async () => {
+    const logger = createLogger();
+    const error = new Error("database unavailable");
+    userFindUniqueMock.mockRejectedValueOnce(error);
+
+    const result = await getMobileReviewAccessStatus({ logger } as never);
+
+    expect(result).toEqual({ enabled: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Mobile review access unavailable",
+      expect.objectContaining({
+        error,
+        reason: "review_user_lookup_failed",
+      }),
+    );
+  });
+
   it("rejects invalid review codes before querying the database", async () => {
     const logger = createLogger();
 

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -2,17 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-const { createSessionMock, makeSignatureMock, mockedEnv, userFindUniqueMock } =
-  vi.hoisted(() => ({
-    createSessionMock: vi.fn(),
-    makeSignatureMock: vi.fn(),
-    mockedEnv: {
-      APP_REVIEW_DEMO_CODE: "review-code",
-      APP_REVIEW_DEMO_EMAIL: "review@example.com",
-      APP_REVIEW_DEMO_ENABLED: true,
-    },
-    userFindUniqueMock: vi.fn(),
-  }));
+const {
+  createSessionMock,
+  emailAccountFindUniqueMock,
+  makeSignatureMock,
+  mockedEnv,
+} = vi.hoisted(() => ({
+  createSessionMock: vi.fn(),
+  emailAccountFindUniqueMock: vi.fn(),
+  makeSignatureMock: vi.fn(),
+  mockedEnv: {
+    APP_REVIEW_DEMO_CODE: "review-code",
+    APP_REVIEW_DEMO_EMAIL: "review@example.com",
+    APP_REVIEW_DEMO_ENABLED: true,
+  },
+}));
 
 vi.mock("better-auth/crypto", () => ({
   makeSignature: (...args: unknown[]) => makeSignatureMock(...args),
@@ -49,8 +53,8 @@ vi.mock("@/utils/auth", () => ({
 
 vi.mock("@/utils/prisma", () => ({
   default: {
-    user: {
-      findUnique: (...args: unknown[]) => userFindUniqueMock(...args),
+    emailAccount: {
+      findUnique: (...args: unknown[]) => emailAccountFindUniqueMock(...args),
     },
   },
 }));
@@ -90,11 +94,7 @@ describe("mobile review access", () => {
 
   it("reports disabled status when the configured review account has no email account", async () => {
     const logger = createLogger();
-    userFindUniqueMock.mockResolvedValueOnce({
-      email: "review@example.com",
-      emailAccounts: [],
-      id: "user-1",
-    });
+    emailAccountFindUniqueMock.mockResolvedValueOnce(null);
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
 
@@ -102,7 +102,7 @@ describe("mobile review access", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "Mobile review access unavailable",
       expect.objectContaining({
-        hasUser: true,
+        hasEmailAccount: false,
         ok: false,
         reason: "review_user_missing_email_account",
       }),
@@ -111,10 +111,13 @@ describe("mobile review access", () => {
 
   it("reports enabled status when the configured review account is usable", async () => {
     const logger = createLogger();
-    userFindUniqueMock.mockResolvedValueOnce({
+    emailAccountFindUniqueMock.mockResolvedValueOnce({
       email: "review@example.com",
-      emailAccounts: [{ id: "account-1" }],
-      id: "user-1",
+      id: "account-1",
+      user: {
+        email: "owner@example.com",
+        id: "user-1",
+      },
     });
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
@@ -126,7 +129,7 @@ describe("mobile review access", () => {
   it("reports disabled status when the review user lookup fails", async () => {
     const logger = createLogger();
     const error = new Error("database unavailable");
-    userFindUniqueMock.mockRejectedValueOnce(error);
+    emailAccountFindUniqueMock.mockRejectedValueOnce(error);
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
 
@@ -151,7 +154,7 @@ describe("mobile review access", () => {
       statusCode: 401,
     });
 
-    expect(userFindUniqueMock).not.toHaveBeenCalled();
+    expect(emailAccountFindUniqueMock).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith("Mobile review sign-in rejected", {
       reason: "invalid_review_demo_code",
     });
@@ -159,11 +162,7 @@ describe("mobile review access", () => {
 
   it("rejects valid review codes when the configured review account cannot create a session", async () => {
     const logger = createLogger();
-    userFindUniqueMock.mockResolvedValueOnce({
-      email: "review@example.com",
-      emailAccounts: [],
-      id: "user-1",
-    });
+    emailAccountFindUniqueMock.mockResolvedValueOnce(null);
 
     await expect(
       createMobileReviewSession({ code: "review-code", logger } as never),
@@ -175,7 +174,7 @@ describe("mobile review access", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "Mobile review sign-in unavailable",
       expect.objectContaining({
-        hasUser: true,
+        hasEmailAccount: false,
         ok: false,
         reason: "review_user_missing_email_account",
       }),

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -56,7 +56,17 @@ export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
     return { enabled: false as const };
   }
 
-  const reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+  let reviewUser: MobileReviewUserResult;
+  try {
+    reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+  } catch (error) {
+    input.logger.warn("Mobile review access unavailable", {
+      reason: "review_user_lookup_failed",
+      error,
+    });
+    return { enabled: false as const };
+  }
+
   if (!reviewUser.ok) {
     input.logger.warn("Mobile review access unavailable", reviewUser);
     return { enabled: false as const };

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -6,6 +6,38 @@ import { SafeError } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 
+type MobileReviewConfigResult =
+  | {
+      ok: true;
+      reviewDemoCode: string;
+      reviewDemoEmail: string;
+    }
+  | {
+      ok: false;
+      reason: "review_demo_disabled";
+    }
+  | {
+      ok: false;
+      hasReviewDemoCode: boolean;
+      hasReviewDemoEmail: boolean;
+      reason: "review_demo_misconfigured";
+    };
+
+type MobileReviewUserResult =
+  | {
+      ok: true;
+      user: {
+        email: string;
+        emailAccountId: string;
+        id: string;
+      };
+    }
+  | {
+      ok: false;
+      hasUser: boolean;
+      reason: "review_user_missing_email_account";
+    };
+
 export function isMobileReviewEnabled(): boolean {
   return Boolean(
     env.APP_REVIEW_DEMO_ENABLED &&
@@ -14,72 +46,62 @@ export function isMobileReviewEnabled(): boolean {
   );
 }
 
+export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
+  const config = getMobileReviewConfig();
+  if (!config.ok) {
+    input.logger.warn("Mobile review access unavailable", {
+      ...config,
+      ok: undefined,
+    });
+    return { enabled: false as const };
+  }
+
+  const reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+  if (!reviewUser.ok) {
+    input.logger.warn("Mobile review access unavailable", reviewUser);
+    return { enabled: false as const };
+  }
+
+  return { enabled: true as const };
+}
+
 export async function createMobileReviewSession(input: {
   code: string;
   logger: Logger;
 }) {
-  if (!env.APP_REVIEW_DEMO_ENABLED) {
+  const config = getMobileReviewConfig();
+  if (!config.ok) {
     input.logger.warn("Mobile review sign-in unavailable", {
-      reason: "review_demo_disabled",
+      ...config,
+      ok: undefined,
     });
     throw new SafeError("Review access is unavailable");
   }
 
-  const reviewDemoCode = env.APP_REVIEW_DEMO_CODE?.trim();
-  const reviewDemoEmail = env.APP_REVIEW_DEMO_EMAIL?.trim().toLowerCase();
-
-  if (!reviewDemoCode || !reviewDemoEmail) {
-    input.logger.warn("Mobile review sign-in unavailable", {
-      hasReviewDemoCode: Boolean(reviewDemoCode),
-      hasReviewDemoEmail: Boolean(reviewDemoEmail),
-      reason: "review_demo_misconfigured",
-    });
-    throw new SafeError("Review access is unavailable");
-  }
-
-  if (!codesMatch(input.code, reviewDemoCode)) {
+  if (!codesMatch(input.code, config.reviewDemoCode)) {
     input.logger.warn("Mobile review sign-in rejected", {
       reason: "invalid_review_demo_code",
     });
     throw new SafeError("Invalid review access code", 401);
   }
 
-  const user = await prisma.user.findUnique({
-    where: { email: reviewDemoEmail },
-    select: {
-      email: true,
-      id: true,
-      emailAccounts: {
-        select: {
-          id: true,
-        },
-        take: 1,
-        orderBy: {
-          createdAt: "asc",
-        },
-      },
-    },
-  });
-
-  if (!user?.emailAccounts.length) {
-    input.logger.warn("Mobile review sign-in unavailable", {
-      hasUser: Boolean(user),
-      reason: "review_user_missing_email_account",
-    });
+  const reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+  if (!reviewUser.ok) {
+    input.logger.warn("Mobile review sign-in unavailable", reviewUser);
     throw new SafeError("Review access is unavailable");
   }
 
   const authContext = await betterAuthConfig.$context;
   const session = await authContext.internalAdapter.createSession(
-    user.id,
+    reviewUser.user.id,
     false,
     {},
   );
 
   return {
-    userId: user.id,
-    userEmail: user.email,
-    emailAccountId: user.emailAccounts[0].id,
+    userId: reviewUser.user.id,
+    userEmail: reviewUser.user.email,
+    emailAccountId: reviewUser.user.emailAccountId,
     sessionCookie: await buildSessionCookie({
       authContext,
       expiresAt: session.expiresAt,
@@ -131,4 +153,66 @@ function codesMatch(input: string, expected: string): boolean {
 
 function normalizeCode(code: string): Buffer {
   return Buffer.from(code.trim(), "utf8");
+}
+
+function getMobileReviewConfig(): MobileReviewConfigResult {
+  if (!env.APP_REVIEW_DEMO_ENABLED) {
+    return { ok: false, reason: "review_demo_disabled" };
+  }
+
+  const reviewDemoCode = env.APP_REVIEW_DEMO_CODE?.trim();
+  const reviewDemoEmail = env.APP_REVIEW_DEMO_EMAIL?.trim().toLowerCase();
+
+  if (!reviewDemoCode || !reviewDemoEmail) {
+    return {
+      ok: false,
+      hasReviewDemoCode: Boolean(reviewDemoCode),
+      hasReviewDemoEmail: Boolean(reviewDemoEmail),
+      reason: "review_demo_misconfigured",
+    };
+  }
+
+  return {
+    ok: true,
+    reviewDemoCode,
+    reviewDemoEmail,
+  };
+}
+
+async function getMobileReviewUser(
+  reviewDemoEmail: string,
+): Promise<MobileReviewUserResult> {
+  const user = await prisma.user.findUnique({
+    where: { email: reviewDemoEmail },
+    select: {
+      email: true,
+      id: true,
+      emailAccounts: {
+        select: {
+          id: true,
+        },
+        take: 1,
+        orderBy: {
+          createdAt: "asc",
+        },
+      },
+    },
+  });
+
+  if (!user?.emailAccounts.length) {
+    return {
+      ok: false,
+      hasUser: Boolean(user),
+      reason: "review_user_missing_email_account",
+    };
+  }
+
+  return {
+    ok: true,
+    user: {
+      email: user.email,
+      emailAccountId: user.emailAccounts[0].id,
+      id: user.id,
+    },
+  };
 }

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -34,7 +34,7 @@ type MobileReviewUserResult =
     }
   | {
       ok: false;
-      hasUser: boolean;
+      hasEmailAccount: boolean;
       reason: "review_user_missing_email_account";
     };
 
@@ -192,27 +192,24 @@ function getMobileReviewConfig(): MobileReviewConfigResult {
 async function getMobileReviewUser(
   reviewDemoEmail: string,
 ): Promise<MobileReviewUserResult> {
-  const user = await prisma.user.findUnique({
+  const emailAccount = await prisma.emailAccount.findUnique({
     where: { email: reviewDemoEmail },
     select: {
       email: true,
       id: true,
-      emailAccounts: {
+      user: {
         select: {
+          email: true,
           id: true,
-        },
-        take: 1,
-        orderBy: {
-          createdAt: "asc",
         },
       },
     },
   });
 
-  if (!user?.emailAccounts.length) {
+  if (!emailAccount) {
     return {
       ok: false,
-      hasUser: Boolean(user),
+      hasEmailAccount: false,
       reason: "review_user_missing_email_account",
     };
   }
@@ -220,9 +217,9 @@ async function getMobileReviewUser(
   return {
     ok: true,
     user: {
-      email: user.email,
-      emailAccountId: user.emailAccounts[0].id,
-      id: user.id,
+      email: emailAccount.user.email,
+      emailAccountId: emailAccount.id,
+      id: emailAccount.user.id,
     },
   };
 }


### PR DESCRIPTION
# User description
## Summary
- validate the configured mobile review account in `/api/mobile-review/status` instead of only checking env flags
- log structured unavailability reasons for status and sign-in failures
- add focused tests for review access validation and the status route

## Testing
- pnpm exec vitest run utils/mobile-review.test.ts app/api/mobile-review/status/route.test.ts app/api/mobile-review/sign-in/route.test.ts
- pnpm exec biome check utils/mobile-review.ts utils/mobile-review.test.ts app/api/mobile-review/status/route.ts app/api/mobile-review/status/route.test.ts app/api/mobile-review/sign-in/route.ts app/api/mobile-review/sign-in/route.test.ts

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Validate the configured mobile review account and log structured reasons before reporting access via <code>getMobileReviewAccessStatus</code> and <code>createMobileReviewSession</code>. Update the status route to fetch this validation result and add focused tests that assert the delegated behavior and logging.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2263?tool=ast&topic=Status+route>Status route</a>
        </td><td>Exercise the status route with mocks to ensure it calls <code>getMobileReviewAccessStatus</code> and returns its enabled flag.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/mobile-review/status/route.test.ts</li>
<li>apps/web/app/api/mobile-review/status/route.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>mobile review: add inv...</td><td>April 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2263?tool=ast&topic=Review+access>Review access</a>
        </td><td>Validate mobile review configuration and user availability before creating sessions or reporting enabled status, logging structured reasons for each failure and expanding tests accordingly.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/mobile-review.test.ts</li>
<li>apps/web/utils/mobile-review.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Improve mobile sign-in...</td><td>April 14, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2263?tool=ast>(Baz)</a>.