### PR TITLE
fix: extract JSON from prose-wrapped LLM responses

### DIFF
--- a/apps/web/app/api/outlook/webhook/process-lifecycle.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-lifecycle.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import prisma from "@/utils/prisma";
 import { getWebhookEmailAccount } from "@/utils/webhook/validate-webhook-account";
@@ -29,6 +37,15 @@ vi.mock("@/utils/outlook/backfill-recent-messages", () => ({
 
 describe("processOutlookLifecycleNotification", () => {
   const logger = createTestLogger();
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-16T11:30:00.000Z"));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -157,6 +157,36 @@ describe("createGenerateObject repairText", () => {
     expect(JSON.parse(repaired)).toEqual({ category: "updates" });
   });
 
+  it("extracts JSON object when text has a prose preamble", async () => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({
+      text: 'Here is the answer: {"foo":"bar"}',
+    });
+
+    expect(JSON.parse(repaired)).toEqual({ foo: "bar" });
+  });
+
+  it("extracts JSON array when text has a prose preamble and trailing text", async () => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({
+      text: 'The JSON is: [{"a":1},{"a":2}] and more',
+    });
+
+    expect(JSON.parse(repaired)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it("extracts nested JSON object when surrounded by prose", async () => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({
+      text: 'Sure! {"category": "updates", "nested": {"x": 1}} thanks',
+    });
+
+    expect(JSON.parse(repaired)).toEqual({
+      category: "updates",
+      nested: { x: 1 },
+    });
+  });
+
   it("injects centralized hardening into the object generation system prompt", async () => {
     const generateObject = await createTestGenerateObject();
 

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -175,6 +175,24 @@ describe("createGenerateObject repairText", () => {
     expect(JSON.parse(repaired)).toEqual([{ a: 1 }, { a: 2 }]);
   });
 
+  it("skips bracketed prose tokens and extracts the actual JSON payload", async () => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({
+      text: 'Step [1]: here is the JSON {"foo":"bar"}',
+    });
+
+    expect(JSON.parse(repaired)).toEqual({ foo: "bar" });
+  });
+
+  it("extracts the longer balanced array when brackets also appear in prose", async () => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({
+      text: "[note] The result: [1,2,3,4]",
+    });
+
+    expect(JSON.parse(repaired)).toEqual([1, 2, 3, 4]);
+  });
+
   it("extracts nested JSON object when surrounded by prose", async () => {
     const repairText = await getRepairText();
     const repaired = await repairText({

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -76,7 +76,7 @@ const NO_USER_AI_FIELDS: UserAIFields = {
 };
 
 type LLMProviderOptions = Record<string, Record<string, JSONValue>>;
-type RepairCandidateKind = "original" | "trimmed" | "unwrapped";
+type RepairCandidateKind = "original" | "trimmed" | "unwrapped" | "extracted";
 type RepairResultKind = "object-or-array" | "string-wrapped-object-or-array";
 type RepairAttemptState = {
   inputLength: number;
@@ -1217,12 +1217,61 @@ function repairObjectText(text: string, label: string) {
 function getRepairCandidates(text: string) {
   const trimmed = text.trim();
   const unwrapped = unwrapQuotedJson(trimmed);
+  const extracted = extractBalancedJson(trimmed);
 
   return dedupeRepairCandidates([
     { kind: "unwrapped", text: unwrapped },
+    { kind: "extracted", text: extracted },
     { kind: "trimmed", text: trimmed },
     { kind: "original", text },
   ]);
+}
+
+function extractBalancedJson(text: string): string | undefined {
+  const openIdx = text.search(/[{[]/);
+  if (openIdx === -1) return;
+
+  const openChar = text[openIdx];
+  const closeChar = openChar === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let stringChar: string | undefined;
+  let escaped = false;
+
+  for (let i = openIdx; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (inString) {
+      if (ch === "\\") {
+        escaped = true;
+      } else if (ch === stringChar) {
+        inString = false;
+        stringChar = undefined;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inString = true;
+      stringChar = ch;
+      continue;
+    }
+
+    if (ch === "{" || ch === "[") {
+      depth++;
+    } else if (ch === "}" || ch === "]") {
+      depth--;
+      if (depth === 0) {
+        if (ch !== closeChar) return;
+        return text.slice(openIdx, i + 1);
+      }
+    }
+  }
 }
 
 function unwrapQuotedJson(text: string) {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -1217,20 +1217,47 @@ function repairObjectText(text: string, label: string) {
 function getRepairCandidates(text: string) {
   const trimmed = text.trim();
   const unwrapped = unwrapQuotedJson(trimmed);
-  const extracted = extractBalancedJson(trimmed);
+  const extracted = extractBalancedJsonRegions(trimmed);
 
   return dedupeRepairCandidates([
     { kind: "unwrapped", text: unwrapped },
-    { kind: "extracted", text: extracted },
+    ...extracted.map((region) => ({
+      kind: "extracted" as const,
+      text: region,
+    })),
     { kind: "trimmed", text: trimmed },
     { kind: "original", text },
   ]);
 }
 
-function extractBalancedJson(text: string): string | undefined {
-  const openIdx = text.search(/[{[]/);
-  if (openIdx === -1) return;
+function extractBalancedJsonRegions(text: string): string[] {
+  const regions: string[] = [];
+  let i = 0;
 
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "{" || ch === "[") {
+      const region = walkBalancedJsonFrom(text, i);
+      if (region) {
+        regions.push(region);
+        i += region.length;
+        continue;
+      }
+    }
+    i++;
+  }
+
+  return regions.sort((a, b) => {
+    if (a.length !== b.length) return b.length - a.length;
+    if (a[0] === b[0]) return 0;
+    return a[0] === "{" ? -1 : 1;
+  });
+}
+
+function walkBalancedJsonFrom(
+  text: string,
+  openIdx: number,
+): string | undefined {
   const openChar = text[openIdx];
   const closeChar = openChar === "{" ? "}" : "]";
   let depth = 0;


### PR DESCRIPTION
## Summary
- Object generation repair now tries a balanced JSON substring candidate, so prose preambles or trailing text around a JSON object/array no longer cause `NoObjectGeneratedError`.
- Adds regression tests covering preambles, trailing text, and nested structures.

## Test plan
- [x] `pnpm test utils/llms/`