### PR TITLE
fix: wait for persistence on save memory and create rule confirmations

### DIFF
--- a/apps/web/utils/actions/assistant-chat-create-rule.test.ts
+++ b/apps/web/utils/actions/assistant-chat-create-rule.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
 
 const createRuleMock = vi.hoisted(() => vi.fn());
@@ -72,6 +72,112 @@ describe("confirmAssistantCreateRule", () => {
       id: "rule-created-1",
       actions: [],
     } as Awaited<ReturnType<typeof createRuleMock>>);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for pending rule persistence when waitForPersistence is enabled", async () => {
+    vi.useFakeTimers();
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingCreateRulePart()],
+        },
+      ] as never);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [
+        buildPendingCreateRulePart({
+          output: {
+            confirmationState: "processing",
+            confirmationProcessingAt: "2026-02-23T00:00:00.000Z",
+          },
+        }),
+      ],
+    } as never);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const resultPromise = confirmAssistantCreateRuleForAccount({
+      chatId: "chat-1",
+      toolCallId: "tool-cr-1",
+      waitForPersistence: true,
+      emailAccountId: "ea_1",
+      provider: "google",
+      logger: createScopedLogger("assistant-chat-create-rule.test"),
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
+    expect(createRuleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for pending rule persistence in the web confirmation action", async () => {
+    vi.useFakeTimers();
+
+    (
+      prisma.emailAccount.findUnique as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      email: "owner@example.com",
+      account: { userId: "u1", provider: "google" },
+    });
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingCreateRulePart()],
+        },
+      ] as never);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [
+        buildPendingCreateRulePart({
+          output: {
+            confirmationState: "processing",
+            confirmationProcessingAt: "2026-02-23T00:00:00.000Z",
+          },
+        }),
+      ],
+    } as never);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const resultPromise = confirmAssistantCreateRule(
+      "ea_1" as never,
+      {
+        chatId: "chat-1",
+        toolCallId: "tool-cr-1",
+      } as never,
+    );
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
+    expect(createRuleMock).toHaveBeenCalledTimes(1);
   });
 
   it("creates rule with chat risk confirmation and persists assistant part", async () => {

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -5,6 +5,7 @@ import {
   confirmAssistantEmailAction,
   confirmAssistantEmailActionForAccount,
   confirmAssistantSaveMemory,
+  confirmAssistantSaveMemoryForAccount,
 } from "@/utils/actions/assistant-chat";
 import { createScopedLogger } from "@/utils/logger";
 
@@ -1043,9 +1044,9 @@ describe("confirmAssistantEmailAction", () => {
       parts: [buildPendingSendPart()],
     };
 
-    prisma.chatMessage.findFirst.mockImplementation(async () => {
-      return { ...storedMessage } as any;
-    });
+    prisma.chatMessage.findFirst.mockImplementation(
+      async () => ({ ...storedMessage }) as any,
+    );
 
     prisma.chatMessage.updateMany.mockImplementation(async (args) => {
       const where = args.where as { updatedAt?: Date };
@@ -1120,9 +1121,9 @@ describe("confirmAssistantEmailAction", () => {
       parts: [buildPendingSendPart()],
     };
 
-    prisma.chatMessage.findFirst.mockImplementation(async () => {
-      return { ...storedMessage } as any;
-    });
+    prisma.chatMessage.findFirst.mockImplementation(
+      async () => ({ ...storedMessage }) as any,
+    );
 
     let persistAttempts = 0;
     prisma.chatMessage.updateMany.mockImplementation(async (args) => {
@@ -1176,6 +1177,99 @@ describe("confirmAssistantEmailAction", () => {
 describe("confirmAssistantSaveMemory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for pending memory persistence when waitForPersistence is enabled", async () => {
+    vi.useFakeTimers();
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingSaveMemoryPart()],
+        },
+      ] as any);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildProcessingSaveMemoryPart()],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+    prisma.chatMemory.findFirst.mockResolvedValue(null);
+    prisma.chatMemory.create.mockResolvedValue({ id: "memory-1" } as any);
+
+    const resultPromise = confirmAssistantSaveMemoryForAccount({
+      chatId: "chat-1",
+      toolCallId: "tool-1",
+      waitForPersistence: true,
+      emailAccountId: "ea_1",
+      logger: createScopedLogger("test/assistant-save-memory-confirmation"),
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
+    expect(prisma.chatMemory.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for pending memory persistence in the web confirmation action", async () => {
+    vi.useFakeTimers();
+
+    (prisma.emailAccount.findUnique as any).mockResolvedValue({
+      email: "owner@example.com",
+      account: { userId: "u1", provider: "google" },
+    });
+
+    prisma.chatMessage.findMany
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "assistant-message-1",
+          chatId: "chat-1",
+          updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+          parts: [buildPendingSaveMemoryPart()],
+        },
+      ] as any);
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildProcessingSaveMemoryPart()],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+    prisma.chatMemory.findFirst.mockResolvedValue(null);
+    prisma.chatMemory.create.mockResolvedValue({ id: "memory-1" } as any);
+
+    const resultPromise = confirmAssistantSaveMemory(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        toolCallId: "tool-1",
+      } as any,
+    );
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(prisma.chatMessage.findMany).toHaveBeenCalledTimes(3);
+    expect(prisma.chatMemory.create).toHaveBeenCalledTimes(1);
   });
 
   it("persists a pending memory after confirmation", async () => {

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -107,6 +107,7 @@ export const confirmAssistantCreateRule = actionClient
         chatId,
         chatMessageId,
         toolCallId,
+        waitForPersistence: true,
         emailAccountId,
         provider,
         logger,
@@ -125,6 +126,7 @@ export const confirmAssistantSaveMemory = actionClient
         chatId,
         chatMessageId,
         toolCallId,
+        waitForPersistence: true,
         emailAccountId,
         logger,
       }),
@@ -236,6 +238,7 @@ export async function confirmAssistantCreateRuleForAccount({
   chatId,
   chatMessageId,
   toolCallId,
+  waitForPersistence,
   emailAccountId,
   provider,
   logger,
@@ -243,6 +246,7 @@ export async function confirmAssistantCreateRuleForAccount({
   chatId: string;
   chatMessageId?: string;
   toolCallId: string;
+  waitForPersistence?: boolean;
   emailAccountId: string;
   provider: string;
   logger: Logger;
@@ -252,6 +256,7 @@ export async function confirmAssistantCreateRuleForAccount({
     chatMessageId,
     toolCallId,
     emailAccountId,
+    waitForPersistence,
     logger,
   });
 
@@ -371,12 +376,14 @@ export async function confirmAssistantSaveMemoryForAccount({
   chatId,
   chatMessageId,
   toolCallId,
+  waitForPersistence,
   emailAccountId,
   logger,
 }: {
   chatId: string;
   chatMessageId?: string;
   toolCallId: string;
+  waitForPersistence?: boolean;
   emailAccountId: string;
   logger: Logger;
 }) {
@@ -385,6 +392,7 @@ export async function confirmAssistantSaveMemoryForAccount({
     chatMessageId,
     toolCallId,
     emailAccountId,
+    waitForPersistence,
     logger,
   });
 
@@ -1294,16 +1302,21 @@ async function reservePendingAssistantSaveMemory({
   chatMessageId,
   toolCallId,
   emailAccountId,
+  waitForPersistence,
   logger,
 }: {
   chatId: string;
   chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
+  waitForPersistence?: boolean;
   logger: Logger;
 }) {
   const matchSaveMemoryParts = (parts: unknown) =>
     !!findPendingAssistantSaveMemoryPart({ parts, toolCallId });
+  const waitForPersistenceMs = waitForPersistence
+    ? PENDING_ACTION_PERSIST_WAIT_MS
+    : undefined;
 
   const chatMessage = await findChatMessageForPendingAction({
     chatId,
@@ -1312,6 +1325,7 @@ async function reservePendingAssistantSaveMemory({
     logger,
     matchParts: matchSaveMemoryParts,
     logPrefix: "Assistant save memory confirmation",
+    waitForPersistenceMs,
   });
 
   if (!chatMessage) {
@@ -1389,6 +1403,7 @@ async function reservePendingAssistantSaveMemory({
     logger,
     matchParts: matchSaveMemoryParts,
     logPrefix: "Assistant save memory confirmation",
+    waitForPersistenceMs,
   });
 
   if (!latestMessage) {
@@ -1419,16 +1434,21 @@ async function reservePendingAssistantCreateRule({
   chatMessageId,
   toolCallId,
   emailAccountId,
+  waitForPersistence,
   logger,
 }: {
   chatId: string;
   chatMessageId?: string;
   toolCallId: string;
   emailAccountId: string;
+  waitForPersistence?: boolean;
   logger: Logger;
 }) {
   const matchCreateRuleParts = (parts: unknown) =>
     !!findPendingAssistantCreateRulePart({ parts, toolCallId });
+  const waitForPersistenceMs = waitForPersistence
+    ? PENDING_ACTION_PERSIST_WAIT_MS
+    : undefined;
 
   const chatMessage = await findChatMessageForPendingAction({
     chatId,
@@ -1437,6 +1457,7 @@ async function reservePendingAssistantCreateRule({
     logger,
     matchParts: matchCreateRuleParts,
     logPrefix: "Assistant create rule confirmation",
+    waitForPersistenceMs,
   });
 
   if (!chatMessage) {
@@ -1510,6 +1531,7 @@ async function reservePendingAssistantCreateRule({
     logger,
     matchParts: matchCreateRuleParts,
     logPrefix: "Assistant create rule confirmation",
+    waitForPersistenceMs,
   });
 
   if (!latestMessage) {


### PR DESCRIPTION
Fixes a race where confirming an assistant save-memory or create-rule action before the chat message has been persisted fails with "Chat message not found", while email confirmations already polled briefly for persistence. Brings both paths in line with the existing email-action behavior.

- Adds an optional `waitForPersistence` to the save-memory and create-rule reserve/confirm helpers, forwarding it into `findChatMessageForPendingAction` on both the initial lookup and the reservation-race fallback.
- Server actions now pass `waitForPersistence: true`, matching the email confirmation server action.
- New TDD tests exercise the polling path for both helpers and both server actions.