### PR TITLE
Fix inactive billing plan display

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
@@ -32,10 +32,7 @@ export function BillingSection() {
 
   return (
     <LoadingContent loading={isLoading}>
-      {premium &&
-      (isPremium ||
-        premium.lemonSqueezyCustomerId ||
-        premium.stripeSubscriptionId) ? (
+      {premium && isPremium ? (
         <Item size="sm">
           <ItemContent>
             <ItemTitle>{getPremiumTierName(premium.tier)} plan</ItemTitle>


### PR DESCRIPTION
Updates the billing settings page so historical subscription identifiers do not make an inactive premium record appear as a current plan.\n\nValidation: pnpm test --run hooks/usePremium.test.ts; pnpm exec ultracite check apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx