### PR TITLE
billing: sync Stripe refunds to payments

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -6,7 +6,6 @@ import { processEvent } from "./route";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
 
 const {
-  mockGetStripe,
   mockSyncStripeDataToDb,
   mockSyncStripeInvoicePayment,
   mockSyncAiGenerationOverageForUpcomingInvoice,
@@ -19,7 +18,6 @@ const {
   mockCompleteReferralAndGrantReward,
   mockCaptureException,
 } = vi.hoisted(() => ({
-  mockGetStripe: vi.fn(),
   mockSyncStripeDataToDb: vi.fn(),
   mockSyncStripeInvoicePayment: vi.fn(),
   mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
@@ -45,7 +43,7 @@ vi.mock("next/server", () => ({
 }));
 
 vi.mock("@/ee/billing/stripe", () => ({
-  getStripe: mockGetStripe,
+  getStripe: vi.fn(),
 }));
 
 vi.mock("@/utils/middleware", () => ({
@@ -100,14 +98,6 @@ const logger = createScopedLogger("stripe-webhook-route-test");
 describe("processEvent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetStripe.mockReturnValue({
-      charges: {
-        retrieve: vi.fn(),
-      },
-      paymentIntents: {
-        retrieve: vi.fn(),
-      },
-    });
     mockFindUnique.mockResolvedValue(null);
     mockUpdateMany.mockResolvedValue({ count: 0 });
     mockSyncStripeInvoicePayment.mockResolvedValue(undefined);
@@ -151,34 +141,6 @@ describe("processEvent", () => {
     expect(
       mockSyncAiGenerationOverageForUpcomingInvoice,
     ).not.toHaveBeenCalled();
-  });
-
-  it("resolves the customer from refund events before running the shared sync flow", async () => {
-    const mockChargeRetrieve = vi.fn().mockResolvedValue({
-      customer: "cus_test",
-    });
-
-    mockGetStripe.mockReturnValue({
-      charges: {
-        retrieve: mockChargeRetrieve,
-      },
-      paymentIntents: {
-        retrieve: vi.fn(),
-      },
-    });
-    mockSyncStripeDataToDb.mockResolvedValue(undefined);
-
-    await processEvent(refundEvent(), logger);
-
-    expect(mockChargeRetrieve).toHaveBeenCalledWith("ch_test");
-    expect(mockSyncStripeDataToDb).toHaveBeenCalledWith({
-      customerId: "cus_test",
-      logger,
-    });
-    expect(mockSyncStripeInvoicePayment).toHaveBeenCalledWith({
-      event: expect.objectContaining({ type: "refund.created" }),
-      logger,
-    });
   });
 });
 
@@ -362,27 +324,6 @@ function subscriptionEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
         trial_end: null,
       },
       previous_attributes: {},
-    },
-    ...overrides,
-  } as Stripe.Event;
-}
-
-function refundEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
-  return {
-    id: "evt_refund_test",
-    type: "refund.created",
-    object: "event",
-    api_version: "2025-03-31.basil",
-    created: 1_700_000_500,
-    livemode: false,
-    pending_webhooks: 0,
-    request: { id: null, idempotency_key: null },
-    data: {
-      object: {
-        id: "re_test",
-        charge: "ch_test",
-        payment_intent: null,
-      },
     },
     ...overrides,
   } as Stripe.Event;

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -6,6 +6,7 @@ import { processEvent } from "./route";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
 
 const {
+  mockGetStripe,
   mockSyncStripeDataToDb,
   mockSyncStripeInvoicePayment,
   mockSyncAiGenerationOverageForUpcomingInvoice,
@@ -18,6 +19,7 @@ const {
   mockCompleteReferralAndGrantReward,
   mockCaptureException,
 } = vi.hoisted(() => ({
+  mockGetStripe: vi.fn(),
   mockSyncStripeDataToDb: vi.fn(),
   mockSyncStripeInvoicePayment: vi.fn(),
   mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
@@ -43,7 +45,7 @@ vi.mock("next/server", () => ({
 }));
 
 vi.mock("@/ee/billing/stripe", () => ({
-  getStripe: vi.fn(),
+  getStripe: mockGetStripe,
 }));
 
 vi.mock("@/utils/middleware", () => ({
@@ -98,6 +100,14 @@ const logger = createScopedLogger("stripe-webhook-route-test");
 describe("processEvent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetStripe.mockReturnValue({
+      charges: {
+        retrieve: vi.fn(),
+      },
+      paymentIntents: {
+        retrieve: vi.fn(),
+      },
+    });
     mockFindUnique.mockResolvedValue(null);
     mockUpdateMany.mockResolvedValue({ count: 0 });
     mockSyncStripeInvoicePayment.mockResolvedValue(undefined);
@@ -141,6 +151,34 @@ describe("processEvent", () => {
     expect(
       mockSyncAiGenerationOverageForUpcomingInvoice,
     ).not.toHaveBeenCalled();
+  });
+
+  it("resolves the customer from refund events before running the shared sync flow", async () => {
+    const mockChargeRetrieve = vi.fn().mockResolvedValue({
+      customer: "cus_test",
+    });
+
+    mockGetStripe.mockReturnValue({
+      charges: {
+        retrieve: mockChargeRetrieve,
+      },
+      paymentIntents: {
+        retrieve: vi.fn(),
+      },
+    });
+    mockSyncStripeDataToDb.mockResolvedValue(undefined);
+
+    await processEvent(refundEvent(), logger);
+
+    expect(mockChargeRetrieve).toHaveBeenCalledWith("ch_test");
+    expect(mockSyncStripeDataToDb).toHaveBeenCalledWith({
+      customerId: "cus_test",
+      logger,
+    });
+    expect(mockSyncStripeInvoicePayment).toHaveBeenCalledWith({
+      event: expect.objectContaining({ type: "refund.created" }),
+      logger,
+    });
   });
 });
 
@@ -324,6 +362,27 @@ function subscriptionEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
         trial_end: null,
       },
       previous_attributes: {},
+    },
+    ...overrides,
+  } as Stripe.Event;
+}
+
+function refundEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
+  return {
+    id: "evt_refund_test",
+    type: "refund.created",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1_700_000_500,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "re_test",
+        charge: "ch_test",
+        payment_intent: null,
+      },
     },
     ...overrides,
   } as Stripe.Event;

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -84,14 +84,15 @@ const allowedEvents: Stripe.Event.Type[] = [
   "payment_intent.succeeded",
   "payment_intent.payment_failed",
   "payment_intent.canceled",
+  "refund.created",
+  "refund.updated",
+  "refund.failed",
 ];
 
 export async function processEvent(event: Stripe.Event, logger: Logger) {
   if (!allowedEvents.includes(event.type)) return;
 
-  // All the events we track have a customerId
-  const customerId =
-    "customer" in event.data.object ? event.data.object.customer : null;
+  const customerId = await getStripeCustomerIdForEvent(event);
 
   if (!customerId || typeof customerId !== "string") {
     logger.error("ID isn't string", { event });
@@ -250,4 +251,43 @@ async function getCustomerEmail(customerId: string) {
   });
 
   return premium?.users[0]?.email;
+}
+
+async function getStripeCustomerIdForEvent(event: Stripe.Event) {
+  const object = event.data.object;
+  const customerId =
+    "customer" in object ? normalizeStripeId(object.customer) : null;
+
+  if (customerId) {
+    return customerId;
+  }
+
+  if (!event.type.startsWith("refund.")) {
+    return null;
+  }
+
+  const refund = object as Stripe.Refund;
+  const stripe = getStripe();
+
+  const chargeId = normalizeStripeId(refund.charge);
+  if (chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    return normalizeStripeId(charge.customer);
+  }
+
+  const paymentIntentId = normalizeStripeId(refund.payment_intent);
+  if (paymentIntentId) {
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    return normalizeStripeId(paymentIntent.customer);
+  }
+
+  return null;
+}
+
+function normalizeStripeId(value: string | { id: string } | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  return typeof value === "string" ? value : value.id;
 }

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -2,6 +2,11 @@ import type Stripe from "stripe";
 import { headers } from "next/headers";
 import { after, NextResponse } from "next/server";
 import { getStripe } from "@/ee/billing/stripe";
+import {
+  getStripeCustomerIdForRefund,
+  isStripeRefundEventType,
+  stripeRefundEvents,
+} from "@/ee/billing/stripe/refunds";
 import { withError } from "@/utils/middleware";
 import type { Logger } from "@/utils/logger";
 import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
@@ -84,9 +89,7 @@ const allowedEvents: Stripe.Event.Type[] = [
   "payment_intent.succeeded",
   "payment_intent.payment_failed",
   "payment_intent.canceled",
-  "refund.created",
-  "refund.updated",
-  "refund.failed",
+  ...stripeRefundEvents,
 ];
 
 export async function processEvent(event: Stripe.Event, logger: Logger) {
@@ -262,26 +265,11 @@ async function getStripeCustomerIdForEvent(event: Stripe.Event) {
     return customerId;
   }
 
-  if (!event.type.startsWith("refund.")) {
+  if (!isStripeRefundEventType(event.type)) {
     return null;
   }
 
-  const refund = object as Stripe.Refund;
-  const stripe = getStripe();
-
-  const chargeId = normalizeStripeId(refund.charge);
-  if (chargeId) {
-    const charge = await stripe.charges.retrieve(chargeId);
-    return normalizeStripeId(charge.customer);
-  }
-
-  const paymentIntentId = normalizeStripeId(refund.payment_intent);
-  if (paymentIntentId) {
-    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
-    return normalizeStripeId(paymentIntent.customer);
-  }
-
-  return null;
+  return await getStripeCustomerIdForRefund(object as Stripe.Refund);
 }
 
 function normalizeStripeId(value: string | { id: string } | null | undefined) {

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -3,18 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProcessorType } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 
-const {
-  mockFindUnique,
-  mockUpsert,
-  mockChargeRetrieve,
-  mockPaymentIntentRetrieve,
-  mockInvoiceRetrieve,
-} = vi.hoisted(() => ({
+const { mockFindUnique, mockUpsert } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
   mockUpsert: vi.fn(),
-  mockChargeRetrieve: vi.fn(),
-  mockPaymentIntentRetrieve: vi.fn(),
-  mockInvoiceRetrieve: vi.fn(),
 }));
 
 vi.mock("@/utils/prisma", () => ({
@@ -26,20 +17,6 @@ vi.mock("@/utils/prisma", () => ({
       upsert: mockUpsert,
     },
   },
-}));
-
-vi.mock("@/ee/billing/stripe", () => ({
-  getStripe: () => ({
-    charges: {
-      retrieve: mockChargeRetrieve,
-    },
-    paymentIntents: {
-      retrieve: mockPaymentIntentRetrieve,
-    },
-    invoices: {
-      retrieve: mockInvoiceRetrieve,
-    },
-  }),
 }));
 
 const logger = createScopedLogger("stripe-payments-test");
@@ -172,69 +149,6 @@ describe("syncStripeInvoicePayment", () => {
     expect(mockFindUnique).not.toHaveBeenCalled();
     expect(mockUpsert).not.toHaveBeenCalled();
   });
-
-  it("updates the same payment row when a refund event is received", async () => {
-    mockFindUnique.mockResolvedValue({ id: "premium_123" });
-    mockChargeRetrieve.mockResolvedValue({
-      invoice: "in_123",
-    });
-    mockInvoiceRetrieve.mockResolvedValue({
-      id: "in_123",
-      customer: "cus_123",
-      parent: {
-        subscription_details: {
-          subscription: "sub_123",
-        },
-      },
-      created: 1_700_000_000,
-      currency: "usd",
-      total: 2000,
-      status: "paid",
-      billing_reason: "subscription_cycle",
-      total_taxes: [],
-      status_transitions: {
-        paid_at: 1_700_000_100,
-      },
-      charge: {
-        amount_refunded: 500,
-        refunds: {
-          data: [
-            {
-              created: 1_700_000_450,
-              status: "succeeded",
-            },
-          ],
-        },
-      },
-    });
-
-    const { syncStripeInvoicePayment } = await import("./payments");
-
-    await syncStripeInvoicePayment({
-      event: refundEvent(),
-      logger,
-    });
-
-    expect(mockChargeRetrieve).toHaveBeenCalledWith("ch_123");
-    expect(mockInvoiceRetrieve).toHaveBeenCalledWith("in_123", {
-      expand: ["charge", "charge.refunds"],
-    });
-    expect(mockUpsert).toHaveBeenCalledWith({
-      where: { processorId: "in_123" },
-      create: expect.objectContaining({
-        refunded: true,
-        refundedAmount: 500,
-        refundedAt: new Date("2023-11-14T22:20:50.000Z"),
-        status: "partially_refunded",
-      }),
-      update: expect.objectContaining({
-        refunded: true,
-        refundedAmount: 500,
-        refundedAt: new Date("2023-11-14T22:20:50.000Z"),
-        status: "partially_refunded",
-      }),
-    });
-  });
 });
 
 function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
@@ -263,27 +177,6 @@ function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
         billing_reason: "subscription_cycle",
         total_taxes: [],
         status_transitions: {},
-      },
-    },
-    ...overrides,
-  } as Stripe.Event;
-}
-
-function refundEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
-  return {
-    id: "evt_refund",
-    type: "refund.created",
-    object: "event",
-    api_version: "2025-03-31.basil",
-    created: 1_700_000_500,
-    livemode: false,
-    pending_webhooks: 0,
-    request: { id: null, idempotency_key: null },
-    data: {
-      object: {
-        id: "re_123",
-        charge: "ch_123",
-        payment_intent: null,
       },
     },
     ...overrides,

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -3,8 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProcessorType } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 
-const mockFindUnique = vi.fn();
-const mockUpsert = vi.fn();
+const {
+  mockFindUnique,
+  mockUpsert,
+  mockChargeRetrieve,
+  mockPaymentIntentRetrieve,
+  mockInvoiceRetrieve,
+} = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockUpsert: vi.fn(),
+  mockChargeRetrieve: vi.fn(),
+  mockPaymentIntentRetrieve: vi.fn(),
+  mockInvoiceRetrieve: vi.fn(),
+}));
 
 vi.mock("@/utils/prisma", () => ({
   default: {
@@ -15,6 +26,20 @@ vi.mock("@/utils/prisma", () => ({
       upsert: mockUpsert,
     },
   },
+}));
+
+vi.mock("@/ee/billing/stripe", () => ({
+  getStripe: () => ({
+    charges: {
+      retrieve: mockChargeRetrieve,
+    },
+    paymentIntents: {
+      retrieve: mockPaymentIntentRetrieve,
+    },
+    invoices: {
+      retrieve: mockInvoiceRetrieve,
+    },
+  }),
 }));
 
 const logger = createScopedLogger("stripe-payments-test");
@@ -84,6 +109,9 @@ describe("syncStripeInvoicePayment", () => {
         status: "paid",
         tax: 300,
         taxInclusive: false,
+        refunded: false,
+        refundedAt: null,
+        refundedAmount: null,
         billingReason: "subscription_cycle",
         createdAt: new Date("2023-11-14T22:13:20.000Z"),
         updatedAt: new Date("2023-11-14T22:20:00.000Z"),
@@ -144,6 +172,69 @@ describe("syncStripeInvoicePayment", () => {
     expect(mockFindUnique).not.toHaveBeenCalled();
     expect(mockUpsert).not.toHaveBeenCalled();
   });
+
+  it("updates the same payment row when a refund event is received", async () => {
+    mockFindUnique.mockResolvedValue({ id: "premium_123" });
+    mockChargeRetrieve.mockResolvedValue({
+      invoice: "in_123",
+    });
+    mockInvoiceRetrieve.mockResolvedValue({
+      id: "in_123",
+      customer: "cus_123",
+      parent: {
+        subscription_details: {
+          subscription: "sub_123",
+        },
+      },
+      created: 1_700_000_000,
+      currency: "usd",
+      total: 2000,
+      status: "paid",
+      billing_reason: "subscription_cycle",
+      total_taxes: [],
+      status_transitions: {
+        paid_at: 1_700_000_100,
+      },
+      charge: {
+        amount_refunded: 500,
+        refunds: {
+          data: [
+            {
+              created: 1_700_000_450,
+              status: "succeeded",
+            },
+          ],
+        },
+      },
+    });
+
+    const { syncStripeInvoicePayment } = await import("./payments");
+
+    await syncStripeInvoicePayment({
+      event: refundEvent(),
+      logger,
+    });
+
+    expect(mockChargeRetrieve).toHaveBeenCalledWith("ch_123");
+    expect(mockInvoiceRetrieve).toHaveBeenCalledWith("in_123", {
+      expand: ["charge", "charge.refunds"],
+    });
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { processorId: "in_123" },
+      create: expect.objectContaining({
+        refunded: true,
+        refundedAmount: 500,
+        refundedAt: new Date("2023-11-14T22:20:50.000Z"),
+        status: "partially_refunded",
+      }),
+      update: expect.objectContaining({
+        refunded: true,
+        refundedAmount: 500,
+        refundedAt: new Date("2023-11-14T22:20:50.000Z"),
+        status: "partially_refunded",
+      }),
+    });
+  });
 });
 
 function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
@@ -172,6 +263,27 @@ function invoiceEvent(overrides: Partial<Stripe.Event>): Stripe.Event {
         billing_reason: "subscription_cycle",
         total_taxes: [],
         status_transitions: {},
+      },
+    },
+    ...overrides,
+  } as Stripe.Event;
+}
+
+function refundEvent(overrides: Partial<Stripe.Event> = {}): Stripe.Event {
+  return {
+    id: "evt_refund",
+    type: "refund.created",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1_700_000_500,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "re_123",
+        charge: "ch_123",
+        payment_intent: null,
       },
     },
     ...overrides,

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -1,6 +1,11 @@
 import type Stripe from "stripe";
 import { ProcessorType } from "@/generated/prisma/enums";
-import { getStripe } from "@/ee/billing/stripe";
+import {
+  getStripeInvoiceForRefundEvent,
+  getStripeRefundState,
+  isStripeRefundEventType,
+  stripeRefundEvents,
+} from "@/ee/billing/stripe/refunds";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 
@@ -10,9 +15,7 @@ const stripeInvoicePaymentEvents = new Set<Stripe.Event.Type>([
   "invoice.payment_failed",
   "invoice.payment_action_required",
   "invoice.marked_uncollectible",
-  "refund.created",
-  "refund.updated",
-  "refund.failed",
+  ...stripeRefundEvents,
 ]);
 
 export async function syncStripeInvoicePayment({
@@ -100,7 +103,7 @@ export async function getStripeInvoiceForPaymentSync(
 ) {
   if (!stripeInvoicePaymentEvents.has(event.type)) return null;
 
-  if (event.type.startsWith("refund.")) {
+  if (isStripeRefundEventType(event.type)) {
     return await getStripeInvoiceForRefundEvent({
       refund: event.data.object as Stripe.Refund,
       logger,
@@ -128,11 +131,7 @@ export function buildStripePaymentData({
     invoice.parent?.subscription_details?.subscription ?? null,
   );
   const tax = getStripeInvoiceTaxAmount(invoice);
-  const charge =
-    invoice.charge && typeof invoice.charge !== "string"
-      ? invoice.charge
-      : null;
-  const refundedAmount = charge?.amount_refunded ?? 0;
+  const refundState = getStripeRefundState(invoice);
 
   return {
     premiumId,
@@ -146,14 +145,14 @@ export function buildStripePaymentData({
     processorCustomerId: customerId,
     amount: invoice.total,
     currency: invoice.currency.toUpperCase(),
-    status: getStripePaymentStatus(invoice, refundedAmount),
+    status: refundState.status,
     tax,
     // Stripe invoice payloads do not expose a single reliable invoice-level
     // inclusive/exclusive boolean without expanded line-price inspection.
     taxInclusive: false,
-    refunded: refundedAmount > 0,
-    refundedAt: refundedAmount > 0 ? getLatestRefundedAt(charge) : null,
-    refundedAmount: refundedAmount > 0 ? refundedAmount : null,
+    refunded: refundState.refunded,
+    refundedAt: refundState.refundedAt,
+    refundedAmount: refundState.refundedAmount,
     billingReason: invoice.billing_reason ?? null,
   };
 }
@@ -178,104 +177,6 @@ function getStripeInvoiceUpdatedAtUnix(
     eventCreated ??
     invoice.created
   );
-}
-
-async function getStripeInvoiceForRefundEvent({
-  refund,
-  logger,
-  eventType,
-}: {
-  refund: Stripe.Refund;
-  logger: Logger;
-  eventType: Stripe.Event.Type;
-}) {
-  const stripe = getStripe();
-
-  const chargeId = normalizeStripeId(refund.charge);
-  if (chargeId) {
-    const charge = await stripe.charges.retrieve(chargeId);
-    const invoiceId = normalizeStripeId(charge.invoice);
-    if (!invoiceId) {
-      logger.warn(
-        "Skipping Stripe refund payment sync due to missing invoice",
-        {
-          refundId: refund.id,
-          chargeId,
-          eventType,
-        },
-      );
-      return null;
-    }
-
-    return await stripe.invoices.retrieve(invoiceId, {
-      expand: ["charge", "charge.refunds"],
-    });
-  }
-
-  const paymentIntentId = normalizeStripeId(refund.payment_intent);
-  if (paymentIntentId) {
-    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
-    const invoiceId = normalizeStripeId(paymentIntent.invoice);
-    if (!invoiceId) {
-      logger.warn(
-        "Skipping Stripe refund payment sync due to missing invoice",
-        {
-          refundId: refund.id,
-          paymentIntentId,
-          eventType,
-        },
-      );
-      return null;
-    }
-
-    return await stripe.invoices.retrieve(invoiceId, {
-      expand: ["charge", "charge.refunds"],
-    });
-  }
-
-  logger.warn(
-    "Skipping Stripe refund payment sync due to missing payment link",
-    {
-      refundId: refund.id,
-      eventType,
-    },
-  );
-  return null;
-}
-
-function getStripePaymentStatus(
-  invoice: Stripe.Invoice,
-  refundedAmount: number,
-) {
-  if (refundedAmount >= invoice.total && refundedAmount > 0) {
-    return "refunded";
-  }
-
-  if (refundedAmount > 0) {
-    return "partially_refunded";
-  }
-
-  return invoice.status ?? "unknown";
-}
-
-function getLatestRefundedAt(charge: Stripe.Charge | null) {
-  if (!charge) {
-    return null;
-  }
-
-  let latestRefundTimestamp = 0;
-
-  for (const refund of charge.refunds.data) {
-    if (refund.status === "failed") {
-      continue;
-    }
-
-    if (refund.created > latestRefundTimestamp) {
-      latestRefundTimestamp = refund.created;
-    }
-  }
-
-  return latestRefundTimestamp ? new Date(latestRefundTimestamp * 1000) : null;
 }
 
 function normalizeStripeId(

--- a/apps/web/ee/billing/stripe/payments.ts
+++ b/apps/web/ee/billing/stripe/payments.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 import { ProcessorType } from "@/generated/prisma/enums";
+import { getStripe } from "@/ee/billing/stripe";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 
@@ -9,6 +10,9 @@ const stripeInvoicePaymentEvents = new Set<Stripe.Event.Type>([
   "invoice.payment_failed",
   "invoice.payment_action_required",
   "invoice.marked_uncollectible",
+  "refund.created",
+  "refund.updated",
+  "refund.failed",
 ]);
 
 export async function syncStripeInvoicePayment({
@@ -18,7 +22,7 @@ export async function syncStripeInvoicePayment({
   event: Stripe.Event;
   logger: Logger;
 }) {
-  const invoice = getStripeInvoiceForPaymentSync(event);
+  const invoice = await getStripeInvoiceForPaymentSync(event, logger);
   if (!invoice) return;
 
   await upsertStripeInvoicePayment({
@@ -90,8 +94,19 @@ export async function upsertStripeInvoicePayment({
   });
 }
 
-export function getStripeInvoiceForPaymentSync(event: Stripe.Event) {
+export async function getStripeInvoiceForPaymentSync(
+  event: Stripe.Event,
+  logger: Logger,
+) {
   if (!stripeInvoicePaymentEvents.has(event.type)) return null;
+
+  if (event.type.startsWith("refund.")) {
+    return await getStripeInvoiceForRefundEvent({
+      refund: event.data.object as Stripe.Refund,
+      logger,
+      eventType: event.type,
+    });
+  }
 
   const invoice = event.data.object as Stripe.Invoice;
   if (!invoice?.id) return null;
@@ -113,6 +128,11 @@ export function buildStripePaymentData({
     invoice.parent?.subscription_details?.subscription ?? null,
   );
   const tax = getStripeInvoiceTaxAmount(invoice);
+  const charge =
+    invoice.charge && typeof invoice.charge !== "string"
+      ? invoice.charge
+      : null;
+  const refundedAmount = charge?.amount_refunded ?? 0;
 
   return {
     premiumId,
@@ -126,11 +146,14 @@ export function buildStripePaymentData({
     processorCustomerId: customerId,
     amount: invoice.total,
     currency: invoice.currency.toUpperCase(),
-    status: invoice.status ?? "unknown",
+    status: getStripePaymentStatus(invoice, refundedAmount),
     tax,
     // Stripe invoice payloads do not expose a single reliable invoice-level
     // inclusive/exclusive boolean without expanded line-price inspection.
     taxInclusive: false,
+    refunded: refundedAmount > 0,
+    refundedAt: refundedAmount > 0 ? getLatestRefundedAt(charge) : null,
+    refundedAmount: refundedAmount > 0 ? refundedAmount : null,
     billingReason: invoice.billing_reason ?? null,
   };
 }
@@ -155,6 +178,104 @@ function getStripeInvoiceUpdatedAtUnix(
     eventCreated ??
     invoice.created
   );
+}
+
+async function getStripeInvoiceForRefundEvent({
+  refund,
+  logger,
+  eventType,
+}: {
+  refund: Stripe.Refund;
+  logger: Logger;
+  eventType: Stripe.Event.Type;
+}) {
+  const stripe = getStripe();
+
+  const chargeId = normalizeStripeId(refund.charge);
+  if (chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    const invoiceId = normalizeStripeId(charge.invoice);
+    if (!invoiceId) {
+      logger.warn(
+        "Skipping Stripe refund payment sync due to missing invoice",
+        {
+          refundId: refund.id,
+          chargeId,
+          eventType,
+        },
+      );
+      return null;
+    }
+
+    return await stripe.invoices.retrieve(invoiceId, {
+      expand: ["charge", "charge.refunds"],
+    });
+  }
+
+  const paymentIntentId = normalizeStripeId(refund.payment_intent);
+  if (paymentIntentId) {
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    const invoiceId = normalizeStripeId(paymentIntent.invoice);
+    if (!invoiceId) {
+      logger.warn(
+        "Skipping Stripe refund payment sync due to missing invoice",
+        {
+          refundId: refund.id,
+          paymentIntentId,
+          eventType,
+        },
+      );
+      return null;
+    }
+
+    return await stripe.invoices.retrieve(invoiceId, {
+      expand: ["charge", "charge.refunds"],
+    });
+  }
+
+  logger.warn(
+    "Skipping Stripe refund payment sync due to missing payment link",
+    {
+      refundId: refund.id,
+      eventType,
+    },
+  );
+  return null;
+}
+
+function getStripePaymentStatus(
+  invoice: Stripe.Invoice,
+  refundedAmount: number,
+) {
+  if (refundedAmount >= invoice.total && refundedAmount > 0) {
+    return "refunded";
+  }
+
+  if (refundedAmount > 0) {
+    return "partially_refunded";
+  }
+
+  return invoice.status ?? "unknown";
+}
+
+function getLatestRefundedAt(charge: Stripe.Charge | null) {
+  if (!charge) {
+    return null;
+  }
+
+  let latestRefundTimestamp = 0;
+
+  for (const refund of charge.refunds.data) {
+    if (refund.status === "failed") {
+      continue;
+    }
+
+    if (refund.created > latestRefundTimestamp) {
+      latestRefundTimestamp = refund.created;
+    }
+  }
+
+  return latestRefundTimestamp ? new Date(latestRefundTimestamp * 1000) : null;
 }
 
 function normalizeStripeId(

--- a/apps/web/ee/billing/stripe/refunds.test.ts
+++ b/apps/web/ee/billing/stripe/refunds.test.ts
@@ -124,6 +124,34 @@ describe("getStripeRefundState", () => {
       refundedAmount: 500,
     });
   });
+
+  it("treats a fully refunded discounted charge as refunded", async () => {
+    const { getStripeRefundState } = await import("./refunds");
+
+    expect(
+      getStripeRefundState({
+        total: 2000,
+        status: "paid",
+        charge: {
+          amount: 1500,
+          amount_refunded: 1500,
+          refunds: {
+            data: [
+              {
+                created: 1_700_000_450,
+                status: "succeeded",
+              },
+            ],
+          },
+        },
+      } as Stripe.Invoice),
+    ).toEqual({
+      status: "refunded",
+      refunded: true,
+      refundedAt: new Date("2023-11-14T22:20:50.000Z"),
+      refundedAmount: 1500,
+    });
+  });
 });
 
 function refund(overrides: Partial<Stripe.Refund> = {}): Stripe.Refund {

--- a/apps/web/ee/billing/stripe/refunds.test.ts
+++ b/apps/web/ee/billing/stripe/refunds.test.ts
@@ -1,0 +1,136 @@
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createScopedLogger } from "@/utils/logger";
+
+const { mockChargeRetrieve, mockPaymentIntentRetrieve, mockInvoiceRetrieve } =
+  vi.hoisted(() => ({
+    mockChargeRetrieve: vi.fn(),
+    mockPaymentIntentRetrieve: vi.fn(),
+    mockInvoiceRetrieve: vi.fn(),
+  }));
+
+vi.mock("@/ee/billing/stripe", () => ({
+  getStripe: () => ({
+    charges: {
+      retrieve: mockChargeRetrieve,
+    },
+    paymentIntents: {
+      retrieve: mockPaymentIntentRetrieve,
+    },
+    invoices: {
+      retrieve: mockInvoiceRetrieve,
+    },
+  }),
+}));
+
+const logger = createScopedLogger("stripe-refunds-test");
+
+describe("getStripeCustomerIdForRefund", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves the customer from the refund charge", async () => {
+    mockChargeRetrieve.mockResolvedValue({
+      customer: "cus_123",
+    });
+
+    const { getStripeCustomerIdForRefund } = await import("./refunds");
+
+    await expect(
+      getStripeCustomerIdForRefund(refund({ charge: "ch_123" })),
+    ).resolves.toBe("cus_123");
+
+    expect(mockChargeRetrieve).toHaveBeenCalledWith("ch_123");
+    expect(mockPaymentIntentRetrieve).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the payment intent when the refund has no charge", async () => {
+    mockPaymentIntentRetrieve.mockResolvedValue({
+      customer: "cus_123",
+    });
+
+    const { getStripeCustomerIdForRefund } = await import("./refunds");
+
+    await expect(
+      getStripeCustomerIdForRefund(
+        refund({
+          charge: null,
+          payment_intent: "pi_123",
+        }),
+      ),
+    ).resolves.toBe("cus_123");
+
+    expect(mockPaymentIntentRetrieve).toHaveBeenCalledWith("pi_123");
+  });
+});
+
+describe("getStripeInvoiceForRefundEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the source invoice for refund payment syncing", async () => {
+    const invoice = {
+      id: "in_123",
+      customer: "cus_123",
+    };
+
+    mockChargeRetrieve.mockResolvedValue({
+      invoice: "in_123",
+    });
+    mockInvoiceRetrieve.mockResolvedValue(invoice);
+
+    const { getStripeInvoiceForRefundEvent } = await import("./refunds");
+
+    await expect(
+      getStripeInvoiceForRefundEvent({
+        refund: refund({ charge: "ch_123" }),
+        logger,
+        eventType: "refund.created",
+      }),
+    ).resolves.toBe(invoice);
+
+    expect(mockInvoiceRetrieve).toHaveBeenCalledWith("in_123", {
+      expand: ["charge", "charge.refunds"],
+    });
+  });
+});
+
+describe("getStripeRefundState", () => {
+  it("returns refunded payment metadata from the invoice charge", async () => {
+    const { getStripeRefundState } = await import("./refunds");
+
+    expect(
+      getStripeRefundState({
+        total: 2000,
+        status: "paid",
+        charge: {
+          amount_refunded: 500,
+          refunds: {
+            data: [
+              {
+                created: 1_700_000_450,
+                status: "succeeded",
+              },
+            ],
+          },
+        },
+      } as Stripe.Invoice),
+    ).toEqual({
+      status: "partially_refunded",
+      refunded: true,
+      refundedAt: new Date("2023-11-14T22:20:50.000Z"),
+      refundedAmount: 500,
+    });
+  });
+});
+
+function refund(overrides: Partial<Stripe.Refund> = {}): Stripe.Refund {
+  return {
+    id: "re_123",
+    charge: null,
+    payment_intent: null,
+    ...overrides,
+  } as Stripe.Refund;
+}

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -69,7 +69,7 @@ export async function getStripeInvoiceForRefundEvent({
   const paymentIntentId = normalizeStripeId(refund.payment_intent);
   if (paymentIntentId) {
     const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
-    const invoiceId = normalizeStripeId(paymentIntent.invoice);
+    const invoiceId = getPaymentIntentInvoiceId(paymentIntent);
     if (!invoiceId) {
       logger.warn(
         "Skipping Stripe refund payment sync due to missing invoice",
@@ -153,6 +153,16 @@ function getChargeInvoiceId(charge: Stripe.Charge) {
   return normalizeStripeId(
     (charge as Stripe.Charge & { invoice?: string | { id: string } | null })
       .invoice,
+  );
+}
+
+function getPaymentIntentInvoiceId(paymentIntent: Stripe.PaymentIntent) {
+  return normalizeStripeId(
+    (
+      paymentIntent as Stripe.PaymentIntent & {
+        invoice?: string | { id: string } | null;
+      }
+    ).invoice,
   );
 }
 

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -103,9 +103,10 @@ export function getStripeRefundState(invoice: Stripe.Invoice) {
       ? invoice.charge
       : null;
   const refundedAmount = charge?.amount_refunded ?? 0;
+  const chargedAmount = charge?.amount ?? null;
 
   return {
-    status: getStripePaymentStatus(invoice, refundedAmount),
+    status: getStripePaymentStatus(invoice, refundedAmount, chargedAmount),
     refunded: refundedAmount > 0,
     refundedAt: refundedAmount > 0 ? getLatestRefundedAt(charge) : null,
     refundedAmount: refundedAmount > 0 ? refundedAmount : null,
@@ -115,8 +116,9 @@ export function getStripeRefundState(invoice: Stripe.Invoice) {
 function getStripePaymentStatus(
   invoice: Stripe.Invoice,
   refundedAmount: number,
+  chargedAmount: number | null,
 ) {
-  if (refundedAmount >= invoice.total && refundedAmount > 0) {
+  if (chargedAmount && refundedAmount >= chargedAmount && refundedAmount > 0) {
     return "refunded";
   }
 

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -9,7 +9,11 @@ export const stripeRefundEvents = [
 ] as const satisfies ReadonlyArray<Stripe.Event.Type>;
 
 export function isStripeRefundEventType(eventType: Stripe.Event.Type) {
-  return stripeRefundEvents.includes(eventType);
+  return (
+    eventType === "refund.created" ||
+    eventType === "refund.updated" ||
+    eventType === "refund.failed"
+  );
 }
 
 export async function getStripeCustomerIdForRefund(refund: Stripe.Refund) {

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -1,0 +1,152 @@
+import type Stripe from "stripe";
+import { getStripe } from "@/ee/billing/stripe";
+import type { Logger } from "@/utils/logger";
+
+export const stripeRefundEvents = [
+  "refund.created",
+  "refund.updated",
+  "refund.failed",
+] as const satisfies ReadonlyArray<Stripe.Event.Type>;
+
+export function isStripeRefundEventType(eventType: Stripe.Event.Type) {
+  return stripeRefundEvents.includes(eventType);
+}
+
+export async function getStripeCustomerIdForRefund(refund: Stripe.Refund) {
+  const stripe = getStripe();
+
+  const chargeId = normalizeStripeId(refund.charge);
+  if (chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    return normalizeStripeId(charge.customer);
+  }
+
+  const paymentIntentId = normalizeStripeId(refund.payment_intent);
+  if (paymentIntentId) {
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    return normalizeStripeId(paymentIntent.customer);
+  }
+
+  return null;
+}
+
+export async function getStripeInvoiceForRefundEvent({
+  refund,
+  logger,
+  eventType,
+}: {
+  refund: Stripe.Refund;
+  logger: Logger;
+  eventType: Stripe.Event.Type;
+}) {
+  const stripe = getStripe();
+
+  const chargeId = normalizeStripeId(refund.charge);
+  if (chargeId) {
+    const charge = await stripe.charges.retrieve(chargeId);
+    const invoiceId = normalizeStripeId(charge.invoice);
+    if (!invoiceId) {
+      logger.warn(
+        "Skipping Stripe refund payment sync due to missing invoice",
+        {
+          refundId: refund.id,
+          chargeId,
+          eventType,
+        },
+      );
+      return null;
+    }
+
+    return await stripe.invoices.retrieve(invoiceId, {
+      expand: ["charge", "charge.refunds"],
+    });
+  }
+
+  const paymentIntentId = normalizeStripeId(refund.payment_intent);
+  if (paymentIntentId) {
+    const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    const invoiceId = normalizeStripeId(paymentIntent.invoice);
+    if (!invoiceId) {
+      logger.warn(
+        "Skipping Stripe refund payment sync due to missing invoice",
+        {
+          refundId: refund.id,
+          paymentIntentId,
+          eventType,
+        },
+      );
+      return null;
+    }
+
+    return await stripe.invoices.retrieve(invoiceId, {
+      expand: ["charge", "charge.refunds"],
+    });
+  }
+
+  logger.warn(
+    "Skipping Stripe refund payment sync due to missing payment link",
+    {
+      refundId: refund.id,
+      eventType,
+    },
+  );
+  return null;
+}
+
+export function getStripeRefundState(invoice: Stripe.Invoice) {
+  const charge =
+    invoice.charge && typeof invoice.charge !== "string"
+      ? invoice.charge
+      : null;
+  const refundedAmount = charge?.amount_refunded ?? 0;
+
+  return {
+    status: getStripePaymentStatus(invoice, refundedAmount),
+    refunded: refundedAmount > 0,
+    refundedAt: refundedAmount > 0 ? getLatestRefundedAt(charge) : null,
+    refundedAmount: refundedAmount > 0 ? refundedAmount : null,
+  };
+}
+
+function getStripePaymentStatus(
+  invoice: Stripe.Invoice,
+  refundedAmount: number,
+) {
+  if (refundedAmount >= invoice.total && refundedAmount > 0) {
+    return "refunded";
+  }
+
+  if (refundedAmount > 0) {
+    return "partially_refunded";
+  }
+
+  return invoice.status ?? "unknown";
+}
+
+function getLatestRefundedAt(charge: Stripe.Charge | null) {
+  if (!charge) {
+    return null;
+  }
+
+  let latestRefundTimestamp = 0;
+
+  for (const refund of charge.refunds.data) {
+    if (refund.status === "failed") {
+      continue;
+    }
+
+    if (refund.created > latestRefundTimestamp) {
+      latestRefundTimestamp = refund.created;
+    }
+  }
+
+  return latestRefundTimestamp ? new Date(latestRefundTimestamp * 1000) : null;
+}
+
+function normalizeStripeId(value: string | { id: string } | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  return typeof value === "string" ? value : value.id;
+}

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -48,7 +48,7 @@ export async function getStripeInvoiceForRefundEvent({
   const chargeId = normalizeStripeId(refund.charge);
   if (chargeId) {
     const charge = await stripe.charges.retrieve(chargeId);
-    const invoiceId = normalizeStripeId(charge.invoice);
+    const invoiceId = getChargeInvoiceId(charge);
     if (!invoiceId) {
       logger.warn(
         "Skipping Stripe refund payment sync due to missing invoice",
@@ -147,6 +147,13 @@ function getLatestRefundedAt(charge: Stripe.Charge | null) {
   }
 
   return latestRefundTimestamp ? new Date(latestRefundTimestamp * 1000) : null;
+}
+
+function getChargeInvoiceId(charge: Stripe.Charge) {
+  return normalizeStripeId(
+    (charge as Stripe.Charge & { invoice?: string | { id: string } | null })
+      .invoice,
+  );
 }
 
 function normalizeStripeId(value: string | { id: string } | null | undefined) {

--- a/apps/web/ee/billing/stripe/refunds.ts
+++ b/apps/web/ee/billing/stripe/refunds.ts
@@ -98,10 +98,7 @@ export async function getStripeInvoiceForRefundEvent({
 }
 
 export function getStripeRefundState(invoice: Stripe.Invoice) {
-  const charge =
-    invoice.charge && typeof invoice.charge !== "string"
-      ? invoice.charge
-      : null;
+  const charge = getInvoiceCharge(invoice);
   const refundedAmount = charge?.amount_refunded ?? 0;
   const chargedAmount = charge?.amount ?? null;
 
@@ -135,8 +132,9 @@ function getLatestRefundedAt(charge: Stripe.Charge | null) {
   }
 
   let latestRefundTimestamp = 0;
+  const refunds = charge.refunds?.data ?? [];
 
-  for (const refund of charge.refunds.data) {
+  for (const refund of refunds) {
     if (refund.status === "failed") {
       continue;
     }
@@ -154,6 +152,20 @@ function getChargeInvoiceId(charge: Stripe.Charge) {
     (charge as Stripe.Charge & { invoice?: string | { id: string } | null })
       .invoice,
   );
+}
+
+function getInvoiceCharge(invoice: Stripe.Invoice) {
+  const charge = (
+    invoice as Stripe.Invoice & {
+      charge?: string | Stripe.Charge | null;
+    }
+  ).charge;
+
+  if (!charge || typeof charge === "string") {
+    return null;
+  }
+
+  return charge;
 }
 
 function getPaymentIntentInvoiceId(paymentIntent: Stripe.PaymentIntent) {


### PR DESCRIPTION
## Summary
- add Stripe refund webhook handling to the shared billing flow
- resolve refund events back to their original invoice before syncing payments
- update existing payment records with refunded status and amounts, plus focused webhook/payment tests

## Test plan
- [x] `cd apps/web && pnpm test --run ee/billing/stripe/payments.test.ts app/api/stripe/webhook/route.test.ts`
- [x] `cd apps/web && pnpm exec biome check ee/billing/stripe/payments.ts ee/billing/stripe/payments.test.ts app/api/stripe/webhook/route.ts app/api/stripe/webhook/route.test.ts`

Made with [Cursor](https://cursor.com)