### PR TITLE
Improve cold email intro classification

### DIFF
--- a/apps/web/__tests__/eval/cold-email.test.ts
+++ b/apps/web/__tests__/eval/cold-email.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, expect, test, vi } from "vitest";
+import { getEmail } from "@/__tests__/helpers";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { isColdEmail } from "@/utils/cold-email/is-cold-email";
+
+// pnpm test-ai eval/cold-email
+// Multi-model: EVAL_MODELS=all pnpm test-ai eval/cold-email
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 60_000;
+
+const testCases = [
+  {
+    name: "third-party introduction is not cold",
+    email: getEmail({
+      from: "claire@example.com",
+      to: "alice@example.com, bob@example.com",
+      subject: "Intro: Alice <> Bob",
+      content: `Hi Alice and Bob,
+
+Good speaking with both of you earlier.
+
+Alice is building workflow software for operations teams.
+Bob leads a firm that works with companies in that space.
+
+Thought it would be useful to connect you two directly.
+
+Best,
+Claire`,
+      date: new Date("2026-04-21T10:00:00Z"),
+    }),
+    expectedColdEmail: false,
+  },
+  {
+    name: "direct service pitch is cold",
+    email: getEmail({
+      from: "growth@agency.example",
+      subject: "Can we help your team ship faster?",
+      content: `Hi there,
+
+We help software teams move faster with product design, engineering, and recruiting support.
+
+Would you be open to a quick call next week to see if we can help?`,
+      date: new Date("2026-04-21T10:00:00Z"),
+    }),
+    expectedColdEmail: true,
+  },
+];
+
+describe.runIf(shouldRunEval)("Eval: cold email", () => {
+  const evalReporter = createEvalReporter();
+
+  describeEvalMatrix("cold email", (model, emailAccount) => {
+    for (const testCase of testCases) {
+      test(
+        testCase.name,
+        async () => {
+          const result = await isColdEmail({
+            email: testCase.email,
+            emailAccount,
+            provider: {
+              hasPreviousCommunicationsWithSenderOrDomain: async () => false,
+            } as any,
+            coldEmailRule: null,
+          });
+
+          const actual = String(result.isColdEmail);
+          const expected = String(testCase.expectedColdEmail);
+          const pass = result.isColdEmail === testCase.expectedColdEmail;
+
+          evalReporter.record({
+            testName: testCase.name,
+            model: model.label,
+            pass,
+            actual,
+            expected,
+          });
+
+          expect(result.isColdEmail).toBe(testCase.expectedColdEmail);
+        },
+        TIMEOUT,
+      );
+    }
+  });
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});

--- a/apps/web/utils/cold-email/prompt.ts
+++ b/apps/web/utils/cold-email/prompt.ts
@@ -7,6 +7,7 @@ Emails that are NOT cold emails include:
 - Email from an investor that wants to learn more or invest in the company
 - Email from a friend or colleague
 - Email from someone you met at a conference
+- Intro emails where someone is introducing you to another person
 - Email from a customer
 - Newsletter
 - Password reset


### PR DESCRIPTION
Adds regression coverage for third-party introduction emails in the cold email eval suite.

Updates the default cold email prompt so introduction emails are treated as non-cold.
Keeps a direct outreach control case in the eval to preserve cold-email detection coverage.