### PR TITLE
Fix Outlook lifecycle webhook validation

### DIFF
--- a/apps/web/app/api/outlook/webhook/types.test.ts
+++ b/apps/web/app/api/outlook/webhook/types.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { webhookBodySchema } from "@/app/api/outlook/webhook/types";
+
+describe("webhookBodySchema", () => {
+  it("accepts lifecycle notifications with null resource data", () => {
+    const result = webhookBodySchema.safeParse({
+      value: [
+        {
+          subscriptionId: "subscription-id",
+          lifecycleEvent: "missed",
+          resourceData: null,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects change notifications with null resource data", () => {
+    const result = webhookBodySchema.safeParse({
+      value: [
+        {
+          subscriptionId: "subscription-id",
+          changeType: "updated",
+          resourceData: null,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/app/api/outlook/webhook/types.ts
+++ b/apps/web/app/api/outlook/webhook/types.ts
@@ -26,7 +26,7 @@ const changeNotificationSchema = notificationBaseSchema.extend({
 
 const lifecycleNotificationSchema = notificationBaseSchema.extend({
   changeType: z.string().optional(),
-  resourceData: resourceDataSchema.optional(),
+  resourceData: resourceDataSchema.nullish(),
   lifecycleEvent: z.enum([
     "subscriptionRemoved",
     "missed",


### PR DESCRIPTION
# User description
Allow Outlook lifecycle notifications to pass validation when Microsoft sends null resource data.

This keeps change notifications strict while accepting the lifecycle payload shape used by the provider.
It also adds a regression test covering the accepted lifecycle case and the rejected change-notification case.
Targeted test run: `pnpm test --run app/api/outlook/webhook/types.test.ts`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Allow the Outlook webhook schema to accept lifecycle notifications with null resource data while keeping change notifications strict by adjusting <code>lifecycleNotificationSchema</code> validation. Add regression tests covering the accepted lifecycle and rejected change cases via <code>webhookBodySchema</code> validation checks.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>outlook: add lifecycle...</td><td>April 16, 2026</td></tr>
<tr><td>mojkakec12345@gmail.com</td><td>Outlook webhook POC</td><td>June 11, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2285?tool=ast>(Baz)</a>.