### PR TITLE
rule processing: Preserve reply drafts

### DIFF
--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   ensureConversationRuleContinuity,
+  ensureConversationRuleForAiCalendarMatch,
   CONVERSATION_TRACKING_META_RULE_ID,
   limitDraftEmailActions,
   runRules,
@@ -252,6 +253,144 @@ describe("ensureConversationRuleContinuity", () => {
       },
       select: { id: true },
     });
+  });
+});
+
+describe("ensureConversationRuleForAiCalendarMatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds the conversation meta rule for AI-selected calendar matches", () => {
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR);
+    const matches = [
+      {
+        rule: calendarRule,
+        matchReasons: [{ type: ConditionType.AI }],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [toReplyRule],
+      regularRules: [calendarRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(matches[0]);
+    expect(result[1]).toEqual({
+      rule: conversationMetaRule,
+      matchReasons: [{ type: ConditionType.STATIC }],
+    });
+  });
+
+  it("does not add the conversation meta rule for preset calendar matches", () => {
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR);
+    const matches = [
+      {
+        rule: calendarRule,
+        matchReasons: [
+          { type: ConditionType.PRESET, systemType: SystemType.CALENDAR },
+        ],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [toReplyRule],
+      regularRules: [calendarRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toEqual(matches);
+  });
+
+  it("does not add the conversation meta rule when a preset calendar match also has an AI reason", () => {
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR);
+    const matches = [
+      {
+        rule: calendarRule,
+        matchReasons: [
+          { type: ConditionType.PRESET, systemType: SystemType.CALENDAR },
+          { type: ConditionType.AI },
+        ],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [toReplyRule],
+      regularRules: [calendarRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toEqual(matches);
+  });
+
+  it("does not add the conversation meta rule when conversation rules are disabled", () => {
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR);
+    const disabledToReplyRule = {
+      ...toReplyRule,
+      enabled: false,
+    };
+    const matches = [
+      {
+        rule: calendarRule,
+        matchReasons: [{ type: ConditionType.AI }],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [disabledToReplyRule],
+      regularRules: [calendarRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toEqual(matches);
+  });
+
+  it("does not add a duplicate conversation meta rule", () => {
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR);
+    const matches = [
+      {
+        rule: calendarRule,
+        matchReasons: [{ type: ConditionType.AI }],
+      },
+      {
+        rule: conversationMetaRule,
+        matchReasons: [{ type: ConditionType.STATIC }],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [toReplyRule],
+      regularRules: [calendarRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toEqual(matches);
+  });
+
+  it("does not add the conversation meta rule for non-calendar AI matches", () => {
+    const marketingRule = createRule("marketing-rule", SystemType.MARKETING);
+    const matches = [
+      {
+        rule: marketingRule,
+        matchReasons: [{ type: ConditionType.AI }],
+      },
+    ];
+
+    const result = ensureConversationRuleForAiCalendarMatch({
+      conversationRules: [toReplyRule],
+      regularRules: [marketingRule, conversationMetaRule],
+      matches,
+      logger,
+    });
+
+    expect(result).toEqual(matches);
   });
 });
 
@@ -889,6 +1028,216 @@ describe("limitDraftEmailActions", () => {
 describe("runRules - double draft prevention", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("keeps a reply draft when an AI-selected calendar message needs a response", async () => {
+    const { findMatchingRules } = await import(
+      "@/utils/ai/choose-rule/match-rules"
+    );
+    const { determineConversationStatus } = await import(
+      "@/utils/reply-tracker/handle-conversation-status"
+    );
+    const { getActionItemsWithAiArgs } = await import(
+      "@/utils/ai/choose-rule/choose-args"
+    );
+
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR, [
+      getAction({
+        id: "label-calendar",
+        type: ActionType.LABEL,
+        label: "Calendar",
+        ruleId: "calendar-rule",
+      }),
+    ]);
+    const toReplyWithDraft = createRule("to-reply-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "label-to-reply",
+        type: ActionType.LABEL,
+        label: "To Reply",
+        ruleId: "to-reply-rule",
+      }),
+      getAction({
+        id: "draft-to-reply",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "to-reply-rule",
+      }),
+    ]);
+
+    vi.mocked(findMatchingRules).mockResolvedValue({
+      matches: [
+        {
+          rule: calendarRule,
+          matchReasons: [{ type: ConditionType.AI }],
+        },
+      ],
+      reasoning: "Scheduling conversation",
+    });
+
+    vi.mocked(determineConversationStatus).mockResolvedValue({
+      rule: toReplyWithDraft,
+      reason: "Email needs a reply",
+    });
+
+    vi.mocked(getActionItemsWithAiArgs).mockImplementation(
+      async ({ selectedRule }) =>
+        selectedRule.actions.map((action) => ({
+          ...action,
+          type: action.type as ActionType,
+        })),
+    );
+
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+
+    const createdActionTypes: ActionType[][] = [];
+    (prisma.executedRule.create as any).mockImplementation(
+      async (args: any) => {
+        const actionItems = args.data.actionItems?.createMany?.data || [];
+        createdActionTypes.push(actionItems.map((action: any) => action.type));
+        return {
+          id: `exec-${createdActionTypes.length}`,
+          status: ExecutedRuleStatus.APPLYING,
+          ruleId: args.data.rule?.connect?.id ?? null,
+          threadId: args.data.threadId,
+          messageId: args.data.messageId,
+          actionItems: actionItems.map((action: any, index: number) => ({
+            ...action,
+            id: action.id || `action-${createdActionTypes.length}-${index}`,
+            executedRuleId: `exec-${createdActionTypes.length}`,
+          })),
+        };
+      },
+    );
+
+    await runRules({
+      provider: {} as any,
+      message: {
+        ...getEmail(),
+        id: "message-1",
+        threadId,
+        snippet: "",
+        historyId: "history-1",
+        inline: [],
+        attachments: [],
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Lunch next week?",
+          date: "Mon, 1 Jan 2026 12:00:00 +0000",
+          "message-id": "<message-1>",
+        },
+      } as any,
+      rules: [calendarRule, toReplyWithDraft],
+      emailAccount: getEmailAccount(),
+      isTest: false,
+      modelType: "default" as any,
+      logger,
+    });
+
+    expect(createdActionTypes).toEqual([
+      [ActionType.LABEL],
+      [ActionType.LABEL, ActionType.DRAFT_EMAIL],
+    ]);
+  });
+
+  it("does not resolve conversation status for calendar invite preset matches", async () => {
+    const { findMatchingRules } = await import(
+      "@/utils/ai/choose-rule/match-rules"
+    );
+    const { determineConversationStatus } = await import(
+      "@/utils/reply-tracker/handle-conversation-status"
+    );
+    const { getActionItemsWithAiArgs } = await import(
+      "@/utils/ai/choose-rule/choose-args"
+    );
+
+    const calendarRule = createRule("calendar-rule", SystemType.CALENDAR, [
+      getAction({
+        id: "label-calendar",
+        type: ActionType.LABEL,
+        label: "Calendar",
+        ruleId: "calendar-rule",
+      }),
+    ]);
+    const toReplyWithDraft = createRule("to-reply-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "draft-to-reply",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "to-reply-rule",
+      }),
+    ]);
+
+    vi.mocked(findMatchingRules).mockResolvedValue({
+      matches: [
+        {
+          rule: calendarRule,
+          matchReasons: [
+            { type: ConditionType.PRESET, systemType: SystemType.CALENDAR },
+            { type: ConditionType.AI },
+          ],
+        },
+      ],
+      reasoning: "Calendar invite",
+    });
+
+    vi.mocked(getActionItemsWithAiArgs).mockImplementation(
+      async ({ selectedRule }) =>
+        selectedRule.actions.map((action) => ({
+          ...action,
+          type: action.type as ActionType,
+        })),
+    );
+
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+
+    const createdActionTypes: ActionType[][] = [];
+    (prisma.executedRule.create as any).mockImplementation(
+      async (args: any) => {
+        const actionItems = args.data.actionItems?.createMany?.data || [];
+        createdActionTypes.push(actionItems.map((action: any) => action.type));
+        return {
+          id: `exec-${createdActionTypes.length}`,
+          status: ExecutedRuleStatus.APPLYING,
+          ruleId: args.data.rule?.connect?.id ?? null,
+          threadId: args.data.threadId,
+          messageId: args.data.messageId,
+          actionItems: actionItems.map((action: any, index: number) => ({
+            ...action,
+            id: action.id || `action-${createdActionTypes.length}-${index}`,
+            executedRuleId: `exec-${createdActionTypes.length}`,
+          })),
+        };
+      },
+    );
+
+    await runRules({
+      provider: {} as any,
+      message: {
+        ...getEmail(),
+        id: "message-1",
+        threadId,
+        snippet: "",
+        historyId: "history-1",
+        inline: [],
+        attachments: [],
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Calendar invite",
+          date: "Mon, 1 Jan 2026 12:00:00 +0000",
+          "message-id": "<message-1>",
+        },
+      } as any,
+      rules: [calendarRule, toReplyWithDraft],
+      emailAccount: getEmailAccount(),
+      isTest: false,
+      modelType: "default" as any,
+      logger,
+    });
+
+    expect(determineConversationStatus).not.toHaveBeenCalled();
+    expect(createdActionTypes).toEqual([[ActionType.LABEL]]);
   });
 
   it("executes only one DRAFT_EMAIL when custom rule and TO_REPLY both have drafts", async () => {

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -127,13 +127,20 @@ export async function runRules({
     logger,
   });
 
+  const calendarAwareMatches = ensureConversationRuleForAiCalendarMatch({
+    conversationRules,
+    regularRules,
+    matches: results.matches,
+    logger,
+  });
+
   // Auto-reapply conversation tracking for thread continuity
   const conversationAwareMatches = await ensureConversationRuleContinuity({
     emailAccountId: emailAccount.id,
     threadId: message.threadId,
     conversationRules,
     regularRules,
-    matches: results.matches,
+    matches: calendarAwareMatches,
     logger,
   });
 
@@ -295,6 +302,60 @@ function prepareRulesWithMetaRule(rules: RuleWithActions[]): {
   }
 
   return { regularRules, conversationRules };
+}
+
+export function ensureConversationRuleForAiCalendarMatch<
+  T extends { rule: RuleWithActions; matchReasons?: MatchReason[] },
+>({
+  conversationRules,
+  regularRules,
+  matches,
+  logger,
+}: {
+  conversationRules: RuleWithActions[];
+  regularRules: RuleWithActions[];
+  matches: T[];
+  logger: Logger;
+}): T[] {
+  if (!conversationRules.some((rule) => rule.enabled)) {
+    return matches;
+  }
+
+  const hasAiCalendarMatch = matches.some(
+    (match) =>
+      match.rule.systemType === SystemType.CALENDAR &&
+      !match.matchReasons?.some(
+        (reason) =>
+          reason.type === ConditionType.PRESET &&
+          reason.systemType === SystemType.CALENDAR,
+      ) &&
+      match.matchReasons?.some((reason) => reason.type === ConditionType.AI),
+  );
+
+  if (!hasAiCalendarMatch) {
+    return matches;
+  }
+
+  if (matches.some((match) => isConversationRule(match.rule.id))) {
+    return matches;
+  }
+
+  const metaRule = regularRules.find((rule) => isConversationRule(rule.id));
+  if (!metaRule) {
+    return matches;
+  }
+
+  logger.info("Adding conversation meta rule for AI-selected calendar match", {
+    module: MODULE,
+  });
+
+  return [
+    ...matches,
+    {
+      rule: metaRule,
+      matchReasons: [{ type: ConditionType.STATIC }],
+    } as T,
+  ];
 }
 
 async function executeMatchedRule(

--- a/docs/essentials/email-ai-personal-assistant.mdx
+++ b/docs/essentials/email-ai-personal-assistant.mdx
@@ -131,6 +131,14 @@ Everything outside the `{{...}}` placeholders will remain exactly as written.
 
 When "Apply to Threads" is disabled on a rule, that rule is skipped for replies and only runs on the first email in a conversation. This is useful for rules that target standalone emails like newsletters or receipts — disabling it means the AI evaluates fewer rules on threaded emails, improving speed and accuracy.
 
+#### When Multiple Rules Can Apply
+
+If multi-rule selection is off, the AI normally chooses one rule. A few automatic behaviors can still add another label:
+
+* A static rule, like `From` contains `@company.com`, can label an email as `Team` while `To Reply` adds a draft if the message needs a response.
+* If a thread was already marked `To Reply` or `Awaiting Reply`, replies in that thread can keep the conversation moving between those labels.
+* A message like "Does Wednesday at 2pm work?" can be labeled `Calendar` and also `To Reply`, so you get a draft response. Calendar invite files and event reminders stay `Calendar` only.
+
 ### Test Rules
 
 You can test your rules by going to the [Test](https://www.getinboxzero.com/automation?tab=test) tab.
@@ -154,4 +162,3 @@ If a rule isn't behaving as expected (e.g., incorrectly marking emails as "to re
 5. The AI will adjust the rule accordingly
 
 Alternatively, use the [AI Chat](/essentials/ai-chat) to describe the issue and get help fixing it.
-


### PR DESCRIPTION
Allows scheduling-related rule matches to also resolve reply state when a response is needed. Keeps calendar invite and reminder matches calendar-only, expands focused test coverage, and documents when automatic labels can still combine with reply workflow labels.

Tests: `pnpm --filter inbox-zero-ai test utils/ai/choose-rule/run-rules.test.ts`