### PR TITLE
Fix: show validation message when saving rule without actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { type SubmitHandler, useFieldArray, useForm } from "react-hook-form";
+import { type SubmitHandler, useFieldArray, useForm, type FieldErrors } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { usePostHog } from "posthog-js/react";
 import { env } from "@/env";
@@ -355,10 +355,34 @@ export function RuleForm({
     [ruleEditorActions],
   );
 
-  const formErrors = useMemo(() => {
-    return Object.values(formState.errors)
-      .filter((error): error is { message: string } => Boolean(error.message))
-      .map((error) => error.message);
+  // Collect all top-level form error messages into a single list
+  function getErrorMessages(errors: FieldErrors<CreateRuleBody>): string[] {
+    const messages: string[] = [];
+
+    if (!errors) return messages;
+
+    if (typeof errors.name?.message === "string") {
+      messages.push(errors.name.message);
+    }
+
+    const actionsMessage =
+      errors.actions?.root?.message ?? errors.actions?.message;
+    if (typeof actionsMessage === "string") {
+      messages.push(actionsMessage);
+    }
+
+    const conditionsMessage =
+      errors.conditions?.root?.message ?? errors.conditions?.message;
+    if (typeof conditionsMessage === "string") {
+      messages.push(conditionsMessage);
+    }
+
+    return messages;
+  }
+
+  const errorMessages = useMemo(() => {
+    return getErrorMessages(errors);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Must be [formState], NOT [errors] — React Hook Form uses a Proxy
   }, [formState]);
 
   const typeOptions = useMemo(() => {
@@ -398,13 +422,13 @@ export function RuleForm({
   return (
     <Form {...form}>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-        {isSubmitted && formErrors.length > 0 && (
+        {isSubmitted && errorMessages.length > 0 && (
           <div className="mt-4">
             <AlertError
               title="Error"
               description={
-                <ul className="list-disc">
-                  {formErrors.map((message) => (
+                <ul className="list-inside list-disc">
+                  {errorMessages.map((message) => (
                     <li key={message}>{message}</li>
                   ))}
                 </ul>


### PR DESCRIPTION
### Problem
Saving a rule without any actions triggers a validation error, but the UI only displays an empty error box with no message.

This occurs because React Hook Form + Zod attaches array validation errors (e.g., `.min(1)`) to nested paths like `errors.actions.root.message` (or `errors.actions.message`).  
The existing implementation only iterates over `Object.values(formState.errors)`, which misses these nested messages.

---

### Fix
- Added a helper to safely extract validation messages from:
  - `name`
  - `actions` (including `.root.message`)
  - `conditions`
- Updated error rendering to display all extracted messages inside `<AlertError>`
- Ensured proper memoization using `useMemo` to prevent stale error state

---

### Result
Validation errors are now correctly displayed.  
For example, saving a rule without actions shows:  
"You must have at least one action" instead of an empty error box.

---

### How to Test
1. Open or edit a rule  
2. Remove all actions  
3. Click **Save**  
4. Confirm that a validation message is displayed  

---

### Notes
- No changes to validation logic itself—only error extraction and rendering  
- No new dependencies introduced  

Closes #912