### PR TITLE
reply-tracking: refine conversation status handling

### DIFF
--- a/apps/web/__tests__/ai-regression/determine-thread-status.test.ts
+++ b/apps/web/__tests__/ai-regression/determine-thread-status.test.ts
@@ -643,6 +643,39 @@ In your specific case I'd recommend adding custom rules to get the most out of i
   );
 
   test(
+    "identifies ACTIONED when user confirms they will handle the request",
+    async () => {
+      const emailAccount = getEmailAccount();
+      const messages = [
+        getEmail({
+          from: "customer@example.com",
+          to: emailAccount.email,
+          subject: "Please stop the renewal charge",
+          content: "Please stop trying to charge for renewal.",
+        }),
+        getEmail({
+          from: emailAccount.email,
+          to: "customer@example.com",
+          subject: "Re: Please stop the renewal charge",
+          content:
+            "Really sorry about that. I'll make sure the renewal is cancelled.",
+        }),
+      ];
+
+      const result = await aiDetermineThreadStatus({
+        emailAccount,
+        threadMessages: messages,
+        userSentLastEmail: true,
+      });
+
+      console.debug("Result:", result);
+      expect(result.status).toBe(SystemType.ACTIONED);
+      expect(result.rationale).toBeDefined();
+    },
+    TIMEOUT,
+  );
+
+  test(
     "auto-converts FYI to ACTIONED when user sends the last email",
     async () => {
       const emailAccount = getEmailAccount();

--- a/apps/web/__tests__/eval/determine-thread-status.test.ts
+++ b/apps/web/__tests__/eval/determine-thread-status.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, describe, expect, test, vi } from "vitest";
+import { getEmail } from "@/__tests__/helpers";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { SystemType } from "@/generated/prisma/enums";
+import { aiDetermineThreadStatus } from "@/utils/ai/reply/determine-thread-status";
+
+// pnpm test-ai eval/determine-thread-status
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 60_000;
+
+describe.runIf(shouldRunEval)("Eval: determine thread status", () => {
+  const evalReporter = createEvalReporter();
+
+  describeEvalMatrix("determine-thread-status", (model, emailAccount) => {
+    test(
+      "marks handled renewal cancellation thread as ACTIONED",
+      async () => {
+        const result = await aiDetermineThreadStatus({
+          emailAccount,
+          userSentLastEmail: true,
+          threadMessages: getHandledRenewalCancellationThread(
+            emailAccount.email,
+          ),
+        });
+
+        const actual = result.status;
+        const pass = actual === SystemType.ACTIONED;
+
+        evalReporter.record({
+          testName: "handled renewal cancellation thread",
+          model: model.label,
+          pass,
+          actual,
+          expected: SystemType.ACTIONED,
+        });
+
+        expect(actual).toBe(SystemType.ACTIONED);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "keeps explicit future follow-up promise as TO_REPLY",
+      async () => {
+        const result = await aiDetermineThreadStatus({
+          emailAccount,
+          userSentLastEmail: true,
+          threadMessages: [
+            getEmail({
+              from: emailAccount.email,
+              to: "customer@example.com",
+              subject: "Re: Updated deck",
+              content:
+                "I'll send the revised deck with the pricing changes tomorrow morning.",
+            }),
+          ],
+        });
+
+        const actual = result.status;
+        const pass = actual === SystemType.TO_REPLY;
+
+        evalReporter.record({
+          testName: "explicit future follow-up promise",
+          model: model.label,
+          pass,
+          actual,
+          expected: SystemType.TO_REPLY,
+        });
+
+        expect(actual).toBe(SystemType.TO_REPLY);
+      },
+      TIMEOUT,
+    );
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+function getHandledRenewalCancellationThread(userEmail: string) {
+  return [
+    getEmail({
+      from: "customer@example.com",
+      to: userEmail,
+      subject: "Please stop the renewal charge",
+      content: "Please stop trying to charge for renewal.",
+    }),
+    getEmail({
+      from: userEmail,
+      to: "customer@example.com",
+      subject: "Re: Please stop the renewal charge",
+      content:
+        "Really sorry about that. I'll make sure the renewal is cancelled.",
+    }),
+  ];
+}

--- a/apps/web/utils/ai/reply/determine-thread-status.ts
+++ b/apps/web/utils/ai/reply/determine-thread-status.ts
@@ -37,7 +37,7 @@ DETAILED CRITERIA:
 - The user needs to provide specific input
 - Someone follows up on a conversation requiring the user's response
 - There are ANY unanswered questions/requests in the thread that the user hasn't addressed yet
-- The user made a promise/commitment to get back to someone or deliver something and hasn't followed through yet
+- The user promised to send a follow-up reply, answer, or deliverable back to someone and hasn't sent that follow-up yet
 - IMPORTANT: In multi-person threads, track the USER'S specific commitments even if other people are having separate conversations
 - CRITICAL: If the user asked a clarifying question AND got an answer BUT still has a pending commitment/deliverable, it's TO_REPLY (not AWAITING_REPLY) - the answered question was just to help complete the commitment
 
@@ -73,20 +73,21 @@ CRITICAL RULES - READ CAREFULLY:
 2. **Unanswered questions persist**: If an earlier message contains an unanswered question or request, and a later message contains only informational content, the status is still determined by the unanswered question/request
 3. **Promises from different perspectives**: 
    - If SOMEONE ELSE promised to do something → AWAITING_REPLY (waiting for them)
-   - If YOU promised to do something → TO_REPLY (you need to follow through)
+   - If YOU promised a future reply, answer, or deliverable back to the sender → TO_REPLY
 4. **Multi-person threads**: In threads with multiple participants, focus ONLY on what the user (the perspective being analyzed) needs to do. Ignore conversations between other people that don't involve the user's commitments.
 5. **Request fulfillment**: If the user asked for something (information, help, etc.) and received it, AND the user has no pending commitments/deliverables, they are no longer awaiting a reply. The status should be ${userSentLastEmail ? "ACTIONED (if fully resolved)" : "FYI (if informational) or ACTIONED (if fully resolved)"}. However, if the user still has a pending commitment, see Rule 6.
 6. **Clarifying questions don't cancel commitments**: If the user has a pending commitment/deliverable and asks a clarifying question that gets answered, the status is TO_REPLY (not AWAITING_REPLY). The user needs to complete their original commitment now that they have the clarification.
-7. **User sends info/recommendations**: When the user SENDS informational content, advice, or recommendations without asking questions or expecting specific actions, it's ACTIONED (not AWAITING_REPLY). The user completed their action and isn't waiting for anything.
-8. **Latest message context matters**: If the latest message is purely informational but there are unresolved items earlier in the thread, prioritize the unresolved items${
+7. **Taking ownership can fulfill the request**: If the sender asked the user to do something and the user's latest reply takes ownership of it ("I'll handle it", "I'll take care of it", "I'll get that fixed"), treat the request as fulfilled and classify ACTIONED unless that reply clearly promises another email update, answer, or deliverable later.
+8. **User sends info/recommendations**: When the user SENDS informational content, advice, or recommendations without asking questions or expecting specific actions, it's ACTIONED (not AWAITING_REPLY). The user completed their action and isn't waiting for anything.
+9. **Latest message context matters**: If the latest message is purely informational but there are unresolved items earlier in the thread, prioritize the unresolved items${
     userSentLastEmail
       ? ""
       : `
-9. **FYI is only when nothing is pending**: Use FYI ONLY when there are absolutely no questions, requests, or pending actions in the entire thread`
+10. **FYI is only when nothing is pending**: Use FYI ONLY when there are absolutely no questions, requests, or pending actions in the entire thread`
   }${
     userSentLastEmail
       ? `
-9. **User sent last email**: Since the user sent the last email, FYI is NOT an option. Choose AWAITING_REPLY if waiting for a response, or ACTIONED if the thread is complete.`
+10. **User sent last email**: Since the user sent the last email, FYI is NOT an option. Choose AWAITING_REPLY if waiting for a response, or ACTIONED if the thread is complete.`
       : ""
   }
 


### PR DESCRIPTION
# User description
Narrow conversation status classification for handled requests and add focused coverage for the distinction between actioned threads and pending follow-ups.

- treat ownership replies as actioned unless a future email follow-up is implied
- add focused eval and regression coverage for handled-request threads

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Refine <code>aiDetermineThreadStatus</code> instructions to treat ownership replies as resolved unless a future deliverable or email follow-up is promised, clarifying how explicit future-commitment language should still trigger <code>TO_REPLY</code>. Expand the <code>determine-thread-status</code> regression and evaluation suites to ensure handled renewal cancellations are marked <code>ACTIONED</code> while explicit follow-up promises remain <code>TO_REPLY</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2271?tool=ast&topic=Handled+request+tests>Handled request tests</a>
        </td><td>Add regression and eval coverage around <code>determine-thread-status</code> to confirm handled renewal cancellations report <code>ACTIONED</code> and explicit future follow-up promises keep <code>TO_REPLY</code>.<details><summary>Modified files (2)</summary><ul><li>apps/web/__tests__/ai-regression/determine-thread-status.test.ts</li>
<li>apps/web/__tests__/eval/determine-thread-status.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>chore: reorganize AI t...</td><td>April 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2271?tool=ast&topic=Conversation+status+rules>Conversation status rules</a>
        </td><td>Refine <code>aiDetermineThreadStatus</code> instructions to treat ownership replies that don’t promise another deliverable as <code>ACTIONED</code> while keeping explicit future-commitment language mapped to <code>TO_REPLY</code>.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/ai/reply/determine-thread-status.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>AI: centralize prompt ...</td><td>March 31, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2271?tool=ast>(Baz)</a>.