### PR TITLE
email-stream: isolate SSE subscriptions

### DIFF
--- a/apps/web/app/api/clean/gmail/route.ts
+++ b/apps/web/app/api/clean/gmail/route.ts
@@ -10,6 +10,7 @@ import type { Logger } from "@/utils/logger";
 import { CleanAction } from "@/generated/prisma/enums";
 import { updateThread } from "@/utils/redis/clean";
 import { withQstashOrInternal } from "@/utils/qstash";
+import { assertCleanerApiEnabled } from "@/utils/cleaner-feature";
 
 const cleanGmailSchema = z.object({
   emailAccountId: z.string(),
@@ -140,6 +141,8 @@ async function saveToDatabase({
 export const POST = withError(
   "clean/gmail",
   withQstashOrInternal(async (request: RequestWithLogger) => {
+    assertCleanerApiEnabled();
+
     const json = await request.json();
     const body = cleanGmailSchema.parse(json);
 

--- a/apps/web/app/api/clean/history/route.test.ts
+++ b/apps/web/app/api/clean/history/route.test.ts
@@ -1,0 +1,82 @@
+vi.mock("server-only", () => ({}));
+
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeError } from "@/utils/error";
+
+const { cleanerEnv, mockFindMany } = vi.hoisted(() => ({
+  cleanerEnv: {
+    NEXT_PUBLIC_CLEANER_ENABLED: true,
+  },
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: cleanerEnv,
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    cleanupJob: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (
+      _scope: string,
+      handler: (
+        request: NextRequest & {
+          auth: { emailAccountId: string; userId: string; email: string };
+        },
+      ) => Promise<Response>,
+    ) =>
+    async (request: NextRequest) => {
+      const emailRequest = request as NextRequest & {
+        auth: { emailAccountId: string; userId: string; email: string };
+      };
+      emailRequest.auth = {
+        emailAccountId: "email-account-id",
+        userId: "user-1",
+        email: "user@example.com",
+      };
+      try {
+        return await handler(emailRequest);
+      } catch (error) {
+        if (error instanceof SafeError) {
+          return NextResponse.json(
+            { error: error.safeMessage, isKnownError: true },
+            { status: error.statusCode ?? 400 },
+          );
+        }
+
+        throw error;
+      }
+    },
+}));
+
+import { GET } from "./route";
+
+describe("clean history route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = true;
+  });
+
+  it("returns not found when cleaner is disabled on self-hosted", async () => {
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = false;
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/clean/history"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Cleaner is not enabled",
+      isKnownError: true,
+    });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/clean/history/route.ts
+++ b/apps/web/app/api/clean/history/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
+import { assertCleanerApiEnabled } from "@/utils/cleaner-feature";
 
 export type CleanHistoryResponse = Awaited<ReturnType<typeof getCleanHistory>>;
 
@@ -14,6 +15,8 @@ async function getCleanHistory({ emailAccountId }: { emailAccountId: string }) {
 }
 
 export const GET = withEmailAccount("clean/history", async (request) => {
+  assertCleanerApiEnabled();
+
   const emailAccountId = request.auth.emailAccountId;
 
   const result = await getCleanHistory({ emailAccountId });

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -1,11 +1,46 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { cleanThread } from "./route";
+import { NextRequest } from "next/server";
 import { GmailLabel } from "@/utils/gmail/label";
 import type { ParsedMessage } from "@/utils/types";
 import { CleanAction } from "@/generated/prisma/enums";
 import { getMockMessage } from "@/__tests__/helpers";
+import { SafeError } from "@/utils/error";
 
 vi.mock("server-only", () => ({}));
+
+const { cleanerEnv } = vi.hoisted(() => ({
+  cleanerEnv: {
+    NEXT_PUBLIC_CLEANER_ENABLED: true,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: cleanerEnv,
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withError: ((scopeOrHandler: unknown, maybeHandler?: unknown) => {
+    const handler =
+      typeof maybeHandler === "function" ? maybeHandler : scopeOrHandler;
+
+    return async (request: Request) => {
+      try {
+        return await (handler as (request: Request) => Promise<Response>)(
+          request,
+        );
+      } catch (error) {
+        if (error instanceof SafeError) {
+          return Response.json(
+            { error: error.safeMessage, isKnownError: true },
+            { status: error.statusCode ?? 400 },
+          );
+        }
+
+        throw error;
+      }
+    };
+  }) as typeof import("@/utils/middleware").withError,
+}));
 
 const mockPublishToQstash = vi.fn();
 vi.mock("@/utils/upstash", () => ({
@@ -34,6 +69,10 @@ vi.mock("@/utils/redis/clean", () => ({
   updateThread: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/utils/qstash", () => ({
+  withQstashOrInternal: (handler: unknown) => handler,
+}));
+
 const mockAiClean = vi.fn();
 vi.mock("@/utils/ai/clean/ai-clean", () => ({
   aiClean: (...args: unknown[]) => mockAiClean(...args),
@@ -45,9 +84,11 @@ vi.mock("@/utils/ai/group/find-newsletters", () => ({
 
 vi.mock("@/utils/ai/group/find-receipts", () => ({
   isReceipt: vi.fn().mockReturnValue(false),
-  isMaybeReceipt: vi.fn().mockImplementation((message: ParsedMessage) => {
-    return message.headers.subject.toLowerCase().includes("payment");
-  }),
+  isMaybeReceipt: vi
+    .fn()
+    .mockImplementation((message: ParsedMessage) =>
+      message.headers.subject.toLowerCase().includes("payment"),
+    ),
 }));
 
 vi.mock("@/utils/parse/parseHtml.server", () => ({
@@ -57,6 +98,8 @@ vi.mock("@/utils/parse/parseHtml.server", () => ({
 vi.mock("@/utils/parse/calender-event", () => ({
   getCalendarEventStatus: vi.fn().mockReturnValue({ isEvent: false }),
 }));
+
+import { POST, cleanThread } from "./route";
 
 const mockLogger = {
   info: vi.fn(),
@@ -89,6 +132,7 @@ function getDefaultParams() {
 describe("cleanThread", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = true;
 
     mockGetEmailAccountWithAiAndTokens.mockResolvedValue({
       id: "email-account-id",
@@ -238,5 +282,22 @@ describe("cleanThread", () => {
 
       expect(mockAiClean).toHaveBeenCalled();
     });
+  });
+
+  it("returns not found when cleaner is disabled on self-hosted", async () => {
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = false;
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/clean", {
+        method: "POST",
+      }) as any,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Cleaner is not enabled",
+      isKnownError: true,
+    });
+    expect(mockGetThreadMessages).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/clean/route.ts
+++ b/apps/web/app/api/clean/route.ts
@@ -24,6 +24,7 @@ import { CleanAction } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
 import { isActivePremium } from "@/utils/premium";
 import { withQstashOrInternal } from "@/utils/qstash";
+import { assertCleanerApiEnabled } from "@/utils/cleaner-feature";
 
 const cleanThreadBody = z.object({
   emailAccountId: z.string(),
@@ -295,6 +296,8 @@ function getPublish({
 
 export const POST = withError(
   withQstashOrInternal(async (request: RequestWithLogger) => {
+    assertCleanerApiEnabled();
+
     const json = await request.json();
     const body = cleanThreadBody.parse(json);
 

--- a/apps/web/app/api/email-stream/route.test.ts
+++ b/apps/web/app/api/email-stream/route.test.ts
@@ -1,9 +1,10 @@
 vi.mock("server-only", () => ({}));
 
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeError } from "@/utils/error";
 
-const { mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
+const { cleanerEnv, mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
   const listeners = new Map<
     string,
     Set<(...args: [string, string, string]) => void>
@@ -49,6 +50,9 @@ const { mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
   };
 
   return {
+    cleanerEnv: {
+      NEXT_PUBLIC_CLEANER_ENABLED: true,
+    },
     mockGetEmailAccount: vi.fn(),
     subscriberState: {
       subscriber,
@@ -72,6 +76,10 @@ const { mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
   };
 });
 
+vi.mock("@/env", () => ({
+  env: cleanerEnv,
+}));
+
 vi.mock("@/utils/middleware", () => ({
   withAuth:
     (
@@ -83,7 +91,7 @@ vi.mock("@/utils/middleware", () => ({
         },
       ) => Promise<Response>,
     ) =>
-    (request: NextRequest) => {
+    async (request: NextRequest) => {
       const authRequest = request as NextRequest & {
         auth: { userId: string };
         logger: typeof mockLogger;
@@ -92,7 +100,18 @@ vi.mock("@/utils/middleware", () => ({
       authRequest.auth = { userId: "user-1" };
       authRequest.logger = mockLogger;
 
-      return handler(authRequest);
+      try {
+        return await handler(authRequest);
+      } catch (error) {
+        if (error instanceof SafeError) {
+          return NextResponse.json(
+            { error: error.safeMessage, isKnownError: true },
+            { status: error.statusCode ?? 400 },
+          );
+        }
+
+        throw error;
+      }
     },
 }));
 
@@ -119,6 +138,7 @@ const mockLogger = {
 describe("email-stream route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = true;
     subscriberState.reset();
     mockGetEmailAccount.mockImplementation(
       async ({ emailAccountId }: { emailAccountId: string }) => ({
@@ -164,6 +184,19 @@ describe("email-stream route", () => {
 
     expect(await reader?.read()).toEqual({ done: true, value: undefined });
     expect(subscriberState.listenerCount("pmessage")).toBe(0);
+  });
+
+  it("returns a not found error when cleaner is disabled on self-hosted", async () => {
+    cleanerEnv.NEXT_PUBLIC_CLEANER_ENABLED = false;
+
+    const response = await GET(createRequest("account-a"));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: "Cleaner is not enabled",
+      isKnownError: true,
+    });
+    expect(subscriberState.subscriber.psubscribe).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/app/api/email-stream/route.test.ts
+++ b/apps/web/app/api/email-stream/route.test.ts
@@ -1,0 +1,190 @@
+vi.mock("server-only", () => ({}));
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
+  const listeners = new Map<
+    string,
+    Set<(...args: [string, string, string]) => void>
+  >();
+
+  const getListeners = (event: string) => {
+    let eventListeners = listeners.get(event);
+
+    if (!eventListeners) {
+      eventListeners = new Set();
+      listeners.set(event, eventListeners);
+    }
+
+    return eventListeners;
+  };
+
+  const subscriber = {
+    psubscribe: vi.fn(
+      (_pattern: string, callback?: (error: Error | null) => void) => {
+        callback?.(null);
+      },
+    ),
+    punsubscribe: vi.fn(),
+    disconnect: vi.fn(),
+    on: vi.fn(
+      (
+        event: string,
+        listener: (...args: [string, string, string]) => void,
+      ) => {
+        getListeners(event).add(listener);
+        return subscriber;
+      },
+    ),
+    off: vi.fn(
+      (
+        event: string,
+        listener: (...args: [string, string, string]) => void,
+      ) => {
+        listeners.get(event)?.delete(listener);
+        return subscriber;
+      },
+    ),
+  };
+
+  return {
+    mockGetEmailAccount: vi.fn(),
+    subscriberState: {
+      subscriber,
+      emit(event: string, ...args: [string, string, string]) {
+        for (const listener of listeners.get(event) ?? []) {
+          listener(...args);
+        }
+      },
+      listenerCount(event: string) {
+        return listeners.get(event)?.size ?? 0;
+      },
+      reset() {
+        listeners.clear();
+        subscriber.psubscribe.mockClear();
+        subscriber.punsubscribe.mockClear();
+        subscriber.disconnect.mockClear();
+        subscriber.on.mockClear();
+        subscriber.off.mockClear();
+      },
+    },
+  };
+});
+
+vi.mock("@/utils/middleware", () => ({
+  withAuth:
+    (
+      _scope: string,
+      handler: (
+        request: NextRequest & {
+          auth: { userId: string };
+          logger: typeof mockLogger;
+        },
+      ) => Promise<Response>,
+    ) =>
+    (request: NextRequest) => {
+      const authRequest = request as NextRequest & {
+        auth: { userId: string };
+        logger: typeof mockLogger;
+      };
+
+      authRequest.auth = { userId: "user-1" };
+      authRequest.logger = mockLogger;
+
+      return handler(authRequest);
+    },
+}));
+
+vi.mock("@/utils/redis/account-validation", () => ({
+  getEmailAccount: (...args: unknown[]) => mockGetEmailAccount(...args),
+}));
+
+vi.mock("@/utils/redis/subscriber", () => ({
+  RedisSubscriber: {
+    createInstance: () => subscriberState.subscriber,
+  },
+}));
+
+import { GET } from "./route";
+
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+};
+
+describe("email-stream route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subscriberState.reset();
+    mockGetEmailAccount.mockImplementation(
+      async ({ emailAccountId }: { emailAccountId: string }) => ({
+        id: emailAccountId,
+      }),
+    );
+  });
+
+  it("only streams thread events for the authenticated email account", async () => {
+    const responseA = await GET(createRequest("account-a"));
+    const responseB = await GET(createRequest("account-b"));
+
+    const readA = readThreadEvent(responseA);
+    const readB = readThreadEvent(responseB);
+
+    subscriberState.emit(
+      "pmessage",
+      "thread:account-a:*",
+      "thread:account-a:thread-1",
+      JSON.stringify({ id: "message-a" }),
+    );
+    subscriberState.emit(
+      "pmessage",
+      "thread:account-b:*",
+      "thread:account-b:thread-1",
+      JSON.stringify({ id: "message-b" }),
+    );
+
+    expect(await readA).toContain('"message-a"');
+    expect(await readB).toContain('"message-b"');
+  });
+
+  it("removes the Redis listener when the request is aborted", async () => {
+    const abortController = new AbortController();
+    const response = await GET(createRequest("account-a", abortController));
+    const reader = response.body?.getReader();
+
+    expect(reader).toBeDefined();
+    expect(subscriberState.listenerCount("pmessage")).toBe(1);
+
+    abortController.abort();
+    await Promise.resolve();
+
+    expect(await reader?.read()).toEqual({ done: true, value: undefined });
+    expect(subscriberState.listenerCount("pmessage")).toBe(0);
+  });
+});
+
+function createRequest(
+  emailAccountId: string,
+  abortController = new AbortController(),
+) {
+  return new NextRequest(
+    `http://localhost:3000/api/email-stream?emailAccountId=${emailAccountId}`,
+    { signal: abortController.signal },
+  );
+}
+
+async function readThreadEvent(response: Response) {
+  const reader = response.body?.getReader();
+
+  if (!reader) throw new Error("Expected SSE response body");
+
+  const chunk = await reader.read();
+
+  if (chunk.done || !chunk.value) throw new Error("Expected SSE event chunk");
+
+  return new TextDecoder().decode(chunk.value);
+}

--- a/apps/web/app/api/email-stream/route.test.ts
+++ b/apps/web/app/api/email-stream/route.test.ts
@@ -148,41 +148,50 @@ describe("email-stream route", () => {
   });
 
   it("only streams thread events for the authenticated email account", async () => {
-    const responseA = await GET(createRequest("account-a"));
-    const responseB = await GET(createRequest("account-b"));
+    const abortControllerA = new AbortController();
+    const abortControllerB = new AbortController();
+    const responseA = await GET(createRequest("account-a", abortControllerA));
+    const responseB = await GET(createRequest("account-b", abortControllerB));
+    const readerA = getStreamReader(responseA);
+    const readerB = getStreamReader(responseB);
 
-    const readA = readThreadEvent(responseA);
-    const readB = readThreadEvent(responseB);
+    try {
+      const readA = readThreadEvent(readerA);
+      const readB = readThreadEvent(readerB);
 
-    subscriberState.emit(
-      "pmessage",
-      "thread:account-a:*",
-      "thread:account-a:thread-1",
-      JSON.stringify({ id: "message-a" }),
-    );
-    subscriberState.emit(
-      "pmessage",
-      "thread:account-b:*",
-      "thread:account-b:thread-1",
-      JSON.stringify({ id: "message-b" }),
-    );
+      subscriberState.emit(
+        "pmessage",
+        "thread:account-a:*",
+        "thread:account-a:thread-1",
+        JSON.stringify({ id: "message-a" }),
+      );
+      subscriberState.emit(
+        "pmessage",
+        "thread:account-b:*",
+        "thread:account-b:thread-1",
+        JSON.stringify({ id: "message-b" }),
+      );
 
-    expect(await readA).toContain('"message-a"');
-    expect(await readB).toContain('"message-b"');
+      expect(await readA).toContain('"message-a"');
+      expect(await readB).toContain('"message-b"');
+    } finally {
+      abortControllerA.abort();
+      abortControllerB.abort();
+      await Promise.all([readerA.read(), readerB.read()]);
+    }
   });
 
   it("removes the Redis listener when the request is aborted", async () => {
     const abortController = new AbortController();
     const response = await GET(createRequest("account-a", abortController));
-    const reader = response.body?.getReader();
+    const reader = getStreamReader(response);
 
-    expect(reader).toBeDefined();
     expect(subscriberState.listenerCount("pmessage")).toBe(1);
 
     abortController.abort();
     await Promise.resolve();
 
-    expect(await reader?.read()).toEqual({ done: true, value: undefined });
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
     expect(subscriberState.listenerCount("pmessage")).toBe(0);
   });
 
@@ -210,11 +219,15 @@ function createRequest(
   );
 }
 
-async function readThreadEvent(response: Response) {
+function getStreamReader(response: Response) {
   const reader = response.body?.getReader();
-
   if (!reader) throw new Error("Expected SSE response body");
+  return reader;
+}
 
+async function readThreadEvent(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+) {
   const chunk = await reader.read();
 
   if (chunk.done || !chunk.value) throw new Error("Expected SSE event chunk");

--- a/apps/web/app/api/email-stream/route.ts
+++ b/apps/web/app/api/email-stream/route.ts
@@ -2,6 +2,7 @@ import { RedisSubscriber } from "@/utils/redis/subscriber";
 import { withAuth } from "@/utils/middleware";
 import { NextResponse } from "next/server";
 import { getEmailAccount } from "@/utils/redis/account-validation";
+import { assertCleanerApiEnabled } from "@/utils/cleaner-feature";
 
 export const maxDuration = 300;
 
@@ -9,6 +10,8 @@ export const maxDuration = 300;
 const INACTIVITY_TIMEOUT = 5 * 60 * 1000;
 
 export const GET = withAuth("email-stream", async (request) => {
+  assertCleanerApiEnabled();
+
   const { userId } = request.auth;
 
   const url = new URL(request.url);

--- a/apps/web/app/api/email-stream/route.ts
+++ b/apps/web/app/api/email-stream/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth("email-stream", async (request) => {
   });
 
   const pattern = `thread:${emailAccountId}:*`;
-  const redisSubscriber = RedisSubscriber.getInstance();
+  const redisSubscriber = RedisSubscriber.createInstance();
 
   redisSubscriber.psubscribe(pattern, (err) => {
     if (err)
@@ -60,6 +60,7 @@ export const GET = withAuth("email-stream", async (request) => {
     async start(controller) {
       let inactivityTimer: NodeJS.Timeout;
       let isControllerClosed = false;
+      let isCleanedUp = false;
 
       const resetInactivityTimer = () => {
         if (inactivityTimer) clearTimeout(inactivityTimer);
@@ -71,40 +72,52 @@ export const GET = withAuth("email-stream", async (request) => {
             isControllerClosed = true;
             controller.close();
           }
-          redisSubscriber.punsubscribe(pattern);
+          cleanup();
         }, INACTIVITY_TIMEOUT);
+      };
+
+      const handleMessage = (
+        matchedPattern: string,
+        _channel: string,
+        message: string,
+      ) => {
+        if (matchedPattern !== pattern || isControllerClosed) return;
+
+        try {
+          controller.enqueue(
+            encoder.encode(`event: thread\ndata: ${message}\n\n`),
+          );
+          resetInactivityTimer();
+        } catch (error) {
+          request.logger.error("Error enqueueing message", { error });
+          isControllerClosed = true;
+          cleanup();
+        }
+      };
+
+      const cleanup = () => {
+        if (isCleanedUp) return;
+
+        isCleanedUp = true;
+        clearTimeout(inactivityTimer);
+        redisSubscriber.off("pmessage", handleMessage);
+        redisSubscriber.disconnect();
       };
 
       // Start initial inactivity timer
       resetInactivityTimer();
 
-      redisSubscriber.on("pmessage", (_pattern, _channel, message) => {
-        // Only enqueue if controller is not closed
-        if (!isControllerClosed) {
-          try {
-            controller.enqueue(
-              encoder.encode(`event: thread\ndata: ${message}\n\n`),
-            );
-            resetInactivityTimer(); // Reset timer on message
-          } catch (error) {
-            request.logger.error("Error enqueueing message", { error });
-            // If we hit an error, mark controller as closed and clean up
-            isControllerClosed = true;
-            redisSubscriber.punsubscribe(pattern);
-          }
-        }
-      });
+      redisSubscriber.on("pmessage", handleMessage);
 
       request.signal.addEventListener("abort", () => {
         request.logger.info("Cleaning up Redis subscription", {
           emailAccountId,
         });
-        clearTimeout(inactivityTimer);
         if (!isControllerClosed) {
           isControllerClosed = true;
           controller.close();
         }
-        redisSubscriber.punsubscribe(pattern);
+        cleanup();
       });
     },
   });

--- a/apps/web/utils/cleaner-feature.test.ts
+++ b/apps/web/utils/cleaner-feature.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SafeError } from "@/utils/error";
+
+const { featureEnv } = vi.hoisted(() => ({
+  featureEnv: {
+    NEXT_PUBLIC_CLEANER_ENABLED: false,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: featureEnv,
+}));
+
+import { assertCleanerApiEnabled } from "./cleaner-feature";
+
+describe("assertCleanerApiEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    featureEnv.NEXT_PUBLIC_CLEANER_ENABLED = false;
+  });
+
+  it("throws on self-hosted deployments when cleaner is disabled", () => {
+    expect(() => assertCleanerApiEnabled()).toThrowError(
+      new SafeError("Cleaner is not enabled", 404),
+    );
+  });
+
+  it("allows self-hosted deployments when cleaner is enabled", () => {
+    featureEnv.NEXT_PUBLIC_CLEANER_ENABLED = true;
+
+    expect(() => assertCleanerApiEnabled()).not.toThrow();
+  });
+
+  it("allows Vercel deployments without the env gate", () => {
+    vi.stubEnv("VERCEL", "1");
+
+    expect(() => assertCleanerApiEnabled()).not.toThrow();
+  });
+});

--- a/apps/web/utils/cleaner-feature.ts
+++ b/apps/web/utils/cleaner-feature.ts
@@ -1,0 +1,9 @@
+import { env } from "@/env";
+import { SafeError } from "@/utils/error";
+
+export function assertCleanerApiEnabled() {
+  if (process.env.VERCEL === "1") return;
+  if (env.NEXT_PUBLIC_CLEANER_ENABLED) return;
+
+  throw new SafeError("Cleaner is not enabled", 404);
+}

--- a/apps/web/utils/redis/subscriber.ts
+++ b/apps/web/utils/redis/subscriber.ts
@@ -6,36 +6,23 @@ const logger = createScopedLogger("ioredis");
 
 // biome-ignore lint/complexity/noStaticOnlyClass: ignore
 class RedisSubscriber {
-  private static instance: Redis | null = null;
-
-  static getInstance(): Redis {
-    if (!RedisSubscriber.instance) {
-      if (!env.REDIS_URL) {
-        throw new Error("REDIS_URL is not set");
-      }
-
-      logger.info("Initializing Redis subscriber connection");
-      RedisSubscriber.instance = new Redis(env.REDIS_URL);
-
-      // Handle connection events
-      RedisSubscriber.instance.on("error", (error) => {
-        logger.error("Redis connection error", { error });
-      });
-
-      RedisSubscriber.instance.on("connect", () => {
-        logger.info("Redis connected successfully");
-      });
+  static createInstance(): Redis {
+    if (!env.REDIS_URL) {
+      throw new Error("REDIS_URL is not set");
     }
 
-    return RedisSubscriber.instance;
-  }
+    logger.info("Initializing Redis subscriber connection");
+    const redisSubscriber = new Redis(env.REDIS_URL);
 
-  static disconnect(): void {
-    if (RedisSubscriber.instance) {
-      RedisSubscriber.instance.disconnect();
-      RedisSubscriber.instance = null;
-      logger.info("Redis disconnected");
-    }
+    redisSubscriber.on("error", (error) => {
+      logger.error("Redis connection error", { error });
+    });
+
+    redisSubscriber.on("connect", () => {
+      logger.info("Redis connected successfully");
+    });
+
+    return redisSubscriber;
   }
 }
 


### PR DESCRIPTION
Isolates email stream Redis subscriptions per request to prevent cross-account SSE delivery.

- replace shared subscriber usage with per-request subscriber instances
- remove listeners and disconnect Redis clients during stream cleanup
- add regression tests for concurrent streams and abort cleanup