### PR TITLE
fix(assistant-chat): align inline email detail test with rendered output

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -139,7 +139,6 @@ describe("AssistantInlineEmailResponse", () => {
 
     expect(screen.getByText("Subject")).toBeTruthy();
     expect(screen.getByText("Focus on the action item.")).toBeTruthy();
-    expect(screen.getByText("Rendered detail subject")).toBeTruthy();
     expect(screen.getByText("Rendered detail body")).toBeTruthy();
     expect(screen.getByRole("link").getAttribute("href")).toBe(
       getEmailUrlForMessage(


### PR DESCRIPTION
## Summary
- Drop the stale assertion on `Rendered detail subject` in `assistant-inline-email-response.test.tsx`.
- The compact `EmailPreview` used by `InlineEmailDetail` does not render the thread message's subject; the header shows the lookup subject (`meta?.subject`) and the body shows message text only, so the assertion can never pass.
- Introduced by #2336 (the `test` job is currently red on main because of this).

## Test plan
- [x] `cd apps/web && pnpm test components/assistant-chat/assistant-inline-email-response.test.tsx` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)