### PR TITLE
billing: add Payment(premiumId, createdAt) composite index

### DIFF
--- a/apps/web/prisma/migrations/20260422220000_add_payment_premiumid_createdat_index/migration.sql
+++ b/apps/web/prisma/migrations/20260422220000_add_payment_premiumid_createdat_index/migration.sql
@@ -1,2 +1,5 @@
+-- DropIndex
+DROP INDEX IF EXISTS "Payment_premiumId_idx";
+
 -- CreateIndex
-CREATE INDEX "Payment_premiumId_createdAt_idx" ON "Payment"("premiumId", "createdAt");
+CREATE INDEX IF NOT EXISTS "Payment_premiumId_createdAt_idx" ON "Payment"("premiumId", "createdAt");

--- a/apps/web/prisma/migrations/20260422220000_add_payment_premiumid_createdat_index/migration.sql
+++ b/apps/web/prisma/migrations/20260422220000_add_payment_premiumid_createdat_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Payment_premiumId_createdAt_idx" ON "Payment"("premiumId", "createdAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1002,7 +1002,6 @@ model Payment {
   // Metadata
   billingReason String? // initial, renewal, update, etc.
 
-  @@index([premiumId])
   @@index([premiumId, createdAt])
 }
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1003,6 +1003,7 @@ model Payment {
   billingReason String? // initial, renewal, update, etc.
 
   @@index([premiumId])
+  @@index([premiumId, createdAt])
 }
 
 model DraftSendLog {


### PR DESCRIPTION
## Summary
- Adds a composite index on `Payment(premiumId, createdAt)` via a new Prisma migration.

## Why
The admin dashboard's churn and cancellations views compute `MIN(Payment.createdAt)` and net revenue per Premium, plus a few time-windowed aggregates. With only the single-column `premiumId` index, Postgres re-scans matching rows for each `MIN` lookup. The composite lets the `MIN` seek along the leading edge of the index instead.

The main app only touches Payment via `prisma.payment.upsert` on the unique `processorId`, so this index is specifically for the admin-side read paths. Write overhead should be minimal — payments are low-churn.

## Test plan
- [ ] `pnpm prisma migrate deploy` runs cleanly against a staging DB
- [ ] Admin churn page (`/churn`) and cancellations page (`/cancellations`) render in comparable or better time
- [ ] `EXPLAIN ANALYZE` on the `MIN(pay."createdAt") WHERE pay."premiumId" = \$1` subquery shows the new index being used

🤖 Generated with [Claude Code](https://claude.com/claude-code)