### PR TITLE
Fix review issues in Outlook lifecycle recovery

### DIFF
--- a/apps/web/app/api/outlook/webhook/process-lifecycle.ts
+++ b/apps/web/app/api/outlook/webhook/process-lifecycle.ts
@@ -32,7 +32,6 @@ export async function processOutlookLifecycleNotification({
     lifecycleEvent: notification.lifecycleEvent,
     email: emailAccount?.email,
     emailAccountId: emailAccount?.id,
-    subscriptionId: notification.subscriptionId,
   });
 
   if (!emailAccount) {

--- a/apps/web/utils/outlook/backfill-recent-messages.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.ts
@@ -67,20 +67,29 @@ export async function backfillRecentOutlookMessages({
     subscriptionId,
   });
 
+  let processedCount = 0;
   for (const message of unseenMessages) {
-    await processHistoryForUser({
-      emailAddress,
-      subscriptionId,
-      resourceData: {
-        id: message.id,
-        conversationId: message.threadId,
-      },
-      logger: logger.with({ messageId: message.id }),
-    });
+    try {
+      await processHistoryForUser({
+        emailAddress,
+        subscriptionId,
+        resourceData: {
+          id: message.id,
+          conversationId: message.threadId,
+        },
+        logger: logger.with({ messageId: message.id }),
+      });
+      processedCount++;
+    } catch (error) {
+      logger.error("Failed to process message during backfill", {
+        messageId: message.id,
+        error,
+      });
+    }
   }
 
   return {
-    processedCount: unseenMessages.length,
+    processedCount,
     candidateCount: candidateMessages.length,
   };
 }

--- a/apps/web/utils/outlook/subscription-manager.ts
+++ b/apps/web/utils/outlook/subscription-manager.ts
@@ -102,17 +102,6 @@ export class OutlookSubscriptionManager {
     }
   }
 
-  async ensureSubscription(): Promise<Date | null> {
-    return (await this.createAndPersistSubscription())?.expirationDate ?? null;
-  }
-
-  async refreshSubscription(): Promise<Date | null> {
-    return (
-      (await this.createAndPersistSubscription({ forceRefresh: true }))
-        ?.expirationDate ?? null
-    );
-  }
-
   /**
    * Creates (or reuses) a subscription, persists it to the DB when changed,
    * and cleans up orphaned subscriptions on DB failure.


### PR DESCRIPTION
# User description
## Summary
- Remove duplicate `subscriptionId` from logger context in lifecycle notification handler (already bound by caller in route.ts)
- Remove unused `ensureSubscription` and `refreshSubscription` dead code methods from subscription manager
- Add per-message error handling in backfill recovery loop so a transient failure on one message doesn't abort processing of remaining messages, and track actual processed count

## Test plan
- [x] All 16 existing tests pass (backfill, subscription-manager, process-lifecycle)
- [ ] Verify lifecycle recovery works end-to-end with missed/removed notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Remove the redundant <code>subscriptionId</code> binding in the lifecycle notification handler and trim unused helper methods from the subscription manager to keep lifecycle wiring lean. Add per-message error handling and accurate success counts in the Outlook message backfill flow to prevent one failure from aborting recovery.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2276?tool=ast&topic=Backfill+recovery>Backfill recovery</a>
        </td><td>Add try/catch handling around each <code>processHistoryForUser</code> call in the backfill loop, log failures, and report only successfully processed messages to keep recovery moving past transient errors.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/outlook/backfill-recent-messages.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>outlook: add lifecycle...</td><td>April 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2276?tool=ast&topic=Lifecycle+cleanup>Lifecycle cleanup</a>
        </td><td>Remove redundant <code>subscriptionId</code> logging in <code>processOutlookLifecycleNotification</code> and drop the unused <code>ensureSubscription</code>/<code>refreshSubscription</code> helpers so the subscription manager stays focused on creating and persisting subscriptions.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/api/outlook/webhook/process-lifecycle.ts</li>
<li>apps/web/utils/outlook/subscription-manager.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>outlook: add lifecycle...</td><td>April 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2276?tool=ast>(Baz)</a>.