### PR TITLE
billing: sync Stripe invoices to payments

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -1,6 +1,147 @@
 import type Stripe from "stripe";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createScopedLogger } from "@/utils/logger";
+import { processEvent } from "./route";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
+
+const {
+  mockSyncStripeDataToDb,
+  mockSyncStripeInvoicePayment,
+  mockSyncAiGenerationOverageForUpcomingInvoice,
+  mockTrackStripeEvent,
+  mockTrackBillingTrialStarted,
+  mockTrackTrialStarted,
+  mockTrackSubscriptionTrialStarted,
+  mockFindUnique,
+  mockUpdateMany,
+  mockCompleteReferralAndGrantReward,
+  mockCaptureException,
+} = vi.hoisted(() => ({
+  mockSyncStripeDataToDb: vi.fn(),
+  mockSyncStripeInvoicePayment: vi.fn(),
+  mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
+  mockTrackStripeEvent: vi.fn(),
+  mockTrackBillingTrialStarted: vi.fn(),
+  mockTrackTrialStarted: vi.fn(),
+  mockTrackSubscriptionTrialStarted: vi.fn(),
+  mockFindUnique: vi.fn(),
+  mockUpdateMany: vi.fn(),
+  mockCompleteReferralAndGrantReward: vi.fn(),
+  mockCaptureException: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  after: vi.fn(),
+  NextResponse: {
+    json: vi.fn(),
+  },
+}));
+
+vi.mock("@/ee/billing/stripe", () => ({
+  getStripe: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withError: vi.fn((_: string, handler: unknown) => handler),
+}));
+
+vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
+  syncStripeDataToDb: mockSyncStripeDataToDb,
+}));
+
+vi.mock("@/ee/billing/stripe/payments", () => ({
+  syncStripeInvoicePayment: mockSyncStripeInvoicePayment,
+}));
+
+vi.mock("@/ee/billing/stripe/ai-overage", () => ({
+  syncAiGenerationOverageForUpcomingInvoice:
+    mockSyncAiGenerationOverageForUpcomingInvoice,
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+  },
+}));
+
+vi.mock("@/utils/posthog", () => ({
+  trackBillingTrialStarted: mockTrackBillingTrialStarted,
+  trackStripeEvent: mockTrackStripeEvent,
+  trackSubscriptionTrialStarted: mockTrackSubscriptionTrialStarted,
+  trackTrialStarted: mockTrackTrialStarted,
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    premium: {
+      findUnique: mockFindUnique,
+      updateMany: mockUpdateMany,
+    },
+  },
+}));
+
+vi.mock("@/utils/referral/referral-tracking", () => ({
+  completeReferralAndGrantReward: mockCompleteReferralAndGrantReward,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: mockCaptureException,
+}));
+
+const logger = createScopedLogger("stripe-webhook-route-test");
+
+describe("processEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue(null);
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+    mockSyncStripeInvoicePayment.mockResolvedValue(undefined);
+    mockSyncAiGenerationOverageForUpcomingInvoice.mockResolvedValue(undefined);
+    mockTrackStripeEvent.mockResolvedValue(undefined);
+    mockTrackBillingTrialStarted.mockResolvedValue(undefined);
+    mockTrackTrialStarted.mockResolvedValue(undefined);
+    mockTrackSubscriptionTrialStarted.mockResolvedValue(undefined);
+    mockCompleteReferralAndGrantReward.mockResolvedValue(undefined);
+  });
+
+  it("syncs invoice payments after customer sync succeeds", async () => {
+    mockSyncStripeDataToDb.mockResolvedValue(undefined);
+
+    await processEvent(invoiceEvent(), logger);
+
+    expect(mockSyncStripeDataToDb).toHaveBeenCalledWith({
+      customerId: "cus_test",
+      logger,
+    });
+    expect(mockSyncStripeInvoicePayment).toHaveBeenCalledWith({
+      event: expect.objectContaining({ type: "invoice.paid" }),
+      logger,
+    });
+    expect(mockSyncAiGenerationOverageForUpcomingInvoice).toHaveBeenCalledWith({
+      event: expect.objectContaining({ type: "invoice.paid" }),
+      logger,
+    });
+  });
+
+  it("skips dependent billing syncs after customer sync fails", async () => {
+    mockSyncStripeDataToDb.mockRejectedValue(new Error("sync failed"));
+
+    await processEvent(invoiceEvent(), logger);
+
+    expect(mockSyncStripeDataToDb).toHaveBeenCalledWith({
+      customerId: "cus_test",
+      logger,
+    });
+    expect(mockSyncStripeInvoicePayment).not.toHaveBeenCalled();
+    expect(
+      mockSyncAiGenerationOverageForUpcomingInvoice,
+    ).not.toHaveBeenCalled();
+  });
+});
 
 describe("getStripeTrialConvertedAt", () => {
   it("returns the event timestamp when a trial converts to active", () => {
@@ -56,6 +197,28 @@ describe("getStripeTrialConvertedAt", () => {
   });
 });
 
+function invoiceEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
+  return {
+    id: "evt_invoice_test",
+    type: "invoice.paid",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1_700_000_500,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "in_test",
+        customer: "cus_test",
+        created: 1_700_000_000,
+        status: "paid",
+      },
+    },
+    ...overrides,
+  } as Stripe.Event;
+}
+
 function subscriptionEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
   return {
     id: "evt_test",
@@ -69,6 +232,7 @@ function subscriptionEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
     data: {
       object: {
         id: "sub_test",
+        customer: "cus_test",
         status: "trialing",
         trial_end: null,
       },

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -85,7 +85,7 @@ const allowedEvents: Stripe.Event.Type[] = [
   "payment_intent.canceled",
 ];
 
-async function processEvent(event: Stripe.Event, logger: Logger) {
+export async function processEvent(event: Stripe.Event, logger: Logger) {
   if (!allowedEvents.includes(event.type)) return;
 
   // All the events we track have a customerId
@@ -109,14 +109,14 @@ async function processEvent(event: Stripe.Event, logger: Logger) {
     trackEvent(email, event),
     trackBillingMilestones(email, event, customerId),
     handleReferralCompletion(customerId, event, logger),
-    syncStripeInvoicePayment({ event, logger }),
   ];
 
   if (stripeSync.status === "fulfilled") {
+    tasks.push(syncStripeInvoicePayment({ event, logger }));
     tasks.push(syncAiGenerationOverageForUpcomingInvoice({ event, logger }));
   } else {
     logger.error(
-      "Skipping AI overage sync because Stripe customer sync failed",
+      "Skipping dependent Stripe billing syncs because customer sync failed",
       {
         customerId,
         eventType: event.type,

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@ import { withError } from "@/utils/middleware";
 import type { Logger } from "@/utils/logger";
 import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
 import { getStripeTrialStartedProperties } from "@/ee/billing/stripe/posthog-events";
+import { syncStripeInvoicePayment } from "@/ee/billing/stripe/payments";
 import { syncAiGenerationOverageForUpcomingInvoice } from "@/ee/billing/stripe/ai-overage";
 import { env } from "@/env";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
@@ -108,6 +109,7 @@ async function processEvent(event: Stripe.Event, logger: Logger) {
     trackEvent(email, event),
     trackBillingMilestones(email, event, customerId),
     handleReferralCompletion(customerId, event, logger),
+    syncStripeInvoicePayment({ event, logger }),
   ];
 
   if (stripeSync.status === "fulfilled") {

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -37,7 +37,11 @@ describe("syncStripeInvoicePayment", () => {
           object: {
             id: "in_123",
             customer: "cus_123",
-            subscription: "sub_123",
+            parent: {
+              subscription_details: {
+                subscription: "sub_123",
+              },
+            },
             created: 1_700_000_000,
             currency: "usd",
             total: 2000,
@@ -121,7 +125,11 @@ function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
       object: {
         id: "in_default",
         customer: "cus_default",
-        subscription: "sub_default",
+        parent: {
+          subscription_details: {
+            subscription: "sub_default",
+          },
+        },
         created: 1_700_000_000,
         currency: "usd",
         total: 1000,

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -1,0 +1,136 @@
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProcessorType } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+
+const mockFindUnique = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    premium: {
+      findUnique: mockFindUnique,
+    },
+    payment: {
+      upsert: mockUpsert,
+    },
+  },
+}));
+
+const logger = createScopedLogger("stripe-payments-test");
+
+describe("syncStripeInvoicePayment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts a Stripe invoice into the Payment table", async () => {
+    mockFindUnique.mockResolvedValue({ id: "premium_123" });
+
+    const { syncStripeInvoicePayment } = await import("./payments");
+
+    await syncStripeInvoicePayment({
+      event: invoiceEvent({
+        created: 1_700_000_500,
+        type: "invoice.paid",
+        data: {
+          object: {
+            id: "in_123",
+            customer: "cus_123",
+            subscription: "sub_123",
+            created: 1_700_000_000,
+            currency: "usd",
+            total: 2000,
+            status: "paid",
+            billing_reason: "subscription_cycle",
+            total_tax_amounts: [{ amount: 300 }],
+            status_transitions: {
+              paid_at: 1_700_000_400,
+            },
+          },
+        },
+      }),
+      logger,
+    });
+
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { stripeCustomerId: "cus_123" },
+      select: { id: true },
+    });
+
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { processorId: "in_123" },
+      create: expect.objectContaining({
+        premiumId: "premium_123",
+        processorType: ProcessorType.STRIPE,
+        processorId: "in_123",
+        processorSubscriptionId: "sub_123",
+        processorCustomerId: "cus_123",
+        amount: 2000,
+        currency: "USD",
+        status: "paid",
+        tax: 300,
+        taxInclusive: false,
+        billingReason: "subscription_cycle",
+        createdAt: new Date("2023-11-14T22:13:20.000Z"),
+        updatedAt: new Date("2023-11-14T22:20:00.000Z"),
+      }),
+      update: expect.objectContaining({
+        premiumId: "premium_123",
+        status: "paid",
+      }),
+    });
+  });
+
+  it("ignores non-invoice payment events", async () => {
+    const { syncStripeInvoicePayment } = await import("./payments");
+
+    await syncStripeInvoicePayment({
+      event: {
+        id: "evt_test",
+        type: "customer.subscription.updated",
+        object: "event",
+        api_version: "2025-03-31.basil",
+        created: 1,
+        livemode: false,
+        pending_webhooks: 0,
+        request: { id: null, idempotency_key: null },
+        data: {
+          object: { id: "sub_123" },
+        },
+      } as Stripe.Event,
+      logger,
+    });
+
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});
+
+function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
+  return {
+    id: "evt_test",
+    type: "invoice.paid",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "in_default",
+        customer: "cus_default",
+        subscription: "sub_default",
+        created: 1_700_000_000,
+        currency: "usd",
+        total: 1000,
+        status: "paid",
+        billing_reason: "subscription_cycle",
+        total_tax_amounts: [],
+        status_transitions: {},
+      },
+    },
+    ...overrides,
+  } as Stripe.Event;
+}

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -47,7 +47,16 @@ describe("syncStripeInvoicePayment", () => {
             total: 2000,
             status: "paid",
             billing_reason: "subscription_cycle",
-            total_tax_amounts: [{ amount: 300 }],
+            total_taxes: [
+              {
+                amount: 300,
+                tax_behavior: "exclusive",
+                tax_rate_details: null,
+                taxability_reason: "standard_rated",
+                taxable_amount: 1700,
+                type: "tax_rate_details",
+              },
+            ],
             status_transitions: {
               paid_at: 1_700_000_400,
             },
@@ -135,7 +144,7 @@ function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
         total: 1000,
         status: "paid",
         billing_reason: "subscription_cycle",
-        total_tax_amounts: [],
+        total_taxes: [],
         status_transitions: {},
       },
     },

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -99,7 +99,9 @@ export function buildStripePaymentData({
   premiumId: string | null;
 }) {
   const customerId = normalizeStripeId(invoice.customer);
-  const subscriptionId = normalizeStripeId(invoice.subscription);
+  const subscriptionId = normalizeStripeId(
+    invoice.parent?.subscription_details?.subscription ?? null,
+  );
   const tax = getStripeInvoiceTaxAmount(invoice);
 
   return {

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -1,0 +1,159 @@
+import type Stripe from "stripe";
+import { ProcessorType } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+
+const stripeInvoicePaymentEvents = new Set<Stripe.Event.Type>([
+  "invoice.paid",
+  "invoice.payment_succeeded",
+  "invoice.payment_failed",
+  "invoice.payment_action_required",
+  "invoice.marked_uncollectible",
+]);
+
+export async function syncStripeInvoicePayment({
+  event,
+  logger,
+}: {
+  event: Stripe.Event;
+  logger: Logger;
+}) {
+  const invoice = getStripeInvoiceForPaymentSync(event);
+  if (!invoice) return;
+
+  await upsertStripeInvoicePayment({
+    invoice,
+    updatedAtUnix: event.created,
+    logger,
+    context: {
+      eventType: event.type,
+    },
+  });
+}
+
+export async function upsertStripeInvoicePayment({
+  invoice,
+  updatedAtUnix,
+  logger,
+  context,
+}: {
+  invoice: Stripe.Invoice;
+  updatedAtUnix?: number;
+  logger: Logger;
+  context?: Record<string, unknown>;
+}) {
+  const invoiceId = invoice.id;
+  const customerId = normalizeStripeId(invoice.customer);
+
+  if (!invoiceId || !customerId) {
+    logger.warn("Skipping Stripe payment sync due to missing invoice fields", {
+      invoiceId: invoiceId ?? null,
+      hasCustomerId: !!customerId,
+      ...context,
+    });
+    return;
+  }
+
+  const premium = await prisma.premium.findUnique({
+    where: { stripeCustomerId: customerId },
+    select: { id: true },
+  });
+
+  const paymentData = buildStripePaymentData({
+    invoice,
+    eventCreated: updatedAtUnix,
+    premiumId: premium?.id ?? null,
+  });
+
+  await prisma.payment.upsert({
+    where: { processorId: invoiceId },
+    create: paymentData,
+    update: paymentData,
+  });
+
+  logger.info("Synced Stripe invoice to Payment table", {
+    invoiceId,
+    customerId,
+    premiumId: premium?.id ?? null,
+    status: paymentData.status,
+    ...context,
+  });
+}
+
+export function getStripeInvoiceForPaymentSync(event: Stripe.Event) {
+  if (!stripeInvoicePaymentEvents.has(event.type)) return null;
+
+  const invoice = event.data.object as Stripe.Invoice;
+  if (!invoice?.id) return null;
+
+  return invoice;
+}
+
+export function buildStripePaymentData({
+  invoice,
+  eventCreated,
+  premiumId,
+}: {
+  invoice: Stripe.Invoice;
+  eventCreated?: number;
+  premiumId: string | null;
+}) {
+  const customerId = normalizeStripeId(invoice.customer);
+  const subscriptionId = normalizeStripeId(invoice.subscription);
+  const tax = getStripeInvoiceTaxAmount(invoice);
+
+  return {
+    premiumId,
+    createdAt: new Date(invoice.created * 1000),
+    updatedAt: new Date(
+      getStripeInvoiceUpdatedAtUnix(invoice, eventCreated) * 1000,
+    ),
+    processorType: ProcessorType.STRIPE,
+    processorId: invoice.id,
+    processorSubscriptionId: subscriptionId,
+    processorCustomerId: customerId,
+    amount: invoice.total,
+    currency: invoice.currency.toUpperCase(),
+    status: invoice.status ?? "unknown",
+    tax,
+    // Stripe invoice payloads do not expose a single reliable invoice-level
+    // inclusive/exclusive boolean without expanded line-price inspection.
+    taxInclusive: false,
+    billingReason: invoice.billing_reason ?? null,
+  };
+}
+
+function getStripeInvoiceTaxAmount(invoice: Stripe.Invoice) {
+  return (
+    invoice.total_tax_amounts?.reduce((sum, taxAmount) => {
+      return sum + taxAmount.amount;
+    }, 0) ?? 0
+  );
+}
+
+function getStripeInvoiceUpdatedAtUnix(
+  invoice: Stripe.Invoice,
+  eventCreated?: number,
+) {
+  return (
+    invoice.status_transitions?.paid_at ??
+    invoice.status_transitions?.marked_uncollectible_at ??
+    invoice.status_transitions?.voided_at ??
+    invoice.status_transitions?.finalized_at ??
+    eventCreated ??
+    invoice.created
+  );
+}
+
+function normalizeStripeId(
+  value:
+    | string
+    | Stripe.Customer
+    | Stripe.DeletedCustomer
+    | Stripe.Subscription
+    | Stripe.DeletedSubscription
+    | null,
+) {
+  if (!value) return null;
+  return typeof value === "string" ? value : value.id;
+}

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -127,7 +127,7 @@ export function buildStripePaymentData({
 
 function getStripeInvoiceTaxAmount(invoice: Stripe.Invoice) {
   return (
-    invoice.total_tax_amounts?.reduce((sum, taxAmount) => {
+    invoice.total_taxes?.reduce((sum, taxAmount) => {
       return sum + taxAmount.amount;
     }, 0) ?? 0
   );

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -153,7 +153,6 @@ function normalizeStripeId(
     | Stripe.Customer
     | Stripe.DeletedCustomer
     | Stripe.Subscription
-    | Stripe.DeletedSubscription
     | null,
 ) {
   if (!value) return null;

--- a/apps/web/scripts/backfillStripePayments.ts
+++ b/apps/web/scripts/backfillStripePayments.ts
@@ -1,0 +1,270 @@
+// Run with:
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripePayments.ts`
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripePayments.ts --write`
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripePayments.ts --premium-id <premiumId> --write`
+
+import "dotenv/config";
+import { getStripe } from "@/ee/billing/stripe";
+import { upsertStripeInvoicePayment } from "@/ee/billing/stripe/payments";
+import prisma from "@/utils/prisma";
+import { createScopedLogger } from "@/utils/logger";
+
+type ScriptOptions = {
+  write: boolean;
+  limit?: number;
+  batchSize: number;
+  premiumId?: string;
+  customerId?: string;
+};
+
+type ScriptStats = {
+  scannedPremiums: number;
+  scannedInvoices: number;
+  skippedDraftInvoices: number;
+  upsertedInvoices: number;
+};
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const stripe = getStripe();
+  const logger = createScopedLogger("scripts/backfill-stripe-payments");
+  const stats: ScriptStats = {
+    scannedPremiums: 0,
+    scannedInvoices: 0,
+    skippedDraftInvoices: 0,
+    upsertedInvoices: 0,
+  };
+
+  process.stdout.write(
+    `${[
+      "Starting Stripe payment backfill",
+      `mode=${options.write ? "write" : "dry-run"}`,
+      `batchSize=${options.batchSize}`,
+      `limit=${options.limit ?? "none"}`,
+      `premiumId=${options.premiumId ?? "all"}`,
+      `customerId=${options.customerId ?? "all"}`,
+    ].join(" ")}\n`,
+  );
+
+  let cursor: string | undefined;
+
+  while (true) {
+    const premiums = await prisma.premium.findMany({
+      where: {
+        ...(options.premiumId ? { id: options.premiumId } : {}),
+        ...(options.customerId
+          ? { stripeCustomerId: options.customerId }
+          : { stripeCustomerId: { not: null } }),
+      },
+      select: {
+        id: true,
+        stripeCustomerId: true,
+      },
+      orderBy: { id: "asc" },
+      take: getPageSize(options, stats.scannedPremiums),
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+
+    if (!premiums.length) break;
+
+    for (const premium of premiums) {
+      if (hasReachedLimit(options, stats.scannedPremiums)) break;
+      if (!premium.stripeCustomerId) continue;
+
+      stats.scannedPremiums += 1;
+
+      const invoices = await listCustomerInvoices(
+        stripe,
+        premium.stripeCustomerId,
+      );
+
+      for (const invoice of invoices) {
+        stats.scannedInvoices += 1;
+
+        if (invoice.status === "draft") {
+          stats.skippedDraftInvoices += 1;
+          continue;
+        }
+
+        if (!options.write) {
+          process.stdout.write(
+            `${[
+              "[dry-run] would upsert Stripe payment",
+              `premium=${premium.id}`,
+              `customer=${premium.stripeCustomerId}`,
+              `invoice=${invoice.id}`,
+              `status=${invoice.status ?? "unknown"}`,
+              `total=${invoice.total}`,
+            ].join(" ")}\n`,
+          );
+          continue;
+        }
+
+        await upsertStripeInvoicePayment({
+          invoice,
+          logger,
+          context: {
+            source: "backfill",
+            premiumId: premium.id,
+          },
+        });
+        stats.upsertedInvoices += 1;
+      }
+    }
+
+    if (hasReachedLimit(options, stats.scannedPremiums)) break;
+    cursor = premiums[premiums.length - 1]?.id;
+  }
+
+  process.stdout.write("\nSummary\n");
+  process.stdout.write(`  mode: ${options.write ? "write" : "dry-run"}\n`);
+  process.stdout.write(`  scanned premiums: ${stats.scannedPremiums}\n`);
+  process.stdout.write(`  scanned invoices: ${stats.scannedInvoices}\n`);
+  process.stdout.write(
+    `  skipped draft invoices: ${stats.skippedDraftInvoices}\n`,
+  );
+  process.stdout.write(`  upserted invoices: ${stats.upsertedInvoices}\n`);
+}
+
+async function listCustomerInvoices(
+  stripe: ReturnType<typeof getStripe>,
+  customerId: string,
+) {
+  const invoices = [];
+  let startingAfter: string | undefined;
+
+  while (true) {
+    const page = await stripe.invoices.list({
+      customer: customerId,
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+
+    invoices.push(...page.data);
+
+    if (!page.has_more || page.data.length === 0) {
+      return invoices;
+    }
+
+    startingAfter = page.data[page.data.length - 1]?.id;
+  }
+}
+
+function parseOptions(args: string[]): ScriptOptions {
+  let write = false;
+  let limit: number | undefined;
+  let batchSize = 100;
+  let premiumId: string | undefined;
+  let customerId: string | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      printHelpAndExit();
+    }
+
+    if (arg === "--write") {
+      write = true;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --limit");
+      limit = parsePositiveInteger(value, "--limit");
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--batch-size") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --batch-size");
+      batchSize = parsePositiveInteger(value, "--batch-size");
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--premium-id") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --premium-id");
+      premiumId = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--customer-id") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --customer-id");
+      customerId = value;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    write,
+    batchSize,
+    ...(typeof limit === "number" ? { limit } : {}),
+    ...(premiumId ? { premiumId } : {}),
+    ...(customerId ? { customerId } : {}),
+  };
+}
+
+function printHelpAndExit(): never {
+  process.stdout.write(
+    "Usage: tsx scripts/backfillStripePayments.ts [options]\n",
+  );
+  process.stdout.write("Options:\n");
+  process.stdout.write(
+    "  --write                      Persist updates. Default is dry-run.\n",
+  );
+  process.stdout.write(
+    "  --limit <n>                  Maximum number of premiums to scan.\n",
+  );
+  process.stdout.write(
+    "  --batch-size <n>             Number of premiums to fetch per DB page. Default: 100.\n",
+  );
+  process.stdout.write(
+    "  --premium-id <id>            Only process one Premium row.\n",
+  );
+  process.stdout.write(
+    "  --customer-id <id>           Only process one Stripe customer.\n",
+  );
+  process.stdout.write(
+    "  -h, --help                   Show this help message.\n",
+  );
+  process.exit(0);
+}
+
+function getPageSize(options: ScriptOptions, scanned: number) {
+  if (!options.limit) return options.batchSize;
+  return Math.min(options.batchSize, Math.max(options.limit - scanned, 1));
+}
+
+function hasReachedLimit(options: ScriptOptions, scanned: number) {
+  return typeof options.limit === "number" && scanned >= options.limit;
+}
+
+function parsePositiveInteger(value: string, flagName: string) {
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+main()
+  .catch((error) => {
+    process.stderr.write(
+      `Failed to backfill Stripe payments: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/web/scripts/backfillStripeTrialConvertedAt.ts
+++ b/apps/web/scripts/backfillStripeTrialConvertedAt.ts
@@ -1,0 +1,487 @@
+// Run with:
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripeTrialConvertedAt.ts`
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripeTrialConvertedAt.ts --write`
+// `pnpm --filter inbox-zero-ai exec tsx scripts/backfillStripeTrialConvertedAt.ts --premium-id <premiumId> --write`
+
+import "dotenv/config";
+import type Stripe from "stripe";
+import type { Prisma } from "@/generated/prisma/client";
+import { getStripe } from "@/ee/billing/stripe";
+import prisma from "@/utils/prisma";
+
+type ScriptOptions = {
+  write: boolean;
+  limit?: number;
+  batchSize: number;
+  premiumId?: string;
+  subscriptionId?: string;
+  verbose: boolean;
+};
+
+type PremiumCandidate = {
+  id: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  stripeSubscriptionStatus: string | null;
+  stripeTrialEnd: Date | null;
+};
+
+type ScriptStats = {
+  scanned: number;
+  updated: number;
+  alreadySet: number;
+  noSubscription: number;
+  noTrial: number;
+  stillTrialing: number;
+  noPaidInvoiceAfterTrial: number;
+  stripeErrors: number;
+};
+
+type TrialConversionCandidate = {
+  invoiceId: string;
+  paidAt: number;
+  createdAt: number;
+  billingReason: string | null;
+  amountDue: number;
+  amountPaid: number;
+};
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+
+  printRunHeader(options);
+
+  const stripe = getStripe();
+  const stats: ScriptStats = {
+    scanned: 0,
+    updated: 0,
+    alreadySet: 0,
+    noSubscription: 0,
+    noTrial: 0,
+    stillTrialing: 0,
+    noPaidInvoiceAfterTrial: 0,
+    stripeErrors: 0,
+  };
+
+  let cursor: string | undefined;
+
+  while (true) {
+    const premiums = await prisma.premium.findMany({
+      where: buildPremiumWhereClause(options),
+      select: {
+        id: true,
+        stripeCustomerId: true,
+        stripeSubscriptionId: true,
+        stripeSubscriptionStatus: true,
+        stripeTrialEnd: true,
+      },
+      orderBy: { id: "asc" },
+      take: getPageSize(options, stats.scanned),
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+
+    if (!premiums.length) break;
+
+    for (const premium of premiums) {
+      if (hasReachedLimit(options, stats.scanned)) break;
+
+      stats.scanned += 1;
+      await processPremium({
+        premium,
+        options,
+        stats,
+        stripe,
+      });
+    }
+
+    if (hasReachedLimit(options, stats.scanned)) break;
+
+    cursor = premiums[premiums.length - 1]?.id;
+  }
+
+  printSummary(stats, options);
+}
+
+async function processPremium({
+  premium,
+  options,
+  stats,
+  stripe,
+}: {
+  premium: PremiumCandidate;
+  options: ScriptOptions;
+  stats: ScriptStats;
+  stripe: Stripe;
+}) {
+  const subscriptionId = premium.stripeSubscriptionId;
+
+  if (!subscriptionId) {
+    stats.noSubscription += 1;
+    logVerbose(options, "Skipping premium with no Stripe subscription ID", {
+      premiumId: premium.id,
+      stripeCustomerId: premium.stripeCustomerId,
+    });
+    return;
+  }
+
+  try {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const trialEnd = subscription.trial_end;
+
+    if (!trialEnd) {
+      stats.noTrial += 1;
+      logVerbose(options, "Skipping subscription with no trial_end in Stripe", {
+        premiumId: premium.id,
+        subscriptionId,
+        dbTrialEnd: premium.stripeTrialEnd?.toISOString() ?? null,
+        subscriptionStatus: subscription.status,
+      });
+      return;
+    }
+
+    if (subscription.status === "trialing" && trialEnd > getNowUnixSeconds()) {
+      stats.stillTrialing += 1;
+      logVerbose(options, "Skipping subscription still in trial", {
+        premiumId: premium.id,
+        subscriptionId,
+        trialEnd: toIsoString(trialEnd),
+      });
+      return;
+    }
+
+    const invoices = await listInvoicesCreatedOnOrAfterTrialEnd({
+      stripe,
+      subscriptionId,
+      trialEnd,
+    });
+    const trialConversion = getTrialConversionCandidate(invoices, trialEnd);
+
+    if (!trialConversion) {
+      stats.noPaidInvoiceAfterTrial += 1;
+      logVerbose(
+        options,
+        "No paid invoice found on or after trial end for subscription",
+        {
+          premiumId: premium.id,
+          subscriptionId,
+          trialEnd: toIsoString(trialEnd),
+          subscriptionStatus: subscription.status,
+          invoiceCount: invoices.length,
+        },
+      );
+      return;
+    }
+
+    const trialConvertedAt = new Date(trialConversion.paidAt * 1000);
+
+    if (!options.write) {
+      process.stdout.write(
+        `${[
+          "[dry-run] would set stripeTrialConvertedAt",
+          `premium=${premium.id}`,
+          `subscription=${subscriptionId}`,
+          `trialEnd=${toIsoString(trialEnd)}`,
+          `trialConvertedAt=${trialConvertedAt.toISOString()}`,
+          `invoice=${trialConversion.invoiceId}`,
+          `billingReason=${trialConversion.billingReason ?? "unknown"}`,
+        ].join(" ")}\n`,
+      );
+      return;
+    }
+
+    const updateResult = await prisma.premium.updateMany({
+      where: {
+        id: premium.id,
+        stripeTrialConvertedAt: null,
+      },
+      data: {
+        stripeTrialConvertedAt: trialConvertedAt,
+      },
+    });
+
+    if (updateResult.count === 0) {
+      stats.alreadySet += 1;
+      process.stdout.write(
+        `${[
+          "[skip] stripeTrialConvertedAt already set",
+          `premium=${premium.id}`,
+          `subscription=${subscriptionId}`,
+        ].join(" ")}\n`,
+      );
+      return;
+    }
+
+    stats.updated += 1;
+    process.stdout.write(
+      `${[
+        "[write] set stripeTrialConvertedAt",
+        `premium=${premium.id}`,
+        `subscription=${subscriptionId}`,
+        `trialEnd=${toIsoString(trialEnd)}`,
+        `trialConvertedAt=${trialConvertedAt.toISOString()}`,
+        `invoice=${trialConversion.invoiceId}`,
+        `billingReason=${trialConversion.billingReason ?? "unknown"}`,
+      ].join(" ")}\n`,
+    );
+  } catch (error) {
+    stats.stripeErrors += 1;
+    process.stderr.write(
+      `${[
+        "[error] failed to process premium",
+        `premium=${premium.id}`,
+        `subscription=${subscriptionId}`,
+        `error=${error instanceof Error ? error.message : String(error)}`,
+      ].join(" ")}\n`,
+    );
+  }
+}
+
+async function listInvoicesCreatedOnOrAfterTrialEnd({
+  stripe,
+  subscriptionId,
+  trialEnd,
+}: {
+  stripe: Stripe;
+  subscriptionId: string;
+  trialEnd: number;
+}) {
+  const invoices: Stripe.Invoice[] = [];
+  let startingAfter: string | undefined;
+
+  while (true) {
+    const page = await stripe.invoices.list({
+      subscription: subscriptionId,
+      created: { gte: trialEnd },
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+
+    invoices.push(...page.data);
+
+    if (!page.has_more || page.data.length === 0) {
+      return invoices;
+    }
+
+    startingAfter = page.data[page.data.length - 1]?.id;
+  }
+}
+
+function getTrialConversionCandidate(
+  invoices: Stripe.Invoice[],
+  trialEnd: number,
+) {
+  const candidates = invoices
+    .flatMap((invoice) => {
+      const paidAt = invoice.status_transitions?.paid_at;
+      if (!paidAt) return [];
+      if (invoice.created < trialEnd) return [];
+      if (paidAt < trialEnd) return [];
+
+      const candidate: TrialConversionCandidate = {
+        invoiceId: invoice.id,
+        paidAt,
+        createdAt: invoice.created,
+        billingReason: invoice.billing_reason,
+        amountDue: invoice.amount_due,
+        amountPaid: invoice.amount_paid,
+      };
+
+      return [candidate];
+    })
+    .sort((a, b) => {
+      if (a.paidAt !== b.paidAt) return a.paidAt - b.paidAt;
+      return a.createdAt - b.createdAt;
+    });
+
+  return candidates[0] ?? null;
+}
+
+function buildPremiumWhereClause(options: ScriptOptions) {
+  const where: Prisma.PremiumWhereInput = {
+    stripeTrialConvertedAt: null,
+  };
+
+  if (options.premiumId) where.id = options.premiumId;
+
+  if (options.subscriptionId) {
+    where.stripeSubscriptionId = options.subscriptionId;
+  } else {
+    where.stripeSubscriptionId = { not: null };
+  }
+
+  return where;
+}
+
+function parseOptions(args: string[]): ScriptOptions {
+  let write = false;
+  let limit: number | undefined;
+  let batchSize = 100;
+  let premiumId: string | undefined;
+  let subscriptionId: string | undefined;
+  let verbose = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      printHelpAndExit();
+    }
+
+    if (arg === "--write") {
+      write = true;
+      continue;
+    }
+
+    if (arg === "--verbose") {
+      verbose = true;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --limit");
+      limit = parsePositiveInteger(value, "--limit");
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--batch-size") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --batch-size");
+      batchSize = parsePositiveInteger(value, "--batch-size");
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--premium-id") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --premium-id");
+      premiumId = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--subscription-id") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --subscription-id");
+      subscriptionId = value;
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    write,
+    batchSize,
+    verbose,
+    ...(typeof limit === "number" ? { limit } : {}),
+    ...(premiumId ? { premiumId } : {}),
+    ...(subscriptionId ? { subscriptionId } : {}),
+  };
+}
+
+function printHelpAndExit(): never {
+  process.stdout.write(
+    "Usage: tsx scripts/backfillStripeTrialConvertedAt.ts [options]\n",
+  );
+  process.stdout.write("Options:\n");
+  process.stdout.write(
+    "  --write                      Persist updates. Default is dry-run.\n",
+  );
+  process.stdout.write(
+    "  --limit <n>                  Maximum number of premiums to scan.\n",
+  );
+  process.stdout.write(
+    "  --batch-size <n>             Number of premiums to fetch per DB page. Default: 100.\n",
+  );
+  process.stdout.write(
+    "  --premium-id <id>            Only process one Premium row.\n",
+  );
+  process.stdout.write(
+    "  --subscription-id <id>       Only process one Stripe subscription.\n",
+  );
+  process.stdout.write(
+    "  --verbose                    Print skip reasons while scanning.\n",
+  );
+  process.stdout.write(
+    "  -h, --help                   Show this help message.\n",
+  );
+  process.exit(0);
+}
+
+function printRunHeader(options: ScriptOptions) {
+  process.stdout.write(
+    `${[
+      "Starting Stripe trial conversion backfill",
+      `mode=${options.write ? "write" : "dry-run"}`,
+      `batchSize=${options.batchSize}`,
+      `limit=${options.limit ?? "none"}`,
+      `premiumId=${options.premiumId ?? "all"}`,
+      `subscriptionId=${options.subscriptionId ?? "all"}`,
+    ].join(" ")}\n`,
+  );
+}
+
+function printSummary(stats: ScriptStats, options: ScriptOptions) {
+  process.stdout.write("\nSummary\n");
+  process.stdout.write(`  mode: ${options.write ? "write" : "dry-run"}\n`);
+  process.stdout.write(`  scanned: ${stats.scanned}\n`);
+  process.stdout.write(`  updated: ${stats.updated}\n`);
+  process.stdout.write(`  already set: ${stats.alreadySet}\n`);
+  process.stdout.write(`  no subscription id: ${stats.noSubscription}\n`);
+  process.stdout.write(`  no trial in Stripe: ${stats.noTrial}\n`);
+  process.stdout.write(`  still trialing: ${stats.stillTrialing}\n`);
+  process.stdout.write(
+    `  no paid invoice after trial: ${stats.noPaidInvoiceAfterTrial}\n`,
+  );
+  process.stdout.write(`  stripe errors: ${stats.stripeErrors}\n`);
+}
+
+function getPageSize(options: ScriptOptions, scanned: number) {
+  if (!options.limit) return options.batchSize;
+  return Math.min(options.batchSize, Math.max(options.limit - scanned, 1));
+}
+
+function hasReachedLimit(options: ScriptOptions, scanned: number) {
+  return typeof options.limit === "number" && scanned >= options.limit;
+}
+
+function parsePositiveInteger(value: string, flagName: string) {
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function logVerbose(
+  options: ScriptOptions,
+  message: string,
+  details: Record<string, unknown>,
+) {
+  if (!options.verbose) return;
+  process.stdout.write(`${message} ${JSON.stringify(details)}\n`);
+}
+
+function getNowUnixSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function toIsoString(unixSeconds: number) {
+  return new Date(unixSeconds * 1000).toISOString();
+}
+
+main()
+  .catch((error) => {
+    process.stderr.write(
+      `Failed to backfill stripeTrialConvertedAt: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Persist Stripe invoice state into the existing Payment table so billing analytics no longer depend on manual syncs alone. Also add a backfill script for historical Stripe invoices.

- upsert Stripe invoice payment rows from invoice-related webhook events
- share the invoice-to-payment mapping between live webhook sync and backfill
- add focused tests plus a dry-run-first backfill script for historical invoices