### PR TITLE
queue: use shared internal API headers

### DIFF
--- a/apps/web/utils/queue/forward-to-internal-api.test.ts
+++ b/apps/web/utils/queue/forward-to-internal-api.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+
+vi.mock("server-only", () => ({}));
+
+describe("forwardQueueMessageToInternalApi", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("uses shared internal API headers when forwarding queue messages", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.doMock("@/utils/internal-api", () => ({
+      getInternalApiUrl: () => "https://worker.example.com",
+      getInternalApiHeaders: () => ({
+        "x-api-key": "internal-api-key",
+        "x-inbox-zero-caller-id": "worker.example.com",
+      }),
+    }));
+
+    const { forwardQueueMessageToInternalApi } = await import(
+      "./forward-to-internal-api"
+    );
+
+    await forwardQueueMessageToInternalApi({
+      path: "/api/test",
+      body: { id: "job-1" },
+      logger: createTestLogger(),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://worker.example.com/api/test",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ id: "job-1" }),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-api-key": "internal-api-key",
+          "x-inbox-zero-caller-id": "worker.example.com",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/utils/queue/forward-to-internal-api.ts
+++ b/apps/web/utils/queue/forward-to-internal-api.ts
@@ -1,8 +1,4 @@
-import { env } from "@/env";
-import {
-  INTERNAL_API_KEY_HEADER,
-  getInternalApiUrl,
-} from "@/utils/internal-api";
+import { getInternalApiHeaders, getInternalApiUrl } from "@/utils/internal-api";
 import type { Logger } from "@/utils/logger";
 
 export async function forwardQueueMessageToInternalApi<T>({
@@ -21,7 +17,7 @@ export async function forwardQueueMessageToInternalApi<T>({
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        [INTERNAL_API_KEY_HEADER]: env.INTERNAL_API_KEY,
+        ...getInternalApiHeaders(),
       },
       body: JSON.stringify(body),
     });
@@ -55,6 +51,6 @@ async function getResponseBody(response: Response) {
   try {
     return await response.text();
   } catch {
-    return undefined;
+    return;
   }
 }

--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -59,8 +59,11 @@ async function loadUpstashModule({
   }));
 
   vi.doMock("@/utils/internal-api", () => ({
-    INTERNAL_API_KEY_HEADER: "x-api-key",
     getInternalApiUrl: () => internalApiUrl,
+    getInternalApiHeaders: () => ({
+      "x-api-key": "internal-api-key",
+      "x-inbox-zero-caller-id": "public.example.com",
+    }),
   }));
 
   return import("./index");

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -1,10 +1,7 @@
 import { Client, type FlowControl, type HeadersInit } from "@upstash/qstash";
 import { after } from "next/server";
+import { getInternalApiHeaders, getInternalApiUrl } from "@/utils/internal-api";
 import { env } from "@/env";
-import {
-  INTERNAL_API_KEY_HEADER,
-  getInternalApiUrl,
-} from "@/utils/internal-api";
 import { createScopedLogger } from "@/utils/logger";
 import { isSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
 
@@ -147,7 +144,9 @@ async function fallbackPublishToQstash<T>(
           : headers,
   );
   internalHeaders.set("Content-Type", "application/json");
-  internalHeaders.set(INTERNAL_API_KEY_HEADER, env.INTERNAL_API_KEY);
+  for (const [key, value] of Object.entries(getInternalApiHeaders())) {
+    internalHeaders.set(key, value);
+  }
 
   after(async () => {
     try {


### PR DESCRIPTION
Use the shared internal header builder for the remaining direct self-call paths so queue and fallback dispatches carry the same internal caller metadata.

This updates the queue forwarder and the Upstash fallback path while preserving existing caller-supplied headers, and adds focused test coverage for the queue forwarding path.

Validated with targeted unit tests and the app's CI-aligned build check.