### PR TITLE
assistant: Add rule suggestion inbox evals

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -381,12 +381,12 @@ describe("aiProcessAssistantChat", () => {
     const args = mockToolCallAgentStream.mock.calls[0][0];
     const systemPrompt = String(args.messages[0].content);
 
-    expect(systemPrompt).toContain("Rule discovery workflow:");
+    expect(systemPrompt).toContain("Rule suggestions:");
     expect(systemPrompt).toContain(
-      "inspect the latest rules/settings and search a representative inbox sample",
+      "Most users already have generic newsletter, marketing, receipt, and notification handling",
     );
     expect(systemPrompt).toContain(
-      "ask one focused calibration question before creating broad automation",
+      "Suggest account-specific patterns that appear repeatedly in the inbox",
     );
     expect(args.tools.getUserRulesAndSettings.description).toContain(
       "suggesting new rules",

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -383,7 +383,10 @@ describe("aiProcessAssistantChat", () => {
 
     expect(systemPrompt).toContain("Rule suggestions:");
     expect(systemPrompt).toContain(
-      "Check whether this user already has generic newsletter, marketing, receipt, or notification handling",
+      "Check what this user already has handled before suggesting a category or rule",
+    );
+    expect(systemPrompt).toContain(
+      "Do not suggest rules just to create more automation",
     );
     expect(systemPrompt).toContain(
       "ask whether the relevant inbox items are important, low-priority, safe to archive, or need attention",

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -383,10 +383,10 @@ describe("aiProcessAssistantChat", () => {
 
     expect(systemPrompt).toContain("Rule suggestions:");
     expect(systemPrompt).toContain(
-      "Most users already have generic newsletter, marketing, receipt, and notification handling",
+      "Check whether this user already has generic newsletter, marketing, receipt, or notification handling",
     );
     expect(systemPrompt).toContain(
-      "Suggest account-specific patterns that appear repeatedly in the inbox",
+      "ask whether the relevant inbox items are important, low-priority, safe to archive, or need attention",
     );
     expect(args.tools.getUserRulesAndSettings.description).toContain(
       "Retrieve the latest rules and personal instructions for the user",

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -391,7 +391,9 @@ describe("aiProcessAssistantChat", () => {
     expect(args.tools.getUserRulesAndSettings.description).toContain(
       "suggesting new rules",
     );
-    expect(args.tools.searchInbox.description).toContain("rule ideas");
+    expect(args.tools.searchInbox.description).toContain(
+      "Search inbox messages and return concise message metadata",
+    );
   });
 
   it("does not expose webhook rule actions when webhook actions are disabled", async () => {

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -389,7 +389,7 @@ describe("aiProcessAssistantChat", () => {
       "Suggest account-specific patterns that appear repeatedly in the inbox",
     );
     expect(args.tools.getUserRulesAndSettings.description).toContain(
-      "suggesting new rules",
+      "Retrieve the latest rules and personal instructions for the user",
     );
     expect(args.tools.searchInbox.description).toContain(
       "Search inbox messages and return concise message metadata",

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -357,6 +357,43 @@ describe("aiProcessAssistantChat", () => {
     expect(systemPrompt).not.toContain("Draft replies in rules:");
   });
 
+  it("guides rule recommendations through existing rules and inbox evidence", async () => {
+    const { aiProcessAssistantChat } = await loadAssistantChatModule({
+      emailSend: true,
+    });
+
+    mockToolCallAgentStream.mockResolvedValue({
+      toUIMessageStreamResponse: vi.fn(),
+    });
+
+    await aiProcessAssistantChat({
+      messages: [
+        {
+          role: "user",
+          content: "Give me some ideas of rules I could add.",
+        },
+      ],
+      emailAccountId: "email-account-id",
+      user: getEmailAccount(),
+      logger,
+    });
+
+    const args = mockToolCallAgentStream.mock.calls[0][0];
+    const systemPrompt = String(args.messages[0].content);
+
+    expect(systemPrompt).toContain("Rule discovery workflow:");
+    expect(systemPrompt).toContain(
+      "inspect the latest rules/settings and search a representative inbox sample",
+    );
+    expect(systemPrompt).toContain(
+      "ask one focused calibration question before creating broad automation",
+    );
+    expect(args.tools.getUserRulesAndSettings.description).toContain(
+      "suggesting new rules",
+    );
+    expect(args.tools.searchInbox.description).toContain("rule ideas");
+  });
+
   it("does not expose webhook rule actions when webhook actions are disabled", async () => {
     const { aiProcessAssistantChat } = await loadAssistantChatModule({
       emailSend: true,

--- a/apps/web/__tests__/eval/assistant-chat-episode-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-episode-utils.ts
@@ -1,0 +1,70 @@
+import type { ModelMessage } from "ai";
+import type { getEmailAccount } from "@/__tests__/helpers";
+import {
+  captureAssistantChatTrace,
+  type AssistantChatTrace,
+} from "@/__tests__/eval/assistant-chat-eval-utils";
+import type { MessageContext } from "@/app/api/chat/validation";
+import type { Logger } from "@/utils/logger";
+
+export type AssistantChatEpisodeTurn = {
+  userMessage: string;
+  inboxStats?: { total: number; unread: number } | null;
+  context?: MessageContext;
+};
+
+export type AssistantChatEpisode = {
+  transcript: ModelMessage[];
+  traces: AssistantChatTrace[];
+  finalText: string;
+};
+
+export async function runAssistantEpisode({
+  emailAccount,
+  logger,
+  turns,
+  initialMessages = [],
+  defaultInboxStats,
+}: {
+  emailAccount: ReturnType<typeof getEmailAccount>;
+  logger: Logger;
+  turns: AssistantChatEpisodeTurn[];
+  initialMessages?: ModelMessage[];
+  defaultInboxStats?: { total: number; unread: number } | null;
+}): Promise<AssistantChatEpisode> {
+  const transcript = [...initialMessages];
+  const traces: AssistantChatTrace[] = [];
+
+  for (const turn of turns) {
+    transcript.push({
+      role: "user",
+      content: turn.userMessage,
+    });
+
+    const trace = await captureAssistantChatTrace({
+      emailAccount,
+      logger,
+      messages: transcript,
+      inboxStats: turn.inboxStats ?? defaultInboxStats,
+      context: turn.context,
+      chatHasHistory: transcript.length > 1,
+    });
+    const finalText = await Promise.resolve(trace.finalText);
+    const normalizedTrace = {
+      ...trace,
+      finalText,
+    };
+
+    traces.push(normalizedTrace);
+    transcript.push({
+      role: "assistant",
+      content: finalText,
+    });
+  }
+
+  return {
+    transcript,
+    traces,
+    finalText: traces.at(-1)?.finalText ?? "",
+  };
+}

--- a/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
@@ -83,6 +83,7 @@ export async function captureAssistantChatTrace({
   });
 
   await result.consumeStream();
+  const finalText = await Promise.resolve(result.text);
 
   const debugArtifactPath = writeEvalDebugArtifact({
     kind: "assistant-chat-trace",
@@ -96,13 +97,13 @@ export async function captureAssistantChatTrace({
       resolvedModels,
       steps,
       toolCalls: recordedToolCalls,
-      finalText: result.text,
+      finalText,
     },
   });
 
   return {
     debugArtifactPath,
-    finalText: result.text,
+    finalText,
     resolvedModels,
     steps,
     toolCalls: recordedToolCalls,

--- a/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
@@ -141,7 +141,7 @@ const scenarios: Scenario[] = [
   {
     name: "open-ended rule ideas from a mixed inbox sample",
     expected:
-      "Gemini should inspect existing rules and inbox samples, avoid generic defaults, propose account-specific rule ideas with evidence, and ask one concrete question when priority is unclear.",
+      "Gemini should inspect existing rules and inbox samples, avoid duplicate generic rules, propose user-specific rule ideas with evidence, and ask focused questions about important vs low-priority items when priority is unclear.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 1840, unread: 73 },
@@ -157,7 +157,7 @@ const scenarios: Scenario[] = [
   {
     name: "avoid duplicate default rules and find custom opportunities",
     expected:
-      "Gemini should notice newsletters, marketing, receipts, and notifications are already covered, then focus on account-specific candidates like customer escalations, security/compliance, and auditor requests.",
+      "Gemini should check that newsletters, marketing, receipts, and notifications are already covered for this user, then focus on user-specific candidates like customer escalations, security/compliance, and auditor requests.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 2310, unread: 118 },

--- a/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
@@ -141,7 +141,7 @@ const scenarios: Scenario[] = [
   {
     name: "open-ended rule ideas from a mixed inbox sample",
     expected:
-      "Gemini should inspect existing rules and inbox samples, avoid duplicate generic rules, propose user-specific rule ideas with evidence, and ask focused questions about important vs low-priority items when priority is unclear.",
+      "Gemini should inspect existing rules and enough inbox evidence to find recurring patterns, avoid duplicate suggestions, propose user-specific rule ideas that improve inbox efficiency, and ask focused questions about important vs low-priority items when priority is unclear.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 1840, unread: 73 },
@@ -157,7 +157,7 @@ const scenarios: Scenario[] = [
   {
     name: "avoid duplicate default rules and find custom opportunities",
     expected:
-      "Gemini should check that newsletters, marketing, receipts, and notifications are already covered for this user, then focus on user-specific candidates like customer escalations, security/compliance, and auditor requests.",
+      "Gemini should check what this user already has handled, then focus on user-specific candidates like customer escalations, security/compliance, and auditor requests.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 2310, unread: 118 },

--- a/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
@@ -1,0 +1,608 @@
+import type { ModelMessage } from "ai";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  runAssistantEpisode,
+  type AssistantChatEpisodeTurn,
+} from "@/__tests__/eval/assistant-chat-episode-utils";
+import {
+  captureAssistantChatTrace,
+  summarizeRecordedToolCalls,
+  type AssistantChatTrace,
+  type RecordedToolCall,
+} from "@/__tests__/eval/assistant-chat-eval-utils";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import {
+  buildRuleFixtureRow,
+  toRuleRows,
+  type DemoInboxRuleRow,
+} from "@/__tests__/fixtures/inboxes/adapters";
+import {
+  saasFounderRuleSuggestionFixture,
+  type AssistantRuleSuggestionFixture,
+} from "@/__tests__/eval/assistant-rule-suggestion-fixtures";
+import {
+  configurePrismaForAssistantRuleSuggestionState,
+  createAssistantRuleSuggestionState,
+  createRuleInAssistantState,
+  partialUpdateRuleInAssistantState,
+  updateRuleActionsInAssistantState,
+} from "@/__tests__/eval/assistant-rule-suggestion-state";
+import type { DemoInboxFixture } from "@/__tests__/fixtures/inboxes/types";
+import { ActionType } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+
+// EVAL_MODELS=gemini-3-flash pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-rule-suggestions.test.ts
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const evalReporter = createEvalReporter();
+const logger = createScopedLogger("eval-assistant-chat-rule-suggestions");
+const TIMEOUT = 120_000;
+
+const hoisted = vi.hoisted(() => ({
+  mockCreateRule: vi.fn(),
+  mockPartialUpdateRule: vi.fn(),
+  mockUpdateRuleActions: vi.fn(),
+  mockSaveLearnedPatterns: vi.fn(),
+  mockCreateEmailProvider: vi.fn(),
+  mockPosthogCaptureEvent: vi.fn(),
+  mockRedis: {
+    set: vi.fn(),
+    rpush: vi.fn(),
+    hincrby: vi.fn(),
+    expire: vi.fn(),
+    keys: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    llen: vi.fn().mockResolvedValue(0),
+    lrange: vi.fn().mockResolvedValue([]),
+  },
+  mockUnsubscribeSenderAndMark: vi.fn(),
+  mockSearchMessages: vi.fn(),
+  mockGetMessage: vi.fn(),
+  mockArchiveThreadWithLabel: vi.fn(),
+  mockMarkReadThread: vi.fn(),
+  mockBulkArchiveFromSenders: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/rule", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/rule/rule")>();
+
+  return {
+    ...actual,
+    createRule: hoisted.mockCreateRule,
+    partialUpdateRule: hoisted.mockPartialUpdateRule,
+    updateRuleActions: hoisted.mockUpdateRuleActions,
+  };
+});
+
+vi.mock("@/utils/rule/learned-patterns", () => ({
+  saveLearnedPatterns: hoisted.mockSaveLearnedPatterns,
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: hoisted.mockCreateEmailProvider,
+}));
+
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: hoisted.mockPosthogCaptureEvent,
+  getPosthogLlmClient: () => null,
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: hoisted.mockRedis,
+}));
+
+vi.mock("@/utils/senders/unsubscribe", () => ({
+  unsubscribeSenderAndMark: hoisted.mockUnsubscribeSenderAndMark,
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_EMAIL_SEND_ENABLED: true,
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+    NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: true,
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+type Scenario = {
+  name: string;
+  expected: string;
+  fixture: DemoInboxFixture;
+  account: AssistantRuleSuggestionFixture["account"];
+  inboxStats: { total: number; unread: number };
+  messages: ModelMessage[];
+  rules?: DemoInboxRuleRow[];
+  expectRuleWrite?: boolean;
+};
+
+type EpisodeScenario = {
+  name: string;
+  expected: string;
+  fixture: DemoInboxFixture;
+  account: AssistantRuleSuggestionFixture["account"];
+  inboxStats: { total: number; unread: number };
+  turns: AssistantChatEpisodeTurn[];
+};
+
+const saasRules = toRuleRows({
+  rules: saasFounderRuleSuggestionFixture.rules,
+});
+
+const scenarios: Scenario[] = [
+  {
+    name: "open-ended rule ideas from a mixed inbox sample",
+    expected:
+      "Gemini should inspect existing rules and inbox samples, propose a ranked mix of high-priority and low-priority rule ideas, avoid creating rules, and ask one calibration question.",
+    fixture: saasFounderRuleSuggestionFixture.inbox,
+    account: saasFounderRuleSuggestionFixture.account,
+    inboxStats: { total: 1840, unread: 73 },
+    messages: [
+      {
+        role: "user",
+        content:
+          "Give me some ideas of rules I could add. Look at my inbox and interview me if you need to.",
+      },
+    ],
+    rules: saasRules,
+  },
+  {
+    name: "avoid duplicate default rules and find custom opportunities",
+    expected:
+      "Gemini should notice newsletters, marketing, receipts, and notifications are already covered, then focus on custom candidates like customer escalations, security/compliance, and auditor requests.",
+    fixture: saasFounderRuleSuggestionFixture.inbox,
+    account: saasFounderRuleSuggestionFixture.account,
+    inboxStats: { total: 2310, unread: 118 },
+    messages: [
+      {
+        role: "user",
+        content:
+          "I already have the basic rules. What new rules would actually make my inbox cleaner?",
+      },
+    ],
+    rules: [
+      ...saasRules,
+      buildRuleFixtureRow({
+        name: "Recruiting",
+        instructions:
+          "Recruiting coordinators, interview scheduling, candidate feedback, and offer logistics.",
+        actions: [labelAction("Recruiting")],
+        runOnThreads: true,
+      }),
+    ],
+  },
+  {
+    name: "calibrated follow-up creates a low-priority updates rule",
+    expected:
+      "After the user explicitly confirms priority and action, Gemini may create a Product Updates rule that labels and archives vendor product digests while excluding security and billing alerts.",
+    fixture: saasFounderRuleSuggestionFixture.inbox,
+    account: saasFounderRuleSuggestionFixture.account,
+    inboxStats: { total: 1840, unread: 73 },
+    messages: [
+      {
+        role: "user",
+        content:
+          "Give me ideas for rules that would reduce low-priority noise.",
+      },
+      {
+        role: "assistant",
+        content:
+          "One likely candidate is product update digests from SaaS vendors, but I want to confirm whether those are low priority for you before automating.",
+      },
+      {
+        role: "user",
+        content:
+          "Yes, product update digests from SaaS vendors are low priority. Create a rule that labels them Product Updates and archives them. Do not include security alerts or billing emails.",
+      },
+    ],
+    rules: saasRules,
+    expectRuleWrite: true,
+  },
+];
+
+const episodeScenarios: EpisodeScenario[] = [
+  {
+    name: "multi-turn rule discovery calibrates before creating a rule",
+    expected:
+      "Gemini should first inspect rules and the inbox, then create a Product Updates rule only after the user confirms that category and exclusions.",
+    fixture: saasFounderRuleSuggestionFixture.inbox,
+    account: saasFounderRuleSuggestionFixture.account,
+    inboxStats: { total: 1840, unread: 73 },
+    turns: [
+      {
+        userMessage:
+          "Give me a few rule ideas that would reduce low-priority noise.",
+      },
+      {
+        userMessage:
+          "Yes, product update digests are low priority. Create that rule, label them Product Updates, archive them, and exclude security or billing alerts.",
+      },
+    ],
+  },
+];
+
+describe.runIf(shouldRunEval)("Eval: assistant chat rule suggestions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    hoisted.mockCreateRule.mockResolvedValue({ id: "created-rule-id" });
+    hoisted.mockPartialUpdateRule.mockResolvedValue({ id: "updated-rule-id" });
+    hoisted.mockUpdateRuleActions.mockResolvedValue({ id: "updated-rule-id" });
+    hoisted.mockSaveLearnedPatterns.mockResolvedValue({ success: true });
+  });
+
+  describeEvalMatrix(
+    "assistant-chat rule suggestions",
+    (model, emailAccount) => {
+      test.each(scenarios)(
+        "$name",
+        async (scenario) => {
+          const state = configureScenario(scenario);
+
+          const startedAt = Date.now();
+          const evalEmailAccount = {
+            ...emailAccount,
+            userId: "",
+          };
+
+          let trace: AssistantChatTrace;
+
+          try {
+            trace = await captureNormalizedTrace({
+              emailAccount: evalEmailAccount,
+              inboxStats: scenario.inboxStats,
+              messages: scenario.messages,
+            });
+          } catch (error) {
+            evalReporter.record({
+              testName: scenario.name,
+              model: model.label,
+              pass: false,
+              durationMs: Date.now() - startedAt,
+              expected: scenario.expected,
+              actual: formatErrorForReport(error),
+            });
+            return;
+          }
+
+          const analysis = analyzeTrace(trace);
+          const expectRuleWrite =
+            scenario.expectRuleWrite ?? scenario.name.includes("creates");
+          const pass =
+            analysis.usedRulesTool &&
+            analysis.usedSearchTool &&
+            (expectRuleWrite
+              ? analysis.usedCreateRule
+              : analysis.noRuleWrite) &&
+            analysis.mentionsEvidence &&
+            analysis.mentionsPriority;
+
+          evalReporter.record({
+            testName: scenario.name,
+            model: model.label,
+            pass,
+            durationMs: Date.now() - startedAt,
+            expected: scenario.expected,
+            actual: formatTraceForReport(trace, analysis, state),
+          });
+
+          expect(trace.finalText.trim().length).toBeGreaterThan(0);
+        },
+        TIMEOUT,
+      );
+
+      test.each(episodeScenarios)(
+        "$name",
+        async (scenario) => {
+          const state = configureScenario({
+            ...scenario,
+            messages: [],
+            account: scenario.account,
+            rules: saasRules,
+            expectRuleWrite: true,
+          });
+
+          const startedAt = Date.now();
+          const evalEmailAccount = {
+            ...emailAccount,
+            userId: "",
+          };
+
+          try {
+            const episode = await runAssistantEpisode({
+              emailAccount: evalEmailAccount,
+              logger,
+              turns: scenario.turns.map((turn) => ({
+                ...turn,
+                inboxStats: turn.inboxStats ?? scenario.inboxStats,
+              })),
+              defaultInboxStats: scenario.inboxStats,
+            });
+            const toolCalls = episode.traces.flatMap(
+              (trace) => trace.toolCalls,
+            );
+            const firstTurnAnalysis = analyzeTrace(episode.traces[0]);
+            const finalAnalysis = analyzeAssistantOutput({
+              finalText: episode.finalText,
+              toolCalls,
+            });
+            const pass =
+              firstTurnAnalysis.usedRulesTool &&
+              firstTurnAnalysis.usedSearchTool &&
+              firstTurnAnalysis.noRuleWrite &&
+              finalAnalysis.usedCreateRule &&
+              state.createdRules.some((rule) =>
+                rule.name.toLowerCase().includes("product"),
+              );
+
+            evalReporter.record({
+              testName: scenario.name,
+              model: model.label,
+              pass,
+              durationMs: Date.now() - startedAt,
+              expected: scenario.expected,
+              actual: formatEpisodeForReport({
+                episode,
+                analysis: finalAnalysis,
+                state,
+              }),
+            });
+
+            expect(episode.finalText.trim().length).toBeGreaterThan(0);
+          } catch (error) {
+            evalReporter.record({
+              testName: scenario.name,
+              model: model.label,
+              pass: false,
+              durationMs: Date.now() - startedAt,
+              expected: scenario.expected,
+              actual: formatErrorForReport(error),
+            });
+          }
+        },
+        TIMEOUT,
+      );
+    },
+  );
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+async function captureNormalizedTrace({
+  emailAccount,
+  inboxStats,
+  messages,
+}: {
+  emailAccount: Parameters<typeof captureAssistantChatTrace>[0]["emailAccount"];
+  inboxStats: { total: number; unread: number };
+  messages: ModelMessage[];
+}) {
+  const trace = await captureAssistantChatTrace({
+    emailAccount,
+    inboxStats,
+    logger,
+    messages,
+  });
+
+  return {
+    ...trace,
+    finalText: await Promise.resolve(trace.finalText),
+  };
+}
+
+function configureScenario(scenario: Scenario) {
+  const state = createAssistantRuleSuggestionState({
+    fixture: scenario.fixture,
+    account: scenario.account,
+    rules: scenario.rules ?? toRuleRows({}),
+  });
+
+  configurePrismaForAssistantRuleSuggestionState({ prisma, state });
+
+  hoisted.mockCreateEmailProvider.mockResolvedValue(state.provider);
+  hoisted.mockCreateRule.mockImplementation((args) =>
+    createRuleInAssistantState(state, args),
+  );
+  hoisted.mockPartialUpdateRule.mockImplementation((args) =>
+    partialUpdateRuleInAssistantState(state, args),
+  );
+  hoisted.mockUpdateRuleActions.mockImplementation((args) =>
+    updateRuleActionsInAssistantState(state, args),
+  );
+
+  return state;
+}
+
+function labelAction(label: string) {
+  return {
+    type: ActionType.LABEL,
+    label,
+  };
+}
+
+function analyzeTrace(trace: AssistantChatTrace) {
+  return analyzeAssistantOutput({
+    finalText: trace.finalText,
+    toolCalls: trace.toolCalls,
+  });
+}
+
+function analyzeAssistantOutput({
+  finalText,
+  toolCalls,
+}: {
+  finalText: string;
+  toolCalls: RecordedToolCall[];
+}) {
+  const lowerText = finalText.toLowerCase();
+  const usedRulesTool = hasTool(toolCalls, "getUserRulesAndSettings");
+  const usedSearchTool = hasTool(toolCalls, "searchInbox");
+  const usedCreateRule = hasTool(toolCalls, "createRule");
+  const writeToolNames = new Set([
+    "createRule",
+    "updateRuleConditions",
+    "updateRuleActions",
+    "updateLearnedPatterns",
+    "updatePersonalInstructions",
+    "updateAssistantSettings",
+    "manageInbox",
+  ]);
+
+  return {
+    usedRulesTool,
+    usedSearchTool,
+    usedCreateRule,
+    noRuleWrite: !toolCalls.some((toolCall) =>
+      writeToolNames.has(toolCall.toolName),
+    ),
+    asksQuestion: finalText.includes("?"),
+    mentionsEvidence: [
+      "sample",
+      "found",
+      "saw",
+      "inbox",
+      "existing",
+      "already",
+      "rule",
+    ].some((term) => lowerText.includes(term)),
+    mentionsPriority: ["priority", "urgent", "high", "low", "important"].some(
+      (term) => lowerText.includes(term),
+    ),
+  };
+}
+
+function hasTool(toolCalls: RecordedToolCall[], toolName: string) {
+  return toolCalls.some((toolCall) => toolCall.toolName === toolName);
+}
+
+function formatTraceForReport(
+  trace: AssistantChatTrace,
+  analysis: ReturnType<typeof analyzeTrace>,
+  state: ReturnType<typeof createAssistantRuleSuggestionState>,
+) {
+  return JSON.stringify({
+    analysis,
+    fixtureId: state.fixture.id,
+    searchQueries: state.searchQueries,
+    createdRules: summarizeRules(state.createdRules),
+    toolCalls: summarizeRecordedToolCalls(trace.toolCalls, summarizeToolCall),
+    rawToolCalls: trace.toolCalls,
+    finalText: trace.finalText,
+    debugArtifactPath: trace.debugArtifactPath,
+  });
+}
+
+function formatEpisodeForReport({
+  episode,
+  analysis,
+  state,
+}: {
+  episode: Awaited<ReturnType<typeof runAssistantEpisode>>;
+  analysis: ReturnType<typeof analyzeAssistantOutput>;
+  state: ReturnType<typeof createAssistantRuleSuggestionState>;
+}) {
+  const toolCalls = episode.traces.flatMap((trace) => trace.toolCalls);
+
+  return JSON.stringify({
+    analysis,
+    fixtureId: state.fixture.id,
+    searchQueries: state.searchQueries,
+    createdRules: summarizeRules(state.createdRules),
+    finalRules: summarizeRules(state.rules),
+    transcript: episode.transcript,
+    toolCalls: summarizeRecordedToolCalls(toolCalls, summarizeToolCall),
+    rawToolCalls: toolCalls,
+    finalText: episode.finalText,
+    debugArtifactPaths: episode.traces.map((trace) => trace.debugArtifactPath),
+  });
+}
+
+function summarizeRules(rules: DemoInboxRuleRow[]) {
+  return rules.map((rule) => ({
+    name: rule.name,
+    instructions: rule.instructions,
+    from: rule.from,
+    to: rule.to,
+    subject: rule.subject,
+    actions: rule.actions.map((action) => ({
+      type: action.type,
+      label: action.label,
+      folderName: action.folderName,
+    })),
+  }));
+}
+
+function formatErrorForReport(error: unknown) {
+  if (error instanceof Error) {
+    return JSON.stringify({
+      errorName: error.name,
+      message: error.message,
+    });
+  }
+
+  return JSON.stringify({ message: String(error) });
+}
+
+function summarizeToolCall(toolCall: RecordedToolCall) {
+  if (toolCall.toolName === "searchInbox") {
+    const input = toolCall.input as { query?: string; limit?: number };
+    return `searchInbox(query=${input.query ?? ""}, limit=${input.limit ?? "default"})`;
+  }
+
+  if (toolCall.toolName === "createRule") {
+    const input = toolCall.input as {
+      name?: string;
+      condition?: {
+        aiInstructions?: string | null;
+        static?: {
+          from?: string | null;
+          to?: string | null;
+          subject?: string | null;
+        };
+      };
+      actions?: Array<{
+        type?: string;
+        fields?: {
+          label?: string | null;
+          folderName?: string | null;
+        } | null;
+      }>;
+    };
+    const actions = input.actions
+      ?.map((action) =>
+        [
+          action.type,
+          action.fields?.label ? `label=${action.fields.label}` : null,
+          action.fields?.folderName
+            ? `folder=${action.fields.folderName}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(":"),
+      )
+      .join(",");
+    const condition =
+      input.condition?.aiInstructions ||
+      input.condition?.static?.from ||
+      input.condition?.static?.subject ||
+      "";
+
+    return `createRule(name=${input.name ?? ""}, condition=${truncate(condition, 120)}, actions=${actions ?? ""})`;
+  }
+
+  return toolCall.toolName;
+}
+
+function truncate(value: string, maxLength: number) {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}

--- a/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
@@ -141,7 +141,7 @@ const scenarios: Scenario[] = [
   {
     name: "open-ended rule ideas from a mixed inbox sample",
     expected:
-      "Gemini should inspect existing rules and inbox samples, propose a ranked mix of high-priority and low-priority rule ideas, avoid creating rules, and ask one calibration question.",
+      "Gemini should inspect existing rules and inbox samples, avoid generic defaults, propose account-specific rule ideas with evidence, and ask one concrete question when priority is unclear.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 1840, unread: 73 },
@@ -157,7 +157,7 @@ const scenarios: Scenario[] = [
   {
     name: "avoid duplicate default rules and find custom opportunities",
     expected:
-      "Gemini should notice newsletters, marketing, receipts, and notifications are already covered, then focus on custom candidates like customer escalations, security/compliance, and auditor requests.",
+      "Gemini should notice newsletters, marketing, receipts, and notifications are already covered, then focus on account-specific candidates like customer escalations, security/compliance, and auditor requests.",
     fixture: saasFounderRuleSuggestionFixture.inbox,
     account: saasFounderRuleSuggestionFixture.account,
     inboxStats: { total: 2310, unread: 118 },

--- a/apps/web/__tests__/eval/assistant-rule-suggestion-fixtures.ts
+++ b/apps/web/__tests__/eval/assistant-rule-suggestion-fixtures.ts
@@ -1,0 +1,34 @@
+import { ActionType } from "@/generated/prisma/enums";
+import type { DemoInboxFixture } from "@/__tests__/fixtures/inboxes/types";
+import { saasFounderMixedInbox } from "@/__tests__/fixtures/inboxes/demo-inboxes";
+import type { DemoRuleFixture } from "@/__tests__/fixtures/inboxes/adapters";
+
+export type AssistantRuleSuggestionFixture = {
+  inbox: DemoInboxFixture;
+  account: {
+    email: string;
+    timezone: string;
+    about: string;
+  };
+  rules: DemoRuleFixture[];
+};
+
+export const saasFounderRuleSuggestionFixture: AssistantRuleSuggestionFixture =
+  {
+    inbox: saasFounderMixedInbox,
+    account: {
+      email: saasFounderMixedInbox.mailbox.email,
+      timezone: saasFounderMixedInbox.mailbox.timezone,
+      about:
+        "I run a B2B SaaS company and want important customer, security, billing, and compliance mail surfaced quickly.",
+    },
+    rules: [
+      {
+        name: "VIP Customers",
+        instructions:
+          "Emails from active enterprise customers that need same-day attention.",
+        runOnThreads: true,
+        actions: [{ type: ActionType.LABEL, label: "VIP Customer" }],
+      },
+    ],
+  };

--- a/apps/web/__tests__/eval/assistant-rule-suggestion-state.ts
+++ b/apps/web/__tests__/eval/assistant-rule-suggestion-state.ts
@@ -1,0 +1,280 @@
+import type { CreateOrUpdateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+import type prismaMock from "@/utils/__mocks__/prisma";
+import type { EmailProvider } from "@/utils/email/types";
+import type { DemoInboxFixture } from "@/__tests__/fixtures/inboxes/types";
+import {
+  buildRuleRow,
+  searchFixtureMessages,
+  toFixtureLabelRows,
+  toMockMessages,
+  toRuleRows,
+  type DemoInboxRuleRow,
+} from "@/__tests__/fixtures/inboxes/adapters";
+
+type AssistantRuleSuggestionState = {
+  fixture: DemoInboxFixture;
+  account: {
+    email: string;
+    timezone: string;
+    about: string;
+  };
+  labels: ReturnType<typeof toFixtureLabelRows>;
+  rules: DemoInboxRuleRow[];
+  rulesRevision: number;
+  createdRules: DemoInboxRuleRow[];
+  searchQueries: string[];
+  provider: EmailProvider;
+};
+
+type CreateRuleMockArgs = {
+  result: CreateOrUpdateRuleSchema;
+  runOnThreads: boolean;
+};
+
+type UpdateRuleActionsMockArgs = {
+  ruleId: string;
+  actions: CreateOrUpdateRuleSchema["actions"];
+};
+
+type PartialUpdateRuleMockArgs = {
+  ruleId: string;
+  data: Partial<DemoInboxRuleRow>;
+};
+
+export function createAssistantRuleSuggestionState({
+  fixture,
+  account = {
+    email: fixture.mailbox.email,
+    timezone: fixture.mailbox.timezone,
+    about: "Not set",
+  },
+  rules = toRuleRows({}),
+}: {
+  fixture: DemoInboxFixture;
+  account?: {
+    email: string;
+    timezone: string;
+    about: string;
+  };
+  rules?: DemoInboxRuleRow[];
+}): AssistantRuleSuggestionState {
+  const state: AssistantRuleSuggestionState = {
+    fixture,
+    account,
+    labels: toFixtureLabelRows(fixture),
+    rules: rules.map(cloneRuleRow),
+    rulesRevision: 1,
+    createdRules: [],
+    searchQueries: [],
+    provider: {} as EmailProvider,
+  };
+
+  state.provider = createProviderMock(state);
+
+  return state;
+}
+
+export function configurePrismaForAssistantRuleSuggestionState({
+  prisma,
+  state,
+}: {
+  prisma: typeof prismaMock;
+  state: AssistantRuleSuggestionState;
+}) {
+  prisma.emailAccount.findUnique.mockImplementation(async ({ select }) => {
+    if (select?.rulesRevision && !select?.rules) {
+      return { rulesRevision: state.rulesRevision };
+    }
+
+    if (select?.rules) {
+      return {
+        about: state.account.about,
+        rulesRevision: state.rulesRevision,
+        rules: state.rules,
+      };
+    }
+
+    if (select?.email) {
+      return {
+        email: state.account.email,
+        timezone: state.account.timezone,
+        meetingBriefingsEnabled: false,
+        meetingBriefingsMinutesBefore: 15,
+        meetingBriefsSendEmail: false,
+        filingEnabled: false,
+        filingPrompt: null,
+        filingFolders: [],
+        driveConnections: [],
+      };
+    }
+
+    return {
+      about: state.account.about,
+    };
+  });
+
+  prisma.emailAccount.update.mockResolvedValue({
+    about: state.account.about,
+  });
+
+  prisma.rule.findUnique.mockImplementation(async ({ where, select }) => {
+    const ruleName = where?.name_emailAccountId?.name;
+    const ruleId = where?.id;
+    const rule = state.rules.find(
+      (candidate) => candidate.name === ruleName || candidate.id === ruleId,
+    );
+
+    if (!rule) return null;
+
+    if (select?.group) {
+      return {
+        ...rule,
+        group: { items: [] },
+      };
+    }
+
+    return {
+      ...rule,
+      emailAccount: { rulesRevision: state.rulesRevision },
+    };
+  });
+
+  prisma.rule.findMany.mockImplementation(async () =>
+    state.rules.map((rule) => ({
+      ...rule,
+      group: { items: [] },
+    })),
+  );
+}
+
+export async function createRuleInAssistantState(
+  state: AssistantRuleSuggestionState,
+  { result, runOnThreads }: CreateRuleMockArgs,
+) {
+  const rule = buildRuleRow({
+    name: result.name,
+    instructions: result.condition.aiInstructions ?? null,
+    from: result.condition.static?.from ?? null,
+    to: result.condition.static?.to ?? null,
+    subject: result.condition.static?.subject ?? null,
+    conditionalOperator: result.condition.conditionalOperator ?? undefined,
+    actions: result.actions.map((action) => ({
+      type: action.type,
+      content: action.fields?.content ?? null,
+      label: action.fields?.label ?? null,
+      to: action.fields?.to ?? null,
+      cc: action.fields?.cc ?? null,
+      bcc: action.fields?.bcc ?? null,
+      subject: action.fields?.subject ?? null,
+      url: action.fields?.webhookUrl ?? null,
+      folderName: action.fields?.folderName ?? null,
+      delayInMinutes: action.delayInMinutes ?? null,
+    })),
+    runOnThreads,
+  });
+
+  state.rules.push(rule);
+  state.createdRules.push(rule);
+  state.rulesRevision += 1;
+
+  return { id: rule.id };
+}
+
+export async function updateRuleActionsInAssistantState(
+  state: AssistantRuleSuggestionState,
+  { ruleId, actions }: UpdateRuleActionsMockArgs,
+) {
+  const rule = state.rules.find((candidate) => candidate.id === ruleId);
+  if (!rule) return { id: ruleId };
+
+  rule.actions = actions.map((action) => ({
+    type: action.type,
+    content: action.fields?.content ?? null,
+    label: action.fields?.label ?? null,
+    to: action.fields?.to ?? null,
+    cc: action.fields?.cc ?? null,
+    bcc: action.fields?.bcc ?? null,
+    subject: action.fields?.subject ?? null,
+    url: action.fields?.webhookUrl ?? null,
+    folderName: action.fields?.folderName ?? null,
+    delayInMinutes: action.delayInMinutes ?? null,
+  }));
+  rule.updatedAt = new Date();
+  state.rulesRevision += 1;
+
+  return { id: rule.id };
+}
+
+export async function partialUpdateRuleInAssistantState(
+  state: AssistantRuleSuggestionState,
+  { ruleId, data }: PartialUpdateRuleMockArgs,
+) {
+  const rule = state.rules.find((candidate) => candidate.id === ruleId);
+  if (!rule) return { id: ruleId };
+
+  Object.assign(rule, data, { updatedAt: new Date() });
+  state.rulesRevision += 1;
+
+  return { id: rule.id };
+}
+
+function cloneRuleRow(rule: DemoInboxRuleRow): DemoInboxRuleRow {
+  return {
+    ...rule,
+    updatedAt: new Date(rule.updatedAt),
+    actions: rule.actions.map((action) => ({ ...action })),
+  };
+}
+
+function createProviderMock(
+  state: AssistantRuleSuggestionState,
+): EmailProvider {
+  const messages = toMockMessages(state.fixture);
+  const messageById = new Map(messages.map((message) => [message.id, message]));
+
+  return {
+    searchMessages: async ({ query, maxResults, pageToken }) => {
+      state.searchQueries.push(query);
+      return searchFixtureMessages({
+        fixture: state.fixture,
+        query,
+        maxResults,
+        pageToken,
+      });
+    },
+    getLabels: async () => state.labels,
+    createLabel: async (name) => {
+      const label = {
+        id: `Label_${name}`,
+        name,
+        type: "user" as const,
+      };
+      state.labels.push(label);
+      return label;
+    },
+    getMessage: async (messageId) => {
+      const message = messageById.get(messageId);
+      if (!message) throw new Error(`Unexpected messageId: ${messageId}`);
+      return message;
+    },
+    getMessagesWithPagination: async ({ maxResults = 20, pageToken }) => {
+      const offset = pageToken ? Number.parseInt(pageToken, 10) || 0 : 0;
+      const page = messages.slice(offset, offset + maxResults);
+      const nextOffset = offset + page.length;
+
+      return {
+        messages: page,
+        nextPageToken:
+          nextOffset < messages.length ? String(nextOffset) : undefined,
+      };
+    },
+    getInboxStats: async () => ({
+      total: messages.length,
+      unread: messages.filter((message) => message.labelIds.includes("UNREAD"))
+        .length,
+    }),
+    archiveThreadWithLabel: async () => undefined,
+    markReadThread: async () => undefined,
+    bulkArchiveFromSenders: async () => undefined,
+  } as Partial<EmailProvider> as EmailProvider;
+}

--- a/apps/web/__tests__/fixtures/inboxes/adapters.test.ts
+++ b/apps/web/__tests__/fixtures/inboxes/adapters.test.ts
@@ -72,6 +72,26 @@ describe("demo inbox fixture adapters", () => {
     );
   });
 
+  test("preserves internal hyphens while dropping negative search terms", () => {
+    const followUp = searchFixtureMessages({
+      fixture: saasFounderMixedInbox,
+      query: "follow-up",
+      maxResults: 10,
+    });
+    const deployment = searchFixtureMessages({
+      fixture: saasFounderMixedInbox,
+      query: "inbox-zero-ai -security",
+      maxResults: 10,
+    });
+
+    expect(followUp.messages.map((message) => message.subject)).toContain(
+      "Follow-up on Q2 metrics",
+    );
+    expect(deployment.messages.map((message) => message.subject)).toContain(
+      "Production deployment succeeded",
+    );
+  });
+
   test("builds default system rules alongside eval-provided rules", () => {
     const rules = toRuleRows({
       rules: [

--- a/apps/web/__tests__/fixtures/inboxes/adapters.test.ts
+++ b/apps/web/__tests__/fixtures/inboxes/adapters.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import { saasFounderMixedInbox } from "@/__tests__/fixtures/inboxes/demo-inboxes";
+import {
+  buildRuleFixtureRow,
+  searchFixtureMessages,
+  toGmailSeedMessages,
+  toMockMessages,
+  toRuleRows,
+} from "@/__tests__/fixtures/inboxes/adapters";
+import { ActionType } from "@/generated/prisma/enums";
+
+describe("demo inbox fixture adapters", () => {
+  test("converts every fixture message into Gmail seed data", () => {
+    const seedMessages = toGmailSeedMessages(saasFounderMixedInbox);
+    const fixtureMessageCount = saasFounderMixedInbox.threads.reduce(
+      (count, thread) => count + thread.messages.length,
+      0,
+    );
+
+    expect(seedMessages).toHaveLength(fixtureMessageCount);
+    expect(seedMessages).toContainEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^[a-f0-9]{16}$/),
+        user_email: saasFounderMixedInbox.mailbox.email,
+        from: "AWS Security <no-reply-aws@amazon.com>",
+        subject: "Root MFA disabled on production account",
+        label_ids: expect.arrayContaining(["INBOX", "UNREAD"]),
+      }),
+    );
+  });
+
+  test("converts fixture messages into ParsedMessage-like test messages", () => {
+    const messages = toMockMessages(saasFounderMixedInbox);
+    const customerMessage = messages.find(
+      (message) =>
+        message.subject === "Escalation: renewal terms still unresolved",
+    );
+
+    expect(customerMessage).toEqual(
+      expect.objectContaining({
+        threadId: expect.stringMatching(/^[a-f0-9]{16}$/),
+        subject: "Escalation: renewal terms still unresolved",
+        textPlain: expect.stringContaining("procurement will pause"),
+        labelIds: expect.arrayContaining(["INBOX", "UNREAD"]),
+      }),
+    );
+  });
+
+  test("searches fixture messages by common Gmail-style query terms", () => {
+    const productUpdates = searchFixtureMessages({
+      fixture: saasFounderMixedInbox,
+      query: "in:inbox product update",
+      maxResults: 10,
+    });
+    const unreadSecurity = searchFixtureMessages({
+      fixture: saasFounderMixedInbox,
+      query: "is:unread security",
+      maxResults: 10,
+    });
+
+    expect(productUpdates.messages.map((message) => message.subject)).toEqual(
+      expect.arrayContaining([
+        "What's new in Notion this month",
+        "Vercel product update: new observability features",
+      ]),
+    );
+    expect(unreadSecurity.messages.map((message) => message.subject)).toEqual(
+      expect.arrayContaining([
+        "Root MFA disabled on production account",
+        "New suspicious login detected",
+      ]),
+    );
+  });
+
+  test("builds default system rules alongside eval-provided rules", () => {
+    const rules = toRuleRows({
+      rules: [
+        {
+          name: "VIP Customers",
+          instructions:
+            "Emails from active enterprise customers that need same-day attention.",
+          actions: [{ type: ActionType.LABEL, label: "VIP Customer" }],
+        },
+      ],
+    });
+
+    expect(rules.map((rule) => rule.name)).toEqual(
+      expect.arrayContaining(["To Reply", "Newsletter", "VIP Customers"]),
+    );
+    expect(
+      buildRuleFixtureRow({
+        name: "Security",
+        instructions: "Security alerts.",
+        actions: [{ type: ActionType.LABEL, label: "Security" }],
+      }).actions,
+    ).toEqual([
+      expect.objectContaining({ type: ActionType.LABEL, label: "Security" }),
+    ]);
+  });
+});

--- a/apps/web/__tests__/fixtures/inboxes/adapters.ts
+++ b/apps/web/__tests__/fixtures/inboxes/adapters.ts
@@ -1,0 +1,376 @@
+import { getMockMessage } from "@/__tests__/helpers";
+import type {
+  DemoInboxAddress,
+  DemoInboxFixture,
+  DemoInboxMessage,
+} from "@/__tests__/fixtures/inboxes/types";
+import {
+  type ActionType,
+  LogicalOperator,
+  SystemType,
+} from "@/generated/prisma/enums";
+import { getDefaultActions, getRuleConfig } from "@/utils/rule/consts";
+
+export type GmailSeedMessage = {
+  id: string;
+  user_email: string;
+  from: string;
+  to: string;
+  subject: string;
+  body_text: string;
+  body_html?: string;
+  label_ids: string[];
+  internal_date: string;
+};
+
+export type DemoInboxRuleRow = ReturnType<typeof buildRuleRow>;
+
+export type DemoRuleFixture = {
+  name: string;
+  instructions: string;
+  actions: DemoRuleActionFixture[];
+  runOnThreads?: boolean;
+  systemType?: SystemType | null;
+};
+
+export type DemoRuleActionFixture = {
+  type: ActionType;
+  label?: string | null;
+  content?: string | null;
+  to?: string | null;
+  cc?: string | null;
+  bcc?: string | null;
+  subject?: string | null;
+  url?: string | null;
+  folderName?: string | null;
+  delayInMinutes?: number | null;
+};
+
+const DEFAULT_SYSTEM_TYPES = [
+  SystemType.TO_REPLY,
+  SystemType.FYI,
+  SystemType.NEWSLETTER,
+  SystemType.MARKETING,
+  SystemType.RECEIPT,
+  SystemType.NOTIFICATION,
+];
+
+export function flattenFixtureMessages(fixture: DemoInboxFixture) {
+  return fixture.threads.flatMap((thread) =>
+    thread.messages.map((message) => ({
+      thread,
+      message,
+    })),
+  );
+}
+
+export function toGmailSeedMessages(
+  fixture: DemoInboxFixture,
+): GmailSeedMessage[] {
+  return flattenFixtureMessages(fixture).map(({ message }) => ({
+    id: message.id,
+    user_email: fixture.mailbox.email,
+    from: formatAddress(message.from),
+    to: message.to.map(formatAddress).join(", "),
+    subject: message.subject,
+    body_text: message.bodyText,
+    body_html: message.bodyHtml,
+    label_ids: getMessageLabelIds(fixture, message),
+    internal_date: String(new Date(message.date).getTime()),
+  }));
+}
+
+export function toMockMessages(fixture: DemoInboxFixture) {
+  return flattenFixtureMessages(fixture).map(({ thread, message }) =>
+    getMockMessage({
+      id: message.id,
+      threadId: thread.id,
+      from: formatAddress(message.from),
+      to: message.to.map(formatAddress).join(", "),
+      subject: message.subject,
+      snippet: getSnippet(message.bodyText),
+      textPlain: message.bodyText,
+      textHtml: message.bodyHtml ?? `<p>${message.bodyText}</p>`,
+      labelIds: getMessageLabelIds(fixture, message),
+    }),
+  );
+}
+
+export function searchFixtureMessages({
+  fixture,
+  query,
+  maxResults = 20,
+  pageToken,
+}: {
+  fixture: DemoInboxFixture;
+  query: string;
+  maxResults?: number;
+  pageToken?: string;
+}) {
+  const offset = pageToken ? Number.parseInt(pageToken, 10) || 0 : 0;
+  const normalizedQuery = query.trim().toLowerCase();
+  const matchingMessages = toMockMessages(fixture).filter((message) =>
+    messageMatchesQuery({
+      fixture,
+      subject: message.subject,
+      textPlain: message.textPlain,
+      from: message.headers.from,
+      to: message.headers.to,
+      labelIds: message.labelIds,
+      normalizedQuery,
+    }),
+  );
+  const page = matchingMessages.slice(offset, offset + maxResults);
+  const nextOffset = offset + page.length;
+
+  return {
+    messages: page,
+    nextPageToken:
+      nextOffset < matchingMessages.length ? String(nextOffset) : undefined,
+  };
+}
+
+export function toFixtureLabelRows(fixture: DemoInboxFixture) {
+  return fixture.labels.map((label) => ({
+    id: label.id,
+    name: label.name,
+    type: label.type,
+  }));
+}
+
+export function toRuleRows({
+  rules = [],
+  includeSystemRules = true,
+  extraRules = [],
+}: {
+  rules?: DemoRuleFixture[];
+  includeSystemRules?: boolean;
+  extraRules?: DemoRuleFixture[];
+}) {
+  const systemRules = includeSystemRules
+    ? buildSystemRuleRows(DEFAULT_SYSTEM_TYPES)
+    : [];
+
+  return [
+    ...systemRules,
+    ...rules.map(buildRuleFixtureRow),
+    ...extraRules.map(buildRuleFixtureRow),
+  ];
+}
+
+export function buildRuleFixtureRow(rule: DemoRuleFixture) {
+  return buildRuleRow({
+    name: rule.name,
+    instructions: rule.instructions,
+    actions: rule.actions,
+    runOnThreads: rule.runOnThreads ?? false,
+    systemType: rule.systemType ?? null,
+  });
+}
+
+export function buildRuleRow({
+  name,
+  instructions,
+  actions,
+  runOnThreads = false,
+  systemType = null,
+  from = null,
+  to = null,
+  subject = null,
+  conditionalOperator = LogicalOperator.AND,
+}: {
+  name: string;
+  instructions: string | null;
+  actions: Array<{
+    type: ActionType;
+    content?: string | null;
+    label?: string | null;
+    to?: string | null;
+    cc?: string | null;
+    bcc?: string | null;
+    subject?: string | null;
+    url?: string | null;
+    folderName?: string | null;
+    delayInMinutes?: number | null;
+  }>;
+  runOnThreads?: boolean;
+  systemType?: SystemType | null;
+  from?: string | null;
+  to?: string | null;
+  subject?: string | null;
+  conditionalOperator?: LogicalOperator;
+}) {
+  return {
+    id: `${name.toLowerCase().replace(/\s+/g, "-")}-rule-id`,
+    name,
+    instructions,
+    updatedAt: new Date("2026-04-20T12:00:00.000Z"),
+    from,
+    to,
+    subject,
+    conditionalOperator,
+    enabled: true,
+    runOnThreads,
+    systemType,
+    actions: actions.map((action) => ({
+      type: action.type,
+      content: action.content ?? null,
+      label: action.label ?? null,
+      to: action.to ?? null,
+      cc: action.cc ?? null,
+      bcc: action.bcc ?? null,
+      subject: action.subject ?? null,
+      url: action.url ?? null,
+      folderName: action.folderName ?? null,
+      delayInMinutes: action.delayInMinutes ?? null,
+    })),
+  };
+}
+
+function buildSystemRuleRows(systemTypes: SystemType[]) {
+  return systemTypes.map((systemType) => {
+    const config = getRuleConfig(systemType);
+
+    return buildRuleRow({
+      name: config.name,
+      instructions: config.instructions,
+      actions: getDefaultActions(systemType, "google").map((action) => ({
+        type: action.type,
+        content: action.content,
+        label: action.label,
+        to: action.to,
+        cc: action.cc,
+        bcc: action.bcc,
+        subject: action.subject,
+        url: action.url,
+        folderName: action.folderName,
+        delayInMinutes: action.delayInMinutes,
+      })),
+      runOnThreads: config.runOnThreads,
+      systemType,
+    });
+  });
+}
+
+function messageMatchesQuery({
+  fixture,
+  subject,
+  textPlain,
+  from,
+  to,
+  labelIds,
+  normalizedQuery,
+}: {
+  fixture: DemoInboxFixture;
+  subject: string;
+  textPlain: string;
+  from: string;
+  to: string;
+  labelIds: string[];
+  normalizedQuery: string;
+}) {
+  if (!normalizedQuery) return true;
+
+  if (hasTerm(normalizedQuery, "is:unread") && !labelIds.includes("UNREAD")) {
+    return false;
+  }
+  if (hasTerm(normalizedQuery, "in:inbox") && !labelIds.includes("INBOX")) {
+    return false;
+  }
+
+  const fromFilter = getOperatorValue(normalizedQuery, "from");
+  if (fromFilter && !from.toLowerCase().includes(fromFilter)) return false;
+
+  const toFilter = getOperatorValue(normalizedQuery, "to");
+  if (toFilter && !to.toLowerCase().includes(toFilter)) return false;
+
+  const subjectFilter = getOperatorValue(normalizedQuery, "subject");
+  if (subjectFilter && !subject.toLowerCase().includes(subjectFilter)) {
+    return false;
+  }
+
+  const labelFilter = getOperatorValue(normalizedQuery, "label");
+  if (labelFilter && !messageHasLabel(fixture, labelIds, labelFilter)) {
+    return false;
+  }
+
+  const searchableText = [from, to, subject, textPlain].join(" ").toLowerCase();
+  const freeTextTerms = getFreeTextTerms(normalizedQuery);
+  if (/\bor\b/.test(normalizedQuery)) {
+    return (
+      freeTextTerms.length === 0 ||
+      freeTextTerms.some((term) => searchableText.includes(term))
+    );
+  }
+
+  return freeTextTerms.every((term) => searchableText.includes(term));
+}
+
+function getMessageLabelIds(
+  fixture: DemoInboxFixture,
+  message: DemoInboxMessage,
+) {
+  const labelLookup = new Map(
+    fixture.labels.flatMap((label) => [
+      [label.id.toLowerCase(), label.id],
+      [label.name.toLowerCase(), label.id],
+    ]),
+  );
+  const ids = new Set(
+    (message.labels ?? ["INBOX"]).map(
+      (label) => labelLookup.get(label.toLowerCase()) ?? label,
+    ),
+  );
+
+  if (message.unread) ids.add("UNREAD");
+
+  return [...ids];
+}
+
+function messageHasLabel(
+  fixture: DemoInboxFixture,
+  labelIds: string[],
+  labelFilter: string,
+) {
+  const expectedLabel = labelFilter.replace(/^["']|["']$/g, "").toLowerCase();
+
+  return labelIds.some((labelId) => {
+    const label = fixture.labels.find((candidate) => candidate.id === labelId);
+    return (
+      labelId.toLowerCase().includes(expectedLabel) ||
+      label?.name.toLowerCase().includes(expectedLabel)
+    );
+  });
+}
+
+function formatAddress(address: DemoInboxAddress) {
+  return address.name ? `${address.name} <${address.email}>` : address.email;
+}
+
+function getSnippet(text: string) {
+  return text.length > 180 ? `${text.slice(0, 177)}...` : text;
+}
+
+function hasTerm(query: string, term: string) {
+  return query.split(/\s+/).includes(term);
+}
+
+function getOperatorValue(query: string, operator: string) {
+  const match = query.match(new RegExp(`${operator}:("[^"]+"|'[^']+'|\\S+)`));
+  return match?.[1]?.replace(/^["']|["']$/g, "").toLowerCase() ?? null;
+}
+
+function getFreeTextTerms(query: string) {
+  return query
+    .replace(/-\S+/g, " ")
+    .replace(/\b(from|to|subject|label):("[^"]+"|'[^']+'|\S+)/g, " ")
+    .replace(/\b(is|in|after|before|newer_than|older_than):\S+/g, " ")
+    .replace(/[()"']/g, " ")
+    .split(/\s+/)
+    .map((term) => term.trim().toLowerCase())
+    .filter(
+      (term) =>
+        term.length > 2 &&
+        !["and", "or", "not", "the", "with", "for"].includes(term),
+    );
+}

--- a/apps/web/__tests__/fixtures/inboxes/adapters.ts
+++ b/apps/web/__tests__/fixtures/inboxes/adapters.ts
@@ -362,7 +362,7 @@ function getOperatorValue(query: string, operator: string) {
 
 function getFreeTextTerms(query: string) {
   return query
-    .replace(/-\S+/g, " ")
+    .replace(/(^|\s)-("[^"]+"|'[^']+'|\S+)/g, " ")
     .replace(/\b(from|to|subject|label):("[^"]+"|'[^']+'|\S+)/g, " ")
     .replace(/\b(is|in|after|before|newer_than|older_than):\S+/g, " ")
     .replace(/[()"']/g, " ")

--- a/apps/web/__tests__/fixtures/inboxes/demo-inboxes.ts
+++ b/apps/web/__tests__/fixtures/inboxes/demo-inboxes.ts
@@ -1,0 +1,539 @@
+import type {
+  DemoInboxAddress,
+  DemoInboxFixture,
+  DemoInboxMessage,
+  DemoInboxThread,
+} from "@/__tests__/fixtures/inboxes/types";
+
+export const saasFounderMixedInbox: DemoInboxFixture = {
+  id: "saasFounderMixed",
+  name: "SaaS Founder Mixed Inbox",
+  description:
+    "A founder inbox with urgent customer work, security/billing alerts, operational digests, newsletters, recruiting, and cold sales.",
+  mailbox: {
+    email: "alex@northstarhq.com",
+    displayName: "Alex Morgan",
+    timezone: "America/Los_Angeles",
+  },
+  labels: baseLabels(),
+  threads: [
+    thread("18f51c0a769e2f41", [
+      message({
+        id: "18f51c0b4a9d7c02",
+        from: person("Maya Chen", "maya@acme-customer.com"),
+        subject: "Approval needed today: Q2 rollout copy",
+        bodyText:
+          "Can you approve the revised launch copy before 3pm? The customer team is blocked until we get a yes from you.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-20T16:10:00.000Z",
+      }),
+      message({
+        id: "18f51c0e1d6b90aa",
+        from: person("Maya Chen", "maya@acme-customer.com"),
+        subject: "Re: Approval needed today: Q2 rollout copy",
+        bodyText:
+          "Adding the final customer notes here. We can ship once you approve the highlighted paragraph.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-20T17:25:00.000Z",
+      }),
+    ]),
+    thread("18f51c1517ef3149", [
+      message({
+        id: "18f51c1674a83c6d",
+        from: person("Nora Patel", "nora@northwindhq.com"),
+        subject: "Escalation: renewal terms still unresolved",
+        bodyText:
+          "We need an answer on renewal terms before legal review tomorrow. If this slips, procurement will pause the renewal.",
+        unread: true,
+        labels: ["INBOX", "To Reply", "VIP Customer"],
+        date: "2026-04-21T15:40:00.000Z",
+      }),
+      message({
+        id: "18f51c18ad90ef32",
+        from: person("Ari Cohen", "ari@northstarhq.com"),
+        subject: "Re: Escalation: renewal terms still unresolved",
+        bodyText:
+          "I can jump in, but they are asking for your final position on the multi-year discount.",
+        unread: false,
+        labels: ["INBOX", "VIP Customer"],
+        date: "2026-04-21T16:12:00.000Z",
+      }),
+    ]),
+    thread("18f51c1e62cbb940", [
+      message({
+        id: "18f51c208d54b71a",
+        from: person("AWS Security", "no-reply-aws@amazon.com"),
+        subject: "Root MFA disabled on production account",
+        bodyText:
+          "Security alert: root multi-factor authentication was disabled on your production account. Review this event immediately.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-21T03:05:00.000Z",
+      }),
+    ]),
+    thread("18f51c24d1a6405c", [
+      message({
+        id: "18f51c25a97eb0d1",
+        from: person("Okta Security", "security@okta.com"),
+        subject: "New suspicious login detected",
+        bodyText:
+          "A new suspicious login was detected for your organization. Review this security alert and reset credentials if needed.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-21T07:44:00.000Z",
+      }),
+    ]),
+    thread("18f51c297ab3d84e", [
+      message({
+        id: "18f51c2a0e832979",
+        from: person("Figma Billing", "billing@figma.com"),
+        subject: "Payment failed for invoice INV-4432",
+        bodyText:
+          "Update your payment method to avoid service interruption. The failed invoice is INV-4432.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-20T21:18:00.000Z",
+      }),
+    ]),
+    thread("18f51c2e4a97b21f", [
+      message({
+        id: "18f51c2fd2a9146b",
+        from: person("Vercel Billing", "billing@vercel.com"),
+        subject: "Invoice payment failed",
+        bodyText:
+          "Please update your payment method for your Vercel team. Failed payments may disable production deployments.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-22T06:15:00.000Z",
+      }),
+    ]),
+    thread("18f51c34479cb286", [
+      message({
+        id: "18f51c353f6bd109",
+        from: person("SOC2 Auditor", "auditor@secureframe.com"),
+        subject: "Evidence request due Friday",
+        bodyText:
+          "Please upload access review evidence before Friday's audit checkpoint. We still need admin role exports.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-21T19:30:00.000Z",
+      }),
+      message({
+        id: "18f51c377206e4bc",
+        from: person("SOC2 Auditor", "auditor@secureframe.com"),
+        subject: "Re: Evidence request due Friday",
+        bodyText:
+          "Following up because the access review evidence is still missing from the portal.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T13:10:00.000Z",
+      }),
+    ]),
+    thread("18f51c3bb925a4f7", [
+      message({
+        id: "18f51c3c6cae1075",
+        from: person("GitHub", "notifications@github.com"),
+        subject: "Review requested on inbox-zero-ai#4821",
+        bodyText:
+          "You were requested as a reviewer for a pull request touching billing and rule automation.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-22T09:05:00.000Z",
+      }),
+    ]),
+    thread("18f51c409f36e2ad", [
+      message({
+        id: "18f51c4160bd8b2a",
+        from: person("Vercel", "notifications@vercel.com"),
+        subject: "Production deployment succeeded",
+        bodyText:
+          "inbox-zero-ai deployed successfully to production. Commit 4f91e7 is now live.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-22T10:12:00.000Z",
+      }),
+    ]),
+    thread("18f51c47ab305e91", [
+      message({
+        id: "18f51c4872d91c0a",
+        from: person("Linear", "digest@linear.app"),
+        subject: "Weekly workspace digest",
+        bodyText:
+          "12 issues closed, 8 issues created, and project updates from the workspace.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-20T12:00:00.000Z",
+      }),
+    ]),
+    thread("18f51c4c1a6d0bb2", [
+      message({
+        id: "18f51c4d8a035a0d",
+        from: person("Lenny's Newsletter", "newsletter@lennysnewsletter.com"),
+        subject: "This week: pricing pages that convert",
+        bodyText:
+          "New essay plus sponsor notes and upcoming events for product and growth teams.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-20T14:00:00.000Z",
+      }),
+    ]),
+    thread("18f51c51cb8450a4", [
+      message({
+        id: "18f51c5222ec01f6",
+        from: person("Notion", "updates@mail.notion.so"),
+        subject: "What's new in Notion this month",
+        bodyText:
+          "Product updates, templates, workspace improvements, and a monthly guide roundup.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-19T18:10:00.000Z",
+      }),
+    ]),
+    thread("18f51c56549273bf", [
+      message({
+        id: "18f51c571e9a4830",
+        from: person("Vercel", "updates@vercel.com"),
+        subject: "Vercel product update: new observability features",
+        bodyText:
+          "A monthly roundup of product launches, observability features, and guides.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-18T15:20:00.000Z",
+      }),
+    ]),
+    thread("18f51c5bd84ca9e2", [
+      message({
+        id: "18f51c5c9baf016e",
+        from: person("Rina Levi", "rina@horizonsearch.co"),
+        subject: "Final interview loop for Platform Lead",
+        bodyText:
+          "Can you confirm whether Thursday 11am works for the final interview loop?",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T11:45:00.000Z",
+      }),
+      message({
+        id: "18f51c5f2ab740d3",
+        from: person("Rina Levi", "rina@horizonsearch.co"),
+        subject: "Re: Final interview loop for Platform Lead",
+        bodyText:
+          "The candidate can also do Friday afternoon if Thursday is too tight.",
+        unread: false,
+        labels: ["INBOX"],
+        date: "2026-04-22T12:16:00.000Z",
+      }),
+    ]),
+    thread("18f51c63f0a48bc8", [
+      message({
+        id: "18f51c64c77539a0",
+        from: person("Stripe", "receipts@stripe.com"),
+        subject: "Your receipt from OpenAI",
+        bodyText:
+          "Payment receipt for your monthly subscription. This is not a failed payment alert.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-18T07:30:00.000Z",
+      }),
+    ]),
+    thread("18f51c685b4d107e", [
+      message({
+        id: "18f51c6972ef2c45",
+        from: person("Cal Parker", "cal@pipelinepilot.io"),
+        subject: "Quick idea to 10x your pipeline",
+        bodyText:
+          "We help SaaS founders book more demos with AI outbound. Are you free for 15 minutes?",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-17T17:02:00.000Z",
+      }),
+    ]),
+    thread("18f51c6d44a90e7b", [
+      message({
+        id: "18f51c6e1785b221",
+        from: person("Leah Goldman", "leah@northstar.vc"),
+        subject: "Follow-up on Q2 metrics",
+        bodyText:
+          "Thanks for the update. Could you send ARR, retention, and enterprise pipeline before our partner meeting?",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T14:42:00.000Z",
+      }),
+      message({
+        id: "18f51c708364f9c1",
+        from: person("Alex Morgan", "alex@northstarhq.com"),
+        subject: "Re: Follow-up on Q2 metrics",
+        bodyText: "Yes, I will send the full sheet after finance closes March.",
+        unread: false,
+        labels: ["SENT"],
+        date: "2026-04-22T15:01:00.000Z",
+      }),
+    ]),
+  ],
+};
+
+export const supportOpsHeavyInbox: DemoInboxFixture = {
+  id: "supportOpsHeavy",
+  name: "Support Ops Heavy Inbox",
+  description:
+    "A support lead inbox with customer bugs, refunds, docs questions, internal handoffs, and vendor noise.",
+  mailbox: {
+    email: "support@luminahq.com",
+    displayName: "Sam Rivera",
+    timezone: "America/New_York",
+  },
+  labels: baseLabels(),
+  threads: [
+    thread("18f51d0a33b82d45", [
+      message({
+        id: "18f51d0b4c16eae2",
+        from: person("Taylor Brooks", "taylor@brightlane.co"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Refund approval needed for duplicate charge",
+        bodyText:
+          "We were charged twice for our annual plan and need approval before month end.",
+        unread: true,
+        labels: ["INBOX", "To Reply", "Refunds"],
+        date: "2026-04-21T13:20:00.000Z",
+      }),
+    ]),
+    thread("18f51d106ba349d0", [
+      message({
+        id: "18f51d11d90b8f7c",
+        from: person("Priya Shah", "priya@enterpriseops.io"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "P1 bug: exports failing for all admins",
+        bodyText:
+          "Exports have failed for every admin since this morning. Our compliance report is blocked.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T09:30:00.000Z",
+      }),
+      message({
+        id: "18f51d13ab624ef5",
+        from: person("Engineering Triage", "triage@luminahq.com"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Re: P1 bug: exports failing for all admins",
+        bodyText:
+          "We confirmed the regression and need the customer's export job ID.",
+        unread: false,
+        labels: ["INBOX"],
+        date: "2026-04-22T10:00:00.000Z",
+      }),
+    ]),
+    thread("18f51d18194b3c62", [
+      message({
+        id: "18f51d19ea73bf0d",
+        from: person("Jamie Ortiz", "jamie@riseops.co"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Question about webhook retry docs",
+        bodyText:
+          "Can you point me to the retry policy for failed webhooks? The docs page has two different values.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-21T18:15:00.000Z",
+      }),
+    ]),
+    thread("18f51d1d5e8b41a9", [
+      message({
+        id: "18f51d1e0587bc34",
+        from: person("Intercom", "notifications@intercom.io"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Weekly CSAT digest",
+        bodyText:
+          "Your support inbox had 94 percent customer satisfaction this week.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-20T12:00:00.000Z",
+      }),
+    ]),
+    thread("18f51d22cc509f6a", [
+      message({
+        id: "18f51d2349af651e",
+        from: person("Casey Miller", "casey@supportbench.ai"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Support automation benchmark report",
+        bodyText:
+          "We benchmark support teams and can show you how to lower ticket volume.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-19T14:30:00.000Z",
+      }),
+    ]),
+    thread("18f51d27f4a3b9c8", [
+      message({
+        id: "18f51d28c0e75a21",
+        from: person("Statuspage", "noreply@statuspage.io"),
+        to: [person("Sam Rivera", "support@luminahq.com")],
+        subject: "Incident resolved: delayed notifications",
+        bodyText:
+          "The incident affecting delayed notifications has been resolved.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-21T03:10:00.000Z",
+      }),
+    ]),
+  ],
+};
+
+export const execCalendarRecruitingInbox: DemoInboxFixture = {
+  id: "execCalendarRecruiting",
+  name: "Executive Calendar and Recruiting Inbox",
+  description:
+    "An executive inbox focused on scheduling, recruiting loops, investor/admin messages, travel, and vendor mail.",
+  mailbox: {
+    email: "jordan@orbitworks.co",
+    displayName: "Jordan Lee",
+    timezone: "America/Los_Angeles",
+  },
+  labels: baseLabels(),
+  threads: [
+    thread("18f51e0a20c94177", [
+      message({
+        id: "18f51e0b174a6d85",
+        from: person("Board Assistant", "assistant@northstar.vc"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Board prep moved to Thursday",
+        bodyText:
+          "Can you confirm Thursday 2pm for board prep? The deck review is blocked on your availability.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T16:30:00.000Z",
+      }),
+    ]),
+    thread("18f51e10ad9f62cb", [
+      message({
+        id: "18f51e119c4b07f2",
+        from: person("Talent Team", "talent@orbitworks.co"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "VP Sales candidate debrief",
+        bodyText:
+          "Please send your notes on the VP Sales candidate before the debrief at 4pm.",
+        unread: true,
+        labels: ["INBOX", "To Reply", "Recruiting"],
+        date: "2026-04-22T12:20:00.000Z",
+      }),
+      message({
+        id: "18f51e13f760a51d",
+        from: person("Talent Team", "talent@orbitworks.co"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Re: VP Sales candidate debrief",
+        bodyText: "Adding the scorecard link and compensation notes here.",
+        unread: false,
+        labels: ["INBOX", "Recruiting"],
+        date: "2026-04-22T13:05:00.000Z",
+      }),
+    ]),
+    thread("18f51e18bb279fa0", [
+      message({
+        id: "18f51e19a35c0d6e",
+        from: person("TripIt", "alerts@tripit.com"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Flight change: SFO to JFK",
+        bodyText:
+          "Your SFO to JFK flight was delayed by 90 minutes. Connection risk is now high.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-21T22:40:00.000Z",
+      }),
+    ]),
+    thread("18f51e1d6e8a9243", [
+      message({
+        id: "18f51e1e42b67c1a",
+        from: person("Northstar Ops", "ops@northstar.vc"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Signature needed on updated side letter",
+        bodyText:
+          "Please sign the updated side letter today so legal can close the packet.",
+        unread: true,
+        labels: ["INBOX", "To Reply"],
+        date: "2026-04-22T08:10:00.000Z",
+      }),
+    ]),
+    thread("18f51e22dc3719b5", [
+      message({
+        id: "18f51e23a56d8420",
+        from: person("Growth Vendor", "sales@growthvendor.io"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Calendar benchmark for executive teams",
+        bodyText:
+          "We help executive teams recover calendar time. Can we book a quick demo?",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-20T15:10:00.000Z",
+      }),
+    ]),
+    thread("18f51e278941f0ca", [
+      message({
+        id: "18f51e287b30d94e",
+        from: person("Ramp", "digest@ramp.com"),
+        to: [person("Jordan Lee", "jordan@orbitworks.co")],
+        subject: "Weekly card activity digest",
+        bodyText:
+          "Your team had 43 card transactions this week. No approvals are pending.",
+        unread: true,
+        labels: ["INBOX"],
+        date: "2026-04-19T16:00:00.000Z",
+      }),
+    ]),
+  ],
+};
+
+function baseLabels() {
+  return [
+    { id: "INBOX", name: "INBOX", type: "system" as const },
+    { id: "UNREAD", name: "UNREAD", type: "system" as const },
+    { id: "SENT", name: "SENT", type: "system" as const },
+    { id: "Label_To Reply", name: "To Reply", type: "user" as const },
+    { id: "Label_FYI", name: "FYI", type: "user" as const },
+    { id: "Label_Newsletter", name: "Newsletter", type: "user" as const },
+    { id: "Label_Marketing", name: "Marketing", type: "user" as const },
+    { id: "Label_Receipt", name: "Receipt", type: "user" as const },
+    { id: "Label_Notification", name: "Notification", type: "user" as const },
+    { id: "Label_VIP Customer", name: "VIP Customer", type: "user" as const },
+    { id: "Label_Recruiting", name: "Recruiting", type: "user" as const },
+    {
+      id: "Label_Product Updates",
+      name: "Product Updates",
+      type: "user" as const,
+    },
+    { id: "Label_Security", name: "Security", type: "user" as const },
+    { id: "Label_Billing", name: "Billing", type: "user" as const },
+    { id: "Label_Refunds", name: "Refunds", type: "user" as const },
+  ];
+}
+
+function thread(id: string, messages: DemoInboxMessage[]): DemoInboxThread {
+  return { id, messages };
+}
+
+function message({
+  id,
+  from,
+  to,
+  cc,
+  subject,
+  bodyText,
+  bodyHtml,
+  date,
+  unread,
+  labels,
+}: Omit<DemoInboxMessage, "to"> & { to?: DemoInboxAddress[] }) {
+  return {
+    id,
+    from,
+    to: to ?? [person("Alex Morgan", "alex@northstarhq.com")],
+    cc,
+    subject,
+    bodyText,
+    bodyHtml,
+    date,
+    unread,
+    labels,
+  };
+}
+
+function person(name: string, email: string): DemoInboxAddress {
+  return { name, email };
+}

--- a/apps/web/__tests__/fixtures/inboxes/types.ts
+++ b/apps/web/__tests__/fixtures/inboxes/types.ts
@@ -1,0 +1,43 @@
+export type DemoInboxFixture = {
+  id: string;
+  name: string;
+  description: string;
+  mailbox: DemoInboxMailbox;
+  labels: DemoInboxLabel[];
+  threads: DemoInboxThread[];
+};
+
+export type DemoInboxMailbox = {
+  email: string;
+  displayName: string;
+  timezone: string;
+};
+
+export type DemoInboxLabel = {
+  id: string;
+  name: string;
+  type: "system" | "user";
+};
+
+export type DemoInboxThread = {
+  id: string;
+  messages: DemoInboxMessage[];
+};
+
+export type DemoInboxMessage = {
+  id: string;
+  from: DemoInboxAddress;
+  to: DemoInboxAddress[];
+  cc?: DemoInboxAddress[];
+  subject: string;
+  bodyText: string;
+  bodyHtml?: string;
+  date: string;
+  unread?: boolean;
+  labels?: string[];
+};
+
+export type DemoInboxAddress = {
+  name?: string;
+  email: string;
+};

--- a/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
+++ b/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
@@ -9,6 +9,7 @@ import {
 vi.mock("server-only", () => ({}));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const TEST_PORT = 4120;
 
 describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "demo inbox fixture Gmail emulator adapter",
@@ -18,14 +19,14 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
     beforeAll(async () => {
       harness = await createGmailTestHarness({
-        port: 4111,
+        port: TEST_PORT,
         email: saasFounderMixedInbox.mailbox.email,
         messages: toGmailSeedMessages(saasFounderMixedInbox),
       });
     });
 
-    afterAll(() => {
-      harness?.emulator.close();
+    afterAll(async () => {
+      await harness?.emulator.close();
     });
 
     test("searches and reads a message from the shared fixture", async () => {

--- a/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
+++ b/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
@@ -9,7 +9,6 @@ import {
 vi.mock("server-only", () => ({}));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
-const TEST_PORT = 4120;
 
 describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "demo inbox fixture Gmail emulator adapter",
@@ -19,7 +18,6 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
     beforeAll(async () => {
       harness = await createGmailTestHarness({
-        port: TEST_PORT,
         email: saasFounderMixedInbox.mailbox.email,
         messages: toGmailSeedMessages(saasFounderMixedInbox),
       });

--- a/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
+++ b/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { saasFounderMixedInbox } from "@/__tests__/fixtures/inboxes/demo-inboxes";
+import { toGmailSeedMessages } from "@/__tests__/fixtures/inboxes/adapters";
+import {
+  createGmailTestHarness,
+  type GmailTestHarness,
+} from "@/__tests__/integration/helpers";
+
+vi.mock("server-only", () => ({}));
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "demo inbox fixture Gmail emulator adapter",
+  { timeout: 30_000 },
+  () => {
+    let harness: GmailTestHarness;
+
+    beforeAll(async () => {
+      harness = await createGmailTestHarness({
+        port: 4111,
+        email: saasFounderMixedInbox.mailbox.email,
+        messages: toGmailSeedMessages(saasFounderMixedInbox),
+      });
+    });
+
+    afterAll(() => {
+      harness?.emulator.close();
+    });
+
+    test("searches and reads a message from the shared fixture", async () => {
+      const result = await harness.provider.searchMessages({
+        query: "from:no-reply-aws@amazon.com",
+        maxResults: 5,
+      });
+      const securityMessage = result.messages.find(
+        (message) =>
+          message.subject === "Root MFA disabled on production account",
+      );
+
+      expect(securityMessage).toBeDefined();
+      expect(securityMessage?.threadId).toBe(
+        harness.threadIds[securityMessage!.id],
+      );
+
+      const fullMessage = await harness.provider.getMessage(
+        securityMessage!.id,
+      );
+
+      expect(fullMessage.subject).toBe(
+        "Root MFA disabled on production account",
+      );
+      expect(fullMessage.textPlain).toContain(
+        "root multi-factor authentication was disabled",
+      );
+    });
+  },
+);

--- a/apps/web/__tests__/integration/helpers.ts
+++ b/apps/web/__tests__/integration/helpers.ts
@@ -9,6 +9,7 @@
 import { createEmulator, type Emulator } from "emulate";
 import { gmail, auth } from "@googleapis/gmail";
 import { Client } from "@microsoft/microsoft-graph-client";
+import { createServer } from "node:net";
 import { createTestLogger } from "@/__tests__/helpers";
 import { GmailProvider } from "@/utils/email/google";
 import { OutlookProvider } from "@/utils/email/microsoft";
@@ -77,13 +78,14 @@ export async function createGmailTestHarness({
   email,
   messages,
 }: {
-  port: number;
+  port?: number;
   email: string;
   messages: GmailSeedMessage[];
 }): Promise<GmailTestHarness> {
+  const emulatorPort = port ?? (await getAvailablePort());
   const emulator = await createEmulator({
     service: "google",
-    port,
+    port: emulatorPort,
     seed: {
       google: {
         users: [{ email, name: "Test User" }],
@@ -141,14 +143,15 @@ export async function createOutlookTestHarness({
   messages,
   categories,
 }: {
-  port: number;
+  port?: number;
   email: string;
   messages: OutlookSeedMessage[];
   categories?: Array<{ display_name: string; color?: string }>;
 }): Promise<OutlookTestHarness> {
+  const emulatorPort = port ?? (await getAvailablePort());
   const emulator = await createEmulator({
     service: "microsoft",
-    port,
+    port: emulatorPort,
     seed: {
       microsoft: {
         users: [{ email, name: "Test User" }],
@@ -215,4 +218,30 @@ export async function createOutlookTestHarness({
   const provider = new OutlookProvider(outlookClient, logger);
 
   return { emulator, graphClient, provider, restoreFetch };
+}
+
+async function getAvailablePort() {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        if (typeof address === "object" && address?.port) {
+          resolve(address.port);
+          return;
+        }
+
+        reject(new Error("Failed to allocate an emulator port"));
+      });
+    });
+  });
 }

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -85,8 +85,8 @@ export function Chat({ open }: { open: boolean }) {
   }, []);
 
   const readFileAsDataUrl = useCallback(
-    (file: File): Promise<Attachment | undefined> => {
-      return new Promise((resolve) => {
+    (file: File): Promise<Attachment | undefined> =>
+      new Promise((resolve) => {
         if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
           resolve(undefined);
           return;
@@ -107,8 +107,7 @@ export function Chat({ open }: { open: boolean }) {
         };
         reader.onerror = () => resolve(undefined);
         reader.readAsDataURL(file);
-      });
-    },
+      }),
     [],
   );
 
@@ -362,6 +361,7 @@ function ChatMessagesView({
 
 const CHAT_EXAMPLES = [
   "Help me handle my inbox today",
+  "Suggest rules I should add",
   "Clean up my inbox",
   "Auto-archive newsletters for me",
 ];

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -361,9 +361,8 @@ function ChatMessagesView({
 
 const CHAT_EXAMPLES = [
   "Help me handle my inbox today",
-  "Suggest rules I should add",
   "Clean up my inbox",
-  "Auto-archive newsletters for me",
+  "Suggest rules I should add",
 ];
 
 function NewChatView({

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -459,7 +459,7 @@ export const searchInboxTool = ({
 }) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata. Use this with getUserRulesAndSettings when the user asks for rule ideas so recommendations are grounded in real inbox patterns instead of guesses. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
+      "Search inbox messages and return concise message metadata. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
     inputSchema: searchInboxInputSchema(provider),
     execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -459,7 +459,7 @@ export const searchInboxTool = ({
 }) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
+      "Search inbox messages and return concise message metadata. Use this with getUserRulesAndSettings when the user asks for rule ideas so recommendations are grounded in real inbox patterns instead of guesses. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
     inputSchema: searchInboxInputSchema(provider),
     execute: async ({ query, limit, pageToken }) => {
       trackToolCall({ tool: "search_inbox", email, logger });

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -740,10 +740,10 @@ export function buildResolvedSystemPrompt({
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
 - For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.`,
     `Rule suggestions:
-- When the user asks for rules to add, first inspect existing rules/settings and a small inbox sample.
-- Most users already have generic newsletter, marketing, receipt, and notification handling. Do not lead with those unless the account is missing them or the user asks.
-- Suggest account-specific patterns that appear repeatedly in the inbox and can be described with real senders, domains, subjects, or labels. Examples: mark customer escalations as important, label security or billing alerts from vendors, label recruiting or scheduling threads, route support handoffs, or label product feedback.
-- For each suggested rule, include the condition, action, and evidence. If priority is unclear, ask one concrete question before creating it.
+- When the user asks for rules to add, first inspect this user's existing rules/settings and a small inbox sample.
+- Check whether this user already has generic newsletter, marketing, receipt, or notification handling before suggesting those, and avoid duplicates.
+- Suggest user-specific patterns that appear repeatedly in the inbox and can be described with real senders, domains, subjects, or labels. Examples: mark customer escalations as important, label security or billing alerts from vendors, label recruiting or scheduling threads, route support handoffs, or label product feedback.
+- For each suggested rule, include the condition, action, and evidence. If priority is unclear, ask whether the relevant inbox items are important, low-priority, safe to archive, or need attention.
 - Do not create a rule until the user confirms the exact rule and action.`,
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -739,13 +739,12 @@ export function buildResolvedSystemPrompt({
 - For all-matching cleanup, continue paginating and handling results until searchInbox returns hasMore=false, and do not claim full completion earlier.
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
 - For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.`,
-    `Rule discovery workflow:
-- When the user asks for rule ideas or rule recommendations, inspect the latest rules/settings and search a representative inbox sample before proposing new automation.
-- Compare proposed rules against existing rules. Prefer improving an existing rule when that would avoid overlap, and do not suggest duplicates.
-- Look for both high-priority recurring work (replies needed, approvals, scheduling, customers, VIPs, billing, security) and low-priority recurring clutter (newsletters, digests, automated notifications, promotions, social updates).
-- Rank a short list of rule candidates by expected inbox impact, with the email pattern, suggested action, and the evidence or uncertainty behind it.
-- Treat priority as user-specific. If a sender, domain, or pattern could reasonably be high- or low-priority, ask one focused calibration question before creating broad automation.
-- Do not create rules from recommendations in the same turn unless the user explicitly confirms the specific rule or action.`,
+    `Rule suggestions:
+- When the user asks for rules to add, first inspect existing rules/settings and a small inbox sample.
+- Most users already have generic newsletter, marketing, receipt, and notification handling. Do not lead with those unless the account is missing them or the user asks.
+- Suggest account-specific patterns that appear repeatedly in the inbox and can be described with real senders, domains, subjects, or labels. Examples: mark customer escalations as important, label security or billing alerts from vendors, label recruiting or scheduling threads, route support handoffs, or label product feedback.
+- For each suggested rule, include the condition, action, and evidence. If priority is unclear, ask one concrete question before creating it.
+- Do not create a rule until the user confirms the exact rule and action.`,
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.
 - Prefer updating an existing rule over creating an overlapping duplicate. Do not create semantic duplicates like "Notification" and "Notifications".

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -740,8 +740,9 @@ export function buildResolvedSystemPrompt({
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
 - For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.`,
     `Rule suggestions:
-- When the user asks for rules to add, first inspect this user's existing rules/settings and a small inbox sample.
-- Check whether this user already has generic newsletter, marketing, receipt, or notification handling before suggesting those, and avoid duplicates.
+- When the user asks for rules to add, first inspect this user's existing rules/settings and enough inbox evidence to understand recurring patterns.
+- Check what this user already has handled before suggesting a category or rule, and avoid duplicates.
+- Focus on rules that would save the user time, reduce recurring inbox decisions, or protect important messages. Do not suggest rules just to create more automation.
 - Suggest user-specific patterns that appear repeatedly in the inbox and can be described with real senders, domains, subjects, or labels. Examples: mark customer escalations as important, label security or billing alerts from vendors, label recruiting or scheduling threads, route support handoffs, or label product feedback.
 - For each suggested rule, include the condition, action, and evidence. If priority is unclear, ask whether the relevant inbox items are important, low-priority, safe to archive, or need attention.
 - Do not create a rule until the user confirms the exact rule and action.`,

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -739,6 +739,13 @@ export function buildResolvedSystemPrompt({
 - For all-matching cleanup, continue paginating and handling results until searchInbox returns hasMore=false, and do not claim full completion earlier.
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
 - For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.`,
+    `Rule discovery workflow:
+- When the user asks for rule ideas or rule recommendations, inspect the latest rules/settings and search a representative inbox sample before proposing new automation.
+- Compare proposed rules against existing rules. Prefer improving an existing rule when that would avoid overlap, and do not suggest duplicates.
+- Look for both high-priority recurring work (replies needed, approvals, scheduling, customers, VIPs, billing, security) and low-priority recurring clutter (newsletters, digests, automated notifications, promotions, social updates).
+- Rank a short list of rule candidates by expected inbox impact, with the email pattern, suggested action, and the evidence or uncertainty behind it.
+- Treat priority as user-specific. If a sender, domain, or pattern could reasonably be high- or low-priority, ask one focused calibration question before creating broad automation.
+- Do not create rules from recommendations in the same turn unless the user explicitly confirms the specific rule or action.`,
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.
 - Prefer updating an existing rule over creating an overlapping duplicate. Do not create semantic duplicates like "Notification" and "Notifications".

--- a/apps/web/utils/ai/assistant/tools/rules/get-user-rules-and-settings-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/get-user-rules-and-settings-tool.ts
@@ -63,7 +63,7 @@ export const getUserRulesAndSettingsTool = ({
 }) =>
   tool<z.infer<typeof emptyInputSchema>, GetUserRulesAndSettingsOutput>({
     description:
-      "Retrieve the latest rules and personal instructions for the user. Use this before editing rules, suggesting new rules, or comparing proposed automation against the user's current rules.",
+      "Retrieve the latest rules and personal instructions for the user.",
     inputSchema: emptyInputSchema,
     execute: async () => {
       trackRuleToolCall({

--- a/apps/web/utils/ai/assistant/tools/rules/get-user-rules-and-settings-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/get-user-rules-and-settings-tool.ts
@@ -63,7 +63,7 @@ export const getUserRulesAndSettingsTool = ({
 }) =>
   tool<z.infer<typeof emptyInputSchema>, GetUserRulesAndSettingsOutput>({
     description:
-      "Retrieve the latest rules and personal instructions for the user. Use this before editing rules.",
+      "Retrieve the latest rules and personal instructions for the user. Use this before editing rules, suggesting new rules, or comparing proposed automation against the user's current rules.",
     inputSchema: emptyInputSchema,
     execute: async () => {
       trackRuleToolCall({


### PR DESCRIPTION
Adds shared realistic inbox fixtures and assistant eval flows for rule suggestion behavior. Also adds a default chat starter and prompt/tool guidance so recommendations inspect rules and inbox evidence before creating automations.

- Adds pure inbox fixtures with opaque IDs plus adapters for emulator and eval mocks
- Adds mutable assistant state and scripted multi-turn eval runner for rule suggestion flows
- Adds Gmail emulator coverage and Gemini 3 Flash eval scenarios
- Validation: fixture adapter unit test, Gmail emulator integration test, assistant chat unit test, targeted Biome check, git diff check, Gemini 3 Flash eval