### PR TITLE
fix: avoid unique constraint error on empty notification message id

### DIFF
--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createMockEmailProvider } from "@/__tests__/mocks/email-provider.mock";
+import { createScopedLogger } from "@/utils/logger";
+import {
+  sendAskNotification,
+  sendFiledNotification,
+} from "./filing-notifications";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+const logger = createScopedLogger("filing-notifications-test");
+
+const sourceMessage = {
+  headerMessageId: "<original@example.com>",
+  threadId: "thread-1",
+};
+
+const filingId = "filing-1";
+
+describe("filing-notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.documentFiling.findUnique.mockResolvedValue({
+      id: filingId,
+      filename: "receipt.pdf",
+      folderPath: "Receipts",
+      reasoning: null,
+      driveConnection: { provider: "outlook" },
+    } as any);
+  });
+
+  describe("sendFiledNotification", () => {
+    it("does not write an empty notificationMessageId when provider returns none", async () => {
+      const emailProvider = createMockEmailProvider({
+        sendEmailWithHtml: vi
+          .fn()
+          .mockResolvedValue({ messageId: "", threadId: "thread-1" }),
+      });
+
+      await sendFiledNotification({
+        emailProvider,
+        userEmail: "user@example.com",
+        filingId,
+        sourceMessage,
+        logger,
+      });
+
+      const updateCall = prisma.documentFiling.update.mock.calls[0]?.[0] as
+        | { data: { notificationMessageId?: string | null } }
+        | undefined;
+      expect(updateCall?.data.notificationMessageId ?? null).not.toBe("");
+    });
+
+    it("writes the returned messageId when provider returns one", async () => {
+      const emailProvider = createMockEmailProvider({
+        sendEmailWithHtml: vi
+          .fn()
+          .mockResolvedValue({ messageId: "sent-123", threadId: "thread-1" }),
+      });
+
+      await sendFiledNotification({
+        emailProvider,
+        userEmail: "user@example.com",
+        filingId,
+        sourceMessage,
+        logger,
+      });
+
+      expect(prisma.documentFiling.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: filingId },
+          data: expect.objectContaining({
+            notificationMessageId: "sent-123",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("sendAskNotification", () => {
+    it("does not write an empty notificationMessageId when provider returns none", async () => {
+      const emailProvider = createMockEmailProvider({
+        sendEmailWithHtml: vi
+          .fn()
+          .mockResolvedValue({ messageId: "", threadId: "thread-1" }),
+      });
+
+      await sendAskNotification({
+        emailProvider,
+        userEmail: "user@example.com",
+        filingId,
+        sourceMessage,
+        logger,
+      });
+
+      const updateCall = prisma.documentFiling.update.mock.calls[0]?.[0] as
+        | { data: { notificationMessageId?: string | null } }
+        | undefined;
+      expect(updateCall?.data.notificationMessageId ?? null).not.toBe("");
+    });
+  });
+});

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -78,7 +78,7 @@ export async function sendFiledNotification({
     await prisma.documentFiling.update({
       where: { id: filingId },
       data: {
-        notificationMessageId: result.messageId,
+        notificationMessageId: result.messageId || null,
         notificationSentAt: new Date(),
       },
     });
@@ -135,7 +135,7 @@ export async function sendAskNotification({
     await prisma.documentFiling.update({
       where: { id: filingId },
       data: {
-        notificationMessageId: result.messageId,
+        notificationMessageId: result.messageId || null,
         notificationSentAt: new Date(),
       },
     });


### PR DESCRIPTION
# User description
## Summary
- When the email provider returns an empty `messageId` from a notification send, we were writing `""` to `DocumentFiling.notificationMessageId` (a nullable `@unique` column). The first row succeeded, subsequent rows hit `P2002` on `DocumentFiling_notificationMessageId_key`.
- Fix coerces an empty `messageId` to `null` in both `sendFiledNotification` and `sendAskNotification`, so rows without a real provider id simply leave the column null.
- Added unit tests covering the empty-id and populated-id paths.

## Test plan
- [x] `pnpm test --run utils/drive` (50 passed)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Coerce empty provider <code>messageId</code>s to null in <code>sendFiledNotification</code> and <code>sendAskNotification</code> so <code>DocumentFiling</code> only stores real IDs. Add tests covering both empty and populated <code>messageId</code> responses to keep notification sending resilient.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2286?tool=ast&topic=Notification+tests>Notification tests</a>
        </td><td>Add tests covering both empty and populated provider <code>messageId</code> responses to ensure <code>sendFiledNotification</code> and <code>sendAskNotification</code> behave correctly.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/drive/filing-notifications.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2286?tool=ast&topic=Notification+IDs>Notification IDs</a>
        </td><td>Coerce empty provider <code>messageId</code>s to null in <code>sendFiledNotification</code> and <code>sendAskNotification</code> before updating <code>DocumentFiling</code>, preventing unique constraint failures.<details><summary>Modified files (1)</summary><ul><li>apps/web/utils/drive/filing-notifications.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix lint errors across...</td><td>March 08, 2026</td></tr>
<tr><td>josh@jshwrnr.com</td><td>Show Inbox Zero Assist...</td><td>February 09, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2286?tool=ast>(Baz)</a>.