### PR TITLE
Update starter pricing configuration

### DIFF
--- a/apps/web/app/(app)/premium/config.test.ts
+++ b/apps/web/app/(app)/premium/config.test.ts
@@ -9,7 +9,6 @@ vi.mock("@/env", () => ({
     NEXT_PUBLIC_BUSINESS_MONTHLY_VARIANT_ID: 5,
     NEXT_PUBLIC_BUSINESS_ANNUALLY_VARIANT_ID: 6,
     NEXT_PUBLIC_COPILOT_MONTHLY_VARIANT_ID: 7,
-    // This current price also exists in oldPriceIds, which is the case under test.
     NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PRICE_ID:
       "price_1S5u73KGf8mwZWHn8VYFdALA",
     NEXT_PUBLIC_STRIPE_BUSINESS_ANNUALLY_PRICE_ID:

--- a/apps/web/app/(app)/premium/config.test.ts
+++ b/apps/web/app/(app)/premium/config.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/env", () => ({
     NEXT_PUBLIC_BUSINESS_MONTHLY_VARIANT_ID: 5,
     NEXT_PUBLIC_BUSINESS_ANNUALLY_VARIANT_ID: 6,
     NEXT_PUBLIC_COPILOT_MONTHLY_VARIANT_ID: 7,
+    // This current price also exists in oldPriceIds, which is the case under test.
     NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PRICE_ID:
       "price_1S5u73KGf8mwZWHn8VYFdALA",
     NEXT_PUBLIC_STRIPE_BUSINESS_ANNUALLY_PRICE_ID:
@@ -33,7 +34,7 @@ import {
 } from "./config";
 
 describe("hasLegacyStripePriceId", () => {
-  it("returns false when the subscription uses the current Stripe price", () => {
+  it("returns false when the current Stripe price also appears in legacy ids", () => {
     expect(
       hasLegacyStripePriceId({
         tier: "STARTER_MONTHLY",
@@ -117,7 +118,7 @@ describe("shouldShowLegacyStripePricingNotice", () => {
     ).toBe(false);
   });
 
-  it("hides the notice when the Stripe price is current", () => {
+  it("hides the notice when the current Stripe price also appears in legacy ids", () => {
     expect(
       shouldShowLegacyStripePricingNotice({
         tier: "STARTER_MONTHLY",

--- a/apps/web/app/(app)/premium/config.test.ts
+++ b/apps/web/app/(app)/premium/config.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/env", () => ({
     NEXT_PUBLIC_BUSINESS_ANNUALLY_VARIANT_ID: 6,
     NEXT_PUBLIC_COPILOT_MONTHLY_VARIANT_ID: 7,
     NEXT_PUBLIC_STRIPE_BUSINESS_MONTHLY_PRICE_ID:
-      "price_current_starter_monthly",
+      "price_1S5u73KGf8mwZWHn8VYFdALA",
     NEXT_PUBLIC_STRIPE_BUSINESS_ANNUALLY_PRICE_ID:
       "price_current_starter_annual",
     NEXT_PUBLIC_STRIPE_PLUS_MONTHLY_PRICE_ID: "price_current_plus_monthly",
@@ -37,7 +37,7 @@ describe("hasLegacyStripePriceId", () => {
     expect(
       hasLegacyStripePriceId({
         tier: "STARTER_MONTHLY",
-        priceId: "price_current_starter_monthly",
+        priceId: "price_1S5u73KGf8mwZWHn8VYFdALA",
       }),
     ).toBe(false);
   });
@@ -64,7 +64,7 @@ describe("hasLegacyStripePriceId", () => {
     expect(
       hasLegacyStripePriceId({
         tier: null,
-        priceId: "price_current_starter_monthly",
+        priceId: "price_1S5u73KGf8mwZWHn8VYFdALA",
       }),
     ).toBe(false);
 
@@ -121,7 +121,7 @@ describe("shouldShowLegacyStripePricingNotice", () => {
     expect(
       shouldShowLegacyStripePricingNotice({
         tier: "STARTER_MONTHLY",
-        stripePriceId: "price_current_starter_monthly",
+        stripePriceId: "price_1S5u73KGf8mwZWHn8VYFdALA",
         stripeSubscriptionStatus: "active",
       }),
     ).toBe(false);
@@ -131,7 +131,7 @@ describe("shouldShowLegacyStripePricingNotice", () => {
 describe("monthly pricing config", () => {
   it("uses the active monthly Stripe price ids for checkout", () => {
     expect(getStripePriceId({ tier: "STARTER_MONTHLY" })).toBe(
-      "price_current_starter_monthly",
+      "price_1S5u73KGf8mwZWHn8VYFdALA",
     );
     expect(getStripePriceId({ tier: "PLUS_MONTHLY" })).toBe(
       "price_current_plus_monthly",
@@ -143,7 +143,7 @@ describe("monthly pricing config", () => {
 
   it("marks only the active monthly prices for special seat billing", () => {
     expect(
-      hasIncludedEmailAccountsStripePriceId("price_current_starter_monthly"),
+      hasIncludedEmailAccountsStripePriceId("price_1S5u73KGf8mwZWHn8VYFdALA"),
     ).toBe(false);
     expect(
       hasIncludedEmailAccountsStripePriceId("price_current_plus_monthly"),

--- a/apps/web/app/(app)/premium/config.ts
+++ b/apps/web/app/(app)/premium/config.ts
@@ -180,6 +180,7 @@ export function hasLegacyStripePriceId({
 
   const tierConfig = STRIPE_PRICE_ID_CONFIG[resolvedTier];
   if (!tierConfig) return false;
+  // We sometimes reuse a historical price as the active price again.
   if (tierConfig.priceId === priceId) return false;
 
   return tierConfig.oldPriceIds?.includes(priceId) ?? false;

--- a/apps/web/app/(app)/premium/config.ts
+++ b/apps/web/app/(app)/premium/config.ts
@@ -21,7 +21,7 @@ const pricing: Record<PremiumTier, number> = {
   BASIC_ANNUALLY: 8,
   PRO_MONTHLY: 16,
   PRO_ANNUALLY: 10,
-  STARTER_MONTHLY: 25,
+  STARTER_MONTHLY: 20,
   STARTER_ANNUALLY: 18,
   PLUS_MONTHLY: 35,
   PLUS_ANNUALLY: 28,
@@ -178,10 +178,11 @@ export function hasLegacyStripePriceId({
   const resolvedTier = tier || getStripeSubscriptionTier({ priceId });
   if (!resolvedTier) return false;
 
-  return (
-    STRIPE_PRICE_ID_CONFIG[resolvedTier]?.oldPriceIds?.includes(priceId) ??
-    false
-  );
+  const tierConfig = STRIPE_PRICE_ID_CONFIG[resolvedTier];
+  if (!tierConfig) return false;
+  if (tierConfig.priceId === priceId) return false;
+
+  return tierConfig.oldPriceIds?.includes(priceId) ?? false;
 }
 
 export function shouldShowLegacyStripePricingNotice(


### PR DESCRIPTION
Updates starter pricing configuration for the current monthly plan while preserving legacy subscription handling.

- set the starter monthly display price to $20
- keep the checkout price env-driven and avoid flagging the active price as legacy
- update focused pricing tests to cover the active monthly price configuration