### PR TITLE
Polish channels settings UI

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting.tsx
@@ -161,11 +161,16 @@ export function ProactiveUpdatesSetting({
     () => describeCronSchedule(cronExpression),
     [cronExpression],
   );
-  const destinationLabel = getScheduledCheckInsDestinationLabel(channel);
-  const summaryText =
-    activeForChannel && job
-      ? `${describeCronSchedule(job.cronExpression ?? DEFAULT_AUTOMATION_JOB_CRON)}. ${destinationLabel}`
-      : "Get periodic summaries in chat.";
+  const isSlack = channel.provider === MessagingProvider.SLACK;
+  let summaryText = "Get periodic summaries in chat.";
+  if (activeForChannel && job) {
+    const schedule = describeCronSchedule(
+      job.cronExpression ?? DEFAULT_AUTOMATION_JOB_CRON,
+    );
+    summaryText = isSlack
+      ? `${schedule}. ${getScheduledCheckInsDestinationLabel(channel)}`
+      : schedule;
+  }
 
   const handleSave = useCallback(() => {
     executeSave({
@@ -193,7 +198,7 @@ export function ProactiveUpdatesSetting({
               <Settings2Icon className="h-4 w-4" />
             </Button>
           </Tooltip>
-          {channel.provider === MessagingProvider.SLACK ? (
+          {isSlack && (
             <SlackNotificationTargetSelect
               emailAccountId={emailAccountId}
               messagingChannelId={channel.id}
@@ -205,12 +210,7 @@ export function ProactiveUpdatesSetting({
               canSendAsDm={channel.canSendAsDm}
               onUpdate={onUpdate}
               disabled={saveStatus === "executing"}
-              className="h-8 min-w-[170px]"
             />
-          ) : (
-            <div className="min-w-[120px] text-right text-sm text-muted-foreground">
-              {destinationLabel}
-            </div>
           )}
           <Toggle
             name={`scheduled-checkins-${channel.id}`}
@@ -345,17 +345,6 @@ function getSlackScheduledCheckInsTargetValue(channel: Channel) {
 function getScheduledCheckInsDestinationLabel(channel: Channel) {
   const destination = channel.destinations.scheduledCheckIns;
   if (destination.targetLabel) return destination.targetLabel;
-  if (
-    channel.destinations.scheduledCheckIns.isDm ||
-    channel.provider !== MessagingProvider.SLACK ||
-    channel.canSendAsDm
-  ) {
-    return "Direct message";
-  }
-
-  if (channel.teamName) {
-    return `${getMessagingProviderName(channel.provider)} workspace`;
-  }
-
+  if (destination.isDm || channel.canSendAsDm) return "Direct message";
   return "Select destination";
 }

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -3,8 +3,8 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import {
-  ArrowUpRightIcon,
   CheckIcon,
+  ChevronRightIcon,
   LogOutIcon,
   MoreVerticalIcon,
   Settings2Icon,
@@ -328,15 +328,15 @@ function ConnectedChannelSection({
         </div>
       }
     >
-      {isSlack && (
-        <ItemCard>
-          <Item size="sm">
-            <ItemContent>
-              <ItemTitle>Rule notifications</ItemTitle>
-              <ItemDescription>
-                Choose where rule notifications and chat replies go.
-              </ItemDescription>
-            </ItemContent>
+      <ItemCard>
+        <Item size="sm">
+          <ItemContent>
+            <ItemTitle>Rule notifications</ItemTitle>
+            <ItemDescription>
+              Choose which rules send notifications and where they go.
+            </ItemDescription>
+          </ItemContent>
+          {isSlack && (
             <ItemActions>
               <SlackNotificationTargetSelect
                 emailAccountId={emailAccountId}
@@ -349,18 +349,7 @@ function ConnectedChannelSection({
                 onUpdate={onUpdate}
               />
             </ItemActions>
-          </Item>
-        </ItemCard>
-      )}
-
-      <ItemCard>
-        <Item size="sm">
-          <ItemContent>
-            <ItemTitle>Rules</ItemTitle>
-            <ItemDescription>
-              Choose which rules send notifications to this channel.
-            </ItemDescription>
-          </ItemContent>
+          )}
         </Item>
         <ItemSeparator />
         <div className="max-h-80 overflow-y-auto">
@@ -778,7 +767,7 @@ function FeatureRouteAction({
       <Tooltip content="Open settings">
         <Button asChild variant="ghost" size="icon" className="h-8 w-8">
           <Link href={href}>
-            <ArrowUpRightIcon className="h-4 w-4" />
+            <ChevronRightIcon className="h-4 w-4" />
           </Link>
         </Button>
       </Tooltip>

--- a/apps/web/components/SlackNotificationTargetSelect.tsx
+++ b/apps/web/components/SlackNotificationTargetSelect.tsx
@@ -28,7 +28,7 @@ export function SlackNotificationTargetSelect({
   onUpdate,
   onValueChange,
   placeholder = "Select channel",
-  className = "h-8 w-[180px]",
+  className = "h-8 w-[180px] [&>span]:min-w-0 [&>span]:text-left",
   disabled = false,
 }: {
   emailAccountId: string;


### PR DESCRIPTION
## Summary
- Combine the rule-notifications destination select into the Rules card
- Use a chevron icon for rows that navigate to a sub-page (the previous arrow-up-right iconography reads as external)
- Hide the destination select/label for non-Slack providers (Telegram/Teams) where everything is a DM
- Normalize select widths across feature rows and left-align truncated values in the Slack destination select

## Test plan
- [ ] Visit Channels settings with Slack connected and confirm the combined Rules card renders correctly
- [ ] Confirm long channel names truncate left-aligned (no centered appearance)
- [ ] Confirm Telegram connection shows no destination label on Scheduled check-ins or feature rows
- [ ] Confirm feature row selects align horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)