### PR TITLE
fix: tighten HTML detection in similarity-score

### DIFF
--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -251,6 +251,24 @@ On Tue, 1 Apr 2026 at 10:00, Sender <sender@example.com> wrote:
       expect(score).toBeLessThan(1.0);
     });
 
+    it("should not strip email addresses whose local part starts with an HTML tag letter", () => {
+      const storedContent = "Please contact <alice@example.com>";
+      const gmailMessage = createParsedMessage(
+        "Please contact <alex@example.com>",
+      );
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBeLessThan(1.0);
+    });
+
+    it("should not misclassify plain text starting with <a... as HTML", () => {
+      const storedContent = "The <apple> is red";
+      const gmailMessage = createParsedMessage("The <banana> is yellow");
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBeLessThan(1.0);
+    });
+
     it.each([
       { emoji: "👋", decimal: "128075", name: "waving hand" },
       { emoji: "😀", decimal: "128512", name: "grinning face" },

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -19,6 +19,11 @@ const HTML_TAG_NAMES = [
   "meta",
 ];
 
+const HTML_TAG_PATTERN = new RegExp(
+  `<\\/?(?:${HTML_TAG_NAMES.join("|")})(?:\\s|\\/|>)`,
+  "i",
+);
+
 /**
  * Normalizes content for Outlook (HTML) comparison.
  * Converts \n to <br> and then to plain text, strips quoted content.
@@ -117,12 +122,6 @@ export function calculateSimilarity(
 }
 
 function looksLikeHtmlContent(content: string): boolean {
-  const lowerContent = content.toLowerCase();
-
-  if (lowerContent.includes("<!doctype html")) return true;
-
-  return HTML_TAG_NAMES.some(
-    (tag) =>
-      lowerContent.includes(`<${tag}`) || lowerContent.includes(`</${tag}>`),
-  );
+  if (/<!doctype html/i.test(content)) return true;
+  return HTML_TAG_PATTERN.test(content);
 }


### PR DESCRIPTION
## Summary
- Fix `looksLikeHtmlContent` so plain text containing angle-bracketed content (like email addresses) is no longer misclassified as HTML and stripped during normalization.
- Replace substring checks (`includes('<a')`) with a regex that requires a boundary (`\s`, `/`, or `>`) after the tag name.
- Add regression tests covering email addresses and pseudo-tags whose first letter overlaps an HTML tag name.

## Test plan
- [x] `pnpm test utils/similarity-score.test.ts`