### PR TITLE
feat: add Invite Members entry points in sidebar and settings

### DIFF
--- a/apps/web/app/(app)/settings/TeamSection.tsx
+++ b/apps/web/app/(app)/settings/TeamSection.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from "@/components/ui/item";
+import { InviteMemberModal } from "@/components/InviteMemberModal";
+import { useUser } from "@/hooks/useUser";
+import { useAccount } from "@/providers/EmailAccountProvider";
+
+export function TeamSection() {
+  const { emailAccountId } = useAccount();
+  const { data: user } = useUser();
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
+
+  const organizationId = user?.members?.find(
+    (member) => member.emailAccountId === emailAccountId,
+  )?.organizationId;
+
+  return (
+    <>
+      <Item size="sm">
+        <ItemContent>
+          <ItemTitle>Invite members</ItemTitle>
+          <ItemDescription>
+            Share your plan by inviting teammates to your organization.
+          </ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setIsInviteDialogOpen(true)}
+          >
+            Invite
+          </Button>
+        </ItemActions>
+      </Item>
+
+      <InviteMemberModal
+        organizationId={organizationId}
+        open={isInviteDialogOpen}
+        onOpenChange={setIsInviteDialogOpen}
+        trigger={null}
+      />
+    </>
+  );
+}

--- a/apps/web/app/(app)/settings/TeamSection.tsx
+++ b/apps/web/app/(app)/settings/TeamSection.tsx
@@ -10,17 +10,11 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { InviteMemberModal } from "@/components/InviteMemberModal";
-import { useUser } from "@/hooks/useUser";
-import { useAccount } from "@/providers/EmailAccountProvider";
+import { useOrganizationId } from "@/hooks/useOrganizationId";
 
 export function TeamSection() {
-  const { emailAccountId } = useAccount();
-  const { data: user } = useUser();
+  const organizationId = useOrganizationId();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
-
-  const organizationId = user?.members?.find(
-    (member) => member.emailAccountId === emailAccountId,
-  )?.organizationId;
 
   return (
     <>

--- a/apps/web/app/(app)/settings/TeamSection.tsx
+++ b/apps/web/app/(app)/settings/TeamSection.tsx
@@ -10,10 +10,10 @@ import {
   ItemTitle,
 } from "@/components/ui/item";
 import { InviteMemberModal } from "@/components/InviteMemberModal";
-import { useOrganizationId } from "@/hooks/useOrganizationId";
+import { useCurrentOrganization } from "@/hooks/useCurrentOrganization";
 
 export function TeamSection() {
-  const organizationId = useOrganizationId();
+  const organization = useCurrentOrganization();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   return (
@@ -37,7 +37,7 @@ export function TeamSection() {
       </Item>
 
       <InviteMemberModal
-        organizationId={organizationId}
+        organizationId={organization?.id}
         open={isInviteDialogOpen}
         onOpenChange={setIsInviteDialogOpen}
         trigger={null}

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   SendIcon,
   SparklesIcon,
   UserIcon,
+  UsersIcon,
   WebhookIcon,
 } from "lucide-react";
 import { ApiKeysSection } from "@/app/(app)/[emailAccountId]/settings/ApiKeysSection";
@@ -44,16 +45,25 @@ import {
 } from "@/components/ui/item";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
+import { useUser } from "@/hooks/useUser";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import { InviteMemberModal } from "@/components/InviteMemberModal";
 import { cn } from "@/utils";
 import { env } from "@/env";
 
 export default function SettingsPage() {
   const { emailAccountId: activeEmailAccountId } = useAccount();
   const { data, isLoading, error } = useAccounts();
+  const { data: user } = useUser();
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(
     null,
   );
+
+  const activeMember = user?.members?.find(
+    (member) => member.emailAccountId === activeEmailAccountId,
+  );
+  const organizationId = activeMember?.organizationId;
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   const handleSlackConnected = useCallback(
     (connectedEmailAccountId: string | null) => {
@@ -152,6 +162,28 @@ export default function SettingsPage() {
           </SettingsGroup>
         )}
 
+        <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
+          <ItemCard>
+            <Item size="sm">
+              <ItemContent>
+                <ItemTitle>Invite members</ItemTitle>
+                <ItemDescription>
+                  Share your plan by inviting teammates to your organization.
+                </ItemDescription>
+              </ItemContent>
+              <ItemActions>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setIsInviteDialogOpen(true)}
+                >
+                  Invite
+                </Button>
+              </ItemActions>
+            </Item>
+          </ItemCard>
+        </SettingsGroup>
+
         <SettingsGroup icon={<UserIcon className="size-5" />} title="Account">
           <ItemCard>
             <AppearanceSection />
@@ -175,6 +207,13 @@ export default function SettingsPage() {
           </ItemCard>
         </SettingsGroup>
       </div>
+
+      <InviteMemberModal
+        organizationId={organizationId}
+        open={isInviteDialogOpen}
+        onOpenChange={setIsInviteDialogOpen}
+        trigger={null}
+      />
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { ApiKeysSection } from "@/app/(app)/[emailAccountId]/settings/ApiKeysSection";
 import { AppearanceSection } from "@/app/(app)/settings/AppearanceSection";
+import { TeamSection } from "@/app/(app)/settings/TeamSection";
 import { BillingSection } from "@/app/(app)/[emailAccountId]/settings/BillingSection";
 import { CleanupDraftsSection } from "@/app/(app)/[emailAccountId]/settings/CleanupDraftsSection";
 import { useSlackNotifications } from "@/app/(app)/[emailAccountId]/settings/ConnectedAppsSection";
@@ -45,25 +46,16 @@ import {
 } from "@/components/ui/item";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
-import { useUser } from "@/hooks/useUser";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { InviteMemberModal } from "@/components/InviteMemberModal";
 import { cn } from "@/utils";
 import { env } from "@/env";
 
 export default function SettingsPage() {
   const { emailAccountId: activeEmailAccountId } = useAccount();
   const { data, isLoading, error } = useAccounts();
-  const { data: user } = useUser();
   const [expandedAccountId, setExpandedAccountId] = useState<string | null>(
     null,
   );
-
-  const activeMember = user?.members?.find(
-    (member) => member.emailAccountId === activeEmailAccountId,
-  );
-  const organizationId = activeMember?.organizationId;
-  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   const handleSlackConnected = useCallback(
     (connectedEmailAccountId: string | null) => {
@@ -138,23 +130,7 @@ export default function SettingsPage() {
 
         <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
           <ItemCard>
-            <Item size="sm">
-              <ItemContent>
-                <ItemTitle>Invite members</ItemTitle>
-                <ItemDescription>
-                  Share your plan by inviting teammates to your organization.
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setIsInviteDialogOpen(true)}
-                >
-                  Invite
-                </Button>
-              </ItemActions>
-            </Item>
+            <TeamSection />
           </ItemCard>
         </SettingsGroup>
 
@@ -207,13 +183,6 @@ export default function SettingsPage() {
           </ItemCard>
         </SettingsGroup>
       </div>
-
-      <InviteMemberModal
-        organizationId={organizationId}
-        open={isInviteDialogOpen}
-        onOpenChange={setIsInviteDialogOpen}
-        trigger={null}
-      />
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -136,6 +136,28 @@ export default function SettingsPage() {
           </SettingsGroup>
         )}
 
+        <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
+          <ItemCard>
+            <Item size="sm">
+              <ItemContent>
+                <ItemTitle>Invite members</ItemTitle>
+                <ItemDescription>
+                  Share your plan by inviting teammates to your organization.
+                </ItemDescription>
+              </ItemContent>
+              <ItemActions>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setIsInviteDialogOpen(true)}
+                >
+                  Invite
+                </Button>
+              </ItemActions>
+            </Item>
+          </ItemCard>
+        </SettingsGroup>
+
         <SettingsGroup
           icon={<SparklesIcon className="size-5" />}
           title="AI Model"
@@ -161,28 +183,6 @@ export default function SettingsPage() {
             </ItemCard>
           </SettingsGroup>
         )}
-
-        <SettingsGroup icon={<UsersIcon className="size-5" />} title="Team">
-          <ItemCard>
-            <Item size="sm">
-              <ItemContent>
-                <ItemTitle>Invite members</ItemTitle>
-                <ItemDescription>
-                  Share your plan by inviting teammates to your organization.
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setIsInviteDialogOpen(true)}
-                >
-                  Invite
-                </Button>
-              </ItemActions>
-            </Item>
-          </ItemCard>
-        </SettingsGroup>
 
         <SettingsGroup icon={<UserIcon className="size-5" />} title="Account">
           <ItemCard>

--- a/apps/web/components/NavUser.tsx
+++ b/apps/web/components/NavUser.tsx
@@ -31,23 +31,19 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { EXTENSION_URL } from "@/utils/config";
-import { useUser } from "@/hooks/useUser";
+import { useCurrentOrganization } from "@/hooks/useCurrentOrganization";
 import { env } from "@/env";
 import { Referrals } from "@/components/ReferralDialog";
 
 export function NavUser() {
   const { emailAccountId, emailAccount, provider } = useAccount();
   const { closeMobileSidebar, isMobile, state } = useSidebar();
-  const { data: user } = useUser();
   const [isReferralDialogOpen, setIsReferralDialogOpen] = useState(false);
 
   const currentEmailAccountId = emailAccount?.id || emailAccountId;
-  const currentEmailAccountMembers =
-    user?.members?.filter(
-      (member) => member.emailAccountId === currentEmailAccountId,
-    ) || [];
-  const hasOrganization = currentEmailAccountMembers.length > 0;
-  const organizationName = currentEmailAccountMembers[0]?.organization?.name;
+  const organization = useCurrentOrganization();
+  const hasOrganization = !!organization;
+  const organizationName = organization?.name;
 
   const isExpandedSidebar = state.includes("left-sidebar");
 

--- a/apps/web/components/NavUser.tsx
+++ b/apps/web/components/NavUser.tsx
@@ -14,6 +14,7 @@ import {
   GiftIcon,
   GlobeIcon,
   SettingsIcon,
+  UserPlusIcon,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -34,12 +35,14 @@ import { EXTENSION_URL } from "@/utils/config";
 import { useUser } from "@/hooks/useUser";
 import { env } from "@/env";
 import { Referrals } from "@/components/ReferralDialog";
+import { InviteMemberModal } from "@/components/InviteMemberModal";
 
 export function NavUser() {
   const { emailAccountId, emailAccount, provider } = useAccount();
   const { closeMobileSidebar, isMobile, state } = useSidebar();
   const { data: user } = useUser();
   const [isReferralDialogOpen, setIsReferralDialogOpen] = useState(false);
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   const currentEmailAccountId = emailAccount?.id || emailAccountId;
   const currentEmailAccountMembers =
@@ -47,6 +50,7 @@ export function NavUser() {
       (member) => member.emailAccountId === currentEmailAccountId,
     ) || [];
   const hasOrganization = currentEmailAccountMembers.length > 0;
+  const organizationId = currentEmailAccountMembers[0]?.organizationId;
   const organizationName = currentEmailAccountMembers[0]?.organization?.name;
 
   const isExpandedSidebar = state.includes("left-sidebar");
@@ -99,6 +103,15 @@ export function NavUser() {
                 <SettingsIcon className="mr-2 size-4" />
                 Settings
               </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                closeMobileSidebar("left-sidebar");
+                setIsInviteDialogOpen(true);
+              }}
+            >
+              <UserPlusIcon className="mr-2 size-4" />
+              Invite members
             </DropdownMenuItem>
             {!hasOrganization && (
               <DropdownMenuItem asChild>
@@ -240,6 +253,13 @@ export function NavUser() {
           <Referrals />
         </DialogContent>
       </Dialog>
+
+      <InviteMemberModal
+        organizationId={organizationId}
+        open={isInviteDialogOpen}
+        onOpenChange={setIsInviteDialogOpen}
+        trigger={null}
+      />
     </>
   );
 }

--- a/apps/web/components/NavUser.tsx
+++ b/apps/web/components/NavUser.tsx
@@ -14,7 +14,6 @@ import {
   GiftIcon,
   GlobeIcon,
   SettingsIcon,
-  UserPlusIcon,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -35,14 +34,12 @@ import { EXTENSION_URL } from "@/utils/config";
 import { useUser } from "@/hooks/useUser";
 import { env } from "@/env";
 import { Referrals } from "@/components/ReferralDialog";
-import { InviteMemberModal } from "@/components/InviteMemberModal";
 
 export function NavUser() {
   const { emailAccountId, emailAccount, provider } = useAccount();
   const { closeMobileSidebar, isMobile, state } = useSidebar();
   const { data: user } = useUser();
   const [isReferralDialogOpen, setIsReferralDialogOpen] = useState(false);
-  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   const currentEmailAccountId = emailAccount?.id || emailAccountId;
   const currentEmailAccountMembers =
@@ -50,7 +47,6 @@ export function NavUser() {
       (member) => member.emailAccountId === currentEmailAccountId,
     ) || [];
   const hasOrganization = currentEmailAccountMembers.length > 0;
-  const organizationId = currentEmailAccountMembers[0]?.organizationId;
   const organizationName = currentEmailAccountMembers[0]?.organization?.name;
 
   const isExpandedSidebar = state.includes("left-sidebar");
@@ -103,15 +99,6 @@ export function NavUser() {
                 <SettingsIcon className="mr-2 size-4" />
                 Settings
               </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={() => {
-                closeMobileSidebar("left-sidebar");
-                setIsInviteDialogOpen(true);
-              }}
-            >
-              <UserPlusIcon className="mr-2 size-4" />
-              Invite members
             </DropdownMenuItem>
             {!hasOrganization && (
               <DropdownMenuItem asChild>
@@ -253,13 +240,6 @@ export function NavUser() {
           <Referrals />
         </DialogContent>
       </Dialog>
-
-      <InviteMemberModal
-        organizationId={organizationId}
-        open={isInviteDialogOpen}
-        onOpenChange={setIsInviteDialogOpen}
-        trigger={null}
-      />
     </>
   );
 }

--- a/apps/web/hooks/useCurrentOrganization.ts
+++ b/apps/web/hooks/useCurrentOrganization.ts
@@ -1,12 +1,19 @@
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useUser } from "@/hooks/useUser";
 
-export function useOrganizationId() {
+export function useCurrentOrganization() {
   const { emailAccountId, emailAccount } = useAccount();
   const { data: user } = useUser();
   const currentEmailAccountId = emailAccount?.id || emailAccountId;
 
-  return user?.members?.find(
-    (member) => member.emailAccountId === currentEmailAccountId,
-  )?.organizationId;
+  const member = user?.members?.find(
+    (m) => m.emailAccountId === currentEmailAccountId,
+  );
+
+  if (!member?.organizationId) return;
+
+  return {
+    id: member.organizationId,
+    name: member.organization?.name,
+  };
 }

--- a/apps/web/hooks/useOrganizationId.ts
+++ b/apps/web/hooks/useOrganizationId.ts
@@ -1,0 +1,12 @@
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { useUser } from "@/hooks/useUser";
+
+export function useOrganizationId() {
+  const { emailAccountId, emailAccount } = useAccount();
+  const { data: user } = useUser();
+  const currentEmailAccountId = emailAccount?.id || emailAccountId;
+
+  return user?.members?.find(
+    (member) => member.emailAccountId === currentEmailAccountId,
+  )?.organizationId;
+}


### PR DESCRIPTION
## Summary
- Add an Invite Members item to the sidebar user dropdown that opens the existing invite modal.
- Add a Team section to the settings page with an Invite button that opens the same modal.
- Both entry points pass the current organization id when available so invites attach to an existing org instead of creating a new one.

## Test plan
- [ ] Open sidebar user dropdown and confirm Invite Members opens the modal.
- [ ] Open /settings and confirm the Team section renders an Invite button that opens the modal.
- [ ] Verify the modal behaves correctly both with and without an existing organization.