### PR TITLE
rules: streamline action attachment execution

### DIFF
--- a/apps/web/__tests__/integration/rule-execution.test.ts
+++ b/apps/web/__tests__/integration/rule-execution.test.ts
@@ -106,6 +106,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     let gmailClient: GmailTestHarness["gmailClient"];
     let provider: GmailTestHarness["provider"];
     let threadIds: GmailTestHarness["threadIds"];
+    const emailAccount = {
+      email: TEST_EMAIL,
+      id: "test-account-id",
+      userId: "test-user-id",
+    };
 
     beforeAll(async () => {
       harness = await createGmailTestHarness({
@@ -209,9 +214,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount,
         logger: createTestLogger(),
       });
 
@@ -258,9 +261,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount,
         logger: createTestLogger(),
       });
 
@@ -292,9 +293,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount,
         logger: createTestLogger(),
       });
 
@@ -321,9 +320,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount,
         logger: createTestLogger(),
       });
 

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -924,9 +924,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           messagingChannelId: persistedAction.messagingChannelId,
           content: persistedAction.content,
         },
-        userEmail: "user@example.com",
-        userId: "user-1",
-        emailAccountId,
+        emailAccount: {
+          email: "user@example.com",
+          id: emailAccountId,
+          userId: "user-1",
+        },
         executedRule: {
           id: "executed-rule-1",
           threadId,

--- a/apps/web/__tests__/integration/webhook-action.test.ts
+++ b/apps/web/__tests__/integration/webhook-action.test.ts
@@ -222,9 +222,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: harness.provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount: {
+          email: TEST_EMAIL,
+          id: "test-account-id",
+          userId: "test-user-id",
+        },
         logger: createTestLogger(),
       });
 
@@ -340,9 +342,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         client: harness.provider,
         executedRule,
         message,
-        userEmail: TEST_EMAIL,
-        userId: "test-user-id",
-        emailAccountId: "test-account-id",
+        emailAccount: {
+          email: TEST_EMAIL,
+          id: "test-account-id",
+          userId: "test-user-id",
+        },
         logger: createTestLogger(),
       });
 

--- a/apps/web/__tests__/integration/webhook-flow.test.ts
+++ b/apps/web/__tests__/integration/webhook-flow.test.ts
@@ -109,9 +109,11 @@ vi.mock("@/utils/ai/choose-rule/run-rules", () => ({
       client: provider,
       executedRule,
       message,
-      userEmail: "webhook-flow@example.com",
-      userId: "test-user-id",
-      emailAccountId: "test-account-id",
+      emailAccount: {
+        email: "webhook-flow@example.com",
+        id: "test-account-id",
+        userId: "test-user-id",
+      },
       logger,
     });
 

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -119,7 +119,14 @@ export const runRulesAction = actionClient
             emailAccountId,
             enabled: true,
           },
-          include: { actions: true },
+          include: {
+            actions: true,
+            _count: {
+              select: {
+                attachmentSources: true,
+              },
+            },
+          },
         })
         .catch((error) => {
           logger.error("Failed to load enabled rules for execution", { error });
@@ -186,7 +193,14 @@ export const testAiCustomContentAction = actionClient
           enabled: true,
           instructions: { not: null },
         },
-        include: { actions: true },
+        include: {
+          actions: true,
+          _count: {
+            select: {
+              attachmentSources: true,
+            },
+          },
+        },
       });
 
       const result = await runRules({

--- a/apps/web/utils/ai/action-attachments.ts
+++ b/apps/web/utils/ai/action-attachments.ts
@@ -1,41 +1,54 @@
-import type { ExecutedRule } from "@/generated/prisma/client";
 import { AttachmentSourceType } from "@/generated/prisma/enums";
 import {
   type SelectedAttachment,
   attachmentSourceInputSchema,
 } from "@/utils/attachments/source-schema";
 import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
-import type { ActionItem, EmailForAction } from "@/utils/ai/types";
+import type {
+  ActionExecutionEmailAccount,
+  ActionItem,
+  EmailForAction,
+  ExecutedRuleForAction,
+} from "@/utils/ai/types";
 import type { Logger } from "@/utils/logger";
 import { getReplyWithConfidence } from "@/utils/redis/reply";
 
 export async function resolveActionAttachments({
   email,
-  emailAccountId,
+  emailAccount,
   executedRule,
-  userId,
   logger,
   staticAttachments,
   includeAiSelectedAttachments,
 }: {
   email: EmailForAction;
-  emailAccountId: string;
-  executedRule: ExecutedRule;
-  userId: string;
+  emailAccount: ActionExecutionEmailAccount;
+  executedRule: ExecutedRuleForAction;
   logger: Logger;
   staticAttachments?: ActionItem["staticAttachments"];
   includeAiSelectedAttachments: boolean;
 }) {
+  const staticSelectedAttachments = parseStaticAttachments(staticAttachments);
+
+  if (
+    staticSelectedAttachments.length === 0 &&
+    (!includeAiSelectedAttachments ||
+      executedRule.hasAttachmentSources === false ||
+      !executedRule.ruleId)
+  ) {
+    return [];
+  }
+
   const [aiSelectedAttachments, staticSelected] = await Promise.all([
     includeAiSelectedAttachments
       ? getDraftSelectedAttachments({
           email,
-          emailAccountId,
+          emailAccountId: emailAccount.id,
           executedRule,
           logger,
         })
       : Promise.resolve([]),
-    Promise.resolve(parseStaticAttachments(staticAttachments)),
+    Promise.resolve(staticSelectedAttachments),
   ]);
 
   const allSelected = [
@@ -50,8 +63,8 @@ export async function resolveActionAttachments({
   if (allSelected.length === 0) return [];
 
   const attachments = await resolveDraftAttachments({
-    emailAccountId,
-    userId,
+    emailAccountId: emailAccount.id,
+    userId: emailAccount.userId,
     selectedAttachments: allSelected,
     logger,
   });
@@ -75,7 +88,7 @@ async function getDraftSelectedAttachments({
 }: {
   email: EmailForAction;
   emailAccountId: string;
-  executedRule: ExecutedRule;
+  executedRule: ExecutedRuleForAction;
   logger: Logger;
 }): Promise<SelectedAttachment[]> {
   if (!executedRule.ruleId) return [];

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -16,6 +16,7 @@ import {
   sendMessagingRuleNotification,
 } from "@/utils/messaging/rule-notifications";
 import type { ParsedMessage } from "@/utils/types";
+import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 vi.mock("server-only", () => ({}));
 
@@ -39,8 +40,21 @@ vi.mock("@/utils/messaging/rule-notifications", () => ({
   sendMessagingRuleNotification: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    executedAction: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
 describe("runActionFunction", () => {
   const logger = createTestLogger();
+  const emailAccount = {
+    email: "user@example.com",
+    id: "account-1",
+    userId: "user-1",
+  };
   const email = {
     id: "message-1",
     threadId: "thread-1",
@@ -60,6 +74,7 @@ describe("runActionFunction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.executedAction.update).mockResolvedValue({});
     vi.mocked(getMessagingRuleNotificationResult).mockResolvedValue({
       delivered: true,
       kind: "interactive",
@@ -98,9 +113,7 @@ describe("runActionFunction", () => {
         type: ActionType.DRAFT_EMAIL,
         content: "Attached the requested PDF.",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -142,7 +155,7 @@ describe("runActionFunction", () => {
           }),
         ],
       }),
-      "user@example.com",
+      emailAccount.email,
       expect.objectContaining({ id: "executed-rule-1" }),
     );
   });
@@ -160,9 +173,7 @@ describe("runActionFunction", () => {
         type: ActionType.DRAFT_EMAIL,
         content: "Attached the requested PDF.",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -180,7 +191,7 @@ describe("runActionFunction", () => {
         content: "Attached the requested PDF.",
         attachments: [],
       }),
-      "user@example.com",
+      emailAccount.email,
       expect.objectContaining({ id: "executed-rule-1" }),
     );
   });
@@ -197,9 +208,7 @@ describe("runActionFunction", () => {
         messagingChannelId: "channel-1",
         content: "Draft in chat",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -229,9 +238,7 @@ describe("runActionFunction", () => {
         messagingChannelId: "channel-1",
         content: "Draft in chat",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -261,9 +268,7 @@ describe("runActionFunction", () => {
         messagingChannelId: "channel-1",
         content: "Draft in chat",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -293,9 +298,7 @@ describe("runActionFunction", () => {
         messagingChannelId: "channel-1",
         content: "Draft in chat",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -323,9 +326,7 @@ describe("runActionFunction", () => {
           messagingChannelId: "channel-1",
           content: "Draft in chat",
         },
-        userEmail: "user@example.com",
-        userId: "user-1",
-        emailAccountId: "account-1",
+        emailAccount,
         executedRule: {
           id: "executed-rule-1",
           threadId: "thread-1",
@@ -348,9 +349,7 @@ describe("runActionFunction", () => {
         type: ActionType.NOTIFY_MESSAGING_CHANNEL,
         messagingChannelId: "channel-1",
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -379,9 +378,7 @@ describe("runActionFunction", () => {
           type: ActionType.NOTIFY_MESSAGING_CHANNEL,
           messagingChannelId: null,
         },
-        userEmail: "user@example.com",
-        userId: "user-1",
-        emailAccountId: "account-1",
+        emailAccount,
         executedRule: {
           id: "executed-rule-1",
           threadId: "thread-1",
@@ -421,9 +418,7 @@ describe("runActionFunction", () => {
           },
         ],
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -491,9 +486,7 @@ describe("runActionFunction", () => {
           },
         ],
       },
-      userEmail: "user@example.com",
-      userId: "user-1",
-      emailAccountId: "account-1",
+      emailAccount,
       executedRule: {
         id: "executed-rule-1",
         threadId: "thread-1",
@@ -530,5 +523,32 @@ describe("runActionFunction", () => {
         ],
       }),
     );
+  });
+
+  it("skips cache lookup when drafts have no attachment sources or static files", async () => {
+    const client = createMockEmailProvider();
+
+    await runActionFunction({
+      client,
+      email,
+      action: {
+        id: "action-1",
+        type: ActionType.DRAFT_EMAIL,
+        content: "No attachments.",
+      },
+      emailAccount,
+      executedRule: {
+        id: "executed-rule-1",
+        threadId: "thread-1",
+        emailAccountId: "account-1",
+        ruleId: "rule-1",
+        hasAttachmentSources: false,
+      } as any,
+      logger,
+    });
+
+    expect(getReplyWithConfidence).not.toHaveBeenCalled();
+    expect(resolveDraftAttachments).not.toHaveBeenCalled();
+    expect(client.draftEmail).toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -1,9 +1,13 @@
 import { after } from "next/server";
 import { ActionType, MessagingMessageStatus } from "@/generated/prisma/enums";
-import type { ExecutedRule } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
 import { callWebhook } from "@/utils/webhook";
-import type { ActionItem, EmailForAction } from "@/utils/ai/types";
+import type {
+  ActionExecutionEmailAccount,
+  ActionItem,
+  EmailForAction,
+  ExecutedRuleForAction,
+} from "@/utils/ai/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { enqueueDigestItem } from "@/utils/digest/index";
 import { filterNullProperties } from "@/utils";
@@ -24,17 +28,11 @@ import { isMessagingDraftActionType } from "@/utils/actions/draft-reply";
 
 const MODULE = "ai-actions";
 
-type ExecutedRuleForAction = ExecutedRule & {
-  actionItems?: Pick<ActionItem, "type">[];
-};
-
 type ActionFunction<T extends Partial<Omit<ActionItem, "type">>> = (options: {
   client: EmailProvider;
   email: EmailForAction;
   args: T & Pick<ActionItem, "id">;
-  userEmail: string;
-  userId: string;
-  emailAccountId: string;
+  emailAccount: ActionExecutionEmailAccount;
   executedRule: ExecutedRuleForAction;
   logger: Logger;
 }) => Promise<unknown>;
@@ -43,18 +41,16 @@ export const runActionFunction = async (options: {
   client: EmailProvider;
   email: EmailForAction;
   action: ActionItem;
-  userEmail: string;
-  userId: string;
-  emailAccountId: string;
+  emailAccount: ActionExecutionEmailAccount;
   executedRule: ExecutedRuleForAction;
   logger: Logger;
 }) => {
-  const { action, userEmail, logger } = options;
+  const { action, emailAccount, logger } = options;
   const log = logger.with({ module: MODULE });
 
   log.info("Running action", {
     actionType: action.type,
-    userEmail,
+    userEmail: emailAccount.email,
     id: action.id,
   });
   log.trace("Running action", () => filterNullProperties(action));
@@ -105,15 +101,15 @@ export const runActionFunction = async (options: {
 const archive: ActionFunction<Record<string, unknown>> = async ({
   client,
   email,
-  userEmail,
+  emailAccount,
 }) => {
-  await client.archiveThread(email.threadId, userEmail);
+  await client.archiveThread(email.threadId, emailAccount.email);
 };
 
 const label: ActionFunction<{
   label?: string | null;
   labelId?: string | null;
-}> = async ({ client, email, args, emailAccountId, logger }) => {
+}> = async ({ client, email, args, emailAccount, logger }) => {
   logger.info("Label action started", {
     label: args.label,
     labelId: args.labelId,
@@ -151,7 +147,7 @@ const label: ActionFunction<{
     messageId: email.id,
     labelId: labelIdToUse,
     labelName: args.label || null,
-    emailAccountId,
+    emailAccountId: emailAccount.id,
     logger,
   });
 
@@ -160,7 +156,7 @@ const label: ActionFunction<{
       lazyUpdateActionLabelId({
         labelName: args.label!,
         labelId: labelIdToUse!,
-        emailAccountId,
+        emailAccountId: emailAccount.id,
         logger,
       }),
     );
@@ -175,16 +171,7 @@ const draft: ActionFunction<{
   cc?: string | null;
   bcc?: string | null;
   staticAttachments?: ActionItem["staticAttachments"];
-}> = async ({
-  client,
-  email,
-  args,
-  userEmail,
-  userId,
-  emailAccountId,
-  executedRule,
-  logger,
-}) => {
+}> = async ({ client, email, args, emailAccount, executedRule, logger }) => {
   if (env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED) return;
 
   if (
@@ -220,9 +207,8 @@ const draft: ActionFunction<{
 
   const attachments = await resolveActionAttachments({
     email,
-    emailAccountId,
+    emailAccount,
     executedRule,
-    userId,
     logger,
     staticAttachments: args.staticAttachments,
     includeAiSelectedAttachments: true,
@@ -254,7 +240,7 @@ const draft: ActionFunction<{
       attachments: email.attachments,
     },
     draftArgs,
-    userEmail,
+    emailAccount.email,
     executedRule,
   );
   return { draftId: result.draftId };
@@ -325,22 +311,13 @@ const reply: ActionFunction<{
   cc?: string | null;
   bcc?: string | null;
   staticAttachments?: ActionItem["staticAttachments"];
-}> = async ({
-  client,
-  email,
-  args,
-  userId,
-  emailAccountId,
-  executedRule,
-  logger,
-}) => {
+}> = async ({ client, email, args, emailAccount, executedRule, logger }) => {
   if (!args.content) return;
 
   const attachments = await resolveActionAttachments({
     email,
-    emailAccountId,
+    emailAccount,
     executedRule,
-    userId,
     logger,
     staticAttachments: args.staticAttachments,
     includeAiSelectedAttachments: false,
@@ -372,22 +349,13 @@ const send_email: ActionFunction<{
   cc?: string | null;
   bcc?: string | null;
   staticAttachments?: ActionItem["staticAttachments"];
-}> = async ({
-  client,
-  args,
-  email,
-  userId,
-  emailAccountId,
-  executedRule,
-  logger,
-}) => {
+}> = async ({ client, args, email, emailAccount, executedRule, logger }) => {
   if (!args.to || !args.subject || !args.content) return;
 
   const attachments = await resolveActionAttachments({
     email,
-    emailAccountId,
+    emailAccount,
     executedRule,
-    userId,
     logger,
     staticAttachments: args.staticAttachments,
     includeAiSelectedAttachments: false,
@@ -447,7 +415,7 @@ const mark_spam: ActionFunction<Record<string, unknown>> = async ({
 const call_webhook: ActionFunction<{ url?: string | null }> = async ({
   email,
   args,
-  userId,
+  emailAccount,
   executedRule,
 }) => {
   if (!args.url) return;
@@ -471,7 +439,7 @@ const call_webhook: ActionFunction<{ url?: string | null }> = async ({
     },
   };
 
-  await callWebhook(userId, args.url, payload);
+  await callWebhook(emailAccount.userId, args.url, payload);
 };
 
 const mark_read: ActionFunction<Record<string, unknown>> = async ({
@@ -483,19 +451,24 @@ const mark_read: ActionFunction<Record<string, unknown>> = async ({
 
 const digest: ActionFunction<{ id?: string }> = async ({
   email,
-  emailAccountId,
+  emailAccount,
   args,
   logger,
 }) => {
   if (!args.id) return;
   const actionId = args.id;
-  await enqueueDigestItem({ email, emailAccountId, actionId, logger });
+  await enqueueDigestItem({
+    email,
+    emailAccountId: emailAccount.id,
+    actionId,
+    logger,
+  });
 };
 
 const move_folder: ActionFunction<{
   folderId?: string | null;
   folderName?: string | null;
-}> = async ({ client, email, userEmail, emailAccountId, args, logger }) => {
+}> = async ({ client, email, emailAccount, args, logger }) => {
   const originalFolderId = args.folderId;
   let folderIdToUse = originalFolderId;
 
@@ -519,7 +492,11 @@ const move_folder: ActionFunction<{
 
   if (!folderIdToUse) return;
 
-  await client.moveThreadToFolder(email.threadId, userEmail, folderIdToUse);
+  await client.moveThreadToFolder(
+    email.threadId,
+    emailAccount.email,
+    folderIdToUse,
+  );
 
   // lazy-update the folderId in the database for future runs
   if (!originalFolderId && folderIdToUse && args.folderName) {
@@ -527,7 +504,7 @@ const move_folder: ActionFunction<{
       lazyUpdateActionFolderId({
         folderName: args.folderName!,
         folderId: folderIdToUse!,
-        emailAccountId,
+        emailAccountId: emailAccount.id,
         logger,
       }),
     );
@@ -536,8 +513,7 @@ const move_folder: ActionFunction<{
 
 const notify_sender: ActionFunction<Record<string, unknown>> = async ({
   email,
-  emailAccountId,
-  userEmail,
+  emailAccount,
   logger,
 }) => {
   const senderEmail = extractEmailAddress(email.headers.from);
@@ -548,7 +524,7 @@ const notify_sender: ActionFunction<Record<string, unknown>> = async ({
 
   const result = await sendColdEmailNotification({
     senderEmail,
-    recipientEmail: userEmail,
+    recipientEmail: emailAccount.email,
     originalSubject: email.headers.subject,
     originalMessageId: email.headers["message-id"],
     logger,
@@ -570,7 +546,7 @@ const notify_sender: ActionFunction<Record<string, unknown>> = async ({
     captureException(
       new Error(result.error ?? "Cold email notification failed"),
       {
-        emailAccountId,
+        emailAccountId: emailAccount.id,
         extra: { actionType: ActionType.NOTIFY_SENDER },
         sampleRate: 0.01,
       },

--- a/apps/web/utils/ai/choose-rule/bulk-process-emails.ts
+++ b/apps/web/utils/ai/choose-rule/bulk-process-emails.ts
@@ -36,7 +36,14 @@ export async function bulkProcessInboxEmails({
           emailAccountId: emailAccount.id,
           enabled: true,
         },
-        include: { actions: true },
+        include: {
+          actions: true,
+          _count: {
+            select: {
+              attachmentSources: true,
+            },
+          },
+        },
       }),
     ]);
 

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -24,6 +24,11 @@ vi.mock("@/utils/prisma", () => ({
 describe("executeAct", () => {
   const logger = createTestLogger();
   const mockClient = {} as EmailProvider;
+  const emailAccount = {
+    email: "recipient@example.com",
+    id: "email-account-1",
+    userId: "user-1",
+  };
   const message: ParsedMessage = {
     id: "message-id-1",
     threadId: "thread-id-1",
@@ -78,9 +83,7 @@ describe("executeAct", () => {
       client: mockClient,
       executedRule,
       message,
-      userEmail: "recipient@example.com",
-      userId: "user-1",
-      emailAccountId: "email-account-1",
+      emailAccount,
       logger,
     });
 
@@ -107,9 +110,7 @@ describe("executeAct", () => {
       client: mockClient,
       executedRule,
       message,
-      userEmail: "recipient@example.com",
-      userId: "user-1",
-      emailAccountId: "email-account-1",
+      emailAccount,
       logger,
     });
 
@@ -133,9 +134,7 @@ describe("executeAct", () => {
         client: mockClient,
         executedRule,
         message,
-        userEmail: "recipient@example.com",
-        userId: "user-1",
-        emailAccountId: "email-account-1",
+        emailAccount,
         logger,
       }),
     ).rejects.toThrow("boom");

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -7,13 +7,17 @@ import type { ParsedMessage } from "@/utils/types";
 import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-management";
 import type { EmailProvider } from "@/utils/email/types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
-import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
+import type {
+  ActionExecutionEmailAccount,
+  ExecutedRuleForAction,
+} from "@/utils/ai/types";
 
 const MODULE = "ai-execute-act";
 
 type ExecutedRuleWithActionItems = Prisma.ExecutedRuleGetPayload<{
   include: { actionItems: true };
-}>;
+}> &
+  Pick<ExecutedRuleForAction, "hasAttachmentSources">;
 
 type ActionFailure = {
   type: ActionType;

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -7,6 +7,7 @@ import type { ParsedMessage } from "@/utils/types";
 import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-management";
 import type { EmailProvider } from "@/utils/email/types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
+import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
 
 const MODULE = "ai-execute-act";
 
@@ -22,18 +23,14 @@ type ActionFailure = {
 export async function executeAct({
   client,
   executedRule,
-  userEmail,
-  userId,
-  emailAccountId,
+  emailAccount,
   message,
   logger,
 }: {
   client: EmailProvider;
   executedRule: ExecutedRuleWithActionItems;
   message: ParsedMessage;
-  userEmail: string;
-  userId: string;
-  emailAccountId: string;
+  emailAccount: ActionExecutionEmailAccount;
   logger: Logger;
 }) {
   const log = logger.with({
@@ -52,9 +49,7 @@ export async function executeAct({
         client,
         email: message,
         action,
-        userEmail,
-        userId,
-        emailAccountId,
+        emailAccount,
         executedRule,
         logger: log,
       });
@@ -83,7 +78,7 @@ export async function executeAct({
         error,
         dedupeKeyParts: {
           scope: "ai/choose-rule/execute",
-          emailAccountId,
+          emailAccountId: emailAccount.id,
           actionType: action.type,
         },
       });

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -90,7 +90,14 @@ export async function findMatchingRules({
     if (coldEmailResult.isColdEmail) {
       const coldRule = await prisma.rule.findUniqueOrThrow({
         where: { id: coldEmailRule.id },
-        include: { actions: true },
+        include: {
+          actions: true,
+          _count: {
+            select: {
+              attachmentSources: true,
+            },
+          },
+        },
       });
 
       return {

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -496,11 +496,16 @@ async function executeMatchedRule(
     if (immediateActions?.length > 0) {
       await executeAct({
         client,
-        userEmail: emailAccount.email,
+        emailAccount: {
+          email: emailAccount.email,
+          id: emailAccount.id,
+          userId: emailAccount.userId,
+        },
         logger,
-        userId: emailAccount.userId,
-        emailAccountId: emailAccount.id,
-        executedRule,
+        executedRule: {
+          ...executedRule,
+          hasAttachmentSources: getRuleHasAttachmentSources(rule),
+        },
         message,
       });
     } else if (!delayedActions?.length) {
@@ -526,6 +531,18 @@ async function executeMatchedRule(
     matchReasons,
     createdAt: batchTimestamp,
   };
+}
+
+function getRuleHasAttachmentSources(rule: RuleWithActions) {
+  if ("_count" in rule && rule._count?.attachmentSources != null) {
+    return rule._count.attachmentSources > 0;
+  }
+
+  if ("attachmentSources" in rule && Array.isArray(rule.attachmentSources)) {
+    return rule.attachmentSources.length > 0;
+  }
+
+  return undefined;
 }
 
 async function analyzeSenderPatternIfAiMatch({

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -534,15 +534,32 @@ async function executeMatchedRule(
 }
 
 function getRuleHasAttachmentSources(rule: RuleWithActions) {
-  if ("_count" in rule && rule._count?.attachmentSources != null) {
+  if (hasAttachmentSourceCount(rule)) {
     return rule._count.attachmentSources > 0;
   }
 
-  if ("attachmentSources" in rule && Array.isArray(rule.attachmentSources)) {
+  if (hasAttachmentSourcesArray(rule)) {
     return rule.attachmentSources.length > 0;
   }
 
   return undefined;
+}
+
+function hasAttachmentSourceCount(
+  rule: RuleWithActions,
+): rule is RuleWithActions & { _count: { attachmentSources: number } } {
+  return (
+    typeof (rule as { _count?: { attachmentSources?: unknown } })._count
+      ?.attachmentSources === "number"
+  );
+}
+
+function hasAttachmentSourcesArray(
+  rule: RuleWithActions,
+): rule is RuleWithActions & { attachmentSources: unknown[] } {
+  return Array.isArray(
+    (rule as { attachmentSources?: unknown }).attachmentSources,
+  );
 }
 
 async function analyzeSenderPatternIfAiMatch({

--- a/apps/web/utils/ai/types.ts
+++ b/apps/web/utils/ai/types.ts
@@ -1,5 +1,9 @@
 import type { ParsedMessage } from "@/utils/types";
-import type { ExecutedAction } from "@/generated/prisma/client";
+import type {
+  EmailAccount,
+  ExecutedAction,
+  ExecutedRule,
+} from "@/generated/prisma/client";
 
 export type EmailForAction = Pick<
   ParsedMessage,
@@ -30,4 +34,14 @@ export type ActionItem = {
   folderId?: ExecutedAction["folderId"];
   delayInMinutes?: number | null;
   staticAttachments?: ExecutedAction["staticAttachments"];
+};
+
+export type ActionExecutionEmailAccount = Pick<
+  EmailAccount,
+  "email" | "id" | "userId"
+>;
+
+export type ExecutedRuleForAction = ExecutedRule & {
+  actionItems?: Pick<ActionItem, "type">[];
+  hasAttachmentSources?: boolean;
 };

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -548,14 +548,17 @@ async function handleDraftSend({
       );
       const attachments = await resolveActionAttachments({
         email: sourceMessage,
-        emailAccountId: context.executedRule.emailAccount.id,
+        emailAccount: {
+          email: context.executedRule.emailAccount.email,
+          id: context.executedRule.emailAccount.id,
+          userId: context.executedRule.emailAccount.userId,
+        },
         executedRule: {
           id: context.executedRule.id,
           threadId: context.executedRule.threadId,
           emailAccountId: context.executedRule.emailAccount.id,
           ruleId: context.executedRule.ruleId,
         } as ExecutedRule,
-        userId: context.executedRule.emailAccount.userId,
         logger,
         staticAttachments: context.staticAttachments,
         includeAiSelectedAttachments: true,

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -7,7 +7,11 @@ import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { getEmailAccountWithAiAndTokens } from "@/utils/user/get";
 import { runActionFunction } from "@/utils/ai/actions";
-import type { ActionItem, EmailForAction } from "@/utils/ai/types";
+import type {
+  ActionExecutionEmailAccount,
+  ActionItem,
+  EmailForAction,
+} from "@/utils/ai/types";
 import type { EmailProvider } from "@/utils/email/types";
 
 const MODULE = "scheduled-actions-executor";
@@ -155,7 +159,7 @@ async function executeDelayedAction({
   client: EmailProvider;
   actionItem: ActionItem;
   emailMessage: EmailForAction;
-  emailAccount: { email: string; userId: string; id: string };
+  emailAccount: ActionExecutionEmailAccount;
   scheduledAction: ScheduledAction;
   log: Logger;
 }) {
@@ -176,7 +180,18 @@ async function executeDelayedAction({
 
   const executedRule = await prisma.executedRule.findUnique({
     where: { id: scheduledAction.executedRuleId },
-    include: { actionItems: true },
+    include: {
+      actionItems: true,
+      rule: {
+        select: {
+          _count: {
+            select: {
+              attachmentSources: true,
+            },
+          },
+        },
+      },
+    },
   });
 
   if (!executedRule) {
@@ -204,10 +219,14 @@ async function executeDelayedAction({
     client,
     email,
     action: executedAction,
-    userEmail: emailAccount.email,
-    userId: emailAccount.userId,
-    emailAccountId: emailAccount.id,
-    executedRule,
+    emailAccount,
+    executedRule: {
+      ...executedRule,
+      hasAttachmentSources:
+        executedRule.rule?._count.attachmentSources != null
+          ? executedRule.rule._count.attachmentSources > 0
+          : undefined,
+    },
     logger: log,
   });
 

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -45,7 +45,14 @@ const webhookEmailAccountSelect = {
   },
   rules: {
     where: { enabled: true },
-    include: { actions: true },
+    include: {
+      actions: true,
+      _count: {
+        select: {
+          attachmentSources: true,
+        },
+      },
+    },
   },
   user: {
     select: {


### PR DESCRIPTION
# User description
This refines action execution to pass account context directly and skip attachment work sooner.

- thread email account context through action execution and attachment resolution
- surface attachment source presence during rule loading and cover the updated path in tests

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Thread action execution and attachment helpers through shared <code>emailAccount</code> context so <code>runActionFunction</code>, webhook handlers, and scheduled executors channel consistent account info to provider APIs. Surface attachment source metadata while loading rules and in tests so <code>resolveActionAttachments</code> can skip extra work when drafts have no attachments.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2270?tool=ast&topic=Attachment+Awareness>Attachment Awareness</a>
        </td><td>Add attachment source metadata to rule queries and <code>resolveActionAttachments</code> so the helper can bypass cache/draft lookups when no static or AI-selected attachments exist.<details><summary>Modified files (6)</summary><ul><li>apps/web/utils/actions/ai-rule.ts</li>
<li>apps/web/utils/ai/action-attachments.ts</li>
<li>apps/web/utils/ai/choose-rule/bulk-process-emails.ts</li>
<li>apps/web/utils/ai/choose-rule/match-rules.ts</li>
<li>apps/web/utils/ai/choose-rule/run-rules.ts</li>
<li>apps/web/utils/ai/types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: remove circular d...</td><td>April 06, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Add provider to filter...</td><td>August 13, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2270?tool=ast&topic=Action+Execution>Action Execution</a>
        </td><td>Update runActionFunction, action helpers, scheduled executors, webhook loaders, and integration tests to accept and propagate <code>emailAccount</code>, ensuring API calls, notifications, and logging share consistent account context.<details><summary>Modified files (11)</summary><ul><li>apps/web/__tests__/integration/rule-execution.test.ts</li>
<li>apps/web/__tests__/integration/slack-notifications.test.ts</li>
<li>apps/web/__tests__/integration/webhook-action.test.ts</li>
<li>apps/web/__tests__/integration/webhook-flow.test.ts</li>
<li>apps/web/utils/ai/actions.test.ts</li>
<li>apps/web/utils/ai/actions.ts</li>
<li>apps/web/utils/ai/choose-rule/execute.test.ts</li>
<li>apps/web/utils/ai/choose-rule/execute.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li>
<li>apps/web/utils/scheduled-actions/executor.ts</li>
<li>apps/web/utils/webhook/validate-webhook-account.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Add Telegram send acti...</td><td>April 15, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Extract shared Gmail t...</td><td>March 25, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2270?tool=ast>(Baz)</a>.