### PR TITLE
billing: skip zero-amount Stripe invoice payments

### DIFF
--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -118,6 +118,32 @@ describe("syncStripeInvoicePayment", () => {
     expect(mockFindUnique).not.toHaveBeenCalled();
     expect(mockUpsert).not.toHaveBeenCalled();
   });
+
+  it("skips zero-amount invoices", async () => {
+    const { syncStripeInvoicePayment } = await import("./payments");
+
+    await syncStripeInvoicePayment({
+      event: invoiceEvent({
+        data: {
+          object: {
+            id: "in_zero",
+            customer: "cus_123",
+            created: 1_700_000_000,
+            currency: "usd",
+            total: 0,
+            status: "paid",
+            billing_reason: "subscription_cycle",
+            total_taxes: [],
+            status_transitions: {},
+          },
+        },
+      }),
+      logger,
+    });
+
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
 });
 
 function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -54,6 +54,16 @@ export async function upsertStripeInvoicePayment({
     return;
   }
 
+  if (invoice.total === 0) {
+    logger.info("Skipping zero-amount Stripe invoice for Payment sync", {
+      invoiceId,
+      customerId,
+      status: invoice.status ?? "unknown",
+      ...context,
+    });
+    return;
+  }
+
   const premium = await prisma.premium.findUnique({
     where: { stripeCustomerId: customerId },
     select: { id: true },


### PR DESCRIPTION
Skip Stripe invoice sync when the invoice total is zero so we do not create meaningless payment records.

- return early for zero-amount invoices before premium lookup or payment upsert
- add a focused test covering the zero-amount invoice case