### PR TITLE
billing: Add admin premium grants

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
@@ -22,7 +22,7 @@ import {
 import { hasActiveAppleSubscription } from "@/utils/premium";
 
 export function BillingSection() {
-  const { premium, isPremium, isLoading } = usePremium();
+  const { premium, isPremium, isLoading, tier } = usePremium();
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
   const hasAppleSubscription = hasActiveAppleSubscription(
     premium?.appleExpiresAt || null,
@@ -35,7 +35,7 @@ export function BillingSection() {
       {premium && isPremium ? (
         <Item size="sm">
           <ItemContent>
-            <ItemTitle>{getPremiumTierName(premium.tier)} plan</ItemTitle>
+            <ItemTitle>{getPremiumTierName(tier)} plan</ItemTitle>
             {hasAppleSubscription ? (
               <ItemDescription>
                 This subscription is billed through Apple. Manage or cancel it

--- a/apps/web/app/(app)/[emailAccountId]/settings/MultiAccountSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/MultiAccountSection.tsx
@@ -98,7 +98,7 @@ export function MultiAccountSection() {
                 <div className="mt-4">
                   <MultiAccountForm
                     emailAddresses={data.emailAccounts}
-                    isLifetime={premium?.tier === "LIFETIME"}
+                    isLifetime={premiumTier === "LIFETIME"}
                     emailAccountsAccess={premium?.emailAccountsAccess || 0}
                     pendingInvites={premium?.pendingInvites || []}
                     onUpdate={mutate}

--- a/apps/web/app/(app)/[emailAccountId]/settings/MultiAccountSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/MultiAccountSection.tsx
@@ -24,7 +24,7 @@ import type { MultiAccountEmailsResponse } from "@/app/api/user/settings/multi-a
 import { AlertBasic, AlertWithButton } from "@/components/Alert";
 import { usePremium } from "@/hooks/usePremium";
 import type { PremiumTier } from "@/generated/prisma/enums";
-import { getUserTier, isAdminForPremium } from "@/utils/premium";
+import { isAdminForPremium } from "@/utils/premium";
 import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 import { useAction } from "next-safe-action/hooks";
 import { toastError, toastSuccess } from "@/components/Toast";
@@ -38,11 +38,10 @@ export function MultiAccountSection() {
   const {
     isPremium,
     premium,
+    tier: premiumTier,
     isLoading: isLoadingPremium,
     error: errorPremium,
   } = usePremium();
-
-  const premiumTier = getUserTier(premium);
 
   const { openModal, PremiumModal } = usePremiumModal();
 

--- a/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
+++ b/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
@@ -166,7 +166,7 @@ export const AdminUpgradeUserForm = () => {
       <Input
         type="number"
         name="count"
-        label="Grant duration"
+        label="Months/Years"
         registerProps={register("count", { valueAsNumber: true })}
         error={errors.count}
       />
@@ -184,7 +184,7 @@ export const AdminUpgradeUserForm = () => {
             });
           }}
         >
-          Grant
+          Upgrade
         </Button>
         <Button
           type="button"
@@ -199,7 +199,7 @@ export const AdminUpgradeUserForm = () => {
             });
           }}
         >
-          Revoke grant
+          Downgrade
         </Button>
       </div>
     </form>

--- a/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
+++ b/apps/web/app/(app)/admin/AdminUpgradeUserForm.tsx
@@ -80,7 +80,6 @@ export const AdminUpgradeUserForm = () => {
       changePremiumStatus({
         ...data,
         count: data.count || 1,
-        lemonSqueezyCustomerId: data.lemonSqueezyCustomerId || undefined,
         emailAccountsAccess: data.emailAccountsAccess || undefined,
       });
     },
@@ -97,15 +96,6 @@ export const AdminUpgradeUserForm = () => {
         label="Email"
         registerProps={register("email", { required: true })}
         error={errors.email}
-      />
-      <Input
-        type="number"
-        name="lemonSqueezyCustomerId"
-        label="Lemon Squeezy Customer Id"
-        registerProps={register("lemonSqueezyCustomerId", {
-          valueAsNumber: true,
-        })}
-        error={errors.lemonSqueezyCustomerId}
       />
       <Input
         type="number"
@@ -176,7 +166,7 @@ export const AdminUpgradeUserForm = () => {
       <Input
         type="number"
         name="count"
-        label="Months/Years"
+        label="Grant duration"
         registerProps={register("count", { valueAsNumber: true })}
         error={errors.count}
       />
@@ -187,7 +177,6 @@ export const AdminUpgradeUserForm = () => {
           onClick={() => {
             onSubmit({
               email: getValues("email"),
-              lemonSqueezyCustomerId: getValues("lemonSqueezyCustomerId"),
               emailAccountsAccess: getValues("emailAccountsAccess"),
               period,
               count: getValues("count"),
@@ -195,7 +184,7 @@ export const AdminUpgradeUserForm = () => {
             });
           }}
         >
-          Upgrade
+          Grant
         </Button>
         <Button
           type="button"
@@ -210,7 +199,7 @@ export const AdminUpgradeUserForm = () => {
             });
           }}
         >
-          Downgrade
+          Revoke grant
         </Button>
       </div>
     </form>

--- a/apps/web/app/(app)/admin/AdminUserInfo.tsx
+++ b/apps/web/app/(app)/admin/AdminUserInfo.tsx
@@ -79,6 +79,18 @@ export function AdminUserInfo() {
               value={data.premium?.tier || "None"}
             />
             <InfoRow
+              label="Admin Grant Tier"
+              value={data.premium?.adminGrantTier || "None"}
+            />
+            <InfoRow
+              label="Admin Grant Expires"
+              value={
+                data.premium?.adminGrantExpiresAt
+                  ? formatDate(data.premium.adminGrantExpiresAt)
+                  : "N/A"
+              }
+            />
+            <InfoRow
               label="Subscription Status"
               value={data.premium?.subscriptionStatus || "N/A"}
             />

--- a/apps/web/app/(app)/admin/validation.tsx
+++ b/apps/web/app/(app)/admin/validation.tsx
@@ -3,7 +3,6 @@ import { PremiumTier } from "@/generated/prisma/enums";
 
 export const changePremiumStatusSchema = z.object({
   email: z.string().email(),
-  lemonSqueezyCustomerId: z.number().optional(),
   emailAccountsAccess: z.number().optional(),
   period: z.nativeEnum(PremiumTier),
   count: z.number().optional(),

--- a/apps/web/app/api/mcp/[integration]/auth-url/route.ts
+++ b/apps/web/app/api/mcp/[integration]/auth-url/route.ts
@@ -11,7 +11,11 @@ import {
 } from "@/utils/oauth/state";
 import { getIntegration } from "@/utils/mcp/integrations";
 import { generateOAuthUrl } from "@/utils/mcp/oauth";
-import { hasTierAccess } from "@/utils/premium";
+import {
+  getUserTier,
+  hasTierAccess,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import prisma from "@/utils/prisma";
 
 export type GetMcpAuthUrlResponse = { url: string };
@@ -30,12 +34,16 @@ export const GET = withEmailAccount(
     // Check premium tier - integrations require Business Plus
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: { premium: { select: { tier: true } } },
+      select: {
+        premium: {
+          select: premiumEntitlementSelect,
+        },
+      },
     });
 
     if (
       !hasTierAccess({
-        tier: user?.premium?.tier ?? null,
+        tier: getUserTier(user?.premium),
         minimumTier: "PLUS_MONTHLY",
       })
     ) {

--- a/apps/web/app/api/outlook/watch/all/route.ts
+++ b/apps/web/app/api/outlook/watch/all/route.ts
@@ -3,7 +3,12 @@ import prisma from "@/utils/prisma";
 import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
 import { withError } from "@/utils/middleware";
 import { captureException } from "@/utils/error";
-import { hasAiAccess, getPremiumUserFilter } from "@/utils/premium";
+import {
+  getPremiumUserFilter,
+  getUserTier,
+  hasAiAccess,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import { createManagedOutlookSubscription } from "@/utils/outlook/subscription-manager";
 import type { Logger } from "@/utils/logger";
 
@@ -53,7 +58,9 @@ async function watchAllEmails(logger: Logger) {
       user: {
         select: {
           aiApiKey: true,
-          premium: { select: { tier: true } },
+          premium: {
+            select: premiumEntitlementSelect,
+          },
         },
       },
     },
@@ -72,7 +79,7 @@ async function watchAllEmails(logger: Logger) {
       });
 
       const userHasAiAccess = hasAiAccess(
-        emailAccount.user.premium?.tier || null,
+        getUserTier(emailAccount.user.premium),
         !!emailAccount.user.aiApiKey,
       );
 

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/utils/prisma";
 import { withError } from "@/utils/middleware";
 import { SafeError } from "@/utils/error";
 import { auth } from "@/utils/auth";
+import { premiumEntitlementSelect } from "@/utils/premium";
 
 export type UserResponse = Awaited<ReturnType<typeof getUser>> | null;
 
@@ -26,18 +27,13 @@ async function getUser({
       dismissedHints: true,
       premium: {
         select: {
-          appleExpiresAt: true,
-          appleRevokedAt: true,
-          appleSubscriptionStatus: true,
+          ...premiumEntitlementSelect,
           lemonSqueezyCustomerId: true,
           lemonSqueezySubscriptionId: true,
-          lemonSqueezyRenewsAt: true,
           stripeCustomerId: true,
           stripePriceId: true,
           stripeSubscriptionId: true,
-          stripeSubscriptionStatus: true,
           unsubscribeCredits: true,
-          tier: true,
           emailAccountsAccess: true,
           lemonLicenseKey: true,
           pendingInvites: true,

--- a/apps/web/components/PremiumCard.tsx
+++ b/apps/web/components/PremiumCard.tsx
@@ -10,6 +10,7 @@ import { Card } from "@/components/ui/card";
 import { cn } from "@/utils";
 import { HoverCard } from "@/components/HoverCard";
 import { MutedText } from "@/components/Typography";
+import type { PremiumTier } from "@/generated/prisma/enums";
 
 interface PremiumData {
   appleExpiresAt?: Date | string | null;
@@ -19,7 +20,7 @@ interface PremiumData {
   lemonSqueezySubscriptionId?: number | string | null;
   stripeSubscriptionId?: string | null;
   stripeSubscriptionStatus?: string | null;
-  tier?: string | null;
+  tier?: PremiumTier | null;
 }
 
 interface PremiumExpiredCardProps {

--- a/apps/web/hooks/usePremium.test.ts
+++ b/apps/web/hooks/usePremium.test.ts
@@ -75,4 +75,32 @@ describe("usePremium", () => {
     expect(result.current.isPremium).toBe(true);
     expect(result.current.hasAiAccess).toBe(true);
   });
+
+  it("uses the active admin grant tier for AI access", () => {
+    mockUseUser.mockReturnValue({
+      data: {
+        premium: {
+          tier: "BASIC_MONTHLY",
+          stripeSubscriptionStatus: null,
+          lemonSqueezyRenewsAt: null,
+          appleExpiresAt: null,
+          appleRevokedAt: null,
+          appleSubscriptionStatus: null,
+          adminGrantExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          adminGrantTier: "STARTER_MONTHLY",
+          unsubscribeCredits: 0,
+        },
+        hasAiApiKey: false,
+      },
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    const { result } = renderHook(() => usePremium());
+
+    expect(result.current.isPremium).toBe(true);
+    expect(result.current.tier).toBe("STARTER_MONTHLY");
+    expect(result.current.hasAiAccess).toBe(true);
+  });
 });

--- a/apps/web/hooks/usePremium.ts
+++ b/apps/web/hooks/usePremium.ts
@@ -3,6 +3,7 @@
 import { env } from "@/env";
 import { useUser } from "@/hooks/useUser";
 import {
+  getUserTier,
   hasAiAccess,
   hasUnsubscribeAccess,
   isPremiumRecord,
@@ -28,10 +29,10 @@ export function usePremium() {
   }
 
   const isUserPremium = isPremiumRecord(premium);
+  const tier = getUserTier(premium);
 
   const isProPlanWithoutApiKey =
-    (premium?.tier === "PRO_MONTHLY" || premium?.tier === "PRO_ANNUALLY") &&
-    !hasAiApiKey;
+    (tier === "PRO_MONTHLY" || tier === "PRO_ANNUALLY") && !hasAiApiKey;
 
   return {
     ...swrResponse,
@@ -39,10 +40,9 @@ export function usePremium() {
     isPremium: isUserPremium,
     hasUnsubscribeAccess:
       isUserPremium ||
-      hasUnsubscribeAccess(premium?.tier || null, premium?.unsubscribeCredits),
-    hasAiAccess:
-      isUserPremium && hasAiAccess(premium?.tier || null, hasAiApiKey),
+      hasUnsubscribeAccess(tier || null, premium?.unsubscribeCredits),
+    hasAiAccess: isUserPremium && hasAiAccess(tier || null, hasAiApiKey),
     isProPlanWithoutApiKey,
-    tier: premium?.tier,
+    tier,
   };
 }

--- a/apps/web/prisma/migrations/20260426000000_add_admin_premium_grants/migration.sql
+++ b/apps/web/prisma/migrations/20260426000000_add_admin_premium_grants/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Premium" ADD COLUMN "adminGrantExpiresAt" TIMESTAMP(3),
+ADD COLUMN "adminGrantTier" "PremiumTier";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -395,6 +395,10 @@ model Premium {
   appleExpiresAt                  DateTime?
   appleRevokedAt                  DateTime?
 
+  // manually granted by admin
+  adminGrantExpiresAt DateTime?
+  adminGrantTier      PremiumTier?
+
   tier PremiumTier?
 
   emailAccountsAccess Int?

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -403,8 +403,7 @@ export const adminGetUserInfoAction = adminActionClient
             subscriptionStatus:
               user.premium.stripeSubscriptionStatus ||
               user.premium.lemonSubscriptionStatus ||
-              (hasActiveAdminGrant ? "admin_grant" : null) ||
-              null,
+              (hasActiveAdminGrant ? "admin_grant" : null),
             adminGrantTier: user.premium.adminGrantTier,
             adminGrantExpiresAt: user.premium.adminGrantExpiresAt,
           }

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -8,6 +8,7 @@ import { adminActionClient } from "@/utils/actions/safe-action";
 import { SafeError } from "@/utils/error";
 import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
 import { getStripe } from "@/ee/billing/stripe";
+import { premiumEntitlementSelect } from "@/utils/premium";
 import { createEmailProvider } from "@/utils/email/provider";
 import { processProviderHistory } from "@/utils/webhook/process-history";
 import { hash } from "@/utils/hash";
@@ -382,6 +383,9 @@ export const adminGetUserInfoAction = adminActionClient
     const lastExecutedMap = new Map(
       lastExecutedRules.map((r) => [r.emailAccountId, r._max.createdAt]),
     );
+    const hasActiveAdminGrant =
+      user.premium?.adminGrantExpiresAt &&
+      user.premium.adminGrantExpiresAt > new Date();
 
     return {
       id: user.id,
@@ -394,11 +398,15 @@ export const adminGetUserInfoAction = adminActionClient
             renewsAt:
               user.premium.stripeRenewsAt ||
               user.premium.lemonSqueezyRenewsAt ||
+              user.premium.adminGrantExpiresAt ||
               null,
             subscriptionStatus:
               user.premium.stripeSubscriptionStatus ||
               user.premium.lemonSubscriptionStatus ||
+              (hasActiveAdminGrant ? "admin_grant" : null) ||
               null,
+            adminGrantTier: user.premium.adminGrantTier,
+            adminGrantExpiresAt: user.premium.adminGrantExpiresAt,
           }
         : null,
       emailAccounts: user.emailAccounts.map((ea) => ({
@@ -513,10 +521,8 @@ async function findUserWithDetails(email?: string, userId?: string) {
       lastLogin: true,
       premium: {
         select: {
-          tier: true,
-          lemonSqueezyRenewsAt: true,
+          ...premiumEntitlementSelect,
           stripeRenewsAt: true,
-          stripeSubscriptionStatus: true,
           lemonSubscriptionStatus: true,
         },
       },

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -6,12 +6,14 @@ import uniq from "lodash/uniq";
 import prisma from "@/utils/prisma";
 import { env } from "@/env";
 import {
+  getUserTier,
   isAdminForPremium,
   isOnHigherTier,
   isPremiumRecord,
+  premiumEntitlementSelect,
 } from "@/utils/premium";
 import {
-  cancelPremiumLemon,
+  grantPremiumAdmin,
   upgradeToPremiumLemon,
 } from "@/utils/premium/server";
 import {
@@ -19,10 +21,7 @@ import {
   syncPremiumSeats,
 } from "@/utils/premium/seats";
 import { changePremiumStatusSchema } from "@/app/(app)/admin/validation";
-import {
-  activateLemonLicenseKey,
-  getLemonCustomer,
-} from "@/ee/billing/lemon/index";
+import { activateLemonLicenseKey } from "@/ee/billing/lemon/index";
 import { PremiumTier } from "@/generated/prisma/enums";
 import { ONE_MONTH_MS, ONE_YEAR_MS } from "@/utils/date";
 import { getStripePriceId } from "@/app/(app)/premium/config";
@@ -52,11 +51,7 @@ export const decrementUnsubscribeCreditAction = actionClientUser
             id: true,
             unsubscribeCredits: true,
             unsubscribeMonth: true,
-            appleExpiresAt: true,
-            appleRevokedAt: true,
-            appleSubscriptionStatus: true,
-            lemonSqueezyRenewsAt: true,
-            stripeSubscriptionStatus: true,
+            ...premiumEntitlementSelect,
           },
         },
       },
@@ -107,7 +102,7 @@ export const updateMultiAccountPremiumAction = actionClientUser
         premium: {
           select: {
             id: true,
-            tier: true,
+            ...premiumEntitlementSelect,
             lemonSqueezySubscriptionItemId: true,
             stripeSubscriptionItemId: true,
             emailAccountsAccess: true,
@@ -138,7 +133,9 @@ export const updateMultiAccountPremiumAction = actionClientUser
 
     // make sure that the users being added to this plan are not on higher tiers already
     for (const userToAdd of otherUsers) {
-      if (isOnHigherTier(userToAdd.premium?.tier, premium.tier)) {
+      if (
+        isOnHigherTier(getUserTier(userToAdd.premium), getUserTier(premium))
+      ) {
         throw new SafeError(
           "One of the users you are adding to your plan already has premium and cannot be added.",
         );
@@ -279,14 +276,7 @@ export const adminChangePremiumStatusAction = adminActionClient
   .inputSchema(changePremiumStatusSchema)
   .action(
     async ({
-      parsedInput: {
-        email,
-        period,
-        count,
-        emailAccountsAccess,
-        lemonSqueezyCustomerId,
-        upgrade,
-      },
+      parsedInput: { email, period, count, emailAccountsAccess, upgrade },
     }) => {
       const userToUpgrade = await prisma.emailAccount.findUnique({
         where: { email },
@@ -298,46 +288,8 @@ export const adminChangePremiumStatusAction = adminActionClient
 
       if (!userToUpgrade?.user) throw new SafeError("User not found");
 
-      let lemonSqueezySubscriptionId: number | null = null;
-      let lemonSqueezySubscriptionItemId: number | null = null;
-      let lemonSqueezyOrderId: number | null = null;
-      let lemonSqueezyProductId: number | null = null;
-      let lemonSqueezyVariantId: number | null = null;
-
       if (upgrade) {
-        if (lemonSqueezyCustomerId) {
-          const lemonCustomer = await getLemonCustomer(
-            lemonSqueezyCustomerId.toString(),
-          );
-          if (!lemonCustomer.data)
-            throw new SafeError("Lemon customer not found");
-          const subscription = lemonCustomer.data.included?.find(
-            (i) => i.type === "subscriptions",
-          );
-          if (!subscription) throw new SafeError("Subscription not found");
-          lemonSqueezySubscriptionId = Number.parseInt(subscription.id);
-          const attributes = subscription.attributes as {
-            first_subscription_item?: { id?: string | null };
-            order_id?: string;
-            product_id?: string;
-            variant_id?: string;
-          };
-          lemonSqueezyOrderId = attributes.order_id
-            ? Number.parseInt(attributes.order_id)
-            : null;
-          lemonSqueezyProductId = attributes.product_id
-            ? Number.parseInt(attributes.product_id)
-            : null;
-          lemonSqueezyVariantId = attributes.variant_id
-            ? Number.parseInt(attributes.variant_id)
-            : null;
-          lemonSqueezySubscriptionItemId = attributes.first_subscription_item
-            ?.id
-            ? Number.parseInt(attributes.first_subscription_item.id)
-            : null;
-        }
-
-        const getRenewsAt = (period: PremiumTier): Date | null => {
+        const getGrantExpiresAt = (period: PremiumTier): Date | null => {
           const now = new Date();
           switch (period) {
             case PremiumTier.BASIC_ANNUALLY:
@@ -360,22 +312,19 @@ export const adminChangePremiumStatusAction = adminActionClient
           }
         };
 
-        await upgradeToPremiumLemon({
+        await grantPremiumAdmin({
           userId: userToUpgrade.user.id,
           tier: period,
-          lemonSqueezyCustomerId: lemonSqueezyCustomerId || null,
-          lemonSqueezySubscriptionId,
-          lemonSqueezySubscriptionItemId,
-          lemonSqueezyOrderId,
-          lemonSqueezyProductId,
-          lemonSqueezyVariantId,
-          lemonSqueezyRenewsAt: getRenewsAt(period),
+          adminGrantExpiresAt: getGrantExpiresAt(period),
           emailAccountsAccess,
         });
       } else if (userToUpgrade.user.premiumId) {
-        await cancelPremiumLemon({
-          premiumId: userToUpgrade.user.premiumId,
-          lemonSqueezyEndsAt: new Date(),
+        await prisma.premium.update({
+          where: { id: userToUpgrade.user.premiumId },
+          data: {
+            adminGrantExpiresAt: null,
+            adminGrantTier: null,
+          },
         });
       } else {
         throw new SafeError("User not premium.");

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -1,5 +1,10 @@
 import prisma from "@/utils/prisma";
-import { hasAiAccess, getPremiumUserFilter } from "@/utils/premium";
+import {
+  getPremiumUserFilter,
+  getUserTier,
+  hasAiAccess,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import type { Logger } from "@/utils/logger";
 import { createEmailProvider } from "@/utils/email/provider";
 import { captureException } from "@/utils/error";
@@ -59,11 +64,7 @@ async function getEmailAccountsToWatch(userIds: string[] | null) {
           id: true,
           aiApiKey: true,
           premium: {
-            select: {
-              tier: true,
-              lemonSqueezyRenewsAt: true,
-              stripeSubscriptionStatus: true,
-            },
+            select: premiumEntitlementSelect,
           },
         },
       },
@@ -132,7 +133,7 @@ async function watchEmailAccount(
   const { account, user, watchEmailsExpirationDate } = emailAccount;
 
   const userHasAiAccess = hasAiAccess(
-    user.premium?.tier || null,
+    getUserTier(user.premium),
     !!user.aiApiKey,
   );
 

--- a/apps/web/utils/premium/index.test.ts
+++ b/apps/web/utils/premium/index.test.ts
@@ -69,6 +69,47 @@ describe("Apple premium helpers", () => {
     ).toBe("STARTER_MONTHLY");
   });
 
+  it("treats active admin grants as premium", () => {
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+
+    expect(
+      isPremiumRecord({
+        adminGrantExpiresAt: futureDate,
+        adminGrantTier: "PLUS_MONTHLY",
+        lemonSqueezyRenewsAt: null,
+        stripeSubscriptionStatus: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses the active admin grant tier when it is higher than the processor tier", () => {
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+
+    expect(
+      getUserTier({
+        tier: "STARTER_MONTHLY",
+        stripeSubscriptionStatus: "trialing",
+        adminGrantExpiresAt: futureDate,
+        adminGrantTier: "PROFESSIONAL_MONTHLY",
+        lemonSqueezyRenewsAt: null,
+      }),
+    ).toBe("PROFESSIONAL_MONTHLY");
+  });
+
+  it("ignores expired admin grant tiers", () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+
+    expect(
+      getUserTier({
+        tier: "STARTER_MONTHLY",
+        stripeSubscriptionStatus: "active",
+        adminGrantExpiresAt: pastDate,
+        adminGrantTier: "PROFESSIONAL_MONTHLY",
+        lemonSqueezyRenewsAt: null,
+      }),
+    ).toBe("STARTER_MONTHLY");
+  });
+
   it("treats missing premium records as premium when bypass checks are enabled", () => {
     envMock.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS = true;
 
@@ -84,15 +125,41 @@ describe("digest access", () => {
   it("filters premium users by minimum tier when requested", () => {
     const filter = getPremiumUserFilter({ minimumTier: "PLUS_MONTHLY" });
 
-    expect(filter.user.premium.tier).toEqual({
-      in: [
-        "PLUS_MONTHLY",
-        "PLUS_ANNUALLY",
-        "PROFESSIONAL_MONTHLY",
-        "PROFESSIONAL_ANNUALLY",
-        "COPILOT_MONTHLY",
-        "LIFETIME",
-      ],
-    });
+    expect(filter.user.premium.OR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          AND: expect.arrayContaining([
+            {
+              tier: {
+                in: [
+                  "PLUS_MONTHLY",
+                  "PLUS_ANNUALLY",
+                  "PROFESSIONAL_MONTHLY",
+                  "PROFESSIONAL_ANNUALLY",
+                  "COPILOT_MONTHLY",
+                  "LIFETIME",
+                ],
+              },
+            },
+          ]),
+        }),
+        expect.objectContaining({
+          AND: expect.arrayContaining([
+            {
+              adminGrantTier: {
+                in: [
+                  "PLUS_MONTHLY",
+                  "PLUS_ANNUALLY",
+                  "PROFESSIONAL_MONTHLY",
+                  "PROFESSIONAL_ANNUALLY",
+                  "COPILOT_MONTHLY",
+                  "LIFETIME",
+                ],
+              },
+            },
+          ]),
+        }),
+      ]),
+    );
   });
 });

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -8,6 +8,17 @@ const APPLE_ACTIVE_STATUSES = new Set([
   "BILLING_RETRY",
 ]);
 
+export const premiumEntitlementSelect = {
+  appleExpiresAt: true,
+  appleRevokedAt: true,
+  appleSubscriptionStatus: true,
+  adminGrantExpiresAt: true,
+  adminGrantTier: true,
+  lemonSqueezyRenewsAt: true,
+  stripeSubscriptionStatus: true,
+  tier: true,
+} as const;
+
 function isPremiumStripe(stripeSubscriptionStatus: string | null): boolean {
   if (!stripeSubscriptionStatus) return false;
   const activeStatuses = ["active", "trialing"];
@@ -19,6 +30,13 @@ function isPremiumLemonSqueezy(
 ): boolean {
   if (!lemonSqueezyRenewsAt) return false;
   return new Date(lemonSqueezyRenewsAt) > new Date();
+}
+
+function isPremiumAdminGrant(
+  adminGrantExpiresAt: Date | string | null,
+): boolean {
+  if (!adminGrantExpiresAt) return false;
+  return new Date(adminGrantExpiresAt) > new Date();
 }
 
 export function hasActiveAppleSubscription(
@@ -46,12 +64,14 @@ export const isPremium = (
   appleExpiresAt?: Date | string | null,
   appleRevokedAt?: Date | string | null,
   appleSubscriptionStatus?: string | null,
+  adminGrantExpiresAt?: Date | string | null,
 ): boolean => {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return true;
 
   return (
     isPremiumStripe(stripeSubscriptionStatus) ||
     isPremiumLemonSqueezy(lemonSqueezyRenewsAt) ||
+    isPremiumAdminGrant(adminGrantExpiresAt || null) ||
     hasActiveAppleSubscription(
       appleExpiresAt || null,
       appleRevokedAt || null,
@@ -64,8 +84,11 @@ type PremiumStatusRecord = {
   appleExpiresAt?: Date | string | null;
   appleRevokedAt?: Date | string | null;
   appleSubscriptionStatus?: string | null;
+  adminGrantExpiresAt?: Date | string | null;
+  adminGrantTier?: PremiumTier | null;
   lemonSqueezyRenewsAt?: Date | string | null;
   stripeSubscriptionStatus?: string | null;
+  tier?: PremiumTier | null;
 };
 
 export const isPremiumRecord = (
@@ -80,6 +103,7 @@ export const isPremiumRecord = (
     premium.appleExpiresAt ?? null,
     premium.appleRevokedAt ?? null,
     premium.appleSubscriptionStatus ?? null,
+    premium.adminGrantExpiresAt ?? null,
   );
 };
 
@@ -93,6 +117,7 @@ export const isActivePremium = (
   return (
     premium.stripeSubscriptionStatus === "active" ||
     isPremiumLemonSqueezy(premium.lemonSqueezyRenewsAt ?? null) ||
+    isPremiumAdminGrant(premium.adminGrantExpiresAt ?? null) ||
     hasActiveAppleSubscription(
       premium.appleExpiresAt ?? null,
       premium.appleRevokedAt ?? null,
@@ -107,6 +132,8 @@ export const getUserTier = (
     | "appleExpiresAt"
     | "appleRevokedAt"
     | "appleSubscriptionStatus"
+    | "adminGrantExpiresAt"
+    | "adminGrantTier"
     | "tier"
     | "lemonSqueezyRenewsAt"
     | "stripeSubscriptionStatus"
@@ -116,11 +143,31 @@ export const getUserTier = (
     return "PROFESSIONAL_ANNUALLY" as const;
   }
 
-  const isActive = isPremiumRecord(premium);
+  if (!premium) return null;
 
-  if (!isActive) return null;
+  const hasActiveProcessorEntitlement =
+    isPremiumStripe(premium.stripeSubscriptionStatus ?? null) ||
+    isPremiumLemonSqueezy(premium.lemonSqueezyRenewsAt ?? null) ||
+    hasActiveAppleSubscription(
+      premium.appleExpiresAt ?? null,
+      premium.appleRevokedAt ?? null,
+      premium.appleSubscriptionStatus,
+    );
+  const processorTier = hasActiveProcessorEntitlement
+    ? premium.tier || null
+    : null;
+  const adminGrantTier = isPremiumAdminGrant(
+    premium.adminGrantExpiresAt ?? null,
+  )
+    ? premium.adminGrantTier || null
+    : null;
 
-  return premium?.tier || null;
+  if (!processorTier) return adminGrantTier;
+  if (!adminGrantTier) return processorTier;
+
+  return isOnHigherTier(adminGrantTier, processorTier)
+    ? adminGrantTier
+    : processorTier;
 };
 
 export const isAdminForPremium = (
@@ -219,21 +266,39 @@ export function getPremiumUserFilter({
 } = {}) {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return {};
 
+  const minimumTiers = minimumTier ? getTiersAtOrAbove(minimumTier) : undefined;
+  const tierFilter = minimumTiers ? [{ tier: { in: minimumTiers } }] : [];
+  const adminGrantTierFilter = minimumTiers
+    ? [{ adminGrantTier: { in: minimumTiers } }]
+    : [];
+  const now = new Date();
+
   return {
     user: {
       premium: {
-        ...(minimumTier
-          ? { tier: { in: getTiersAtOrAbove(minimumTier) } }
-          : {}),
         OR: [
           {
             AND: [
-              { appleExpiresAt: { gt: new Date() } },
+              { appleExpiresAt: { gt: now } },
               { appleRevokedAt: null },
+              ...tierFilter,
             ],
           },
-          { lemonSqueezyRenewsAt: { gt: new Date() } },
-          { stripeSubscriptionStatus: { in: ["active", "trialing"] } },
+          {
+            AND: [{ lemonSqueezyRenewsAt: { gt: now } }, ...tierFilter],
+          },
+          {
+            AND: [
+              { stripeSubscriptionStatus: { in: ["active", "trialing"] } },
+              ...tierFilter,
+            ],
+          },
+          {
+            AND: [
+              { adminGrantExpiresAt: { gt: now } },
+              ...adminGrantTierFilter,
+            ],
+          },
         ],
       },
     },

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -103,23 +103,23 @@ export async function grantPremiumAdmin(options: {
     throw new Error("User not found");
   }
 
+  const grantData = {
+    adminGrantTier: data.tier,
+    adminGrantExpiresAt: data.adminGrantExpiresAt,
+    emailAccountsAccess: data.emailAccountsAccess,
+  };
+
   const premiumRecord = user.premiumId
     ? await prisma.premium.update({
         where: { id: user.premiumId },
-        data: {
-          adminGrantTier: data.tier,
-          adminGrantExpiresAt: data.adminGrantExpiresAt,
-          emailAccountsAccess: data.emailAccountsAccess,
-        },
+        data: grantData,
         select: { users: { select: { id: true, email: true } } },
       })
     : await prisma.premium.create({
         data: {
           users: { connect: { id: userId } },
           admins: { connect: { id: userId } },
-          adminGrantTier: data.tier,
-          adminGrantExpiresAt: data.adminGrantExpiresAt,
-          emailAccountsAccess: data.emailAccountsAccess,
+          ...grantData,
         },
         select: { users: { select: { id: true, email: true } } },
       });

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -3,7 +3,12 @@ import prisma from "@/utils/prisma";
 import type { PremiumTier } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
-import { hasTierAccess, isPremiumRecord } from "@/utils/premium";
+import {
+  getUserTier,
+  hasTierAccess,
+  isPremiumRecord,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import { SafeError } from "@/utils/error";
 import { env } from "@/env";
 
@@ -80,6 +85,58 @@ export async function extendPremiumLemon(options: {
   });
 }
 
+export async function grantPremiumAdmin(options: {
+  userId: string;
+  tier: PremiumTier;
+  adminGrantExpiresAt: Date | null;
+  emailAccountsAccess?: number;
+}) {
+  const { userId, ...data } = options;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { premiumId: true },
+  });
+
+  if (!user) {
+    logger.error("User not found", { userId });
+    throw new Error("User not found");
+  }
+
+  const premiumRecord = user.premiumId
+    ? await prisma.premium.update({
+        where: { id: user.premiumId },
+        data: {
+          adminGrantTier: data.tier,
+          adminGrantExpiresAt: data.adminGrantExpiresAt,
+          emailAccountsAccess: data.emailAccountsAccess,
+        },
+        select: { users: { select: { id: true, email: true } } },
+      })
+    : await prisma.premium.create({
+        data: {
+          users: { connect: { id: userId } },
+          admins: { connect: { id: userId } },
+          adminGrantTier: data.tier,
+          adminGrantExpiresAt: data.adminGrantExpiresAt,
+          emailAccountsAccess: data.emailAccountsAccess,
+        },
+        select: { users: { select: { id: true, email: true } } },
+      });
+
+  after(() => {
+    const userIds = premiumRecord.users.map((premiumUser) => premiumUser.id);
+    ensureEmailAccountsWatched({ userIds, logger }).catch((error) => {
+      logger.error("Failed to ensure email watches after premium grant", {
+        userIds,
+        error,
+      });
+    });
+  });
+
+  return premiumRecord;
+}
+
 export async function cancelPremiumLemon({
   premiumId,
   lemonSqueezyEndsAt,
@@ -120,14 +177,7 @@ export async function checkHasAccess({
     where: { id: userId },
     select: {
       premium: {
-        select: {
-          appleExpiresAt: true,
-          appleRevokedAt: true,
-          appleSubscriptionStatus: true,
-          tier: true,
-          stripeSubscriptionStatus: true,
-          lemonSqueezyRenewsAt: true,
-        },
+        select: premiumEntitlementSelect,
       },
     },
   });
@@ -139,7 +189,7 @@ export async function checkHasAccess({
   }
 
   return hasTierAccess({
-    tier: user.premium?.tier || null,
+    tier: getUserTier(user.premium),
     minimumTier,
   });
 }

--- a/apps/web/utils/user/validate.ts
+++ b/apps/web/utils/user/validate.ts
@@ -1,5 +1,10 @@
 import { SafeError } from "@/utils/error";
-import { hasAiAccess, isPremiumRecord } from "@/utils/premium";
+import {
+  getUserTier,
+  hasAiAccess,
+  isPremiumRecord,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import prisma from "@/utils/prisma";
 
 export async function validateUserAndAiAccess({
@@ -23,14 +28,7 @@ export async function validateUserAndAiAccess({
           aiModel: true,
           aiApiKey: true,
           premium: {
-            select: {
-              appleExpiresAt: true,
-              appleRevokedAt: true,
-              appleSubscriptionStatus: true,
-              tier: true,
-              lemonSqueezyRenewsAt: true,
-              stripeSubscriptionStatus: true,
-            },
+            select: premiumEntitlementSelect,
           },
         },
       },
@@ -43,7 +41,7 @@ export async function validateUserAndAiAccess({
   if (!isUserPremium) throw new SafeError("Please upgrade for AI access");
 
   const userHasAiAccess = hasAiAccess(
-    emailAccount.user.premium?.tier || null,
+    getUserTier(emailAccount.user.premium),
     !!emailAccount.user.aiApiKey,
   );
   if (!userHasAiAccess) throw new SafeError("Please upgrade for AI access");

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -297,7 +297,16 @@ function getWebhookAccountPremium(
   emailAccount: NonNullable<ValidatedWebhookAccountData>,
 ) {
   return env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS
-    ? { tier: "PROFESSIONAL_ANNUALLY" as const }
+    ? {
+        tier: "PROFESSIONAL_ANNUALLY" as const,
+        stripeSubscriptionStatus: "active",
+        lemonSqueezyRenewsAt: null,
+        appleSubscriptionStatus: null,
+        appleExpiresAt: null,
+        appleRevokedAt: null,
+        adminGrantExpiresAt: null,
+        adminGrantTier: null,
+      }
     : isPremiumRecord(emailAccount.user.premium)
       ? emailAccount.user.premium
       : undefined;

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { env } from "@/env";
-import { hasAiAccess, isPremiumRecord } from "@/utils/premium";
+import {
+  getUserTier,
+  hasAiAccess,
+  isPremiumRecord,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
 import { unwatchEmails } from "@/utils/email/watch-manager";
 import { createEmailProvider } from "@/utils/email/provider";
 import {
@@ -55,14 +60,7 @@ const webhookEmailAccountSelect = {
       aiModel: true,
       aiApiKey: true,
       premium: {
-        select: {
-          appleExpiresAt: true,
-          appleRevokedAt: true,
-          appleSubscriptionStatus: true,
-          lemonSqueezyRenewsAt: true,
-          stripeSubscriptionStatus: true,
-          tier: true,
-        },
+        select: premiumEntitlementSelect,
       },
     },
   },
@@ -166,7 +164,7 @@ export async function cleanupWebhookAccountOnRateLimitSkip(
 
   const premium = getWebhookAccountPremium(emailAccount);
   const userHasAiAccess = hasAiAccess(
-    premium?.tier || null,
+    getUserTier(premium),
     !!emailAccount.user.aiApiKey,
   );
   const shouldUnwatch =
@@ -252,13 +250,13 @@ export async function validateWebhookAccount(
   }
 
   const userHasAiAccess = hasAiAccess(
-    premium.tier,
+    getUserTier(premium),
     !!emailAccount.user.aiApiKey,
   );
 
   if (!userHasAiAccess) {
     logger.info("Does not have ai access - unwatching", {
-      tier: premium.tier,
+      tier: getUserTier(premium),
       hasApiKey: !!emailAccount.user.aiApiKey,
     });
     await unwatchEmails({

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -249,14 +249,12 @@ export async function validateWebhookAccount(
     return { success: false, response: NextResponse.json({ ok: true }) };
   }
 
-  const userHasAiAccess = hasAiAccess(
-    getUserTier(premium),
-    !!emailAccount.user.aiApiKey,
-  );
+  const tier = getUserTier(premium);
+  const userHasAiAccess = hasAiAccess(tier, !!emailAccount.user.aiApiKey);
 
   if (!userHasAiAccess) {
     logger.info("Does not have ai access - unwatching", {
-      tier: getUserTier(premium),
+      tier,
       hasApiKey: !!emailAccount.user.aiApiKey,
     });
     await unwatchEmails({


### PR DESCRIPTION
Adds admin-managed premium grants with their own tier and expiry, separate from payment processor fields.

- Updates premium entitlement checks to consider active admin grants.
- Replaces the admin upgrade flow with grant and revoke behavior.
- Adds focused coverage for admin grant access and effective tier handling.