### PR TITLE
rules: skip history snapshot on rule deletion

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/debug/rule-history/[ruleId]/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/rule-history/[ruleId]/page.tsx
@@ -22,7 +22,6 @@ const triggerTypeLabels: Record<RuleHistoryTrigger, string> = {
   instructions_updated: "Instructions Updated",
   enabled_updated: "Enabled Toggled",
   run_on_threads_updated: "Thread Mode Updated",
-  deleted: "Deleted",
 };
 
 export default async function RuleHistoryPage(props: {

--- a/apps/web/utils/rule/rule-history.test.ts
+++ b/apps/web/utils/rule/rule-history.test.ts
@@ -1,16 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { ActionType } from "@/generated/prisma/enums";
-import {
-  createRuleHistory,
-  getRuleForHistory,
-  ruleHistoryRuleInclude,
-} from "./rule-history";
+import { createRuleHistory } from "./rule-history";
 import type { RuleWithRelations } from "./types";
 
 vi.mock("@/utils/prisma");
 
-function sampleRule(overrides: Partial<RuleWithRelations> = {}): RuleWithRelations {
+function sampleRule(
+  overrides: Partial<RuleWithRelations> = {},
+): RuleWithRelations {
   return {
     id: "rule-1",
     name: "Newsletters",
@@ -107,30 +105,5 @@ describe("createRuleHistory", () => {
         data: expect.objectContaining({ version: 5 }),
       }),
     );
-  });
-});
-
-describe("getRuleForHistory", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("loads the rule scoped to the email account with history includes", async () => {
-    vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
-
-    await getRuleForHistory({
-      ruleId: "rule-1",
-      emailAccountId: "email-acct-1",
-    });
-
-    expect(prisma.rule.findUnique).toHaveBeenCalledWith({
-      where: {
-        id_emailAccountId: {
-          id: "rule-1",
-          emailAccountId: "email-acct-1",
-        },
-      },
-      include: ruleHistoryRuleInclude,
-    });
   });
 });

--- a/apps/web/utils/rule/rule-history.ts
+++ b/apps/web/utils/rule/rule-history.ts
@@ -9,8 +9,7 @@ export type RuleHistoryTrigger =
   | "conditions_updated"
   | "instructions_updated"
   | "enabled_updated"
-  | "run_on_threads_updated"
-  | "deleted";
+  | "run_on_threads_updated";
 
 export const ruleHistoryRuleInclude = {
   actions: true,
@@ -76,23 +75,5 @@ export async function createRuleHistory({
       // Note: this is unique and can fail in race conditions. Not a big deal for now.
       version: nextVersion,
     },
-  });
-}
-
-export async function getRuleForHistory({
-  ruleId,
-  emailAccountId,
-}: {
-  ruleId: string;
-  emailAccountId: string;
-}) {
-  return prisma.rule.findUnique({
-    where: {
-      id_emailAccountId: {
-        id: ruleId,
-        emailAccountId,
-      },
-    },
-    include: ruleHistoryRuleInclude,
   });
 }

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -5,15 +5,12 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { WEBHOOK_ACTION_DISABLED_MESSAGE } from "@/utils/webhook-action";
 import { getActionRiskLevel } from "@/utils/risk";
 
-const { createRuleHistoryMock, getRuleForHistoryMock, mockEnv } = vi.hoisted(
-  () => ({
-    createRuleHistoryMock: vi.fn(),
-    getRuleForHistoryMock: vi.fn(),
-    mockEnv: {
-      webhookActionsEnabled: true,
-    },
-  }),
-);
+const { createRuleHistoryMock, mockEnv } = vi.hoisted(() => ({
+  createRuleHistoryMock: vi.fn(),
+  mockEnv: {
+    webhookActionsEnabled: true,
+  },
+}));
 
 vi.mock("@/utils/prisma");
 vi.mock("next/server", () => ({
@@ -27,7 +24,6 @@ vi.mock("@/app/(app)/[emailAccountId]/assistant/examples", () => ({
 }));
 vi.mock("@/utils/rule/rule-history", () => ({
   createRuleHistory: createRuleHistoryMock,
-  getRuleForHistory: getRuleForHistoryMock,
   ruleHistoryRuleInclude: { actions: true, group: true },
 }));
 vi.mock("@/utils/email/provider-types", () => ({
@@ -77,23 +73,6 @@ describe("deleteRule", () => {
       level: "low",
       message: "safe",
     });
-    getRuleForHistoryMock.mockResolvedValue({
-      id: "rule-id",
-      enabled: true,
-      automate: true,
-      runOnThreads: true,
-      conditionalOperator: "AND",
-      name: "Rule",
-      instructions: null,
-      from: null,
-      to: null,
-      subject: null,
-      body: null,
-      systemType: null,
-      promptText: null,
-      actions: [],
-      group: null,
-    });
   });
 
   it("deletes the group first and relies on cascade delete for grouped rules", async () => {
@@ -109,6 +88,7 @@ describe("deleteRule", () => {
       where: { id: "group-id", emailAccountId: "email-account-id" },
     });
     expect(prisma.rule.delete).not.toHaveBeenCalled();
+    expect(createRuleHistoryMock).not.toHaveBeenCalled();
   });
 
   it("falls back to deleting the rule when the group is already gone", async () => {
@@ -127,10 +107,7 @@ describe("deleteRule", () => {
     expect(prisma.rule.delete).toHaveBeenCalledWith({
       where: { id: "rule-id", emailAccountId: "email-account-id" },
     });
-    expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
-      triggerType: "deleted",
-    });
+    expect(createRuleHistoryMock).not.toHaveBeenCalled();
   });
 
   it("deletes the rule directly when there is no group", async () => {
@@ -146,10 +123,7 @@ describe("deleteRule", () => {
     expect(prisma.rule.delete).toHaveBeenCalledWith({
       where: { id: "rule-id", emailAccountId: "email-account-id" },
     });
-    expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
-      triggerType: "deleted",
-    });
+    expect(createRuleHistoryMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -9,7 +9,6 @@ import { getActionRiskLevel, type RiskAction } from "@/utils/risk";
 import { hasExampleParams } from "@/app/(app)/[emailAccountId]/assistant/examples";
 import {
   createRuleHistory,
-  getRuleForHistory,
   ruleHistoryRuleInclude,
   type RuleHistoryTrigger,
 } from "@/utils/rule/rule-history";
@@ -607,19 +606,6 @@ export async function deleteRule({
   ruleId: string;
   groupId?: string | null;
 }) {
-  const rule = await getRuleForHistory({ ruleId, emailAccountId });
-  if (!rule) {
-    await prisma.rule.delete({ where: { id: ruleId, emailAccountId } });
-    return;
-  }
-
-  // RuleHistory still references Rule, so deletes must snapshot before
-  // removing the rule row.
-  await createRuleHistory({
-    rule,
-    triggerType: "deleted",
-  });
-
   if (groupId) {
     const deletedGroups = await prisma.group.deleteMany({
       where: { id: groupId, emailAccountId },


### PR DESCRIPTION
## Summary
- `deleteRule` was creating a RuleHistory snapshot that the cascade delete chain (Group → Rule → RuleHistory) immediately removed, so the snapshot was silently lost.
- Since rule deletes don't need a history snapshot, drop the snapshot call, the now-unused `getRuleForHistory` helper, and the `"deleted"` variant of `RuleHistoryTrigger` (plus its debug-page label).
- Tests updated to assert no history is written on delete.

## Test plan
- [x] `pnpm test utils/rule/rule.test.ts utils/rule/rule-history.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)