### PR TITLE
messaging: fix reply sender and threading

### DIFF
--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -253,10 +253,15 @@ describe("confirmAssistantEmailAction", () => {
   });
 
   it("sends a pending prepared reply and persists confirmed output", async () => {
-    (prisma.emailAccount.findUnique as any).mockResolvedValueOnce({
-      email: "owner@example.com",
-      account: { userId: "u1", provider: "google" },
-    });
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
 
     prisma.chatMessage.findFirst.mockResolvedValue({
       id: "chat-message-1",
@@ -296,7 +301,9 @@ describe("confirmAssistantEmailAction", () => {
       } as any,
     );
 
-    expect(replyToEmail).toHaveBeenCalledWith(sourceMessage, "Thanks!");
+    expect(replyToEmail).toHaveBeenCalledWith(sourceMessage, "Thanks!", {
+      from: "Owner <owner@example.com>",
+    });
     expect(result?.data?.confirmationState).toBe("confirmed");
     expect(result?.data?.confirmationResult).toMatchObject({
       actionType: "reply_email",
@@ -308,10 +315,15 @@ describe("confirmAssistantEmailAction", () => {
   });
 
   it("sends a pending prepared forward and persists confirmed output", async () => {
-    (prisma.emailAccount.findUnique as any).mockResolvedValueOnce({
-      email: "owner@example.com",
-      account: { userId: "u1", provider: "google" },
-    });
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
 
     prisma.chatMessage.findFirst.mockResolvedValue({
       id: "chat-message-1",
@@ -355,6 +367,7 @@ describe("confirmAssistantEmailAction", () => {
       cc: undefined,
       bcc: undefined,
       content: "FYI",
+      from: "Owner <owner@example.com>",
     });
     expect(result?.data?.confirmationState).toBe("confirmed");
     expect(result?.data?.confirmationResult).toMatchObject({

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -490,6 +490,7 @@ async function executeAssistantEmailAction({
       return confirmPendingReplyEmailAction({
         output,
         emailProvider,
+        emailAccountId,
         confirmedAt,
         contentOverride,
       });
@@ -497,6 +498,7 @@ async function executeAssistantEmailAction({
       return confirmPendingForwardEmailAction({
         output,
         emailProvider,
+        emailAccountId,
         confirmedAt,
         contentOverride,
       });
@@ -553,21 +555,30 @@ async function confirmPendingSendEmailAction({
 async function confirmPendingReplyEmailAction({
   output,
   emailProvider,
+  emailAccountId,
   confirmedAt,
   contentOverride,
 }: {
   output: PendingReplyEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
+  emailAccountId: string;
   confirmedAt: string;
   contentOverride?: string;
 }) {
-  const message = await emailProvider.getMessage(
+  const sourceMessage = await emailProvider.getMessage(
     output.pendingAction.messageId,
   );
+  const message = applyReferenceThreadIdFallback(
+    sourceMessage,
+    output.reference?.threadId,
+  );
+  const from = await getFormattedSenderAddress({ emailAccountId });
+  const replyOptions = from ? { from } : undefined;
   const sentAfter = new Date();
   await emailProvider.replyToEmail(
     message,
     contentOverride || output.pendingAction.content,
+    replyOptions,
   );
 
   const messageId = await resolveSentMessageId({
@@ -589,24 +600,33 @@ async function confirmPendingReplyEmailAction({
 async function confirmPendingForwardEmailAction({
   output,
   emailProvider,
+  emailAccountId,
   confirmedAt,
   contentOverride,
 }: {
   output: PendingForwardEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
+  emailAccountId: string;
   confirmedAt: string;
   contentOverride?: string;
 }) {
-  const message = await emailProvider.getMessage(
+  const sourceMessage = await emailProvider.getMessage(
     output.pendingAction.messageId,
   );
-  const sentAfter = new Date();
-  await emailProvider.forwardEmail(message, {
+  const message = applyReferenceThreadIdFallback(
+    sourceMessage,
+    output.reference?.threadId,
+  );
+  const from = await getFormattedSenderAddress({ emailAccountId });
+  const forwardArgs = {
     to: output.pendingAction.to,
     cc: output.pendingAction.cc || undefined,
     bcc: output.pendingAction.bcc || undefined,
     content: contentOverride || output.pendingAction.content || undefined,
-  });
+    ...(from ? { from } : {}),
+  };
+  const sentAfter = new Date();
+  await emailProvider.forwardEmail(message, forwardArgs);
 
   const messageId = await resolveSentMessageId({
     emailProvider,
@@ -1804,6 +1824,18 @@ function parsePendingForwardEmailOutput(output: unknown) {
 function getOutputWithoutProcessingMetadata(output: Record<string, unknown>) {
   const { confirmationProcessingAt: _, ...rest } = output;
   return rest;
+}
+
+function applyReferenceThreadIdFallback<T extends { threadId?: string | null }>(
+  message: T,
+  fallbackThreadId?: string | null,
+) {
+  if (message.threadId || !fallbackThreadId) return message;
+
+  return {
+    ...message,
+    threadId: fallbackThreadId,
+  };
 }
 
 function getPendingActionContentPatch(

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -894,7 +894,13 @@ export class GmailProvider implements EmailProvider {
 
   async forwardEmail(
     email: ParsedMessage,
-    args: { to: string; cc?: string; bcc?: string; content?: string },
+    args: {
+      to: string;
+      cc?: string;
+      bcc?: string;
+      content?: string;
+      from?: string;
+    },
   ): Promise<void> {
     const parsedMessage = await this.getMessage(email.id);
 

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -711,7 +711,13 @@ export class OutlookProvider implements EmailProvider {
 
   async forwardEmail(
     email: ParsedMessage,
-    args: { to: string; cc?: string; bcc?: string; content?: string },
+    args: {
+      to: string;
+      cc?: string;
+      bcc?: string;
+      content?: string;
+      from?: string;
+    },
   ): Promise<void> {
     await forwardEmail(
       this.client,

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -2,7 +2,6 @@ import type { ParsedMessage } from "@/utils/types";
 import type { InboxZeroLabel } from "@/utils/label";
 import type { ThreadsQuery } from "@/app/api/threads/validation";
 import type { OutlookFolder } from "@/utils/outlook/folders";
-import type { Logger } from "@/utils/logger";
 import type { Attachment as MailAttachment } from "nodemailer/lib/mailer";
 
 export interface EmailThread {
@@ -102,7 +101,13 @@ export interface EmailProvider {
   ): Promise<{ draftId: string }>;
   forwardEmail(
     email: ParsedMessage,
-    args: { to: string; cc?: string; bcc?: string; content?: string },
+    args: {
+      to: string;
+      cc?: string;
+      bcc?: string;
+      content?: string;
+      from?: string;
+    },
   ): Promise<void>;
   getAccessToken(): string;
   getAttachment(

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -212,6 +212,7 @@ export async function forwardEmail(
     cc?: string;
     bcc?: string;
     content?: string;
+    from?: string;
   },
 ) {
   ensureEmailSendingEnabled();
@@ -241,6 +242,7 @@ export async function forwardEmail(
 
   const raw = await createRawMailMessage({
     to: options.to,
+    from: options.from,
     cc: options.cc,
     bcc: options.bcc,
     subject: forwardEmailSubject(message.headers.subject),

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -14,7 +14,6 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const mockCreateEmailProvider = vi.fn();
-const mockGetFormattedSenderAddress = vi.fn();
 const mockSendAutomationMessage = vi.fn();
 const mockSlackPostMessage = vi.fn();
 const mockSlackJoin = vi.fn();
@@ -28,11 +27,6 @@ vi.mock("@/utils/email/provider", () => ({
 vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: (...args: unknown[]) =>
     mockSendAutomationMessage(...args),
-}));
-
-vi.mock("@/utils/email/get-formatted-sender-address", () => ({
-  getFormattedSenderAddress: (...args: unknown[]) =>
-    mockGetFormattedSenderAddress(...args),
 }));
 
 vi.mock("@/utils/messaging/providers/slack/client", () => ({
@@ -65,7 +59,6 @@ describe("handleRuleNotificationAction", () => {
       channelId: "teams-thread-1",
       messageId: "teams-message-1",
     });
-    mockGetFormattedSenderAddress.mockResolvedValue(null);
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackJoin.mockResolvedValue({});
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
@@ -405,20 +398,18 @@ describe("handleRuleNotificationAction", () => {
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
     expect(editMessage).toHaveBeenCalledTimes(1);
   });
+});
 
-  it("uses the account display name when sending a Slack draft reply", async () => {
-    const provider = {
-      sendEmailWithHtml: vi.fn().mockResolvedValue(undefined),
-      getMessage: vi.fn().mockResolvedValue({
+describe("buildNotificationReplySendBody", () => {
+  it("includes the formatted sender when provided", async () => {
+    const { buildNotificationReplySendBody } = await import(
+      "./rule-notifications"
+    );
+
+    const body = buildNotificationReplySendBody({
+      sourceMessage: {
         id: "message-1",
         threadId: "thread-1",
-        textPlain: "Original message body",
-        textHtml: "<p>Original message body</p>",
-        subject: "Test subject",
-        date: new Date().toISOString(),
-        snippet: "Original message body",
-        historyId: "2",
-        internalDate: "2",
         headers: {
           from: "sender@example.com",
           to: "user@example.com",
@@ -426,66 +417,29 @@ describe("handleRuleNotificationAction", () => {
           date: "Mon, 1 Jan 2024 11:00:00 +0000",
           "message-id": "<message-1@example.com>",
         },
-        attachments: [],
-        labelIds: [],
-        inline: [],
-      } satisfies ParsedMessage),
-    };
-
-    mockCreateEmailProvider.mockResolvedValue(provider);
-    mockGetFormattedSenderAddress.mockResolvedValue(
-      "Elie Steinbock <elie@getinboxzero.com>",
-    );
-    prisma.executedAction.findUnique.mockResolvedValue(
-      getNotificationContext({
-        id: "action-1",
-        type: ActionType.DRAFT_MESSAGING_CHANNEL,
-        content: "Thanks for checking in.",
-      }) as never,
-    );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
-    prisma.executedAction.update.mockResolvedValue({} as never);
-
-    const event = {
-      actionId: "rule_draft_send",
-      value: "action-1",
-      user: { userId: "user-1" },
-      raw: { team: { id: "team-1" } },
-      threadId: "slack-thread-1",
-      messageId: "slack-message-1",
-      adapter: { editMessage: vi.fn().mockResolvedValue(undefined) },
-      thread: { postEphemeral: vi.fn() },
-    } as any;
-
-    const { handleRuleNotificationAction } = await import(
-      "./rule-notifications"
-    );
-
-    await handleRuleNotificationAction({
-      event,
-      logger: createScopedLogger("test"),
+      } as ParsedMessage,
+      fallbackThreadId: "thread-fallback",
+      content: "Thanks for checking in.",
+      formattedFrom: "Elie Steinbock <elie@getinboxzero.com>",
+      attachments: [],
     });
 
-    expect(provider.sendEmailWithHtml).toHaveBeenCalledWith(
+    expect(body).toEqual(
       expect.objectContaining({
         from: "Elie Steinbock <elie@getinboxzero.com>",
       }),
     );
   });
 
-  it("falls back to the executed thread id when the fetched source message omits it", async () => {
-    const provider = {
-      sendEmailWithHtml: vi.fn().mockResolvedValue(undefined),
-      getMessage: vi.fn().mockResolvedValue({
+  it("falls back to the stored thread id when the source message omits it", async () => {
+    const { buildNotificationReplySendBody } = await import(
+      "./rule-notifications"
+    );
+
+    const body = buildNotificationReplySendBody({
+      sourceMessage: {
         id: "message-1",
         threadId: "",
-        textPlain: "Original message body",
-        textHtml: "<p>Original message body</p>",
-        subject: "Test subject",
-        date: new Date().toISOString(),
-        snippet: "Original message body",
-        historyId: "2",
-        internalDate: "2",
         headers: {
           from: "sender@example.com",
           to: "user@example.com",
@@ -493,47 +447,13 @@ describe("handleRuleNotificationAction", () => {
           date: "Mon, 1 Jan 2024 11:00:00 +0000",
           "message-id": "<message-1@example.com>",
         },
-        attachments: [],
-        labelIds: [],
-        inline: [],
-      } satisfies ParsedMessage),
-    };
-
-    mockCreateEmailProvider.mockResolvedValue(provider);
-    mockGetFormattedSenderAddress.mockResolvedValue(
-      "Elie Steinbock <elie@getinboxzero.com>",
-    );
-    prisma.executedAction.findUnique.mockResolvedValue(
-      getNotificationContext({
-        id: "action-1",
-        type: ActionType.DRAFT_MESSAGING_CHANNEL,
-        content: "Thanks for checking in.",
-      }) as never,
-    );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
-    prisma.executedAction.update.mockResolvedValue({} as never);
-
-    const event = {
-      actionId: "rule_draft_send",
-      value: "action-1",
-      user: { userId: "user-1" },
-      raw: { team: { id: "team-1" } },
-      threadId: "slack-thread-1",
-      messageId: "slack-message-1",
-      adapter: { editMessage: vi.fn().mockResolvedValue(undefined) },
-      thread: { postEphemeral: vi.fn() },
-    } as any;
-
-    const { handleRuleNotificationAction } = await import(
-      "./rule-notifications"
-    );
-
-    await handleRuleNotificationAction({
-      event,
-      logger: createScopedLogger("test"),
+      } as ParsedMessage,
+      fallbackThreadId: "thread-1",
+      content: "Thanks for checking in.",
+      attachments: [],
     });
 
-    expect(provider.sendEmailWithHtml).toHaveBeenCalledWith(
+    expect(body).toEqual(
       expect.objectContaining({
         replyToEmail: expect.objectContaining({
           threadId: "thread-1",

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -398,6 +398,144 @@ describe("handleRuleNotificationAction", () => {
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
     expect(editMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("uses the account display name when sending a Slack draft reply", async () => {
+    const provider = {
+      sendEmailWithHtml: vi.fn().mockResolvedValue(undefined),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      name: "Elie Steinbock",
+      email: "elie@getinboxzero.com",
+    } as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Thanks for checking in.",
+      }) as never,
+    );
+    prisma.executedAction.findFirst.mockResolvedValue(null as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const event = {
+      actionId: "rule_draft_send",
+      value: "action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { editMessage: vi.fn().mockResolvedValue(undefined) },
+      thread: { postEphemeral: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.sendEmailWithHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Elie Steinbock <elie@getinboxzero.com>",
+      }),
+    );
+  });
+
+  it("falls back to the executed thread id when the fetched source message omits it", async () => {
+    const provider = {
+      sendEmailWithHtml: vi.fn().mockResolvedValue(undefined),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      name: "Elie Steinbock",
+      email: "elie@getinboxzero.com",
+    } as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Thanks for checking in.",
+      }) as never,
+    );
+    prisma.executedAction.findFirst.mockResolvedValue(null as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const event = {
+      actionId: "rule_draft_send",
+      value: "action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { editMessage: vi.fn().mockResolvedValue(undefined) },
+      thread: { postEphemeral: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.sendEmailWithHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToEmail: expect.objectContaining({
+          threadId: "thread-1",
+        }),
+      }),
+    );
+  });
 });
 
 describe("sendMessagingRuleNotification", () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -14,6 +14,7 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const mockCreateEmailProvider = vi.fn();
+const mockGetFormattedSenderAddress = vi.fn();
 const mockSendAutomationMessage = vi.fn();
 const mockSlackPostMessage = vi.fn();
 const mockSlackJoin = vi.fn();
@@ -27,6 +28,11 @@ vi.mock("@/utils/email/provider", () => ({
 vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: (...args: unknown[]) =>
     mockSendAutomationMessage(...args),
+}));
+
+vi.mock("@/utils/email/get-formatted-sender-address", () => ({
+  getFormattedSenderAddress: (...args: unknown[]) =>
+    mockGetFormattedSenderAddress(...args),
 }));
 
 vi.mock("@/utils/messaging/providers/slack/client", () => ({
@@ -59,6 +65,7 @@ describe("handleRuleNotificationAction", () => {
       channelId: "teams-thread-1",
       messageId: "teams-message-1",
     });
+    mockGetFormattedSenderAddress.mockResolvedValue(null);
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackJoin.mockResolvedValue({});
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
@@ -426,10 +433,9 @@ describe("handleRuleNotificationAction", () => {
     };
 
     mockCreateEmailProvider.mockResolvedValue(provider);
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      name: "Elie Steinbock",
-      email: "elie@getinboxzero.com",
-    } as never);
+    mockGetFormattedSenderAddress.mockResolvedValue(
+      "Elie Steinbock <elie@getinboxzero.com>",
+    );
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
         id: "action-1",
@@ -494,10 +500,9 @@ describe("handleRuleNotificationAction", () => {
     };
 
     mockCreateEmailProvider.mockResolvedValue(provider);
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      name: "Elie Steinbock",
-      email: "elie@getinboxzero.com",
-    } as never);
+    mockGetFormattedSenderAddress.mockResolvedValue(
+      "Elie Steinbock <elie@getinboxzero.com>",
+    );
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
         id: "action-1",

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -41,6 +41,7 @@ import {
 } from "@/utils/string";
 import { analyzeCalendarEvent } from "@/utils/parse/calender-event";
 import { createEmailProvider } from "@/utils/email/provider";
+import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
 import { resolveActionAttachments } from "@/utils/ai/action-attachments";
 import { quotePlainTextContent } from "@/utils/email/quoted-plain-text";
 import { formatReplySubject } from "@/utils/email/subject";
@@ -693,7 +694,7 @@ async function handleDraftSend({
 
       await provider.sendEmailWithHtml({
         replyToEmail: {
-          threadId: sourceMessage.threadId,
+          threadId: sourceMessage.threadId || context.executedRule.threadId,
           headerMessageId: sourceMessage.headers["message-id"] || "",
           references: sourceMessage.headers.references,
           messageId: sourceMessage.id,
@@ -707,6 +708,11 @@ async function handleDraftSend({
         subject:
           context.subject || formatReplySubject(sourceMessage.headers.subject),
         messageHtml: convertNewlinesToBr(escapeHtml(content)),
+        from:
+          (await getFormattedSenderAddress({
+            emailAccountId: context.executedRule.emailAccount.id,
+            fallbackEmail: context.executedRule.emailAccount.email,
+          })) || undefined,
         attachments: serializeMailAttachments(attachments),
       });
     }

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -692,29 +692,24 @@ async function handleDraftSend({
         return;
       }
 
-      await provider.sendEmailWithHtml({
-        replyToEmail: {
-          threadId: sourceMessage.threadId || context.executedRule.threadId,
-          headerMessageId: sourceMessage.headers["message-id"] || "",
-          references: sourceMessage.headers.references,
-          messageId: sourceMessage.id,
-        },
-        to:
-          context.to ||
-          sourceMessage.headers["reply-to"] ||
-          sourceMessage.headers.from,
-        cc: context.cc ?? undefined,
-        bcc: context.bcc ?? undefined,
-        subject:
-          context.subject || formatReplySubject(sourceMessage.headers.subject),
-        messageHtml: convertNewlinesToBr(escapeHtml(content)),
-        from:
-          (await getFormattedSenderAddress({
-            emailAccountId: context.executedRule.emailAccount.id,
-            fallbackEmail: context.executedRule.emailAccount.email,
-          })) || undefined,
-        attachments: serializeMailAttachments(attachments),
+      const formattedFrom = await getFormattedSenderAddress({
+        emailAccountId: context.executedRule.emailAccount.id,
+        fallbackEmail: context.executedRule.emailAccount.email,
       });
+
+      await provider.sendEmailWithHtml(
+        buildNotificationReplySendBody({
+          sourceMessage,
+          fallbackThreadId: context.executedRule.threadId,
+          to: context.to,
+          cc: context.cc,
+          bcc: context.bcc,
+          subject: context.subject,
+          content,
+          formattedFrom,
+          attachments: serializeMailAttachments(attachments),
+        }),
+      );
     }
 
     await prisma.executedAction.update({
@@ -754,6 +749,48 @@ async function handleDraftSend({
       text: "I couldn't send that draft. Please try again.",
     });
   }
+}
+
+export function buildNotificationReplySendBody({
+  sourceMessage,
+  fallbackThreadId,
+  to,
+  cc,
+  bcc,
+  subject,
+  content,
+  formattedFrom,
+  attachments,
+}: {
+  sourceMessage: Pick<ParsedMessage, "id" | "threadId" | "headers">;
+  fallbackThreadId: string;
+  to?: string | null;
+  cc?: string | null;
+  bcc?: string | null;
+  subject?: string | null;
+  content: string;
+  formattedFrom?: string | null;
+  attachments: Array<{
+    filename: string;
+    content: string;
+    contentType: string;
+  }>;
+}) {
+  return {
+    replyToEmail: {
+      threadId: sourceMessage.threadId || fallbackThreadId,
+      headerMessageId: sourceMessage.headers["message-id"] || "",
+      references: sourceMessage.headers.references,
+      messageId: sourceMessage.id,
+    },
+    to: to || sourceMessage.headers["reply-to"] || sourceMessage.headers.from,
+    cc: cc ?? undefined,
+    bcc: bcc ?? undefined,
+    subject: subject || formatReplySubject(sourceMessage.headers.subject),
+    messageHtml: convertNewlinesToBr(escapeHtml(content)),
+    ...(formattedFrom ? { from: formattedFrom } : {}),
+    attachments,
+  };
 }
 
 async function handleDraftEdit({

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -2,7 +2,7 @@ import type { Message } from "@microsoft/microsoft-graph-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
 import { createScopedLogger } from "@/utils/logger";
-import { sendEmailWithHtml } from "./mail";
+import { forwardEmail, sendEmailWithHtml } from "./mail";
 
 vi.mock("@/utils/mail", () => ({
   ensureEmailSendingEnabled: vi.fn(),
@@ -524,8 +524,115 @@ describe("sendEmailWithHtml", () => {
   });
 });
 
+describe("forwardEmail", () => {
+  it("creates a forward draft, applies the formatted sender, and sends it", async () => {
+    const getMessage = vi.fn(async () => {
+      return {
+        id: "message-1",
+        conversationId: "conversation-1",
+        subject: "Original subject",
+        bodyPreview: "Original preview",
+        body: { content: "<p>Original body</p>" },
+        from: {
+          emailAddress: {
+            address: "sender@example.com",
+            name: "Sender Name",
+          },
+        },
+        toRecipients: [
+          {
+            emailAddress: {
+              address: "recipient@example.com",
+              name: "Recipient Name",
+            },
+          },
+        ],
+        receivedDateTime: "2025-02-06T22:35:00.000Z",
+      } as Message;
+    });
+    const createForwardDraft = vi.fn(async () => {
+      return {
+        id: "draft-1",
+        conversationId: "conversation-1",
+        from: {
+          emailAddress: {
+            address: "owner@example.com",
+          },
+        },
+      } as Message;
+    });
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") return { get: getMessage };
+      if (path === "/me/messages/message-1/createForward") {
+        return { post: createForwardDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await forwardEmail(
+      client,
+      {
+        messageId: "message-1",
+        to: "Recipient Name <recipient@example.com>",
+        cc: "CC Person <cc@example.com>",
+        bcc: "bcc@example.com",
+        content: "Forwarding this",
+        from: "Owner Name <owner@example.com>",
+      },
+      createScopedLogger("outlook-mail-test"),
+    );
+
+    expect(createForwardDraft).toHaveBeenCalledWith({});
+    expect(updateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toRecipients: [
+          {
+            emailAddress: {
+              address: "recipient@example.com",
+              name: "Recipient Name",
+            },
+          },
+        ],
+        ccRecipients: [
+          {
+            emailAddress: {
+              address: "cc@example.com",
+              name: "CC Person",
+            },
+          },
+        ],
+        bccRecipients: [
+          {
+            emailAddress: {
+              address: "bcc@example.com",
+            },
+          },
+        ],
+        from: {
+          emailAddress: {
+            address: "owner@example.com",
+            name: "Owner Name",
+          },
+        },
+        subject: "Fwd: Original subject",
+        body: expect.objectContaining({
+          contentType: "html",
+          content: expect.stringContaining("Forwarding this"),
+        }),
+      }),
+    );
+    expect(sendDraft).toHaveBeenCalledTimes(1);
+  });
+});
+
 function createMockOutlookClient(
   getEndpoint: (path: string) => {
+    get?: () => Promise<unknown>;
     post?: (body: unknown) => Promise<unknown>;
     patch?: (body: unknown) => Promise<unknown>;
   },
@@ -533,6 +640,7 @@ function createMockOutlookClient(
   const api = vi.fn((path: string) => {
     const endpoint = getEndpoint(path);
     return {
+      get: endpoint.get ?? vi.fn(async () => ({})),
       post: endpoint.post ?? vi.fn(async () => ({})),
       patch: endpoint.patch ?? vi.fn(async () => ({})),
     };

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -26,18 +26,6 @@ const MAX_GRAPH_ATTACHMENT_SIZE_BYTES = 3 * 1024 * 1024;
 const MAX_GRAPH_UPLOAD_SESSION_SIZE_BYTES = 150 * 1024 * 1024;
 const GRAPH_UPLOAD_CHUNK_SIZE_BYTES = 320 * 1024;
 
-interface OutlookMessageRequest {
-  bccRecipients?: GraphRecipient[];
-  body: {
-    contentType: string;
-    content: string;
-  };
-  ccRecipients?: GraphRecipient[];
-  replyTo?: GraphRecipient[];
-  subject: string;
-  toRecipients: GraphRecipient[];
-}
-
 type SentEmailResult = Pick<Message, "id" | "conversationId">;
 
 export async function sendEmailWithHtml(
@@ -133,20 +121,10 @@ export async function replyToEmail(
     logger,
   );
 
-  // Build the from field if a display name is provided
-  const fromField = options?.from
-    ? {
-        from: {
-          emailAddress: {
-            name: extractNameFromEmail(options.from),
-            address:
-              extractEmailAddress(options.from) ||
-              replyDraft.from?.emailAddress?.address ||
-              "",
-          },
-        },
-      }
-    : {};
+  const fromField = buildGraphFromField(
+    options?.from,
+    replyDraft.from?.emailAddress?.address,
+  );
 
   // Update the draft with our content
   await withOutlookRetry(
@@ -159,7 +137,7 @@ export async function replyToEmail(
             contentType: "html",
             content: html,
           },
-          ...fromField,
+          ...(fromField ? { from: fromField } : {}),
           ...(options?.replyTo
             ? {
                 replyTo: [{ emailAddress: { address: options.replyTo } }],
@@ -207,6 +185,11 @@ export async function forwardEmail(
 
   if (!options.to.trim()) throw new Error("Recipient address is required");
 
+  const toRecipients = buildGraphRecipients(options.to);
+  if (!toRecipients?.length) throw new Error("Recipient address is required");
+  const ccRecipients = buildGraphRecipients(options.cc);
+  const bccRecipients = buildGraphRecipients(options.bcc);
+
   // Get the original message
   const originalMessage: Message = await withOutlookRetry(
     () => client.getClient().api(`/me/messages/${options.messageId}`).get(),
@@ -233,31 +216,52 @@ export async function forwardEmail(
     conversationIndex: originalMessage.conversationId || "",
   };
 
-  const forwardMessage: OutlookMessageRequest = {
-    toRecipients: [{ emailAddress: { address: options.to } }],
-    ...(options.cc
-      ? { ccRecipients: [{ emailAddress: { address: options.cc } }] }
-      : {}),
-    ...(options.bcc
-      ? { bccRecipients: [{ emailAddress: { address: options.bcc } }] }
-      : {}),
-    subject: forwardEmailSubject(message.headers.subject),
-    body: {
-      contentType: "html",
-      content: forwardEmailHtml({ content: options.content ?? "", message }),
-    },
-  };
-
-  const result = await withOutlookRetry(
+  const forwardDraft: Message = await withOutlookRetry(
     () =>
       client
         .getClient()
-        .api(`/me/messages/${options.messageId}/forward`)
-        .post({ message: forwardMessage }),
+        .api(`/me/messages/${options.messageId}/createForward`)
+        .post({}),
     logger,
   );
 
-  return result;
+  const fromField = buildGraphFromField(
+    options.from,
+    forwardDraft.from?.emailAddress?.address,
+  );
+
+  await withOutlookRetry(
+    () =>
+      client
+        .getClient()
+        .api(`/me/messages/${forwardDraft.id}`)
+        .patch({
+          toRecipients,
+          ...(ccRecipients ? { ccRecipients } : {}),
+          ...(bccRecipients ? { bccRecipients } : {}),
+          ...(fromField ? { from: fromField } : {}),
+          subject: forwardEmailSubject(message.headers.subject),
+          body: {
+            contentType: "html",
+            content: forwardEmailHtml({
+              content: options.content ?? "",
+              message,
+            }),
+          },
+        }),
+    logger,
+  );
+
+  await withOutlookRetry(
+    () =>
+      client.getClient().api(`/me/messages/${forwardDraft.id}/send`).post({}),
+    logger,
+  );
+
+  return {
+    id: "",
+    conversationId: forwardDraft.conversationId,
+  };
 }
 
 export async function draftEmail(
@@ -504,6 +508,22 @@ function buildGraphRecipients(
     seen.add(key);
     return true;
   });
+}
+
+function buildGraphFromField(formattedFrom?: string, fallbackAddress?: string) {
+  if (!formattedFrom) return undefined;
+
+  const address = extractEmailAddress(formattedFrom) || fallbackAddress;
+  if (!address) return undefined;
+
+  const name = extractNameFromEmail(formattedFrom).trim();
+
+  return {
+    emailAddress: {
+      address,
+      ...(name && name !== address ? { name } : {}),
+    },
+  };
 }
 
 async function addAttachmentsToDraft({

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -510,7 +510,10 @@ function buildGraphRecipients(
   });
 }
 
-function buildGraphFromField(formattedFrom?: string, fallbackAddress?: string) {
+function buildGraphFromField(
+  formattedFrom?: string,
+  fallbackAddress?: string | null,
+) {
   if (!formattedFrom) return undefined;
 
   const address = extractEmailAddress(formattedFrom) || fallbackAddress;

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -199,6 +199,7 @@ export async function forwardEmail(
     cc?: string;
     bcc?: string;
     content?: string;
+    from?: string;
   },
   logger: Logger,
 ) {


### PR DESCRIPTION
# User description
Fixes messaging email send paths so reply and forward actions preserve sender metadata and thread context.

- propagate formatted sender metadata through assistant reply and forward confirmations
- fall back to stored thread ids when notification sends receive incomplete provider message data
- add regression coverage for Slack notification sends and assistant email confirmations

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure assistant chat confirmations route replies and forwards through <code>EmailProvider</code> helpers after filling missing thread IDs and formatted sender metadata. Improve notification reply bodies to reapply stored thread identifiers and formatted senders when notification providers return incomplete message data.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2269?tool=ast&topic=Notification+replies>Notification replies</a>
        </td><td>Return thread-aware notification send payloads that reapply fallback IDs and optional <code>formattedFrom</code> data when building Slack notification reply bodies.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/messaging/rule-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add Telegram send acti...</td><td>April 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2269?tool=ast&topic=Assistant+email+flow>Assistant email flow</a>
        </td><td>Ensure <code>confirmPendingReplyEmailAction</code> and <code>confirmPendingForwardEmailAction</code> supply formatted sender addresses and thread fallbacks before invoking the <code>EmailProvider</code> reply/forward helpers.<details><summary>Modified files (8)</summary><ul><li>apps/web/utils/actions/assistant-chat.test.ts</li>
<li>apps/web/utils/actions/assistant-chat.ts</li>
<li>apps/web/utils/email/google.ts</li>
<li>apps/web/utils/email/microsoft.ts</li>
<li>apps/web/utils/email/types.ts</li>
<li>apps/web/utils/gmail/mail.ts</li>
<li>apps/web/utils/outlook/mail.test.ts</li>
<li>apps/web/utils/outlook/mail.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: recover chat emai...</td><td>April 14, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Fix auto-filer reply s...</td><td>February 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2269?tool=ast>(Baz)</a>.