### PR TITLE
fix: register after() side effects only after DB writes succeed

### DIFF
--- a/apps/web/utils/actions/email-account.test.ts
+++ b/apps/web/utils/actions/email-account.test.ts
@@ -20,6 +20,7 @@ vi.mock("next/server", async (importOriginal) => {
 vi.mock("@sentry/nextjs", () => ({
   setTag: vi.fn(),
   setUser: vi.fn(),
+  captureException: vi.fn(),
   withServerActionInstrumentation: vi.fn(
     async (_name: string, callback: () => Promise<unknown>) => callback(),
   ),
@@ -48,9 +49,9 @@ describe("updateEmailAccountRoleAction", () => {
         provider: "google",
       },
     } as Awaited<ReturnType<typeof prisma.emailAccount.findUnique>>);
-    prisma.$transaction.mockImplementation(async (operations) => {
-      return Promise.all(operations as Promise<unknown>[]);
-    });
+    prisma.$transaction.mockImplementation(async (operations) =>
+      Promise.all(operations as Promise<unknown>[]),
+    );
     prisma.emailAccount.update.mockResolvedValue({
       id: "email-account-1",
     } as any);
@@ -79,5 +80,16 @@ describe("updateEmailAccountRoleAction", () => {
       email: "user@example.com",
       role: "Founder",
     });
+  });
+
+  it("does not schedule the Loops role update when the DB transaction fails", async () => {
+    prisma.$transaction.mockRejectedValue(new Error("db down"));
+
+    const result = await updateEmailAccountRoleAction("email-account-1", {
+      role: "Founder",
+    });
+
+    expect(result?.serverError).toBeDefined();
+    expect(updateContactRoleMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/email-account.ts
+++ b/apps/web/utils/actions/email-account.ts
@@ -23,15 +23,6 @@ export const updateEmailAccountRoleAction = actionClient
       ctx: { emailAccountId, userEmail, userId, logger },
       parsedInput: { role },
     }) => {
-      after(async () => {
-        await updateContactRole({
-          email: userEmail,
-          role,
-        }).catch((error) => {
-          logger.error("Loops: Error updating role", { error });
-        });
-      });
-
       await prisma.$transaction([
         prisma.emailAccount.update({
           where: { id: emailAccountId },
@@ -45,6 +36,15 @@ export const updateEmailAccountRoleAction = actionClient
           },
         }),
       ]);
+
+      after(async () => {
+        await updateContactRole({
+          email: userEmail,
+          role,
+        }).catch((error) => {
+          logger.error("Loops: Error updating role", { error });
+        });
+      });
     },
   );
 

--- a/apps/web/utils/actions/onboarding.test.ts
+++ b/apps/web/utils/actions/onboarding.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { saveOnboardingAnswersAction } from "./onboarding";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+
+  return {
+    ...actual,
+    after: vi.fn((callback: () => Promise<void> | void) => callback()),
+  };
+});
+vi.mock("@sentry/nextjs", () => ({
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+  captureException: vi.fn(),
+  withServerActionInstrumentation: vi.fn(
+    async (_name: string, callback: () => Promise<unknown>) => callback(),
+  ),
+}));
+
+const { updateContactRoleMock, updateContactCompanySizeMock } = vi.hoisted(
+  () => ({
+    updateContactRoleMock: vi.fn().mockResolvedValue(undefined),
+    updateContactCompanySizeMock: vi.fn().mockResolvedValue(undefined),
+  }),
+);
+
+vi.mock("@inboxzero/loops", async (importActual) => {
+  const actual = await importActual<typeof import("@inboxzero/loops")>();
+
+  return {
+    ...actual,
+    updateContactRole: updateContactRoleMock,
+    updateContactCompanySize: updateContactCompanySizeMock,
+  };
+});
+
+const { trackOnboardingAnswerMock } = vi.hoisted(() => ({
+  trackOnboardingAnswerMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/utils/posthog", async (importActual) => {
+  const actual = await importActual<typeof import("@/utils/posthog")>();
+
+  return {
+    ...actual,
+    trackOnboardingAnswer: trackOnboardingAnswerMock,
+  };
+});
+
+describe("saveOnboardingAnswersAction", () => {
+  const questions = [{ key: "role" }, { key: "company_size" }] as any;
+  const answers = {
+    $survey_response: "Founder",
+    $survey_response_1: "10",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("schedules side effects when the DB update succeeds", async () => {
+    prisma.user.update.mockResolvedValue({ id: "user-1" } as any);
+
+    const result = await saveOnboardingAnswersAction({
+      surveyId: "s1",
+      questions,
+      answers,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(updateContactRoleMock).toHaveBeenCalledWith({
+      email: "user@example.com",
+      role: "Founder",
+    });
+    expect(updateContactCompanySizeMock).toHaveBeenCalledWith({
+      email: "user@example.com",
+      companySize: 10,
+    });
+    expect(trackOnboardingAnswerMock).toHaveBeenCalled();
+  });
+
+  it("does not schedule side effects when the DB update fails", async () => {
+    prisma.user.update.mockRejectedValue(new Error("db down"));
+
+    const result = await saveOnboardingAnswersAction({
+      surveyId: "s1",
+      questions,
+      answers,
+    });
+
+    expect(result?.serverError).toBeDefined();
+    expect(updateContactRoleMock).not.toHaveBeenCalled();
+    expect(updateContactCompanySizeMock).not.toHaveBeenCalled();
+    expect(trackOnboardingAnswerMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/onboarding.ts
+++ b/apps/web/utils/actions/onboarding.ts
@@ -109,6 +109,19 @@ export const saveOnboardingAnswersAction = actionClientUser
 
       const extractedAnswers = extractSurveyAnswers(questions, answers);
 
+      await prisma.user.update({
+        where: { id: userId },
+        data: {
+          onboardingAnswers: { surveyId, questions, answers },
+          surveyFeatures: extractedAnswers.surveyFeatures,
+          surveyRole: extractedAnswers.surveyRole,
+          surveyGoal: extractedAnswers.surveyGoal,
+          surveyCompanySize: extractedAnswers.surveyCompanySize,
+          surveySource: extractedAnswers.surveySource,
+          surveyImprovements: extractedAnswers.surveyImprovements,
+        },
+      });
+
       after(async () => {
         await Promise.all([
           extractedAnswers.surveyRole
@@ -137,19 +150,6 @@ export const saveOnboardingAnswersAction = actionClientUser
               )
             : null,
         ]);
-      });
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          onboardingAnswers: { surveyId, questions, answers },
-          surveyFeatures: extractedAnswers.surveyFeatures,
-          surveyRole: extractedAnswers.surveyRole,
-          surveyGoal: extractedAnswers.surveyGoal,
-          surveyCompanySize: extractedAnswers.surveyCompanySize,
-          surveySource: extractedAnswers.surveySource,
-          surveyImprovements: extractedAnswers.surveyImprovements,
-        },
       });
     },
   );


### PR DESCRIPTION
## Summary
- Side effects scheduled via Next.js `after()` run even when the handler throws, so Loops/PostHog updates were firing when the Prisma write failed in `saveOnboardingAnswersAction` and `updateEmailAccountRoleAction`.
- Moved the `after()` registration below the DB write so external side effects are scheduled only when the DB update succeeds.
- Added unit tests covering both the success path and the DB-failure path for each action.

## Test plan
- [x] `pnpm test utils/actions/onboarding.test.ts utils/actions/email-account.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)