### PR TITLE
rules: add history snapshots for rule edits

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -36,6 +36,10 @@ const {
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    ruleHistory: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({}),
+    },
     knowledge: {
       create: vi.fn(),
     },

--- a/apps/web/app/(app)/[emailAccountId]/debug/rule-history/[ruleId]/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/rule-history/[ruleId]/page.tsx
@@ -12,6 +12,18 @@ import { notFound } from "next/navigation";
 import { formatDistanceToNow } from "date-fns";
 import { auth } from "@/utils/auth";
 import { getEmailTerminology } from "@/utils/terminology";
+import type { RuleHistoryTrigger } from "@/utils/rule/rule-history";
+
+const triggerTypeLabels: Record<RuleHistoryTrigger, string> = {
+  created: "Created",
+  updated: "Updated",
+  actions_updated: "Actions Updated",
+  conditions_updated: "Conditions Updated",
+  instructions_updated: "Instructions Updated",
+  enabled_updated: "Enabled Toggled",
+  run_on_threads_updated: "Thread Mode Updated",
+  deleted: "Deleted",
+};
 
 export default async function RuleHistoryPage(props: {
   params: Promise<{ emailAccountId: string; ruleId: string }>;
@@ -50,15 +62,6 @@ export default async function RuleHistoryPage(props: {
     },
   });
 
-  const triggerTypeLabels: Record<string, string> = {
-    ai_update: "AI Update",
-    manual_update: "Manual Update",
-    ai_creation: "AI Creation",
-    manual_creation: "Manual Creation",
-    system_creation: "System Creation",
-    system_update: "System Update",
-  };
-
   return (
     <div className="container mx-auto p-4">
       <PageHeading>Rule History: {rule.name}</PageHeading>
@@ -77,8 +80,9 @@ export default async function RuleHistoryPage(props: {
                   </CardTitle>
                   <div className="flex items-center gap-2">
                     <Badge variant="outline">
-                      {triggerTypeLabels[history.triggerType] ||
-                        history.triggerType}
+                      {triggerTypeLabels[
+                        history.triggerType as RuleHistoryTrigger
+                      ] ?? history.triggerType}
                     </Badge>
                     <MutedText>
                       {formatDistanceToNow(history.createdAt, {
@@ -195,7 +199,7 @@ export default async function RuleHistoryPage(props: {
                             )}
                             {action.content && (
                               <span>
-                                Content: {action.content.substring(0, 50)}...
+                                Content: {action.content.slice(0, 50)}...
                               </span>
                             )}
                             {action.to && <span>To: {action.to}</span>}

--- a/apps/web/utils/rule/rule-history.ts
+++ b/apps/web/utils/rule/rule-history.ts
@@ -96,21 +96,3 @@ export async function getRuleForHistory({
     include: ruleHistoryRuleInclude,
   });
 }
-
-export async function createRuleHistoryFromRuleId({
-  ruleId,
-  emailAccountId,
-  triggerType,
-}: {
-  ruleId: string;
-  emailAccountId: string;
-  triggerType: RuleHistoryTrigger;
-}) {
-  const rule = await getRuleForHistory({ ruleId, emailAccountId });
-  if (!rule) return null;
-
-  return createRuleHistory({
-    rule,
-    triggerType,
-  });
-}

--- a/apps/web/utils/rule/rule-history.ts
+++ b/apps/web/utils/rule/rule-history.ts
@@ -1,7 +1,21 @@
 import prisma from "@/utils/prisma";
+import type { Prisma } from "@/generated/prisma/client";
 import type { RuleWithRelations } from "@/utils/rule/types";
 
-export type RuleHistoryTrigger = "created" | "updated";
+export type RuleHistoryTrigger =
+  | "created"
+  | "updated"
+  | "actions_updated"
+  | "conditions_updated"
+  | "instructions_updated"
+  | "enabled_updated"
+  | "run_on_threads_updated"
+  | "deleted";
+
+export const ruleHistoryRuleInclude = {
+  actions: true,
+  group: true,
+} satisfies Prisma.RuleInclude;
 
 /**
  * Creates a complete snapshot of a rule in the RuleHistory table
@@ -26,13 +40,20 @@ export async function createRuleHistory({
   const actionsSnapshot = rule.actions.map((action) => ({
     id: action.id,
     type: action.type,
+    messagingChannelId: action.messagingChannelId,
+    messagingChannelEmailAccountId: action.messagingChannelEmailAccountId,
     label: action.label,
+    labelId: action.labelId,
     subject: action.subject,
     content: action.content,
     to: action.to,
     cc: action.cc,
     bcc: action.bcc,
     url: action.url,
+    folderName: action.folderName,
+    folderId: action.folderId,
+    delayInMinutes: action.delayInMinutes,
+    staticAttachments: action.staticAttachments,
   }));
 
   return prisma.ruleHistory.create({
@@ -55,5 +76,41 @@ export async function createRuleHistory({
       // Note: this is unique and can fail in race conditions. Not a big deal for now.
       version: nextVersion,
     },
+  });
+}
+
+export async function getRuleForHistory({
+  ruleId,
+  emailAccountId,
+}: {
+  ruleId: string;
+  emailAccountId: string;
+}) {
+  return prisma.rule.findUnique({
+    where: {
+      id_emailAccountId: {
+        id: ruleId,
+        emailAccountId,
+      },
+    },
+    include: ruleHistoryRuleInclude,
+  });
+}
+
+export async function createRuleHistoryFromRuleId({
+  ruleId,
+  emailAccountId,
+  triggerType,
+}: {
+  ruleId: string;
+  emailAccountId: string;
+  triggerType: RuleHistoryTrigger;
+}) {
+  const rule = await getRuleForHistory({ ruleId, emailAccountId });
+  if (!rule) return null;
+
+  return createRuleHistory({
+    rule,
+    triggerType,
   });
 }

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -5,13 +5,24 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { WEBHOOK_ACTION_DISABLED_MESSAGE } from "@/utils/webhook-action";
 import { getActionRiskLevel } from "@/utils/risk";
 
-const { mockEnv } = vi.hoisted(() => ({
+const {
+  createRuleHistoryMock,
+  createRuleHistoryFromRuleIdMock,
+  getRuleForHistoryMock,
+  mockEnv,
+} = vi.hoisted(() => ({
+  createRuleHistoryMock: vi.fn(),
+  createRuleHistoryFromRuleIdMock: vi.fn(),
+  getRuleForHistoryMock: vi.fn(),
   mockEnv: {
     webhookActionsEnabled: true,
   },
 }));
 
 vi.mock("@/utils/prisma");
+vi.mock("next/server", () => ({
+  after: vi.fn((callback: () => Promise<void> | void) => callback()),
+}));
 vi.mock("@/utils/risk", () => ({
   getActionRiskLevel: vi.fn(),
 }));
@@ -19,7 +30,9 @@ vi.mock("@/app/(app)/[emailAccountId]/assistant/examples", () => ({
   hasExampleParams: vi.fn(() => false),
 }));
 vi.mock("@/utils/rule/rule-history", () => ({
-  createRuleHistory: vi.fn(),
+  createRuleHistory: createRuleHistoryMock,
+  createRuleHistoryFromRuleId: createRuleHistoryFromRuleIdMock,
+  getRuleForHistory: getRuleForHistoryMock,
 }));
 vi.mock("@/utils/email/provider-types", () => ({
   isMicrosoftProvider: vi.fn(() => false),
@@ -50,7 +63,10 @@ import {
   deleteRule,
   partialUpdateRule,
   replaceRuleWithResolvedActions,
+  setRuleEnabled,
+  setRuleRunOnThreads,
   updateRule,
+  updateRuleInstructions,
   updateRuleActions,
 } from "./rule";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -64,6 +80,23 @@ describe("deleteRule", () => {
     vi.mocked(getActionRiskLevel).mockReturnValue({
       level: "low",
       message: "safe",
+    });
+    getRuleForHistoryMock.mockResolvedValue({
+      id: "rule-id",
+      enabled: true,
+      automate: true,
+      runOnThreads: true,
+      conditionalOperator: "AND",
+      name: "Rule",
+      instructions: null,
+      from: null,
+      to: null,
+      subject: null,
+      body: null,
+      systemType: null,
+      promptText: null,
+      actions: [],
+      group: null,
     });
   });
 
@@ -98,6 +131,10 @@ describe("deleteRule", () => {
     expect(prisma.rule.delete).toHaveBeenCalledWith({
       where: { id: "rule-id", emailAccountId: "email-account-id" },
     });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
+      triggerType: "deleted",
+    });
   });
 
   it("deletes the rule directly when there is no group", async () => {
@@ -112,6 +149,10 @@ describe("deleteRule", () => {
     expect(prisma.group.deleteMany).not.toHaveBeenCalled();
     expect(prisma.rule.delete).toHaveBeenCalledWith({
       where: { id: "rule-id", emailAccountId: "email-account-id" },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
+      triggerType: "deleted",
     });
   });
 });
@@ -303,6 +344,11 @@ describe("outbound action guardrails", () => {
           },
         },
       },
+      include: { actions: true, group: true },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
+      triggerType: "actions_updated",
     });
   });
 
@@ -392,6 +438,10 @@ describe("outbound action guardrails", () => {
       where: { id: "rule-id", emailAccountId: "email-account-id" },
       data: { instructions: "updated instructions" },
       include: { actions: true, group: true },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
+      triggerType: "conditions_updated",
     });
   });
 
@@ -486,6 +536,72 @@ describe("replaceRuleWithResolvedActions", () => {
     });
 
     expect(prisma.group.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("rule history snapshots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.webhookActionsEnabled = true;
+    vi.mocked(getActionRiskLevel).mockReturnValue({
+      level: "low",
+      message: "safe",
+    });
+  });
+
+  it("writes history when updating instructions", async () => {
+    prisma.rule.update.mockResolvedValue({
+      id: "rule-id",
+    } as any);
+
+    await updateRuleInstructions({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      instructions: "updated instructions",
+    });
+
+    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      triggerType: "instructions_updated",
+    });
+  });
+
+  it("writes history when toggling rule enablement", async () => {
+    prisma.rule.update.mockResolvedValue({
+      id: "rule-id",
+      actions: [],
+    } as any);
+
+    await setRuleEnabled({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      enabled: false,
+    });
+
+    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      triggerType: "enabled_updated",
+    });
+  });
+
+  it("writes history when changing thread execution mode", async () => {
+    prisma.rule.update.mockResolvedValue({
+      id: "rule-id",
+    } as any);
+
+    await setRuleRunOnThreads({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      runOnThreads: false,
+    });
+
+    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      triggerType: "run_on_threads_updated",
+    });
   });
 });
 

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -5,19 +5,15 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { WEBHOOK_ACTION_DISABLED_MESSAGE } from "@/utils/webhook-action";
 import { getActionRiskLevel } from "@/utils/risk";
 
-const {
-  createRuleHistoryMock,
-  createRuleHistoryFromRuleIdMock,
-  getRuleForHistoryMock,
-  mockEnv,
-} = vi.hoisted(() => ({
-  createRuleHistoryMock: vi.fn(),
-  createRuleHistoryFromRuleIdMock: vi.fn(),
-  getRuleForHistoryMock: vi.fn(),
-  mockEnv: {
-    webhookActionsEnabled: true,
-  },
-}));
+const { createRuleHistoryMock, getRuleForHistoryMock, mockEnv } = vi.hoisted(
+  () => ({
+    createRuleHistoryMock: vi.fn(),
+    getRuleForHistoryMock: vi.fn(),
+    mockEnv: {
+      webhookActionsEnabled: true,
+    },
+  }),
+);
 
 vi.mock("@/utils/prisma");
 vi.mock("next/server", () => ({
@@ -31,8 +27,8 @@ vi.mock("@/app/(app)/[emailAccountId]/assistant/examples", () => ({
 }));
 vi.mock("@/utils/rule/rule-history", () => ({
   createRuleHistory: createRuleHistoryMock,
-  createRuleHistoryFromRuleId: createRuleHistoryFromRuleIdMock,
   getRuleForHistory: getRuleForHistoryMock,
+  ruleHistoryRuleInclude: { actions: true, group: true },
 }));
 vi.mock("@/utils/email/provider-types", () => ({
   isMicrosoftProvider: vi.fn(() => false),
@@ -552,6 +548,8 @@ describe("rule history snapshots", () => {
   it("writes history when updating instructions", async () => {
     prisma.rule.update.mockResolvedValue({
       id: "rule-id",
+      actions: [],
+      group: null,
     } as any);
 
     await updateRuleInstructions({
@@ -560,9 +558,13 @@ describe("rule history snapshots", () => {
       instructions: "updated instructions",
     });
 
-    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+    expect(prisma.rule.update).toHaveBeenCalledWith({
+      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      data: { instructions: "updated instructions" },
+      include: { actions: true, group: true },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
       triggerType: "instructions_updated",
     });
   });
@@ -571,6 +573,7 @@ describe("rule history snapshots", () => {
     prisma.rule.update.mockResolvedValue({
       id: "rule-id",
       actions: [],
+      group: null,
     } as any);
 
     await setRuleEnabled({
@@ -579,9 +582,13 @@ describe("rule history snapshots", () => {
       enabled: false,
     });
 
-    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+    expect(prisma.rule.update).toHaveBeenCalledWith({
+      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      data: { enabled: false },
+      include: { actions: true, group: true },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
       triggerType: "enabled_updated",
     });
   });
@@ -589,6 +596,8 @@ describe("rule history snapshots", () => {
   it("writes history when changing thread execution mode", async () => {
     prisma.rule.update.mockResolvedValue({
       id: "rule-id",
+      actions: [],
+      group: null,
     } as any);
 
     await setRuleRunOnThreads({
@@ -597,9 +606,13 @@ describe("rule history snapshots", () => {
       runOnThreads: false,
     });
 
-    expect(createRuleHistoryFromRuleIdMock).toHaveBeenCalledWith({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+    expect(prisma.rule.update).toHaveBeenCalledWith({
+      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      data: { runOnThreads: false },
+      include: { actions: true, group: true },
+    });
+    expect(createRuleHistoryMock).toHaveBeenCalledWith({
+      rule: expect.objectContaining({ id: "rule-id" }),
       triggerType: "run_on_threads_updated",
     });
   });

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -9,8 +9,9 @@ import { getActionRiskLevel, type RiskAction } from "@/utils/risk";
 import { hasExampleParams } from "@/app/(app)/[emailAccountId]/assistant/examples";
 import {
   createRuleHistory,
-  createRuleHistoryFromRuleId,
   getRuleForHistory,
+  ruleHistoryRuleInclude,
+  type RuleHistoryTrigger,
 } from "@/utils/rule/rule-history";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -134,13 +135,10 @@ export async function partialUpdateRule({
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data,
-    include: { actions: true, group: true },
+    include: ruleHistoryRuleInclude,
   });
 
-  queueRuleHistory({
-    rule,
-    triggerType: "conditions_updated",
-  });
+  queueRuleHistory({ rule, triggerType: "conditions_updated" });
 
   return rule;
 }
@@ -157,13 +155,10 @@ export async function updateRuleInstructions({
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { instructions },
+    include: ruleHistoryRuleInclude,
   });
 
-  queueRuleHistoryFromRuleId({
-    ruleId,
-    emailAccountId,
-    triggerType: "instructions_updated",
-  });
+  queueRuleHistory({ rule, triggerType: "instructions_updated" });
 
   return rule;
 }
@@ -180,13 +175,10 @@ export async function setRuleRunOnThreads({
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { runOnThreads },
+    include: ruleHistoryRuleInclude,
   });
 
-  queueRuleHistoryFromRuleId({
-    ruleId,
-    emailAccountId,
-    triggerType: "run_on_threads_updated",
-  });
+  queueRuleHistory({ rule, triggerType: "run_on_threads_updated" });
 
   return rule;
 }
@@ -203,14 +195,10 @@ export async function setRuleEnabled({
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { enabled },
-    include: { actions: true },
+    include: ruleHistoryRuleInclude,
   });
 
-  queueRuleHistoryFromRuleId({
-    ruleId,
-    emailAccountId,
-    triggerType: "enabled_updated",
-  });
+  queueRuleHistory({ rule, triggerType: "enabled_updated" });
 
   return rule;
 }
@@ -592,13 +580,10 @@ export async function updateRuleActions({
         },
       },
     },
-    include: { actions: true, group: true },
+    include: ruleHistoryRuleInclude,
   });
 
-  queueRuleHistory({
-    rule,
-    triggerType: "actions_updated",
-  });
+  queueRuleHistory({ rule, triggerType: "actions_updated" });
 
   return rule;
 }
@@ -850,17 +835,9 @@ function validateWebhookUrlsInActions(actions: RuleActionCreateData[]) {
 
 function queueRuleHistory(params: {
   rule: RuleWithRelations;
-  triggerType: Parameters<typeof createRuleHistory>[0]["triggerType"];
+  triggerType: RuleHistoryTrigger;
 }) {
   after(() => createRuleHistory(params));
-}
-
-function queueRuleHistoryFromRuleId(params: {
-  ruleId: string;
-  emailAccountId: string;
-  triggerType: Parameters<typeof createRuleHistoryFromRuleId>[0]["triggerType"];
-}) {
-  after(() => createRuleHistoryFromRuleId(params));
 }
 
 function addNestedActionOwnershipToInputs(

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -123,7 +123,29 @@ type RuleRecordData = {
   groupId?: string | null;
 };
 
-export async function partialUpdateRule({
+async function updateRuleAndQueueHistory({
+  ruleId,
+  emailAccountId,
+  data,
+  triggerType,
+}: {
+  ruleId: string;
+  emailAccountId: string;
+  data: Prisma.RuleUpdateInput;
+  triggerType: RuleHistoryTrigger;
+}) {
+  const rule = await prisma.rule.update({
+    where: { id: ruleId, emailAccountId },
+    data,
+    include: ruleHistoryRuleInclude,
+  });
+
+  queueRuleHistory({ rule, triggerType });
+
+  return rule;
+}
+
+export function partialUpdateRule({
   ruleId,
   emailAccountId,
   data,
@@ -132,18 +154,15 @@ export async function partialUpdateRule({
   emailAccountId: string;
   data: Partial<Rule>;
 }) {
-  const rule = await prisma.rule.update({
-    where: { id: ruleId, emailAccountId },
+  return updateRuleAndQueueHistory({
+    ruleId,
+    emailAccountId,
     data,
-    include: ruleHistoryRuleInclude,
+    triggerType: "conditions_updated",
   });
-
-  queueRuleHistory({ rule, triggerType: "conditions_updated" });
-
-  return rule;
 }
 
-export async function updateRuleInstructions({
+export function updateRuleInstructions({
   ruleId,
   emailAccountId,
   instructions,
@@ -152,18 +171,15 @@ export async function updateRuleInstructions({
   emailAccountId: string;
   instructions: string;
 }) {
-  const rule = await prisma.rule.update({
-    where: { id: ruleId, emailAccountId },
+  return updateRuleAndQueueHistory({
+    ruleId,
+    emailAccountId,
     data: { instructions },
-    include: ruleHistoryRuleInclude,
+    triggerType: "instructions_updated",
   });
-
-  queueRuleHistory({ rule, triggerType: "instructions_updated" });
-
-  return rule;
 }
 
-export async function setRuleRunOnThreads({
+export function setRuleRunOnThreads({
   ruleId,
   emailAccountId,
   runOnThreads,
@@ -172,18 +188,15 @@ export async function setRuleRunOnThreads({
   emailAccountId: string;
   runOnThreads: boolean;
 }) {
-  const rule = await prisma.rule.update({
-    where: { id: ruleId, emailAccountId },
+  return updateRuleAndQueueHistory({
+    ruleId,
+    emailAccountId,
     data: { runOnThreads },
-    include: ruleHistoryRuleInclude,
+    triggerType: "run_on_threads_updated",
   });
-
-  queueRuleHistory({ rule, triggerType: "run_on_threads_updated" });
-
-  return rule;
 }
 
-export async function setRuleEnabled({
+export function setRuleEnabled({
   ruleId,
   emailAccountId,
   enabled,
@@ -192,15 +205,12 @@ export async function setRuleEnabled({
   emailAccountId: string;
   enabled: boolean;
 }) {
-  const rule = await prisma.rule.update({
-    where: { id: ruleId, emailAccountId },
+  return updateRuleAndQueueHistory({
+    ruleId,
+    emailAccountId,
     data: { enabled },
-    include: ruleHistoryRuleInclude,
+    triggerType: "enabled_updated",
   });
-
-  queueRuleHistory({ rule, triggerType: "enabled_updated" });
-
-  return rule;
 }
 
 export async function createRuleWithResolvedActions({

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -1,4 +1,5 @@
 import type { CreateOrUpdateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+import { after } from "next/server";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { ActionType } from "@/generated/prisma/enums";
@@ -6,7 +7,11 @@ import type { SystemType } from "@/generated/prisma/enums";
 import type { Prisma, Rule } from "@/generated/prisma/client";
 import { getActionRiskLevel, type RiskAction } from "@/utils/risk";
 import { hasExampleParams } from "@/app/(app)/[emailAccountId]/assistant/examples";
-import { createRuleHistory } from "@/utils/rule/rule-history";
+import {
+  createRuleHistory,
+  createRuleHistoryFromRuleId,
+  getRuleForHistory,
+} from "@/utils/rule/rule-history";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { createEmailProvider } from "@/utils/email/provider";
 import { resolveLabelNameAndId } from "@/utils/label/resolve-label";
@@ -117,7 +122,7 @@ type RuleRecordData = {
   groupId?: string | null;
 };
 
-export function partialUpdateRule({
+export async function partialUpdateRule({
   ruleId,
   emailAccountId,
   data,
@@ -126,14 +131,21 @@ export function partialUpdateRule({
   emailAccountId: string;
   data: Partial<Rule>;
 }) {
-  return prisma.rule.update({
+  const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data,
     include: { actions: true, group: true },
   });
+
+  queueRuleHistory({
+    rule,
+    triggerType: "conditions_updated",
+  });
+
+  return rule;
 }
 
-export function updateRuleInstructions({
+export async function updateRuleInstructions({
   ruleId,
   emailAccountId,
   instructions,
@@ -142,13 +154,21 @@ export function updateRuleInstructions({
   emailAccountId: string;
   instructions: string;
 }) {
-  return prisma.rule.update({
+  const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { instructions },
   });
+
+  queueRuleHistoryFromRuleId({
+    ruleId,
+    emailAccountId,
+    triggerType: "instructions_updated",
+  });
+
+  return rule;
 }
 
-export function setRuleRunOnThreads({
+export async function setRuleRunOnThreads({
   ruleId,
   emailAccountId,
   runOnThreads,
@@ -157,13 +177,21 @@ export function setRuleRunOnThreads({
   emailAccountId: string;
   runOnThreads: boolean;
 }) {
-  return prisma.rule.update({
+  const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { runOnThreads },
   });
+
+  queueRuleHistoryFromRuleId({
+    ruleId,
+    emailAccountId,
+    triggerType: "run_on_threads_updated",
+  });
+
+  return rule;
 }
 
-export function setRuleEnabled({
+export async function setRuleEnabled({
   ruleId,
   emailAccountId,
   enabled,
@@ -172,11 +200,19 @@ export function setRuleEnabled({
   emailAccountId: string;
   enabled: boolean;
 }) {
-  return prisma.rule.update({
+  const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: { enabled },
     include: { actions: true },
   });
+
+  queueRuleHistoryFromRuleId({
+    ruleId,
+    emailAccountId,
+    triggerType: "enabled_updated",
+  });
+
+  return rule;
 }
 
 export async function createRuleWithResolvedActions({
@@ -222,7 +258,7 @@ export async function createRuleWithResolvedActions({
     include: { actions: true, group: true },
   });
 
-  return rule as RuleWithRelations;
+  return rule;
 }
 
 export async function replaceRuleWithResolvedActions({
@@ -282,7 +318,7 @@ export async function replaceRuleWithResolvedActions({
     });
   }
 
-  return rule as RuleWithRelations;
+  return rule;
 }
 
 export async function createRule({
@@ -349,7 +385,7 @@ export async function createRule({
       actions: mappedActions,
     });
 
-    await createRuleHistory({ rule, triggerType: "created" });
+    queueRuleHistory({ rule, triggerType: "created" });
 
     return rule;
   } catch (error) {
@@ -408,7 +444,7 @@ export async function updateRule({
       actions: mappedActions,
     });
 
-    await createRuleHistory({ rule, triggerType: "updated" });
+    queueRuleHistory({ rule, triggerType: "updated" });
 
     return rule;
   } catch (error) {
@@ -469,7 +505,7 @@ export async function upsertSystemRule({
       actions,
     });
 
-    await createRuleHistory({ rule, triggerType: "updated" });
+    queueRuleHistory({ rule, triggerType: "updated" });
     return rule;
   } else {
     logger.info("Creating new system rule");
@@ -483,7 +519,7 @@ export async function upsertSystemRule({
         actions,
       });
 
-      await createRuleHistory({ rule, triggerType: "created" });
+      queueRuleHistory({ rule, triggerType: "created" });
       return rule;
     } catch (error) {
       if (!isDuplicateError(error, "name")) throw error;
@@ -503,7 +539,7 @@ export async function upsertSystemRule({
         actions,
       });
 
-      await createRuleHistory({ rule, triggerType: "updated" });
+      queueRuleHistory({ rule, triggerType: "updated" });
       return rule;
     }
   }
@@ -546,7 +582,7 @@ export async function updateRuleActions({
   );
   validateWebhookUrlsInActions(mappedActions);
 
-  return prisma.rule.update({
+  const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data: {
       actions: {
@@ -556,7 +592,15 @@ export async function updateRuleActions({
         },
       },
     },
+    include: { actions: true, group: true },
   });
+
+  queueRuleHistory({
+    rule,
+    triggerType: "actions_updated",
+  });
+
+  return rule;
 }
 
 export async function deleteRule({
@@ -568,6 +612,19 @@ export async function deleteRule({
   ruleId: string;
   groupId?: string | null;
 }) {
+  const rule = await getRuleForHistory({ ruleId, emailAccountId });
+  if (!rule) {
+    await prisma.rule.delete({ where: { id: ruleId, emailAccountId } });
+    return;
+  }
+
+  // RuleHistory still references Rule, so deletes must snapshot before
+  // removing the rule row.
+  await createRuleHistory({
+    rule,
+    triggerType: "deleted",
+  });
+
   if (groupId) {
     const deletedGroups = await prisma.group.deleteMany({
       where: { id: groupId, emailAccountId },
@@ -789,6 +846,21 @@ function validateWebhookUrlsInActions(actions: RuleActionCreateData[]) {
       throw new SafeError(`Invalid webhook URL: ${result.error}`, 400);
     }
   }
+}
+
+function queueRuleHistory(params: {
+  rule: RuleWithRelations;
+  triggerType: Parameters<typeof createRuleHistory>[0]["triggerType"];
+}) {
+  after(() => createRuleHistory(params));
+}
+
+function queueRuleHistoryFromRuleId(params: {
+  ruleId: string;
+  emailAccountId: string;
+  triggerType: Parameters<typeof createRuleHistoryFromRuleId>[0]["triggerType"];
+}) {
+  after(() => createRuleHistoryFromRuleId(params));
 }
 
 function addNestedActionOwnershipToInputs(

--- a/apps/web/utils/rule/types.ts
+++ b/apps/web/utils/rule/types.ts
@@ -1,16 +1,8 @@
-import type { Action, Rule, Prisma } from "@/generated/prisma/client";
+import type { Prisma } from "@/generated/prisma/client";
 
-export type RuleWithRelations = Rule & {
-  actions: Action[];
-  group?:
-    | (Prisma.GroupGetPayload<{
-        select: { id: true; name: true };
-      }> & {
-        items?:
-          | Prisma.GroupItemGetPayload<{
-              select: { id: true; type: true; value: true };
-            }>[]
-          | null;
-      })
-    | null;
-};
+export type RuleWithRelations = Prisma.RuleGetPayload<{
+  include: {
+    actions: true;
+    group: true;
+  };
+}>;


### PR DESCRIPTION
# User description
Add rule history snapshots for rule edits

Capture rule history for previously unaudited rule and action changes.
This keeps rule snapshots available when rule actions are changed outside the main save flow.

- snapshot full action metadata in rule history
- record history for rule action, condition, enablement, instruction, and delete updates
- cover onboarding, import, copy, digest, and messaging channel action mutations

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Capture rule snapshots for action and metadata changes by expanding the <code>rule-history</code> utilities and wiring every save path through <code>queueRuleHistory</code> in the <code>rule</code> service. Update the debug history page to display the new <code>RuleHistoryTrigger</code> labels so editors can see why each snapshot was created.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2288?tool=ast&topic=History+labels>History labels</a>
        </td><td>Update the history UI to use <code>RuleHistoryTrigger</code> labels and trim action content with <code>slice</code> so the new trigger names appear consistently in the debug view.<details><summary>Modified files (1)</summary><ul><li>apps/web/app/(app)/[emailAccountId]/debug/rule-history/[ruleId]/page.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>Fix lint errors across...</td><td>March 08, 2026</td></tr>
<tr><td>eduardoleliss@gmail.com</td><td>Major better-auth refa...</td><td>August 06, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/elie222/inbox-zero/2288?tool=ast&topic=History+capture>History capture</a>
        </td><td>Capture rule snapshots for edits by expanding <code>ruleHistory</code> utilities, queuing <code>createRuleHistory</code> after <code>updateRuleAndQueueHistory</code>, and exercising the new triggers through <code>updateRuleInstructions</code>, <code>setRuleEnabled</code>, <code>setRuleRunOnThreads</code>, <code>updateRuleActions</code>, and delete flows.<details><summary>Modified files (5)</summary><ul><li>apps/web/__tests__/ai-assistant-chat.test.ts</li>
<li>apps/web/utils/rule/rule-history.ts</li>
<li>apps/web/utils/rule/rule.test.ts</li>
<li>apps/web/utils/rule/rule.ts</li>
<li>apps/web/utils/rule/types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>elie222</td><td>assistant: add sender ...</td><td>April 17, 2026</td></tr>
<tr><td>petejsmith333@gmail.com</td><td>fix: validate webhook ...</td><td>April 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/elie222/inbox-zero/2288?tool=ast>(Baz)</a>.