### PR TITLE
bulk-unsubscribe: Refine bulk action notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,10 @@
 - Prefer the `EmailProvider` abstraction; only use provider-type checks (`isGoogleProvider`, `isMicrosoftProvider`) at true provider boundary/integration code.
 - Infer types from Zod schemas using `z.infer<typeof schema>` instead of duplicating as separate interfaces
 - Avoid premature abstraction. Duplicating 2-3 times is fine; extract when a stable pattern emerges.
-- Don't extract single-use helper functions that just rename and forward parameters; inline the logic at the call site.
-- Avoid large nested ternaries. Prefer a small helper or other straightforward control flow when it improves readability.
+- Default to inlining and co-locating logic at the call site.
+- Extract a helper when doing so makes the call site clearly easier to read — e.g., a non-obvious computation gets a name, or a nested branch becomes a clean lookup. The bar is "the call site is better," not "the helper looks nice."
+- Don't extract helpers that just rename and forward parameters; that's a layer without meaning.
+- Avoid large/nested ternaries. Prefer a small helper, an early-return cascade, or a lookup table.
 - No barrel files. Import directly from source files.
 - Colocate page components next to their `page.tsx`. No nested `components/` subfolders in route directories.
 - Reusable components shared across pages go in `apps/web/components/`

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -605,19 +605,12 @@ export function useBulkAutoArchive<T extends Row>({
         successMessage: "set to auto archive",
         errorMessage: "Failed to set auto archive for",
         processItem: async (item) => {
-          await onAutoArchive({
+          await blockSender({
+            sender: item.name,
             emailAccountId,
-            from: item.name,
-            gmailLabelId: undefined,
-            labelName: undefined,
+            queueArchiveSenders,
             showSuccessToast: false,
           });
-          await setNewsletterStatusAction(emailAccountId, {
-            newsletterEmail: item.name,
-            status: NewsletterStatus.AUTO_ARCHIVED,
-          });
-          await decrementUnsubscribeCreditAction();
-          await queueArchiveSenders({ senders: [item.name] });
         },
         onComplete: refetchPremium,
       });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useAction } from "next-safe-action/hooks";
 import type { PostHog } from "posthog-js/react";
 import { onAutoArchive, onDeleteFilter } from "@/utils/actions/client";
+import { toastSuccess } from "@/components/Toast";
 import {
   setNewsletterStatusAction,
   unsubscribeSenderAction,
@@ -212,24 +213,18 @@ async function blockSender({
   labelId,
   labelName,
   queueArchiveSenders,
-  successDescription = "Sender blocked. Future emails will be archived.",
-  showSuccessToast = true,
 }: {
   sender: string;
   emailAccountId: string;
   labelId?: string;
   labelName?: string;
   queueArchiveSenders: QueueArchiveSendersFn;
-  successDescription?: string;
-  showSuccessToast?: boolean;
-}) {
-  await onAutoArchive({
+}): Promise<boolean> {
+  const ok = await onAutoArchive({
     emailAccountId,
     from: sender,
     gmailLabelId: labelId,
     labelName,
-    successDescription,
-    showSuccessToast,
   });
   await setNewsletterStatusAction(emailAccountId, {
     newsletterEmail: sender,
@@ -243,10 +238,11 @@ async function blockSender({
       labelId,
       emailAccountId,
     });
-    return;
+  } else {
+    await queueArchiveSenders({ senders: [sender] });
   }
 
-  await queueArchiveSenders({ senders: [sender] });
+  return ok;
 }
 
 export function useUnsubscribe<T extends Row>({
@@ -289,11 +285,16 @@ export function useUnsubscribe<T extends Row>({
         await mutate();
       } else {
         if (!userFacingUnsubscribeLink) {
-          await blockSender({
+          const ok = await blockSender({
             sender: item.name,
             emailAccountId,
             queueArchiveSenders,
           });
+          if (ok) {
+            toastSuccess({
+              description: "Sender blocked. Future emails will be archived.",
+            });
+          }
           await mutate();
           await refetchPremium();
           return;
@@ -366,27 +367,7 @@ export function useBulkUnsubscribe<T extends Row>({
       if (!hasUnsubscribeAccess) return;
       posthog.capture("Clicked Bulk Unsubscribe");
 
-      const hasAutomaticUnsubscribeItems = items.some((item) =>
-        getAutomaticUnsubscribeLink(item.unsubscribeLink),
-      );
-      const hasBlockFallbackItems = items.some(
-        (item) => !getAutomaticUnsubscribeLink(item.unsubscribeLink),
-      );
-      const isMixedUnsubscribeAndBlock =
-        hasAutomaticUnsubscribeItems && hasBlockFallbackItems;
-      let loadingMessage = "Unsubscribing from";
-      let successMessage = "unsubscribed";
-      let errorMessage = "Failed to unsubscribe from";
-
-      if (isMixedUnsubscribeAndBlock) {
-        loadingMessage = "Processing";
-        successMessage = "processed";
-        errorMessage = "Failed to process";
-      } else if (hasBlockFallbackItems) {
-        loadingMessage = "Blocking";
-        successMessage = "blocked";
-        errorMessage = "Failed to block";
-      }
+      const messages = getBulkUnsubscribeMessages(items);
 
       await executeBulkOperation({
         items,
@@ -398,16 +379,13 @@ export function useBulkUnsubscribe<T extends Row>({
           getAutomaticUnsubscribeLink(item.unsubscribeLink)
             ? NewsletterStatus.UNSUBSCRIBED
             : NewsletterStatus.AUTO_ARCHIVED,
-        loadingMessage,
-        successMessage,
-        errorMessage,
+        ...messages,
         processItem: async (item) => {
           if (!getAutomaticUnsubscribeLink(item.unsubscribeLink)) {
             await blockSender({
               sender: item.name,
               emailAccountId,
               queueArchiveSenders,
-              showSuccessToast: false,
             });
             return;
           }
@@ -462,14 +440,16 @@ async function autoArchive({
   emailAccountId: string;
   queueArchiveSenders: QueueArchiveSendersFn;
 }) {
-  await blockSender({
+  const ok = await blockSender({
     sender: name,
     emailAccountId,
     labelId,
     labelName,
     queueArchiveSenders,
-    successDescription: "Auto archive enabled!",
   });
+  if (ok) {
+    toastSuccess({ description: "Auto archive enabled!" });
+  }
   await mutate();
   await refetchPremium();
 }
@@ -609,7 +589,6 @@ export function useBulkAutoArchive<T extends Row>({
             sender: item.name,
             emailAccountId,
             queueArchiveSenders,
-            showSuccessToast: false,
           });
         },
         onComplete: refetchPremium,
@@ -993,6 +972,8 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
           onAutoArchive({
             emailAccountId,
             from: item.name,
+          }).then((ok) => {
+            if (ok) toastSuccess({ description: "Auto archive enabled!" });
           });
           await setNewsletterStatusAction(emailAccountId, {
             newsletterEmail: item.name,
@@ -1014,11 +995,16 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
           );
 
           if (!userFacingUnsubscribeLink) {
-            await blockSender({
+            const ok = await blockSender({
               sender: item.name,
               emailAccountId,
               queueArchiveSenders,
             });
+            if (ok) {
+              toastSuccess({
+                description: "Sender blocked. Future emails will be archived.",
+              });
+            }
             await mutate();
             await refetchPremium();
             return;
@@ -1131,4 +1117,33 @@ function getManualUnsubscribeLink(unsubscribeLink?: string | null) {
   return getUserFacingUnsubscribeLink({
     unsubscribeLink,
   });
+}
+
+function getBulkUnsubscribeMessages<T extends Row>(items: T[]) {
+  const hasAutomatic = items.some((item) =>
+    getAutomaticUnsubscribeLink(item.unsubscribeLink),
+  );
+  const hasBlock = items.some(
+    (item) => !getAutomaticUnsubscribeLink(item.unsubscribeLink),
+  );
+
+  if (hasAutomatic && hasBlock) {
+    return {
+      loadingMessage: "Processing",
+      successMessage: "processed",
+      errorMessage: "Failed to process",
+    };
+  }
+  if (hasBlock) {
+    return {
+      loadingMessage: "Blocking",
+      successMessage: "blocked",
+      errorMessage: "Failed to block",
+    };
+  }
+  return {
+    loadingMessage: "Unsubscribing from",
+    successMessage: "unsubscribed",
+    errorMessage: "Failed to unsubscribe from",
+  };
 }

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -212,18 +212,24 @@ async function blockSender({
   labelId,
   labelName,
   queueArchiveSenders,
+  successDescription = "Sender blocked. Future emails will be archived.",
+  showSuccessToast = true,
 }: {
   sender: string;
   emailAccountId: string;
   labelId?: string;
   labelName?: string;
   queueArchiveSenders: QueueArchiveSendersFn;
+  successDescription?: string;
+  showSuccessToast?: boolean;
 }) {
   await onAutoArchive({
     emailAccountId,
     from: sender,
     gmailLabelId: labelId,
     labelName,
+    successDescription,
+    showSuccessToast,
   });
   await setNewsletterStatusAction(emailAccountId, {
     newsletterEmail: sender,
@@ -360,6 +366,28 @@ export function useBulkUnsubscribe<T extends Row>({
       if (!hasUnsubscribeAccess) return;
       posthog.capture("Clicked Bulk Unsubscribe");
 
+      const hasAutomaticUnsubscribeItems = items.some((item) =>
+        getAutomaticUnsubscribeLink(item.unsubscribeLink),
+      );
+      const hasBlockFallbackItems = items.some(
+        (item) => !getAutomaticUnsubscribeLink(item.unsubscribeLink),
+      );
+      const isMixedUnsubscribeAndBlock =
+        hasAutomaticUnsubscribeItems && hasBlockFallbackItems;
+      let loadingMessage = "Unsubscribing from";
+      let successMessage = "unsubscribed";
+      let errorMessage = "Failed to unsubscribe from";
+
+      if (isMixedUnsubscribeAndBlock) {
+        loadingMessage = "Processing";
+        successMessage = "processed";
+        errorMessage = "Failed to process";
+      } else if (hasBlockFallbackItems) {
+        loadingMessage = "Blocking";
+        successMessage = "blocked";
+        errorMessage = "Failed to block";
+      }
+
       await executeBulkOperation({
         items,
         mutate,
@@ -370,15 +398,16 @@ export function useBulkUnsubscribe<T extends Row>({
           getAutomaticUnsubscribeLink(item.unsubscribeLink)
             ? NewsletterStatus.UNSUBSCRIBED
             : NewsletterStatus.AUTO_ARCHIVED,
-        loadingMessage: "Unsubscribing from",
-        successMessage: "unsubscribed",
-        errorMessage: "Failed to unsubscribe from",
+        loadingMessage,
+        successMessage,
+        errorMessage,
         processItem: async (item) => {
           if (!getAutomaticUnsubscribeLink(item.unsubscribeLink)) {
             await blockSender({
               sender: item.name,
               emailAccountId,
               queueArchiveSenders,
+              showSuccessToast: false,
             });
             return;
           }
@@ -439,6 +468,7 @@ async function autoArchive({
     labelId,
     labelName,
     queueArchiveSenders,
+    successDescription: "Auto archive enabled!",
   });
   await mutate();
   await refetchPremium();
@@ -580,6 +610,7 @@ export function useBulkAutoArchive<T extends Row>({
             from: item.name,
             gmailLabelId: undefined,
             labelName: undefined,
+            showSuccessToast: false,
           });
           await setNewsletterStatusAction(emailAccountId, {
             newsletterEmail: item.name,

--- a/apps/web/utils/actions/client.ts
+++ b/apps/web/utils/actions/client.ts
@@ -10,16 +10,12 @@ export async function onAutoArchive({
   from,
   gmailLabelId,
   labelName,
-  successDescription = "Auto archive enabled!",
-  showSuccessToast = true,
 }: {
   emailAccountId: string;
   from: string;
   gmailLabelId?: string;
   labelName?: string;
-  successDescription?: string;
-  showSuccessToast?: boolean;
-}) {
+}): Promise<boolean> {
   const result = await createAutoArchiveFilterAction(emailAccountId, {
     from,
     gmailLabelId,
@@ -31,11 +27,9 @@ export async function onAutoArchive({
       description:
         `There was an error enabling auto archive. ${result.serverError || ""}`.trim(),
     });
-  } else if (showSuccessToast) {
-    toastSuccess({
-      description: successDescription,
-    });
+    return false;
   }
+  return true;
 }
 
 export async function onDeleteFilter({

--- a/apps/web/utils/actions/client.ts
+++ b/apps/web/utils/actions/client.ts
@@ -10,11 +10,15 @@ export async function onAutoArchive({
   from,
   gmailLabelId,
   labelName,
+  successDescription = "Auto archive enabled!",
+  showSuccessToast = true,
 }: {
   emailAccountId: string;
   from: string;
   gmailLabelId?: string;
   labelName?: string;
+  successDescription?: string;
+  showSuccessToast?: boolean;
 }) {
   const result = await createAutoArchiveFilterAction(emailAccountId, {
     from,
@@ -27,9 +31,9 @@ export async function onAutoArchive({
       description:
         `There was an error enabling auto archive. ${result.serverError || ""}`.trim(),
     });
-  } else {
+  } else if (showSuccessToast) {
     toastSuccess({
-      description: "Auto archive enabled!",
+      description: successDescription,
     });
   }
 }


### PR DESCRIPTION
Adjusts bulk action notifications so per-item auto-archive success toasts can be suppressed and fallback block copy is clearer.

Bulk unsubscribe now uses aggregate messages for unsubscribe, block, or mixed batches while preserving error toasts.

Validation: pnpm exec biome check 'apps/web/utils/actions/client.ts' 'apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts'.