### PR TITLE
fix: custom test email incorrectly treated as thread reply

### DIFF
--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -193,13 +193,17 @@ export const testAiCustomContentAction = actionClient
         },
       });
 
+      const testId = `testMessageId-${Date.now()}`;
+
       const result = await runRules({
         isTest: true,
         provider: emailProvider,
         logger,
         message: {
-          id: `testMessageId-${Date.now()}`,
-          threadId: `testThreadId-${Date.now()}`,
+          id: testId,
+          // Match id so Gmail's isReplyInThread (which compares id !== threadId)
+          // treats this synthetic test message as the first message in a thread.
+          threadId: testId,
           snippet: content,
           textPlain: content,
           headers: {


### PR DESCRIPTION
## Summary
- The Custom Test form built a synthetic message with distinct `id` and `threadId` values. Gmail's `isReplyInThread` returns `true` when those differ, so every custom test email was treated as a thread reply and rules with `runOnThreads=false` (e.g. Conversations) were silently skipped.
- Reuse a single id for both fields so the synthetic message is treated as the first message in a thread.

## Test plan
- [ ] Run a Custom Test against content that should match a `runOnThreads=false` rule and confirm the rule matches instead of showing "No match found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)