### PR TITLE
llm: Add opt-in CLI providers

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -146,6 +146,17 @@ LLM_API_KEY=
 # DEFAULT_LLM_MODEL=qwen3.5:4b
 # OPENAI_COMPATIBLE_BASE_URL=http://localhost:1234/v1
 
+# --- CLI LLM providers (experimental, self-host only) ---
+# These use community AI SDK provider packages that spawn local CLI tools.
+# Review and pin the package versions before enabling.
+# CLI_LLM_ENABLED=true
+# DEFAULT_LLM_PROVIDER=codex-cli
+# DEFAULT_LLM_MODEL=gpt-5.3-codex
+# CODEX_CLI_ALLOW_NPX=false
+# CODEX_CLI_PATH=
+# DEFAULT_LLM_PROVIDER=claude-code
+# DEFAULT_LLM_MODEL=sonnet
+
 # --- Optional Provider Fallback Chain (ordered) ---
 # Format: provider:model,provider:model (explicit model required)
 # DEFAULT_LLM_FALLBACKS=openrouter:anthropic/claude-sonnet-4.6,openai:gpt-5.4-mini

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestScheduleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestScheduleForm.tsx
@@ -32,7 +32,7 @@ const digestScheduleFormSchema = z.object({
   dayOfWeek: z.string().min(1, "Please select a day"),
   hour: z.string().min(1, "Please select an hour"),
   minute: z.string().min(1, "Please select minutes"),
-  ampm: z.enum(["AM", "PM"], { required_error: "Please select AM or PM" }),
+  ampm: z.enum(["AM", "PM"], { error: "Please select AM or PM" }),
 });
 
 type DigestScheduleFormValues = z.infer<typeof digestScheduleFormSchema>;

--- a/apps/web/app/(app)/admin/validation.tsx
+++ b/apps/web/app/(app)/admin/validation.tsx
@@ -3,10 +3,10 @@ import { PremiumTier } from "@/generated/prisma/enums";
 
 export const changePremiumStatusSchema = z.object({
   email: z.string().email(),
-  lemonSqueezyCustomerId: z.coerce.number().optional(),
-  emailAccountsAccess: z.coerce.number().optional(),
+  lemonSqueezyCustomerId: z.number().optional(),
+  emailAccountsAccess: z.number().optional(),
   period: z.nativeEnum(PremiumTier),
-  count: z.coerce.number().optional(),
+  count: z.number().optional(),
   upgrade: z.boolean(),
 });
 export type ChangePremiumStatusOptions = z.infer<

--- a/apps/web/app/api/automation-jobs/execute/queue/route.ts
+++ b/apps/web/app/api/automation-jobs/execute/queue/route.ts
@@ -17,7 +17,7 @@ export const POST = handleCallback<z.infer<typeof executeAutomationJobBody>>(
     const parseResult = executeAutomationJobBody.safeParse(message);
     if (!parseResult.success) {
       logger.error("Invalid automation jobs queue payload", {
-        errors: parseResult.error.errors,
+        errors: parseResult.error.issues,
         queueMessageId: metadata.messageId,
       });
       return;
@@ -48,12 +48,10 @@ export const POST = handleCallback<z.infer<typeof executeAutomationJobBody>>(
   },
   {
     visibilityTimeoutSeconds: 330,
-    retry: (_error, metadata) => {
-      return {
-        afterSeconds: getQueueRetryBackoffSeconds({
-          deliveryCount: metadata.deliveryCount,
-        }),
-      };
-    },
+    retry: (_error, metadata) => ({
+      afterSeconds: getQueueRetryBackoffSeconds({
+        deliveryCount: metadata.deliveryCount,
+      }),
+    }),
   },
 );

--- a/apps/web/app/api/automation-jobs/execute/route.ts
+++ b/apps/web/app/api/automation-jobs/execute/route.ts
@@ -17,7 +17,7 @@ export const POST = withError(
 
     if (!validation.success) {
       logger.error("Invalid automation job execute payload", {
-        errors: validation.error.errors,
+        errors: validation.error.issues,
       });
       return new Response("Invalid payload", { status: 400 });
     }

--- a/apps/web/app/api/chat/confirm-email-action/route.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.ts
@@ -26,7 +26,7 @@ export const POST = withEmailAccount(
 
     const { data, error } = confirmAssistantEmailActionBody.safeParse(json);
     if (error) {
-      return NextResponse.json({ error: error.errors }, { status: 400 });
+      return NextResponse.json({ error: error.issues }, { status: 400 });
     }
 
     const result = await confirmAssistantEmailActionForAccount({

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -52,7 +52,7 @@ export const POST = withEmailAccount("chat", async (request) => {
   const json = await request.json();
   const { data, error } = assistantInputSchema.safeParse(json);
 
-  if (error) return NextResponse.json({ error: error.errors }, { status: 400 });
+  if (error) return NextResponse.json({ error: error.issues }, { status: 400 });
 
   const chat =
     (await getChatWithCompactions(data.id)) ||
@@ -323,7 +323,7 @@ async function createNewChat({
     return newChat;
   } catch (error) {
     logger.error("Failed to create new chat", { error, emailAccountId });
-    return undefined;
+    return;
   }
 }
 

--- a/apps/web/app/api/chats/[chatId]/route.ts
+++ b/apps/web/app/api/chats/[chatId]/route.ts
@@ -52,7 +52,7 @@ export const PATCH = withEmailAccount(
 
     const { data, error } = updateChatSchema.safeParse(body);
     if (error) {
-      return NextResponse.json({ error: error.errors }, { status: 400 });
+      return NextResponse.json({ error: error.issues }, { status: 400 });
     }
 
     if (data.name === undefined) {

--- a/apps/web/app/api/follow-up-reminders/account/queue/route.ts
+++ b/apps/web/app/api/follow-up-reminders/account/queue/route.ts
@@ -18,7 +18,7 @@ export const POST = handleCallback<z.infer<typeof queuePayloadSchema>>(
     const parseResult = queuePayloadSchema.safeParse(message);
     if (!parseResult.success) {
       logger.error("Invalid follow-up reminder queue payload", {
-        errors: parseResult.error.errors,
+        errors: parseResult.error.issues,
         queueMessageId: metadata.messageId,
       });
       return;
@@ -50,12 +50,10 @@ export const POST = handleCallback<z.infer<typeof queuePayloadSchema>>(
   },
   {
     visibilityTimeoutSeconds: 780,
-    retry: (_error, metadata) => {
-      return {
-        afterSeconds: getQueueRetryBackoffSeconds({
-          deliveryCount: metadata.deliveryCount,
-        }),
-      };
-    },
+    retry: (_error, metadata) => ({
+      afterSeconds: getQueueRetryBackoffSeconds({
+        deliveryCount: metadata.deliveryCount,
+      }),
+    }),
   },
 );

--- a/apps/web/app/api/follow-up-reminders/account/route.ts
+++ b/apps/web/app/api/follow-up-reminders/account/route.ts
@@ -30,10 +30,10 @@ export const POST = withError(
     const parseResult = bodySchema.safeParse(await request.json());
     if (!parseResult.success) {
       request.logger.error("Invalid follow-up reminder account payload", {
-        errors: parseResult.error.errors,
+        errors: parseResult.error.issues,
       });
       return NextResponse.json(
-        { error: "Invalid payload", details: parseResult.error.errors },
+        { error: "Invalid payload", details: parseResult.error.issues },
         { status: 400 },
       );
     }

--- a/apps/web/app/api/outlook/webhook/route.ts
+++ b/apps/web/app/api/outlook/webhook/route.ts
@@ -34,12 +34,12 @@ export const POST = withError("outlook/webhook", async (request) => {
   if (!parseResult.success) {
     logger.error("Invalid webhook payload", {
       body: rawBody,
-      errors: parseResult.error.errors,
+      errors: parseResult.error.issues,
     });
     return NextResponse.json(
       {
         error: "Invalid webhook payload",
-        details: parseResult.error.errors,
+        details: parseResult.error.issues,
       },
       { status: 400 },
     );

--- a/apps/web/app/api/scheduled-actions/execute/route.ts
+++ b/apps/web/app/api/scheduled-actions/execute/route.ts
@@ -29,7 +29,7 @@ export const POST = withError(
 
       if (!validationResult.success) {
         logger.error("Invalid payload structure", {
-          errors: validationResult.error.errors,
+          errors: validationResult.error.issues,
           receivedPayload: rawPayload,
         });
         return new Response("Invalid payload structure", { status: 400 });

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -15,6 +15,8 @@ const llmProviderEnum = z.enum([
   "aigateway",
   "ollama",
   "openai-compatible",
+  "codex-cli",
+  "claude-code",
 ]);
 
 /** For Vercel preview deployments, auto-detect from VERCEL_URL. */
@@ -124,6 +126,9 @@ const parsedEnv = createEnv({
     OLLAMA_MODEL: z.string().optional(),
     OPENAI_COMPATIBLE_BASE_URL: z.string().optional(),
     OPENAI_COMPATIBLE_MODEL: z.string().optional(),
+    CLI_LLM_ENABLED: booleanString.optional().default(false),
+    CODEX_CLI_ALLOW_NPX: booleanString.optional().default(false),
+    CODEX_CLI_PATH: z.string().optional(),
 
     OPENAI_ZERO_DATA_RETENTION: booleanString.optional().default(false),
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,7 +57,7 @@
     "@googleapis/gmail": "16.1.1",
     "@googleapis/people": "7.0.1",
     "@headlessui/react": "2.2.10",
-    "@hookform/resolvers": "4.1.0",
+    "@hookform/resolvers": "5.2.2",
     "@inboxzero/image-proxy": "workspace:*",
     "@inboxzero/loops": "workspace:*",
     "@inboxzero/resend": "workspace:*",
@@ -199,7 +199,7 @@
     "unpdf": "1.6.0",
     "use-stick-to-bottom": "1.1.3",
     "usehooks-ts": "3.1.1",
-    "zod": "3.25.76"
+    "zod": "4.2.1"
   },
   "devDependencies": {
     "@headlessui/tailwindcss": "0.2.2",

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -57,7 +57,26 @@ export function getAvailableActions(provider: string) {
 export const getExtraActions = (existingActionTypes: ActionType[] = []) =>
   getExtraAvailableActionsForRuleEditor(existingActionTypes);
 
-export const createRuleActionSchema = (provider: string) => {
+export type RuleActionFields = {
+  label?: string | null;
+  to?: string | null;
+  cc?: string | null;
+  bcc?: string | null;
+  subject?: string | null;
+  content?: string | null;
+  webhookUrl?: string | null;
+  folderName?: string | null;
+};
+
+export type RuleAction = {
+  type: ActionType;
+  fields?: RuleActionFields | null;
+  delayInMinutes?: number | null;
+};
+
+export const createRuleActionSchema = (
+  provider: string,
+): z.ZodType<RuleAction> => {
   const allowedActionTypes = new Set([
     ...getAvailableActionsForRuleEditor({ provider }),
     ...getExtraAvailableActionsForRuleEditor(),
@@ -113,7 +132,7 @@ export const createRuleActionSchema = (provider: string) => {
       : []),
   ];
 
-  return z.union(actionSchemas);
+  return z.union(actionSchemas) as z.ZodType<RuleAction>;
 };
 
 export const createRuleSchema = (provider: string) =>

--- a/apps/web/utils/calendar/oauth-callback-helpers.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.ts
@@ -116,7 +116,7 @@ export function parseAndValidateCalendarState(
   const validationResult = calendarOAuthStateSchema.safeParse(rawState);
   if (!validationResult.success) {
     logger.error("State validation failed", {
-      errors: validationResult.error.errors,
+      errors: validationResult.error.issues,
     });
     redirectUrl.searchParams.set("error", "invalid_state_format");
     throw new RedirectError(redirectUrl, responseHeaders);

--- a/apps/web/utils/drive/handle-drive-callback.ts
+++ b/apps/web/utils/drive/handle-drive-callback.ts
@@ -222,7 +222,7 @@ function parseAndValidateDriveState(
   const validationResult = driveOAuthStateSchema.safeParse(rawState);
   if (!validationResult.success) {
     logger.error("State validation failed", {
-      errors: validationResult.error.errors,
+      errors: validationResult.error.issues,
     });
     redirectUrl.searchParams.set("error", "invalid_state_format");
     throw new RedirectError(redirectUrl, responseHeaders);

--- a/apps/web/utils/llms/cli-provider.ts
+++ b/apps/web/utils/llms/cli-provider.ts
@@ -1,0 +1,162 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { env } from "@/env";
+import { SafeError } from "@/utils/error";
+import { Provider } from "@/utils/llms/config";
+
+type CliProvider = string;
+
+type CliProviderModule = Record<string, unknown>;
+
+type CliModelFactory = (
+  modelName: string,
+  settings?: Record<string, unknown>,
+) => LanguageModelV3;
+
+const runtimeImport = (specifier: string): Promise<CliProviderModule> =>
+  import(/* webpackIgnore: true */ specifier);
+
+export function assertCliLlmEnabled(provider: CliProvider) {
+  if (env.CLI_LLM_ENABLED) return;
+
+  throw new SafeError(
+    `CLI LLM provider "${provider}" is disabled. Set CLI_LLM_ENABLED=true and install the matching community provider package to use it.`,
+  );
+}
+
+export function createCliLanguageModel({
+  provider,
+  modelName,
+}: {
+  provider: CliProvider;
+  modelName: string;
+}): LanguageModelV3 {
+  assertCliLlmEnabled(provider);
+
+  let modelPromise: Promise<LanguageModelV3> | undefined;
+
+  const getModel = () => {
+    modelPromise ??= loadCliLanguageModel({ provider, modelName });
+    return modelPromise;
+  };
+
+  return {
+    specificationVersion: "v3",
+    provider,
+    modelId: modelName,
+    supportedUrls: {},
+    async doGenerate(...args: unknown[]) {
+      const model = await getModel();
+      const doGenerate = getModelMethod(model, "doGenerate", provider);
+      return doGenerate(...args);
+    },
+    async doStream(...args: unknown[]) {
+      const model = await getModel();
+      const doStream = getModelMethod(model, "doStream", provider);
+      return doStream(...args);
+    },
+  } as unknown as LanguageModelV3;
+}
+
+async function loadCliLanguageModel({
+  provider,
+  modelName,
+}: {
+  provider: CliProvider;
+  modelName: string;
+}): Promise<LanguageModelV3> {
+  switch (provider) {
+    case Provider.CODEX_CLI:
+      return createCodexCliLanguageModel(modelName);
+    case Provider.CLAUDE_CODE:
+      return createClaudeCodeLanguageModel(modelName);
+    default:
+      throw new SafeError(`Unsupported CLI LLM provider: ${provider}`);
+  }
+}
+
+async function createCodexCliLanguageModel(modelName: string) {
+  const module = await importOptionalProviderPackage(
+    "ai-sdk-provider-codex-cli",
+    Provider.CODEX_CLI,
+  );
+  const codexExec = getFactory(module, "codexExec", Provider.CODEX_CLI);
+
+  return codexExec(modelName, {
+    allowNpx: env.CODEX_CLI_ALLOW_NPX,
+    skipGitRepoCheck: true,
+    approvalMode: "never",
+    sandboxMode: "read-only",
+    ...(env.CODEX_CLI_PATH ? { codexPath: env.CODEX_CLI_PATH } : {}),
+    logger: false,
+  });
+}
+
+async function createClaudeCodeLanguageModel(modelName: string) {
+  const module = await importOptionalProviderPackage(
+    "ai-sdk-provider-claude-code",
+    Provider.CLAUDE_CODE,
+  );
+  const claudeCode = getFactory(module, "claudeCode", Provider.CLAUDE_CODE);
+
+  return claudeCode(modelName, {
+    settingSources: [],
+    allowedTools: [],
+    permissionMode: "default",
+    sandbox: { enabled: true },
+  });
+}
+
+async function importOptionalProviderPackage(
+  packageName: string,
+  provider: CliProvider,
+) {
+  try {
+    return await runtimeImport(packageName);
+  } catch (error) {
+    const message = isMissingOptionalPackageError(error, packageName)
+      ? `CLI LLM provider "${provider}" requires optional package "${packageName}". Install it in apps/web and pin an exact version before enabling this provider.`
+      : `CLI LLM provider "${provider}" failed to load optional package "${packageName}". Check the installed package version and peer dependencies.`;
+    const safeError = new SafeError(message);
+    (safeError as Error & { cause?: unknown }).cause = error;
+    throw safeError;
+  }
+}
+
+function getFactory(
+  module: CliProviderModule,
+  exportName: string,
+  provider: CliProvider,
+): CliModelFactory {
+  const factory = module[exportName];
+
+  if (typeof factory !== "function") {
+    throw new SafeError(
+      `CLI LLM provider "${provider}" package does not export "${exportName}". Check the installed package version.`,
+    );
+  }
+
+  return factory as CliModelFactory;
+}
+
+function getModelMethod(
+  model: LanguageModelV3,
+  methodName: "doGenerate" | "doStream",
+  provider: CliProvider,
+) {
+  const method = model[methodName];
+
+  if (typeof method !== "function") {
+    throw new SafeError(
+      `CLI LLM provider "${provider}" returned a model without ${methodName}. Check the installed package version.`,
+    );
+  }
+
+  return method.bind(model) as (...args: unknown[]) => unknown;
+}
+
+function isMissingOptionalPackageError(error: unknown, packageName: string) {
+  if (!(error instanceof Error)) return false;
+
+  const code = (error as Error & { code?: string }).code;
+  return code === "ERR_MODULE_NOT_FOUND" && error.message.includes(packageName);
+}

--- a/apps/web/utils/llms/config.ts
+++ b/apps/web/utils/llms/config.ts
@@ -12,6 +12,8 @@ export const Provider = {
   AI_GATEWAY: "aigateway",
   OLLAMA: "ollama",
   OPENAI_COMPATIBLE: "openai-compatible",
+  CODEX_CLI: "codex-cli",
+  CLAUDE_CODE: "claude-code",
 };
 
 export const providerOptions: { label: string; value: string }[] = [

--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -92,6 +92,9 @@ vi.mock("@/env", () => ({
     OLLAMA_MODEL: "llama3",
     OPENAI_COMPATIBLE_BASE_URL: "http://localhost:1234/v1",
     OPENAI_COMPATIBLE_MODEL: "llama-3.2-3b-instruct",
+    CLI_LLM_ENABLED: false,
+    CODEX_CLI_ALLOW_NPX: false,
+    CODEX_CLI_PATH: undefined,
     BEDROCK_REGION: "us-west-2",
     BEDROCK_ACCESS_KEY: "",
     BEDROCK_SECRET_KEY: "",
@@ -134,6 +137,9 @@ describe("Models", () => {
     vi.mocked(env).OLLAMA_MODEL = "llama3";
     vi.mocked(env).OPENAI_COMPATIBLE_BASE_URL = "http://localhost:1234/v1";
     vi.mocked(env).OPENAI_COMPATIBLE_MODEL = "llama-3.2-3b-instruct";
+    vi.mocked(env).CLI_LLM_ENABLED = false;
+    vi.mocked(env).CODEX_CLI_ALLOW_NPX = false;
+    vi.mocked(env).CODEX_CLI_PATH = undefined;
     vi.mocked(env).BEDROCK_ACCESS_KEY = "";
     vi.mocked(env).BEDROCK_SECRET_KEY = "";
   });
@@ -1078,6 +1084,81 @@ describe("Models", () => {
         provider: Provider.OPENAI_COMPATIBLE,
         modelName: "llama3",
       });
+    });
+
+    it("should require explicit enablement for CLI LLM providers", () => {
+      const userAi: UserAIFields = {
+        aiApiKey: null,
+        aiProvider: null,
+        aiModel: null,
+      };
+
+      vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CODEX_CLI;
+      vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.3-codex";
+      vi.mocked(env).CLI_LLM_ENABLED = false;
+
+      expect(() => getModel(userAi)).toThrow(
+        'CLI LLM provider "codex-cli" is disabled',
+      );
+    });
+
+    it("should configure Codex CLI provider when explicitly enabled", () => {
+      const userAi: UserAIFields = {
+        aiApiKey: null,
+        aiProvider: null,
+        aiModel: null,
+      };
+
+      vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CODEX_CLI;
+      vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.3-codex";
+      vi.mocked(env).CLI_LLM_ENABLED = true;
+
+      const result = getModel(userAi);
+
+      expect(result.provider).toBe(Provider.CODEX_CLI);
+      expect(result.modelName).toBe("gpt-5.3-codex");
+      expect(result.model).toMatchObject({
+        provider: Provider.CODEX_CLI,
+        modelId: "gpt-5.3-codex",
+      });
+    });
+
+    it("should configure Claude Code provider when explicitly enabled", () => {
+      const userAi: UserAIFields = {
+        aiApiKey: null,
+        aiProvider: null,
+        aiModel: null,
+      };
+
+      vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CLAUDE_CODE;
+      vi.mocked(env).DEFAULT_LLM_MODEL = "sonnet";
+      vi.mocked(env).CLI_LLM_ENABLED = true;
+
+      const result = getModel(userAi);
+
+      expect(result.provider).toBe(Provider.CLAUDE_CODE);
+      expect(result.modelName).toBe("sonnet");
+      expect(result.model).toMatchObject({
+        provider: Provider.CLAUDE_CODE,
+        modelId: "sonnet",
+      });
+    });
+
+    it("should skip CLI fallback providers when CLI LLMs are disabled", () => {
+      const userAi: UserAIFields = {
+        aiApiKey: null,
+        aiProvider: null,
+        aiModel: null,
+      };
+
+      vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai";
+      vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.1";
+      vi.mocked(env).DEFAULT_LLM_FALLBACKS = "codex-cli:gpt-5.3-codex";
+      vi.mocked(env).CLI_LLM_ENABLED = false;
+
+      const result = getModel(userAi);
+
+      expect(result.fallbackModels).toEqual([]);
     });
   });
 });

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -16,6 +16,7 @@ import { Provider } from "@/utils/llms/config";
 import type { UserAIFields } from "@/utils/llms/types";
 import { createScopedLogger } from "@/utils/logger";
 import { SafeError } from "../error";
+import { assertCliLlmEnabled, createCliLanguageModel } from "./cli-provider";
 
 const DEFAULT_GOOGLE_THINKING_BUDGET = 128;
 
@@ -257,6 +258,28 @@ function selectModel(
         provider: Provider.OPENAI_COMPATIBLE,
         modelName,
         model: openaiCompatible(modelName),
+      };
+    }
+    case Provider.CODEX_CLI: {
+      const modelName = aiModel || "gpt-5.3-codex";
+      return {
+        provider: Provider.CODEX_CLI,
+        modelName,
+        model: createCliLanguageModel({
+          provider: Provider.CODEX_CLI,
+          modelName,
+        }),
+      };
+    }
+    case Provider.CLAUDE_CODE: {
+      const modelName = aiModel || "sonnet";
+      return {
+        provider: Provider.CLAUDE_CODE,
+        modelName,
+        model: createCliLanguageModel({
+          provider: Provider.CLAUDE_CODE,
+          modelName,
+        }),
       };
     }
 
@@ -536,9 +559,20 @@ function getProviderApiKey(provider: string) {
     // Returns a placeholder so the fallback chain doesn't skip this provider
     // when no API key is configured (many OpenAI-compatible servers don't require one)
     [Provider.OPENAI_COMPATIBLE]: env.LLM_API_KEY || "not-required",
+    [Provider.CODEX_CLI]: getCliProviderAvailability(Provider.CODEX_CLI),
+    [Provider.CLAUDE_CODE]: getCliProviderAvailability(Provider.CLAUDE_CODE),
   };
 
   return providerApiKeys[provider];
+}
+
+function getCliProviderAvailability(provider: string) {
+  try {
+    assertCliLlmEnabled(provider);
+    return "cli-provider";
+  } catch {
+    return;
+  }
 }
 
 function resolveApiKey(

--- a/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
+++ b/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
@@ -279,7 +279,7 @@ function parseAndValidateSlackState(
   const validationResult = slackOAuthStateSchema.safeParse(rawState);
   if (!validationResult.success) {
     logger.error("State validation failed", {
-      errors: validationResult.error.errors,
+      errors: validationResult.error.issues,
     });
     redirectUrl.searchParams.set("error", "invalid_state_format");
     throw new RedirectError(redirectUrl, responseHeaders);

--- a/apps/web/utils/queue/create-forwarding-queue-handler.ts
+++ b/apps/web/utils/queue/create-forwarding-queue-handler.ts
@@ -39,7 +39,7 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
       const parseResult = schema.safeParse(message);
       if (!parseResult.success) {
         logger.error(invalidPayloadMessage, {
-          errors: parseResult.error.errors,
+          errors: parseResult.error.issues,
           queueMessageId: metadata.messageId,
         });
         return;
@@ -64,13 +64,11 @@ export function createForwardingQueueHandler<TSchema extends z.ZodTypeAny>({
     },
     {
       visibilityTimeoutSeconds,
-      retry: (_error, metadata) => {
-        return {
-          afterSeconds: getQueueRetryBackoffSeconds({
-            deliveryCount: metadata.deliveryCount,
-          }),
-        };
-      },
+      retry: (_error, metadata) => ({
+        afterSeconds: getQueueRetryBackoffSeconds({
+          deliveryCount: metadata.deliveryCount,
+        }),
+      }),
     },
   );
 }

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -44,7 +44,7 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `NEXT_PUBLIC_IMAGE_PROXY_USE_APP_ROUTE` | No | Set to `true` to proxy remote images through the app's own Next.js route at `/api/image-proxy` instead of a separate proxy service | `false` |
 | `IMAGE_PROXY_SIGNING_SECRET` | No | Shared HMAC secret used to sign proxy URLs for the bundled Cloudflare Worker or a compatible proxy. Proxy validators may use a comma-separated list, but each signer should still be configured with a single secret. | — |
 | **LLM Provider Selection** ||||
-| `DEFAULT_LLM_PROVIDER` | Yes | Primary LLM provider (`anthropic`, `azure`, `vertex`, `google`, `openai`, `bedrock`, `openrouter`, `groq`, `aigateway`, `ollama`) | — |
+| `DEFAULT_LLM_PROVIDER` | Yes | Primary LLM provider (`anthropic`, `azure`, `vertex`, `google`, `openai`, `bedrock`, `openrouter`, `groq`, `aigateway`, `ollama`, `openai-compatible`, `codex-cli`, `claude-code`) | — |
 | `DEFAULT_LLM_MODEL` | No | Model to use with default provider | Provider default |
 | `DEFAULT_LLM_FALLBACKS` | No | Ordered fallback chain (`provider:model,provider:model`, explicit model required) | — |
 | `DEFAULT_OPENROUTER_PROVIDERS` | No | Comma-separated list of OpenRouter providers | — |
@@ -84,6 +84,10 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `OLLAMA_BASE_URL` | No | Ollama API endpoint (e.g., `http://localhost:11434/api`) | — |
 | **OpenAI-Compatible (Local LLM)** ||||
 | `OPENAI_COMPATIBLE_BASE_URL` | No | Base URL for an OpenAI-compatible server (e.g. LM Studio: `http://localhost:1234/v1`) | `http://localhost:1234/v1` |
+| **CLI LLM Providers (Experimental)** ||||
+| `CLI_LLM_ENABLED` | No | Enables community CLI-backed LLM providers (`codex-cli`, `claude-code`). Self-host only; requires installing optional provider packages. | `false` |
+| `CODEX_CLI_ALLOW_NPX` | No | Allows the Codex community provider to fall back to `npx @openai/codex` if `codex` is not on PATH. Leave disabled unless you trust that install path. | `false` |
+| `CODEX_CLI_PATH` | No | Optional path to the `codex` binary when using `codex-cli`. | — |
 | **Background Jobs (QStash, optional)** ||||
 | `QSTASH_TOKEN` | No | QStash API token (optional; fallback runs jobs via internal API + cron) | — |
 | `QSTASH_CURRENT_SIGNING_KEY` | No | Current signing key for webhooks | — |
@@ -146,6 +150,7 @@ For detailed setup instructions, see the [Setup Guides](/hosting/setup-guides):
 
 - If running the app in Docker and Ollama locally, use `http://host.docker.internal:11434/api` as the `OLLAMA_BASE_URL`.
 - If running the app in Docker and an OpenAI-compatible server locally, replace `localhost` with `host.docker.internal` in `OPENAI_COMPATIBLE_BASE_URL`.
+- CLI LLM providers are experimental and depend on third-party community AI SDK provider packages that spawn local CLI tools. Review their source, pin exact versions, and only enable them on trusted self-hosted deployments.
 - When using Docker Compose with `--profile all`, database and Redis URLs are auto-configured. See the [Docker/VPS Deployment Guide](/hosting/self-hosting) for details.
 - For image privacy, you can deploy the optional proxy separately and point `NEXT_PUBLIC_IMAGE_PROXY_BASE_URL` at it. See the [Image Proxy guide](/hosting/image-proxy).
 - For Azure OpenAI, set `AZURE_RESOURCE_NAME` and either `AZURE_API_KEY` or `LLM_API_KEY` when using `azure` as a default or fallback provider.

--- a/docs/hosting/llm-setup.mdx
+++ b/docs/hosting/llm-setup.mdx
@@ -31,6 +31,8 @@ Use one of these values for `*_LLM_PROVIDER`:
 | [AWS Bedrock](https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock) | `bedrock` |
 | [Ollama](https://ollama.com/) | `ollama` |
 | OpenAI-compatible (LM Studio, vLLM, LiteLLM, etc.) | `openai-compatible` |
+| Codex CLI (experimental, self-host only) | `codex-cli` |
+| Claude Code (experimental, self-host only) | `claude-code` |
 
 ## Tiers
 
@@ -60,3 +62,43 @@ The app also has **Settings → AI** for per-user keys/models, but self-hosted d
 ## Provider-specific details
 
 - `openai-compatible` also requires `OPENAI_COMPATIBLE_BASE_URL`.
+
+### CLI LLM providers
+
+`codex-cli` and `claude-code` are experimental self-host options. They use
+third-party community AI SDK provider packages that spawn local CLI tools, so
+they are disabled unless `CLI_LLM_ENABLED=true`.
+
+Use them only on trusted self-hosted deployments. Review the provider package
+source, pin exact package versions, and make sure you comply with the relevant
+OpenAI or Anthropic terms for your authentication method.
+
+Codex example:
+
+```bash
+cd apps/web
+pnpm add ai-sdk-provider-codex-cli@1.1.0
+pnpm add -g @openai/codex
+codex login
+```
+
+```env
+CLI_LLM_ENABLED=true
+DEFAULT_LLM_PROVIDER=codex-cli
+DEFAULT_LLM_MODEL=gpt-5.3-codex
+CODEX_CLI_ALLOW_NPX=false
+```
+
+Claude Code example:
+
+```bash
+cd apps/web
+pnpm add ai-sdk-provider-claude-code@3.1.0
+claude auth login
+```
+
+```env
+CLI_LLM_ENABLED=true
+DEFAULT_LLM_PROVIDER=claude-code
+DEFAULT_LLM_MODEL=sonnet
+```

--- a/packages/tinybird-ai-analytics/package.json
+++ b/packages/tinybird-ai-analytics/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "main": "src/index.ts",
   "dependencies": {
-    "@chronark/zod-bird": "0.3.10",
-    "zod": "3.25.76"
+    "@chronark/zod-bird": "1.0.0",
+    "zod": "4.2.1"
   },
   "devDependencies": {
     "@types/node": "24.10.1",

--- a/packages/tinybird/package.json
+++ b/packages/tinybird/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "main": "src/index.ts",
   "dependencies": {
-    "@chronark/zod-bird": "0.3.10",
+    "@chronark/zod-bird": "1.0.0",
     "p-retry": "8.0.0",
-    "zod": "3.25.76"
+    "zod": "4.2.1"
   },
   "devDependencies": {
     "@types/node": "24.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,14 +839,14 @@ importers:
   packages/tinybird:
     dependencies:
       '@chronark/zod-bird':
-        specifier: 0.3.10
-        version: 0.3.10
+        specifier: 1.0.0
+        version: 1.0.0(zod@4.2.1)
       p-retry:
         specifier: 8.0.0
         version: 8.0.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.2.1
+        version: 4.2.1
     devDependencies:
       '@types/node':
         specifier: 24.10.1
@@ -861,11 +861,11 @@ importers:
   packages/tinybird-ai-analytics:
     dependencies:
       '@chronark/zod-bird':
-        specifier: 0.3.10
-        version: 0.3.10
+        specifier: 1.0.0
+        version: 1.0.0(zod@4.2.1)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.2.1
+        version: 4.2.1
     devDependencies:
       '@types/node':
         specifier: 24.10.1
@@ -1974,8 +1974,10 @@ packages:
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
-  '@chronark/zod-bird@0.3.10':
-    resolution: {integrity: sha512-QkGvy8Lz+NTGPOfBH2lIEAxiaizp9vrEufxsi1wYz8WM0/ADqs4hUqO1zRjt7ntoZdKiXCcnpZtzUMdOjfo5AQ==}
+  '@chronark/zod-bird@1.0.0':
+    resolution: {integrity: sha512-OWdZt5EULFgDaHTbkxkxN130ohapRxSMaYdaW/fZTcQP3z1c4cYk4izJwbbTPOP4GdQeys18Prls0xz4NpFV0A==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
@@ -13133,9 +13135,6 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.2.1:
     resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
 
@@ -14607,9 +14606,9 @@ snapshots:
 
   '@chevrotain/utils@11.1.2': {}
 
-  '@chronark/zod-bird@0.3.10':
+  '@chronark/zod-bird@1.0.0(zod@4.2.1)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.1
 
   '@clack/core@1.2.0':
     dependencies:
@@ -19968,7 +19967,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -20014,7 +20013,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -27225,8 +27224,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.2.1):
     dependencies:
       zod: 4.2.1
-
-  zod@3.25.76: {}
 
   zod@4.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,55 +80,55 @@ importers:
     dependencies:
       '@ai-sdk/amazon-bedrock':
         specifier: 4.0.96
-        version: 4.0.96(zod@3.25.76)
+        version: 4.0.96(zod@4.2.1)
       '@ai-sdk/anthropic':
         specifier: 3.0.71
-        version: 3.0.71(zod@3.25.76)
+        version: 3.0.71(zod@4.2.1)
       '@ai-sdk/azure':
         specifier: 3.0.54
-        version: 3.0.54(zod@3.25.76)
+        version: 3.0.54(zod@4.2.1)
       '@ai-sdk/gateway':
         specifier: 3.0.104
-        version: 3.0.104(zod@3.25.76)
+        version: 3.0.104(zod@4.2.1)
       '@ai-sdk/google':
         specifier: 3.0.64
-        version: 3.0.64(zod@3.25.76)
+        version: 3.0.64(zod@4.2.1)
       '@ai-sdk/google-vertex':
         specifier: 4.0.112
-        version: 4.0.112(zod@3.25.76)
+        version: 4.0.112(zod@4.2.1)
       '@ai-sdk/groq':
         specifier: 3.0.35
-        version: 3.0.35(zod@3.25.76)
+        version: 3.0.35(zod@4.2.1)
       '@ai-sdk/mcp':
         specifier: 1.0.36
-        version: 1.0.36(zod@3.25.76)
+        version: 1.0.36(zod@4.2.1)
       '@ai-sdk/openai':
         specifier: 3.0.53
-        version: 3.0.53(zod@3.25.76)
+        version: 3.0.53(zod@4.2.1)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.41
-        version: 2.0.41(zod@3.25.76)
+        version: 2.0.41(zod@4.2.1)
       '@ai-sdk/perplexity':
         specifier: 3.0.29
-        version: 3.0.29(zod@3.25.76)
+        version: 3.0.29(zod@4.2.1)
       '@ai-sdk/provider':
         specifier: 3.0.8
         version: 3.0.8
       '@ai-sdk/react':
         specifier: 3.0.170
-        version: 3.0.170(react@19.2.5)(zod@3.25.76)
+        version: 3.0.170(react@19.2.5)(zod@4.2.1)
       '@apple/app-store-server-library':
         specifier: 3.0.0
         version: 3.0.0(encoding@0.1.13)
       '@asteasolutions/zod-to-openapi':
         specifier: 8.5.0
-        version: 8.5.0(zod@3.25.76)
+        version: 8.5.0(zod@4.2.1)
       '@better-auth/expo':
         specifier: 1.6.5
-        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)))
+        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)))
       '@better-auth/sso':
         specifier: 1.6.5
-        version: 1.6.5(520c976c041ab0b185e44339f6d5cac6)
+        version: 1.6.5(784acc98c6f48fb6cb4a5e5dd24c49de)
       '@chat-adapter/slack':
         specifier: 4.26.0
         version: 4.26.0
@@ -169,8 +169,8 @@ importers:
         specifier: 2.2.10
         version: 2.2.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@hookform/resolvers':
-        specifier: 4.1.0
-        version: 4.1.0(react-hook-form@7.72.1(react@19.2.5))
+        specifier: 5.2.2
+        version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
       '@inboxzero/image-proxy':
         specifier: workspace:*
         version: link:../../packages/image-proxy
@@ -200,7 +200,7 @@ importers:
         version: 3.0.7
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
       '@mux/mux-player-react':
         specifier: 3.11.8
         version: 3.11.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -212,13 +212,13 @@ importers:
         version: 16.2.4(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@openrouter/ai-sdk-provider':
         specifier: 2.8.0
-        version: 2.8.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76)
+        version: 2.8.0(ai@6.0.168(zod@4.2.1))(zod@4.2.1)
       '@portabletext/react':
         specifier: 6.0.3
         version: 6.0.3(react@19.2.5)
       '@posthog/ai':
         specifier: 7.16.0
-        version: 7.16.0(@ai-sdk/provider@3.0.8)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(posthog-node@5.29.2(rxjs@7.8.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
+        version: 7.16.0(@ai-sdk/provider@3.0.8)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(posthog-node@5.29.2(rxjs@7.8.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@4.2.1))
       '@prisma/adapter-pg':
         specifier: 7.7.0
         version: 7.7.0
@@ -308,7 +308,7 @@ importers:
         version: 9.2.0
       '@t3-oss/env-nextjs':
         specifier: 0.13.11
-        version: 0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@3.25.76)
+        version: 0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@4.2.1)
       '@tailwindcss/forms':
         specifier: 0.5.11
         version: 0.5.11(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.10.1)(typescript@6.0.3)))
@@ -356,13 +356,13 @@ importers:
         version: 2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vue@3.5.20(typescript@6.0.3))
       ai:
         specifier: 6.0.168
-        version: 6.0.168(zod@3.25.76)
+        version: 6.0.168(zod@4.2.1)
       better-auth:
         specifier: 1.6.5
         version: 1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3))
       braintrust:
         specifier: 3.8.0
-        version: 3.8.0(@aws-sdk/credential-provider-web-identity@3.911.0)(zod@3.25.76)
+        version: 3.8.0(@aws-sdk/credential-provider-web-identity@3.911.0)(zod@4.2.1)
       bullmq:
         specifier: 5.74.1
         version: 5.74.1
@@ -476,10 +476,10 @@ importers:
         version: 2.8.9(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       ollama-ai-provider-v2:
         specifier: 3.5.0
-        version: 3.5.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76)
+        version: 3.5.0(ai@6.0.168(zod@4.2.1))(zod@4.2.1)
       openai:
         specifier: 6.34.0
-        version: 6.34.0(ws@8.19.0)(zod@3.25.76)
+        version: 6.34.0(ws@8.19.0)(zod@4.2.1)
       p-queue:
         specifier: 9.1.2
         version: 9.1.2
@@ -595,8 +595,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(react@19.2.5)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.2.1
+        version: 4.2.1
     devDependencies:
       '@headlessui/tailwindcss':
         specifier: 0.2.2
@@ -3098,10 +3098,10 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hookform/resolvers@4.1.0':
-    resolution: {integrity: sha512-fX/uHKb+OOCpACLc6enuTQsf0ZpRrKbeBBPETg5PCPLCIYV6osP2Bw6ezuclM61lH+wBF9eXcuC0+BFh9XOEnQ==}
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      react-hook-form: ^7.55.0
 
   '@iarna/toml@2.2.3':
     resolution: {integrity: sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==}
@@ -6224,6 +6224,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@stripe/stripe-js@9.2.0':
     resolution: {integrity: sha512-YSzLC0t6VS9MDdPTynSMqU8IxrItFUjkDORALFT6sSMR/XZ5Vgm3RDp/Gk7z727MC4A9s4MFVel0gF0c7+kdrg==}
@@ -13133,6 +13136,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.2.1:
+    resolution: {integrity: sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -13192,98 +13198,98 @@ snapshots:
 
   '@actions/io@3.0.2': {}
 
-  '@ai-sdk/amazon-bedrock@4.0.96(zod@3.25.76)':
+  '@ai-sdk/amazon-bedrock@4.0.96(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.71(zod@4.2.1)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
       '@smithy/eventstream-codec': 4.0.5
       '@smithy/util-utf8': 4.2.2
       aws4fetch: 1.0.20
-      zod: 3.25.76
+      zod: 4.2.1
 
-  '@ai-sdk/anthropic@3.0.71(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.71(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/azure@3.0.54(zod@3.25.76)':
+  '@ai-sdk/azure@3.0.54(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(zod@3.25.76)
+      '@ai-sdk/openai': 3.0.53(zod@4.2.1)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/gateway@3.0.104(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.104(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
       '@vercel/oidc': 3.2.0
-      zod: 3.25.76
+      zod: 4.2.1
 
-  '@ai-sdk/google-vertex@4.0.112(zod@3.25.76)':
+  '@ai-sdk/google-vertex@4.0.112(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.71(zod@3.25.76)
-      '@ai-sdk/google': 3.0.64(zod@3.25.76)
-      '@ai-sdk/openai-compatible': 2.0.41(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.71(zod@4.2.1)
+      '@ai-sdk/google': 3.0.64(zod@4.2.1)
+      '@ai-sdk/openai-compatible': 2.0.41(zod@4.2.1)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
       google-auth-library: 10.6.1
-      zod: 3.25.76
+      zod: 4.2.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/google@3.0.64(zod@3.25.76)':
+  '@ai-sdk/google@3.0.64(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/groq@3.0.35(zod@3.25.76)':
+  '@ai-sdk/groq@3.0.35(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/mcp@1.0.36(zod@3.25.76)':
+  '@ai-sdk/mcp@1.0.36(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
       pkce-challenge: 5.0.1
-      zod: 3.25.76
+      zod: 4.2.1
 
-  '@ai-sdk/openai-compatible@2.0.41(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@2.0.41(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/openai@3.0.53(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.53(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/perplexity@3.0.29(zod@3.25.76)':
+  '@ai-sdk/perplexity@3.0.29(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      zod: 4.2.1
 
-  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 3.25.76
-
-  '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
+  '@ai-sdk/provider-utils@4.0.19(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.2.1
+
+  '@ai-sdk/provider-utils@4.0.23(zod@4.2.1)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.2.1
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -13293,10 +13299,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.170(react@19.2.5)(zod@3.25.76)':
+  '@ai-sdk/react@3.0.170(react@19.2.5)(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      ai: 6.0.168(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
+      ai: 6.0.168(zod@4.2.1)
       react: 19.2.5
       swr: 2.4.1(react@19.2.5)
       throttleit: 2.1.0
@@ -13312,11 +13318,11 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.4
 
-  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.78.0(zod@4.2.1)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.2.1
 
   '@apm-js-collab/code-transformer@0.9.0': {}
 
@@ -13419,10 +13425,10 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@asteasolutions/zod-to-openapi@8.5.0(zod@3.25.76)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.2.1)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.2.1
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -14416,75 +14422,75 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@3.25.76)
+      better-call: 1.3.5(zod@4.2.1)
       jose: 6.2.2
       kysely: 0.28.15
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/expo@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)))':
+  '@better-auth/expo@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)))':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3))
       better-call: 1.3.5(zod@4.3.6)
       zod: 4.3.6
 
-  '@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)':
+  '@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.15
 
-  '@better-auth/memory-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       mongodb: 7.1.0(gcp-metadata@7.0.1)(socks@2.8.7)
 
-  '@better-auth/prisma-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))':
+  '@better-auth/prisma-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       '@prisma/client': 7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       prisma: 7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
 
-  '@better-auth/sso@1.6.5(520c976c041ab0b185e44339f6d5cac6)':
+  '@better-auth/sso@1.6.5(784acc98c6f48fb6cb4a5e5dd24c49de)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       better-auth: 1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3))
-      better-call: 1.3.5(zod@3.25.76)
+      better-call: 1.3.5(zod@4.2.1)
       fast-xml-parser: 5.5.9
       jose: 6.2.2
       samlify: 2.10.2
       tldts: 6.1.86
       zod: 4.3.6
 
-  '@better-auth/telemetry@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -15312,14 +15318,14 @@ snapshots:
 
   '@formkit/auto-animate@0.9.0': {}
 
-  '@google/genai@1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))':
+  '@google/genai@1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.5
       ws: 8.19.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -15375,9 +15381,9 @@ snapshots:
     dependencies:
       hono: 4.12.10
 
-  '@hookform/resolvers@4.1.0(react-hook-form@7.72.1(react@19.2.5))':
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@19.2.5))':
     dependencies:
-      caniuse-lite: 1.0.30001769
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.72.1(react@19.2.5)
 
   '@iarna/toml@2.2.3': {}
@@ -15923,50 +15929,50 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))':
+  '@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
-      zod: 3.25.76
+      zod: 4.2.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))':
     dependencies:
-      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
+      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.6.5(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@langchain/langgraph-sdk@1.6.5(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
+      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@langchain/langgraph@1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.2.1))(zod@4.2.1)':
     dependencies:
-      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.6.5(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))
+      '@langchain/langgraph-sdk': 1.6.5(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
-      zod: 3.25.76
+      zod: 4.2.1
     optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@4.2.1)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -16116,7 +16122,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.10)
       ajv: 8.18.0
@@ -16133,8 +16139,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.2.1
+      zod-to-json-schema: 3.25.2(zod@4.2.1)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -16371,10 +16377,10 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@openrouter/ai-sdk-provider@2.8.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76)':
+  '@openrouter/ai-sdk-provider@2.8.0(ai@6.0.168(zod@4.2.1))(zod@4.2.1)':
     dependencies:
-      ai: 6.0.168(zod@3.25.76)
-      zod: 3.25.76
+      ai: 6.0.168(zod@4.2.1)
+      zod: 4.2.1
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
@@ -16833,17 +16839,17 @@ snapshots:
 
   '@portabletext/types@4.0.2': {}
 
-  '@posthog/ai@7.16.0(@ai-sdk/provider@3.0.8)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(posthog-node@5.29.2(rxjs@7.8.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))':
+  '@posthog/ai@7.16.0(@ai-sdk/provider@3.0.8)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(posthog-node@5.29.2(rxjs@7.8.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@4.2.1))':
     dependencies:
-      '@anthropic-ai/sdk': 0.78.0(zod@4.3.6)
-      '@google/genai': 1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
-      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
+      '@anthropic-ai/sdk': 0.78.0(zod@4.2.1)
+      '@google/genai': 1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))
+      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
       '@posthog/core': 1.25.2
-      langchain: 1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))
-      openai: 6.34.0(ws@8.19.0)(zod@4.3.6)
+      langchain: 1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.2.1))
+      openai: 6.34.0(ws@8.19.0)(zod@4.2.1)
       posthog-node: 5.29.2(rxjs@7.8.2)
       uuid: 11.1.0
-      zod: 4.3.6
+      zod: 4.2.1
     optionalDependencies:
       '@ai-sdk/provider': 3.0.8
       '@opentelemetry/api': 1.9.1
@@ -19212,6 +19218,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@stripe/stripe-js@9.2.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
@@ -19227,19 +19235,19 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@3.25.76)':
+  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@4.2.1)':
     optionalDependencies:
       typescript: 6.0.3
       valibot: 1.2.0(typescript@6.0.3)
-      zod: 3.25.76
+      zod: 4.2.1
 
-  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@3.25.76)':
+  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@4.2.1)':
     dependencies:
-      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@3.25.76)
+      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(valibot@1.2.0(typescript@6.0.3))(zod@4.2.1)
     optionalDependencies:
       typescript: 6.0.3
       valibot: 1.2.0(typescript@6.0.3)
-      zod: 3.25.76
+      zod: 4.2.1
 
   '@tailwindcss/forms@0.5.11(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.10.1)(typescript@6.0.3)))':
     dependencies:
@@ -19960,7 +19968,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -20006,7 +20014,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -20228,13 +20236,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.168(zod@3.25.76):
+  ai@6.0.168(zod@4.2.1):
     dependencies:
-      '@ai-sdk/gateway': 3.0.104(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.104(zod@4.2.1)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.2.1)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.2.1
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -20447,13 +20455,13 @@ snapshots:
 
   better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)):
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)
-      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
-      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)
+      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
@@ -20480,14 +20488,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.5(zod@3.25.76):
+  better-call@1.3.5(zod@4.2.1):
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.2.1
 
   better-call@1.3.5(zod@4.3.6):
     dependencies:
@@ -20579,7 +20587,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@3.8.0(@aws-sdk/credential-provider-web-identity@3.911.0)(zod@3.25.76):
+  braintrust@3.8.0(@aws-sdk/credential-provider-web-identity@3.911.0)(zod@4.2.1):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@apm-js-collab/code-transformer': 0.9.0
@@ -20608,8 +20616,8 @@ snapshots:
       termi-link: 1.1.0
       unplugin: 2.3.11
       uuid: 9.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.2.1
+      zod-to-json-schema: 3.25.2(zod@4.2.1)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - supports-color
@@ -21444,7 +21452,7 @@ snapshots:
 
   dub@0.71.5:
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.1
 
   duck@0.1.12:
     dependencies:
@@ -23113,14 +23121,14 @@ snapshots:
 
   lambda-runtimes@2.0.5: {}
 
-  langchain@1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76)):
+  langchain@1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.2.1)):
     dependencies:
-      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
-      '@langchain/langgraph': 1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)))
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76))
+      '@langchain/core': 1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
+      '@langchain/langgraph': 1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.2.1))(zod@4.2.1)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1))
       uuid: 11.1.0
-      zod: 3.25.76
+      zod: 4.2.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -23138,7 +23146,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
-  langsmith@0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@3.25.76)):
+  langsmith@0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.19.0)(zod@4.2.1)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 5.6.2
@@ -23149,7 +23157,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-      openai: 6.34.0(ws@8.19.0)(zod@3.25.76)
+      openai: 6.34.0(ws@8.19.0)(zod@4.2.1)
 
   layout-base@1.0.2: {}
 
@@ -24257,12 +24265,12 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider-v2@3.5.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76):
+  ollama-ai-provider-v2@3.5.0(ai@6.0.168(zod@4.2.1))(zod@4.2.1):
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
-      ai: 6.0.168(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.2.1)
+      ai: 6.0.168(zod@4.2.1)
+      zod: 4.2.1
 
   on-finished@2.4.1:
     dependencies:
@@ -24295,15 +24303,10 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.34.0(ws@8.19.0)(zod@3.25.76):
+  openai@6.34.0(ws@8.19.0)(zod@4.2.1):
     optionalDependencies:
       ws: 8.19.0
-      zod: 3.25.76
-
-  openai@6.34.0(ws@8.19.0)(zod@4.3.6):
-    optionalDependencies:
-      ws: 8.19.0
-      zod: 4.3.6
+      zod: 4.2.1
 
   openapi3-ts@4.5.0:
     dependencies:
@@ -27219,11 +27222,13 @@ snapshots:
   zimmerframe@1.1.4:
     optional: true
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.2.1):
     dependencies:
-      zod: 3.25.76
+      zod: 4.2.1
 
   zod@3.25.76: {}
+
+  zod@4.2.1: {}
 
   zod@4.3.6: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -73,6 +73,9 @@
         "OLLAMA_MODEL",
         "OPENAI_COMPATIBLE_BASE_URL",
         "OPENAI_COMPATIBLE_MODEL",
+        "CLI_LLM_ENABLED",
+        "CODEX_CLI_ALLOW_NPX",
+        "CODEX_CLI_PATH",
         "PERPLEXITY_API_KEY",
 
         "UPSTASH_REDIS_URL",


### PR DESCRIPTION
Adds self-hosted, opt-in CLI-backed LLM provider support while keeping community provider packages out of the default dependency path.

- Adds env-gated Codex CLI and Claude Code provider selection through the existing LLM model layer
- Documents optional install steps, supply-chain caveats, and CLI provider environment variables
- Upgrades Zod/resolver compatibility and updates validation issue reads for Zod 4

Validation:
- pnpm --filter inbox-zero-ai test --run
- Runtime smoke tested Codex CLI and Claude Code with text, object, and stream generation