### PR TITLE
messaging: restrict Slack private channel targets

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -403,7 +403,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
             provider: MessagingProvider.SLACK,
             isConnected: true,
             teamId: "team-1",
-            providerUserId: null,
+            providerUserId: "user-1",
             accessToken: "emulator-token",
             routes: [
               {
@@ -1008,7 +1008,7 @@ function getNotificationContext({
           provider: MessagingProvider.SLACK,
           isConnected: true,
           teamId: "team-1",
-          providerUserId: null,
+          providerUserId: "user-1",
           accessToken: "emulator-token",
           routes: [
             {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -740,9 +740,7 @@ export function getRuleActionTypeOptions({
       existingActionTypes,
     }),
   );
-  const extraActions = new Set(
-    getExtraAvailableActionsForRuleEditor(existingActionTypes),
-  );
+  const extraActions = new Set(getExtraAvailableActionsForRuleEditor());
 
   return [
     {

--- a/apps/web/app/api/cron/automation-jobs/route.ts
+++ b/apps/web/app/api/cron/automation-jobs/route.ts
@@ -68,6 +68,7 @@ async function enqueueDueAutomationJobs(logger: Logger) {
           provider: true,
           isConnected: true,
           accessToken: true,
+          providerUserId: true,
           routes: {
             select: {
               purpose: true,

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -3,10 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import type { RequestWithEmailAccount } from "@/utils/middleware";
-import {
-  listChannels,
-  listPrivateChannelsForUser,
-} from "@/utils/messaging/providers/slack/channels";
+import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 vi.mock("@/utils/prisma");
@@ -14,7 +11,6 @@ vi.mock("@/utils/middleware", () => ({
   withEmailAccount: (_name: string, handler: unknown) => handler,
 }));
 vi.mock("@/utils/messaging/providers/slack/channels", () => ({
-  listChannels: vi.fn(),
   listPrivateChannelsForUser: vi.fn(),
 }));
 vi.mock("@/utils/messaging/providers/slack/client", () => ({
@@ -65,25 +61,12 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
     });
   });
 
-  it("falls back to private Slack channels for legacy connections without a user id", async () => {
+  it("requires reconnecting Slack when the Slack user id is missing", async () => {
     prisma.messagingChannel.findFirst.mockResolvedValue({
       provider: "SLACK",
       accessToken: "xoxb-token",
       providerUserId: null,
     } as any);
-    vi.mocked(createSlackClient).mockReturnValue({} as never);
-    vi.mocked(listChannels).mockResolvedValue([
-      {
-        id: "C111",
-        name: "public-updates",
-        isPrivate: false,
-      },
-      {
-        id: "C222",
-        name: "legacy-private",
-        isPrivate: true,
-      },
-    ]);
 
     const response = await GET(createRequest("email-account-1"), {
       params: Promise.resolve({ channelId: "channel-1" }),
@@ -92,13 +75,8 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
 
     expect(listPrivateChannelsForUser).not.toHaveBeenCalled();
     expect(body).toEqual({
-      targets: [
-        {
-          id: "C222",
-          name: "legacy-private",
-          isPrivate: true,
-        },
-      ],
+      targets: [],
+      error: "Please reconnect Slack before configuring notifications.",
     });
   });
 });

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import type { RequestWithEmailAccount } from "@/utils/middleware";
-import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
+import {
+  listChannels,
+  listPrivateChannelsForUser,
+} from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 vi.mock("@/utils/prisma");
@@ -11,6 +14,7 @@ vi.mock("@/utils/middleware", () => ({
   withEmailAccount: (_name: string, handler: unknown) => handler,
 }));
 vi.mock("@/utils/messaging/providers/slack/channels", () => ({
+  listChannels: vi.fn(),
   listPrivateChannelsForUser: vi.fn(),
 }));
 vi.mock("@/utils/messaging/providers/slack/client", () => ({
@@ -55,6 +59,43 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
         {
           id: "C234",
           name: "finance-alerts",
+          isPrivate: true,
+        },
+      ],
+    });
+  });
+
+  it("falls back to private Slack channels for legacy connections without a user id", async () => {
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      provider: "SLACK",
+      accessToken: "xoxb-token",
+      providerUserId: null,
+    } as any);
+    vi.mocked(createSlackClient).mockReturnValue({} as never);
+    vi.mocked(listChannels).mockResolvedValue([
+      {
+        id: "C111",
+        name: "public-updates",
+        isPrivate: false,
+      },
+      {
+        id: "C222",
+        name: "legacy-private",
+        isPrivate: true,
+      },
+    ]);
+
+    const response = await GET(createRequest("email-account-1"), {
+      params: Promise.resolve({ channelId: "channel-1" }),
+    });
+    const body = await response.json();
+
+    expect(listPrivateChannelsForUser).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      targets: [
+        {
+          id: "C222",
+          name: "legacy-private",
           isPrivate: true,
         },
       ],

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+import type { RequestWithEmailAccount } from "@/utils/middleware";
+import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
+import { createSlackClient } from "@/utils/messaging/providers/slack/client";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount: (_name: string, handler: unknown) => handler,
+}));
+vi.mock("@/utils/messaging/providers/slack/channels", () => ({
+  listPrivateChannelsForUser: vi.fn(),
+}));
+vi.mock("@/utils/messaging/providers/slack/client", () => ({
+  createSlackClient: vi.fn(),
+}));
+
+import { GET } from "./route";
+
+const logger = createScopedLogger("test");
+
+describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists only private Slack channels shared with the current user", async () => {
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      provider: "SLACK",
+      accessToken: "xoxb-token",
+      providerUserId: "U123",
+    } as any);
+    vi.mocked(createSlackClient).mockReturnValue({} as never);
+    vi.mocked(listPrivateChannelsForUser).mockResolvedValue([
+      {
+        id: "C234",
+        name: "finance-alerts",
+        isPrivate: true,
+      },
+    ]);
+
+    const response = await GET(createRequest("email-account-1"), {
+      params: Promise.resolve({ channelId: "channel-1" }),
+    });
+    const body = await response.json();
+
+    expect(listPrivateChannelsForUser).toHaveBeenCalledWith(
+      expect.anything(),
+      "U123",
+    );
+    expect(body).toEqual({
+      targets: [
+        {
+          id: "C234",
+          name: "finance-alerts",
+          isPrivate: true,
+        },
+      ],
+    });
+  });
+});
+
+function createRequest(emailAccountId: string): RequestWithEmailAccount {
+  return Object.assign(
+    new NextRequest(
+      "http://localhost:3000/api/user/messaging-channels/channel-1/targets",
+    ),
+    {
+      logger,
+      auth: {
+        userId: "user-1",
+        emailAccountId,
+        email: "user@example.com",
+      },
+    },
+  );
+}

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
@@ -3,10 +3,8 @@ import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
 import type { Logger } from "@/utils/logger";
 import { MessagingProvider } from "@/generated/prisma/enums";
-import {
-  listChannels,
-  listPrivateChannelsForUser,
-} from "@/utils/messaging/providers/slack/channels";
+import { getMessagingChannelReconnectMessage } from "@/utils/messaging/channel-validity";
+import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 export type GetChannelTargetsResponse = Awaited<ReturnType<typeof getData>>;
@@ -54,10 +52,18 @@ async function getData({
   try {
     switch (channel.provider) {
       case MessagingProvider.SLACK: {
+        if (!channel.providerUserId) {
+          return {
+            targets: [],
+            error: getMessagingChannelReconnectMessage(MessagingProvider.SLACK),
+          };
+        }
+
         const client = createSlackClient(channel.accessToken);
-        const channels = channel.providerUserId
-          ? await listPrivateChannelsForUser(client, channel.providerUserId)
-          : (await listChannels(client)).filter((channel) => channel.isPrivate);
+        const channels = await listPrivateChannelsForUser(
+          client,
+          channel.providerUserId,
+        );
         return {
           targets: channels.map((c) => ({
             id: c.id,

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
@@ -3,7 +3,10 @@ import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
 import type { Logger } from "@/utils/logger";
 import { MessagingProvider } from "@/generated/prisma/enums";
-import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
+import {
+  listChannels,
+  listPrivateChannelsForUser,
+} from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 export type GetChannelTargetsResponse = Awaited<ReturnType<typeof getData>>;
@@ -44,7 +47,7 @@ async function getData({
     },
   });
 
-  if (!channel?.accessToken || !channel.providerUserId) {
+  if (!channel?.accessToken) {
     return { targets: [], error: "Channel not found or not connected" };
   }
 
@@ -52,10 +55,9 @@ async function getData({
     switch (channel.provider) {
       case MessagingProvider.SLACK: {
         const client = createSlackClient(channel.accessToken);
-        const channels = await listPrivateChannelsForUser(
-          client,
-          channel.providerUserId,
-        );
+        const channels = channel.providerUserId
+          ? await listPrivateChannelsForUser(client, channel.providerUserId)
+          : (await listChannels(client)).filter((channel) => channel.isPrivate);
         return {
           targets: channels.map((c) => ({
             id: c.id,

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts
@@ -3,7 +3,7 @@ import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
 import type { Logger } from "@/utils/logger";
 import { MessagingProvider } from "@/generated/prisma/enums";
-import { listChannels } from "@/utils/messaging/providers/slack/channels";
+import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 export type GetChannelTargetsResponse = Awaited<ReturnType<typeof getData>>;
@@ -40,10 +40,11 @@ async function getData({
     select: {
       provider: true,
       accessToken: true,
+      providerUserId: true,
     },
   });
 
-  if (!channel || !channel.accessToken) {
+  if (!channel?.accessToken || !channel.providerUserId) {
     return { targets: [], error: "Channel not found or not connected" };
   }
 
@@ -51,15 +52,16 @@ async function getData({
     switch (channel.provider) {
       case MessagingProvider.SLACK: {
         const client = createSlackClient(channel.accessToken);
-        const channels = await listChannels(client);
+        const channels = await listPrivateChannelsForUser(
+          client,
+          channel.providerUserId,
+        );
         return {
-          targets: channels
-            .filter((c) => c.isPrivate)
-            .map((c) => ({
-              id: c.id,
-              name: c.name,
-              isPrivate: c.isPrivate,
-            })),
+          targets: channels.map((c) => ({
+            id: c.id,
+            name: c.name,
+            isPrivate: c.isPrivate,
+          })),
         };
       }
       default:

--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -248,6 +248,52 @@ describe("GET /api/user/messaging-channels", () => {
       }),
     ]);
   });
+
+  it("marks invalid Slack and Teams connections as disconnected", async () => {
+    const channels = [
+      {
+        id: "channel-1",
+        provider: "SLACK",
+        teamName: "Workspace",
+        teamId: "team-1",
+        providerUserId: null,
+        accessToken: "xoxb-shared-token",
+        isConnected: true,
+        routes: [],
+        actions: [],
+      },
+      {
+        id: "channel-2",
+        provider: "TEAMS",
+        teamName: "Workspace",
+        teamId: "team-2",
+        providerUserId: null,
+        accessToken: null,
+        isConnected: true,
+        routes: [],
+        actions: [],
+      },
+    ] satisfies MessagingChannelRecord[];
+    prisma.messagingChannel.findMany.mockResolvedValue(channels);
+
+    const response = await GET(createRequest("email-account-1"));
+    const body = await response.json();
+
+    expect(createSlackClient).not.toHaveBeenCalled();
+    expect(listChannels).not.toHaveBeenCalled();
+    expect(body.channels).toEqual([
+      expect.objectContaining({
+        id: "channel-1",
+        isConnected: false,
+        canSendAsDm: false,
+      }),
+      expect.objectContaining({
+        id: "channel-2",
+        isConnected: false,
+        canSendAsDm: false,
+      }),
+    ]);
+  });
 });
 
 function createRequest(emailAccountId: string): RequestWithEmailAccount {

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -117,9 +117,11 @@ async function getSlackTargetNames(
   const slackChannels = channels.filter(isOperationalSlackChannel);
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {
-    const channelIds = channelIdsByToken.get(channel.accessToken) ?? [];
+    const accessToken = channel.accessToken;
+    if (!accessToken) continue;
+    const channelIds = channelIdsByToken.get(accessToken) ?? [];
     channelIds.push(channel.id);
-    channelIdsByToken.set(channel.accessToken, channelIds);
+    channelIdsByToken.set(accessToken, channelIds);
   }
 
   await Promise.all(

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -118,6 +118,7 @@ async function getSlackTargetNames(
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {
     const accessToken = channel.accessToken;
+    if (!accessToken) continue;
     const channelIds = channelIdsByToken.get(accessToken) ?? [];
     channelIds.push(channel.id);
     channelIdsByToken.set(accessToken, channelIds);

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -4,6 +4,7 @@ import { withEmailAccount } from "@/utils/middleware";
 import { env } from "@/env";
 import type { MessagingProvider } from "@/generated/prisma/enums";
 import { MessagingRoutePurpose } from "@/generated/prisma/enums";
+import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import { getMessagingRouteSummary } from "@/utils/messaging/routes";
 import { listChannels } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
@@ -53,27 +54,36 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
 
   return {
     channels: channels.map(
-      ({ routes, providerUserId, accessToken: _accessToken, ...channel }) => ({
-        ...channel,
-        canSendAsDm: channel.provider === "SLACK" && Boolean(providerUserId),
-        destinations: {
-          ruleNotifications: getMessagingRouteSummary(
-            routes,
-            MessagingRoutePurpose.RULE_NOTIFICATIONS,
-            slackTargetNamesByChannelId[channel.id],
-          ),
-          meetingBriefs: getMessagingRouteSummary(
-            routes,
-            MessagingRoutePurpose.MEETING_BRIEFS,
-            slackTargetNamesByChannelId[channel.id],
-          ),
-          documentFilings: getMessagingRouteSummary(
-            routes,
-            MessagingRoutePurpose.DOCUMENT_FILINGS,
-            slackTargetNamesByChannelId[channel.id],
-          ),
-        },
-      }),
+      ({ routes, providerUserId, accessToken: _accessToken, ...channel }) => {
+        const isConnected = isMessagingChannelOperational({
+          ...channel,
+          providerUserId,
+          accessToken: _accessToken,
+        });
+
+        return {
+          ...channel,
+          isConnected,
+          canSendAsDm: channel.provider === "SLACK" && isConnected,
+          destinations: {
+            ruleNotifications: getMessagingRouteSummary(
+              routes,
+              MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              slackTargetNamesByChannelId[channel.id],
+            ),
+            meetingBriefs: getMessagingRouteSummary(
+              routes,
+              MessagingRoutePurpose.MEETING_BRIEFS,
+              slackTargetNamesByChannelId[channel.id],
+            ),
+            documentFilings: getMessagingRouteSummary(
+              routes,
+              MessagingRoutePurpose.DOCUMENT_FILINGS,
+              slackTargetNamesByChannelId[channel.id],
+            ),
+          },
+        };
+      },
     ),
     availableProviders: getAvailableProviders(),
   };
@@ -94,17 +104,15 @@ async function getSlackTargetNames(
     provider: MessagingProvider;
     isConnected: boolean;
     accessToken: string | null;
+    providerUserId: string | null;
   }>,
 ) {
   const targetNamesByChannelId = Object.fromEntries(
     channels.map((channel) => [channel.id, {} as Record<string, string>]),
   );
 
-  const slackChannels = channels.filter(
-    (channel) =>
-      channel.provider === "SLACK" &&
-      channel.isConnected &&
-      Boolean(channel.accessToken),
+  const slackChannels = channels.filter((channel) =>
+    isMessagingChannelOperational(channel),
   );
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -111,8 +111,9 @@ async function getSlackTargetNames(
     channels.map((channel) => [channel.id, {} as Record<string, string>]),
   );
 
-  const slackChannels = channels.filter((channel) =>
-    isMessagingChannelOperational(channel),
+  const slackChannels = channels.filter(
+    (channel) =>
+      channel.provider === "SLACK" && isMessagingChannelOperational(channel),
   );
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -4,7 +4,10 @@ import { withEmailAccount } from "@/utils/middleware";
 import { env } from "@/env";
 import type { MessagingProvider } from "@/generated/prisma/enums";
 import { MessagingRoutePurpose } from "@/generated/prisma/enums";
-import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
+import {
+  isMessagingChannelOperational,
+  isOperationalSlackChannel,
+} from "@/utils/messaging/channel-validity";
 import { getMessagingRouteSummary } from "@/utils/messaging/routes";
 import { listChannels } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
@@ -111,13 +114,10 @@ async function getSlackTargetNames(
     channels.map((channel) => [channel.id, {} as Record<string, string>]),
   );
 
-  const slackChannels = channels.filter(
-    (channel) =>
-      channel.provider === "SLACK" && isMessagingChannelOperational(channel),
-  );
+  const slackChannels = channels.filter(isOperationalSlackChannel);
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {
-    const accessToken = channel.accessToken!;
+    const accessToken = channel.accessToken;
     const channelIds = channelIdsByToken.get(accessToken) ?? [];
     channelIds.push(channel.id);
     channelIdsByToken.set(accessToken, channelIds);

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -117,11 +117,9 @@ async function getSlackTargetNames(
   const slackChannels = channels.filter(isOperationalSlackChannel);
   const channelIdsByToken = new Map<string, string[]>();
   for (const channel of slackChannels) {
-    const accessToken = channel.accessToken;
-    if (!accessToken) continue;
-    const channelIds = channelIdsByToken.get(accessToken) ?? [];
+    const channelIds = channelIdsByToken.get(channel.accessToken) ?? [];
     channelIds.push(channel.id);
-    channelIdsByToken.set(accessToken, channelIds);
+    channelIdsByToken.set(channel.accessToken, channelIds);
   }
 
   await Promise.all(

--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -200,12 +200,14 @@ describe("updateMessagingFeatureRouteAction", () => {
     });
   });
 
-  it("still requires a provider user id for Teams features", async () => {
+  it("still requires a selected target route for Teams features", async () => {
     prisma.messagingChannel.findUnique.mockResolvedValue({
       id: "channel-1",
       emailAccountId: "email-account-1",
       provider: "TEAMS",
       isConnected: true,
+      accessToken: null,
+      providerUserId: "29:teams-user",
       routes: [],
     } as any);
 
@@ -222,6 +224,31 @@ describe("updateMessagingFeatureRouteAction", () => {
       "Please select a target channel before enabling features",
     );
     expect(prisma.messagingChannel.update).not.toHaveBeenCalled();
+  });
+
+  it("requires reconnecting Teams before enabling features", async () => {
+    prisma.messagingChannel.findUnique.mockResolvedValue({
+      id: "channel-1",
+      emailAccountId: "email-account-1",
+      provider: "TEAMS",
+      isConnected: true,
+      accessToken: null,
+      providerUserId: null,
+      routes: [],
+    } as any);
+
+    const result = await updateMessagingFeatureRouteAction(
+      "email-account-1" as any,
+      {
+        channelId: "channel-1",
+        purpose: MessagingRoutePurpose.MEETING_BRIEFS,
+        enabled: true,
+      },
+    );
+
+    expect(result?.serverError).toBe(
+      "Please reconnect Teams before configuring notifications.",
+    );
   });
 });
 
@@ -295,7 +322,7 @@ describe("updateSlackRouteAction", () => {
     });
 
     expect(result?.serverError).toBe(
-      "Please reconnect Slack before selecting a private channel.",
+      "Please reconnect Slack before configuring notifications.",
     );
     expect(listChannels).not.toHaveBeenCalled();
     expect(listPrivateChannelsForUser).not.toHaveBeenCalled();
@@ -368,6 +395,8 @@ describe("toggleRuleChannelAction", () => {
       emailAccountId: "email-account-1",
       provider: "SLACK",
       isConnected: true,
+      accessToken: "xoxb-token",
+      providerUserId: "U123",
       routes: [
         {
           purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
@@ -405,6 +434,8 @@ describe("toggleRuleChannelAction", () => {
       emailAccountId: "email-account-1",
       provider: "SLACK",
       isConnected: true,
+      accessToken: "xoxb-token",
+      providerUserId: "U123",
       routes: [
         {
           purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
@@ -431,5 +462,37 @@ describe("toggleRuleChannelAction", () => {
         messagingChannelId: "channel-1",
       },
     });
+  });
+
+  it("requires reconnecting Teams before enabling notifications", async () => {
+    prisma.rule.findUnique.mockResolvedValue({
+      emailAccountId: "email-account-1",
+      actions: [],
+    } as any);
+    prisma.messagingChannel.findUnique.mockResolvedValue({
+      emailAccountId: "email-account-1",
+      provider: "TEAMS",
+      isConnected: true,
+      accessToken: null,
+      providerUserId: null,
+      routes: [
+        {
+          purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+          targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+          targetId: "29:teams-user",
+        },
+      ],
+    } as any);
+
+    const result = await toggleRuleChannelAction("email-account-1" as any, {
+      ruleId: "rule-1",
+      messagingChannelId: "channel-1",
+      enabled: true,
+    });
+
+    expect(result?.serverError).toBe(
+      "Please reconnect Teams before configuring notifications.",
+    );
+    expect(prisma.action.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -7,8 +7,15 @@ import {
 import {
   createMessagingLinkCodeAction,
   toggleRuleChannelAction,
+  updateSlackRouteAction,
   updateMessagingFeatureRouteAction,
 } from "@/utils/actions/messaging-channels";
+import {
+  getChannelInfo,
+  listPrivateChannelsForUser,
+} from "@/utils/messaging/providers/slack/channels";
+import { createSlackClient } from "@/utils/messaging/providers/slack/client";
+import { sendChannelConfirmation } from "@/utils/messaging/providers/slack/send";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
@@ -16,6 +23,16 @@ vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
+}));
+vi.mock("@/utils/messaging/providers/slack/channels", () => ({
+  getChannelInfo: vi.fn(),
+  listPrivateChannelsForUser: vi.fn(),
+}));
+vi.mock("@/utils/messaging/providers/slack/client", () => ({
+  createSlackClient: vi.fn(),
+}));
+vi.mock("@/utils/messaging/providers/slack/send", () => ({
+  sendChannelConfirmation: vi.fn(),
 }));
 
 const { mockEnv, generateMessagingLinkCodeMock } = vi.hoisted(() => ({
@@ -203,6 +220,55 @@ describe("updateMessagingFeatureRouteAction", () => {
       "Please select a target channel before enabling features",
     );
     expect(prisma.messagingChannel.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateSlackRouteAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: {
+        userId: "user-1",
+        provider: "google",
+      },
+    } as any);
+  });
+
+  it("rejects private Slack channels the user is not a member of", async () => {
+    prisma.messagingChannel.findUnique.mockResolvedValue({
+      provider: "SLACK",
+      isConnected: true,
+      accessToken: "xoxb-token",
+      providerUserId: "U123",
+      botUserId: "B123",
+    } as any);
+    vi.mocked(createSlackClient).mockReturnValue({} as never);
+    vi.mocked(getChannelInfo).mockResolvedValue({
+      id: "C123",
+      name: "private-alerts",
+      isPrivate: true,
+    });
+    vi.mocked(listPrivateChannelsForUser).mockResolvedValue([
+      {
+        id: "C999",
+        name: "other-private-channel",
+        isPrivate: true,
+      },
+    ]);
+
+    const result = await updateSlackRouteAction("email-account-1" as any, {
+      channelId: "channel-1",
+      purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+      targetId: "C123",
+    });
+
+    expect(result?.serverError).toBe(
+      "Only private channels you are a member of are allowed. Please select one of your private channels.",
+    );
+    expect(prisma.messagingRoute.upsert).not.toHaveBeenCalled();
+    expect(sendChannelConfirmation).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/utils/actions/messaging-channels";
 import {
   getChannelInfo,
+  listChannels,
   listPrivateChannelsForUser,
 } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
@@ -26,6 +27,7 @@ vi.mock("@/utils/auth", () => ({
 }));
 vi.mock("@/utils/messaging/providers/slack/channels", () => ({
   getChannelInfo: vi.fn(),
+  listChannels: vi.fn(),
   listPrivateChannelsForUser: vi.fn(),
 }));
 vi.mock("@/utils/messaging/providers/slack/client", () => ({
@@ -269,6 +271,35 @@ describe("updateSlackRouteAction", () => {
     );
     expect(prisma.messagingRoute.upsert).not.toHaveBeenCalled();
     expect(sendChannelConfirmation).not.toHaveBeenCalled();
+  });
+
+  it("rejects private Slack channels when the Slack user id is missing", async () => {
+    prisma.messagingChannel.findUnique.mockResolvedValue({
+      provider: "SLACK",
+      isConnected: true,
+      accessToken: "xoxb-token",
+      providerUserId: null,
+      botUserId: "B123",
+    } as any);
+    vi.mocked(createSlackClient).mockReturnValue({} as never);
+    vi.mocked(getChannelInfo).mockResolvedValue({
+      id: "C123",
+      name: "private-alerts",
+      isPrivate: true,
+    });
+
+    const result = await updateSlackRouteAction("email-account-1" as any, {
+      channelId: "channel-1",
+      purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+      targetId: "C123",
+    });
+
+    expect(result?.serverError).toBe(
+      "Please reconnect Slack before selecting a private channel.",
+    );
+    expect(listChannels).not.toHaveBeenCalled();
+    expect(listPrivateChannelsForUser).not.toHaveBeenCalled();
+    expect(prisma.messagingRoute.upsert).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -23,6 +23,7 @@ import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code"
 import { env } from "@/env";
 import {
   getMessagingChannelReconnectMessage,
+  isOperationalSlackChannel,
   isMessagingChannelOperational,
 } from "@/utils/messaging/channel-validity";
 import {
@@ -78,14 +79,10 @@ export const updateSlackRouteAction = actionClient
         throw new SafeError("Messaging channel is not Slack");
       }
 
-      if (!isMessagingChannelOperational(channel)) {
+      if (!isOperationalSlackChannel(channel)) {
         throw new SafeError(
           getMessagingChannelReconnectMessage(channel.provider),
         );
-      }
-
-      if (!channel.accessToken) {
-        throw new SafeError("Messaging channel has no access token");
       }
 
       const target = await resolveSlackRouteTarget({

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -85,9 +85,17 @@ export const updateSlackRouteAction = actionClient
         );
       }
 
+      const accessToken = channel.accessToken;
+      const providerUserId = channel.providerUserId;
+      if (!accessToken || !providerUserId) {
+        throw new SafeError(
+          getMessagingChannelReconnectMessage(channel.provider),
+        );
+      }
+
       const target = await resolveSlackRouteTarget({
-        accessToken: channel.accessToken,
-        providerUserId: channel.providerUserId,
+        accessToken,
+        providerUserId,
         targetId,
         logger,
       });
@@ -113,7 +121,7 @@ export const updateSlackRouteAction = actionClient
       ) {
         try {
           await sendChannelConfirmation({
-            accessToken: channel.accessToken,
+            accessToken,
             channelId: target.targetId,
             botUserId: channel.botUserId,
           });

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -21,7 +21,10 @@ import {
 } from "@/generated/prisma/enums";
 import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code";
 import { env } from "@/env";
-import { getChannelInfo } from "@/utils/messaging/providers/slack/channels";
+import {
+  getChannelInfo,
+  listPrivateChannelsForUser,
+} from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 import { sendChannelConfirmation } from "@/utils/messaging/providers/slack/send";
 import { sendSlackOnboardingDirectMessageWithLogging } from "@/utils/messaging/providers/slack/send-onboarding-direct-message";
@@ -503,6 +506,25 @@ async function resolveSlackRouteTarget({
     throw new SafeError(
       "Only private channels are allowed. Please select a private channel.",
     );
+  }
+
+  if (providerUserId) {
+    const availablePrivateChannels = await listPrivateChannelsForUser(
+      client,
+      providerUserId,
+    );
+    const isAvailableToUser = availablePrivateChannels.some(
+      (channel) => channel.id === targetId,
+    );
+
+    if (!isAvailableToUser) {
+      logger.error("Slack channel target is unavailable to user", {
+        targetId,
+      });
+      throw new SafeError(
+        "Only private channels you are a member of are allowed. Please select one of your private channels.",
+      );
+    }
   }
 
   return {

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -22,6 +22,10 @@ import {
 import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code";
 import { env } from "@/env";
 import {
+  getMessagingChannelReconnectMessage,
+  isMessagingChannelOperational,
+} from "@/utils/messaging/channel-validity";
+import {
   getChannelInfo,
   listPrivateChannelsForUser,
 } from "@/utils/messaging/providers/slack/channels";
@@ -57,6 +61,7 @@ export const updateSlackRouteAction = actionClient
       const channel = await prisma.messagingChannel.findUnique({
         where,
         select: {
+          id: true,
           provider: true,
           isConnected: true,
           accessToken: true,
@@ -79,6 +84,12 @@ export const updateSlackRouteAction = actionClient
 
       if (!channel.accessToken) {
         throw new SafeError("Messaging channel has no access token");
+      }
+
+      if (!isMessagingChannelOperational(channel)) {
+        throw new SafeError(
+          getMessagingChannelReconnectMessage(channel.provider),
+        );
       }
 
       const target = await resolveSlackRouteTarget({
@@ -136,7 +147,10 @@ export const updateMessagingFeatureRouteAction = actionClient
         where,
         select: {
           id: true,
+          provider: true,
           isConnected: true,
+          accessToken: true,
+          providerUserId: true,
           routes: {
             select: {
               purpose: true,
@@ -153,6 +167,12 @@ export const updateMessagingFeatureRouteAction = actionClient
 
       if (!channel.isConnected) {
         throw new SafeError("Messaging channel is not connected");
+      }
+
+      if (!isMessagingChannelOperational(channel)) {
+        throw new SafeError(
+          getMessagingChannelReconnectMessage(channel.provider),
+        );
       }
 
       await syncMessagingFeatureRoute({
@@ -367,6 +387,8 @@ export const toggleRuleChannelAction = actionClient
           select: {
             isConnected: true,
             provider: true,
+            accessToken: true,
+            providerUserId: true,
             routes: {
               select: {
                 purpose: true,
@@ -398,6 +420,11 @@ export const toggleRuleChannelAction = actionClient
       if (enabled) {
         if (!channel.isConnected) {
           throw new SafeError("Messaging channel is not connected");
+        }
+        if (!isMessagingChannelOperational(channel)) {
+          throw new SafeError(
+            getMessagingChannelReconnectMessage(channel.provider),
+          );
         }
         if (
           !hasMessagingRoute(

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -508,23 +508,30 @@ async function resolveSlackRouteTarget({
     );
   }
 
-  if (providerUserId) {
-    const availablePrivateChannels = await listPrivateChannelsForUser(
-      client,
-      providerUserId,
+  if (!providerUserId) {
+    logger.error("Slack channel target cannot be validated without user id", {
+      targetId,
+    });
+    throw new SafeError(
+      "Please reconnect Slack before selecting a private channel.",
     );
-    const isAvailableToUser = availablePrivateChannels.some(
-      (channel) => channel.id === targetId,
-    );
+  }
 
-    if (!isAvailableToUser) {
-      logger.error("Slack channel target is unavailable to user", {
-        targetId,
-      });
-      throw new SafeError(
-        "Only private channels you are a member of are allowed. Please select one of your private channels.",
-      );
-    }
+  const availablePrivateChannels = await listPrivateChannelsForUser(
+    client,
+    providerUserId,
+  );
+  const isAvailableToUser = availablePrivateChannels.some(
+    (channel) => channel.id === targetId,
+  );
+
+  if (!isAvailableToUser) {
+    logger.error("Slack channel target is unavailable to user", {
+      targetId,
+    });
+    throw new SafeError(
+      "Only private channels you are a member of are allowed. Please select one of your private channels.",
+    );
   }
 
   return {

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -78,18 +78,14 @@ export const updateSlackRouteAction = actionClient
         throw new SafeError("Messaging channel is not Slack");
       }
 
-      if (!channel.isConnected) {
-        throw new SafeError("Messaging channel is not connected");
-      }
-
-      if (!channel.accessToken) {
-        throw new SafeError("Messaging channel has no access token");
-      }
-
       if (!isMessagingChannelOperational(channel)) {
         throw new SafeError(
           getMessagingChannelReconnectMessage(channel.provider),
         );
+      }
+
+      if (!channel.accessToken) {
+        throw new SafeError("Messaging channel has no access token");
       }
 
       const target = await resolveSlackRouteTarget({
@@ -163,10 +159,6 @@ export const updateMessagingFeatureRouteAction = actionClient
 
       if (!channel) {
         throw new SafeError("Messaging channel not found");
-      }
-
-      if (!channel.isConnected) {
-        throw new SafeError("Messaging channel is not connected");
       }
 
       if (!isMessagingChannelOperational(channel)) {
@@ -418,9 +410,6 @@ export const toggleRuleChannelAction = actionClient
       }
 
       if (enabled) {
-        if (!channel.isConnected) {
-          throw new SafeError("Messaging channel is not connected");
-        }
         if (!isMessagingChannelOperational(channel)) {
           throw new SafeError(
             getMessagingChannelReconnectMessage(channel.provider),

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -85,17 +85,9 @@ export const updateSlackRouteAction = actionClient
         );
       }
 
-      const accessToken = channel.accessToken;
-      const providerUserId = channel.providerUserId;
-      if (!accessToken || !providerUserId) {
-        throw new SafeError(
-          getMessagingChannelReconnectMessage(channel.provider),
-        );
-      }
-
       const target = await resolveSlackRouteTarget({
-        accessToken,
-        providerUserId,
+        accessToken: channel.accessToken,
+        providerUserId: channel.providerUserId,
         targetId,
         logger,
       });
@@ -121,7 +113,7 @@ export const updateSlackRouteAction = actionClient
       ) {
         try {
           await sendChannelConfirmation({
-            accessToken,
+            accessToken: channel.accessToken,
             channelId: target.targetId,
             botUserId: channel.botUserId,
           });

--- a/apps/web/utils/ai/rule/action-availability.test.ts
+++ b/apps/web/utils/ai/rule/action-availability.test.ts
@@ -76,14 +76,14 @@ describe("getExtraAvailableActionsForRuleEditor", () => {
     mockEnv.webhookActionsEnabled = true;
   });
 
-  it("hides webhook actions for existing rules when the feature is disabled", () => {
+  it("keeps webhook actions for existing rules when the feature is disabled", () => {
     mockEnv.webhookActionsEnabled = false;
 
     const actions = getExtraAvailableActionsForRuleEditor([
       ActionType.CALL_WEBHOOK,
     ]);
 
-    expect(actions).not.toContain(ActionType.CALL_WEBHOOK);
+    expect(actions).toContain(ActionType.CALL_WEBHOOK);
   });
 
   it("hides webhook actions for new rules when the feature is disabled", () => {

--- a/apps/web/utils/ai/rule/action-availability.test.ts
+++ b/apps/web/utils/ai/rule/action-availability.test.ts
@@ -76,14 +76,12 @@ describe("getExtraAvailableActionsForRuleEditor", () => {
     mockEnv.webhookActionsEnabled = true;
   });
 
-  it("keeps webhook actions for existing rules when the feature is disabled", () => {
+  it("hides webhook actions for existing rules when the feature is disabled", () => {
     mockEnv.webhookActionsEnabled = false;
 
-    const actions = getExtraAvailableActionsForRuleEditor([
-      ActionType.CALL_WEBHOOK,
-    ]);
+    const actions = getExtraAvailableActionsForRuleEditor();
 
-    expect(actions).toContain(ActionType.CALL_WEBHOOK);
+    expect(actions).not.toContain(ActionType.CALL_WEBHOOK);
   });
 
   it("hides webhook actions for new rules when the feature is disabled", () => {

--- a/apps/web/utils/ai/rule/action-availability.test.ts
+++ b/apps/web/utils/ai/rule/action-availability.test.ts
@@ -76,7 +76,7 @@ describe("getExtraAvailableActionsForRuleEditor", () => {
     mockEnv.webhookActionsEnabled = true;
   });
 
-  it("hides webhook actions for existing rules when the feature is disabled", () => {
+  it("hides webhook actions when the feature is disabled", () => {
     mockEnv.webhookActionsEnabled = false;
 
     const actions = getExtraAvailableActionsForRuleEditor();
@@ -84,11 +84,11 @@ describe("getExtraAvailableActionsForRuleEditor", () => {
     expect(actions).not.toContain(ActionType.CALL_WEBHOOK);
   });
 
-  it("hides webhook actions for new rules when the feature is disabled", () => {
-    mockEnv.webhookActionsEnabled = false;
+  it("includes webhook actions when the feature is enabled", () => {
+    mockEnv.webhookActionsEnabled = true;
 
     const actions = getExtraAvailableActionsForRuleEditor();
 
-    expect(actions).not.toContain(ActionType.CALL_WEBHOOK);
+    expect(actions).toContain(ActionType.CALL_WEBHOOK);
   });
 });

--- a/apps/web/utils/ai/rule/action-availability.ts
+++ b/apps/web/utils/ai/rule/action-availability.ts
@@ -36,13 +36,10 @@ export function getAvailableActionsForRuleEditor({
 export function getExtraAvailableActionsForRuleEditor(
   existingActionTypes: ActionType[] = [],
 ) {
-  const includesExistingActionType = (actionType: ActionType) =>
-    existingActionTypes.includes(actionType);
-
   return [
     ActionType.DIGEST,
     ...(env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false ||
-    includesExistingActionType(ActionType.CALL_WEBHOOK)
+    existingActionTypes.includes(ActionType.CALL_WEBHOOK)
       ? [ActionType.CALL_WEBHOOK]
       : []),
   ] as ActionType[];

--- a/apps/web/utils/ai/rule/action-availability.ts
+++ b/apps/web/utils/ai/rule/action-availability.ts
@@ -33,10 +33,16 @@ export function getAvailableActionsForRuleEditor({
   ] as ActionType[];
 }
 
-export function getExtraAvailableActionsForRuleEditor() {
+export function getExtraAvailableActionsForRuleEditor(
+  existingActionTypes: ActionType[] = [],
+) {
+  const includesExistingActionType = (actionType: ActionType) =>
+    existingActionTypes.includes(actionType);
+
   return [
     ActionType.DIGEST,
-    ...(env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false
+    ...(env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false ||
+    includesExistingActionType(ActionType.CALL_WEBHOOK)
       ? [ActionType.CALL_WEBHOOK]
       : []),
   ] as ActionType[];

--- a/apps/web/utils/ai/rule/action-availability.ts
+++ b/apps/web/utils/ai/rule/action-availability.ts
@@ -33,13 +33,10 @@ export function getAvailableActionsForRuleEditor({
   ] as ActionType[];
 }
 
-export function getExtraAvailableActionsForRuleEditor(
-  existingActionTypes: ActionType[] = [],
-) {
+export function getExtraAvailableActionsForRuleEditor() {
   return [
     ActionType.DIGEST,
-    ...(env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false ||
-    existingActionTypes.includes(ActionType.CALL_WEBHOOK)
+    ...(env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED !== false
       ? [ActionType.CALL_WEBHOOK]
       : []),
   ] as ActionType[];

--- a/apps/web/utils/automation-jobs/messaging-channel.ts
+++ b/apps/web/utils/automation-jobs/messaging-channel.ts
@@ -2,6 +2,7 @@ import {
   MessagingProvider,
   MessagingRoutePurpose,
 } from "@/generated/prisma/enums";
+import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import { hasMessagingRoute } from "@/utils/messaging/routes";
 
 export const SUPPORTED_AUTOMATION_MESSAGING_PROVIDERS: MessagingProvider[] = [
@@ -14,6 +15,7 @@ export type AutomationMessagingChannel = {
   provider: MessagingProvider;
   isConnected: boolean;
   accessToken: string | null;
+  providerUserId?: string | null;
   botUserId?: string | null;
   routes: Array<{
     purpose: MessagingRoutePurpose;
@@ -30,17 +32,12 @@ export function isSupportedAutomationMessagingProvider(
 export function isAutomationMessagingChannelReady(
   channel: AutomationMessagingChannel,
 ) {
-  if (!channel.isConnected) return false;
+  if (!isMessagingChannelOperational(channel)) return false;
   if (!isSupportedAutomationMessagingProvider(channel.provider)) return false;
   if (
     !hasMessagingRoute(channel.routes, MessagingRoutePurpose.RULE_NOTIFICATIONS)
   ) {
     return false;
   }
-
-  if (channel.provider === MessagingProvider.SLACK && !channel.accessToken) {
-    return false;
-  }
-
   return true;
 }

--- a/apps/web/utils/automation-jobs/messaging.test.ts
+++ b/apps/web/utils/automation-jobs/messaging.test.ts
@@ -39,6 +39,7 @@ describe("automation job messaging channel helpers", () => {
         createAutomationChannel({
           provider: MessagingProvider.SLACK,
           accessToken: "xoxb-token",
+          providerUserId: "U123",
         }),
       ),
     ).toBe(true);
@@ -48,21 +49,45 @@ describe("automation job messaging channel helpers", () => {
         createAutomationChannel({
           provider: MessagingProvider.SLACK,
           accessToken: null,
+          providerUserId: "U123",
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      isAutomationMessagingChannelReady(
+        createAutomationChannel({
+          provider: MessagingProvider.SLACK,
+          accessToken: "xoxb-token",
+          providerUserId: null,
         }),
       ),
     ).toBe(false);
   });
 
-  it("treats Teams and Telegram as ready when connected with a route", () => {
+  it("requires a provider user id for Teams readiness", () => {
     expect(
       isAutomationMessagingChannelReady(
         createAutomationChannel({
           provider: MessagingProvider.TEAMS,
           accessToken: null,
+          providerUserId: "29:teams-user",
         }),
       ),
     ).toBe(true);
 
+    expect(
+      isAutomationMessagingChannelReady(
+        createAutomationChannel({
+          provider: MessagingProvider.TEAMS,
+          accessToken: null,
+          providerUserId: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats Telegram as ready when connected with a route", () => {
     expect(
       isAutomationMessagingChannelReady(
         createAutomationChannel({
@@ -77,6 +102,7 @@ describe("automation job messaging channel helpers", () => {
 function createAutomationChannel({
   provider,
   accessToken,
+  providerUserId = null,
   routes = [
     {
       purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
@@ -86,6 +112,7 @@ function createAutomationChannel({
 }: {
   provider: MessagingProvider;
   accessToken: string | null;
+  providerUserId?: string | null;
   routes?: Array<{
     purpose: MessagingRoutePurpose;
     targetId: string;
@@ -95,6 +122,7 @@ function createAutomationChannel({
     provider,
     isConnected: true,
     accessToken,
+    providerUserId,
     routes,
   };
 }

--- a/apps/web/utils/drive/filing-messaging-notifications.test.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  MessagingProvider,
+  MessagingRoutePurpose,
+  MessagingRouteTargetType,
+} from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+import { sendFilingMessagingNotifications } from "./filing-messaging-notifications";
+import {
+  resolveSlackRouteDestination,
+  sendDocumentFiledToSlack,
+  sendDocumentAskToSlack,
+} from "@/utils/messaging/providers/slack/send";
+import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/messaging/providers/slack/send", () => ({
+  resolveSlackRouteDestination: vi.fn(),
+  sendDocumentFiledToSlack: vi.fn(),
+  sendDocumentAskToSlack: vi.fn(),
+}));
+vi.mock("@/utils/automation-jobs/messaging", () => ({
+  sendAutomationMessage: vi.fn(),
+}));
+
+const logger = createScopedLogger("filing-messaging-notifications-test");
+
+describe("sendFilingMessagingNotifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.documentFiling.findUnique.mockResolvedValue({
+      id: "filing-1",
+      filename: "invoice.pdf",
+      folderPath: "Invoices",
+      reasoning: null,
+      fileId: "file-1",
+      wasAsked: false,
+      driveConnection: { provider: "google" },
+    } as any);
+  });
+
+  it("skips Slack channels missing a provider user id", async () => {
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+        teamId: "team-1",
+        providerUserId: null,
+        routes: [
+          {
+            purpose: MessagingRoutePurpose.DOCUMENT_FILINGS,
+            targetType: MessagingRouteTargetType.CHANNEL,
+            targetId: "C1",
+          },
+        ],
+      },
+    ] as any);
+
+    await sendFilingMessagingNotifications({
+      emailAccountId: "email-account-1",
+      filingId: "filing-1",
+      logger,
+    });
+
+    expect(resolveSlackRouteDestination).not.toHaveBeenCalled();
+    expect(sendDocumentFiledToSlack).not.toHaveBeenCalled();
+    expect(sendDocumentAskToSlack).not.toHaveBeenCalled();
+  });
+
+  it("skips Teams channels missing a provider user id", async () => {
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-2",
+        provider: MessagingProvider.TEAMS,
+        isConnected: true,
+        accessToken: null,
+        teamId: "team-2",
+        providerUserId: null,
+        routes: [
+          {
+            purpose: MessagingRoutePurpose.DOCUMENT_FILINGS,
+            targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            targetId: "29:teams-user",
+          },
+        ],
+      },
+    ] as any);
+
+    await sendFilingMessagingNotifications({
+      emailAccountId: "email-account-1",
+      filingId: "filing-1",
+      logger,
+    });
+
+    expect(sendAutomationMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/drive/filing-messaging-notifications.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.ts
@@ -41,6 +41,7 @@ export async function sendFilingMessagingNotifications({
     select: {
       id: true,
       provider: true,
+      isConnected: true,
       accessToken: true,
       teamId: true,
       providerUserId: true,

--- a/apps/web/utils/drive/filing-messaging-notifications.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.ts
@@ -14,6 +14,7 @@ import {
   getMessagingRoute,
   getMessagingRouteWhere,
 } from "@/utils/messaging/routes";
+import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 
 export async function sendFilingMessagingNotifications({
   emailAccountId,
@@ -75,6 +76,13 @@ export async function sendFilingMessagingNotifications({
       MessagingRoutePurpose.DOCUMENT_FILINGS,
     );
     if (!route) continue;
+    if (!isMessagingChannelOperational(channel)) {
+      log.warn("Skipping filing notification for invalid messaging channel", {
+        messagingChannelId: channel.id,
+        provider: channel.provider,
+      });
+      continue;
+    }
 
     switch (channel.provider) {
       case MessagingProvider.SLACK: {

--- a/apps/web/utils/meeting-briefs/send-briefing.test.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  MessagingProvider,
+  MessagingRoutePurpose,
+  MessagingRouteTargetType,
+} from "@/generated/prisma/enums";
+import type { CalendarEvent } from "@/utils/calendar/event-types";
+import { createScopedLogger } from "@/utils/logger";
+import { sendBriefing } from "./send-briefing";
+import {
+  resolveSlackRouteDestination,
+  sendMeetingBriefingToSlack,
+} from "@/utils/messaging/providers/slack/send";
+import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/messaging/providers/slack/send", () => ({
+  resolveSlackRouteDestination: vi.fn(),
+  sendMeetingBriefingToSlack: vi.fn(),
+}));
+vi.mock("@/utils/automation-jobs/messaging", () => ({
+  sendAutomationMessage: vi.fn(),
+}));
+vi.mock("@/utils/date", () => ({
+  formatTimeInUserTimezone: vi.fn(() => "Monday, Jan 1 at 10:00 AM"),
+}));
+
+const logger = createScopedLogger("send-briefing-test");
+
+const event: CalendarEvent = {
+  id: "event-1",
+  title: "Sync",
+  startTime: new Date("2026-04-17T10:00:00Z"),
+  endTime: new Date("2026-04-17T11:00:00Z"),
+  videoConferenceLink: null,
+  eventUrl: null,
+} as any;
+
+const briefingContent = {
+  guests: [],
+  internalTeamMembers: [],
+} as any;
+
+describe("sendBriefing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      meetingBriefsSendEmail: false,
+    } as any);
+  });
+
+  it("skips Slack delivery when the channel is missing a provider user id", async () => {
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+        teamId: "team-1",
+        providerUserId: null,
+        routes: [
+          {
+            purpose: MessagingRoutePurpose.MEETING_BRIEFS,
+            targetType: MessagingRouteTargetType.CHANNEL,
+            targetId: "C1",
+          },
+        ],
+      },
+    ] as any);
+
+    await sendBriefing({
+      event,
+      briefingContent,
+      internalTeamMembers: [],
+      emailAccountId: "email-account-1",
+      userEmail: "user@example.com",
+      provider: "google",
+      userTimezone: null,
+      logger,
+    });
+
+    expect(resolveSlackRouteDestination).not.toHaveBeenCalled();
+    expect(sendMeetingBriefingToSlack).not.toHaveBeenCalled();
+  });
+
+  it("skips Teams delivery when the channel is missing a provider user id", async () => {
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-2",
+        provider: MessagingProvider.TEAMS,
+        isConnected: true,
+        accessToken: null,
+        teamId: "team-2",
+        providerUserId: null,
+        routes: [
+          {
+            purpose: MessagingRoutePurpose.MEETING_BRIEFS,
+            targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            targetId: "29:teams-user",
+          },
+        ],
+      },
+    ] as any);
+
+    await sendBriefing({
+      event,
+      briefingContent,
+      internalTeamMembers: [],
+      emailAccountId: "email-account-1",
+      userEmail: "user@example.com",
+      provider: "google",
+      userTimezone: null,
+      logger,
+    });
+
+    expect(sendAutomationMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/meeting-briefs/send-briefing.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.ts
@@ -75,6 +75,7 @@ export async function sendBriefing({
     select: {
       id: true,
       provider: true,
+      isConnected: true,
       accessToken: true,
       teamId: true,
       providerUserId: true,

--- a/apps/web/utils/meeting-briefs/send-briefing.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.ts
@@ -24,6 +24,7 @@ import {
   getMessagingRoute,
   getMessagingRouteWhere,
 } from "@/utils/messaging/routes";
+import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 import { formatTimeInUserTimezone } from "@/utils/date";
 import prisma from "@/utils/prisma";
@@ -109,6 +110,13 @@ export async function sendBriefing({
       MessagingRoutePurpose.MEETING_BRIEFS,
     );
     if (!route) continue;
+    if (!isMessagingChannelOperational(channel)) {
+      logger.warn("Skipping briefing delivery for invalid messaging channel", {
+        messagingChannelId: channel.id,
+        provider: channel.provider,
+      });
+      continue;
+    }
 
     switch (channel.provider) {
       case MessagingProvider.SLACK:

--- a/apps/web/utils/messaging/channel-validity.test.ts
+++ b/apps/web/utils/messaging/channel-validity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { MessagingProvider } from "@/generated/prisma/enums";
+import {
+  getMessagingChannelReconnectMessage,
+  hasRequiredMessagingConnectionFields,
+  isMessagingChannelOperational,
+} from "@/utils/messaging/channel-validity";
+
+describe("messaging channel validity", () => {
+  it("requires both a token and provider user id for Slack", () => {
+    expect(
+      hasRequiredMessagingConnectionFields({
+        provider: MessagingProvider.SLACK,
+        accessToken: "xoxb-token",
+        providerUserId: "U123",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasRequiredMessagingConnectionFields({
+        provider: MessagingProvider.SLACK,
+        accessToken: "xoxb-token",
+        providerUserId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("requires a provider user id for Teams", () => {
+    expect(
+      hasRequiredMessagingConnectionFields({
+        provider: MessagingProvider.TEAMS,
+        accessToken: null,
+        providerUserId: "29:teams-user",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasRequiredMessagingConnectionFields({
+        provider: MessagingProvider.TEAMS,
+        accessToken: null,
+        providerUserId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats Telegram as operational when connected", () => {
+    expect(
+      isMessagingChannelOperational({
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      isMessagingChannelOperational({
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: false,
+        accessToken: null,
+        providerUserId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns provider-specific reconnect messages", () => {
+    expect(getMessagingChannelReconnectMessage(MessagingProvider.SLACK)).toBe(
+      "Please reconnect Slack before configuring notifications.",
+    );
+    expect(getMessagingChannelReconnectMessage(MessagingProvider.TEAMS)).toBe(
+      "Please reconnect Teams before configuring notifications.",
+    );
+  });
+});

--- a/apps/web/utils/messaging/channel-validity.test.ts
+++ b/apps/web/utils/messaging/channel-validity.test.ts
@@ -4,6 +4,8 @@ import {
   getMessagingChannelReconnectMessage,
   hasRequiredMessagingConnectionFields,
   isMessagingChannelOperational,
+  isOperationalSlackChannel,
+  isOperationalTeamsChannel,
 } from "@/utils/messaging/channel-validity";
 
 describe("messaging channel validity", () => {
@@ -70,5 +72,34 @@ describe("messaging channel validity", () => {
     expect(getMessagingChannelReconnectMessage(MessagingProvider.TEAMS)).toBe(
       "Please reconnect Teams before configuring notifications.",
     );
+  });
+
+  it("exposes provider-specific operational guards", () => {
+    expect(
+      isOperationalSlackChannel({
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+        providerUserId: "U123",
+      }),
+    ).toBe(true);
+
+    expect(
+      isOperationalSlackChannel({
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: "U123",
+      }),
+    ).toBe(false);
+
+    expect(
+      isOperationalTeamsChannel({
+        provider: MessagingProvider.TEAMS,
+        isConnected: true,
+        accessToken: null,
+        providerUserId: "29:teams-user",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/utils/messaging/channel-validity.ts
+++ b/apps/web/utils/messaging/channel-validity.ts
@@ -9,16 +9,16 @@ type MessagingChannelConnectionLike = {
 
 type MessagingChannelWithRequiredFields =
   | (MessagingChannelConnectionLike & {
-      provider: MessagingProvider.SLACK;
+      provider: "SLACK";
       accessToken: string;
       providerUserId: string;
     })
   | (MessagingChannelConnectionLike & {
-      provider: MessagingProvider.TEAMS;
+      provider: "TEAMS";
       providerUserId: string;
     })
   | (MessagingChannelConnectionLike & {
-      provider: MessagingProvider.TELEGRAM;
+      provider: "TELEGRAM";
     });
 
 type OperationalMessagingChannel = MessagingChannelWithRequiredFields & {
@@ -51,10 +51,7 @@ export function isMessagingChannelOperational(
 
 export function isOperationalSlackChannel(
   channel: MessagingChannelConnectionLike,
-): channel is Extract<
-  OperationalMessagingChannel,
-  { provider: MessagingProvider.SLACK }
-> {
+): channel is Extract<OperationalMessagingChannel, { provider: "SLACK" }> {
   return (
     channel.provider === MessagingProvider.SLACK &&
     isMessagingChannelOperational(channel)
@@ -63,10 +60,7 @@ export function isOperationalSlackChannel(
 
 export function isOperationalTeamsChannel(
   channel: MessagingChannelConnectionLike,
-): channel is Extract<
-  OperationalMessagingChannel,
-  { provider: MessagingProvider.TEAMS }
-> {
+): channel is Extract<OperationalMessagingChannel, { provider: "TEAMS" }> {
   return (
     channel.provider === MessagingProvider.TEAMS &&
     isMessagingChannelOperational(channel)

--- a/apps/web/utils/messaging/channel-validity.ts
+++ b/apps/web/utils/messaging/channel-validity.ts
@@ -1,0 +1,46 @@
+import { MessagingProvider } from "@/generated/prisma/enums";
+
+type MessagingChannelConnectionLike = {
+  provider: MessagingProvider;
+  isConnected?: boolean;
+  accessToken?: string | null;
+  providerUserId?: string | null;
+};
+
+export function hasRequiredMessagingConnectionFields(
+  channel: MessagingChannelConnectionLike,
+) {
+  switch (channel.provider) {
+    case MessagingProvider.SLACK:
+      return Boolean(channel.accessToken && channel.providerUserId);
+    case MessagingProvider.TEAMS:
+      return Boolean(channel.providerUserId);
+    case MessagingProvider.TELEGRAM:
+      return true;
+    default:
+      return true;
+  }
+}
+
+export function isMessagingChannelOperational(
+  channel: MessagingChannelConnectionLike,
+) {
+  return (
+    Boolean(channel.isConnected) &&
+    hasRequiredMessagingConnectionFields(channel)
+  );
+}
+
+export function getMessagingChannelReconnectMessage(
+  provider: MessagingProvider,
+) {
+  if (provider === MessagingProvider.SLACK) {
+    return "Please reconnect Slack before configuring notifications.";
+  }
+
+  if (provider === MessagingProvider.TEAMS) {
+    return "Please reconnect Teams before configuring notifications.";
+  }
+
+  return "Please reconnect the messaging provider before configuring notifications.";
+}

--- a/apps/web/utils/messaging/channel-validity.ts
+++ b/apps/web/utils/messaging/channel-validity.ts
@@ -7,9 +7,27 @@ type MessagingChannelConnectionLike = {
   providerUserId?: string | null;
 };
 
+type MessagingChannelWithRequiredFields =
+  | (MessagingChannelConnectionLike & {
+      provider: MessagingProvider.SLACK;
+      accessToken: string;
+      providerUserId: string;
+    })
+  | (MessagingChannelConnectionLike & {
+      provider: MessagingProvider.TEAMS;
+      providerUserId: string;
+    })
+  | (MessagingChannelConnectionLike & {
+      provider: MessagingProvider.TELEGRAM;
+    });
+
+type OperationalMessagingChannel = MessagingChannelWithRequiredFields & {
+  isConnected: true;
+};
+
 export function hasRequiredMessagingConnectionFields(
   channel: MessagingChannelConnectionLike,
-) {
+): channel is MessagingChannelWithRequiredFields {
   switch (channel.provider) {
     case MessagingProvider.SLACK:
       return Boolean(channel.accessToken && channel.providerUserId);
@@ -24,10 +42,34 @@ export function hasRequiredMessagingConnectionFields(
 
 export function isMessagingChannelOperational(
   channel: MessagingChannelConnectionLike,
-) {
+): channel is OperationalMessagingChannel {
   return (
     Boolean(channel.isConnected) &&
     hasRequiredMessagingConnectionFields(channel)
+  );
+}
+
+export function isOperationalSlackChannel(
+  channel: MessagingChannelConnectionLike,
+): channel is Extract<
+  OperationalMessagingChannel,
+  { provider: MessagingProvider.SLACK }
+> {
+  return (
+    channel.provider === MessagingProvider.SLACK &&
+    isMessagingChannelOperational(channel)
+  );
+}
+
+export function isOperationalTeamsChannel(
+  channel: MessagingChannelConnectionLike,
+): channel is Extract<
+  OperationalMessagingChannel,
+  { provider: MessagingProvider.TEAMS }
+> {
+  return (
+    channel.provider === MessagingProvider.TEAMS &&
+    isMessagingChannelOperational(channel)
   );
 }
 

--- a/apps/web/utils/messaging/providers/slack/channels.ts
+++ b/apps/web/utils/messaging/providers/slack/channels.ts
@@ -54,3 +54,39 @@ export async function listChannels(client: WebClient): Promise<SlackChannel[]> {
 
   return channels.sort((a, b) => a.name.localeCompare(b.name));
 }
+
+export async function listPrivateChannelsForUser(
+  client: WebClient,
+  userId: string,
+): Promise<SlackChannel[]> {
+  const channels: SlackChannel[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+
+  do {
+    const response = await client.users.conversations({
+      types: "private_channel",
+      exclude_archived: true,
+      limit: 200,
+      cursor,
+      user: userId,
+    });
+
+    if (response.channels) {
+      for (const channel of response.channels) {
+        if (channel.id && channel.name) {
+          channels.push({
+            id: channel.id,
+            name: channel.name,
+            isPrivate: channel.is_private ?? false,
+          });
+        }
+      }
+    }
+
+    cursor = response.response_metadata?.next_cursor;
+    pages++;
+  } while (cursor && pages < MAX_PAGES);
+
+  return channels.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1370,7 +1370,7 @@ function getNotificationContext({
           provider: MessagingProvider.SLACK,
           isConnected: true,
           teamId: "team-1",
-          providerUserId: null,
+          providerUserId: "user-1",
           accessToken: "token",
           channelId: "C123",
           routes: [

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -235,8 +235,7 @@ async function sendSlackRuleNotificationWithContext({
   if (
     !context.messagingChannel ||
     !isMessagingChannelOperational(context.messagingChannel) ||
-    context.messagingChannel.provider !== MessagingProvider.SLACK ||
-    !context.messagingChannel.accessToken
+    context.messagingChannel.provider !== MessagingProvider.SLACK
   ) {
     logger.warn("Skipping messaging notification with inactive Slack channel", {
       executedActionId: context.id,

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -54,6 +54,7 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
+import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
@@ -232,7 +233,8 @@ async function sendSlackRuleNotificationWithContext({
   logger: Logger;
 }): Promise<MessagingRuleNotificationResult> {
   if (
-    !context.messagingChannel?.isConnected ||
+    !context.messagingChannel ||
+    !isMessagingChannelOperational(context.messagingChannel) ||
     context.messagingChannel.provider !== MessagingProvider.SLACK ||
     !context.messagingChannel.accessToken
   ) {
@@ -328,7 +330,8 @@ async function sendLinkedRuleNotification({
   logger: Logger;
 }): Promise<MessagingRuleNotificationResult> {
   if (
-    !context.messagingChannel?.isConnected ||
+    !context.messagingChannel ||
+    !isMessagingChannelOperational(context.messagingChannel) ||
     (context.messagingChannel.provider !== MessagingProvider.TEAMS &&
       context.messagingChannel.provider !== MessagingProvider.TELEGRAM)
   ) {
@@ -989,7 +992,7 @@ async function getAuthorizedSlackNotificationContext({
   if (
     !context?.messagingChannel ||
     context.messagingChannel.provider !== MessagingProvider.SLACK ||
-    !context.messagingChannel.isConnected
+    !isMessagingChannelOperational(context.messagingChannel)
   ) {
     if (event) {
       await postNotificationFeedback({
@@ -1669,27 +1672,16 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
     return;
   }
 
-  if (!context.messagingChannel?.isConnected) {
+  if (
+    !context.messagingChannel ||
+    !isMessagingChannelOperational(context.messagingChannel)
+  ) {
     logger.warn(
       "Skipping messaging draft notification cleanup for disconnected channel",
       {
         executedActionId: context.id,
         messagingChannelId: context.messagingChannelId,
         provider: context.messagingChannel?.provider,
-      },
-    );
-    return;
-  }
-
-  if (
-    context.messagingChannel.provider === MessagingProvider.SLACK &&
-    !context.messagingChannel.accessToken
-  ) {
-    logger.warn(
-      "Skipping Slack draft notification cleanup with no access token",
-      {
-        executedActionId: context.id,
-        messagingChannelId: context.messagingChannelId,
       },
     );
     return;

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -54,7 +54,10 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
-import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
+import {
+  isMessagingChannelOperational,
+  isOperationalSlackChannel,
+} from "@/utils/messaging/channel-validity";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
@@ -234,8 +237,7 @@ async function sendSlackRuleNotificationWithContext({
 }): Promise<MessagingRuleNotificationResult> {
   if (
     !context.messagingChannel ||
-    !isMessagingChannelOperational(context.messagingChannel) ||
-    context.messagingChannel.provider !== MessagingProvider.SLACK
+    !isOperationalSlackChannel(context.messagingChannel)
   ) {
     logger.warn("Skipping messaging notification with inactive Slack channel", {
       executedActionId: context.id,
@@ -990,8 +992,7 @@ async function getAuthorizedSlackNotificationContext({
 
   if (
     !context?.messagingChannel ||
-    context.messagingChannel.provider !== MessagingProvider.SLACK ||
-    !isMessagingChannelOperational(context.messagingChannel)
+    !isOperationalSlackChannel(context.messagingChannel)
   ) {
     if (event) {
       await postNotificationFeedback({
@@ -1709,7 +1710,7 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
     switch (context.messagingChannel.provider) {
       case MessagingProvider.SLACK: {
         const destinationChannelId = await resolveSlackRouteDestination({
-          accessToken: context.messagingChannel.accessToken!,
+          accessToken: context.messagingChannel.accessToken,
           route,
         });
 
@@ -1725,7 +1726,7 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
         }
 
         await createSlackClient(
-          context.messagingChannel.accessToken!,
+          context.messagingChannel.accessToken,
         ).chat.update(
           disableSlackLinkUnfurls({
             channel: destinationChannelId,


### PR DESCRIPTION
# User description
Restricts Slack notification targets to private channels that belong to the current user and keeps server-side validation aligned with that behavior.

- use a user-scoped Slack channel listing for target selection
- reject private channel targets that are not available to the current user
- add regression tests for the target route and action validation

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Limit Slack notification targets to private channels the current Slack user actually belongs to by routing the REST target picker through <code>listPrivateChannelsForUser</code> and validating requests in <code>updateSlackRouteAction</code>. Enforce the new messaging channel validity helpers while decorating automation jobs, channel summaries, and notification senders so Slack and Teams flows only run when <code>isMessagingChannelOperational</code> is true.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2280?tool=ast&topic=Channel+validity>Channel validity</a>
        </td><td>Enforce <code>isMessagingChannelOperational</code> across channel listings, automation cron jobs, channel summaries, and notification delivery flows so Slack and Teams work only when tokens, user ids, and states are valid, backed by reconnect messaging utilities and expanded regression tests.<details><summary>Modified files (15)</summary><ul><li>apps/web/__tests__/integration/slack-notifications.test.ts</li>
<li>apps/web/app/api/cron/automation-jobs/route.ts</li>
<li>apps/web/app/api/user/messaging-channels/route.test.ts</li>
<li>apps/web/app/api/user/messaging-channels/route.ts</li>
<li>apps/web/utils/actions/messaging-channels.test.ts</li>
<li>apps/web/utils/automation-jobs/messaging-channel.ts</li>
<li>apps/web/utils/automation-jobs/messaging.test.ts</li>
<li>apps/web/utils/drive/filing-messaging-notifications.test.ts</li>
<li>apps/web/utils/drive/filing-messaging-notifications.ts</li>
<li>apps/web/utils/meeting-briefs/send-briefing.test.ts</li>
<li>apps/web/utils/meeting-briefs/send-briefing.ts</li>
<li>apps/web/utils/messaging/channel-validity.test.ts</li>
<li>apps/web/utils/messaging/channel-validity.ts</li>
<li>apps/web/utils/messaging/rule-notifications.test.ts</li>
<li>apps/web/utils/messaging/rule-notifications.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>rules: streamline acti...</td><td>April 16, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>Add Slack integration ...</td><td>March 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2280?tool=ast&topic=Rule+action+availability>Rule action availability</a>
        </td><td>Adjust the rule action picker and its feature-flag test so webhook availability no longer depends on pre-existing actions, keeping UI choices aligned with the refreshed provider requirements.<details><summary>Modified files (2)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx</li>
<li>apps/web/utils/ai/rule/action-availability.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>fix: hide disabled web...</td><td>April 16, 2026</td></tr>
<tr><td>joshwerner001@gmail.com</td><td>Remove conditional tit...</td><td>December 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2280?tool=ast&topic=Slack+target+gating>Slack target gating</a>
        </td><td>Limit Slack private target selection to channels returned by <code>listPrivateChannelsForUser</code>, guard against missing provider user ids, and surface informative reconnect errors in the channel‑targets API and messaging actions/tests.<details><summary>Modified files (5)</summary><ul><li>apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts</li>
<li>apps/web/app/api/user/messaging-channels/[channelId]/targets/route.ts</li>
<li>apps/web/utils/actions/messaging-channels.test.ts</li>
<li>apps/web/utils/actions/messaging-channels.ts</li>
<li>apps/web/utils/messaging/providers/slack/channels.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>messaging: refactor no...</td><td>April 06, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2280?tool=ast>(Baz)</a>.