### PR TITLE
analytics: track first-time activation events; drop unused onboarding column

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse, after } from "next/server";
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -5,8 +6,8 @@ import {
   type UIMessage,
 } from "ai";
 import { withEmailAccount } from "@/utils/middleware";
+import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { getEmailAccountWithAi } from "@/utils/user/get";
-import { NextResponse } from "next/server";
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
@@ -88,6 +89,13 @@ export const POST = withEmailAccount("chat", async (request) => {
     role: "user",
     parts: message.parts,
   });
+
+  after(() =>
+    trackFirstTimeEvent({
+      emailAccountId,
+      event: FIRST_TIME_EVENTS.FIRST_CHAT_MESSAGE,
+    }),
+  );
 
   const latestCompaction = chat.compactions[0];
 

--- a/apps/web/prisma/migrations/20260419120000_drop_completed_app_onboarding_at/migration.sql
+++ b/apps/web/prisma/migrations/20260419120000_drop_completed_app_onboarding_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" DROP COLUMN "completedAppOnboardingAt";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -65,14 +65,13 @@ model User {
   sessions      Session[]
 
   // additional fields
-  completedOnboardingAt    DateTime? // questions about the user. e.g. their role
-  completedAppOnboardingAt DateTime? // how to use the app
-  onboardingAnswers        Json?
-  lastLogin                DateTime?
-  utms                     Json?
-  errorMessages            Json? // eg. user set incorrect AI API key
-  announcementDismissedAt  DateTime?
-  dismissedHints           String[]  @default([])
+  completedOnboardingAt   DateTime? // questions about the user. e.g. their role
+  onboardingAnswers       Json?
+  lastLogin               DateTime?
+  utms                    Json?
+  errorMessages           Json? // eg. user set incorrect AI API key
+  announcementDismissedAt DateTime?
+  dismissedHints          String[]  @default([])
 
   // survey answers (extracted from onboardingAnswers for easier querying)
   surveyFeatures     String[] // multiple choice: features user is interested in

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -25,6 +25,7 @@ import { sanitizeActionFields } from "@/utils/action-item";
 import { extractEmailAddress } from "@/utils/email";
 import { filterNullProperties } from "@/utils";
 import { analyzeSenderPattern } from "@/app/api/ai/analyze-sender-pattern/call-analyze-pattern-api";
+import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import {
   scheduleDelayedActions,
   cancelScheduledActions,
@@ -437,6 +438,13 @@ async function executeMatchedRule(
         include: { actionItems: true },
       }),
     { logger },
+  );
+
+  after(() =>
+    trackFirstTimeEvent({
+      emailAccountId: emailAccount.id,
+      event: FIRST_TIME_EVENTS.FIRST_AUTOMATED_RULE_RUN,
+    }),
   );
 
   if (rule.systemType === SystemType.COLD_EMAIL) {

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -3,6 +3,8 @@ import type { Properties } from "posthog-js";
 import { env } from "@/env";
 import { createScopedLogger } from "@/utils/logger";
 import { hash } from "@/utils/hash";
+import prisma from "@/utils/prisma";
+import { redis } from "@/utils/redis";
 
 const logger = createScopedLogger("posthog");
 let posthogLlmClient: PostHog | undefined;
@@ -344,6 +346,56 @@ export async function trackStripeEvent(email: string, data: any) {
 
 export async function trackUserDeleted(userId: string) {
   return posthogCaptureEvent("anonymous", "User deleted", { userId }, false);
+}
+
+export const FIRST_TIME_EVENTS = {
+  FIRST_AUTOMATED_RULE_RUN: "First automated rule run",
+  FIRST_DRAFT_SENT: "First AI draft sent",
+  FIRST_CHAT_MESSAGE: "First chat message",
+} as const;
+
+type FirstTimeEvent =
+  (typeof FIRST_TIME_EVENTS)[keyof typeof FIRST_TIME_EVENTS];
+
+const FIRST_TIME_EVENT_TTL_SECONDS = 60 * 60 * 24 * 180; // 180 days
+
+/**
+ * Fire a PostHog event the first time it's seen for an emailAccount.
+ * Dedupe via Redis SETNX, so PostHog receives at most one event per account
+ * per milestone. Distinct ID is the User.email so the event attaches to the
+ * same PostHog person as signup/survey/billing events.
+ */
+export async function trackFirstTimeEvent({
+  emailAccountId,
+  event,
+  properties,
+}: {
+  emailAccountId: string;
+  event: FirstTimeEvent;
+  properties?: Record<string, unknown>;
+}) {
+  try {
+    const key = `first-event:${emailAccountId}:${event}`;
+    const firstTime = await redis.set(key, "1", {
+      nx: true,
+      ex: FIRST_TIME_EVENT_TTL_SECONDS,
+    });
+    if (!firstTime) return;
+
+    const emailAccount = await prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: { user: { select: { email: true } } },
+    });
+    const userEmail = emailAccount?.user?.email;
+    if (!userEmail) return;
+
+    await posthogCaptureEvent(userEmail, event, {
+      emailAccountId,
+      ...properties,
+    });
+  } catch (error) {
+    logger.error("Error tracking first-time event", { error, event });
+  }
 }
 
 export async function trackOnboardingAnswer(

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -357,7 +357,6 @@ export const FIRST_TIME_EVENTS = {
 type FirstTimeEvent =
   (typeof FIRST_TIME_EVENTS)[keyof typeof FIRST_TIME_EVENTS];
 
-const FIRST_TIME_EVENT_TTL_SECONDS = 60 * 60 * 24 * 180; // 180 days
 const firedFirstTimeEvents = new Set<string>();
 
 /**
@@ -377,10 +376,7 @@ export async function trackFirstTimeEvent({
   if (firedFirstTimeEvents.has(key)) return;
 
   try {
-    const firstTime = await redis.set(key, "1", {
-      nx: true,
-      ex: FIRST_TIME_EVENT_TTL_SECONDS,
-    });
+    const firstTime = await redis.set(key, "1", { nx: true });
     firedFirstTimeEvents.add(key);
     if (!firstTime) return;
 

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -358,12 +358,11 @@ type FirstTimeEvent =
   (typeof FIRST_TIME_EVENTS)[keyof typeof FIRST_TIME_EVENTS];
 
 const FIRST_TIME_EVENT_TTL_SECONDS = 60 * 60 * 24 * 180; // 180 days
+const firedFirstTimeEvents = new Set<string>();
 
 /**
- * Fire a PostHog event the first time it's seen for an emailAccount.
- * Dedupe via Redis SETNX, so PostHog receives at most one event per account
- * per milestone. Distinct ID is the User.email so the event attaches to the
- * same PostHog person as signup/survey/billing events.
+ * Uses User.email as distinctId (not EmailAccount.email) so the event attaches
+ * to the same PostHog person as signup/billing events.
  */
 export async function trackFirstTimeEvent({
   emailAccountId,
@@ -374,12 +373,15 @@ export async function trackFirstTimeEvent({
   event: FirstTimeEvent;
   properties?: Record<string, unknown>;
 }) {
+  const key = `first-event:${emailAccountId}:${event}`;
+  if (firedFirstTimeEvents.has(key)) return;
+
   try {
-    const key = `first-event:${emailAccountId}:${event}`;
     const firstTime = await redis.set(key, "1", {
       nx: true,
       ex: FIRST_TIME_EVENT_TTL_SECONDS,
     });
+    firedFirstTimeEvents.add(key);
     if (!firstTime) return;
 
     const emailAccount = await prisma.emailAccount.findUnique({

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -13,6 +13,7 @@ import {
 } from "@/utils/ai/reply/reply-memory";
 import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
+import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { logReplyTrackerError } from "./error-logging";
 
 /**
@@ -157,6 +158,13 @@ export async function trackSentDraftStatus({
   logger.info(
     "Successfully created draft send log and updated action status via transaction",
     { executedActionId },
+  );
+
+  after(() =>
+    trackFirstTimeEvent({
+      emailAccountId,
+      event: FIRST_TIME_EVENTS.FIRST_DRAFT_SENT,
+    }),
   );
 
   await replaceMessagingDraftNotificationsWithHandledOnWebState({


### PR DESCRIPTION
## Summary
- Adds first-time PostHog events (first automated rule run, first AI draft sent, first chat message) so we can build activation funnels. Fired at most once per email account via Redis SETNX; attaches to the User.email PostHog person.
- Removes the unused `completedAppOnboardingAt` column from the `User` model (no code writes it; 97% of users never had it set) via a Prisma migration.

## Test plan
- [ ] Run Prisma migration locally
- [ ] Verify new events appear in PostHog after triggering each flow
- [ ] Confirm dedupe works on second occurrence