### PR TITLE
release: update Homebrew formula for v2.29.3

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 jobs:
   build:
@@ -177,10 +178,15 @@ jobs:
           print(content)
           EOF
 
-      - name: Commit formula update
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add Formula/inbox-zero.rb
-          git diff --staged --quiet || git commit -m "chore: update Homebrew formula for ${{ steps.version.outputs.tag }}"
-          git push origin HEAD:main
+      - name: Create formula update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: Formula/inbox-zero.rb
+          branch: automation/homebrew-formula-${{ steps.version.outputs.version }}
+          base: main
+          commit-message: "chore: update Homebrew formula for ${{ steps.version.outputs.tag }}"
+          title: "chore: update Homebrew formula for ${{ steps.version.outputs.tag }}"
+          body: |
+            Update the Homebrew formula for the new CLI release.
+          delete-branch: true

--- a/Formula/inbox-zero.rb
+++ b/Formula/inbox-zero.rb
@@ -3,13 +3,13 @@
 class InboxZero < Formula
   desc "CLI tool for setting up Inbox Zero - AI email assistant"
   homepage "https://www.getinboxzero.com"
-  version "2.29.2"
+  version "2.29.3"
   license "AGPL-3.0-only"
 
   on_macos do
     on_arm do
-      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.2/inbox-zero-darwin-arm64.tar.gz"
-      sha256 "82c16d708e8b892818c38c3250ffc45c9e80e9cff2341faf7580cb920523c0ee"
+      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.3/inbox-zero-darwin-arm64.tar.gz"
+      sha256 "1e6f0ef0f5556efe56bd3bf83e2b6f2172905858fda7a5c317b2ec3d45800841"
 
       def install
         bin.install "inbox-zero-darwin-arm64" => "inbox-zero"
@@ -17,8 +17,8 @@ class InboxZero < Formula
     end
 
     on_intel do
-      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.2/inbox-zero-darwin-x64.tar.gz"
-      sha256 "9e1de1c0e65c68024faf7f31d3c6830f517914625415fa31af614cc43bbfabc6"
+      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.3/inbox-zero-darwin-x64.tar.gz"
+      sha256 "0871d76cb0d9505cd4fc53666cb7ec819bdd18713f7c1b00b6780b881e4f6cf9"
 
       def install
         bin.install "inbox-zero-darwin-x64" => "inbox-zero"
@@ -28,8 +28,8 @@ class InboxZero < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.2/inbox-zero-linux-x64.tar.gz"
-      sha256 "ef257ee5bafe474275d405099b05ce2c5c63fa2ecf675737ea3b6d45d97deac7"
+      url "https://github.com/elie222/inbox-zero/releases/download/v2.29.3/inbox-zero-linux-x64.tar.gz"
+      sha256 "1e46f0aba30905a877509c29a65fcca5be45d7391a1b5e27125bf05518e53be6"
 
       def install
         bin.install "inbox-zero-linux-x64" => "inbox-zero"
@@ -41,4 +41,3 @@ class InboxZero < Formula
     assert_match version.to_s, shell_output("#{bin}/inbox-zero --version")
   end
 end
-


### PR DESCRIPTION
Catch up the Homebrew formula after the original `v2.29.3` release workflow failed to push to protected `main`.

- bump the formula from 2.29.2 to 2.29.3
- point all platform URLs at the v2.29.3 release assets
- update the SHA256 values for the published tarballs