### PR TITLE
ci: Secure workflow test input

### DIFF
--- a/.github/workflows/e2e-flows.yml
+++ b/.github/workflows/e2e-flows.yml
@@ -192,13 +192,23 @@ jobs:
           echo "Tunnel URL: $NGROK_URL"
 
       - name: Run E2E Flow Tests
+        shell: bash
         run: |
-          if [ -n "${{ github.event.inputs.test_file }}" ]; then
-            pnpm -F inbox-zero-ai test-e2e:flows ${{ github.event.inputs.test_file }}
+          if [ -n "$E2E_FLOW_TEST_FILE" ]; then
+            if [[ "$E2E_FLOW_TEST_FILE" == -* ]] ||
+              [[ "$E2E_FLOW_TEST_FILE" == /* ]] ||
+              [[ "$E2E_FLOW_TEST_FILE" == *..* ]] ||
+              ! [[ "$E2E_FLOW_TEST_FILE" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+              echo "::error::Invalid test_file input. Use a relative E2E flow test name or path containing only letters, numbers, dots, underscores, hyphens, and slashes."
+              exit 1
+            fi
+
+            pnpm -F inbox-zero-ai test-e2e:flows -- "$E2E_FLOW_TEST_FILE"
           else
             pnpm -F inbox-zero-ai test-e2e:flows
           fi
         env:
+          E2E_FLOW_TEST_FILE: ${{ github.event.inputs.test_file }}
           NEXT_PUBLIC_BASE_URL: ${{ env.NGROK_URL }}
           # Test control
           RUN_E2E_FLOW_TESTS: "true"


### PR DESCRIPTION
Moves the manual test selector out of the workflow shell template and validates it before use.

- Rejects unsafe relative path values and option-style inputs.
- Passes the selector as a quoted argument to the test command.