### PR TITLE
billing: record user-initiated subscription cancellation timestamp

### DIFF
--- a/apps/web/app/api/stripe/webhook/cancellation-initiated.ts
+++ b/apps/web/app/api/stripe/webhook/cancellation-initiated.ts
@@ -1,0 +1,26 @@
+import type Stripe from "stripe";
+
+export function getStripeCancellationInitiatedAt(event: Stripe.Event) {
+  if (event.type !== "customer.subscription.updated") return null;
+
+  const subscription = event.data.object as Stripe.Subscription;
+  const previousAttributes = event.data.previous_attributes as
+    | Partial<Stripe.Subscription>
+    | undefined;
+
+  if (!previousAttributes) return null;
+
+  const scheduledCancelAt =
+    "cancel_at" in previousAttributes &&
+    previousAttributes.cancel_at == null &&
+    subscription.cancel_at != null;
+
+  const flaggedForPeriodEnd =
+    "cancel_at_period_end" in previousAttributes &&
+    previousAttributes.cancel_at_period_end === false &&
+    subscription.cancel_at_period_end === true;
+
+  if (!scheduledCancelAt && !flaggedForPeriodEnd) return null;
+
+  return new Date(event.created * 1000);
+}

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -1,6 +1,7 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
+import { getStripeCancellationInitiatedAt } from "./cancellation-initiated";
 import { processEvent } from "./route";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
 
@@ -207,6 +208,79 @@ describe("getStripeTrialConvertedAt", () => {
     });
 
     expect(getStripeTrialConvertedAt(event)).toBeNull();
+  });
+});
+
+describe("getStripeCancellationInitiatedAt", () => {
+  it("returns the event timestamp when cancel_at transitions from null to set", () => {
+    const event = subscriptionEvent({
+      created: 1_700_000_000,
+      data: {
+        object: {
+          cancel_at: 1_700_999_000,
+          cancel_at_period_end: false,
+        },
+        previous_attributes: {
+          cancel_at: null,
+        },
+      },
+    });
+
+    expect(getStripeCancellationInitiatedAt(event)).toEqual(
+      new Date("2023-11-14T22:13:20.000Z"),
+    );
+  });
+
+  it("returns the event timestamp when cancel_at_period_end flips to true", () => {
+    const event = subscriptionEvent({
+      created: 1_700_000_000,
+      data: {
+        object: {
+          cancel_at_period_end: true,
+        },
+        previous_attributes: {
+          cancel_at_period_end: false,
+        },
+      },
+    });
+
+    expect(getStripeCancellationInitiatedAt(event)).toEqual(
+      new Date("2023-11-14T22:13:20.000Z"),
+    );
+  });
+
+  it("returns null when cancel_at was already set previously", () => {
+    const event = subscriptionEvent({
+      created: 1_700_000_000,
+      data: {
+        object: {
+          cancel_at: 1_700_999_500,
+        },
+        previous_attributes: {
+          cancel_at: 1_700_999_000,
+        },
+      },
+    });
+
+    expect(getStripeCancellationInitiatedAt(event)).toBeNull();
+  });
+
+  it("returns null when previous_attributes is undefined", () => {
+    const event = subscriptionEvent({
+      data: {
+        object: {
+          cancel_at: 1_700_999_000,
+          cancel_at_period_end: true,
+        },
+      } as Stripe.Event.Data,
+    });
+
+    expect(getStripeCancellationInitiatedAt(event)).toBeNull();
+  });
+
+  it("returns null for non-subscription-updated events", () => {
+    const event = invoiceEvent();
+    expect(getStripeCancellationInitiatedAt(event)).toBeNull();
   });
 });
 

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -9,6 +9,7 @@ import { getStripeTrialStartedProperties } from "@/ee/billing/stripe/posthog-eve
 import { syncStripeInvoicePayment } from "@/ee/billing/stripe/payments";
 import { syncAiGenerationOverageForUpcomingInvoice } from "@/ee/billing/stripe/ai-overage";
 import { env } from "@/env";
+import { getStripeCancellationInitiatedAt } from "./cancellation-initiated";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
 import {
   trackBillingTrialStarted,
@@ -109,6 +110,7 @@ export async function processEvent(event: Stripe.Event, logger: Logger) {
     trackEvent(email, event),
     trackBillingMilestones(email, event, customerId),
     handleReferralCompletion(customerId, event, logger),
+    recordCancellationInitiated(customerId, event, logger),
   ];
 
   if (stripeSync.status === "fulfilled") {
@@ -179,6 +181,32 @@ async function handleReferralCompletion(
   for (const userId of userIds) {
     await completeReferralAndGrantReward(userId, logger);
   }
+}
+
+async function recordCancellationInitiated(
+  customerId: string,
+  event: Stripe.Event,
+  logger: Logger,
+) {
+  const initiatedAt = getStripeCancellationInitiatedAt(event);
+  if (!initiatedAt) return;
+
+  const updateResult = await prisma.premium.updateMany({
+    where: { stripeCustomerId: customerId },
+    data: { stripeCancellationInitiatedAt: initiatedAt },
+  });
+
+  if (updateResult.count === 0) {
+    logger.warn("No premium found for customer during cancellation record", {
+      customerId,
+    });
+    return;
+  }
+
+  logger.info("Recorded user-initiated cancellation timestamp", {
+    customerId,
+    initiatedAt,
+  });
 }
 
 async function trackEvent(email: string | undefined, event: Stripe.Event) {

--- a/apps/web/prisma/migrations/20260421000000_add_stripe_cancellation_initiated_at/migration.sql
+++ b/apps/web/prisma/migrations/20260421000000_add_stripe_cancellation_initiated_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Premium" ADD COLUMN     "stripeCancellationInitiatedAt" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -375,6 +375,7 @@ model Premium {
   stripeRenewsAt               DateTime? // Timestamp for when the current billing period ends and the subscription attempts renewal (if not canceling). Derived from `current_period_end`.
   stripeTrialEnd               DateTime? // Timestamp for when the free trial period ends (if applicable). Important for managing trial-to-paid transitions.
   stripeTrialConvertedAt       DateTime? // Timestamp for when a Stripe trial converted from `trialing` to `active`. Historical data.
+  stripeCancellationInitiatedAt DateTime? // Timestamp for when the user actually initiated cancellation (clicked cancel). Distinct from `stripeCanceledAt`, which is when Stripe processes the scheduled cancellation at period end.
   stripeCanceledAt             DateTime? // Timestamp for when the subscription was definitively marked as canceled in Stripe (might be immediate or after period end). Historical data.
   stripeEndedAt                DateTime? // Timestamp for when the subscription ended permanently for any reason (cancellation, final payment failure). Historical data.
   stripeAiOverageLastInvoiceId String?


### PR DESCRIPTION
## Summary
- Adds `Premium.stripeCancellationInitiatedAt` to capture when a user actually clicks cancel, distinct from `stripeCanceledAt` (which is when Stripe finalizes the scheduled cancellation at period end).
- New `getStripeCancellationInitiatedAt` helper detects cancel intent from `customer.subscription.updated` events when `cancel_at` flips null→set or `cancel_at_period_end` flips false→true, mirroring the existing `trial-conversion` helper.
- Wired into the Stripe webhook route to persist the timestamp on `Premium`, with unit tests covering the transitions, no-op cases, and missing `previous_attributes`.

## Test plan
- [x] `pnpm test app/api/stripe/webhook/route.test.ts` (11 passing, 5 new)
- [ ] After deploy, verify the column populates on the next user-initiated cancel and matches Stripe event timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)