### PR TITLE
Add Telegram send action to draft reply notifications

### DIFF
--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -63,10 +63,10 @@ vi.mock("@/utils/user/get", () => ({
 }));
 
 vi.mock("@/utils/messaging/rule-notifications", () => ({
-  handleSlackRuleNotificationAction: vi.fn(),
+  handleRuleNotificationAction: vi.fn(),
   handleSlackRuleNotificationModalSubmit: vi.fn(),
   SLACK_DRAFT_EDIT_MODAL_ID: "slack-draft-edit-modal",
-  SLACK_RULE_NOTIFICATION_ACTION_IDS: [],
+  RULE_NOTIFICATION_ACTION_IDS: [],
 }));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -329,7 +329,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     test("edited Slack drafts send the synced Gmail draft", async () => {
       const {
         sendMessagingRuleNotification,
-        handleSlackRuleNotificationAction,
+        handleRuleNotificationAction,
         handleSlackRuleNotificationModalSubmit,
       } = await import("@/utils/messaging/rule-notifications");
 
@@ -583,7 +583,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
         expect(editedSlackMessage?.text).toContain(editedContent);
 
-        await handleSlackRuleNotificationAction({
+        await handleRuleNotificationAction({
           event: {
             actionId: "rule_draft_send",
             value: slackActionState.id,

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -52,10 +52,10 @@ import {
   isHelpCommand,
 } from "@/utils/messaging/prompt-commands";
 import {
-  handleSlackRuleNotificationAction,
+  handleRuleNotificationAction,
   handleSlackRuleNotificationModalSubmit,
+  RULE_NOTIFICATION_ACTION_IDS,
   SLACK_DRAFT_EDIT_MODAL_ID,
-  SLACK_RULE_NOTIFICATION_ACTION_IDS,
 } from "@/utils/messaging/rule-notifications";
 import {
   getMessagingAdapterRegistry,
@@ -450,9 +450,9 @@ function registerMessagingHandlers({
     },
   );
 
-  bot.onAction([...SLACK_RULE_NOTIFICATION_ACTION_IDS], async (event) => {
+  bot.onAction([...RULE_NOTIFICATION_ACTION_IDS], async (event) => {
     const handlerLogger = getHandlerLogger();
-    await handleSlackRuleNotificationAction({
+    await handleRuleNotificationAction({
       event,
       logger: handlerLogger,
     });

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -287,6 +287,117 @@ describe("handleRuleNotificationAction", () => {
     expect(cardText).toContain("Status: Reply sent.");
     expect(cardText).toContain("Open in Gmail");
   });
+
+  it("authorizes Telegram send actions against the notification route target", async () => {
+    const provider = {
+      sendDraft: vi.fn().mockResolvedValue(undefined),
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Thanks for checking in.",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Thanks for checking in.",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Thanks for checking in.",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-workspace-id",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.findFirst.mockResolvedValue({
+      id: "draft-action-1",
+      draftId: "draft-1",
+      subject: "Re: Test subject",
+    } as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_draft_send",
+      value: "action-1",
+      user: { userId: "telegram-user-1" },
+      raw: {
+        callback_query: {
+          message: {
+            chat: { id: "telegram-chat-1" },
+          },
+        },
+      },
+      threadId: "telegram:telegram-chat-1",
+      messageId: "telegram-message-1",
+      adapter: {
+        name: "telegram",
+        decodeThreadId: vi.fn().mockReturnValue({ chatId: "telegram-chat-1" }),
+        editMessage,
+      },
+      thread: { post: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(editMessage).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("sendMessagingRuleNotification", () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -17,6 +17,8 @@ const mockCreateEmailProvider = vi.fn();
 const mockSendAutomationMessage = vi.fn();
 const mockSlackPostMessage = vi.fn();
 const mockSlackJoin = vi.fn();
+const mockTelegramOpenDm = vi.fn();
+const mockTelegramPostMessage = vi.fn();
 
 vi.mock("@/utils/email/provider", () => ({
   createEmailProvider: (...args: unknown[]) => mockCreateEmailProvider(...args),
@@ -38,7 +40,19 @@ vi.mock("@/utils/messaging/providers/slack/client", () => ({
   }),
 }));
 
-describe("handleSlackRuleNotificationAction", () => {
+vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
+  getMessagingAdapterRegistry: () => ({
+    adapters: {},
+    typedAdapters: {
+      telegram: {
+        openDM: (...args: unknown[]) => mockTelegramOpenDm(...args),
+        postMessage: (...args: unknown[]) => mockTelegramPostMessage(...args),
+      },
+    },
+  }),
+}));
+
+describe("handleRuleNotificationAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSendAutomationMessage.mockResolvedValue({
@@ -47,6 +61,8 @@ describe("handleSlackRuleNotificationAction", () => {
     });
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackJoin.mockResolvedValue({});
+    mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
+    mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("keeps the draft preview visible after sending from Slack", async () => {
@@ -123,11 +139,11 @@ describe("handleSlackRuleNotificationAction", () => {
       thread: { postEphemeral: vi.fn() },
     } as any;
 
-    const { handleSlackRuleNotificationAction } = await import(
+    const { handleRuleNotificationAction } = await import(
       "./rule-notifications"
     );
 
-    await handleSlackRuleNotificationAction({
+    await handleRuleNotificationAction({
       event,
       logger: createScopedLogger("test"),
     });
@@ -154,6 +170,123 @@ describe("handleSlackRuleNotificationAction", () => {
       "https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
     );
   });
+
+  it("sends Telegram draft replies from the notification Send button", async () => {
+    const provider = {
+      sendDraft: vi.fn().mockResolvedValue(undefined),
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Thanks for checking in.",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Thanks for checking in.",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Thanks for checking in.",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.findFirst.mockResolvedValue({
+      id: "draft-action-1",
+      draftId: "draft-1",
+      subject: "Re: Test subject",
+    } as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_draft_send",
+      value: "action-1",
+      user: { userId: "telegram-user-1" },
+      raw: {
+        callback_query: {
+          message: {
+            chat: { id: "telegram-chat-1" },
+          },
+        },
+      },
+      threadId: "telegram:telegram-chat-1",
+      messageId: "telegram-message-1",
+      adapter: {
+        name: "telegram",
+        decodeThreadId: vi.fn().mockReturnValue({ chatId: "telegram-chat-1" }),
+        editMessage,
+      },
+      thread: { post: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(editMessage).toHaveBeenCalledTimes(1);
+
+    const [, , card] = editMessage.mock.calls[0];
+    const cardText = JSON.stringify(card);
+
+    expect(cardText).toContain("Status: Reply sent.");
+    expect(cardText).toContain("Open in Gmail");
+  });
 });
 
 describe("sendMessagingRuleNotification", () => {
@@ -165,6 +298,8 @@ describe("sendMessagingRuleNotification", () => {
     });
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackJoin.mockResolvedValue({});
+    mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
+    mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("adds an Open in Gmail button for Slack draft notifications on Google accounts", async () => {
@@ -406,6 +541,69 @@ describe("sendMessagingRuleNotification", () => {
     const [{ text }] = mockSendAutomationMessage.mock.calls[0];
     expect(text).not.toContain("\n> First line");
     expect(text).toContain("Slack-only");
+  });
+
+  it("sends Telegram draft notifications with a Send reply action", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSendAutomationMessage).not.toHaveBeenCalled();
+    expect(mockTelegramOpenDm).toHaveBeenCalledWith("telegram-chat-1");
+    expect(mockTelegramPostMessage).toHaveBeenCalledTimes(1);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const serializedCard = JSON.stringify(card);
+
+    expect(serializedCard).toContain("Send reply");
+    expect(serializedCard).toContain("Open in Gmail");
+    expect(serializedCard).not.toContain("Edit draft");
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        messagingMessageId: "telegram-message-1",
+        messagingMessageSentAt: expect.any(Date),
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+      },
+    });
   });
 
   it("skips linked notifications when provider routing data is incomplete", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -987,7 +987,13 @@ async function getAuthorizedTelegramNotificationContext({
     return null;
   }
 
-  if (chatId && context.messagingChannel.teamId !== chatId) {
+  const expectedChatId =
+    getMessagingRoute(
+      context.messagingChannel.routes,
+      MessagingRoutePurpose.RULE_NOTIFICATIONS,
+    )?.targetId ?? context.messagingChannel.teamId;
+
+  if (chatId && expectedChatId !== chatId) {
     if (event) {
       await postNotificationFeedback({
         event,

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -53,25 +53,26 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
+import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 
 const DRAFT_PREVIEW_MAX_CHARS = 900;
 const SUMMARY_PREVIEW_MAX_CHARS = 2000;
-const SLACK_DRAFT_SEND_ACTION_ID = "rule_draft_send";
-const SLACK_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
-const SLACK_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
-const SLACK_NOTIFY_ARCHIVE_ACTION_ID = "rule_notify_archive";
-const SLACK_NOTIFY_MARK_READ_ACTION_ID = "rule_notify_mark_read";
+const RULE_DRAFT_SEND_ACTION_ID = "rule_draft_send";
+const RULE_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
+const RULE_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
+const RULE_NOTIFY_ARCHIVE_ACTION_ID = "rule_notify_archive";
+const RULE_NOTIFY_MARK_READ_ACTION_ID = "rule_notify_mark_read";
 export const SLACK_DRAFT_EDIT_MODAL_ID = "rule_draft_edit_modal";
 const SLACK_DRAFT_EDIT_FIELD_ID = "draft_content";
 
-export const SLACK_RULE_NOTIFICATION_ACTION_IDS = [
-  SLACK_DRAFT_SEND_ACTION_ID,
-  SLACK_DRAFT_EDIT_ACTION_ID,
-  SLACK_DRAFT_DISMISS_ACTION_ID,
-  SLACK_NOTIFY_ARCHIVE_ACTION_ID,
-  SLACK_NOTIFY_MARK_READ_ACTION_ID,
+export const RULE_NOTIFICATION_ACTION_IDS = [
+  RULE_DRAFT_SEND_ACTION_ID,
+  RULE_DRAFT_EDIT_ACTION_ID,
+  RULE_DRAFT_DISMISS_ACTION_ID,
+  RULE_NOTIFY_ARCHIVE_ACTION_ID,
+  RULE_NOTIFY_MARK_READ_ACTION_ID,
 ] as const;
 
 type NotificationContext = NonNullable<
@@ -156,6 +157,17 @@ export async function getMessagingRuleNotificationResult({
 
   if (context.messagingChannel?.provider === MessagingProvider.SLACK) {
     return sendSlackRuleNotificationWithContext({
+      context,
+      email,
+      logger,
+    });
+  }
+
+  if (
+    context.messagingChannel?.provider === MessagingProvider.TELEGRAM &&
+    isDraftReplyActionType(context.type)
+  ) {
+    return sendTelegramRuleNotificationWithContext({
       context,
       email,
       logger,
@@ -346,7 +358,96 @@ async function sendLinkedRuleNotification({
   }
 }
 
-export async function handleSlackRuleNotificationAction({
+async function sendTelegramRuleNotificationWithContext({
+  context,
+  email,
+  logger,
+}: {
+  context: NotificationContext;
+  email: NotificationEmailPreview;
+  logger: Logger;
+}): Promise<MessagingRuleNotificationResult> {
+  if (
+    !context.messagingChannel?.isConnected ||
+    context.messagingChannel.provider !== MessagingProvider.TELEGRAM
+  ) {
+    logger.warn("Skipping Telegram notification with inactive channel", {
+      executedActionId: context.id,
+      messagingChannelId: context.messagingChannelId,
+    });
+    return { delivered: false, kind: "none" };
+  }
+
+  const route = getMessagingRoute(
+    context.messagingChannel.routes,
+    MessagingRoutePurpose.RULE_NOTIFICATIONS,
+  );
+  const destination = route?.targetId || context.messagingChannel.teamId;
+
+  if (!destination) {
+    logger.warn("Skipping Telegram notification with no route destination", {
+      executedActionId: context.id,
+      messagingChannelId: context.messagingChannelId,
+    });
+    return { delivered: false, kind: "none" };
+  }
+
+  let telegramAdapter: ReturnType<
+    typeof getMessagingAdapterRegistry
+  >["typedAdapters"]["telegram"];
+
+  try {
+    telegramAdapter = getMessagingAdapterRegistry().typedAdapters.telegram;
+  } catch {
+    telegramAdapter = undefined;
+  }
+
+  if (!telegramAdapter) {
+    logger.warn("Skipping Telegram notification without adapter", {
+      executedActionId: context.id,
+      messagingChannelId: context.messagingChannelId,
+    });
+    return { delivered: false, kind: "none" };
+  }
+
+  const content = buildNotificationContent({
+    actionType: context.type,
+    email,
+    systemType: context.executedRule.rule?.systemType ?? null,
+    draftContent: context.content,
+    format: "plain",
+  });
+
+  try {
+    const threadId = await telegramAdapter.openDM(destination);
+    const response = await telegramAdapter.postMessage(
+      threadId,
+      buildTelegramNotificationCard({
+        actionId: context.id,
+        content,
+        openLink: getNotificationOpenLink(context),
+      }),
+    );
+
+    await prisma.executedAction.update({
+      where: { id: context.id },
+      data: {
+        messagingMessageId: response.id ?? threadId,
+        messagingMessageSentAt: new Date(),
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+      },
+    });
+    return { delivered: true, kind: "interactive" };
+  } catch (error) {
+    logger.warn("Failed to send Telegram rule notification", {
+      executedActionId: context.id,
+      error,
+    });
+    return { delivered: false, kind: "none" };
+  }
+}
+
+export async function handleRuleNotificationAction({
   event,
   logger,
 }: {
@@ -363,29 +464,46 @@ export async function handleSlackRuleNotificationAction({
     return;
   }
 
-  const context = await getAuthorizedNotificationContext({
-    executedActionId,
-    logger,
-    teamId: getSlackTeamId(event.raw),
-    userId: event.user.userId,
-    event,
-  });
+  const context =
+    event.adapter.name === "telegram"
+      ? await getAuthorizedTelegramNotificationContext({
+          executedActionId,
+          logger,
+          chatId: getTelegramChatId(event),
+          userId: event.user.userId,
+          event,
+        })
+      : await getAuthorizedSlackNotificationContext({
+          executedActionId,
+          logger,
+          teamId: getSlackTeamId(event.raw),
+          userId: event.user.userId,
+          event,
+        });
   if (!context) return;
 
   switch (event.actionId) {
-    case SLACK_DRAFT_SEND_ACTION_ID:
+    case RULE_DRAFT_SEND_ACTION_ID:
       await handleDraftSend({ context, event, logger });
       return;
-    case SLACK_DRAFT_EDIT_ACTION_ID:
+    case RULE_DRAFT_EDIT_ACTION_ID:
+      if (context.messagingChannel?.provider !== MessagingProvider.SLACK) {
+        await postNotificationFeedback({
+          event,
+          logger,
+          text: "Edit isn't available here yet. Reply here with what you want changed instead.",
+        });
+        return;
+      }
       await handleDraftEdit({ context, event, logger });
       return;
-    case SLACK_DRAFT_DISMISS_ACTION_ID:
+    case RULE_DRAFT_DISMISS_ACTION_ID:
       await handleDraftDismiss({ context, event, logger });
       return;
-    case SLACK_NOTIFY_ARCHIVE_ACTION_ID:
+    case RULE_NOTIFY_ARCHIVE_ACTION_ID:
       await handleArchiveNotification({ context, event, logger });
       return;
-    case SLACK_NOTIFY_MARK_READ_ACTION_ID:
+    case RULE_NOTIFY_MARK_READ_ACTION_ID:
       await handleMarkReadNotification({ context, event, logger });
       return;
     default:
@@ -409,7 +527,7 @@ export async function handleSlackRuleNotificationModalSubmit({
     return { action: "close" };
   }
 
-  const context = await getAuthorizedNotificationContext({
+  const context = await getAuthorizedSlackNotificationContext({
     executedActionId,
     logger,
     teamId: getSlackTeamId(event.raw),
@@ -767,7 +885,7 @@ async function handleMarkReadNotification({
   );
 }
 
-async function getAuthorizedNotificationContext({
+async function getAuthorizedSlackNotificationContext({
   executedActionId,
   logger,
   teamId,
@@ -817,6 +935,64 @@ async function getAuthorizedNotificationContext({
         event,
         logger,
         text: "This notification no longer matches this workspace.",
+      });
+    }
+    return null;
+  }
+
+  return context;
+}
+
+async function getAuthorizedTelegramNotificationContext({
+  executedActionId,
+  logger,
+  chatId,
+  userId,
+  event,
+}: {
+  executedActionId: string;
+  logger: Logger;
+  chatId: string | null;
+  userId: string;
+  event?: ActionEvent;
+}) {
+  const context = await getNotificationContext(executedActionId);
+
+  if (
+    !context?.messagingChannel ||
+    context.messagingChannel.provider !== MessagingProvider.TELEGRAM ||
+    !context.messagingChannel.isConnected
+  ) {
+    if (event) {
+      await postNotificationFeedback({
+        event,
+        logger,
+        text: "This notification is no longer active.",
+      });
+    }
+    return null;
+  }
+
+  if (
+    context.messagingChannel.providerUserId &&
+    context.messagingChannel.providerUserId !== userId
+  ) {
+    if (event) {
+      await postNotificationFeedback({
+        event,
+        logger,
+        text: "You don't have permission to act on this notification.",
+      });
+    }
+    return null;
+  }
+
+  if (chatId && context.messagingChannel.teamId !== chatId) {
+    if (event) {
+      await postNotificationFeedback({
+        event,
+        logger,
+        text: "This notification no longer matches this chat.",
       });
     }
     return null;
@@ -1065,32 +1241,32 @@ function buildNotificationCard({
       isDraftReplyActionType(actionType)
         ? [
             Button({
-              id: SLACK_DRAFT_SEND_ACTION_ID,
+              id: RULE_DRAFT_SEND_ACTION_ID,
               label: "Send reply",
               style: "primary",
               value: actionId,
             }),
             Button({
-              id: SLACK_DRAFT_EDIT_ACTION_ID,
+              id: RULE_DRAFT_EDIT_ACTION_ID,
               label: "Edit draft",
               value: actionId,
             }),
             ...(openLink ? [LinkButton(openLink)] : []),
             Button({
-              id: SLACK_DRAFT_DISMISS_ACTION_ID,
+              id: RULE_DRAFT_DISMISS_ACTION_ID,
               label: "Dismiss",
               value: actionId,
             }),
           ]
         : [
             Button({
-              id: SLACK_NOTIFY_ARCHIVE_ACTION_ID,
+              id: RULE_NOTIFY_ARCHIVE_ACTION_ID,
               label: "Archive",
               style: "primary",
               value: actionId,
             }),
             Button({
-              id: SLACK_NOTIFY_MARK_READ_ACTION_ID,
+              id: RULE_NOTIFY_MARK_READ_ACTION_ID,
               label: "Mark read",
               value: actionId,
             }),
@@ -1114,6 +1290,34 @@ function buildTerminalCard({
   return Card({
     title,
     children: [CardText(message)],
+  });
+}
+
+function buildTelegramNotificationCard({
+  actionId,
+  content,
+  openLink,
+}: {
+  actionId: string;
+  content: NotificationContent;
+  openLink?: NotificationOpenLink | null;
+}): CardElement {
+  const children = buildNotificationCardBody(content);
+  children.push(
+    Actions([
+      Button({
+        id: RULE_DRAFT_SEND_ACTION_ID,
+        label: "Send reply",
+        style: "primary",
+        value: actionId,
+      }),
+      ...(openLink ? [LinkButton(openLink)] : []),
+    ]),
+  );
+
+  return Card({
+    title: content.title,
+    children,
   });
 }
 
@@ -1377,12 +1581,25 @@ async function postNotificationFeedback({
   logger: Logger;
   text: string;
 }) {
-  if (!event.thread) return;
+  const thread = event.thread;
+  if (!thread) return;
+
+  if (event.adapter.name === "slack") {
+    try {
+      await thread.postEphemeral(event.user, text, { fallbackToDM: false });
+      return;
+    } catch (error) {
+      logger.warn("Failed to post Slack notification feedback", {
+        actionId: event.actionId,
+        error,
+      });
+    }
+  }
 
   try {
-    await event.thread.postEphemeral(event.user, text, { fallbackToDM: false });
+    await thread.post(text);
   } catch (error) {
-    logger.warn("Failed to post Slack notification feedback", {
+    logger.warn("Failed to post rule notification feedback", {
       actionId: event.actionId,
       error,
     });
@@ -1428,6 +1645,33 @@ function getSlackTeamId(raw: unknown): string | null {
 
   const maybeTeam = (raw as { team?: { id?: string } }).team?.id;
   return maybeTeam || null;
+}
+
+function getTelegramChatId(event: ActionEvent): string | null {
+  const rawChatId =
+    (event.raw as { message?: { chat?: { id?: string | number } } })?.message
+      ?.chat?.id ??
+    (
+      event.raw as {
+        callback_query?: { message?: { chat?: { id?: string | number } } };
+      }
+    )?.callback_query?.message?.chat?.id;
+  if (rawChatId !== undefined && rawChatId !== null) {
+    return String(rawChatId);
+  }
+
+  try {
+    const decoded = event.adapter.decodeThreadId(event.threadId) as {
+      chatId?: string | number;
+    } | null;
+    if (decoded?.chatId !== undefined && decoded.chatId !== null) {
+      return String(decoded.chatId);
+    }
+  } catch {
+    // Fall back to providerUserId-only authorization below.
+  }
+
+  return null;
 }
 
 function isSlackError(


### PR DESCRIPTION
# User description
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an interactive Telegram card for draft-reply rule notifications with a `Send reply` action and optional mailbox deep link
- route rule-notification button clicks through a shared handler so Telegram can authorize and execute send while Slack keeps edit/dismiss/archive behavior
- fix Telegram send-action authorization to validate against the configured rule-notification route target before falling back to `teamId`
- add focused unit coverage for the Telegram send-card path, Telegram send action handling, and the route-target authorization regression

## Testing
- `pnpm test --run utils/messaging/rule-notifications.test.ts`
- `pnpm test --run utils/messaging/chat-sdk/bot.test.ts`
- `pnpm exec biome check utils/messaging/rule-notifications.ts utils/messaging/rule-notifications.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fe29bb8-9b36-457a-a585-fafa7dcdbc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fe29bb8-9b36-457a-a585-fafa7dcdbc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add interactive Telegram cards for draft-reply rule notifications by sending cards through the rule notification sender and wiring new controller logic to handle the Telegram <code>Send reply</code> flow. Route rule-notification button clicks through the shared handler so Telegram can authorize and execute send actions while Slack keeps its edit/dismiss/archive behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2267?tool=ast&topic=Shared+Handler>Shared Handler</a>
        </td><td>Unify rule-notification button handling by renaming action identifiers, sharing <code>handleRuleNotificationAction</code>, and adding provider-aware authorization/feedback plus updated bot wiring and mocks.<details><summary>Modified files (3)</summary><ul><li>apps/web/__tests__/integration/slack-chat.test.ts</li>
<li>apps/web/utils/messaging/chat-sdk/bot.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: recover chat emai...</td><td>April 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2267?tool=ast&topic=Telegram+Flow>Telegram Flow</a>
        </td><td>Deliver interactive Telegram notifications by opening DMs, rendering send‑reply cards, and tracking message status for draft replies while adding focused coverage for the new adapter path.<details><summary>Modified files (3)</summary><ul><li>apps/web/__tests__/integration/slack-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>messaging: Fix linked ...</td><td>April 11, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Add Slack integration ...</td><td>March 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2267?tool=ast>(Baz)</a>.