### PR TITLE
utils: Fix account-targeted email links

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -191,7 +191,7 @@ describe("pending email handled state helpers", () => {
         },
       }),
     ).toBe(
-      "Open in Gmail: https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
+      "Open in Gmail: https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
     );
   });
 

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -181,7 +181,7 @@ describe("handleRuleNotificationAction", () => {
     expect(cardText).toContain("Status: Reply sent.");
     expect(cardText).toContain("Open in Gmail");
     expect(cardText).toContain(
-      "https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
+      "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
     );
   });
 
@@ -693,7 +693,7 @@ describe("sendMessagingRuleNotification", () => {
 
     expect(serializedBlocks).toContain("Open in Gmail");
     expect(serializedBlocks).toContain(
-      "https://mail.google.com/mail/u/0/?authuser=user%40example.com/#all/message-1",
+      "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
     );
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -15,7 +15,7 @@ describe("getEmailUrl", () => {
     it("builds Gmail URL with email address", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "google");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
       );
     });
 
@@ -55,21 +55,21 @@ describe("getEmailUrl", () => {
     it("uses Gmail format when provider is undefined", () => {
       const result = getEmailUrl("msg123", "user@gmail.com");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
       );
     });
 
     it("falls back to default for unknown provider", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "unknown");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
       );
     });
 
     it("falls back to default for empty provider", () => {
       const result = getEmailUrl("msg123", "user@gmail.com", "");
       expect(result).toBe(
-        "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#all/msg123",
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
       );
     });
   });
@@ -164,7 +164,7 @@ describe("getGmailSearchUrl", () => {
   it("builds advanced search URL with from parameter", () => {
     const result = getGmailSearchUrl("sender@example.com", "user@gmail.com");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -190,7 +190,7 @@ describe("getEmailSearchUrl", () => {
       "google",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -212,7 +212,7 @@ describe("getEmailSearchUrl", () => {
       "",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
     );
   });
 
@@ -223,7 +223,7 @@ describe("getEmailSearchUrl", () => {
       "unknown-provider",
     );
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#advanced-search/from=sender%40example.com",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
     );
   });
 });
@@ -232,7 +232,7 @@ describe("getGmailBasicSearchUrl", () => {
   it("builds search URL with query", () => {
     const result = getGmailBasicSearchUrl("user@gmail.com", "is:unread");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#search/is%3Aunread",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#search/is%3Aunread",
     );
   });
 
@@ -259,7 +259,7 @@ describe("getGmailFilterSettingsUrl", () => {
   it("builds filter settings URL with email address", () => {
     const result = getGmailFilterSettingsUrl("user@gmail.com");
     expect(result).toBe(
-      "https://mail.google.com/mail/u/0/?authuser=user%40gmail.com/#settings/filters",
+      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#settings/filters",
     );
   });
 

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -1,7 +1,10 @@
-function getGmailBaseUrl(emailAddress?: string | null) {
-  const base = "https://mail.google.com/mail/u/0";
-  if (!emailAddress) return base;
-  return `${base}/?authuser=${encodeURIComponent(emailAddress)}`;
+function getGmailUrlForFragment(
+  fragment: string,
+  emailAddress?: string | null,
+) {
+  if (!emailAddress) return `https://mail.google.com/mail/u/0/#${fragment}`;
+
+  return `https://mail.google.com/mail/u/?authuser=${encodeURIComponent(emailAddress)}#${fragment}`;
 }
 
 function getOutlookBaseUrl() {
@@ -37,22 +40,24 @@ const PROVIDER_CONFIG: Record<
   google: {
     requiresMessageId: false,
     buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
-      `${getGmailBaseUrl(emailAddress)}/#all/${messageOrThreadId}`,
+      getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
     selectId: (messageId: string, _threadId: string) => messageId,
     buildSearchUrl: (from: string, emailAddress?: string | null) =>
-      `${getGmailBaseUrl(
+      getGmailUrlForFragment(
+        `advanced-search/from=${encodeURIComponent(from)}`,
         emailAddress,
-      )}/#advanced-search/from=${encodeURIComponent(from)}`,
+      ),
   },
   default: {
     requiresMessageId: false,
     buildUrl: (messageOrThreadId: string, emailAddress?: string | null) =>
-      `${getGmailBaseUrl(emailAddress)}/#all/${messageOrThreadId}`,
+      getGmailUrlForFragment(`all/${messageOrThreadId}`, emailAddress),
     selectId: (_messageId: string, threadId: string) => threadId,
     buildSearchUrl: (from: string, emailAddress?: string | null) =>
-      `${getGmailBaseUrl(
+      getGmailUrlForFragment(
+        `advanced-search/from=${encodeURIComponent(from)}`,
         emailAddress,
-      )}/#advanced-search/from=${encodeURIComponent(from)}`,
+      ),
   },
 } as const;
 
@@ -140,9 +145,10 @@ export function getEmailSearchUrl(
 }
 
 export function getGmailBasicSearchUrl(emailAddress: string, query: string) {
-  return `${getGmailBaseUrl(emailAddress)}/#search/${encodeURIComponent(
-    query,
-  )}`;
+  return getGmailUrlForFragment(
+    `search/${encodeURIComponent(query)}`,
+    emailAddress,
+  );
 }
 
 // export function getGmailCreateFilterUrl(
@@ -156,5 +162,5 @@ export function getGmailBasicSearchUrl(emailAddress: string, query: string) {
 // }
 
 export function getGmailFilterSettingsUrl(emailAddress?: string | null) {
-  return `${getGmailBaseUrl(emailAddress)}/#settings/filters`;
+  return getGmailUrlForFragment("settings/filters", emailAddress);
 }


### PR DESCRIPTION
Updates Gmail URL generation so account-targeted links use account selection without pinning the first mailbox.

- Keeps the existing fallback when no account address is available.
- Updates URL and notification tests for the corrected link shape.