### PR TITLE
docs: fix README OG image reference after PNG removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](apps/web/app/opengraph-image.png)](https://www.getinboxzero.com)
+[![](apps/web/app/opengraph-image.jpg)](https://www.getinboxzero.com)
 
 <p align="center">
   <a href="https://www.getinboxzero.com">


### PR DESCRIPTION
## Summary
- `apps/web/app/opengraph-image.png` was removed in #2349 in favor of the new `.jpg`, but `README.md:1` still referenced the PNG path.
- The repo front page was rendering a broken hero image.
- Point the README image link at `opengraph-image.jpg` so the hero renders again.

## Test plan
- [x] Verify the new `opengraph-image.jpg` exists at `apps/web/app/opengraph-image.jpg`
- [x] Verify the old `opengraph-image.png` is 404 on `main`
- [ ] After merge, confirm the image renders on https://github.com/elie222/inbox-zero

Follow-up to #2349.

Generated with [Claude Code](https://claude.com/claude-code)