### PR TITLE
billing: Restrict digest processing by plan

### DIFF
--- a/apps/web/app/(app)/premium/config.ts
+++ b/apps/web/app/(app)/premium/config.ts
@@ -309,6 +309,11 @@ const plusTier: Tier = {
         "Forward important emails and notifications to your Slack channels automatically.",
     },
     {
+      text: "Email digests",
+      tooltip:
+        "Group emails from selected rules into a scheduled summary instead of reading each message individually.",
+    },
+    {
       text: "Auto-file attachments",
       tooltip:
         "Automatically organize and file email attachments to your preferred storage.",

--- a/apps/web/app/(landing)/pricing/PricingComparisonTable.tsx
+++ b/apps/web/app/(landing)/pricing/PricingComparisonTable.tsx
@@ -58,6 +58,12 @@ const features: {
     professional: true,
   },
   {
+    name: "Email digests",
+    starter: false,
+    plus: true,
+    professional: true,
+  },
+  {
     name: "Slack integration",
     starter: false,
     plus: true,

--- a/apps/web/app/api/ai/digest/route.ts
+++ b/apps/web/app/api/ai/digest/route.ts
@@ -13,6 +13,7 @@ import {
   releaseDigestSummarySlot,
   reserveDigestSummarySlot,
 } from "@/utils/digest/summary-limit";
+import { checkHasAccess } from "@/utils/premium/server";
 
 export const POST = withError(
   "digest",
@@ -28,6 +29,15 @@ export const POST = withError(
       const emailAccount = await getEmailAccountWithAi({ emailAccountId });
       if (!emailAccount) {
         throw new Error("Email account not found");
+      }
+
+      const hasDigestAccess = await checkHasAccess({
+        userId: emailAccount.userId,
+        minimumTier: "PLUS_MONTHLY",
+      });
+      if (!hasDigestAccess) {
+        logger.info("Skipping digest item because plan does not include it");
+        return new NextResponse("OK", { status: 200 });
       }
 
       // Don't summarize Digest emails (this will actually block all emails that we send, but that's okay)

--- a/apps/web/app/api/resend/digest/all/route.ts
+++ b/apps/web/app/api/resend/digest/all/route.ts
@@ -46,7 +46,7 @@ async function sendDigestAllUpdate(logger: Logger) {
       digestSchedule: {
         nextOccurrenceAt: { lte: now },
       },
-      ...getPremiumUserFilter(),
+      ...getPremiumUserFilter({ minimumTier: "PLUS_MONTHLY" }),
       createdAt: {
         lt: subDays(now, 1),
       },

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -25,6 +25,7 @@ import {
   sendMessagingRuleNotification,
 } from "@/utils/messaging/rule-notifications";
 import { isMessagingDraftActionType } from "@/utils/actions/draft-reply";
+import { checkHasAccess } from "@/utils/premium/server";
 
 const MODULE = "ai-actions";
 
@@ -456,6 +457,15 @@ const digest: ActionFunction<{ id?: string }> = async ({
   logger,
 }) => {
   if (!args.id) return;
+  const hasDigestAccess = await checkHasAccess({
+    userId: emailAccount.userId,
+    minimumTier: "PLUS_MONTHLY",
+  });
+  if (!hasDigestAccess) {
+    logger.info("Skipping digest action because plan does not include it");
+    return;
+  }
+
   const actionId = args.id;
   await enqueueDigestItem({
     email,

--- a/apps/web/utils/premium/index.test.ts
+++ b/apps/web/utils/premium/index.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/env", () => ({
 }));
 
 import {
+  getPremiumUserFilter,
   getUserTier,
   hasActiveAppleSubscription,
   isPremium,
@@ -72,5 +73,26 @@ describe("Apple premium helpers", () => {
     envMock.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS = true;
 
     expect(isPremiumRecord(null)).toBe(true);
+  });
+});
+
+describe("digest access", () => {
+  afterEach(() => {
+    envMock.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS = false;
+  });
+
+  it("filters premium users by minimum tier when requested", () => {
+    const filter = getPremiumUserFilter({ minimumTier: "PLUS_MONTHLY" });
+
+    expect(filter.user.premium.tier).toEqual({
+      in: [
+        "PLUS_MONTHLY",
+        "PLUS_ANNUALLY",
+        "PROFESSIONAL_MONTHLY",
+        "PROFESSIONAL_ANNUALLY",
+        "COPILOT_MONTHLY",
+        "LIFETIME",
+      ],
+    });
   });
 });

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -147,6 +147,14 @@ const tierRanking = {
   LIFETIME: 12,
 };
 
+function getTiersAtOrAbove(minimumTier: PremiumTier): PremiumTier[] {
+  const minimumRanking = tierRanking[minimumTier];
+
+  return Object.entries(tierRanking)
+    .filter(([, ranking]) => ranking >= minimumRanking)
+    .map(([tier]) => tier as PremiumTier);
+}
+
 export const hasUnsubscribeAccess = (
   tier: PremiumTier | null,
   unsubscribeCredits?: number | null,
@@ -204,12 +212,19 @@ export function isOnHigherTier(
   return tier1Rank > tier2Rank;
 }
 
-export function getPremiumUserFilter() {
+export function getPremiumUserFilter({
+  minimumTier,
+}: {
+  minimumTier?: PremiumTier;
+} = {}) {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return {};
 
   return {
     user: {
       premium: {
+        ...(minimumTier
+          ? { tier: { in: getTiersAtOrAbove(minimumTier) } }
+          : {}),
         OR: [
           {
             AND: [


### PR DESCRIPTION
Limits digest processing to eligible paid tiers in the rule action, digest summarization route, and scheduled digest selection.

- Adds an optional minimum-tier filter to the shared premium query helper.
- Updates pricing surfaces to list email digests on the eligible plan tier.
- Adds focused coverage for the tier-filtered premium query.

Tests: pnpm test --run utils/premium/index.test.ts