### PR TITLE
onboarding: add chat showcase step and hide features question

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
 import { StepWho } from "@/app/(app)/[emailAccountId]/onboarding/StepWho";
 import { StepWelcome } from "@/app/(app)/[emailAccountId]/onboarding/StepWelcome";
+import { StepChat } from "@/app/(app)/[emailAccountId]/onboarding/StepChat";
 import { StepEmailsSorted } from "@/app/(app)/[emailAccountId]/onboarding/StepEmailsSorted";
 import { StepDraftReplies } from "@/app/(app)/[emailAccountId]/onboarding/StepDraftReplies";
 import { StepBulkUnsubscribe } from "@/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe";
@@ -61,6 +62,7 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
 
   const stepMap: Record<string, (() => React.ReactNode) | undefined> = {
     [STEP_KEYS.WELCOME]: () => <StepWelcome onNext={onNext} />,
+    [STEP_KEYS.CHAT]: () => <StepChat onNext={onNext} />,
     [STEP_KEYS.EMAILS_SORTED]: () => <StepEmailsSorted onNext={onNext} />,
     [STEP_KEYS.DRAFT_REPLIES]: env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED
       ? undefined
@@ -130,9 +132,8 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
   );
 
   const getOnboardingStepPath = useCallback(
-    (stepKey: string) => {
-      return getOnboardingStepHref(emailAccountId, stepKey as StepKey);
-    },
+    (stepKey: string) =>
+      getOnboardingStepHref(emailAccountId, stepKey as StepKey),
     [emailAccountId],
   );
 
@@ -155,13 +156,7 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
       totalSteps,
       isOptional: isOptionalOnboardingStep(currentStepKey),
     });
-  }, [
-    analytics,
-    clampedStep,
-    currentStepKey,
-    isMembershipLoading,
-    totalSteps,
-  ]);
+  }, [analytics, clampedStep, currentStepKey, isMembershipLoading, totalSteps]);
 
   const onNext = useCallback(async () => {
     if (!currentStepKey) return;

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -13,11 +13,11 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
           <BulkUnsubscribeIllustration />
         </div>
 
-        <PageHeading className="mb-3">Bulk Unsubscriber & Archiver</PageHeading>
+        <PageHeading className="mb-3">Bulk unsubscribe and archive</PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          See which emails you never read, and one-click unsubscribe and archive
-          them.
+          See which emails you never read. One-click unsubscribe and archive
+          them in bulk.
         </TypographyP>
 
         <div className="flex flex-col gap-2 w-full max-w-xs">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
@@ -13,11 +13,11 @@ export function StepChat({ onNext }: { onNext: () => void }) {
           <ChatIllustration />
         </div>
 
-        <PageHeading className="mb-3">Chat with your inbox</PageHeading>
+        <PageHeading className="mb-3">A chat that runs your email</PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          Ask questions, triage messages, and take action in natural language —
-          right here or from Slack.
+          Clean up, draft replies, set up rules. Works in Slack, Telegram, or
+          here, and pings you when you're needed.
         </TypographyP>
 
         <div className="flex flex-col gap-2 w-full max-w-xs">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ArrowRightIcon } from "lucide-react";
+import { PageHeading, TypographyP } from "@/components/Typography";
+import { Button } from "@/components/ui/button";
+import { ChatIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illustrations/ChatIllustration";
+
+export function StepChat({ onNext }: { onNext: () => void }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
+      <div className="flex flex-col items-center text-center max-w-md">
+        <div className="mb-6 h-[240px] flex items-end justify-center">
+          <ChatIllustration />
+        </div>
+
+        <PageHeading className="mb-3">Chat with your inbox</PageHeading>
+
+        <TypographyP className="text-muted-foreground mb-8">
+          Ask questions, triage messages, and take action in natural language —
+          right here or from Slack.
+        </TypographyP>
+
+        <div className="flex flex-col gap-2 w-full max-w-xs">
+          <Button className="w-full" onClick={onNext}>
+            Continue
+            <ArrowRightIcon className="size-4 ml-2" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepDraftReplies.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepDraftReplies.tsx
@@ -13,11 +13,10 @@ export function StepDraftReplies({ onNext }: { onNext: () => void }) {
           <DraftRepliesIllustration />
         </div>
 
-        <PageHeading className="mb-3">Pre-drafted replies</PageHeading>
+        <PageHeading className="mb-3">Drafts ready to send</PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          When you check your inbox, every email needing a response will have a
-          pre-drafted reply in your tone.
+          Every email needing a reply gets a draft, written in your tone.
         </TypographyP>
 
         <div className="flex flex-col gap-2 w-full max-w-xs">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepEmailsSorted.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepEmailsSorted.tsx
@@ -13,11 +13,13 @@ export function StepEmailsSorted({ onNext }: { onNext: () => void }) {
           <EmailsSortedIllustration />
         </div>
 
-        <PageHeading className="mb-3">Emails automatically sorted</PageHeading>
+        <PageHeading className="mb-3">
+          Your inbox, automatically sorted
+        </PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          Emails are organized into categories like "To Reply", "Newsletters",
-          and "Cold Emails".
+          Every email gets a label like "To Reply", "Newsletter", or "Cold
+          Email".
         </TypographyP>
 
         <div className="flex flex-col gap-2 w-full max-w-xs">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
@@ -14,7 +14,7 @@ export function StepInboxProcessed({ onNext }: { onNext: () => void }) {
     <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
-          <EmailsSortedIllustration />
+          <EmailsSortedIllustration animated={false} />
         </div>
 
         <PageHeading className="mb-3">Labels and drafts are ready</PageHeading>

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
@@ -3,7 +3,7 @@
 import { ArrowRightIcon } from "lucide-react";
 import { PageHeading, TypographyP } from "@/components/Typography";
 import { Button } from "@/components/ui/button";
-import { InboxReadyIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illustrations/InboxReadyIllustration";
+import { EmailsSortedIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illustrations/EmailsSortedIllustration";
 import { ONBOARDING_PROCESS_EMAILS_COUNT } from "@/utils/config";
 import { usePremium } from "@/hooks/usePremium";
 
@@ -14,18 +14,17 @@ export function StepInboxProcessed({ onNext }: { onNext: () => void }) {
     <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
-          <InboxReadyIllustration />
+          <EmailsSortedIllustration />
         </div>
 
-        <PageHeading className="mb-3">Inbox Preview Ready</PageHeading>
+        <PageHeading className="mb-3">Labels and drafts are ready</PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          {`We labeled your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails and drafted replies (nothing was archived).`}
+          {`We labeled your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails and drafted replies. Nothing was archived.`}
           {!isPremium && (
             <>
               <br />
-              To have incoming emails processed automatically, you'll need to
-              upgrade.
+              Upgrade to process new emails automatically.
             </>
           )}
         </TypographyP>

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { ArrowRightIcon, UsersIcon } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
@@ -17,7 +16,7 @@ import {
 import { isValidEmail } from "@/utils/email";
 
 type InviteFormValues = {
-  emails: { value: string }[];
+  emails: { email: string }[];
 };
 
 export function StepInviteTeam({
@@ -34,60 +33,50 @@ export function StepInviteTeam({
   onSkip: () => void;
 }) {
   const posthog = usePostHog();
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const {
     register,
     handleSubmit,
     control,
     watch,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm<InviteFormValues>({
     defaultValues: {
-      emails: [{ value: "" }, { value: "" }, { value: "" }],
+      emails: [{ email: "" }, { email: "" }, { email: "" }],
     },
   });
 
-  const { fields } = useFieldArray({
-    name: "emails",
-    control,
-  });
+  const { fields } = useFieldArray({ name: "emails", control });
 
-  const watchedEmails = watch("emails");
-  const filledEmailCount = watchedEmails.filter(
-    (e) => e.value.trim().length > 0,
+  const filledEmailCount = watch("emails").filter(
+    (e) => e.email.trim().length > 0,
   ).length;
 
   const onSubmit = handleSubmit(async (data) => {
     const emails = data.emails
-      .map((e) => e.value.trim().toLowerCase())
+      .map((e) => e.email.trim().toLowerCase())
       .filter(Boolean);
 
     if (emails.length === 0) return;
 
-    setIsSubmitting(true);
+    let successCount = 0;
+    let errorCount = 0;
 
-    const captureSubmitted = (
-      successfulInvites: number,
-      failedInvites: number,
-    ) => {
-      if (successfulInvites === 0) return;
-      posthog.capture("onboarding_invite_team_submitted", {
-        variant: "onboarding",
-        inviteCount: emails.length,
-        successfulInvites,
-        failedInvites,
-        hasExistingOrganization: Boolean(organizationId),
-      });
-    };
-
-    if (!organizationId) {
+    if (organizationId) {
+      const results = await Promise.all(
+        emails.map((email) =>
+          inviteMemberAction({ email, role: "member", organizationId }),
+        ),
+      );
+      for (const result of results) {
+        if (result?.serverError || result?.validationErrors) errorCount++;
+        else successCount++;
+      }
+    } else {
       const result = await createOrganizationAndInviteAction(emailAccountId, {
         emails,
         userName,
       });
-
-      setIsSubmitting(false);
 
       if (result?.serverError || result?.validationErrors) {
         toastError({
@@ -96,62 +85,33 @@ export function StepInviteTeam({
         return;
       }
 
-      if (result?.data) {
-        const successCount = result.data.results.filter(
-          (r) => r.success,
-        ).length;
-        const errorCount = result.data.results.filter((r) => !r.success).length;
+      if (!result?.data) return;
 
-        if (successCount > 0) {
-          toastSuccess({
-            description: `${successCount} invitation${successCount > 1 ? "s" : ""} sent successfully!`,
-          });
-        }
-        if (errorCount > 0) {
-          toastError({
-            description: `Failed to send ${errorCount} invitation${errorCount > 1 ? "s" : ""}`,
-          });
-        }
-
-        captureSubmitted(successCount, errorCount);
-        onNext();
-      }
-
-      return;
+      successCount = result.data.results.filter((r) => r.success).length;
+      errorCount = result.data.results.filter((r) => !r.success).length;
     }
-
-    let successCount = 0;
-    let errorCount = 0;
-
-    for (const email of emails) {
-      const result = await inviteMemberAction({
-        email,
-        role: "member",
-        organizationId,
-      });
-
-      if (result?.serverError || result?.validationErrors) {
-        errorCount++;
-      } else {
-        successCount++;
-      }
-    }
-
-    setIsSubmitting(false);
 
     if (successCount > 0) {
       toastSuccess({
         description: `${successCount} invitation${successCount > 1 ? "s" : ""} sent successfully!`,
       });
     }
-
     if (errorCount > 0) {
       toastError({
         description: `Failed to send ${errorCount} invitation${errorCount > 1 ? "s" : ""}`,
       });
     }
 
-    captureSubmitted(successCount, errorCount);
+    if (successCount > 0) {
+      posthog.capture("onboarding_invite_team_submitted", {
+        variant: "onboarding",
+        inviteCount: emails.length,
+        successfulInvites: successCount,
+        failedInvites: errorCount,
+        hasExistingOrganization: Boolean(organizationId),
+      });
+    }
+
     onNext();
   });
 
@@ -168,18 +128,18 @@ export function StepInviteTeam({
         </TypographyP>
 
         <form onSubmit={onSubmit}>
-          <div className="mt-6 w-full mx-auto space-y-2 text-left">
+          <div className="mt-6 max-w-md mx-auto space-y-2 text-left">
             {fields.map((field, i) => (
               <Input
                 key={field.id}
                 type="email"
-                name={`emails.${i}.value`}
-                registerProps={register(`emails.${i}.value`, {
+                name={`emails.${i}.email`}
+                registerProps={register(`emails.${i}.email`, {
                   validate: (v) =>
                     !v || isValidEmail(v) || "Enter a valid email",
                 })}
                 placeholder="name@company.com"
-                error={errors.emails?.[i]?.value}
+                error={errors.emails?.[i]?.email}
               />
             ))}
           </div>

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
@@ -1,20 +1,24 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
 import { ArrowRightIcon, UsersIcon } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { PageHeading, TypographyP } from "@/components/Typography";
 import { IconCircle } from "@/app/(app)/[emailAccountId]/onboarding/IconCircle";
 import { OnboardingWrapper } from "@/app/(app)/[emailAccountId]/onboarding/OnboardingWrapper";
 import { Button } from "@/components/ui/button";
-import { TagInput } from "@/components/TagInput";
+import { Input } from "@/components/Input";
 import { toastSuccess, toastError } from "@/components/Toast";
 import {
   inviteMemberAction,
   createOrganizationAndInviteAction,
 } from "@/utils/actions/organization";
 import { isValidEmail } from "@/utils/email";
-import { BRAND_NAME } from "@/utils/branding";
+
+type InviteFormValues = {
+  emails: { value: string }[];
+};
 
 export function StepInviteTeam({
   emailAccountId,
@@ -30,15 +34,43 @@ export function StepInviteTeam({
   onSkip: () => void;
 }) {
   const posthog = usePostHog();
-  const [emails, setEmails] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleEmailsChange = useCallback((newEmails: string[]) => {
-    setEmails(newEmails.map((e) => e.toLowerCase()));
-  }, []);
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors },
+  } = useForm<InviteFormValues>({
+    defaultValues: {
+      emails: [{ value: "" }, { value: "" }, { value: "" }],
+    },
+  });
 
-  const captureInviteSubmitted = useCallback(
-    (successfulInvites: number, failedInvites: number) => {
+  const { fields } = useFieldArray({
+    name: "emails",
+    control,
+  });
+
+  const watchedEmails = watch("emails");
+  const filledEmailCount = watchedEmails.filter(
+    (e) => e.value.trim().length > 0,
+  ).length;
+
+  const onSubmit = handleSubmit(async (data) => {
+    const emails = data.emails
+      .map((e) => e.value.trim().toLowerCase())
+      .filter(Boolean);
+
+    if (emails.length === 0) return;
+
+    setIsSubmitting(true);
+
+    const captureSubmitted = (
+      successfulInvites: number,
+      failedInvites: number,
+    ) => {
       if (successfulInvites === 0) return;
       posthog.capture("onboarding_invite_team_submitted", {
         variant: "onboarding",
@@ -47,16 +79,7 @@ export function StepInviteTeam({
         failedInvites,
         hasExistingOrganization: Boolean(organizationId),
       });
-    },
-    [posthog, emails.length, organizationId],
-  );
-
-  const handleInviteAndContinue = useCallback(async () => {
-    if (emails.length === 0) {
-      return;
-    }
-
-    setIsSubmitting(true);
+    };
 
     if (!organizationId) {
       const result = await createOrganizationAndInviteAction(emailAccountId, {
@@ -90,7 +113,7 @@ export function StepInviteTeam({
           });
         }
 
-        captureInviteSubmitted(successCount, errorCount);
+        captureSubmitted(successCount, errorCount);
         onNext();
       }
 
@@ -128,9 +151,9 @@ export function StepInviteTeam({
       });
     }
 
-    captureInviteSubmitted(successCount, errorCount);
+    captureSubmitted(successCount, errorCount);
     onNext();
-  }, [emails, emailAccountId, organizationId, userName, onNext, posthog, captureInviteSubmitted]);
+  });
 
   return (
     <OnboardingWrapper className="py-0">
@@ -141,49 +164,54 @@ export function StepInviteTeam({
       <div className="text-center mt-4">
         <PageHeading>Invite your team</PageHeading>
         <TypographyP className="mt-2 max-w-lg mx-auto">
-          {`Collaborate with your team on ${BRAND_NAME}. You can always add more members later.`}
+          Add more anytime from settings.
         </TypographyP>
 
-        <TagInput
-          value={emails}
-          onChange={handleEmailsChange}
-          validate={(email) =>
-            isValidEmail(email) ? null : "Please enter a valid email address"
-          }
-          label="Email addresses"
-          id="email-input"
-          placeholder="Enter email addresses separated by commas"
-          className="mt-6 max-w-md mx-auto text-left"
-        />
+        <form onSubmit={onSubmit}>
+          <div className="mt-6 w-full mx-auto space-y-2 text-left">
+            {fields.map((field, i) => (
+              <Input
+                key={field.id}
+                type="email"
+                name={`emails.${i}.value`}
+                registerProps={register(`emails.${i}.value`, {
+                  validate: (v) =>
+                    !v || isValidEmail(v) || "Enter a valid email",
+                })}
+                placeholder="name@company.com"
+                error={errors.emails?.[i]?.value}
+              />
+            ))}
+          </div>
 
-        <div className="flex flex-col gap-2 w-full max-w-xs mx-auto mt-6">
-          <Button
-            type="button"
-            className="w-full"
-            onClick={handleInviteAndContinue}
-            loading={isSubmitting}
-            disabled={emails.length === 0}
-          >
-            Invite & Continue
-            <ArrowRightIcon className="size-4 ml-2" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            className="w-full"
-            onClick={() => {
-              posthog.capture("onboarding_invite_team_skipped", {
-                variant: "onboarding",
-                inviteCount: emails.length,
-                hasExistingOrganization: Boolean(organizationId),
-              });
-              onSkip();
-            }}
-            disabled={isSubmitting}
-          >
-            Skip
-          </Button>
-        </div>
+          <div className="flex flex-col gap-2 w-full max-w-xs mx-auto mt-6">
+            <Button
+              type="submit"
+              className="w-full"
+              loading={isSubmitting}
+              disabled={filledEmailCount === 0}
+            >
+              Send invites
+              <ArrowRightIcon className="size-4 ml-2" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              onClick={() => {
+                posthog.capture("onboarding_invite_team_skipped", {
+                  variant: "onboarding",
+                  inviteCount: filledEmailCount,
+                  hasExistingOrganization: Boolean(organizationId),
+                });
+                onSkip();
+              }}
+              disabled={isSubmitting}
+            >
+              Skip
+            </Button>
+          </div>
+        </form>
       </div>
     </OnboardingWrapper>
   );

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepWelcome.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepWelcome.tsx
@@ -23,10 +23,10 @@ export function StepWelcome({ onNext }: { onNext: () => void }) {
           </motion.div>
         </div>
 
-        <PageHeading className="mb-3">{`Welcome to ${BRAND_NAME}`}</PageHeading>
+        <PageHeading className="mb-3">{`Get to know ${BRAND_NAME}`}</PageHeading>
 
         <TypographyP className="text-muted-foreground mb-8">
-          {`Here's a quick look at what ${BRAND_NAME} can do for you.`}
+          A quick tour before we set you up.
         </TypographyP>
 
         <div className="flex flex-col gap-2 w-full max-w-xs">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/ChatIllustration.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/ChatIllustration.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Mail, Sparkles } from "lucide-react";
+import { Mail } from "lucide-react";
 
 const EASE = [0.25, 0.46, 0.45, 0.94] as const;
 
@@ -21,11 +21,8 @@ export function ChatIllustration() {
         initial={{ opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.4, delay: 0.7, ease: EASE }}
-        className="flex items-start gap-2 self-start max-w-[85%]"
+        className="self-start max-w-[85%]"
       >
-        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-blue-500">
-          <Sparkles className="h-3 w-3 text-white" />
-        </div>
         <div className="rounded-2xl rounded-tl-sm border border-gray-200 bg-white px-3 py-2 text-left shadow-sm dark:border-gray-700 dark:bg-slate-800">
           <div className="text-[11px] leading-snug text-gray-800 dark:text-gray-200">
             Found 12 newsletters from last week. Archiving now.
@@ -53,8 +50,9 @@ export function ChatIllustration() {
         className="mt-2 flex items-center justify-center gap-1.5 self-center rounded-full border border-gray-200 bg-white px-2.5 py-1 shadow-sm dark:border-gray-700 dark:bg-slate-800"
       >
         <SlackIcon className="h-3 w-3" />
+        <TelegramIcon className="h-3 w-3" />
         <span className="text-[10px] font-medium text-gray-700 dark:text-gray-300">
-          Also available in Slack
+          Also in Slack and Telegram
         </span>
       </motion.div>
     </div>
@@ -84,6 +82,23 @@ function SlackIcon({ className }: { className?: string }) {
       <path
         fill="#ECB22E"
         d="M15.161 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.161 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.272a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.317A2.527 2.527 0 0 1 24 15.161a2.528 2.528 0 0 1-2.522 2.523h-6.317z"
+      />
+    </svg>
+  );
+}
+
+function TelegramIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="12" fill="#2AABEE" />
+      <path
+        fill="#fff"
+        d="M5.491 11.74l11.57-4.461c.537-.194 1.006.131.832.943l.001-.001-1.97 9.281c-.146.658-.537.818-1.084.508l-3-2.211-1.447 1.394c-.16.16-.295.295-.605.295l.213-3.053 5.56-5.023c.242-.213-.054-.334-.373-.121l-6.871 4.326-2.962-.924c-.643-.204-.657-.643.136-.953z"
       />
     </svg>
   );

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/ChatIllustration.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/ChatIllustration.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Mail, Sparkles } from "lucide-react";
+
+const EASE = [0.25, 0.46, 0.45, 0.94] as const;
+
+export function ChatIllustration() {
+  return (
+    <div className="flex h-[240px] w-full max-w-[360px] sm:w-[400px] sm:max-w-none flex-col justify-center gap-2">
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.4, ease: EASE }}
+        className="self-end max-w-[80%] rounded-2xl rounded-br-sm bg-blue-600 px-3 py-2 text-left text-[11px] leading-snug text-white shadow-sm"
+      >
+        Archive all newsletters from last week
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.4, delay: 0.7, ease: EASE }}
+        className="flex items-start gap-2 self-start max-w-[85%]"
+      >
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-blue-500">
+          <Sparkles className="h-3 w-3 text-white" />
+        </div>
+        <div className="rounded-2xl rounded-tl-sm border border-gray-200 bg-white px-3 py-2 text-left shadow-sm dark:border-gray-700 dark:bg-slate-800">
+          <div className="text-[11px] leading-snug text-gray-800 dark:text-gray-200">
+            Found 12 newsletters from last week. Archiving now.
+          </div>
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            transition={{ duration: 0.3, delay: 1.5 }}
+            className="overflow-hidden"
+          >
+            <div className="mt-2 flex items-center gap-1.5 rounded-md bg-slate-50 px-2 py-1 dark:bg-slate-900">
+              <Mail className="h-3 w-3 text-gray-500" />
+              <span className="text-[10px] text-gray-600 dark:text-gray-400">
+                12 emails archived
+              </span>
+            </div>
+          </motion.div>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 2.1, ease: EASE }}
+        className="mt-2 flex items-center justify-center gap-1.5 self-center rounded-full border border-gray-200 bg-white px-2.5 py-1 shadow-sm dark:border-gray-700 dark:bg-slate-800"
+      >
+        <SlackIcon className="h-3 w-3" />
+        <span className="text-[10px] font-medium text-gray-700 dark:text-gray-300">
+          Also available in Slack
+        </span>
+      </motion.div>
+    </div>
+  );
+}
+
+function SlackIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        fill="#E01E5A"
+        d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z"
+      />
+      <path
+        fill="#36C5F0"
+        d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z"
+      />
+      <path
+        fill="#2EB67D"
+        d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.272 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.161 0a2.528 2.528 0 0 1 2.523 2.522v6.312z"
+      />
+      <path
+        fill="#ECB22E"
+        d="M15.161 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.161 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.272a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.317A2.527 2.527 0 0 1 24 15.161a2.528 2.528 0 0 1-2.522 2.523h-6.317z"
+      />
+    </svg>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/EmailsSortedIllustration.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/EmailsSortedIllustration.tsx
@@ -34,10 +34,18 @@ const emails = [
   },
 ];
 
-export function EmailsSortedIllustration() {
-  const [showLabels, setShowLabels] = useState([false, false, false]);
+export function EmailsSortedIllustration({
+  animated = true,
+}: {
+  animated?: boolean;
+}) {
+  const [showLabels, setShowLabels] = useState(() =>
+    animated ? [false, false, false] : [true, true, true],
+  );
 
   useEffect(() => {
+    if (!animated) return;
+
     const labelDelays = [1200, 1800, 2400];
     const timeouts: NodeJS.Timeout[] = [];
 
@@ -54,14 +62,14 @@ export function EmailsSortedIllustration() {
     });
 
     return () => timeouts.forEach(clearTimeout);
-  }, []);
+  }, [animated]);
 
   return (
     <div className="flex h-[200px] w-full max-w-[360px] flex-col justify-center gap-2 sm:w-[420px] sm:max-w-none">
       {emails.map((email, index) => (
         <motion.div
           key={email.id}
-          initial={{ opacity: 0, x: -20 }}
+          initial={animated ? { opacity: 0, x: -20 } : false}
           animate={{ opacity: 1, x: 0 }}
           transition={{
             duration: 0.5,
@@ -83,7 +91,7 @@ export function EmailsSortedIllustration() {
 
           <div className="flex h-5 shrink-0 items-center px-2 ml-auto sm:ml-0">
             <motion.span
-              initial={{ opacity: 0, scale: 0.8 }}
+              initial={animated ? { opacity: 0, scale: 0.8 } : false}
               animate={{
                 opacity: showLabels[index] ? 1 : 0,
                 scale: showLabels[index] ? 1 : 0.8,

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
@@ -16,9 +16,9 @@ describe("getVisibleOnboardingStepKeys", () => {
     ).toEqual([
       STEP_KEYS.WELCOME,
       STEP_KEYS.EMAILS_SORTED,
+      STEP_KEYS.CHAT,
       STEP_KEYS.DRAFT_REPLIES,
       STEP_KEYS.BULK_UNSUBSCRIBE,
-      STEP_KEYS.FEATURES,
       STEP_KEYS.WHO,
       STEP_KEYS.COMPANY_SIZE,
       STEP_KEYS.HOW_YOU_HEARD,
@@ -39,8 +39,8 @@ describe("getVisibleOnboardingStepKeys", () => {
     ).toEqual([
       STEP_KEYS.WELCOME,
       STEP_KEYS.EMAILS_SORTED,
+      STEP_KEYS.CHAT,
       STEP_KEYS.BULK_UNSUBSCRIBE,
-      STEP_KEYS.FEATURES,
       STEP_KEYS.WHO,
       STEP_KEYS.COMPANY_SIZE,
       STEP_KEYS.HOW_YOU_HEARD,

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
@@ -2,6 +2,7 @@ import { prefixPath } from "@/utils/path";
 
 export const STEP_KEYS = {
   WELCOME: "welcome",
+  CHAT: "chat",
   EMAILS_SORTED: "emailsSorted",
   DRAFT_REPLIES: "draftReplies",
   BULK_UNSUBSCRIBE: "bulkUnsubscribe",
@@ -21,9 +22,10 @@ export type StepKey = (typeof STEP_KEYS)[keyof typeof STEP_KEYS];
 const onboardingStepOrder: readonly StepKey[] = [
   STEP_KEYS.WELCOME,
   STEP_KEYS.EMAILS_SORTED,
+  STEP_KEYS.CHAT,
   STEP_KEYS.DRAFT_REPLIES,
   STEP_KEYS.BULK_UNSUBSCRIBE,
-  STEP_KEYS.FEATURES,
+  // STEP_KEYS.FEATURES,
   STEP_KEYS.WHO,
   STEP_KEYS.COMPANY_SIZE,
   STEP_KEYS.HOW_YOU_HEARD,

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -23,7 +23,7 @@ import {
   type Tier,
   tiers,
 } from "@/app/(app)/premium/config";
-import { AlertBasic, AlertWithButton } from "@/components/Alert";
+import { AlertBasic } from "@/components/Alert";
 import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { toastError } from "@/components/Toast";
 import {
@@ -125,35 +125,12 @@ export default function Pricing(props: PricingProps) {
             <ManageSubscription premium={premium ?? null} />
 
             {userPremiumTier && (
-              <>
-                <Button className="ml-2" asChild>
-                  <Link href="/setup">
-                    <SparklesIcon className="mr-2 h-4 w-4" />
-                    Go to app
-                  </Link>
-                </Button>
-                <div className="mx-auto mt-4 max-w-md">
-                  {userPremiumTier === "STARTER_MONTHLY" ||
-                  userPremiumTier === "STARTER_ANNUALLY" ||
-                  userPremiumTier === "PLUS_MONTHLY" ||
-                  userPremiumTier === "PLUS_ANNUALLY" ? (
-                    <AlertWithButton
-                      className="bg-background"
-                      variant="blue"
-                      title="Need multiple accounts?"
-                      description="Individual plans are designed for single users. Contact our support team for custom pricing on multiple accounts."
-                      icon={null}
-                      button={
-                        <div className="ml-4 whitespace-nowrap">
-                          <Button asChild>
-                            <Link href="/support">Contact Support</Link>
-                          </Button>
-                        </div>
-                      }
-                    />
-                  ) : null}
-                </div>
-              </>
+              <Button className="ml-2" asChild>
+                <Link href="/setup">
+                  <SparklesIcon className="mr-2 h-4 w-4" />
+                  Go to app
+                </Link>
+              </Button>
             )}
 
             {hasActiveAppleManagedSubscription && (
@@ -195,25 +172,23 @@ export default function Pricing(props: PricingProps) {
               : "max-w-7xl lg:mx-0 lg:max-w-none lg:grid-cols-3",
           )}
         >
-          {displayedTiers.map((tier) => {
-            return (
-              <PriceTier
-                key={tier.name}
-                tier={tier}
-                userPremiumTier={userPremiumTier}
-                frequency={frequency}
-                stripeSubscriptionId={premium?.stripeSubscriptionId}
-                stripeSubscriptionStatus={premium?.stripeSubscriptionStatus}
-                hasActiveAppleManagedSubscription={
-                  hasActiveAppleManagedSubscription
-                }
-                isLoggedIn={isLoggedIn}
-                router={router}
-                userId={data?.id}
-                pricingSource={pricingSource}
-              />
-            );
-          })}
+          {displayedTiers.map((tier) => (
+            <PriceTier
+              key={tier.name}
+              tier={tier}
+              userPremiumTier={userPremiumTier}
+              frequency={frequency}
+              stripeSubscriptionId={premium?.stripeSubscriptionId}
+              stripeSubscriptionStatus={premium?.stripeSubscriptionStatus}
+              hasActiveAppleManagedSubscription={
+                hasActiveAppleManagedSubscription
+              }
+              isLoggedIn={isLoggedIn}
+              router={router}
+              userId={data?.id}
+              pricingSource={pricingSource}
+            />
+          ))}
         </div>
       </div>
     </LoadingContent>

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { after } from "next/server";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
 import {
   createOrganizationBody,
@@ -172,14 +173,16 @@ export const handleInvitationAction = actionClientUser
 
     await acceptInvitation({ emailAccountId, invitationId });
 
-    await posthogCaptureEvent(
-      invitation.email,
-      "organization_invitation_accepted",
-      {
-        organizationId: invitation.organizationId,
-        role: invitation.role,
-        inviterId: invitation.inviterId,
-      },
+    after(() =>
+      posthogCaptureEvent(
+        invitation.email,
+        "organization_invitation_accepted",
+        {
+          organizationId: invitation.organizationId,
+          role: invitation.role,
+          inviterId: invitation.inviterId,
+        },
+      ),
     );
 
     return { organizationId: invitation.organizationId };

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -22,6 +22,7 @@ import {
 } from "@/utils/premium/seats";
 import { env } from "@/env";
 import { slugify } from "@/utils/string";
+import { posthogCaptureEvent } from "@/utils/posthog";
 
 export const createOrganizationAction = actionClient
   .metadata({ name: "createOrganization" })
@@ -170,6 +171,16 @@ export const handleInvitationAction = actionClientUser
     const emailAccountId = emailAccount.id;
 
     await acceptInvitation({ emailAccountId, invitationId });
+
+    await posthogCaptureEvent(
+      invitation.email,
+      "organization_invitation_accepted",
+      {
+        organizationId: invitation.organizationId,
+        role: invitation.role,
+        inviterId: invitation.inviterId,
+      },
+    );
 
     return { organizationId: invitation.organizationId };
   });
@@ -537,7 +548,7 @@ export const createOrganizationAndInviteAction = actionClient
   );
 
 function getRandomId(): string {
-  return Math.random().toString(36).substring(2, 8);
+  return Math.random().toString(36).slice(2, 8);
 }
 
 async function generateUniqueSlug(baseSlug: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Adds a new "Chat with your inbox" showcase step to onboarding (position 3, after Emails Sorted), highlighting the chat feature and its Slack availability
- Comments out the multi-select "How would you like to use Inbox Zero?" features step — keeps all wiring intact so it can be restored with a one-line uncomment
- New illustration uses framer-motion `delay` staging (no render-thrashing state)

## Test plan
- [ ] Walk through onboarding end-to-end; verify order is Welcome → Emails Sorted → Chat → Draft Replies → Bulk Unsubscribe → Who → ...
- [ ] Confirm the features selection screen no longer appears
- [ ] Verify chat illustration animates (user bubble → AI reply → action chip → Slack pill)
- [ ] Check layout on narrow viewport (~360px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)