### PR TITLE
chore: remove sitemap link from footer

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -96,7 +96,6 @@ export const footerNavigation = {
       href: "https://security.getinboxzero.com",
       target: "_blank",
     },
-    { name: "Sitemap", href: "/sitemap.xml" },
   ],
   social: [
     {


### PR DESCRIPTION
Removes the user-facing Sitemap link from the Legal column of the landing footer. The `sitemap.xml` is still discoverable by search engines via `robots.ts`, so there's no SEO impact.