### PR TITLE
assistant: Hide internal corrective tool errors

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -31,6 +31,7 @@ import type { ChatMessage } from "@/components/assistant-chat/types";
 import type { ThreadLookup } from "@/components/assistant-chat/tools";
 import { formatToolLabel } from "@/components/assistant-chat/tool-label";
 import { requiresThreadIds } from "@/utils/ai/assistant/manage-inbox-actions";
+import { getUserVisibleToolFailureMessage } from "@/utils/ai/assistant/chat-response-guard";
 import { pluralize } from "@/utils/string";
 
 interface MessagePartProps {
@@ -45,6 +46,13 @@ interface MessagePartProps {
 
 function ErrorToolCard({ error }: { error: string }) {
   return <div className="text-xs text-muted-foreground">Error: {error}</div>;
+}
+
+function renderToolError(toolCallId: string, output: unknown) {
+  const failureMessage = getToolFailureMessage(output);
+  return failureMessage ? (
+    <ErrorToolCard key={toolCallId} error={failureMessage} />
+  ) : null;
 }
 
 function isOutputWithError(output: unknown): output is { error: unknown } {
@@ -187,7 +195,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       return <ReadEmailResult key={toolCallId} output={output} />;
     }
@@ -227,7 +235,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       return (
         <ManageInboxResult
@@ -321,7 +329,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       const requiresRuleConfirmation =
         getOutputField<boolean>(output, "requiresConfirmation") === true &&
@@ -367,7 +375,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       const ruleId = getOutputField<string>(output, "ruleId");
       if (!ruleId)
@@ -399,7 +407,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       const ruleId = getOutputField<string>(output, "ruleId");
       if (!ruleId)
@@ -431,7 +439,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       const ruleId = getOutputField<string>(output, "ruleId");
       if (!ruleId)
@@ -480,7 +488,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
       return <AddToKnowledgeBase key={toolCallId} args={part.input} />;
     }
@@ -496,7 +504,7 @@ export function MessagePart({
     if (state === "output-available") {
       const { output } = part;
       if (isOutputWithError(output)) {
-        return <ErrorToolCard key={toolCallId} error={String(output.error)} />;
+        return renderToolError(toolCallId, output);
       }
 
       const requiresConfirmation =
@@ -718,23 +726,7 @@ function renderPendingEmailAction({
 }
 
 function getToolFailureMessage(output: unknown): string | null {
-  if (typeof output !== "object" || output === null) return null;
-
-  const record = output as Record<string, unknown>;
-  if (isOutputWithError(output)) {
-    return toMessageString(record.error);
-  }
-
-  if (record.success === false) {
-    return (
-      toMessageString(record.message) ??
-      toMessageString(record.reason) ??
-      toMessageString(record.error) ??
-      "Operation failed"
-    );
-  }
-
-  return null;
+  return getUserVisibleToolFailureMessage(output);
 }
 
 function getToolSuccessMessage(output: unknown): string | null {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -484,6 +484,7 @@ describe("chat inbox tools", () => {
     expect(result).toEqual({
       error:
         'Label "Finance" does not exist. Use createOrGetLabel first if you want to create it.',
+      toolErrorVisibility: "hidden",
     });
     expect(getLabelByName).toHaveBeenCalledWith("Finance");
     expect(getLabelByName).toHaveBeenCalledTimes(1);

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -35,6 +35,7 @@ import {
   requiresSenderEmails,
   requiresThreadIds,
 } from "@/utils/ai/assistant/manage-inbox-actions";
+import { hideToolErrorFromUser } from "@/utils/ai/assistant/tool-error-visibility";
 import {
   type AutomaticUnsubscribeResult,
   unsubscribeSenderAndMark,
@@ -960,12 +961,12 @@ export const manageInboxTool = ({
               error,
               labelName: parsedInput.labelName,
             });
-            return {
+            return hideToolErrorFromUser({
               error:
                 error instanceof Error
                   ? error.message
                   : "Failed to resolve label",
-            };
+            });
           }
         }
 

--- a/apps/web/utils/ai/assistant/chat-response-guard.test.ts
+++ b/apps/web/utils/ai/assistant/chat-response-guard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getToolFailureWarning } from "./chat-response-guard";
+import {
+  getToolFailureWarning,
+  getUserVisibleToolFailureMessage,
+} from "./chat-response-guard";
+import { hideToolErrorFromUser } from "./tool-error-visibility";
 
 describe("getToolFailureWarning", () => {
   it("returns null when there are no tool errors", () => {
@@ -19,8 +23,7 @@ describe("getToolFailureWarning", () => {
             type: "tool-updateRuleConditions",
             state: "output-available",
             output: {
-              error:
-                "No rule was changed. Call getUserRulesAndSettings immediately before updating this rule.",
+              error: "Failed to update rule conditions",
             },
           },
         ],
@@ -40,8 +43,7 @@ describe("getToolFailureWarning", () => {
             type: "tool-updateRuleConditions",
             state: "output-available",
             output: {
-              error:
-                "No rule was changed. Call getUserRulesAndSettings immediately before updating this rule.",
+              error: "Failed to update rule conditions",
             },
           },
         ],
@@ -68,5 +70,64 @@ describe("getToolFailureWarning", () => {
         ],
       }),
     ).toContain("Some tool calls failed during this request.");
+  });
+
+  it("does not warn for internal corrective tool errors", () => {
+    expect(
+      getToolFailureWarning({
+        parts: [
+          {
+            type: "tool-manageInbox",
+            state: "output-available",
+            output: hideToolErrorFromUser({
+              error:
+                'Label "Security" does not exist. Use createOrGetLabel first if you want to create it.',
+            }),
+          },
+          {
+            type: "tool-updateRuleConditions",
+            state: "output-available",
+            output: hideToolErrorFromUser({
+              success: false,
+              error:
+                "No rule was changed. Call getUserRulesAndSettings immediately before updating this rule.",
+            }),
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getUserVisibleToolFailureMessage", () => {
+  it("hides tool errors marked as internal", () => {
+    expect(
+      getUserVisibleToolFailureMessage(
+        hideToolErrorFromUser({
+          error:
+            'Label "Security" does not exist. Use createOrGetLabel first if you want to create it.',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns unmarked label creation instructions", () => {
+    expect(
+      getUserVisibleToolFailureMessage({
+        error:
+          'Label "Security" does not exist. Use createOrGetLabel first if you want to create it.',
+      }),
+    ).toBe(
+      'Label "Security" does not exist. Use createOrGetLabel first if you want to create it.',
+    );
+  });
+
+  it("returns real failure messages", () => {
+    expect(
+      getUserVisibleToolFailureMessage({
+        success: false,
+        error: "Failed to update emails",
+      }),
+    ).toBe("Failed to update emails");
   });
 });

--- a/apps/web/utils/ai/assistant/chat-response-guard.ts
+++ b/apps/web/utils/ai/assistant/chat-response-guard.ts
@@ -1,3 +1,5 @@
+import { isToolErrorHiddenFromUser } from "./tool-error-visibility";
+
 const TOOL_FAILURE_WARNING =
   "Some tool calls failed during this request. Review the failed action cards in this message before relying on the summary.";
 
@@ -12,19 +14,57 @@ export function getToolFailureWarning(
   const parts = message?.parts;
   if (!parts?.length) return null;
 
-  return parts.some(isToolPartWithError) ? TOOL_FAILURE_WARNING : null;
+  return parts.some((part) => {
+    if (!isRecord(part)) return false;
+    if (typeof part.type !== "string" || !part.type.startsWith("tool-")) {
+      return false;
+    }
+
+    return Boolean(getUserVisibleToolFailureMessage(part.output));
+  })
+    ? TOOL_FAILURE_WARNING
+    : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isToolPartWithError(part: unknown) {
-  if (!isRecord(part)) return false;
+export function getUserVisibleToolFailureMessage(output: unknown) {
+  if (isToolErrorHiddenFromUser(output)) return null;
 
-  if (typeof part.type !== "string" || !part.type.startsWith("tool-")) {
-    return false;
+  const failureMessage = getToolFailureMessage(output);
+  return failureMessage;
+}
+
+function getToolFailureMessage(output: unknown): string | null {
+  if (!isRecord(output)) return null;
+
+  if ("error" in output) {
+    return toMessageString(output.error);
   }
 
-  return isRecord(part.output) && typeof part.output.error === "string";
+  if (output.success === false) {
+    return (
+      toMessageString(output.message) ??
+      toMessageString(output.reason) ??
+      toMessageString(output.error) ??
+      "Operation failed"
+    );
+  }
+
+  return null;
+}
+
+function toMessageString(value: unknown): string | null {
+  if (typeof value === "string" && value.trim().length > 0) return value;
+  if (
+    isRecord(value) &&
+    "message" in value &&
+    typeof value.message === "string" &&
+    value.message.trim().length > 0
+  ) {
+    return value.message;
+  }
+  return null;
 }

--- a/apps/web/utils/ai/assistant/tool-error-visibility.ts
+++ b/apps/web/utils/ai/assistant/tool-error-visibility.ts
@@ -1,0 +1,19 @@
+const HIDE_TOOL_ERROR_FROM_USER = "hidden" as const;
+
+export function hideToolErrorFromUser<T extends Record<string, unknown>>(
+  output: T,
+) {
+  return {
+    ...output,
+    toolErrorVisibility: HIDE_TOOL_ERROR_FROM_USER,
+  };
+}
+
+export function isToolErrorHiddenFromUser(output: unknown) {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    "toolErrorVisibility" in output &&
+    output.toolErrorVisibility === HIDE_TOOL_ERROR_FROM_USER
+  );
+}

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
@@ -20,6 +20,34 @@ describe("updateLearnedPatternsTool", () => {
     vi.clearAllMocks();
   });
 
+  it("marks stale-read guidance as hidden from user display", async () => {
+    const toolInstance = updateLearnedPatternsTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      logger,
+      getRuleReadState: () => null,
+    });
+
+    const result = await toolInstance.execute({
+      ruleName: "VIP senders",
+      learnedPatterns: [
+        {
+          include: {
+            from: "vip@example.com",
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "No rule was changed. Call getUserRulesAndSettings immediately before updating this rule.",
+      toolErrorVisibility: "hidden",
+    });
+    expect(prisma.rule.findUnique).not.toHaveBeenCalled();
+  });
+
   it("returns a failure when saving learned patterns fails", async () => {
     prisma.rule.findUnique
       .mockResolvedValueOnce({

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.ts
@@ -4,6 +4,7 @@ import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { GroupItemType } from "@/generated/prisma/enums";
 import { saveLearnedPatterns } from "@/utils/rule/learned-patterns";
+import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
 import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
 
@@ -68,10 +69,10 @@ export const updateLearnedPatternsTool = ({
         });
 
         if (readValidationError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: readValidationError,
-          };
+          });
         }
 
         const rule = await prisma.rule.findUnique({
@@ -103,10 +104,10 @@ export const updateLearnedPatternsTool = ({
           currentRuleUpdatedAt: rule.updatedAt,
         });
         if (staleReadError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: staleReadError,
-          };
+          });
         }
 
         const patternsToSave: Array<{

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
@@ -6,6 +6,7 @@ import { filterNullProperties } from "@/utils";
 import { createRuleActionSchema } from "@/utils/ai/rule/create-rule-schema";
 import { updateRuleActions } from "@/utils/rule/rule";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
+import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
 import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
 
@@ -40,10 +41,10 @@ export const updateRuleActionsTool = ({
         });
 
         if (readValidationError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: readValidationError,
-          };
+          });
         }
 
         const rule = await prisma.rule.findUnique({
@@ -89,10 +90,10 @@ export const updateRuleActionsTool = ({
           currentRuleUpdatedAt: rule.updatedAt,
         });
         if (staleReadError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: staleReadError,
-          };
+          });
         }
 
         const originalActions = rule.actions.map((action) => ({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-conditions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-conditions-tool.ts
@@ -4,6 +4,7 @@ import prisma from "@/utils/prisma";
 import { filterNullProperties } from "@/utils";
 import { updateRuleConditionSchema } from "@/utils/actions/rule.validation";
 import { partialUpdateRule } from "@/utils/rule/rule";
+import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
 import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
 
@@ -31,10 +32,10 @@ export const updateRuleConditionsTool = ({
         });
 
         if (readValidationError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: readValidationError,
-          };
+          });
         }
 
         const rule = await prisma.rule.findUnique({
@@ -71,10 +72,10 @@ export const updateRuleConditionsTool = ({
           currentRuleUpdatedAt: rule.updatedAt,
         });
         if (staleReadError) {
-          return {
+          return hideToolErrorFromUser({
             success: false,
             error: staleReadError,
-          };
+          });
         }
 
         const originalConditions = {


### PR DESCRIPTION
Hides internal corrective tool errors from user-facing assistant output while preserving the underlying tool results for the model flow.

- Suppresses label-creation and rule-refresh instructions in visible error cards and the extra failure warning.
- Keeps real tool failures visible to users.
- Adds focused regression coverage for hidden corrective errors and visible failures.

Tests: pnpm test --run utils/ai/assistant/chat-response-guard.test.ts