### PR TITLE
llms: fall back to next model on content-filter refusals

### DIFF
--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { APICallError } from "ai";
+import { APICallError, NoObjectGeneratedError } from "ai";
 import { createScopedLogger } from "@/utils/logger";
 const { mockSentryCaptureException, mockSetUser } = vi.hoisted(() => ({
   mockSentryCaptureException: vi.fn(),
@@ -18,6 +18,7 @@ import {
   getActionErrorMessage,
   getUserFacingErrorMessage,
   isInsufficientCreditsError,
+  isContentFilterRefusal,
   isHandledUserKeyError,
   isKnownApiError,
   isKnownOutlookError,
@@ -174,6 +175,22 @@ function createAPICallError({
     statusCode,
     responseHeaders: {},
     responseBody: "",
+  });
+}
+
+function createNoObjectGeneratedError({
+  finishReason,
+  text,
+}: {
+  finishReason: "content-filter" | "stop" | "length" | "tool-calls" | "other";
+  text: string;
+}): NoObjectGeneratedError {
+  return new NoObjectGeneratedError({
+    message: "No object generated: could not parse the response.",
+    text,
+    response: { id: "id", timestamp: new Date(), modelId: "test" },
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    finishReason,
   });
 }
 
@@ -540,6 +557,44 @@ describe("isKnownApiError", () => {
       provider: "google",
     });
     expect(isKnownApiError(error)).toBe(true);
+  });
+
+  it("treats LLM content-filter refusals as known errors", () => {
+    const error = createNoObjectGeneratedError({
+      finishReason: "content-filter",
+      text: "I'm sorry, but I cannot assist with that request.",
+    });
+    expect(isKnownApiError(error)).toBe(true);
+  });
+});
+
+describe("isContentFilterRefusal", () => {
+  it("returns true for NoObjectGeneratedError with content-filter finish reason", () => {
+    const error = createNoObjectGeneratedError({
+      finishReason: "content-filter",
+      text: "I'm sorry, but I cannot assist with that request.",
+    });
+    expect(isContentFilterRefusal(error)).toBe(true);
+  });
+
+  it("returns false for NoObjectGeneratedError with other finish reasons", () => {
+    const stopError = createNoObjectGeneratedError({
+      finishReason: "stop",
+      text: "not json",
+    });
+    expect(isContentFilterRefusal(stopError)).toBe(false);
+
+    const lengthError = createNoObjectGeneratedError({
+      finishReason: "length",
+      text: "truncated",
+    });
+    expect(isContentFilterRefusal(lengthError)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isContentFilterRefusal(new Error("boom"))).toBe(false);
+    expect(isContentFilterRefusal(null)).toBe(false);
+    expect(isContentFilterRefusal(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -2,7 +2,7 @@ import {
   captureException as sentryCaptureException,
   setUser,
 } from "@sentry/nextjs";
-import { APICallError, RetryError } from "ai";
+import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
 import type { FlattenedValidationErrors } from "next-safe-action";
 import {
   getProviderRateLimitApiErrorType,
@@ -297,6 +297,17 @@ export function isKnownOutlookError(error: unknown): boolean {
   );
 }
 
+// Provider content moderation refused to produce structured output. Retrying
+// the same model is futile; a fallback model may succeed. Handles p-retry
+// context wrappers that expose the real error on an `error` property.
+export function isContentFilterRefusal(error: unknown): boolean {
+  const unwrapped = (error as { error?: unknown })?.error ?? error;
+  return (
+    NoObjectGeneratedError.isInstance(unwrapped) &&
+    unwrapped.finishReason === "content-filter"
+  );
+}
+
 // we don't want to capture these errors in Sentry
 export function isKnownApiError(error: unknown): boolean {
   return (
@@ -305,6 +316,7 @@ export function isKnownApiError(error: unknown): boolean {
     isGmailRateLimitExceededError(error) ||
     isGmailQuotaExceededError(error) ||
     isKnownOutlookError(error) ||
+    isContentFilterRefusal(error) ||
     (APICallError.isInstance(error) &&
       (isIncorrectAPIKeyError(error) ||
         isInvalidAIModelError(error) ||
@@ -411,13 +423,13 @@ export function getErrorMessage(error: unknown): string | undefined {
   if (error instanceof Error) return error.message;
 
   const outer = asRecord(error);
-  if (!outer) return undefined;
+  if (!outer) return;
 
   const directMessage = getStringProp(outer, "message");
   if (directMessage) return directMessage;
 
   const nested = asRecord(outer.error);
-  if (!nested) return undefined;
+  if (!nested) return;
 
   return getStringProp(nested, "message");
 }

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -5,11 +5,15 @@ vi.mock("server-only", () => ({}));
 const {
   mockAttachLlmRepairMetadata,
   mockGenerateObject,
+  mockIsContentFilterRefusal,
+  mockNoObjectGeneratedErrorIsInstance,
   mockSaveAiUsage,
   mockShouldForceNanoModel,
 } = vi.hoisted(() => ({
   mockAttachLlmRepairMetadata: vi.fn(),
   mockGenerateObject: vi.fn(),
+  mockIsContentFilterRefusal: vi.fn(() => false),
+  mockNoObjectGeneratedErrorIsInstance: vi.fn(() => false),
   mockSaveAiUsage: vi.fn(),
   mockShouldForceNanoModel: vi.fn(),
 }));
@@ -17,7 +21,7 @@ const {
 vi.mock("ai", () => ({
   APICallError: { isInstance: () => false },
   RetryError: { isInstance: () => false },
-  NoObjectGeneratedError: { isInstance: () => false },
+  NoObjectGeneratedError: { isInstance: mockNoObjectGeneratedErrorIsInstance },
   TypeValidationError: { isInstance: () => false },
   ToolLoopAgent: class {},
   generateObject: mockGenerateObject,
@@ -58,6 +62,7 @@ vi.mock("@/utils/error", () => ({
   attachLlmRepairMetadata: mockAttachLlmRepairMetadata,
   captureException: vi.fn(),
   isAnthropicInsufficientBalanceError: vi.fn(() => false),
+  isContentFilterRefusal: mockIsContentFilterRefusal,
   isIncorrectOpenAIAPIKeyError: vi.fn(() => false),
   isInsufficientCreditsError: vi.fn(() => false),
   isInvalidAIModelError: vi.fn(() => false),
@@ -314,6 +319,80 @@ describe("createGenerateObject repairText", () => {
         successfulCandidateKind: "unwrapped",
       }),
     );
+  });
+
+  it("falls back to next model on content-filter refusal without retrying primary", async () => {
+    const contentFilterError = Object.assign(
+      new Error("No object generated: could not parse the response."),
+      {
+        finishReason: "content-filter",
+        text: "I'm sorry, but I cannot assist with that request.",
+      },
+    );
+    const matchesContentFilter = (error: unknown) => {
+      const unwrapped = (error as { error?: unknown })?.error ?? error;
+      return unwrapped === contentFilterError;
+    };
+    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
+      matchesContentFilter,
+    );
+    mockIsContentFilterRefusal.mockImplementation(matchesContentFilter);
+
+    mockGenerateObject
+      .mockRejectedValueOnce(contentFilterError)
+      .mockResolvedValueOnce({ object: { ok: true }, usage: null });
+
+    const generateObject = await createGenerateObjectWithFallback();
+
+    const result = await generateObject({
+      system: "Return JSON.",
+      prompt: "Return JSON.",
+      schema: {} as any,
+    } as any);
+
+    expect(result).toEqual({ object: { ok: true }, usage: null });
+    expect(mockGenerateObject).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws content-filter refusal without Sentry noise when no fallback is configured", async () => {
+    const contentFilterError = Object.assign(
+      new Error("No object generated: could not parse the response."),
+      {
+        finishReason: "content-filter",
+        text: "I'm sorry, but I cannot assist with that request.",
+      },
+    );
+    const matchesContentFilter = (error: unknown) => {
+      const unwrapped = (error as { error?: unknown })?.error ?? error;
+      return unwrapped === contentFilterError;
+    };
+    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
+      matchesContentFilter,
+    );
+    mockIsContentFilterRefusal.mockImplementation(matchesContentFilter);
+
+    mockGenerateObject.mockRejectedValue(contentFilterError);
+
+    const generateObject = await createTestGenerateObject();
+
+    const rejection = await generateObject({
+      system: "Return JSON.",
+      prompt: "Return JSON.",
+      schema: {} as any,
+    } as any).then(
+      () => {
+        throw new Error("Expected rejection");
+      },
+      (error) => error,
+    );
+
+    // withLLMRetry may wrap via p-retry's context; the original refusal must
+    // remain reachable either directly or via `.error` so callers can identify it.
+    const inner = (rejection as { error?: unknown })?.error ?? rejection;
+    expect(inner).toBe(contentFilterError);
+
+    // No retries on the same model — refusal will not succeed on retry.
+    expect(mockGenerateObject).toHaveBeenCalledTimes(1);
   });
 
   it("clears stale repair metadata before trying a fallback model", async () => {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -33,6 +33,7 @@ import {
   attachLlmRepairMetadata,
   captureException,
   isAnthropicInsufficientBalanceError,
+  isContentFilterRefusal,
   isIncorrectOpenAIAPIKeyError,
   isInsufficientCreditsError,
   isInvalidAIModelError,
@@ -394,7 +395,8 @@ export function createGenerateObject({
             withNetworkRetry(() => generate(candidate), {
               label,
               shouldRetry: (error) =>
-                NoObjectGeneratedError.isInstance(error) ||
+                (NoObjectGeneratedError.isInstance(error) &&
+                  !isContentFilterRefusal(error)) ||
                 TypeValidationError.isInstance(error),
             }),
           { label },
@@ -1008,6 +1010,8 @@ function shouldFallbackToNextModel(error: unknown): boolean {
   if (RetryError.isInstance(error) && isAiQuotaExceededError(error)) {
     return true;
   }
+
+  if (isContentFilterRefusal(error)) return true;
 
   const llmErrorInfo = extractLLMErrorInfo(error);
   if (llmErrorInfo.retryable) return true;


### PR DESCRIPTION
## Summary
- Detect `NoObjectGeneratedError` with a `content-filter` finish reason and skip same-model retries that cannot succeed.
- Fall back to the configured fallback model when the primary model refuses structured output.
- Exclude these refusals from Sentry capture via `isKnownApiError`.

## Test plan
- [x] `pnpm --filter inbox-zero-ai exec vitest run utils/error.test.ts utils/llms/`
- [x] Full `utils/` suite (2581 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)