### PR TITLE
assistant: Make settings tool schema provider-safe

### DIFF
--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -84,7 +84,7 @@ const baseAccountSnapshot = {
     cronExpression: "0 9 * * 1-5",
     prompt: "Highlight urgent items.",
     nextRunAt: new Date("2026-02-21T09:00:00.000Z"),
-    messagingChannelId: "channel-1",
+    messagingChannelId: "c000000000000000000000000",
     messagingChannel: {
       provider: "SLACK",
       teamName: "Acme",
@@ -93,7 +93,7 @@ const baseAccountSnapshot = {
   },
   messagingChannels: [
     {
-      id: "channel-1",
+      id: "c000000000000000000000000",
       provider: "SLACK",
       teamName: "Acme",
       isConnected: true,
@@ -189,11 +189,11 @@ describe("chat settings tools", () => {
       value: {
         enabled: true,
         cronExpression: "0 9 * * 1-5",
-        messagingChannelId: "channel-1",
+        messagingChannelId: "c000000000000000000000000",
         messagingChannelName: "#C456 (Acme)",
         availableChannels: [
           {
-            id: "channel-1",
+            id: "c000000000000000000000000",
             label: "#C456 (Acme)",
           },
         ],
@@ -298,6 +298,29 @@ describe("chat settings tools", () => {
     expect(result.appliedChanges).toHaveLength(2);
   });
 
+  it("returns a validation error for invalid updateAssistantSettings payload values", async () => {
+    const toolInstance = updateAssistantSettingsTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      userId: "user-1",
+      logger,
+    });
+
+    const result = await toolInstance.execute({
+      changes: [
+        {
+          path: "assistant.meetingBriefs.minutesBefore",
+          value: "soon",
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      error: expect.stringContaining("Invalid settings update payload."),
+    });
+    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
+  });
+
   it("updates scheduled check-ins configuration", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue(baseAccountSnapshot);
     mockGetUserPremium.mockResolvedValue(null);
@@ -328,7 +351,7 @@ describe("chat settings tools", () => {
         enabled: false,
         cronExpression: "0 9 * * 1-5",
         prompt: "Highlight urgent items.",
-        messagingChannelId: "channel-1",
+        messagingChannelId: "c000000000000000000000000",
       },
     });
     expect(result).toMatchObject({
@@ -433,7 +456,7 @@ describe("chat settings tools", () => {
       value: {
         availableChannels: [
           {
-            id: "channel-1",
+            id: "c000000000000000000000000",
             label: "Acme",
           },
         ],
@@ -453,7 +476,7 @@ describe("chat settings tools", () => {
     });
     prisma.automationJob.findUnique.mockResolvedValue(null);
     prisma.messagingChannel.findUnique.mockResolvedValue({
-      id: "channel-1",
+      id: "c000000000000000000000000",
       provider: "SLACK",
       isConnected: true,
       accessToken: "token-1",
@@ -476,7 +499,7 @@ describe("chat settings tools", () => {
           path: "assistant.scheduledCheckIns.config",
           value: {
             enabled: true,
-            messagingChannelId: "channel-1",
+            messagingChannelId: "c000000000000000000000000",
           },
         },
       ],
@@ -487,7 +510,7 @@ describe("chat settings tools", () => {
     });
     expect(prisma.messagingRoute.create).toHaveBeenCalledWith({
       data: {
-        messagingChannelId: "channel-1",
+        messagingChannelId: "c000000000000000000000000",
         purpose: MessagingRoutePurpose.SCHEDULED_CHECK_INS,
         targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
         targetId: "U123",
@@ -499,7 +522,7 @@ describe("chat settings tools", () => {
         name: "Scheduled check-ins",
         cronExpression: "0 9,14 * * 1-5",
         prompt: null,
-        messagingChannelId: "channel-1",
+        messagingChannelId: "c000000000000000000000000",
         emailAccountId: "email-account-1",
       }),
     });

--- a/apps/web/utils/ai/assistant/tools/settings/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/shared.ts
@@ -194,14 +194,9 @@ export const updateAssistantSettingsInputSchema = z.object({
 
 export const updateAssistantSettingsCompatChangeSchema = z
   .object({
-    path: z
-      .string()
-      .trim()
-      .min(1)
-      .max(120)
-      .describe(
-        "Writable settings path (use a path returned by getAssistantCapabilities).",
-      ),
+    path: settingsPathSchema.describe(
+      "Writable settings path (use a path returned by getAssistantCapabilities).",
+    ),
     value: z
       .unknown()
       .describe(
@@ -221,6 +216,10 @@ export const updateAssistantSettingsCompatInputSchema = z.object({
     .max(20)
     .describe("Structured settings changes to apply."),
 });
+
+export type UpdateAssistantSettingsCompatInput = z.infer<
+  typeof updateAssistantSettingsCompatInputSchema
+>;
 
 export type AccountSettingsSnapshot = {
   id: string;

--- a/apps/web/utils/ai/assistant/tools/settings/update-assistant-settings-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/update-assistant-settings-tool.ts
@@ -5,6 +5,7 @@ import {
   getUpdateAssistantSettingsValidationError,
   isNullableSettingsPath,
   trackSettingsToolCall,
+  type UpdateAssistantSettingsCompatInput,
   updateAssistantSettingsCompatInputSchema,
   updateAssistantSettingsInputSchema,
 } from "./shared";
@@ -22,19 +23,22 @@ export const updateAssistantSettingsTool = ({
 }) =>
   tool({
     description:
-      "Update supported assistant settings. This is the primary tool for writing account settings — always prefer this over updateAssistantSettingsCompat. Batch multiple setting changes into one call when possible. Supported categories: meeting briefs, attachment filing, multi-rule selection, scheduled check-ins, and draft knowledge base. For personal instruction changes, use the dedicated updatePersonalInstructions tool instead.",
-    inputSchema: updateAssistantSettingsInputSchema,
+      "Update supported assistant settings. Batch multiple setting changes into one call when possible. Supported paths and values: assistant.multiRuleSelection.enabled boolean; assistant.meetingBriefs.enabled boolean; assistant.meetingBriefs.minutesBefore integer minutes from 1 to 2880; assistant.meetingBriefs.sendEmail boolean; assistant.attachmentFiling.enabled boolean; assistant.attachmentFiling.prompt string or null; assistant.scheduledCheckIns.config object with enabled, cronExpression, messagingChannelId, or prompt; assistant.draftKnowledgeBase.upsert object with title and content plus optional mode append or replace; assistant.draftKnowledgeBase.delete object with title. For personal instruction changes, use the dedicated updatePersonalInstructions tool instead.",
+    inputSchema: updateAssistantSettingsCompatInputSchema,
     execute: async ({ changes }) => {
       trackSettingsToolCall({
         tool: "update_assistant_settings",
         email,
         logger,
       });
+      const parsedInput = parseUpdateAssistantSettingsChanges(changes);
+      if ("error" in parsedInput) return parsedInput;
+
       return executeUpdateAssistantSettings({
         emailAccountId,
         userId,
         logger,
-        changes,
+        changes: parsedInput.changes,
       });
     },
   });
@@ -61,37 +65,14 @@ export const updateAssistantSettingsCompatTool = ({
         logger,
       });
 
-      const nonNullablePaths = changes
-        .filter(
-          (change) =>
-            change.value === null && !isNullableSettingsPath(change.path),
-        )
-        .map((change) => change.path);
-
-      if (nonNullablePaths.length > 0) {
-        return {
-          error: `These settings cannot be set to null: ${nonNullablePaths.join(", ")}. Provide a valid value instead.`,
-        };
-      }
-
-      const normalizedChanges = changes.map((change) => ({
-        ...change,
-        mode: change.mode ?? undefined,
-      }));
-      const parsedInput = updateAssistantSettingsInputSchema.safeParse({
-        changes: normalizedChanges,
-      });
-      if (!parsedInput.success) {
-        return {
-          error: getUpdateAssistantSettingsValidationError(parsedInput.error),
-        };
-      }
+      const parsedInput = parseUpdateAssistantSettingsChanges(changes);
+      if ("error" in parsedInput) return parsedInput;
 
       return executeUpdateAssistantSettings({
         emailAccountId,
         userId,
         logger,
-        changes: parsedInput.data.changes,
+        changes: parsedInput.changes,
       });
     },
   });
@@ -99,3 +80,34 @@ export const updateAssistantSettingsCompatTool = ({
 export type UpdateAssistantSettingsTool = InferUITool<
   ReturnType<typeof updateAssistantSettingsTool>
 >;
+
+function parseUpdateAssistantSettingsChanges(
+  changes: UpdateAssistantSettingsCompatInput["changes"],
+) {
+  const nonNullablePaths = changes
+    .filter(
+      (change) => change.value === null && !isNullableSettingsPath(change.path),
+    )
+    .map((change) => change.path);
+
+  if (nonNullablePaths.length > 0) {
+    return {
+      error: `These settings cannot be set to null: ${nonNullablePaths.join(", ")}. Provide a valid value instead.`,
+    };
+  }
+
+  const normalizedChanges = changes.map((change) => ({
+    ...change,
+    mode: change.mode ?? undefined,
+  }));
+  const parsedInput = updateAssistantSettingsInputSchema.safeParse({
+    changes: normalizedChanges,
+  });
+  if (!parsedInput.success) {
+    return {
+      error: getUpdateAssistantSettingsValidationError(parsedInput.error),
+    };
+  }
+
+  return parsedInput.data;
+}

--- a/apps/web/utils/llms/unsupported-tools.test.ts
+++ b/apps/web/utils/llms/unsupported-tools.test.ts
@@ -4,7 +4,7 @@ import { Provider } from "@/utils/llms/config";
 import { filterUnsupportedToolsForModel } from "./unsupported-tools";
 
 describe("filterUnsupportedToolsForModel", () => {
-  it("replaces updateAssistantSettings with compat implementation for OpenRouter Grok models", () => {
+  it("removes internal compat tool for OpenRouter Grok models", () => {
     const primaryTool = {} as Tool;
     const compatTool = {} as Tool;
     const tools = {
@@ -20,10 +20,10 @@ describe("filterUnsupportedToolsForModel", () => {
     });
 
     expect(result.excludedTools).toEqual([]);
-    expect(result.replacedTools).toEqual(["updateAssistantSettings"]);
+    expect(result.replacedTools).toEqual([]);
     expect(result.tools).toEqual({
       searchInbox: tools.searchInbox,
-      updateAssistantSettings: compatTool,
+      updateAssistantSettings: primaryTool,
     });
   });
 
@@ -50,7 +50,7 @@ describe("filterUnsupportedToolsForModel", () => {
     });
   });
 
-  it("replaces updateAssistantSettings for mixed-case Grok model names", () => {
+  it("keeps primary updateAssistantSettings for mixed-case Grok model names", () => {
     const primaryTool = {} as Tool;
     const compatTool = {} as Tool;
     const tools = {
@@ -66,14 +66,14 @@ describe("filterUnsupportedToolsForModel", () => {
     });
 
     expect(result.excludedTools).toEqual([]);
-    expect(result.replacedTools).toEqual(["updateAssistantSettings"]);
+    expect(result.replacedTools).toEqual([]);
     expect(result.tools).toEqual({
       searchInbox: tools.searchInbox,
-      updateAssistantSettings: compatTool,
+      updateAssistantSettings: primaryTool,
     });
   });
 
-  it("excludes updateAssistantSettings for Grok when compat tool is unavailable", () => {
+  it("keeps updateAssistantSettings for Grok when compat tool is unavailable", () => {
     const tools = {
       searchInbox: {} as Tool,
       updateAssistantSettings: {} as Tool,
@@ -85,9 +85,12 @@ describe("filterUnsupportedToolsForModel", () => {
       tools,
     });
 
-    expect(result.excludedTools).toEqual(["updateAssistantSettings"]);
+    expect(result.excludedTools).toEqual([]);
     expect(result.replacedTools).toEqual([]);
-    expect(result.tools).toEqual({ searchInbox: tools.searchInbox });
+    expect(result.tools).toEqual({
+      searchInbox: tools.searchInbox,
+      updateAssistantSettings: tools.updateAssistantSettings,
+    });
   });
 
   it("keeps all tools for non-OpenRouter providers", () => {

--- a/apps/web/utils/llms/unsupported-tools.ts
+++ b/apps/web/utils/llms/unsupported-tools.ts
@@ -1,15 +1,8 @@
 import type { Tool } from "ai";
-import { Provider } from "@/utils/llms/config";
 
-const GROK_TOOL_REPLACEMENTS: Record<string, string> = {
-  updateAssistantSettings: "updateAssistantSettingsCompat",
-};
-
-const INTERNAL_TOOL_NAMES = new Set(Object.values(GROK_TOOL_REPLACEMENTS));
+const INTERNAL_TOOL_NAMES = new Set(["updateAssistantSettingsCompat"]);
 
 export function filterUnsupportedToolsForModel({
-  provider,
-  modelName,
   tools,
 }: {
   provider: string;
@@ -30,40 +23,9 @@ export function filterUnsupportedToolsForModel({
     delete candidateTools[internalToolName];
   }
 
-  if (provider !== Provider.OPENROUTER || !isXaiGrokModel(modelName)) {
-    return {
-      tools: candidateTools,
-      excludedTools: [] as string[],
-      replacedTools: [] as string[],
-    };
-  }
-
-  const replacedTools: string[] = [];
-  const excludedTools: string[] = [];
-
-  for (const [toolName, replacementToolName] of Object.entries(
-    GROK_TOOL_REPLACEMENTS,
-  )) {
-    if (!(toolName in candidateTools)) continue;
-
-    const replacementTool = tools[replacementToolName];
-    if (replacementTool) {
-      candidateTools[toolName] = replacementTool;
-      replacedTools.push(toolName);
-      continue;
-    }
-
-    delete candidateTools[toolName];
-    excludedTools.push(toolName);
-  }
-
   return {
     tools: candidateTools,
-    excludedTools,
-    replacedTools,
+    excludedTools: [] as string[],
+    replacedTools: [] as string[],
   };
-}
-
-function isXaiGrokModel(modelName: string): boolean {
-  return modelName.toLowerCase().startsWith("x-ai/grok-");
 }


### PR DESCRIPTION
Make the assistant settings tool expose a provider-safe path/value schema while keeping strict discriminated-union validation on the server side. This removes the Grok-specific replacement path because the primary tool schema is now compatible across providers.

- Parse generic tool input through the existing strict settings schema before execution
- Keep internal compat tooling hidden from model tool lists
- Update settings tool tests and provider filtering tests

Validation:
- pnpm --filter inbox-zero-ai exec vitest run utils/ai/assistant/chat-settings-tools.test.ts utils/llms/unsupported-tools.test.ts
- pnpm --filter inbox-zero-ai exec biome check utils/ai/assistant/tools/settings/shared.ts utils/ai/assistant/tools/settings/update-assistant-settings-tool.ts utils/llms/unsupported-tools.ts utils/llms/unsupported-tools.test.ts utils/ai/assistant/chat-settings-tools.test.ts