### PR TITLE
messaging: collapse stale draft notifications

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -963,12 +963,17 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
     expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
       where: {
         id: "action-1",
-        messagingMessageStatus: {
-          in: [
-            MessagingMessageStatus.SENT,
-            MessagingMessageStatus.DRAFT_EDITED,
-          ],
-        },
+        OR: [
+          { messagingMessageStatus: null },
+          {
+            messagingMessageStatus: {
+              in: [
+                MessagingMessageStatus.SENT,
+                MessagingMessageStatus.DRAFT_EDITED,
+              ],
+            },
+          },
+        ],
       },
       data: {
         messagingMessageStatus: MessagingMessageStatus.EXPIRED,
@@ -1093,15 +1098,129 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
     const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
       await import("./rule-notifications");
 
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 0 } as never);
+
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
       logger: createScopedLogger("test"),
     });
 
-    expect(prisma.executedAction.updateMany).not.toHaveBeenCalled();
+    expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "action-1",
+        OR: [
+          { messagingMessageStatus: null },
+          {
+            messagingMessageStatus: {
+              in: [
+                MessagingMessageStatus.SENT,
+                MessagingMessageStatus.DRAFT_EDITED,
+              ],
+            },
+          },
+        ],
+      },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+      },
+    });
     expect(mockSlackUpdate).not.toHaveBeenCalled();
     expect(mockTeamsEditMessage).not.toHaveBeenCalled();
     expect(mockTelegramEditMessage).not.toHaveBeenCalled();
+  });
+
+  it("expires locally when a Slack notification cannot be edited remotely", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "slack-ts-1",
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.SLACK,
+          isConnected: true,
+          teamId: "team-1",
+          providerUserId: null,
+          accessToken: null,
+          channelId: "C123",
+        },
+      }) as never,
+    );
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "action-1",
+        OR: [
+          { messagingMessageStatus: null },
+          {
+            messagingMessageStatus: {
+              in: [
+                MessagingMessageStatus.SENT,
+                MessagingMessageStatus.DRAFT_EDITED,
+              ],
+            },
+          },
+        ],
+      },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+      },
+    });
+    expect(mockSlackUpdate).not.toHaveBeenCalled();
+  });
+
+  it("expires legacy draft notifications with a null status", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "teams-message-1",
+        messagingMessageStatus: null,
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TEAMS,
+          isConnected: true,
+          teamId: "teams-tenant-1",
+          providerUserId: "29:teams-user",
+          accessToken: null,
+          channelId: null,
+        },
+      }) as never,
+    );
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(mockTeamsOpenDm).toHaveBeenCalledWith("29:teams-user");
+    expect(mockTeamsEditMessage).toHaveBeenCalledWith(
+      "teams-thread-1",
+      "teams-message-1",
+      "Already replied on the web.",
+    );
   });
 
   it("continues collapsing other draft notifications when one lookup fails", async () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -731,7 +731,9 @@ describe("sendMessagingRuleNotification", () => {
 
     const [{ text }] = mockSendAutomationMessage.mock.calls[0];
     expect(text).not.toContain("\n> First line");
-    expect(text).toContain("Slack-only");
+    expect(text).toContain(
+      "One-click draft editing and sending aren't available in Teams yet.",
+    );
   });
 
   it("sends Telegram draft notifications with a Send reply action", async () => {
@@ -877,7 +879,7 @@ describe("sendMessagingRuleNotification", () => {
 });
 
 describe("buildMessagingRuleNotificationText", () => {
-  it("adds a Slack-only caveat for Telegram draft fallbacks", async () => {
+  it("adds a Telegram-specific draft caveat for Telegram fallbacks", async () => {
     const { buildMessagingRuleNotificationText } = await import(
       "./rule-notifications"
     );
@@ -897,7 +899,7 @@ describe("buildMessagingRuleNotificationText", () => {
     expect(text).toContain("New email — reply drafted");
     expect(text).toContain('You got an email from Sender about "Test".');
     expect(text).toContain("details: https://example.com");
-    expect(text).toContain("Slack-only");
+    expect(text).toContain("Draft editing isn't available in Telegram yet.");
   });
 
   it("unescapes Slack entities for Teams fallback", async () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1103,6 +1103,57 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
     expect(mockTeamsEditMessage).not.toHaveBeenCalled();
     expect(mockTelegramEditMessage).not.toHaveBeenCalled();
   });
+
+  it("continues collapsing other draft notifications when one lookup fails", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+      { id: "action-2" },
+    ] as never);
+    prisma.executedAction.findUnique.mockImplementation(async ({ where }) => {
+      if (where?.id === "action-1") {
+        throw new Error("lookup failed");
+      }
+
+      if (where?.id === "action-2") {
+        return getNotificationContext({
+          id: "action-2",
+          type: ActionType.DRAFT_MESSAGING_CHANNEL,
+          content: "Draft body",
+          messagingMessageId: "teams-message-1",
+          messagingMessageStatus: MessagingMessageStatus.SENT,
+          messagingChannel: {
+            id: "channel-1",
+            provider: MessagingProvider.TEAMS,
+            isConnected: true,
+            teamId: "teams-tenant-1",
+            providerUserId: "29:teams-user",
+            accessToken: null,
+            channelId: null,
+          },
+        }) as never;
+      }
+
+      return null as never;
+    });
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await expect(
+      replaceMessagingDraftNotificationsWithHandledOnWebState({
+        executedRuleId: "executed-rule-1",
+        logger: createScopedLogger("test"),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockTeamsOpenDm).toHaveBeenCalledWith("29:teams-user");
+    expect(mockTeamsEditMessage).toHaveBeenCalledWith(
+      "teams-thread-1",
+      "teams-message-1",
+      "Already replied on the web.",
+    );
+  });
 });
 
 function getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/utils/prisma");
 const mockCreateEmailProvider = vi.fn();
 const mockSendAutomationMessage = vi.fn();
 const mockSlackPostMessage = vi.fn();
+const mockSlackUpdate = vi.fn();
 const mockSlackJoin = vi.fn();
 const mockTelegramOpenDm = vi.fn();
 const mockTelegramPostMessage = vi.fn();
@@ -33,6 +34,7 @@ vi.mock("@/utils/messaging/providers/slack/client", () => ({
   createSlackClient: () => ({
     chat: {
       postMessage: (...args: unknown[]) => mockSlackPostMessage(...args),
+      update: (...args: unknown[]) => mockSlackUpdate(...args),
     },
     conversations: {
       join: (...args: unknown[]) => mockSlackJoin(...args),
@@ -60,6 +62,7 @@ describe("handleRuleNotificationAction", () => {
       messageId: "teams-message-1",
     });
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
+    mockSlackUpdate.mockResolvedValue({});
     mockSlackJoin.mockResolvedValue({});
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
@@ -908,12 +911,99 @@ describe("buildMessagingRuleNotificationText", () => {
   });
 });
 
+describe("replaceSlackDraftNotificationsWithHandledOnWebState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSlackUpdate.mockResolvedValue({});
+  });
+
+  it("collapses an active Slack draft notification after a web reply", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "slack-ts-1",
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+      }) as never,
+    );
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceSlackDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceSlackDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "action-1",
+        messagingMessageStatus: {
+          in: [
+            MessagingMessageStatus.SENT,
+            MessagingMessageStatus.DRAFT_EDITED,
+          ],
+        },
+      },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+      },
+    });
+    expect(mockSlackUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        ts: "slack-ts-1",
+        text: expect.stringContaining("Already replied on the web."),
+      }),
+    );
+
+    const [args] = mockSlackUpdate.mock.calls[0];
+    expect(JSON.stringify(args.blocks)).toContain(
+      "Already replied on the web.",
+    );
+    expect(JSON.stringify(args.blocks)).not.toContain("Send reply");
+  });
+
+  it("keeps Slack-sent draft notifications unchanged", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "slack-ts-1",
+        messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+      }) as never,
+    );
+
+    const { replaceSlackDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceSlackDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.updateMany).not.toHaveBeenCalled();
+    expect(mockSlackUpdate).not.toHaveBeenCalled();
+  });
+});
+
 function getNotificationContext({
   id,
   type,
   content,
   messagingChannel,
   accountProvider = "google",
+  messagingMessageId = null,
+  messagingMessageStatus = null,
 }: {
   id: string;
   type: ActionType;
@@ -934,6 +1024,8 @@ function getNotificationContext({
     }>;
   };
   accountProvider?: "google" | "microsoft" | "imap";
+  messagingMessageId?: string | null;
+  messagingMessageStatus?: MessagingMessageStatus | null;
 }) {
   const defaultRoutes =
     messagingChannel?.routes ??
@@ -968,7 +1060,8 @@ function getNotificationContext({
     draftId: null,
     staticAttachments: null,
     messagingChannelId: "channel-1",
-    messagingMessageStatus: null,
+    messagingMessageId,
+    messagingMessageStatus,
     executedRule: {
       id: "executed-rule-1",
       ruleId: "rule-1",

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -18,8 +18,11 @@ const mockSendAutomationMessage = vi.fn();
 const mockSlackPostMessage = vi.fn();
 const mockSlackUpdate = vi.fn();
 const mockSlackJoin = vi.fn();
+const mockTeamsOpenDm = vi.fn();
+const mockTeamsEditMessage = vi.fn();
 const mockTelegramOpenDm = vi.fn();
 const mockTelegramPostMessage = vi.fn();
+const mockTelegramEditMessage = vi.fn();
 
 vi.mock("@/utils/email/provider", () => ({
   createEmailProvider: (...args: unknown[]) => mockCreateEmailProvider(...args),
@@ -46,9 +49,14 @@ vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
   getMessagingAdapterRegistry: () => ({
     adapters: {},
     typedAdapters: {
+      teams: {
+        openDM: (...args: unknown[]) => mockTeamsOpenDm(...args),
+        editMessage: (...args: unknown[]) => mockTeamsEditMessage(...args),
+      },
       telegram: {
         openDM: (...args: unknown[]) => mockTelegramOpenDm(...args),
         postMessage: (...args: unknown[]) => mockTelegramPostMessage(...args),
+        editMessage: (...args: unknown[]) => mockTelegramEditMessage(...args),
       },
     },
   }),
@@ -64,8 +72,11 @@ describe("handleRuleNotificationAction", () => {
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackUpdate.mockResolvedValue({});
     mockSlackJoin.mockResolvedValue({});
+    mockTeamsOpenDm.mockResolvedValue("teams-thread-1");
+    mockTeamsEditMessage.mockResolvedValue({ id: "teams-message-1" });
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
+    mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("keeps the draft preview visible after sending from Slack", async () => {
@@ -475,8 +486,11 @@ describe("sendMessagingRuleNotification", () => {
     });
     mockSlackPostMessage.mockResolvedValue({ ts: "slack-ts-1" });
     mockSlackJoin.mockResolvedValue({});
+    mockTeamsOpenDm.mockResolvedValue("teams-thread-1");
+    mockTeamsEditMessage.mockResolvedValue({ id: "teams-message-1" });
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
+    mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("adds an Open in Gmail button for Slack draft notifications on Google accounts", async () => {
@@ -911,10 +925,14 @@ describe("buildMessagingRuleNotificationText", () => {
   });
 });
 
-describe("replaceSlackDraftNotificationsWithHandledOnWebState", () => {
+describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSlackUpdate.mockResolvedValue({});
+    mockTeamsOpenDm.mockResolvedValue("teams-thread-1");
+    mockTeamsEditMessage.mockResolvedValue({ id: "teams-message-1" });
+    mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
+    mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("collapses an active Slack draft notification after a web reply", async () => {
@@ -932,10 +950,10 @@ describe("replaceSlackDraftNotificationsWithHandledOnWebState", () => {
     );
     prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
 
-    const { replaceSlackDraftNotificationsWithHandledOnWebState } =
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
       await import("./rule-notifications");
 
-    await replaceSlackDraftNotificationsWithHandledOnWebState({
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
       logger: createScopedLogger("test"),
     });
@@ -969,7 +987,94 @@ describe("replaceSlackDraftNotificationsWithHandledOnWebState", () => {
     expect(JSON.stringify(args.blocks)).not.toContain("Send reply");
   });
 
-  it("keeps Slack-sent draft notifications unchanged", async () => {
+  it("collapses a Teams draft notification after a web reply", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "teams-message-1",
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TEAMS,
+          isConnected: true,
+          teamId: "teams-tenant-1",
+          providerUserId: "29:teams-user",
+          accessToken: null,
+          channelId: null,
+        },
+      }) as never,
+    );
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(mockTeamsOpenDm).toHaveBeenCalledWith("29:teams-user");
+    expect(mockTeamsEditMessage).toHaveBeenCalledWith(
+      "teams-thread-1",
+      "teams-message-1",
+      "Already replied on the web.",
+    );
+  });
+
+  it("collapses a Telegram draft notification after a web reply", async () => {
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "action-1" },
+    ] as never);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingMessageId: "telegram-message-1",
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
+      await import("./rule-notifications");
+
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
+      executedRuleId: "executed-rule-1",
+      logger: createScopedLogger("test"),
+    });
+
+    expect(mockTelegramOpenDm).toHaveBeenCalledWith("telegram-chat-1");
+    expect(mockTelegramEditMessage).toHaveBeenCalledWith(
+      "telegram-thread-1",
+      "telegram-message-1",
+      "Already replied on the web.",
+    );
+  });
+
+  it("keeps chat-sent draft notifications unchanged", async () => {
     prisma.executedAction.findMany.mockResolvedValue([
       { id: "action-1" },
     ] as never);
@@ -983,16 +1088,18 @@ describe("replaceSlackDraftNotificationsWithHandledOnWebState", () => {
       }) as never,
     );
 
-    const { replaceSlackDraftNotificationsWithHandledOnWebState } =
+    const { replaceMessagingDraftNotificationsWithHandledOnWebState } =
       await import("./rule-notifications");
 
-    await replaceSlackDraftNotificationsWithHandledOnWebState({
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
       logger: createScopedLogger("test"),
     });
 
     expect(prisma.executedAction.updateMany).not.toHaveBeenCalled();
     expect(mockSlackUpdate).not.toHaveBeenCalled();
+    expect(mockTeamsEditMessage).not.toHaveBeenCalled();
+    expect(mockTelegramEditMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -127,7 +127,7 @@ export async function sendMessagingRuleNotification({
   return result.delivered;
 }
 
-export async function replaceSlackDraftNotificationsWithHandledOnWebState({
+export async function replaceMessagingDraftNotificationsWithHandledOnWebState({
   executedRuleId,
   logger,
 }: {
@@ -140,7 +140,6 @@ export async function replaceSlackDraftNotificationsWithHandledOnWebState({
       type: ActionType.DRAFT_MESSAGING_CHANNEL,
       messagingMessageId: { not: null },
       messagingChannel: {
-        provider: MessagingProvider.SLACK,
         isConnected: true,
       },
     },
@@ -151,7 +150,7 @@ export async function replaceSlackDraftNotificationsWithHandledOnWebState({
 
   await Promise.all(
     notificationActions.map(({ id }) =>
-      replaceSlackDraftNotificationWithHandledOnWebState({
+      replaceMessagingDraftNotificationWithHandledOnWebState({
         executedActionId: id,
         logger,
       }),
@@ -1624,7 +1623,7 @@ async function postSlackCard({
   }
 }
 
-async function replaceSlackDraftNotificationWithHandledOnWebState({
+async function replaceMessagingDraftNotificationWithHandledOnWebState({
   executedActionId,
   logger,
 }: {
@@ -1636,8 +1635,8 @@ async function replaceSlackDraftNotificationWithHandledOnWebState({
   if (
     !context?.messagingMessageId ||
     !context.messagingChannel?.isConnected ||
-    context.messagingChannel.provider !== MessagingProvider.SLACK ||
-    !context.messagingChannel.accessToken
+    (context.messagingChannel.provider === MessagingProvider.SLACK &&
+      !context.messagingChannel.accessToken)
   ) {
     return;
   }
@@ -1659,22 +1658,6 @@ async function replaceSlackDraftNotificationWithHandledOnWebState({
       executedActionId: context.id,
       messagingChannelId: context.messagingChannelId,
     });
-    return;
-  }
-
-  const destinationChannelId = await resolveSlackRouteDestination({
-    accessToken: context.messagingChannel.accessToken,
-    route,
-  });
-
-  if (!destinationChannelId) {
-    logger.warn(
-      "Skipping Slack draft notification cleanup with no destination",
-      {
-        executedActionId: context.id,
-        messagingChannelId: context.messagingChannelId,
-      },
-    );
     return;
   }
 
@@ -1700,19 +1683,119 @@ async function replaceSlackDraftNotificationWithHandledOnWebState({
   });
 
   try {
-    await createSlackClient(context.messagingChannel.accessToken).chat.update(
-      disableSlackLinkUnfurls({
-        channel: destinationChannelId,
-        ts: context.messagingMessageId,
-        text: cardToFallbackText(card),
-        blocks: cardToBlockKit(card),
-      }),
-    );
+    switch (context.messagingChannel.provider) {
+      case MessagingProvider.SLACK: {
+        const destinationChannelId = await resolveSlackRouteDestination({
+          accessToken: context.messagingChannel.accessToken!,
+          route,
+        });
+
+        if (!destinationChannelId) {
+          logger.warn(
+            "Skipping Slack draft notification cleanup with no destination",
+            {
+              executedActionId: context.id,
+              messagingChannelId: context.messagingChannelId,
+            },
+          );
+          return;
+        }
+
+        await createSlackClient(
+          context.messagingChannel.accessToken!,
+        ).chat.update(
+          disableSlackLinkUnfurls({
+            channel: destinationChannelId,
+            ts: context.messagingMessageId,
+            text: cardToFallbackText(card),
+            blocks: cardToBlockKit(card),
+          }),
+        );
+        break;
+      }
+      case MessagingProvider.TEAMS: {
+        const providerUserId =
+          route.targetType === MessagingRouteTargetType.DIRECT_MESSAGE
+            ? route.targetId
+            : context.messagingChannel.providerUserId;
+
+        if (!providerUserId) {
+          logger.warn(
+            "Skipping Teams draft notification cleanup with no destination user",
+            {
+              executedActionId: context.id,
+              messagingChannelId: context.messagingChannelId,
+            },
+          );
+          return;
+        }
+
+        const teamsAdapter = getMessagingAdapterRegistry().typedAdapters.teams;
+        if (!teamsAdapter) {
+          logger.warn(
+            "Skipping Teams draft notification cleanup without adapter",
+            {
+              executedActionId: context.id,
+              messagingChannelId: context.messagingChannelId,
+            },
+          );
+          return;
+        }
+
+        const threadId = await teamsAdapter.openDM(providerUserId);
+        await teamsAdapter.editMessage(
+          threadId,
+          context.messagingMessageId,
+          "Already replied on the web.",
+        );
+        break;
+      }
+      case MessagingProvider.TELEGRAM: {
+        const destination = route.targetId || context.messagingChannel.teamId;
+        if (!destination) {
+          logger.warn(
+            "Skipping Telegram draft notification cleanup with no destination",
+            {
+              executedActionId: context.id,
+              messagingChannelId: context.messagingChannelId,
+            },
+          );
+          return;
+        }
+
+        const telegramAdapter =
+          getMessagingAdapterRegistry().typedAdapters.telegram;
+        if (!telegramAdapter) {
+          logger.warn(
+            "Skipping Telegram draft notification cleanup without adapter",
+            {
+              executedActionId: context.id,
+              messagingChannelId: context.messagingChannelId,
+            },
+          );
+          return;
+        }
+
+        const threadId = await telegramAdapter.openDM(destination);
+        await telegramAdapter.editMessage(
+          threadId,
+          context.messagingMessageId,
+          "Already replied on the web.",
+        );
+        break;
+      }
+      default:
+        return;
+    }
   } catch (error) {
-    logger.warn("Failed to collapse Slack draft notification after web reply", {
-      executedActionId: context.id,
-      error,
-    });
+    logger.warn(
+      "Failed to collapse messaging draft notification after web reply",
+      {
+        executedActionId: context.id,
+        provider: context.messagingChannel.provider,
+        error,
+      },
+    );
   }
 }
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1641,19 +1641,57 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
 }) {
   const context = await getNotificationContext(executedActionId);
 
-  if (
-    !context?.messagingMessageId ||
-    !context.messagingChannel?.isConnected ||
-    (context.messagingChannel.provider === MessagingProvider.SLACK &&
-      !context.messagingChannel.accessToken)
-  ) {
+  if (!context?.messagingMessageId) {
+    return;
+  }
+
+  const updated = await prisma.executedAction.updateMany({
+    where: {
+      id: context.id,
+      OR: [
+        { messagingMessageStatus: null },
+        {
+          messagingMessageStatus: {
+            in: [
+              MessagingMessageStatus.SENT,
+              MessagingMessageStatus.DRAFT_EDITED,
+            ],
+          },
+        },
+      ],
+    },
+    data: {
+      messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+    },
+  });
+
+  if (updated.count === 0) {
+    return;
+  }
+
+  if (!context.messagingChannel?.isConnected) {
+    logger.warn(
+      "Skipping messaging draft notification cleanup for disconnected channel",
+      {
+        executedActionId: context.id,
+        messagingChannelId: context.messagingChannelId,
+        provider: context.messagingChannel?.provider,
+      },
+    );
     return;
   }
 
   if (
-    context.messagingMessageStatus !== MessagingMessageStatus.SENT &&
-    context.messagingMessageStatus !== MessagingMessageStatus.DRAFT_EDITED
+    context.messagingChannel.provider === MessagingProvider.SLACK &&
+    !context.messagingChannel.accessToken
   ) {
+    logger.warn(
+      "Skipping Slack draft notification cleanup with no access token",
+      {
+        executedActionId: context.id,
+        messagingChannelId: context.messagingChannelId,
+      },
+    );
     return;
   }
 
@@ -1668,22 +1706,6 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
       messagingChannelId: context.messagingChannelId,
       provider: context.messagingChannel.provider,
     });
-    return;
-  }
-
-  const updated = await prisma.executedAction.updateMany({
-    where: {
-      id: context.id,
-      messagingMessageStatus: {
-        in: [MessagingMessageStatus.SENT, MessagingMessageStatus.DRAFT_EDITED],
-      },
-    },
-    data: {
-      messagingMessageStatus: MessagingMessageStatus.EXPIRED,
-    },
-  });
-
-  if (updated.count === 0) {
     return;
   }
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -127,6 +127,38 @@ export async function sendMessagingRuleNotification({
   return result.delivered;
 }
 
+export async function replaceSlackDraftNotificationsWithHandledOnWebState({
+  executedRuleId,
+  logger,
+}: {
+  executedRuleId: string;
+  logger: Logger;
+}) {
+  const notificationActions = await prisma.executedAction.findMany({
+    where: {
+      executedRuleId,
+      type: ActionType.DRAFT_MESSAGING_CHANNEL,
+      messagingMessageId: { not: null },
+      messagingChannel: {
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  await Promise.all(
+    notificationActions.map(({ id }) =>
+      replaceSlackDraftNotificationWithHandledOnWebState({
+        executedActionId: id,
+        logger,
+      }),
+    ),
+  );
+}
+
 export async function getMessagingRuleNotificationResult({
   executedActionId,
   email,
@@ -1067,6 +1099,7 @@ async function getNotificationContext(executedActionId: string) {
       draftId: true,
       staticAttachments: true,
       messagingChannelId: true,
+      messagingMessageId: true,
       messagingMessageStatus: true,
       executedRule: {
         select: {
@@ -1588,6 +1621,98 @@ async function postSlackCard({
     }
 
     throw error;
+  }
+}
+
+async function replaceSlackDraftNotificationWithHandledOnWebState({
+  executedActionId,
+  logger,
+}: {
+  executedActionId: string;
+  logger: Logger;
+}) {
+  const context = await getNotificationContext(executedActionId);
+
+  if (
+    !context?.messagingMessageId ||
+    !context.messagingChannel?.isConnected ||
+    context.messagingChannel.provider !== MessagingProvider.SLACK ||
+    !context.messagingChannel.accessToken
+  ) {
+    return;
+  }
+
+  if (
+    context.messagingMessageStatus !== MessagingMessageStatus.SENT &&
+    context.messagingMessageStatus !== MessagingMessageStatus.DRAFT_EDITED
+  ) {
+    return;
+  }
+
+  const route = getMessagingRoute(
+    context.messagingChannel.routes,
+    MessagingRoutePurpose.RULE_NOTIFICATIONS,
+  );
+
+  if (!route) {
+    logger.warn("Skipping Slack draft notification cleanup with no route", {
+      executedActionId: context.id,
+      messagingChannelId: context.messagingChannelId,
+    });
+    return;
+  }
+
+  const destinationChannelId = await resolveSlackRouteDestination({
+    accessToken: context.messagingChannel.accessToken,
+    route,
+  });
+
+  if (!destinationChannelId) {
+    logger.warn(
+      "Skipping Slack draft notification cleanup with no destination",
+      {
+        executedActionId: context.id,
+        messagingChannelId: context.messagingChannelId,
+      },
+    );
+    return;
+  }
+
+  const updated = await prisma.executedAction.updateMany({
+    where: {
+      id: context.id,
+      messagingMessageStatus: {
+        in: [MessagingMessageStatus.SENT, MessagingMessageStatus.DRAFT_EDITED],
+      },
+    },
+    data: {
+      messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+    },
+  });
+
+  if (updated.count === 0) {
+    return;
+  }
+
+  const card = buildTerminalCard({
+    title: "Draft reply",
+    message: "Already replied on the web.",
+  });
+
+  try {
+    await createSlackClient(context.messagingChannel.accessToken).chat.update(
+      disableSlackLinkUnfurls({
+        channel: destinationChannelId,
+        ts: context.messagingMessageId,
+        text: cardToFallbackText(card),
+        blocks: cardToBlockKit(card),
+      }),
+    );
+  } catch (error) {
+    logger.warn("Failed to collapse Slack draft notification after web reply", {
+      executedActionId: context.id,
+      error,
+    });
   }
 }
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1654,9 +1654,10 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
   );
 
   if (!route) {
-    logger.warn("Skipping Slack draft notification cleanup with no route", {
+    logger.warn("Skipping messaging draft notification cleanup with no route", {
       executedActionId: context.id,
       messagingChannelId: context.messagingChannelId,
+      provider: context.messagingChannel.provider,
     });
     return;
   }
@@ -1995,7 +1996,9 @@ function getLinkedProviderLimitationText({
     provider === MessagingProvider.TEAMS ? "Teams" : "Telegram";
 
   if (isDraftReplyActionType(actionType)) {
-    return "One-click draft editing and sending are Slack-only right now. Use Inbox Zero or Slack if you want to edit or send this draft from chat.";
+    return provider === MessagingProvider.TEAMS
+      ? "One-click draft editing and sending aren't available in Teams yet. Use Inbox Zero to review or send this draft."
+      : "Draft editing isn't available in Telegram yet. You can send this draft from Telegram or use Inbox Zero to revise it first.";
   }
 
   return `Quick actions like archive and mark read are Slack-only right now, so this ${providerName} message is view-only.`;

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -148,7 +148,7 @@ export async function replaceMessagingDraftNotificationsWithHandledOnWebState({
     },
   });
 
-  await Promise.all(
+  const results = await Promise.allSettled(
     notificationActions.map(({ id }) =>
       replaceMessagingDraftNotificationWithHandledOnWebState({
         executedActionId: id,
@@ -156,6 +156,15 @@ export async function replaceMessagingDraftNotificationsWithHandledOnWebState({
       }),
     ),
   );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      logger.warn("Failed to collapse one messaging draft notification", {
+        executedRuleId,
+        error: result.reason,
+      });
+    }
+  }
 }
 
 export async function getMessagingRuleNotificationResult({

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -98,7 +98,7 @@ describe("trackSentDraftStatus", () => {
     });
   });
 
-  it("collapses Slack draft notifications when the user replies on the web", async () => {
+  it("collapses stale messaging draft notifications when the user replies on the web", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",
       draftId: "draft-1",

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/utils/ai/reply/reply-memory", () => ({
   syncReplyMemoriesFromDraftSendLogs: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/utils/messaging/rule-notifications", () => ({
-  replaceSlackDraftNotificationsWithHandledOnWebState: vi
+  replaceMessagingDraftNotificationsWithHandledOnWebState: vi
     .fn()
     .mockResolvedValue(undefined),
 }));
@@ -30,7 +30,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
-import { replaceSlackDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
+import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 
 const logger = createScopedLogger("draft-tracking-test");
 
@@ -86,7 +86,7 @@ describe("trackSentDraftStatus", () => {
       }),
     );
     expect(
-      replaceSlackDraftNotificationsWithHandledOnWebState,
+      replaceMessagingDraftNotificationsWithHandledOnWebState,
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,
@@ -119,7 +119,7 @@ describe("trackSentDraftStatus", () => {
     });
 
     expect(
-      replaceSlackDraftNotificationsWithHandledOnWebState,
+      replaceMessagingDraftNotificationsWithHandledOnWebState,
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,
@@ -159,7 +159,7 @@ describe("trackSentDraftStatus", () => {
     expect(saveDraftSendLogReplyMemory).not.toHaveBeenCalled();
     expect(syncReplyMemoriesFromDraftSendLogs).not.toHaveBeenCalled();
     expect(
-      replaceSlackDraftNotificationsWithHandledOnWebState,
+      replaceMessagingDraftNotificationsWithHandledOnWebState,
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -18,6 +18,11 @@ vi.mock("@/utils/ai/reply/reply-memory", () => ({
   saveDraftSendLogReplyMemory: vi.fn().mockResolvedValue(undefined),
   syncReplyMemoriesFromDraftSendLogs: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/utils/messaging/rule-notifications", () => ({
+  replaceSlackDraftNotificationsWithHandledOnWebState: vi
+    .fn()
+    .mockResolvedValue(undefined),
+}));
 
 import { calculateSimilarity } from "@/utils/similarity-score";
 import {
@@ -25,6 +30,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
+import { replaceSlackDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 
 const logger = createScopedLogger("draft-tracking-test");
 
@@ -46,6 +52,7 @@ describe("trackSentDraftStatus", () => {
       id: "action-1",
       draftId: "draft-1",
       content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.52);
     vi.mocked(isMeaningfulDraftEdit).mockReturnValue(true);
@@ -78,10 +85,55 @@ describe("trackSentDraftStatus", () => {
         sentText: "Please include pricing for seat counts.",
       }),
     );
+    expect(
+      replaceSlackDraftNotificationsWithHandledOnWebState,
+    ).toHaveBeenCalledWith({
+      executedRuleId: "executed-rule-1",
+      logger,
+    });
     expect(syncReplyMemoriesFromDraftSendLogs).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       provider,
       logger,
+    });
+  });
+
+  it("collapses Slack draft notifications when the user replies on the web", async () => {
+    vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
+      id: "action-1",
+      draftId: "draft-1",
+      content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
+    } as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.14);
+
+    await trackSentDraftStatus({
+      emailAccountId: "account-1",
+      message: createSentMessage(),
+      provider: {
+        getDraft: vi.fn().mockResolvedValue({
+          id: "draft-1",
+        }),
+      } as any,
+      logger,
+    });
+
+    expect(
+      replaceSlackDraftNotificationsWithHandledOnWebState,
+    ).toHaveBeenCalledWith({
+      executedRuleId: "executed-rule-1",
+      logger,
+    });
+    expect(prisma.draftSendLog.create).toHaveBeenCalledWith({
+      data: {
+        executedActionId: "action-1",
+        sentMessageId: "sent-1",
+        similarityScore: 0.14,
+      },
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: { wasDraftSent: false },
     });
   });
 
@@ -90,6 +142,7 @@ describe("trackSentDraftStatus", () => {
       id: "action-1",
       draftId: "draft-1",
       content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.98);
     vi.mocked(isMeaningfulDraftEdit).mockReturnValue(false);
@@ -105,6 +158,12 @@ describe("trackSentDraftStatus", () => {
 
     expect(saveDraftSendLogReplyMemory).not.toHaveBeenCalled();
     expect(syncReplyMemoriesFromDraftSendLogs).not.toHaveBeenCalled();
+    expect(
+      replaceSlackDraftNotificationsWithHandledOnWebState,
+    ).toHaveBeenCalledWith({
+      executedRuleId: "executed-rule-1",
+      logger,
+    });
   });
 });
 

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -11,7 +11,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
-import { replaceSlackDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
+import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { logReplyTrackerError } from "./error-logging";
 
@@ -109,7 +109,7 @@ export async function trackSentDraftStatus({
       "Created draft send log and marked action as not sent (draft still exists)",
       { executedActionId },
     );
-    await replaceSlackDraftNotificationsWithHandledOnWebState({
+    await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: executedAction.executedRuleId,
       logger,
     });
@@ -159,7 +159,7 @@ export async function trackSentDraftStatus({
     { executedActionId },
   );
 
-  await replaceSlackDraftNotificationsWithHandledOnWebState({
+  await replaceMessagingDraftNotificationsWithHandledOnWebState({
     executedRuleId: executedAction.executedRuleId,
     logger,
   });

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -11,6 +11,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
+import { replaceSlackDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { logReplyTrackerError } from "./error-logging";
 
@@ -55,6 +56,7 @@ export async function trackSentDraftStatus({
       id: true,
       content: true,
       draftId: true,
+      executedRuleId: true,
     },
   });
 
@@ -107,6 +109,10 @@ export async function trackSentDraftStatus({
       "Created draft send log and marked action as not sent (draft still exists)",
       { executedActionId },
     );
+    await replaceSlackDraftNotificationsWithHandledOnWebState({
+      executedRuleId: executedAction.executedRuleId,
+      logger,
+    });
     queueReplyMemoryLearning({
       emailAccountId,
       executedActionId,
@@ -152,6 +158,11 @@ export async function trackSentDraftStatus({
     "Successfully created draft send log and updated action status via transaction",
     { executedActionId },
   );
+
+  await replaceSlackDraftNotificationsWithHandledOnWebState({
+    executedRuleId: executedAction.executedRuleId,
+    logger,
+  });
 
   queueReplyMemoryLearning({
     emailAccountId,


### PR DESCRIPTION
# User description
Updates messaging draft cleanup when a reply is sent outside the channel.

Slack draft cards now collapse to a handled state instead of keeping the full interactive history. Reply tracking triggers the cleanup while preserving the existing handled state for replies sent from Slack. Adds targeted tests for notification cleanup and outbound draft tracking.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Collapse stale messaging draft notifications by updating <code>replaceMessagingDraftNotificationsWithHandledOnWebState</code> so provider cards expire and show a handled state once a reply is sent outside the channel. Trigger the same cleanup from <code>trackSentDraftStatus</code> when the reply tracker records a web send, keeping notification state in sync across Slack, Teams, and Telegram.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2278?tool=ast&topic=Draft+notification+cleanup>Draft notification cleanup</a>
        </td><td>Update <code>replaceMessagingDraftNotificationsWithHandledOnWebState</code> to expire draft actions, build a terminal card, and edit Slack/Teams/Telegram notifications after web replies while covering the new behavior with targeted tests for each provider and failure scenario.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/messaging/rule-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rules: streamline acti...</td><td>April 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2278?tool=ast&topic=Reply+tracking+hook>Reply tracking hook</a>
        </td><td>Invoke <code>replaceMessagingDraftNotificationsWithHandledOnWebState</code> from <code>trackSentDraftStatus</code> and its tests so reply tracking now collapses stale draft notifications whenever a web reply is recorded.<details><summary>Modified files (2)</summary><ul><li>apps/web/utils/reply-tracker/draft-tracking.test.ts</li>
<li>apps/web/utils/reply-tracker/draft-tracking.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: handle quoted hid...</td><td>April 04, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>fix webhook email proc...</td><td>July 04, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2278?tool=ast>(Baz)</a>.