### PR TITLE
billing: store Stripe trial conversion timestamp

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,79 @@
+import type Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+import { getStripeTrialConvertedAt } from "./trial-conversion";
+
+describe("getStripeTrialConvertedAt", () => {
+  it("returns the event timestamp when a trial converts to active", () => {
+    const event = subscriptionEvent({
+      created: 1_700_000_000,
+      data: {
+        object: {
+          status: "active",
+          trial_end: 1_699_999_000,
+        },
+        previous_attributes: {
+          status: "trialing",
+        },
+      },
+    });
+
+    expect(getStripeTrialConvertedAt(event)).toEqual(
+      new Date("2023-11-14T22:13:20.000Z"),
+    );
+  });
+
+  it("returns null when the subscription did not transition from trialing", () => {
+    const event = subscriptionEvent({
+      data: {
+        object: {
+          status: "active",
+          trial_end: 1_699_999_000,
+        },
+        previous_attributes: {
+          status: "incomplete",
+        },
+      },
+    });
+
+    expect(getStripeTrialConvertedAt(event)).toBeNull();
+  });
+
+  it("returns null when the trial has not ended yet", () => {
+    const event = subscriptionEvent({
+      created: 1_700_000_000,
+      data: {
+        object: {
+          status: "active",
+          trial_end: 1_700_000_100,
+        },
+        previous_attributes: {
+          status: "trialing",
+        },
+      },
+    });
+
+    expect(getStripeTrialConvertedAt(event)).toBeNull();
+  });
+});
+
+function subscriptionEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
+  return {
+    id: "evt_test",
+    type: "customer.subscription.updated",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "sub_test",
+        status: "trialing",
+        trial_end: null,
+      },
+      previous_attributes: {},
+    },
+    ...overrides,
+  } as Stripe.Event;
+}

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -8,6 +8,7 @@ import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
 import { getStripeTrialStartedProperties } from "@/ee/billing/stripe/posthog-events";
 import { syncAiGenerationOverageForUpcomingInvoice } from "@/ee/billing/stripe/ai-overage";
 import { env } from "@/env";
+import { getStripeTrialConvertedAt } from "./trial-conversion";
 import {
   trackBillingTrialStarted,
   trackStripeEvent,
@@ -130,38 +131,45 @@ async function handleReferralCompletion(
   event: Stripe.Event,
   logger: Logger,
 ) {
-  // Only process subscription updates
-  if (event.type !== "customer.subscription.updated") return;
+  const trialConvertedAt = getStripeTrialConvertedAt(event);
+  if (!trialConvertedAt) return;
 
-  const subscription = event.data.object as Stripe.Subscription;
-  const previousAttributes = event.data
-    .previous_attributes as Partial<Stripe.Subscription>;
-
-  // Check if this is a trial that just converted to active
-  const isTrialConversion =
-    previousAttributes.status === "trialing" &&
-    subscription.status === "active" &&
-    subscription.trial_end &&
-    subscription.trial_end < Math.floor(Date.now() / 1000);
-
-  if (!isTrialConversion) return;
-
-  // Find the user associated with this customer
   const premium = await prisma.premium.findUnique({
     where: { stripeCustomerId: customerId },
-    select: { users: { select: { id: true } } },
+    select: { id: true, users: { select: { id: true } } },
   });
 
-  const userIds = premium?.users.map((user) => user.id);
-  if (!userIds) {
+  if (!premium) {
     logger.warn("No user found for customer during referral completion", {
       customerId,
     });
     return;
   }
 
+  const updateResult = await prisma.premium.updateMany({
+    where: {
+      id: premium.id,
+      stripeTrialConvertedAt: null,
+    },
+    data: {
+      stripeTrialConvertedAt: trialConvertedAt,
+    },
+  });
+
+  if (updateResult.count === 0) return;
+
+  const userIds = premium.users.map((user) => user.id);
+  if (userIds.length === 0) {
+    logger.warn("No users linked to premium during referral completion", {
+      customerId,
+      premiumId: premium.id,
+    });
+    return;
+  }
+
   logger.info("Trial converted to paid subscription, completing referral", {
     customerId,
+    trialConvertedAt,
     userIds,
   });
 

--- a/apps/web/app/api/stripe/webhook/trial-conversion.ts
+++ b/apps/web/app/api/stripe/webhook/trial-conversion.ts
@@ -1,0 +1,19 @@
+import type Stripe from "stripe";
+
+export function getStripeTrialConvertedAt(event: Stripe.Event) {
+  if (event.type !== "customer.subscription.updated") return null;
+
+  const subscription = event.data.object as Stripe.Subscription;
+  const previousAttributes = event.data
+    .previous_attributes as Partial<Stripe.Subscription>;
+
+  const isTrialConversion =
+    previousAttributes.status === "trialing" &&
+    subscription.status === "active" &&
+    subscription.trial_end &&
+    subscription.trial_end < event.created;
+
+  if (!isTrialConversion) return null;
+
+  return new Date(event.created * 1000);
+}

--- a/apps/web/prisma/migrations/20260419104529_add_stripe_trial_converted_at/migration.sql
+++ b/apps/web/prisma/migrations/20260419104529_add_stripe_trial_converted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Premium" ADD COLUMN     "stripeTrialConvertedAt" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -375,6 +375,7 @@ model Premium {
   stripeCancelAtPeriodEnd      Boolean? // If true, the subscription is set to cancel automatically at the end of the current billing period, rather than renew.
   stripeRenewsAt               DateTime? // Timestamp for when the current billing period ends and the subscription attempts renewal (if not canceling). Derived from `current_period_end`.
   stripeTrialEnd               DateTime? // Timestamp for when the free trial period ends (if applicable). Important for managing trial-to-paid transitions.
+  stripeTrialConvertedAt       DateTime? // Timestamp for when a Stripe trial converted from `trialing` to `active`. Historical data.
   stripeCanceledAt             DateTime? // Timestamp for when the subscription was definitively marked as canceled in Stripe (might be immediate or after period end). Historical data.
   stripeEndedAt                DateTime? // Timestamp for when the subscription ended permanently for any reason (cancellation, final payment failure). Historical data.
   stripeAiOverageLastInvoiceId String?


### PR DESCRIPTION
Store an exact Stripe trial conversion timestamp on `Premium` so trial-to-paid timing is queryable from SQL.

- add `Premium.stripeTrialConvertedAt` with a Prisma migration
- set it from `customer.subscription.updated` when Stripe moves a trial to `active`
- keep the webhook path idempotent and cover the conversion detection with tests