### PR TITLE
billing: guard against undefined previous_attributes in trial conversion

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -38,6 +38,19 @@ describe("getStripeTrialConvertedAt", () => {
     expect(getStripeTrialConvertedAt(event)).toBeNull();
   });
 
+  it("returns null when previous_attributes is undefined", () => {
+    const event = subscriptionEvent({
+      data: {
+        object: {
+          status: "active",
+          trial_end: 1_699_999_000,
+        },
+      } as Stripe.Event.Data,
+    });
+
+    expect(getStripeTrialConvertedAt(event)).toBeNull();
+  });
+
   it("returns null when the trial has not ended yet", () => {
     const event = subscriptionEvent({
       created: 1_700_000_000,

--- a/apps/web/app/api/stripe/webhook/trial-conversion.ts
+++ b/apps/web/app/api/stripe/webhook/trial-conversion.ts
@@ -4,11 +4,12 @@ export function getStripeTrialConvertedAt(event: Stripe.Event) {
   if (event.type !== "customer.subscription.updated") return null;
 
   const subscription = event.data.object as Stripe.Subscription;
-  const previousAttributes = event.data
-    .previous_attributes as Partial<Stripe.Subscription>;
+  const previousAttributes = event.data.previous_attributes as
+    | Partial<Stripe.Subscription>
+    | undefined;
 
   const isTrialConversion =
-    previousAttributes.status === "trialing" &&
+    previousAttributes?.status === "trialing" &&
     subscription.status === "active" &&
     subscription.trial_end &&
     subscription.trial_end < event.created;


### PR DESCRIPTION
## Summary
- `getStripeTrialConvertedAt` crashed with a TypeError when a `customer.subscription.updated` webhook arrived without `previous_attributes`, since Stripe marks that field as optional.
- Use optional chaining and a nullable type so the function safely returns `null` for events missing previous attributes.
- Added a regression test covering the undefined case.

## Test plan
- [x] `pnpm test app/api/stripe/webhook/route.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)