### PR TITLE
docs: Update code style guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,10 @@
 - No re-export patterns. Import from the original source.
 - Prefer the `EmailProvider` abstraction; only use provider-type checks (`isGoogleProvider`, `isMicrosoftProvider`) at true provider boundary/integration code.
 - Infer types from Zod schemas using `z.infer<typeof schema>` instead of duplicating as separate interfaces
-- Avoid premature abstraction. Duplicating 2-3 times is fine; extract when a stable pattern emerges.
 - Default to inlining and co-locating logic at the call site.
-- Extract a helper when it makes the call site clearly easier to read, names a meaningful domain concept, or centralizes shared behavior that should stay consistent across flows.
-- The bar is that the surrounding code gets clearer or safer, not that the helper looks nice in isolation.
+- Avoid premature abstraction. Small duplicated expressions are fine when extraction would add indirection without clearer meaning.
+- Do not duplicate substantial logic or correctness-sensitive rules. If copied code must stay in sync to avoid bugs, extract or centralize it early.
+- Extract helpers when they make surrounding code clearer, name a meaningful domain concept, or keep shared behavior consistent across flows.
 - Don't extract helpers that just rename and forward parameters; that's a layer without meaning.
 - Avoid large/nested ternaries. Prefer straightforward control flow, a small helper, or a lookup table when it improves readability.
 - No barrel files. Import directly from source files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,10 @@
 - Infer types from Zod schemas using `z.infer<typeof schema>` instead of duplicating as separate interfaces
 - Avoid premature abstraction. Duplicating 2-3 times is fine; extract when a stable pattern emerges.
 - Default to inlining and co-locating logic at the call site.
-- Extract a helper when doing so makes the call site clearly easier to read — e.g., a non-obvious computation gets a name, or a nested branch becomes a clean lookup. The bar is "the call site is better," not "the helper looks nice."
+- Extract a helper when it makes the call site clearly easier to read, names a meaningful domain concept, or centralizes shared behavior that should stay consistent across flows.
+- The bar is that the surrounding code gets clearer or safer, not that the helper looks nice in isolation.
 - Don't extract helpers that just rename and forward parameters; that's a layer without meaning.
-- Avoid large/nested ternaries. Prefer a small helper, an early-return cascade, or a lookup table.
+- Avoid large/nested ternaries. Prefer straightforward control flow, a small helper, or a lookup table when it improves readability.
 - No barrel files. Import directly from source files.
 - Colocate page components next to their `page.tsx`. No nested `components/` subfolders in route directories.
 - Reusable components shared across pages go in `apps/web/components/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 - Prefer the `EmailProvider` abstraction; only use provider-type checks (`isGoogleProvider`, `isMicrosoftProvider`) at true provider boundary/integration code.
 - Infer types from Zod schemas using `z.infer<typeof schema>` instead of duplicating as separate interfaces
 - Default to inlining and co-locating logic at the call site.
-- Avoid premature abstraction. Small duplicated expressions are fine when extraction would add indirection without clearer meaning.
+- Avoid premature abstraction. Small duplicated expressions are usually fine; extracting them often adds indirection without meaning.
 - Do not duplicate substantial logic or correctness-sensitive rules. If copied code must stay in sync to avoid bugs, extract or centralize it early.
 - Extract helpers when they make surrounding code clearer, name a meaningful domain concept, or keep shared behavior consistent across flows.
 - Don't extract helpers that just rename and forward parameters; that's a layer without meaning.


### PR DESCRIPTION
Updates contributor guidance around when to inline logic versus extracting helpers.

The wording keeps co-location as the default while allowing helpers for clearer call sites, meaningful domain concepts, or shared behavior that should stay consistent across flows.

Validation: docs-only change.