### PR TITLE
fix(#2231): replace discriminatedUnion with flat object schema in saveMemory

### DIFF
--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -88,7 +88,7 @@ const saveMemoryToolInputSchema = z
     source: z
       .enum(["user_message", "assistant_inference"])
       .describe(
-        'Use "user_message" when the user directly states a fact or preference. Use "assistant_inference" for details inferred by the assistant.',
+        'Use "user_message" when the user directly states a fact or preference — userEvidence is required in this case. Use "assistant_inference" for details inferred by the assistant — userEvidence is optional.',
       ),
     userEvidence: z
       .string()

--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -82,22 +82,32 @@ const memoryContentSchema = z
   .max(1000)
   .describe("The memory content to save.");
 
-const saveMemoryToolInputSchema = z.object({
-  content: memoryContentSchema,
-  source: z
-    .enum(["user_message", "assistant_inference"])
-    .describe(
-      'Use "user_message" when the user directly states a fact or preference. Use "assistant_inference" for details inferred by the assistant.',
-    ),
-  userEvidence: z
-    .string()
-    .trim()
-    .max(500)
-    .optional()
-    .describe(
-      'A short exact quote from a user-authored chat message. Required when source is "user_message".',
-    ),
-});
+const saveMemoryToolInputSchema = z
+  .object({
+    content: memoryContentSchema,
+    source: z
+      .enum(["user_message", "assistant_inference"])
+      .describe(
+        'Use "user_message" when the user directly states a fact or preference. Use "assistant_inference" for details inferred by the assistant.',
+      ),
+    userEvidence: z
+      .string()
+      .trim()
+      .max(500)
+      .optional()
+      .describe(
+        'A short exact quote from a user-authored chat message. Required when source is "user_message".',
+      ),
+  })
+  .superRefine((val, ctx) => {
+    if (val.source === "user_message" && !val.userEvidence) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "userEvidence is required when source is user_message",
+        path: ["userEvidence"],
+      });
+    }
+  });
 
 export const saveMemoryTool = ({
   email,

--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -82,36 +82,22 @@ const memoryContentSchema = z
   .max(1000)
   .describe("The memory content to save.");
 
-const userEvidenceSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .max(500)
-  .describe("A short exact quote from a user-authored chat message.");
-
-const saveMemoryToolInputSchema = z.discriminatedUnion("source", [
-  z.object({
-    content: memoryContentSchema,
-    source: z
-      .literal("user_message")
-      .describe("The memory content came from a user-authored chat message."),
-    userEvidence: userEvidenceSchema,
-  }),
-  z.object({
-    content: memoryContentSchema,
-    source: z
-      .literal("assistant_inference")
-      .describe(
-        "The memory content was inferred by the assistant and requires confirmation before saving.",
-      ),
-    userEvidence: z
-      .string()
-      .trim()
-      .max(500)
-      .optional()
-      .describe("Optional supporting quote when available."),
-  }),
-]);
+const saveMemoryToolInputSchema = z.object({
+  content: memoryContentSchema,
+  source: z
+    .enum(["user_message", "assistant_inference"])
+    .describe(
+      'Use "user_message" when the user directly states a fact or preference. Use "assistant_inference" for details inferred by the assistant.',
+    ),
+  userEvidence: z
+    .string()
+    .trim()
+    .max(500)
+    .optional()
+    .describe(
+      'A short exact quote from a user-authored chat message. Required when source is "user_message".',
+    ),
+});
 
 export const saveMemoryTool = ({
   email,


### PR DESCRIPTION
## Summary

- `saveMemoryTool` used `z.discriminatedUnion` which serializes to `{ anyOf: [...] }` — no top-level `type: "object"`
- OpenAI's function-calling API rejects this with a 400: "schema must be a JSON Schema of 'type: \"object\"'"
- Anthropic is permissive and accepted it, so the bug only surfaced on OpenAI
- Replaced with a flat `z.object` using `z.enum` for `source` and `optional` `userEvidence`; runtime enforcement is unchanged in `execute()` via `validateUserMemoryEvidence`

Fixes #2231

## Test plan
- [x] All 49 existing `__tests__/ai-assistant-chat.test.ts` tests pass
- [x] Manual smoke test: set OpenAI key in Settings → AI, send a chat message — should respond without 400
