### PR TITLE
fix(categorization): atomic progress increment to avoid stuck status

### DIFF
--- a/apps/web/utils/redis/categorization-progress.test.ts
+++ b/apps/web/utils/redis/categorization-progress.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/utils/redis", () => ({
     get: vi.fn(),
     set: vi.fn(),
     del: vi.fn(),
+    eval: vi.fn(),
   },
 }));
 
@@ -53,14 +54,16 @@ describe("categorization progress", () => {
     );
   });
 
-  it("marks progress completed when completedItems reaches totalItems", async () => {
-    vi.mocked(redis.get).mockResolvedValueOnce({
-      totalItems: 4,
-      completedItems: 3,
-      status: "running",
-      startedAt: "2026-04-16T11:55:00.000Z",
-      updatedAt: "2026-04-16T11:59:00.000Z",
-    });
+  it("atomically increments progress via the Redis Lua script", async () => {
+    vi.mocked(redis.eval).mockResolvedValueOnce(
+      JSON.stringify({
+        totalItems: 4,
+        completedItems: 4,
+        status: "completed",
+        startedAt: "2026-04-16T11:55:00.000Z",
+        updatedAt: "2026-04-16T12:00:00.000Z",
+      }),
+    );
 
     const progress = await saveCategorizationProgress({
       emailAccountId: "account-1",
@@ -74,17 +77,22 @@ describe("categorization progress", () => {
       startedAt: "2026-04-16T11:55:00.000Z",
       updatedAt: "2026-04-16T12:00:00.000Z",
     });
-    expect(redis.set).toHaveBeenCalledWith(
-      "categorization-progress:account-1",
-      {
-        totalItems: 4,
-        completedItems: 4,
-        status: "completed",
-        startedAt: "2026-04-16T11:55:00.000Z",
-        updatedAt: "2026-04-16T12:00:00.000Z",
-      },
-      { ex: 900 },
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("cjson.decode"),
+      ["categorization-progress:account-1"],
+      ["2", "2026-04-16T12:00:00.000Z", "900"],
     );
+  });
+
+  it("returns null when the Lua script reports no existing progress", async () => {
+    vi.mocked(redis.eval).mockResolvedValueOnce(null);
+
+    const progress = await saveCategorizationProgress({
+      emailAccountId: "account-1",
+      incrementCompleted: 1,
+    });
+
+    expect(progress).toBeNull();
   });
 
   it("returns null when no progress exists", async () => {
@@ -114,6 +122,71 @@ describe("categorization progress", () => {
       startedAt: "2026-04-16T12:00:00.000Z",
       updatedAt: "2026-04-16T12:00:00.000Z",
     });
+  });
+
+  it("does not lose increments under concurrent writes", async () => {
+    let stored: {
+      totalItems: number;
+      completedItems: number;
+      status: "running" | "completed";
+      startedAt: string;
+      updatedAt: string;
+    } | null = {
+      totalItems: 100,
+      completedItems: 40,
+      status: "running",
+      startedAt: "2026-04-16T11:55:00.000Z",
+      updatedAt: "2026-04-16T11:59:00.000Z",
+    };
+
+    vi.mocked(redis.get).mockImplementation(async () =>
+      stored ? { ...stored } : null,
+    );
+
+    // Simulate real Redis: each eval invocation runs atomically end-to-end,
+    // but concurrent invocations are serialized by the Redis server.
+    let serial: Promise<unknown> = Promise.resolve();
+    vi.mocked(redis.eval).mockImplementation(
+      async (_script: string, _keys: string[], argv: string[]) => {
+        const next = serial.then(async () => {
+          if (!stored) return null;
+          const increment = Number(argv[0]);
+          const now = argv[1];
+          const newCompleted = Math.min(
+            stored.totalItems,
+            stored.completedItems + increment,
+          );
+          stored = {
+            ...stored,
+            completedItems: newCompleted,
+            status: newCompleted >= stored.totalItems ? "completed" : "running",
+            updatedAt: now,
+          };
+          return JSON.stringify(stored);
+        });
+        serial = next;
+        return next as Promise<string | null>;
+      },
+    );
+
+    await Promise.all([
+      saveCategorizationProgress({
+        emailAccountId: "account-1",
+        incrementCompleted: 50,
+      }),
+      saveCategorizationProgress({
+        emailAccountId: "account-1",
+        incrementCompleted: 50,
+      }),
+      saveCategorizationProgress({
+        emailAccountId: "account-1",
+        incrementCompleted: 10,
+      }),
+    ]);
+
+    expect(stored).not.toBeNull();
+    expect(stored?.completedItems).toBe(100);
+    expect(stored?.status).toBe("completed");
   });
 
   it("returns an idle snapshot when no progress exists", () => {

--- a/apps/web/utils/redis/categorization-progress.ts
+++ b/apps/web/utils/redis/categorization-progress.ts
@@ -3,6 +3,29 @@ import { redis } from "@/utils/redis";
 
 const CATEGORIZATION_PROGRESS_TTL_SECONDS = 15 * 60;
 
+const INCREMENT_PROGRESS_SCRIPT = `
+local data = redis.call("GET", KEYS[1])
+if not data then return nil end
+
+local progress = cjson.decode(data)
+local totalItems = tonumber(progress.totalItems) or 0
+local increment = tonumber(ARGV[1])
+local current = tonumber(progress.completedItems) or 0
+local newCompleted = current + increment
+if newCompleted > totalItems then newCompleted = totalItems end
+
+progress.completedItems = newCompleted
+if newCompleted >= totalItems then
+  progress.status = "completed"
+else
+  progress.status = "running"
+end
+progress.updatedAt = ARGV[2]
+
+redis.call("SET", KEYS[1], cjson.encode(progress), "EX", ARGV[3])
+return cjson.encode(progress)
+`.trim();
+
 const categorizationProgressCountsSchema = z.object({
   totalItems: z.number().int().min(0),
   completedItems: z.number().int().min(0),
@@ -81,26 +104,24 @@ export async function saveCategorizationProgress({
   emailAccountId: string;
   incrementCompleted: number;
 }) {
-  const existingProgress = await getCategorizationProgress({ emailAccountId });
-  if (!existingProgress) return null;
-
   const key = getKey({ emailAccountId });
-  const completedItems = Math.min(
-    existingProgress.totalItems,
-    existingProgress.completedItems + incrementCompleted,
+  const result = await redis.eval<string[], string | null>(
+    INCREMENT_PROGRESS_SCRIPT,
+    [key],
+    [
+      incrementCompleted.toString(),
+      new Date().toISOString(),
+      CATEGORIZATION_PROGRESS_TTL_SECONDS.toString(),
+    ],
   );
-  const updatedProgress: CategorizationProgress = {
-    ...existingProgress,
-    completedItems,
-    status:
-      completedItems >= existingProgress.totalItems ? "completed" : "running",
-    updatedAt: new Date().toISOString(),
-  };
 
-  await redis.set(key, updatedProgress, {
-    ex: CATEGORIZATION_PROGRESS_TTL_SECONDS,
-  });
-  return updatedProgress;
+  if (!result) return null;
+
+  const parsed =
+    typeof result === "string"
+      ? (JSON.parse(result) as unknown)
+      : (result as unknown);
+  return categorizationProgressSchema.parse(parsed);
 }
 
 export async function deleteCategorizationProgress({

--- a/apps/web/utils/redis/categorization-progress.ts
+++ b/apps/web/utils/redis/categorization-progress.ts
@@ -21,6 +21,7 @@ else
   progress.status = "running"
 end
 progress.updatedAt = ARGV[2]
+if not progress.startedAt then progress.startedAt = ARGV[2] end
 
 redis.call("SET", KEYS[1], cjson.encode(progress), "EX", ARGV[3])
 return cjson.encode(progress)


### PR DESCRIPTION
## Summary
- Replace the non-atomic read-modify-write in `saveCategorizationProgress` with a Redis Lua script invoked via `redis.eval`, so concurrent batch workers (QStash `parallelism: 3`) cannot lose increments and leave status stuck in `running` until the 15-minute TTL expires.
- Add a failing-first concurrency test plus targeted unit tests around the Lua path.

## Test plan
- [x] `pnpm test utils/redis/categorization-progress.test.ts`
- [x] `pnpm test utils/categorize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)