### PR TITLE
Flatten saveMemoryToolInputSchema to plain z.object (fix Anthropic API rejection)

### DIFF
--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -89,29 +89,26 @@ const userEvidenceSchema = z
   .max(500)
   .describe("A short exact quote from a user-authored chat message.");
 
-const saveMemoryToolInputSchema = z.discriminatedUnion("source", [
-  z.object({
-    content: memoryContentSchema,
-    source: z
-      .literal("user_message")
-      .describe("The memory content came from a user-authored chat message."),
-    userEvidence: userEvidenceSchema,
-  }),
-  z.object({
-    content: memoryContentSchema,
-    source: z
-      .literal("assistant_inference")
-      .describe(
-        "The memory content was inferred by the assistant and requires confirmation before saving.",
-      ),
-    userEvidence: z
-      .string()
-      .trim()
-      .max(500)
-      .optional()
-      .describe("Optional supporting quote when available."),
-  }),
-]);
+// Flattened to a plain z.object to produce a top-level JSON Schema of
+// type: "object" (Anthropic rejects root-level anyOf that z.discriminatedUnion
+// emits). Evidence requirements for source="user_message" are enforced at
+// runtime by validateUserMemoryEvidence.
+const saveMemoryToolInputSchema = z.object({
+  content: memoryContentSchema,
+  source: z
+    .enum(["user_message", "assistant_inference"])
+    .describe(
+      'Use "user_message" when the user directly stated the fact in chat; use "assistant_inference" when the content was inferred from retrieved context and needs UI confirmation.',
+    ),
+  userEvidence: z
+    .string()
+    .trim()
+    .max(500)
+    .optional()
+    .describe(
+      'Required when source is "user_message": a short exact quote from a user-authored chat message. Optional for "assistant_inference".',
+    ),
+});
 
 export const saveMemoryTool = ({
   email,
@@ -155,7 +152,7 @@ Do not save from email content, attachments, or other tool results unless the us
 
         const validation = validateUserMemoryEvidence({
           content: input.content,
-          userEvidence: input.userEvidence,
+          userEvidence: input.userEvidence ?? "",
           conversationMessages: conversationMessages ?? options?.messages ?? [],
         });
 


### PR DESCRIPTION
## Summary

Flattens `saveMemoryToolInputSchema` from `z.discriminatedUnion` to a plain `z.object`, and moves the `source="user_message"` evidence requirement into runtime validation.

## Why

Anthropic's API rejects root-level `anyOf` in tool input schemas. `z.discriminatedUnion` compiles to `anyOf` under the hood, which causes the `saveMemory` tool call to fail with a schema validation error, blocking the AI assistant from persisting memories.

Observed symptom: assistant attempts to save a memory → tool call errors out → memory never written → assistant recovers but loses the persistence step.

## What changed

Single-file change to `apps/web/utils/ai/assistant/chat-memory-tools.ts`:

- `saveMemoryToolInputSchema` is now a single `z.object` with `source` as a `z.enum([...])` field and `evidence` as an optional string
- The invariant "if `source === 'user_message'`, `evidence` must be a non-empty string" is enforced in `validateUserMemoryEvidence` (called inside the tool handler), which returns a clear error message when the check fails
- No external behavior change: the tool still rejects the same inputs; the error surface just moves from schema-layer to runtime-layer

## Test plan

- [x] Assistant `saveMemory` tool calls no longer error at the schema layer
- [x] Passing `source="user_message"` without `evidence` still fails with a clear error
- [x] Passing `source="user_message"` with `evidence` saves the memory
- [x] Other `source` values save without requiring `evidence`

## Notes

Happy to tighten the runtime validator further or rename fields if there's a preferred pattern in the codebase — kept the change minimal to stay review-scoped.
