### PR TITLE
encryption: expand covered fields and add versioned ciphertext

### DIFF
--- a/apps/web/utils/encryption.test.ts
+++ b/apps/web/utils/encryption.test.ts
@@ -97,6 +97,27 @@ describe("Encryption Utilities", () => {
         /Unknown encryption version/,
       );
     });
+
+    it("throws when plaintext coincidentally looks like `v1:<hex>` (documented edge case)", () => {
+      // A user whose plaintext value happens to be a valid-looking v1 blob
+      // (e.g. `v1:deadbeefdeadbeef...`) will hit the versioned path and fail
+      // the GCM auth check. This is only reachable for rows that were stored
+      // plaintext *before* encryption was enabled for a field; new writes go
+      // through encrypt() and this exact string would be stored as ciphertext.
+      const hexPayload = "00".repeat(32);
+      expect(() => decryptToken(`v1:${hexPayload}`)).toThrow();
+    });
+
+    it("double-encrypted value decrypts one layer at a time", () => {
+      // Guards against future callers accidentally wrapping an already-encrypted
+      // value through the write path a second time. Each decrypt should peel
+      // exactly one layer.
+      const inner = encryptToken("hunter2") as string;
+      const outer = encryptToken(inner) as string;
+      expect(outer).not.toBe(inner);
+      expect(decryptToken(outer)).toBe(inner);
+      expect(decryptToken(inner)).toBe("hunter2");
+    });
   });
 
   describe("encryption and decryption cycle", () => {

--- a/apps/web/utils/encryption.test.ts
+++ b/apps/web/utils/encryption.test.ts
@@ -1,17 +1,33 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { encryptToken, decryptToken } from "./encryption";
+import { createCipheriv, randomBytes, scryptSync } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { decryptToken, encryptToken } from "./encryption";
 
-// Mock server-only as it's required for tests
 vi.mock("server-only", () => ({}));
 
-// Mock environment variables
+const { TEST_SECRET, TEST_SALT } = vi.hoisted(() => ({
+  TEST_SECRET: "test-secret-key-for-encryption-testing",
+  TEST_SALT: "test-salt-for-encryption",
+}));
+
 vi.mock("@/env", () => ({
   env: {
     NODE_ENV: "test",
-    EMAIL_ENCRYPT_SECRET: "test-secret-key-for-encryption-testing",
-    EMAIL_ENCRYPT_SALT: "test-salt-for-encryption",
+    EMAIL_ENCRYPT_SECRET: TEST_SECRET,
+    EMAIL_ENCRYPT_SALT: TEST_SALT,
   },
 }));
+
+function legacyEncrypt(text: string): string {
+  const key = scryptSync(TEST_SECRET, TEST_SALT, 32);
+  const iv = randomBytes(16);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(text, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+}
 
 describe("Encryption Utilities", () => {
   beforeEach(() => {
@@ -19,79 +35,83 @@ describe("Encryption Utilities", () => {
   });
 
   describe("encryptToken", () => {
-    it("should return null for null input", () => {
+    it("returns null for null input", () => {
       expect(encryptToken(null)).toBeNull();
     });
 
-    it("should encrypt a string", () => {
-      const originalText = "sensitive-data-to-encrypt";
-      const encrypted = encryptToken(originalText);
-
+    it("encrypts a string to a v1-prefixed ciphertext", () => {
+      const encrypted = encryptToken("sensitive-data-to-encrypt");
       expect(encrypted).not.toBeNull();
-      expect(encrypted).not.toBe(originalText);
-      expect(typeof encrypted).toBe("string");
-      // Encrypted output should be a hex string, so longer than original
-      expect(encrypted!.length).toBeGreaterThan(originalText.length);
+      expect(encrypted).toMatch(/^v1:[0-9a-f]+$/);
     });
 
-    it("should generate different ciphers for the same input", () => {
-      const originalText = "same-input-text";
-      const firstEncryption = encryptToken(originalText);
-      const secondEncryption = encryptToken(originalText);
-
-      expect(firstEncryption).not.toBe(secondEncryption);
+    it("generates different ciphertexts for the same input", () => {
+      const first = encryptToken("same-input-text");
+      const second = encryptToken("same-input-text");
+      expect(first).not.toBe(second);
     });
   });
 
   describe("decryptToken", () => {
-    it("should return null for null input", () => {
+    it("returns null for null input", () => {
       expect(decryptToken(null)).toBeNull();
     });
 
-    it("should decrypt an encrypted string back to the original", () => {
-      const originalText = "test-secret-message";
-      const encrypted = encryptToken(originalText);
-      const decrypted = decryptToken(encrypted!);
-
-      expect(decrypted).toBe(originalText);
+    it("decrypts a v1 ciphertext back to the original", () => {
+      const encrypted = encryptToken("test-secret-message");
+      expect(decryptToken(encrypted)).toBe("test-secret-message");
     });
 
-    it("should handle empty string encryption/decryption", () => {
-      const originalText = "";
-      const encrypted = encryptToken(originalText);
-      const decrypted = decryptToken(encrypted!);
-
-      expect(decrypted).toBe(originalText);
+    it("round-trips an empty string", () => {
+      const encrypted = encryptToken("");
+      expect(decryptToken(encrypted)).toBe("");
     });
 
-    it("should handle long string encryption/decryption", () => {
-      const originalText = "A".repeat(1000);
-      const encrypted = encryptToken(originalText);
-      const decrypted = decryptToken(encrypted!);
-
-      expect(decrypted).toBe(originalText);
+    it("round-trips long strings", () => {
+      const text = "A".repeat(1000);
+      expect(decryptToken(encryptToken(text))).toBe(text);
     });
 
-    it("should return null for invalid encrypted data", () => {
-      expect(decryptToken("invalid-hex-data")).toBeNull();
+    it("decrypts legacy unversioned ciphertext", () => {
+      const legacy = legacyEncrypt("legacy-token");
+      expect(decryptToken(legacy)).toBe("legacy-token");
+    });
+
+    it("returns unknown input as plaintext (backward compatibility)", () => {
+      expect(decryptToken("plaintext-api-key")).toBe("plaintext-api-key");
+      expect(decryptToken("sk-proj-userprovided")).toBe("sk-proj-userprovided");
+    });
+
+    it("treats short hex-looking strings as plaintext", () => {
+      expect(decryptToken("deadbeef")).toBe("deadbeef");
+    });
+
+    it("throws on a corrupted v1 payload (no silent fallback)", () => {
+      const encrypted = encryptToken("original") as string;
+      const corrupted = `${encrypted.slice(0, -4)}dead`;
+      expect(() => decryptToken(corrupted)).toThrow();
+    });
+
+    it("throws on an unknown version prefix", () => {
+      expect(() => decryptToken("v9:deadbeef")).toThrow(
+        /Unknown encryption version/,
+      );
     });
   });
 
   describe("encryption and decryption cycle", () => {
-    it("should handle various types of strings", () => {
+    it("handles various string types", () => {
       const testStrings = [
         "Regular text",
         "Special chars: !@#$%^&*()_+",
         "Unicode: 你好, world! 😊",
         JSON.stringify({ complex: "object", with: ["nested", "arrays"] }),
-        "A".repeat(5000), // Large string
+        "A".repeat(5000),
       ];
 
-      testStrings.forEach((originalText) => {
-        const encrypted = encryptToken(originalText);
-        const decrypted = decryptToken(encrypted!);
-        expect(decrypted).toBe(originalText);
-      });
+      for (const text of testStrings) {
+        expect(decryptToken(encryptToken(text))).toBe(text);
+      }
     });
   });
 });

--- a/apps/web/utils/encryption.ts
+++ b/apps/web/utils/encryption.ts
@@ -9,88 +9,139 @@ import { createScopedLogger } from "@/utils/logger";
 
 const logger = createScopedLogger("encryption");
 
-// Cryptographic constants
 const ALGORITHM = "aes-256-gcm";
-const IV_LENGTH = 16; // 16 bytes for AES GCM
-const AUTH_TAG_LENGTH = 16; // 16 bytes for authentication tag
-const KEY_LENGTH = 32; // 32 bytes for AES-256
-
-let key: Buffer | null = null;
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+const MIN_CIPHERTEXT_BYTES = IV_LENGTH + AUTH_TAG_LENGTH;
 
 /**
- * Encrypts a string using AES-256-GCM
- * Returns a hex string containing: IV + Auth Tag + Encrypted content
+ * Versioned ciphertext lets us rotate keys without a big-bang backfill: a row
+ * carries the key version it was encrypted with, so old rows keep decrypting
+ * with the old key while new writes use the active key.
+ *
+ * To rotate: widen `KeyVersion` (e.g. `1 | 2`), add env vars, register the new
+ * key in `KEY_MATERIAL`, then bump `ACTIVE_VERSION`.
  */
+type KeyVersion = 1;
+const ACTIVE_VERSION: KeyVersion = 1;
+
+const KEY_MATERIAL: Record<KeyVersion, () => { secret: string; salt: string }> =
+  {
+    1: () => ({
+      secret: env.EMAIL_ENCRYPT_SECRET,
+      salt: env.EMAIL_ENCRYPT_SALT,
+    }),
+  };
+
+const keyCache = new Map<KeyVersion, Buffer>();
+
 export function encryptToken(text: string | null): string | null {
   if (text === null || text === undefined) return null;
-
-  try {
-    // Generate a random IV for each encryption
-    const iv = randomBytes(IV_LENGTH);
-
-    const cipher = createCipheriv(ALGORITHM, getEncryptionKey(), iv);
-    const encrypted = Buffer.concat([
-      cipher.update(text, "utf8"),
-      cipher.final(),
-    ]);
-
-    // Get authentication tag
-    const authTag = cipher.getAuthTag();
-
-    // Return IV + Auth Tag + Encrypted content as hex
-    return Buffer.concat([iv, authTag, encrypted]).toString("hex");
-  } catch (error) {
-    logger.error("Encryption failed", { error });
+  if (!isConfigured(ACTIVE_VERSION)) {
+    logger.error("Encryption key not configured; refusing to encrypt");
     return null;
   }
+
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, getKey(ACTIVE_VERSION), iv);
+  const encrypted = Buffer.concat([
+    cipher.update(text, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  const payload = Buffer.concat([iv, authTag, encrypted]).toString("hex");
+  return `v${ACTIVE_VERSION}:${payload}`;
 }
 
 /**
- * Decrypts a string that was encrypted with encryptToken
- * Expects a hex string containing: IV + Auth Tag + Encrypted content
+ * Decrypts a value produced by `encryptToken`. Also accepts:
+ * - Legacy unversioned ciphertext (same format, no `v1:` prefix): transparently decrypted.
+ * - Plaintext (anything that neither parses as a versioned payload nor legacy-decrypts): returned as-is.
+ *
+ * Plaintext pass-through lets us add encryption to a field that currently
+ * holds plaintext without a forced migration. Newly encrypted rows carry the
+ * `v1:` prefix; old rows keep working until they're naturally rewritten.
+ *
+ * Corrupted versioned payloads throw (unlike the legacy behavior of silently
+ * returning null) so callers don't receive invalid data.
  */
-export function decryptToken(encryptedText: string | null): string | null {
-  if (encryptedText === null || encryptedText === undefined) return null;
+export function decryptToken(value: string | null): string | null {
+  if (value === null || value === undefined) return null;
+  if (!isConfigured(ACTIVE_VERSION)) {
+    logger.error("Encryption key not configured; refusing to decrypt");
+    return null;
+  }
 
+  const versioned = parseVersioned(value);
+  if (versioned) return decryptHex(versioned.payload, versioned.version);
+
+  const legacy = tryLegacyDecrypt(value);
+  if (legacy !== null) return legacy;
+
+  return value;
+}
+
+function parseVersioned(
+  value: string,
+): { version: KeyVersion; payload: string } | null {
+  const match = value.match(/^v(\d+):([0-9a-f]+)$/i);
+  if (!match) return null;
+  const version = Number(match[1]);
+  if (!(version in KEY_MATERIAL)) {
+    throw new Error(`Unknown encryption version: v${version}`);
+  }
+  return { version: version as KeyVersion, payload: match[2] };
+}
+
+function decryptHex(hex: string, version: KeyVersion): string {
+  const buffer = Buffer.from(hex, "hex");
+  if (buffer.length < MIN_CIPHERTEXT_BYTES) {
+    throw new Error("Ciphertext too short");
+  }
+  const iv = buffer.subarray(0, IV_LENGTH);
+  const authTag = buffer.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const encrypted = buffer.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, getKey(version), iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
+    "utf8",
+  );
+}
+
+function tryLegacyDecrypt(value: string): string | null {
+  if (!/^[0-9a-f]+$/i.test(value)) return null;
+  if (value.length < MIN_CIPHERTEXT_BYTES * 2) return null;
   try {
-    const buffer = Buffer.from(encryptedText, "hex");
-
-    // Extract IV (first 16 bytes)
-    const iv = buffer.subarray(0, IV_LENGTH);
-
-    // Extract auth tag (next 16 bytes)
-    const authTag = buffer.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
-
-    // Extract encrypted content (remaining bytes)
-    const encrypted = buffer.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
-
-    const decipher = createDecipheriv(ALGORITHM, getEncryptionKey(), iv);
-    decipher.setAuthTag(authTag);
-
-    const decrypted = Buffer.concat([
-      decipher.update(encrypted),
-      decipher.final(),
-    ]);
-
-    return decrypted.toString("utf8");
+    return decryptHex(value, 1);
   } catch (error) {
-    logger.error("Decryption failed", { error });
+    logger.trace("Legacy decrypt attempt failed; treating as plaintext", {
+      error,
+    });
     return null;
   }
 }
 
-function getEncryptionKey() {
-  if (key) return key;
+function isConfigured(version: KeyVersion): boolean {
+  const material = KEY_MATERIAL[version];
+  if (!material) return false;
+  const { secret, salt } = material();
+  return Boolean(secret && salt);
+}
 
-  if (!env.EMAIL_ENCRYPT_SECRET || !env.EMAIL_ENCRYPT_SALT) {
-    throw new Error("Encryption environment variables are not configured");
+function getKey(version: KeyVersion): Buffer {
+  const cached = keyCache.get(version);
+  if (cached) return cached;
+
+  const material = KEY_MATERIAL[version];
+  if (!material) throw new Error(`No key material for v${version}`);
+
+  const { secret, salt } = material();
+  if (!secret || !salt) {
+    throw new Error(`Encryption key v${version} is not configured`);
   }
 
-  key = scryptSync(
-    env.EMAIL_ENCRYPT_SECRET,
-    env.EMAIL_ENCRYPT_SALT,
-    KEY_LENGTH,
-  );
-
+  const key = scryptSync(secret, salt, KEY_LENGTH);
+  keyCache.set(version, key);
   return key;
 }

--- a/apps/web/utils/encryption.ts
+++ b/apps/web/utils/encryption.ts
@@ -115,7 +115,7 @@ function tryLegacyDecrypt(value: string): string | null {
   try {
     return decryptHex(value, 1);
   } catch (error) {
-    logger.trace("Legacy decrypt attempt failed; treating as plaintext", {
+    logger.warn("Legacy decrypt attempt failed; treating as plaintext", {
       error,
     });
     return null;

--- a/apps/web/utils/prisma-extensions.test.ts
+++ b/apps/web/utils/prisma-extensions.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/env", () => ({
+  env: {
+    NODE_ENV: "test",
+    EMAIL_ENCRYPT_SECRET: "test-secret-key-for-encryption-testing",
+    EMAIL_ENCRYPT_SALT: "test-salt-for-encryption",
+  },
+}));
+
+vi.mock("@/generated/prisma/client", () => ({
+  Prisma: {
+    defineExtension: (fn: unknown) => fn,
+  },
+}));
+
+import { __testing__ } from "./prisma-extensions";
+
+const { buildQuery, encryptCreateData, encryptUpdateData } = __testing__;
+
+const FIELDS = ["webhookSecret"] as const;
+
+describe("encryptCreateData", () => {
+  it("encrypts a string field", () => {
+    const data: Record<string, unknown> = { webhookSecret: "hunter2" };
+    encryptCreateData(data, FIELDS);
+    expect(data.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+  });
+
+  it("leaves null untouched", () => {
+    const data: Record<string, unknown> = { webhookSecret: null };
+    encryptCreateData(data, FIELDS);
+    expect(data.webhookSecret).toBeNull();
+  });
+
+  it("leaves absent fields absent", () => {
+    const data: Record<string, unknown> = { otherField: "unchanged" };
+    encryptCreateData(data, FIELDS);
+    expect("webhookSecret" in data).toBe(false);
+  });
+
+  it("ignores non-string values", () => {
+    const data: Record<string, unknown> = { webhookSecret: 42 };
+    encryptCreateData(data, FIELDS);
+    expect(data.webhookSecret).toBe(42);
+  });
+
+  it("no-ops when data is null or undefined", () => {
+    expect(() => encryptCreateData(null, FIELDS)).not.toThrow();
+    expect(() => encryptCreateData(undefined, FIELDS)).not.toThrow();
+  });
+});
+
+describe("encryptUpdateData", () => {
+  it("encrypts a flat string value", () => {
+    const data: Record<string, unknown> = { webhookSecret: "hunter2" };
+    encryptUpdateData(data, FIELDS);
+    expect(data.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+  });
+
+  it("encrypts the inner value of a { set } wrapper", () => {
+    const data: Record<string, unknown> = {
+      webhookSecret: { set: "hunter2" },
+    };
+    encryptUpdateData(data, FIELDS);
+    expect((data.webhookSecret as { set: string }).set).toMatch(
+      /^v1:[0-9a-f]+$/,
+    );
+  });
+
+  it("leaves { set: null } untouched (clearing a field)", () => {
+    const data: Record<string, unknown> = {
+      webhookSecret: { set: null },
+    };
+    encryptUpdateData(data, FIELDS);
+    expect((data.webhookSecret as { set: null }).set).toBeNull();
+  });
+
+  it("leaves null untouched", () => {
+    const data: Record<string, unknown> = { webhookSecret: null };
+    encryptUpdateData(data, FIELDS);
+    expect(data.webhookSecret).toBeNull();
+  });
+
+  it("leaves absent fields absent", () => {
+    const data: Record<string, unknown> = {};
+    encryptUpdateData(data, FIELDS);
+    expect(data).toEqual({});
+  });
+
+  it("ignores wrapper objects without a `set` key", () => {
+    const data: Record<string, unknown> = {
+      webhookSecret: { increment: 1 },
+    };
+    encryptUpdateData(data, FIELDS);
+    expect(data.webhookSecret).toEqual({ increment: 1 });
+  });
+});
+
+describe("buildQuery handlers", () => {
+  const spec = { user: ["webhookSecret"] } as const;
+  const queryFn = vi.fn(async (args: unknown) => args);
+
+  beforeEach(() => {
+    queryFn.mockClear();
+  });
+
+  it("create encrypts args.data and forwards to query()", async () => {
+    const handlers = buildQuery(spec);
+    const args = { data: { webhookSecret: "hunter2" } };
+    await handlers.user.create({ args, query: queryFn });
+    expect(args.data.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+    expect(queryFn).toHaveBeenCalledWith(args);
+  });
+
+  it("update encrypts args.data", async () => {
+    const handlers = buildQuery(spec);
+    const args = { data: { webhookSecret: "hunter2" } };
+    await handlers.user.update({ args, query: queryFn });
+    expect(args.data.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+  });
+
+  it("updateMany encrypts args.data", async () => {
+    const handlers = buildQuery(spec);
+    const args = { data: { webhookSecret: "hunter2" } };
+    await handlers.user.updateMany({ args, query: queryFn });
+    expect(args.data.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+  });
+
+  it("upsert encrypts both create and update branches independently", async () => {
+    const handlers = buildQuery(spec);
+    const args = {
+      create: { webhookSecret: "created-value" },
+      update: { webhookSecret: { set: "updated-value" } },
+    };
+    await handlers.user.upsert({ args, query: queryFn });
+    expect(args.create.webhookSecret).toMatch(/^v1:[0-9a-f]+$/);
+    expect(args.update.webhookSecret.set).toMatch(/^v1:[0-9a-f]+$/);
+  });
+});

--- a/apps/web/utils/prisma-extensions.ts
+++ b/apps/web/utils/prisma-extensions.ts
@@ -49,6 +49,12 @@ function buildResult(spec: FieldSpec) {
   return result;
 }
 
+export const __testing__ = {
+  buildQuery,
+  encryptCreateData,
+  encryptUpdateData,
+};
+
 function buildQuery(spec: FieldSpec) {
   const query: Record<string, Record<string, unknown>> = {};
   for (const [model, fields] of Object.entries(spec)) {

--- a/apps/web/utils/prisma-extensions.ts
+++ b/apps/web/utils/prisma-extensions.ts
@@ -1,516 +1,107 @@
 import { Prisma } from "@/generated/prisma/client";
-import { encryptToken, decryptToken } from "@/utils/encryption";
+import { decryptToken, encryptToken } from "@/utils/encryption";
 
-export const encryptedTokens = Prisma.defineExtension((client) => {
-  return client.$extends({
-    result: {
-      account: {
-        access_token: {
-          needs: { access_token: true },
-          compute(account) {
-            return decryptToken(account.access_token);
-          },
+/**
+ * Fields that are transparently encrypted at rest. To add a new field:
+ *   1. Add it here under the Prisma model name (camelCase).
+ *   2. If the field already has plaintext values in the DB, nothing else is
+ *      needed: reads pass plaintext through untouched until the row is next
+ *      written. Optional: run a backfill to re-save the values so they adopt
+ *      the versioned ciphertext format.
+ *
+ * Do NOT add fields that are queried by value (e.g. Session.sessionToken,
+ * EmailToken.token): random-IV encryption breaks WHERE lookups.
+ */
+const ENCRYPTED_FIELDS = {
+  account: ["access_token", "refresh_token"],
+  calendarConnection: ["accessToken", "refreshToken"],
+  driveConnection: ["accessToken", "refreshToken"],
+  messagingChannel: ["accessToken", "refreshToken"],
+  mcpConnection: ["accessToken", "refreshToken", "apiKey"],
+  mcpIntegration: ["oauthClientSecret"],
+  user: ["aiApiKey", "webhookSecret"],
+} as const satisfies Record<string, readonly string[]>;
+
+type FieldSpec = Record<string, readonly string[]>;
+type MutableData = Record<string, unknown> | undefined | null;
+
+export const encryptedTokens = Prisma.defineExtension((client) =>
+  client.$extends({
+    result: buildResult(ENCRYPTED_FIELDS) as never,
+    query: buildQuery(ENCRYPTED_FIELDS) as never,
+  }),
+);
+
+function buildResult(spec: FieldSpec) {
+  const result: Record<string, Record<string, unknown>> = {};
+  for (const [model, fields] of Object.entries(spec)) {
+    const modelResult: Record<string, unknown> = {};
+    for (const field of fields) {
+      modelResult[field] = {
+        needs: { [field]: true },
+        compute(row: Record<string, string | null>) {
+          return decryptToken(row[field]);
         },
-        refresh_token: {
-          needs: { refresh_token: true },
-          compute(account) {
-            return decryptToken(account.refresh_token);
-          },
-        },
+      };
+    }
+    result[model] = modelResult;
+  }
+  return result;
+}
+
+function buildQuery(spec: FieldSpec) {
+  const query: Record<string, Record<string, unknown>> = {};
+  for (const [model, fields] of Object.entries(spec)) {
+    query[model] = {
+      async create({ args, query }: QueryArgs<"create">) {
+        encryptCreateData(args.data, fields);
+        return query(args);
       },
-      calendarConnection: {
-        accessToken: {
-          needs: { accessToken: true },
-          compute(connection) {
-            return decryptToken(connection.accessToken);
-          },
-        },
-        refreshToken: {
-          needs: { refreshToken: true },
-          compute(connection) {
-            return decryptToken(connection.refreshToken);
-          },
-        },
+      async update({ args, query }: QueryArgs<"update">) {
+        encryptUpdateData(args.data, fields);
+        return query(args);
       },
-      mcpConnection: {
-        accessToken: {
-          needs: { accessToken: true },
-          compute(connection) {
-            return decryptToken(connection.accessToken);
-          },
-        },
-        refreshToken: {
-          needs: { refreshToken: true },
-          compute(connection) {
-            return decryptToken(connection.refreshToken);
-          },
-        },
-        apiKey: {
-          needs: { apiKey: true },
-          compute(connection) {
-            return decryptToken(connection.apiKey);
-          },
-        },
+      async updateMany({ args, query }: QueryArgs<"updateMany">) {
+        encryptUpdateData(args.data, fields);
+        return query(args);
       },
-      driveConnection: {
-        accessToken: {
-          needs: { accessToken: true },
-          compute(connection) {
-            return decryptToken(connection.accessToken);
-          },
-        },
-        refreshToken: {
-          needs: { refreshToken: true },
-          compute(connection) {
-            return decryptToken(connection.refreshToken);
-          },
-        },
+      async upsert({ args, query }: QueryArgs<"upsert">) {
+        encryptCreateData(args.create, fields);
+        encryptUpdateData(args.update, fields);
+        return query(args);
       },
-      messagingChannel: {
-        accessToken: {
-          needs: { accessToken: true },
-          compute(connection) {
-            return decryptToken(connection.accessToken);
-          },
-        },
-        refreshToken: {
-          needs: { refreshToken: true },
-          compute(connection) {
-            return decryptToken(connection.refreshToken);
-          },
-        },
-      },
-    },
-    query: {
-      account: {
-        async create({ args, query }) {
-          if (args.data.access_token) {
-            args.data.access_token = encryptToken(args.data.access_token);
-          }
-          if (args.data.refresh_token) {
-            args.data.refresh_token = encryptToken(args.data.refresh_token);
-          }
-          return query(args);
-        },
-        async update({ args, query }) {
-          if (args.data.access_token) {
-            if (typeof args.data.access_token === "string") {
-              args.data.access_token = encryptToken(args.data.access_token);
-            } else if (args.data.access_token.set) {
-              args.data.access_token.set = encryptToken(
-                args.data.access_token.set,
-              );
-            }
-          }
-          if (args.data.refresh_token) {
-            if (typeof args.data.refresh_token === "string") {
-              args.data.refresh_token = encryptToken(args.data.refresh_token);
-            } else if (args.data.refresh_token.set) {
-              args.data.refresh_token.set = encryptToken(
-                args.data.refresh_token.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async updateMany({ args, query }) {
-          if (args.data.access_token) {
-            if (typeof args.data.access_token === "string") {
-              args.data.access_token = encryptToken(args.data.access_token);
-            } else if (args.data.access_token.set) {
-              args.data.access_token.set = encryptToken(
-                args.data.access_token.set,
-              );
-            }
-          }
-          if (args.data.refresh_token) {
-            if (typeof args.data.refresh_token === "string") {
-              args.data.refresh_token = encryptToken(args.data.refresh_token);
-            } else if (args.data.refresh_token.set) {
-              args.data.refresh_token.set = encryptToken(
-                args.data.refresh_token.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async upsert({ args, query }) {
-          if (args.create.access_token) {
-            args.create.access_token = encryptToken(args.create.access_token);
-          }
-          if (args.create.refresh_token) {
-            args.create.refresh_token = encryptToken(args.create.refresh_token);
-          }
-          if (args.update.access_token) {
-            if (typeof args.update.access_token === "string") {
-              args.update.access_token = encryptToken(args.update.access_token);
-            } else if (args.update.access_token.set) {
-              args.update.access_token.set = encryptToken(
-                args.update.access_token.set,
-              );
-            }
-          }
-          if (args.update.refresh_token) {
-            if (typeof args.update.refresh_token === "string") {
-              args.update.refresh_token = encryptToken(
-                args.update.refresh_token,
-              );
-            } else if (args.update.refresh_token.set) {
-              args.update.refresh_token.set = encryptToken(
-                args.update.refresh_token.set,
-              );
-            }
-          }
-          return query(args);
-        },
-      },
-      calendarConnection: {
-        async create({ args, query }) {
-          if (args.data.accessToken) {
-            args.data.accessToken = encryptToken(args.data.accessToken);
-          }
-          if (args.data.refreshToken) {
-            args.data.refreshToken = encryptToken(args.data.refreshToken);
-          }
-          return query(args);
-        },
-        async update({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async updateMany({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async upsert({ args, query }) {
-          if (args.create.accessToken) {
-            args.create.accessToken = encryptToken(args.create.accessToken);
-          }
-          if (args.create.refreshToken) {
-            args.create.refreshToken = encryptToken(args.create.refreshToken);
-          }
-          if (args.update.accessToken) {
-            if (typeof args.update.accessToken === "string") {
-              args.update.accessToken = encryptToken(args.update.accessToken);
-            } else if (args.update.accessToken.set) {
-              args.update.accessToken.set = encryptToken(
-                args.update.accessToken.set,
-              );
-            }
-          }
-          if (args.update.refreshToken) {
-            if (typeof args.update.refreshToken === "string") {
-              args.update.refreshToken = encryptToken(args.update.refreshToken);
-            } else if (args.update.refreshToken.set) {
-              args.update.refreshToken.set = encryptToken(
-                args.update.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-      },
-      mcpConnection: {
-        async create({ args, query }) {
-          if (args.data.accessToken) {
-            args.data.accessToken = encryptToken(args.data.accessToken);
-          }
-          if (args.data.refreshToken) {
-            args.data.refreshToken = encryptToken(args.data.refreshToken);
-          }
-          if (args.data.apiKey) {
-            args.data.apiKey = encryptToken(args.data.apiKey);
-          }
-          return query(args);
-        },
-        async update({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          if (args.data.apiKey) {
-            if (typeof args.data.apiKey === "string") {
-              args.data.apiKey = encryptToken(args.data.apiKey);
-            } else if (args.data.apiKey.set) {
-              args.data.apiKey.set = encryptToken(args.data.apiKey.set);
-            }
-          }
-          return query(args);
-        },
-        async updateMany({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          if (args.data.apiKey) {
-            if (typeof args.data.apiKey === "string") {
-              args.data.apiKey = encryptToken(args.data.apiKey);
-            } else if (args.data.apiKey.set) {
-              args.data.apiKey.set = encryptToken(args.data.apiKey.set);
-            }
-          }
-          return query(args);
-        },
-        async upsert({ args, query }) {
-          if (args.create.accessToken) {
-            args.create.accessToken = encryptToken(args.create.accessToken);
-          }
-          if (args.create.refreshToken) {
-            args.create.refreshToken = encryptToken(args.create.refreshToken);
-          }
-          if (args.create.apiKey) {
-            args.create.apiKey = encryptToken(args.create.apiKey);
-          }
-          if (args.update.accessToken) {
-            if (typeof args.update.accessToken === "string") {
-              args.update.accessToken = encryptToken(args.update.accessToken);
-            } else if (args.update.accessToken.set) {
-              args.update.accessToken.set = encryptToken(
-                args.update.accessToken.set,
-              );
-            }
-          }
-          if (args.update.refreshToken) {
-            if (typeof args.update.refreshToken === "string") {
-              args.update.refreshToken = encryptToken(args.update.refreshToken);
-            } else if (args.update.refreshToken.set) {
-              args.update.refreshToken.set = encryptToken(
-                args.update.refreshToken.set,
-              );
-            }
-          }
-          if (args.update.apiKey) {
-            if (typeof args.update.apiKey === "string") {
-              args.update.apiKey = encryptToken(args.update.apiKey);
-            } else if (args.update.apiKey.set) {
-              args.update.apiKey.set = encryptToken(args.update.apiKey.set);
-            }
-          }
-          return query(args);
-        },
-      },
-      driveConnection: {
-        async create({ args, query }) {
-          if (args.data.accessToken) {
-            args.data.accessToken = encryptToken(args.data.accessToken);
-          }
-          if (args.data.refreshToken) {
-            args.data.refreshToken = encryptToken(args.data.refreshToken);
-          }
-          return query(args);
-        },
-        async update({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async updateMany({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async upsert({ args, query }) {
-          if (args.create.accessToken) {
-            args.create.accessToken = encryptToken(args.create.accessToken);
-          }
-          if (args.create.refreshToken) {
-            args.create.refreshToken = encryptToken(args.create.refreshToken);
-          }
-          if (args.update.accessToken) {
-            if (typeof args.update.accessToken === "string") {
-              args.update.accessToken = encryptToken(args.update.accessToken);
-            } else if (args.update.accessToken.set) {
-              args.update.accessToken.set = encryptToken(
-                args.update.accessToken.set,
-              );
-            }
-          }
-          if (args.update.refreshToken) {
-            if (typeof args.update.refreshToken === "string") {
-              args.update.refreshToken = encryptToken(args.update.refreshToken);
-            } else if (args.update.refreshToken.set) {
-              args.update.refreshToken.set = encryptToken(
-                args.update.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-      },
-      messagingChannel: {
-        async create({ args, query }) {
-          if (args.data.accessToken) {
-            args.data.accessToken = encryptToken(args.data.accessToken);
-          }
-          if (args.data.refreshToken) {
-            args.data.refreshToken = encryptToken(args.data.refreshToken);
-          }
-          return query(args);
-        },
-        async update({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async updateMany({ args, query }) {
-          if (args.data.accessToken) {
-            if (typeof args.data.accessToken === "string") {
-              args.data.accessToken = encryptToken(args.data.accessToken);
-            } else if (args.data.accessToken.set) {
-              args.data.accessToken.set = encryptToken(
-                args.data.accessToken.set,
-              );
-            }
-          }
-          if (args.data.refreshToken) {
-            if (typeof args.data.refreshToken === "string") {
-              args.data.refreshToken = encryptToken(args.data.refreshToken);
-            } else if (args.data.refreshToken.set) {
-              args.data.refreshToken.set = encryptToken(
-                args.data.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-        async upsert({ args, query }) {
-          if (args.create.accessToken) {
-            args.create.accessToken = encryptToken(args.create.accessToken);
-          }
-          if (args.create.refreshToken) {
-            args.create.refreshToken = encryptToken(args.create.refreshToken);
-          }
-          if (args.update.accessToken) {
-            if (typeof args.update.accessToken === "string") {
-              args.update.accessToken = encryptToken(args.update.accessToken);
-            } else if (args.update.accessToken.set) {
-              args.update.accessToken.set = encryptToken(
-                args.update.accessToken.set,
-              );
-            }
-          }
-          if (args.update.refreshToken) {
-            if (typeof args.update.refreshToken === "string") {
-              args.update.refreshToken = encryptToken(args.update.refreshToken);
-            } else if (args.update.refreshToken.set) {
-              args.update.refreshToken.set = encryptToken(
-                args.update.refreshToken.set,
-              );
-            }
-          }
-          return query(args);
-        },
-      },
-    },
-  });
-});
+    };
+  }
+  return query;
+}
+
+function encryptCreateData(data: MutableData, fields: readonly string[]) {
+  if (!data) return;
+  for (const field of fields) {
+    const value = data[field];
+    if (typeof value === "string") data[field] = encryptToken(value);
+  }
+}
+
+function encryptUpdateData(data: MutableData, fields: readonly string[]) {
+  if (!data) return;
+  for (const field of fields) {
+    const value = data[field];
+    if (typeof value === "string") {
+      data[field] = encryptToken(value);
+    } else if (isSetWrapper(value) && typeof value.set === "string") {
+      value.set = encryptToken(value.set);
+    }
+  }
+}
+
+function isSetWrapper(value: unknown): value is { set: unknown } {
+  return typeof value === "object" && value !== null && "set" in value;
+}
+
+type QueryArgs<Op extends "create" | "update" | "updateMany" | "upsert"> = {
+  args: Op extends "upsert"
+    ? { create: MutableData; update: MutableData }
+    : { data: MutableData };
+  query: (args: unknown) => Promise<unknown>;
+};


### PR DESCRIPTION
## Summary
- Encrypt `User.aiApiKey`, `User.webhookSecret`, and `McpIntegration.oauthClientSecret` at rest alongside the existing OAuth token fields.
- Introduce a versioned ciphertext format (`v1:<hex>`) so future key rotations don't require a big-bang backfill. Legacy unversioned ciphertext and pre-existing plaintext are both transparently handled on read, so no migration is required.
- Refactor the Prisma extension from ~515 lines of hand-written per-model cases to a config-driven generator; adding the next encrypted field is now a one-line change.

## Test plan
- [x] Unit tests for encryption (round-trip, v1 prefix, legacy format, plaintext pass-through, corrupt-payload throws, unknown-version throws, null handling)
- [x] Existing `encryption-missing-env` test still passes (missing env still degrades gracefully)
- [x] Webhook tests still pass
- [ ] Verify on a staging row: existing plaintext `aiApiKey` reads unchanged, then a write rotates it to `v1:...` and reads continue to return the plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)