### PR TITLE
[codex] Support multiple app review demo accounts

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -256,7 +256,6 @@ LOOPS_API_SECRET=
 # IS_OAUTH_PROXY_SERVER=false # Set to true on the server that acts as the OAuth proxy (e.g., staging)
 # ADDITIONAL_TRUSTED_ORIGINS=https://*.vercel.app # Comma-separated list of trusted origins for CORS (supports wildcards)
 # MOBILE_AUTH_ORIGIN=inboxzero:// # Mobile auth deep link origin
-
 # Local development emulators (optional)
 # GOOGLE_EMULATOR_PORT=4002
 # GOOGLE_BASE_URL=http://localhost:4002

--- a/apps/web/app/api/mobile-review/README.md
+++ b/apps/web/app/api/mobile-review/README.md
@@ -1,0 +1,17 @@
+# Mobile App Review Access
+
+These endpoints support internal App Store review access for the private mobile
+app. Do not list these settings in `.env.example`; regular self-hosted users do
+not need them.
+
+Configure `APP_REVIEW_DEMO_ACCOUNTS` with every account App Review needs, such
+as one active account and one expired-subscription account:
+
+```env
+APP_REVIEW_DEMO_ENABLED=true
+APP_REVIEW_DEMO_ACCOUNTS='[{"email":"review-active@example.com","code":"active-password"},{"email":"review-expired@example.com","code":"expired-password"}]'
+```
+
+Each entry maps the email entered in the mobile login form to the access code
+used as the password. The sign-in endpoint requires email and matches both
+values before creating a session.

--- a/apps/web/app/api/mobile-review/sign-in/route.test.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.test.ts
@@ -48,7 +48,10 @@ describe("mobile review sign-in route", () => {
     const request = new NextRequest(
       "http://localhost/api/mobile-review/sign-in",
       {
-        body: JSON.stringify({ code: "review-code" }),
+        body: JSON.stringify({
+          code: "review-code",
+          email: "review@example.com",
+        }),
         headers: {
           "content-type": "application/json",
         },
@@ -62,6 +65,7 @@ describe("mobile review sign-in route", () => {
 
     expect(createMobileReviewSessionMock).toHaveBeenCalledWith({
       code: "review-code",
+      email: "review@example.com",
       logger: request.logger,
     });
     expect(body).toEqual({ success: true });
@@ -78,5 +82,22 @@ describe("mobile review sign-in route", () => {
         reviewUserId: "user-1",
       },
     );
+  });
+
+  it("rejects sign-in requests without an email", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/mobile-review/sign-in",
+      {
+        body: JSON.stringify({ code: "review-code" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    ) as NextRequest & { logger: { info: typeof loggerInfoMock } };
+    request.logger = { info: loggerInfoMock };
+
+    await expect(POST(request, {} as never)).rejects.toThrow();
+    expect(createMobileReviewSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/mobile-review/sign-in/route.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.ts
@@ -5,12 +5,14 @@ import { createMobileReviewSession } from "@/utils/mobile-review";
 
 const signInSchema = z.object({
   code: z.string().trim().min(1).max(128),
+  email: z.string().trim().email(),
 });
 
 export const POST = withError("mobile-review/sign-in", async (request) => {
   const body = signInSchema.parse(await request.json());
   const result = await createMobileReviewSession({
     code: body.code,
+    email: body.email,
     logger: request.logger,
   });
 

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -255,8 +255,7 @@ const parsedEnv = createEnv({
     TELEGRAM_BOT_TOKEN: z.string().optional(),
     TELEGRAM_BOT_SECRET_TOKEN: z.string().optional(),
     APP_REVIEW_DEMO_ENABLED: booleanString.optional().default(false),
-    APP_REVIEW_DEMO_CODE: z.string().optional(),
-    APP_REVIEW_DEMO_EMAIL: z.string().email().optional(),
+    APP_REVIEW_DEMO_ACCOUNTS: z.string().optional(),
     SSO_LOGIN_ENABLED: booleanString.optional().default(false),
   },
   client: {

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -4,16 +4,15 @@ vi.mock("server-only", () => ({}));
 
 const {
   createSessionMock,
-  emailAccountFindUniqueMock,
+  emailAccountFindManyMock,
   makeSignatureMock,
   mockedEnv,
 } = vi.hoisted(() => ({
   createSessionMock: vi.fn(),
-  emailAccountFindUniqueMock: vi.fn(),
+  emailAccountFindManyMock: vi.fn(),
   makeSignatureMock: vi.fn(),
   mockedEnv: {
-    APP_REVIEW_DEMO_CODE: "review-code",
-    APP_REVIEW_DEMO_EMAIL: "review@example.com",
+    APP_REVIEW_DEMO_ACCOUNTS: undefined as string | undefined,
     APP_REVIEW_DEMO_ENABLED: true,
   },
 }));
@@ -54,7 +53,7 @@ vi.mock("@/utils/auth", () => ({
 vi.mock("@/utils/prisma", () => ({
   default: {
     emailAccount: {
-      findUnique: (...args: unknown[]) => emailAccountFindUniqueMock(...args),
+      findMany: (...args: unknown[]) => emailAccountFindManyMock(...args),
     },
   },
 }));
@@ -83,8 +82,9 @@ describe("mobile review access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedEnv.APP_REVIEW_DEMO_ENABLED = true;
-    mockedEnv.APP_REVIEW_DEMO_CODE = "review-code";
-    mockedEnv.APP_REVIEW_DEMO_EMAIL = "review@example.com";
+    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
+      { email: "review@example.com", code: "review-code" },
+    ]);
     makeSignatureMock.mockResolvedValue("signed-token");
     createSessionMock.mockResolvedValue({
       expiresAt: new Date("2026-05-01T00:00:00.000Z"),
@@ -94,7 +94,7 @@ describe("mobile review access", () => {
 
   it("reports disabled status when the configured review account has no email account", async () => {
     const logger = createLogger();
-    emailAccountFindUniqueMock.mockResolvedValueOnce(null);
+    emailAccountFindManyMock.mockResolvedValueOnce([]);
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
 
@@ -102,23 +102,30 @@ describe("mobile review access", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "Mobile review access unavailable",
       expect.objectContaining({
-        hasEmailAccount: false,
-        ok: false,
-        reason: "review_user_missing_email_account",
+        count: 1,
+        reasons: [
+          expect.objectContaining({
+            hasEmailAccount: false,
+            ok: false,
+            reason: "review_user_missing_email_account",
+          }),
+        ],
       }),
     );
   });
 
   it("reports enabled status when the configured review account is usable", async () => {
     const logger = createLogger();
-    emailAccountFindUniqueMock.mockResolvedValueOnce({
-      email: "review@example.com",
-      id: "account-1",
-      user: {
-        email: "owner@example.com",
-        id: "user-1",
+    emailAccountFindManyMock.mockResolvedValueOnce([
+      {
+        email: "review@example.com",
+        id: "account-1",
+        user: {
+          email: "owner@example.com",
+          id: "user-1",
+        },
       },
-    });
+    ]);
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
 
@@ -129,7 +136,7 @@ describe("mobile review access", () => {
   it("reports disabled status when the review user lookup fails", async () => {
     const logger = createLogger();
     const error = new Error("database unavailable");
-    emailAccountFindUniqueMock.mockRejectedValueOnce(error);
+    emailAccountFindManyMock.mockRejectedValueOnce(error);
 
     const result = await getMobileReviewAccessStatus({ logger } as never);
 
@@ -143,18 +150,76 @@ describe("mobile review access", () => {
     );
   });
 
+  it("reports disabled status when review account config is invalid", async () => {
+    const logger = createLogger();
+    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
+      { email: "not-an-email", code: "review-code" },
+    ]);
+
+    const result = await getMobileReviewAccessStatus({ logger } as never);
+
+    expect(result).toEqual({ enabled: false });
+    expect(emailAccountFindManyMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Mobile review access unavailable",
+      expect.objectContaining({
+        hasReviewDemoAccounts: false,
+        reason: "review_demo_misconfigured",
+      }),
+    );
+  });
+
+  it("reports disabled status when any configured review account is missing", async () => {
+    const logger = createLogger();
+    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
+      { email: "active-review@example.com", code: "active-code" },
+      { email: "expired-review@example.com", code: "expired-code" },
+    ]);
+    emailAccountFindManyMock.mockResolvedValueOnce([
+      {
+        email: "active-review@example.com",
+        id: "account-active",
+        user: {
+          email: "active-owner@example.com",
+          id: "user-active",
+        },
+      },
+    ]);
+
+    const result = await getMobileReviewAccessStatus({ logger } as never);
+
+    expect(result).toEqual({ enabled: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Mobile review access unavailable",
+      expect.objectContaining({
+        count: 1,
+        reasons: [
+          expect.objectContaining({
+            hasEmailAccount: false,
+            ok: false,
+            reason: "review_user_missing_email_account",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("rejects invalid review codes before querying the database", async () => {
     const logger = createLogger();
 
     await expect(
-      createMobileReviewSession({ code: "wrong-code", logger } as never),
+      createMobileReviewSession({
+        code: "wrong-code",
+        email: "review@example.com",
+        logger,
+      } as never),
     ).rejects.toMatchObject({
       message: "Invalid review access code",
       safeMessage: "Invalid review access code",
       statusCode: 401,
     });
 
-    expect(emailAccountFindUniqueMock).not.toHaveBeenCalled();
+    expect(emailAccountFindManyMock).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith("Mobile review sign-in rejected", {
       reason: "invalid_review_demo_code",
     });
@@ -162,10 +227,14 @@ describe("mobile review access", () => {
 
   it("rejects valid review codes when the configured review account cannot create a session", async () => {
     const logger = createLogger();
-    emailAccountFindUniqueMock.mockResolvedValueOnce(null);
+    emailAccountFindManyMock.mockResolvedValueOnce([]);
 
     await expect(
-      createMobileReviewSession({ code: "review-code", logger } as never),
+      createMobileReviewSession({
+        code: "review-code",
+        email: "review@example.com",
+        logger,
+      } as never),
     ).rejects.toMatchObject({
       message: "Review access is unavailable",
       safeMessage: "Review access is unavailable",
@@ -179,5 +248,45 @@ describe("mobile review access", () => {
         reason: "review_user_missing_email_account",
       }),
     );
+  });
+
+  it("creates a session for the matching configured review account", async () => {
+    const logger = createLogger();
+    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
+      { email: "active-review@example.com", code: "active-code" },
+      { email: "expired-review@example.com", code: "expired-code" },
+    ]);
+    emailAccountFindManyMock.mockResolvedValueOnce([
+      {
+        email: "expired-review@example.com",
+        id: "account-expired",
+        user: {
+          email: "expired-owner@example.com",
+          id: "user-expired",
+        },
+      },
+    ]);
+
+    const result = await createMobileReviewSession({
+      code: "expired-code",
+      email: "Expired-Review@Example.com",
+      logger,
+    } as never);
+
+    expect(emailAccountFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          email: {
+            in: ["expired-review@example.com"],
+          },
+        },
+      }),
+    );
+    expect(createSessionMock).toHaveBeenCalledWith("user-expired", false, {});
+    expect(result).toMatchObject({
+      emailAccountId: "account-expired",
+      userEmail: "expired-owner@example.com",
+      userId: "user-expired",
+    });
   });
 });

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import { makeSignature } from "better-auth/crypto";
+import { z } from "zod";
 import { env } from "@/env";
 import { betterAuthConfig } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
@@ -9,8 +10,7 @@ import prisma from "@/utils/prisma";
 type MobileReviewConfigResult =
   | {
       ok: true;
-      reviewDemoCode: string;
-      reviewDemoEmail: string;
+      reviewDemoAccounts: MobileReviewAccount[];
     }
   | {
       ok: false;
@@ -18,8 +18,7 @@ type MobileReviewConfigResult =
     }
   | {
       ok: false;
-      hasReviewDemoCode: boolean;
-      hasReviewDemoEmail: boolean;
+      hasReviewDemoAccounts: boolean;
       reason: "review_demo_misconfigured";
     };
 
@@ -38,11 +37,21 @@ type MobileReviewUserResult =
       reason: "review_user_missing_email_account";
     };
 
+type MobileReviewAccount = {
+  code: string;
+  email: string;
+};
+
+const reviewDemoAccountsSchema = z.array(
+  z.object({
+    code: z.string().trim().min(1),
+    email: z.string().trim().toLowerCase().email(),
+  }),
+);
+
 export function isMobileReviewEnabled(): boolean {
   return Boolean(
-    env.APP_REVIEW_DEMO_ENABLED &&
-      env.APP_REVIEW_DEMO_CODE?.trim() &&
-      env.APP_REVIEW_DEMO_EMAIL?.trim(),
+    env.APP_REVIEW_DEMO_ENABLED && getConfiguredReviewAccounts().length > 0,
   );
 }
 
@@ -56,9 +65,9 @@ export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
     return { enabled: false as const };
   }
 
-  let reviewUser: MobileReviewUserResult;
+  let reviewUsers: MobileReviewUserResult[];
   try {
-    reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+    reviewUsers = await getMobileReviewUsers(config.reviewDemoAccounts);
   } catch (error) {
     input.logger.warn("Mobile review access unavailable", {
       reason: "review_user_lookup_failed",
@@ -67,8 +76,12 @@ export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
     return { enabled: false as const };
   }
 
-  if (!reviewUser.ok) {
-    input.logger.warn("Mobile review access unavailable", reviewUser);
+  const missingReviewUsers = reviewUsers.filter((reviewUser) => !reviewUser.ok);
+  if (missingReviewUsers.length) {
+    input.logger.warn("Mobile review access unavailable", {
+      count: missingReviewUsers.length,
+      reasons: missingReviewUsers,
+    });
     return { enabled: false as const };
   }
 
@@ -77,6 +90,7 @@ export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
 
 export async function createMobileReviewSession(input: {
   code: string;
+  email: string;
   logger: Logger;
 }) {
   const config = getMobileReviewConfig();
@@ -88,14 +102,20 @@ export async function createMobileReviewSession(input: {
     throw new SafeError("Review access is unavailable");
   }
 
-  if (!codesMatch(input.code, config.reviewDemoCode)) {
+  const reviewDemoAccount = getMatchingReviewAccount({
+    code: input.code,
+    email: input.email,
+    reviewDemoAccounts: config.reviewDemoAccounts,
+  });
+
+  if (!reviewDemoAccount) {
     input.logger.warn("Mobile review sign-in rejected", {
       reason: "invalid_review_demo_code",
     });
     throw new SafeError("Invalid review access code", 401);
   }
 
-  const reviewUser = await getMobileReviewUser(config.reviewDemoEmail);
+  const reviewUser = (await getMobileReviewUsers([reviewDemoAccount]))[0];
   if (!reviewUser.ok) {
     input.logger.warn("Mobile review sign-in unavailable", reviewUser);
     throw new SafeError("Review access is unavailable");
@@ -170,30 +190,61 @@ function getMobileReviewConfig(): MobileReviewConfigResult {
     return { ok: false, reason: "review_demo_disabled" };
   }
 
-  const reviewDemoCode = env.APP_REVIEW_DEMO_CODE?.trim();
-  const reviewDemoEmail = env.APP_REVIEW_DEMO_EMAIL?.trim().toLowerCase();
+  const reviewDemoAccounts = getConfiguredReviewAccounts();
 
-  if (!reviewDemoCode || !reviewDemoEmail) {
+  if (!reviewDemoAccounts.length) {
     return {
       ok: false,
-      hasReviewDemoCode: Boolean(reviewDemoCode),
-      hasReviewDemoEmail: Boolean(reviewDemoEmail),
+      hasReviewDemoAccounts: false,
       reason: "review_demo_misconfigured",
     };
   }
 
   return {
     ok: true,
-    reviewDemoCode,
-    reviewDemoEmail,
+    reviewDemoAccounts,
   };
 }
 
-async function getMobileReviewUser(
-  reviewDemoEmail: string,
-): Promise<MobileReviewUserResult> {
-  const emailAccount = await prisma.emailAccount.findUnique({
-    where: { email: reviewDemoEmail },
+function getConfiguredReviewAccounts(): MobileReviewAccount[] {
+  return parseReviewDemoAccounts(env.APP_REVIEW_DEMO_ACCOUNTS);
+}
+
+function parseReviewDemoAccounts(
+  value: string | undefined,
+): MobileReviewAccount[] {
+  if (!value?.trim()) return [];
+
+  try {
+    const parsed = reviewDemoAccountsSchema.safeParse(JSON.parse(value));
+    return parsed.success ? parsed.data : [];
+  } catch {
+    return [];
+  }
+}
+
+function getMatchingReviewAccount(input: {
+  code: string;
+  email: string;
+  reviewDemoAccounts: MobileReviewAccount[];
+}) {
+  const normalizedEmail = input.email.trim().toLowerCase();
+
+  return input.reviewDemoAccounts.find((account) => {
+    if (account.email !== normalizedEmail) return false;
+    return codesMatch(input.code, account.code);
+  });
+}
+
+async function getMobileReviewUsers(
+  reviewDemoAccounts: MobileReviewAccount[],
+): Promise<MobileReviewUserResult[]> {
+  const emailAccounts = await prisma.emailAccount.findMany({
+    where: {
+      email: {
+        in: reviewDemoAccounts.map((account) => account.email),
+      },
+    },
     select: {
       email: true,
       id: true,
@@ -206,20 +257,27 @@ async function getMobileReviewUser(
     },
   });
 
-  if (!emailAccount) {
-    return {
-      ok: false,
-      hasEmailAccount: false,
-      reason: "review_user_missing_email_account",
-    };
-  }
+  const accountsByEmail = new Map(
+    emailAccounts.map((account) => [account.email.toLowerCase(), account]),
+  );
 
-  return {
-    ok: true,
-    user: {
-      email: emailAccount.user.email,
-      emailAccountId: emailAccount.id,
-      id: emailAccount.user.id,
-    },
-  };
+  return reviewDemoAccounts.map((reviewDemoAccount) => {
+    const emailAccount = accountsByEmail.get(reviewDemoAccount.email);
+    if (!emailAccount) {
+      return {
+        ok: false,
+        hasEmailAccount: false,
+        reason: "review_user_missing_email_account",
+      };
+    }
+
+    return {
+      ok: true,
+      user: {
+        email: emailAccount.user.email,
+        emailAccountId: emailAccount.id,
+        id: emailAccount.user.id,
+      },
+    };
+  });
 }

--- a/turbo.json
+++ b/turbo.json
@@ -211,8 +211,7 @@
         "NEXT_PUBLIC_AUTO_DRAFT_DISABLED",
         "SUPERWALL_APP_STORE_CONNECT_FORWARD_URL",
         "APP_REVIEW_DEMO_ENABLED",
-        "APP_REVIEW_DEMO_CODE",
-        "APP_REVIEW_DEMO_EMAIL",
+        "APP_REVIEW_DEMO_ACCOUNTS",
         "SSO_LOGIN_ENABLED"
       ],
       "outputs": [".next/**", "!.next/cache/**"]
@@ -292,8 +291,7 @@
         "NEXT_PUBLIC_AUTO_DRAFT_DISABLED",
         "SUPERWALL_APP_STORE_CONNECT_FORWARD_URL",
         "APP_REVIEW_DEMO_ENABLED",
-        "APP_REVIEW_DEMO_CODE",
-        "APP_REVIEW_DEMO_EMAIL",
+        "APP_REVIEW_DEMO_ACCOUNTS",
         "SSO_LOGIN_ENABLED"
       ],
       "outputs": [".next/**", "!.next/cache/**"]


### PR DESCRIPTION
## Summary
- add APP_REVIEW_DEMO_ACCOUNTS JSON config for mobile App Review demo credentials
- require mobile review sign-in to include email, then route by email plus access code so App Review can use active and expired demo accounts
- validate all configured demo accounts in the review status endpoint, failing closed if any configured account is missing
- update turbo build env allowlists to use APP_REVIEW_DEMO_ACCOUNTS and remove the old review env names
- document the internal env shape next to the mobile-review endpoint instead of the public .env.example

## Why
Apple App Review needs credentials for a demo account with an expired subscription so they can reach and review the subscription page and purchase flow. Previously the backend only supported one configured review account, and code-only sign-in made multi-account routing ambiguous.

## Validation
- pnpm exec vitest run utils/mobile-review.test.ts app/api/mobile-review/sign-in/route.test.ts
- pnpm exec biome check turbo.json apps/web/app/api/mobile-review/README.md apps/web/.env.example apps/web/utils/mobile-review.ts apps/web/app/api/mobile-review/sign-in/route.ts apps/web/utils/mobile-review.test.ts apps/web/app/api/mobile-review/sign-in/route.test.ts apps/web/env.ts