### PR TITLE
Simplify review status check

### DIFF
--- a/apps/web/app/api/mobile-review/status/route.test.ts
+++ b/apps/web/app/api/mobile-review/status/route.test.ts
@@ -3,13 +3,12 @@ vi.mock("server-only", () => ({}));
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getMobileReviewAccessStatusMock } = vi.hoisted(() => ({
-  getMobileReviewAccessStatusMock: vi.fn(),
+const { isMobileReviewEnabledMock } = vi.hoisted(() => ({
+  isMobileReviewEnabledMock: vi.fn(),
 }));
 
 vi.mock("@/utils/mobile-review", () => ({
-  getMobileReviewAccessStatus: (...args: unknown[]) =>
-    getMobileReviewAccessStatusMock(...args),
+  isMobileReviewEnabled: () => isMobileReviewEnabledMock(),
 }));
 
 vi.mock("@/utils/middleware", () => ({
@@ -29,26 +28,17 @@ describe("mobile review status route", () => {
     vi.clearAllMocks();
   });
 
-  it("returns the validated review access status", async () => {
-    getMobileReviewAccessStatusMock.mockResolvedValueOnce({ enabled: false });
+  it("returns the configured review access status", async () => {
+    isMobileReviewEnabledMock.mockReturnValueOnce(false);
 
     const request = new NextRequest(
       "http://localhost/api/mobile-review/status",
-    ) as NextRequest & {
-      logger: {
-        warn: ReturnType<typeof vi.fn>;
-      };
-    };
-    request.logger = {
-      warn: vi.fn(),
-    };
+    );
 
     const response = await GET(request, {} as never);
     const body = await response.json();
 
-    expect(getMobileReviewAccessStatusMock).toHaveBeenCalledWith({
-      logger: request.logger,
-    });
+    expect(isMobileReviewEnabledMock).toHaveBeenCalledOnce();
     expect(body).toEqual({ enabled: false });
   });
 });

--- a/apps/web/app/api/mobile-review/status/route.ts
+++ b/apps/web/app/api/mobile-review/status/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 import { withError } from "@/utils/middleware";
-import { getMobileReviewAccessStatus } from "@/utils/mobile-review";
+import { isMobileReviewEnabled } from "@/utils/mobile-review";
 
-export const GET = withError("mobile-review/status", async (request) => {
-  const { enabled } = await getMobileReviewAccessStatus({
-    logger: request.logger,
-  });
-  return NextResponse.json({ enabled });
-});
+export const GET = withError("mobile-review/status", async () =>
+  NextResponse.json({ enabled: isMobileReviewEnabled() }),
+);

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -60,7 +60,7 @@ vi.mock("@/utils/prisma", () => ({
 
 import {
   createMobileReviewSession,
-  getMobileReviewAccessStatus,
+  isMobileReviewEnabled,
 } from "./mobile-review";
 
 function createLogger() {
@@ -92,116 +92,18 @@ describe("mobile review access", () => {
     });
   });
 
-  it("reports disabled status when the configured review account has no email account", async () => {
-    const logger = createLogger();
-    emailAccountFindManyMock.mockResolvedValueOnce([]);
+  it("reports enabled status from the env flag without validating accounts", () => {
+    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = "not-json";
 
-    const result = await getMobileReviewAccessStatus({ logger } as never);
-
-    expect(result).toEqual({ enabled: false });
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Mobile review access unavailable",
-      expect.objectContaining({
-        count: 1,
-        reasons: [
-          expect.objectContaining({
-            hasEmailAccount: false,
-            ok: false,
-            reason: "review_user_missing_email_account",
-          }),
-        ],
-      }),
-    );
-  });
-
-  it("reports enabled status when the configured review account is usable", async () => {
-    const logger = createLogger();
-    emailAccountFindManyMock.mockResolvedValueOnce([
-      {
-        email: "review@example.com",
-        id: "account-1",
-        user: {
-          email: "owner@example.com",
-          id: "user-1",
-        },
-      },
-    ]);
-
-    const result = await getMobileReviewAccessStatus({ logger } as never);
-
-    expect(result).toEqual({ enabled: true });
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  it("reports disabled status when the review user lookup fails", async () => {
-    const logger = createLogger();
-    const error = new Error("database unavailable");
-    emailAccountFindManyMock.mockRejectedValueOnce(error);
-
-    const result = await getMobileReviewAccessStatus({ logger } as never);
-
-    expect(result).toEqual({ enabled: false });
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Mobile review access unavailable",
-      expect.objectContaining({
-        error,
-        reason: "review_user_lookup_failed",
-      }),
-    );
-  });
-
-  it("reports disabled status when review account config is invalid", async () => {
-    const logger = createLogger();
-    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
-      { email: "not-an-email", code: "review-code" },
-    ]);
-
-    const result = await getMobileReviewAccessStatus({ logger } as never);
-
-    expect(result).toEqual({ enabled: false });
+    expect(isMobileReviewEnabled()).toBe(true);
     expect(emailAccountFindManyMock).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Mobile review access unavailable",
-      expect.objectContaining({
-        hasReviewDemoAccounts: false,
-        reason: "review_demo_misconfigured",
-      }),
-    );
   });
 
-  it("reports disabled status when any configured review account is missing", async () => {
-    const logger = createLogger();
-    mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
-      { email: "active-review@example.com", code: "active-code" },
-      { email: "expired-review@example.com", code: "expired-code" },
-    ]);
-    emailAccountFindManyMock.mockResolvedValueOnce([
-      {
-        email: "active-review@example.com",
-        id: "account-active",
-        user: {
-          email: "active-owner@example.com",
-          id: "user-active",
-        },
-      },
-    ]);
+  it("reports disabled status when the env flag is off", () => {
+    mockedEnv.APP_REVIEW_DEMO_ENABLED = false;
 
-    const result = await getMobileReviewAccessStatus({ logger } as never);
-
-    expect(result).toEqual({ enabled: false });
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Mobile review access unavailable",
-      expect.objectContaining({
-        count: 1,
-        reasons: [
-          expect.objectContaining({
-            hasEmailAccount: false,
-            ok: false,
-            reason: "review_user_missing_email_account",
-          }),
-        ],
-      }),
-    );
+    expect(isMobileReviewEnabled()).toBe(false);
+    expect(emailAccountFindManyMock).not.toHaveBeenCalled();
   });
 
   it("rejects invalid review codes before querying the database", async () => {

--- a/apps/web/utils/mobile-review.ts
+++ b/apps/web/utils/mobile-review.ts
@@ -50,42 +50,7 @@ const reviewDemoAccountsSchema = z.array(
 );
 
 export function isMobileReviewEnabled(): boolean {
-  return Boolean(
-    env.APP_REVIEW_DEMO_ENABLED && getConfiguredReviewAccounts().length > 0,
-  );
-}
-
-export async function getMobileReviewAccessStatus(input: { logger: Logger }) {
-  const config = getMobileReviewConfig();
-  if (!config.ok) {
-    input.logger.warn("Mobile review access unavailable", {
-      ...config,
-      ok: undefined,
-    });
-    return { enabled: false as const };
-  }
-
-  let reviewUsers: MobileReviewUserResult[];
-  try {
-    reviewUsers = await getMobileReviewUsers(config.reviewDemoAccounts);
-  } catch (error) {
-    input.logger.warn("Mobile review access unavailable", {
-      reason: "review_user_lookup_failed",
-      error,
-    });
-    return { enabled: false as const };
-  }
-
-  const missingReviewUsers = reviewUsers.filter((reviewUser) => !reviewUser.ok);
-  if (missingReviewUsers.length) {
-    input.logger.warn("Mobile review access unavailable", {
-      count: missingReviewUsers.length,
-      reasons: missingReviewUsers,
-    });
-    return { enabled: false as const };
-  }
-
-  return { enabled: true as const };
+  return env.APP_REVIEW_DEMO_ENABLED;
 }
 
 export async function createMobileReviewSession(input: {


### PR DESCRIPTION
Updates the review status endpoint to read the server feature flag directly instead of validating backing records. Keeps session creation validation unchanged and updates route and helper tests.