### PR TITLE
Add Delete and Spam buttons to Slack notification cards

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -149,7 +149,7 @@ describe("handleRuleNotificationAction", () => {
       raw: { team: { id: "team-1" } },
       threadId: "slack-thread-1",
       messageId: "slack-message-1",
-      adapter: { editMessage },
+      adapter: { name: "slack", editMessage },
       thread: { postEphemeral: vi.fn() },
     } as any;
 
@@ -412,6 +412,156 @@ describe("handleRuleNotificationAction", () => {
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
     expect(editMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("moves Slack notification messages to trash from the More menu", async () => {
+    const provider = {
+      trashThread: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_notify_more",
+      value: "rule_notify_trash:action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { name: "slack", editMessage },
+      thread: { postEphemeral: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.trashThread).toHaveBeenCalledWith(
+      "thread-1",
+      "user@example.com",
+      "user",
+    );
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editMessage.mock.calls[0][2])).toContain(
+      "Moved to trash.",
+    );
+  });
+
+  it("marks Slack notification messages as spam from the More menu", async () => {
+    const provider = {
+      markSpam: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_notify_more",
+      value: "rule_notify_mark_spam:action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { editMessage },
+      thread: { postEphemeral: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(provider.markSpam).toHaveBeenCalledWith("thread-1");
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editMessage.mock.calls[0][2])).toContain(
+      "Marked as spam.",
+    );
+  });
+
+  it("rejects unsupported Slack More menu selections before loading context", async () => {
+    const postEphemeral = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_notify_more",
+      value: "rule_notify_archive:action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { name: "slack", editMessage: vi.fn() },
+      thread: { postEphemeral },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.findUnique).not.toHaveBeenCalled();
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(postEphemeral).toHaveBeenCalledWith(
+      event.user,
+      "That notification is invalid or expired.",
+      { fallbackToDM: false },
+    );
+  });
+
+  it("rejects direct destructive Slack action IDs before loading context", async () => {
+    const postEphemeral = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_notify_trash",
+      value: "action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { name: "slack", editMessage: vi.fn() },
+      thread: { postEphemeral },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.findUnique).not.toHaveBeenCalled();
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(postEphemeral).toHaveBeenCalledWith(
+      event.user,
+      "That notification is invalid or expired.",
+      { fallbackToDM: false },
+    );
+  });
 });
 
 describe("buildNotificationReplySendBody", () => {
@@ -616,6 +766,71 @@ describe("sendMessagingRuleNotification", () => {
 
     expect(serializedBlocks).not.toContain("Open in Gmail");
     expect(serializedBlocks).not.toContain("Open in Outlook");
+  });
+
+  it("puts destructive Slack notification actions behind a More menu", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+    prisma.executedAction.findFirst.mockResolvedValue(null as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const actionsBlock = args.blocks.find(
+      (block: { type: string }) => block.type === "actions",
+    );
+    const elements = actionsBlock.elements;
+    const buttonLabels = elements
+      .filter((element: { type: string }) => element.type === "button")
+      .map((element: { text: { text: string } }) => element.text.text);
+    const moreMenu = elements.find(
+      (element: { action_id: string }) =>
+        element.action_id === "rule_notify_more",
+    );
+
+    expect(buttonLabels).toEqual(["Archive", "Mark read"]);
+    expect(moreMenu).toEqual(
+      expect.objectContaining({
+        type: "static_select",
+        placeholder: {
+          type: "plain_text",
+          text: "More actions",
+        },
+        options: [
+          expect.objectContaining({
+            text: { type: "plain_text", text: "Delete" },
+            value: "rule_notify_trash:action-1",
+          }),
+          expect.objectContaining({
+            text: { type: "plain_text", text: "Spam" },
+            value: "rule_notify_mark_spam:action-1",
+          }),
+        ],
+      }),
+    );
   });
 
   it("delivers Teams notifications through the linked messaging fallback", async () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -481,7 +481,7 @@ describe("handleRuleNotificationAction", () => {
       raw: { team: { id: "team-1" } },
       threadId: "slack-thread-1",
       messageId: "slack-message-1",
-      adapter: { editMessage },
+      adapter: { name: "slack", editMessage },
       thread: { postEphemeral: vi.fn() },
     } as any;
 
@@ -532,8 +532,21 @@ describe("handleRuleNotificationAction", () => {
     );
   });
 
-  it("rejects direct destructive Slack action IDs before loading context", async () => {
-    const postEphemeral = vi.fn().mockResolvedValue(undefined);
+  it("supports legacy direct destructive Slack action IDs", async () => {
+    const provider = {
+      trashThread: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
     const event = {
       actionId: "rule_notify_trash",
       value: "action-1",
@@ -541,8 +554,8 @@ describe("handleRuleNotificationAction", () => {
       raw: { team: { id: "team-1" } },
       threadId: "slack-thread-1",
       messageId: "slack-message-1",
-      adapter: { name: "slack", editMessage: vi.fn() },
-      thread: { postEphemeral },
+      adapter: { name: "slack", editMessage },
+      thread: { postEphemeral: vi.fn() },
     } as any;
 
     const { handleRuleNotificationAction } = await import(
@@ -554,12 +567,14 @@ describe("handleRuleNotificationAction", () => {
       logger: createScopedLogger("test"),
     });
 
-    expect(prisma.executedAction.findUnique).not.toHaveBeenCalled();
-    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
-    expect(postEphemeral).toHaveBeenCalledWith(
-      event.user,
-      "That notification is invalid or expired.",
-      { fallbackToDM: false },
+    expect(provider.trashThread).toHaveBeenCalledWith(
+      "thread-1",
+      "user@example.com",
+      "user",
+    );
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editMessage.mock.calls[0][2])).toContain(
+      "Moved to trash.",
     );
   });
 });

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -84,6 +84,9 @@ export const RULE_NOTIFICATION_ACTION_IDS = [
   RULE_NOTIFY_ARCHIVE_ACTION_ID,
   RULE_NOTIFY_MARK_READ_ACTION_ID,
   RULE_NOTIFY_MORE_ACTION_ID,
+  // Keep legacy direct listeners for Slack cards posted before destructive actions moved into More.
+  RULE_NOTIFY_TRASH_ACTION_ID,
+  RULE_NOTIFY_MARK_SPAM_ACTION_ID,
 ] as const;
 
 type NotificationContext = NonNullable<
@@ -711,7 +714,9 @@ function isDirectRuleNotificationActionId(actionId: string) {
     actionId === RULE_DRAFT_EDIT_ACTION_ID ||
     actionId === RULE_DRAFT_DISMISS_ACTION_ID ||
     actionId === RULE_NOTIFY_ARCHIVE_ACTION_ID ||
-    actionId === RULE_NOTIFY_MARK_READ_ACTION_ID
+    actionId === RULE_NOTIFY_MARK_READ_ACTION_ID ||
+    actionId === RULE_NOTIFY_TRASH_ACTION_ID ||
+    actionId === RULE_NOTIFY_MARK_SPAM_ACTION_ID
   );
 }
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -69,6 +69,8 @@ const RULE_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
 const RULE_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
 const RULE_NOTIFY_ARCHIVE_ACTION_ID = "rule_notify_archive";
 const RULE_NOTIFY_MARK_READ_ACTION_ID = "rule_notify_mark_read";
+const RULE_NOTIFY_TRASH_ACTION_ID = "rule_notify_trash";
+const RULE_NOTIFY_MARK_SPAM_ACTION_ID = "rule_notify_mark_spam";
 export const SLACK_DRAFT_EDIT_MODAL_ID = "rule_draft_edit_modal";
 const SLACK_DRAFT_EDIT_FIELD_ID = "draft_content";
 
@@ -78,6 +80,8 @@ export const RULE_NOTIFICATION_ACTION_IDS = [
   RULE_DRAFT_DISMISS_ACTION_ID,
   RULE_NOTIFY_ARCHIVE_ACTION_ID,
   RULE_NOTIFY_MARK_READ_ACTION_ID,
+  RULE_NOTIFY_TRASH_ACTION_ID,
+  RULE_NOTIFY_MARK_SPAM_ACTION_ID,
 ] as const;
 
 type NotificationContext = NonNullable<
@@ -551,6 +555,12 @@ export async function handleRuleNotificationAction({
     case RULE_NOTIFY_MARK_READ_ACTION_ID:
       await handleMarkReadNotification({ context, event, logger });
       return;
+    case RULE_NOTIFY_TRASH_ACTION_ID:
+      await handleTrashNotification({ context, event, logger });
+      return;
+    case RULE_NOTIFY_MARK_SPAM_ACTION_ID:
+      await handleMarkSpamNotification({ context, event, logger });
+      return;
     default:
       await postNotificationFeedback({
         event,
@@ -975,6 +985,60 @@ async function handleMarkReadNotification({
   );
 }
 
+async function handleTrashNotification({
+  context,
+  event,
+  logger,
+}: {
+  context: NotificationContext;
+  event: ActionEvent;
+  logger: Logger;
+}) {
+  const provider = await createProviderForContext(context, logger);
+
+  await provider.trashThread(
+    context.executedRule.threadId,
+    context.executedRule.emailAccount.email,
+    "user",
+  );
+
+  await event.adapter.editMessage(
+    event.threadId,
+    event.messageId,
+    buildTerminalCard({
+      title: getInfoNotificationTitle(
+        context.executedRule.rule?.systemType ?? null,
+      ),
+      message: "Moved to trash.",
+    }),
+  );
+}
+
+async function handleMarkSpamNotification({
+  context,
+  event,
+  logger,
+}: {
+  context: NotificationContext;
+  event: ActionEvent;
+  logger: Logger;
+}) {
+  const provider = await createProviderForContext(context, logger);
+
+  await provider.markSpam(context.executedRule.threadId);
+
+  await event.adapter.editMessage(
+    event.threadId,
+    event.messageId,
+    buildTerminalCard({
+      title: getInfoNotificationTitle(
+        context.executedRule.rule?.systemType ?? null,
+      ),
+      message: "Marked as spam.",
+    }),
+  );
+}
+
 async function getAuthorizedSlackNotificationContext({
   executedActionId,
   logger,
@@ -1364,6 +1428,16 @@ function buildNotificationCard({
             Button({
               id: RULE_NOTIFY_MARK_READ_ACTION_ID,
               label: "Mark read",
+              value: actionId,
+            }),
+            Button({
+              id: RULE_NOTIFY_TRASH_ACTION_ID,
+              label: "Delete",
+              value: actionId,
+            }),
+            Button({
+              id: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
+              label: "Spam",
               value: actionId,
             }),
           ],

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -5,6 +5,8 @@ import {
   Card,
   CardText,
   LinkButton,
+  Select,
+  SelectOption,
   type ActionEvent,
   type CardElement,
   type CardChild,
@@ -69,6 +71,7 @@ const RULE_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
 const RULE_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
 const RULE_NOTIFY_ARCHIVE_ACTION_ID = "rule_notify_archive";
 const RULE_NOTIFY_MARK_READ_ACTION_ID = "rule_notify_mark_read";
+const RULE_NOTIFY_MORE_ACTION_ID = "rule_notify_more";
 const RULE_NOTIFY_TRASH_ACTION_ID = "rule_notify_trash";
 const RULE_NOTIFY_MARK_SPAM_ACTION_ID = "rule_notify_mark_spam";
 export const SLACK_DRAFT_EDIT_MODAL_ID = "rule_draft_edit_modal";
@@ -80,8 +83,7 @@ export const RULE_NOTIFICATION_ACTION_IDS = [
   RULE_DRAFT_DISMISS_ACTION_ID,
   RULE_NOTIFY_ARCHIVE_ACTION_ID,
   RULE_NOTIFY_MARK_READ_ACTION_ID,
-  RULE_NOTIFY_TRASH_ACTION_ID,
-  RULE_NOTIFY_MARK_SPAM_ACTION_ID,
+  RULE_NOTIFY_MORE_ACTION_ID,
 ] as const;
 
 type NotificationContext = NonNullable<
@@ -503,8 +505,8 @@ export async function handleRuleNotificationAction({
   event: ActionEvent;
   logger: Logger;
 }) {
-  const executedActionId = event.value?.trim();
-  if (!executedActionId) {
+  const selection = getRuleNotificationActionSelection(event);
+  if (!selection) {
     await postNotificationFeedback({
       event,
       logger,
@@ -516,14 +518,14 @@ export async function handleRuleNotificationAction({
   const context =
     event.adapter.name === "telegram"
       ? await getAuthorizedTelegramNotificationContext({
-          executedActionId,
+          executedActionId: selection.executedActionId,
           logger,
           chatId: getTelegramChatId(event),
           userId: event.user.userId,
           event,
         })
       : await getAuthorizedSlackNotificationContext({
-          executedActionId,
+          executedActionId: selection.executedActionId,
           logger,
           teamId: getSlackTeamId(event.raw),
           userId: event.user.userId,
@@ -531,7 +533,7 @@ export async function handleRuleNotificationAction({
         });
   if (!context) return;
 
-  switch (event.actionId) {
+  switch (selection.actionId) {
     case RULE_DRAFT_SEND_ACTION_ID:
       await handleDraftSend({ context, event, logger });
       return;
@@ -668,6 +670,49 @@ export async function handleSlackRuleNotificationModalSubmit({
   }
 
   return { action: "close" };
+}
+
+function getRuleNotificationActionSelection(event: ActionEvent): {
+  actionId: string;
+  executedActionId: string;
+} | null {
+  const value = event.value?.trim();
+  if (!value) return null;
+
+  if (event.actionId !== RULE_NOTIFY_MORE_ACTION_ID) {
+    if (!isDirectRuleNotificationActionId(event.actionId)) return null;
+
+    return {
+      actionId: event.actionId,
+      executedActionId: value,
+    };
+  }
+
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) return null;
+
+  const selectedActionId = value.slice(0, separatorIndex);
+  if (
+    selectedActionId !== RULE_NOTIFY_TRASH_ACTION_ID &&
+    selectedActionId !== RULE_NOTIFY_MARK_SPAM_ACTION_ID
+  ) {
+    return null;
+  }
+
+  return {
+    actionId: selectedActionId,
+    executedActionId: value.slice(separatorIndex + 1),
+  };
+}
+
+function isDirectRuleNotificationActionId(actionId: string) {
+  return (
+    actionId === RULE_DRAFT_SEND_ACTION_ID ||
+    actionId === RULE_DRAFT_EDIT_ACTION_ID ||
+    actionId === RULE_DRAFT_DISMISS_ACTION_ID ||
+    actionId === RULE_NOTIFY_ARCHIVE_ACTION_ID ||
+    actionId === RULE_NOTIFY_MARK_READ_ACTION_ID
+  );
 }
 
 async function handleDraftSend({
@@ -1430,15 +1475,26 @@ function buildNotificationCard({
               label: "Mark read",
               value: actionId,
             }),
-            Button({
-              id: RULE_NOTIFY_TRASH_ACTION_ID,
-              label: "Delete",
-              value: actionId,
-            }),
-            Button({
-              id: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
-              label: "Spam",
-              value: actionId,
+            Select({
+              id: RULE_NOTIFY_MORE_ACTION_ID,
+              label: "More",
+              placeholder: "More actions",
+              options: [
+                SelectOption({
+                  label: "Delete",
+                  value: getMoreNotificationActionValue({
+                    actionId,
+                    selectedActionId: RULE_NOTIFY_TRASH_ACTION_ID,
+                  }),
+                }),
+                SelectOption({
+                  label: "Spam",
+                  value: getMoreNotificationActionValue({
+                    actionId,
+                    selectedActionId: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
+                  }),
+                }),
+              ],
             }),
           ],
     ),
@@ -1461,6 +1517,16 @@ function buildTerminalCard({
     title,
     children: [CardText(message)],
   });
+}
+
+function getMoreNotificationActionValue({
+  actionId,
+  selectedActionId,
+}: {
+  actionId: string;
+  selectedActionId: string;
+}) {
+  return `${selectedActionId}:${actionId}`;
 }
 
 function buildTelegramNotificationCard({


### PR DESCRIPTION
## Summary

Adds two buttons — **Delete** and **Spam** — to the notify-mode Slack card, alongside the existing Archive and Mark read buttons. Draft-mode cards (Send reply / Edit draft / Dismiss) are unaffected.

## Why

When the `Slack` action notifies a user about a matched email, the current card supports only Archive and Mark read. For rules that catch spammy or clearly deletable senders, users want to trash or mark-as-spam straight from Slack without jumping to Gmail/Outlook.

## What changed

Single-file change to `apps/web/utils/messaging/rule-notifications.ts`:

- Two new action IDs: `rule_notify_trash` and `rule_notify_mark_spam`
- Registered in `RULE_NOTIFICATION_ACTION_IDS` so the Slack adapter routes clicks back to the handler
- Switch cases wired to `handleTrashNotification` and `handleMarkSpamNotification`
- Handlers call `provider.trashThread(threadId, email, "user")` and `provider.markSpam(threadId)` respectively, then edit the Slack card to the terminal "Moved to trash." / "Marked as spam." state (same pattern as the existing Archive/Mark-read handlers)
- Two new `Button(...)` entries appended to the `Actions` block in notify mode

Works for both Gmail and Microsoft providers — the `EmailProvider` interface already exposes `trashThread` and `markSpam` for both backends.

## Test plan

- [x] Triggered rule on Gmail account, clicked Delete on Slack card → thread moved to Gmail Trash, card updated to "Moved to trash."
- [x] Triggered rule on Gmail account, clicked Spam → thread moved to Spam label, card updated to "Marked as spam."
- [x] Existing Archive and Mark read buttons still work
- [x] Draft-mode cards (Send reply / Edit draft / Dismiss) unchanged

## Notes

Kept the handler pattern identical to `handleMarkReadNotification` for review-friendliness. No schema changes, no config, no env vars.
