### PR TITLE
Add product analytics events

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting.tsx
@@ -8,9 +8,11 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { MessagingRoutePurpose } from "@/generated/prisma/enums";
 import { updateMeetingBriefsEmailDeliveryAction } from "@/utils/actions/messaging-channels";
 import { getActionErrorMessage } from "@/utils/error";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 export function DeliveryChannelsSetting() {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics("meeting_briefs");
   const {
     data: briefSettings,
     isLoading: isLoadingBriefSettings,
@@ -21,6 +23,7 @@ export function DeliveryChannelsSetting() {
     updateMeetingBriefsEmailDeliveryAction.bind(null, emailAccountId),
     {
       onSuccess: () => {
+        analytics.captureAction("meeting_briefs_email_delivery_saved");
         toastSuccess({ description: "Settings saved" });
         mutateBriefSettings();
       },
@@ -41,7 +44,12 @@ export function DeliveryChannelsSetting() {
       email={{
         enabled: briefSettings?.meetingBriefsSendEmail ?? true,
         isLoading: isLoadingBriefSettings,
-        onChange: (sendEmail) => executeEmailDelivery({ sendEmail }),
+        onChange: (sendEmail) => {
+          analytics.captureAction("meeting_briefs_email_delivery_toggled", {
+            enabled: sendEmail,
+          });
+          executeEmailDelivery({ sendEmail });
+        },
       }}
       connectSlackCta="Want to receive briefs in Slack?"
     />

--- a/apps/web/app/(app)/[emailAccountId]/briefs/Onboarding.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/briefs/Onboarding.tsx
@@ -55,7 +55,10 @@ export function BriefsOnboarding({
       ) : (
         <>
           <MessageText>Connect your calendar to get started:</MessageText>
-          <ConnectCalendar onboardingReturnPath={`/${emailAccountId}/briefs`} />
+          <ConnectCalendar
+            analyticsPage="meeting_briefs"
+            onboardingReturnPath={`/${emailAccountId}/briefs`}
+          />
         </>
       )}
     </SetupCard>

--- a/apps/web/app/(app)/[emailAccountId]/briefs/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/briefs/page.tsx
@@ -17,9 +17,11 @@ import { UpcomingMeetings } from "@/app/(app)/[emailAccountId]/briefs/UpcomingMe
 import { BriefsOnboarding } from "@/app/(app)/[emailAccountId]/briefs/Onboarding";
 import { IntegrationsSetting } from "@/app/(app)/[emailAccountId]/briefs/IntegrationsSetting";
 import { DeliveryChannelsSetting } from "@/app/(app)/[emailAccountId]/briefs/DeliveryChannelsSetting";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 export default function MeetingBriefsPage() {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics("meeting_briefs");
   const { data: calendarsData, isLoading: isLoadingCalendars } = useCalendars();
   const { data, isLoading, error, mutate } = useMeetingBriefSettings();
 
@@ -30,6 +32,7 @@ export default function MeetingBriefsPage() {
     updateMeetingBriefsEnabledAction.bind(null, emailAccountId),
     {
       onSuccess: () => {
+        analytics.captureAction("meeting_briefs_enabled_saved");
         toastSuccess({ description: "Settings saved!" });
         mutate();
       },
@@ -54,7 +57,12 @@ export default function MeetingBriefsPage() {
       <BriefsOnboarding
         emailAccountId={emailAccountId}
         hasCalendarConnected={hasCalendarConnected}
-        onEnable={() => execute({ enabled: true })}
+        onEnable={() => {
+          analytics.captureAction("meeting_briefs_enable_started", {
+            has_calendar_connected: Boolean(hasCalendarConnected),
+          });
+          execute({ enabled: true });
+        }}
         isEnabling={status === "executing"}
       />
     );
@@ -76,7 +84,12 @@ export default function MeetingBriefsPage() {
                 <Toggle
                   name="enabled"
                   enabled={!!data?.enabled}
-                  onChange={(enabled) => execute({ enabled })}
+                  onChange={(enabled) => {
+                    analytics.captureAction("meeting_briefs_toggled", {
+                      enabled,
+                    });
+                    execute({ enabled });
+                  }}
                   disabled={!hasCalendarConnected}
                 />
               }

--- a/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-archive/BulkArchive.tsx
@@ -18,8 +18,10 @@ import { LoadingContent } from "@/components/LoadingContent";
 import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { PageHeading } from "@/components/Typography";
 import { EmailStatsPreloader } from "@/components/EmailStatsPreloader";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 export function BulkArchive() {
+  const analytics = useProductAnalytics("bulk_archive");
   const { isBulkCategorizing } = useCategorizeProgress();
   const [onboarding] = useQueryState("onboarding", parseAsBoolean);
   const [bulkAction, setBulkAction] = useState<BulkActionType>("archive");
@@ -47,8 +49,9 @@ export function BulkArchive() {
   );
 
   const handleProgressComplete = useCallback(() => {
+    analytics.captureAction("bulk_archive_categorization_completed");
     mutate();
-  }, [mutate]);
+  }, [analytics, mutate]);
 
   const [setupDismissed, setSetupDismissed] = useState(false);
 
@@ -69,7 +72,12 @@ export function BulkArchive() {
           <div className="flex items-center gap-2">
             <BulkArchiveSettingsModal
               selectedAction={bulkAction}
-              onActionChange={setBulkAction}
+              onActionChange={(action) => {
+                analytics.captureAction("bulk_archive_action_changed", {
+                  action,
+                });
+                setBulkAction(action);
+              }}
             />
             <CategorizeWithAiButton
               buttonProps={{ variant: "outline", size: "sm" }}
@@ -87,6 +95,9 @@ export function BulkArchive() {
       <AutoCategorizationSetup
         open={shouldShowSetup}
         onOpenChange={(open) => {
+          analytics.captureAction("bulk_archive_setup_dialog_toggled", {
+            open,
+          });
           if (!open) setSetupDismissed(true);
         }}
       />

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -34,6 +34,7 @@ import {
   getHttpUnsubscribeLink,
   getUserFacingUnsubscribeLink,
 } from "@/utils/parse/unsubscribe";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 // Shared type for SWR mutate function
 type MutateFn = (
@@ -260,6 +261,7 @@ export function useUnsubscribe<T extends Row>({
   posthog: PostHog;
   refetchPremium: () => Promise<UserResponse | null | undefined>;
 }) {
+  const analytics = useProductAnalytics("bulk_unsubscribe");
   const [unsubscribeLoading, setUnsubscribeLoading] = useState(false);
   const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
   const automaticUnsubscribeLink = getAutomaticUnsubscribeLink(
@@ -276,6 +278,11 @@ export function useUnsubscribe<T extends Row>({
 
     try {
       posthog.capture("Clicked Unsubscribe");
+      analytics.captureAction("unsubscribe_sender_started", {
+        status: item.status,
+        has_automatic_unsubscribe_link: Boolean(automaticUnsubscribeLink),
+        has_user_facing_unsubscribe_link: Boolean(userFacingUnsubscribeLink),
+      });
 
       if (item.status === NewsletterStatus.UNSUBSCRIBED) {
         await setNewsletterStatusAction(emailAccountId, {
@@ -291,6 +298,9 @@ export function useUnsubscribe<T extends Row>({
             queueArchiveSenders,
           });
           if (ok) {
+            analytics.captureAction("unsubscribe_sender_completed", {
+              outcome: "blocked_sender",
+            });
             toastSuccess({
               description: "Sender blocked. Future emails will be archived.",
             });
@@ -311,7 +321,14 @@ export function useUnsubscribe<T extends Row>({
           queueArchiveSenders,
         });
         if (!unsubscribed) {
+          analytics.captureAction("unsubscribe_sender_failed", {
+            reason: "automatic_unsubscribe_failed",
+          });
           toast.error(`Could not automatically unsubscribe from ${item.name}`);
+        } else {
+          analytics.captureAction("unsubscribe_sender_completed", {
+            outcome: "unsubscribed_and_archived",
+          });
         }
       }
     } catch (error) {
@@ -325,6 +342,7 @@ export function useUnsubscribe<T extends Row>({
     item.status,
     item.unsubscribeLink,
     automaticUnsubscribeLink,
+    analytics,
     mutate,
     refetchPremium,
     posthog,
@@ -360,12 +378,17 @@ export function useBulkUnsubscribe<T extends Row>({
   onDeselectItem?: (id: string) => void;
   filter: NewsletterFilterType;
 }) {
+  const analytics = useProductAnalytics("bulk_unsubscribe");
   const { queueArchiveSenders } = useArchiveSenderQueueActions(emailAccountId);
 
   const onBulkUnsubscribe = useCallback(
     async (items: T[]) => {
       if (!hasUnsubscribeAccess) return;
       posthog.capture("Clicked Bulk Unsubscribe");
+      analytics.captureAction("bulk_unsubscribe_started", {
+        item_count: items.length,
+        filter,
+      });
 
       const messages = getBulkUnsubscribeMessages(items);
 
@@ -407,6 +430,10 @@ export function useBulkUnsubscribe<T extends Row>({
           await refetchPremium();
         },
       });
+      analytics.captureAction("bulk_unsubscribe_completed", {
+        item_count: items.length,
+        filter,
+      });
     },
     [
       hasUnsubscribeAccess,
@@ -416,6 +443,7 @@ export function useBulkUnsubscribe<T extends Row>({
       emailAccountId,
       onDeselectItem,
       filter,
+      analytics,
       queueArchiveSenders,
     ],
   );

--- a/apps/web/app/(app)/[emailAccountId]/calendars/CalendarConnections.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/CalendarConnections.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConnectCalendar } from "@/app/(app)/[emailAccountId]/calendars/ConnectCalendar";
 import { TypographyP } from "@/components/Typography";
 import { toastError } from "@/components/Toast";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 export function CalendarConnections() {
   useCalendarNotifications();
@@ -72,6 +73,7 @@ function useCalendarNotifications() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const analytics = useProductAnalytics("calendars");
 
   useEffect(() => {
     const errorParam = searchParams.get("error");
@@ -135,7 +137,10 @@ function useCalendarNotifications() {
       title: errorMessage.title,
       description: errorMessage.description,
     });
+    analytics.captureAction("calendar_connect_failed", {
+      error_code: errorParam,
+    });
 
     router.replace(pathname);
-  }, [pathname, router, searchParams]);
+  }, [analytics, pathname, router, searchParams]);
 }

--- a/apps/web/app/(app)/[emailAccountId]/calendars/CalendarSettings.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/CalendarSettings.tsx
@@ -22,6 +22,7 @@ import {
   updateBookingLinkBody,
 } from "@/utils/actions/calendar.validation";
 import { Select } from "@/components/Select";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 const BASE_TIMEZONES = [
   { label: "Samoa (GMT-11)", value: "Pacific/Samoa" },
@@ -56,6 +57,7 @@ const BASE_TIMEZONES = [
 
 export function CalendarSettings() {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics("calendars");
   const { data, isLoading, error, mutate } = useCalendars();
   const timezone = data?.timezone || null;
   const calendarBookingLink = data?.calendarBookingLink || null;
@@ -86,6 +88,9 @@ export function CalendarSettings() {
   const { execute: executeUpdateTimezone, isExecuting: isUpdatingTimezone } =
     useAction(updateEmailAccountTimezoneAction.bind(null, emailAccountId), {
       onSuccess: () => {
+        analytics.captureAction("calendar_timezone_saved", {
+          had_existing_timezone: Boolean(timezone),
+        });
         toastSuccess({ description: "Timezone updated!" });
         mutate();
       },
@@ -96,6 +101,9 @@ export function CalendarSettings() {
     isExecuting: isUpdatingBookingLink,
   } = useAction(updateCalendarBookingLinkAction.bind(null, emailAccountId), {
     onSuccess: () => {
+      analytics.captureAction("calendar_booking_link_saved", {
+        had_existing_booking_link: Boolean(calendarBookingLink),
+      });
       toastSuccess({ description: "Booking link updated!" });
       mutate();
     },
@@ -141,6 +149,9 @@ export function CalendarSettings() {
   const onSubmitTimezone: SubmitHandler<z.infer<typeof updateTimezoneBody>> =
     useCallback(
       (data) => {
+        analytics.captureAction("calendar_timezone_save_started", {
+          auto_detect: data.timezone === "auto-detect",
+        });
         // If user selected "auto-detect", detect and save the actual timezone
         if (data.timezone === "auto-detect") {
           const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -149,16 +160,19 @@ export function CalendarSettings() {
           executeUpdateTimezone(data);
         }
       },
-      [executeUpdateTimezone],
+      [analytics, executeUpdateTimezone],
     );
 
   const onSubmitBookingLink: SubmitHandler<
     z.infer<typeof updateBookingLinkBody>
   > = useCallback(
     (data) => {
+      analytics.captureAction("calendar_booking_link_save_started", {
+        has_booking_link: Boolean(data.bookingLink),
+      });
       executeUpdateBookingLink(data);
     },
-    [executeUpdateBookingLink],
+    [analytics, executeUpdateBookingLink],
   );
 
   return (

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConnectCalendar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConnectCalendar.tsx
@@ -9,13 +9,18 @@ import { captureException } from "@/utils/error";
 import type { GetCalendarAuthUrlResponse } from "@/app/api/google/calendar/auth-url/route";
 import { fetchWithAccount } from "@/utils/fetch";
 import { CALENDAR_ONBOARDING_RETURN_COOKIE } from "@/utils/calendar/constants";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import type { AppPage } from "@/utils/analytics/product";
 
 export function ConnectCalendar({
+  analyticsPage,
   onboardingReturnPath,
 }: {
+  analyticsPage?: AppPage;
   onboardingReturnPath?: string;
 }) {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics(analyticsPage);
   const [isConnectingGoogle, setIsConnectingGoogle] = useState(false);
   const [isConnectingMicrosoft, setIsConnectingMicrosoft] = useState(false);
 
@@ -26,6 +31,10 @@ export function ConnectCalendar({
   };
 
   const handleConnectGoogle = async () => {
+    analytics.captureAction("calendar_connect_started", {
+      provider: "google",
+      has_onboarding_return_path: Boolean(onboardingReturnPath),
+    });
     setIsConnectingGoogle(true);
     try {
       const response = await fetchWithAccount({
@@ -42,6 +51,9 @@ export function ConnectCalendar({
       setOnboardingReturnCookie();
       window.location.href = data.url;
     } catch (error) {
+      analytics.captureAction("calendar_connect_start_failed", {
+        provider: "google",
+      });
       captureException(error, {
         extra: { context: "Google Calendar OAuth initiation" },
       });
@@ -54,6 +66,10 @@ export function ConnectCalendar({
   };
 
   const handleConnectMicrosoft = async () => {
+    analytics.captureAction("calendar_connect_started", {
+      provider: "microsoft",
+      has_onboarding_return_path: Boolean(onboardingReturnPath),
+    });
     setIsConnectingMicrosoft(true);
     try {
       const response = await fetchWithAccount({
@@ -70,6 +86,9 @@ export function ConnectCalendar({
       setOnboardingReturnCookie();
       window.location.href = data.url;
     } catch (error) {
+      analytics.captureAction("calendar_connect_start_failed", {
+        provider: "microsoft",
+      });
       captureException(error, {
         extra: { context: "Microsoft Calendar OAuth initiation" },
       });

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -73,6 +73,7 @@ import type { GetMessagingChannelsResponse } from "@/app/api/user/messaging-chan
 import type { RulesResponse } from "@/app/api/user/rules/route";
 import type { MessagingActionType } from "@/utils/actions/messaging-channels.validation";
 import { prefixPath } from "@/utils/path";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type LinkableProvider = "TEAMS" | "TELEGRAM";
 
@@ -152,7 +153,10 @@ export function Channels() {
       sortRulesForAutomation((rulesData ?? []).filter((rule) => rule.enabled)),
     [rulesData],
   );
-  const connectedProviders = new Set(connectedChannels.map((c) => c.provider));
+  const connectedProviders = useMemo(
+    () => new Set(connectedChannels.map((c) => c.provider)),
+    [connectedChannels],
+  );
   const unconnectedProviders = sortProviders(
     availableProviders.filter((p) => !connectedProviders.has(p)),
   );
@@ -255,6 +259,7 @@ function ConnectedChannelSection({
   emailAccountId: string;
   onUpdate: () => void;
 }) {
+  const analytics = useProductAnalytics("channels");
   const config = PROVIDER_CONFIG[channel.provider];
   const isSlack = channel.provider === "SLACK";
 
@@ -262,6 +267,9 @@ function ConnectedChannelSection({
     disconnectChannelAction.bind(null, emailAccountId),
     {
       onSuccess: () => {
+        analytics.captureAction("channel_disconnected", {
+          provider: channel.provider,
+        });
         toastSuccess({ description: `${config.name} disconnected` });
         onUpdate();
       },
@@ -429,6 +437,7 @@ function UnconnectedProviderSection({
   onConnected: () => void;
 }) {
   const config = PROVIDER_CONFIG[provider];
+  const analytics = useProductAnalytics("channels");
   const { connect: connectSlack, connecting: connectingSlack } =
     useSlackConnect({ emailAccountId, onConnected });
 
@@ -443,6 +452,9 @@ function UnconnectedProviderSection({
     {
       onSuccess: ({ data }) => {
         if (!data?.code || !data.provider) return;
+        analytics.captureAction("channel_link_code_created", {
+          provider: data.provider,
+        });
         setLinkCodeDialog({
           provider: data.provider,
           code: data.code,
@@ -459,6 +471,7 @@ function UnconnectedProviderSection({
   );
 
   const handleConnect = () => {
+    analytics.captureAction("channel_connect_started", { provider });
     if (provider === "SLACK") {
       connectSlack();
     } else {
@@ -569,6 +582,7 @@ function RuleToggle({
   emailAccountId: string;
   onUpdate: () => void;
 }) {
+  const analytics = useProductAnalytics("channels");
   const enabled = currentActionType !== null;
   const isDraft = currentActionType === "DRAFT_MESSAGING_CHANNEL";
 
@@ -599,6 +613,10 @@ function RuleToggle({
 
   const switchMode = (newType: MessagingActionType) => {
     if (newType === currentActionType) return;
+    analytics.captureAction("rule_channel_mode_changed", {
+      action_type: newType,
+      was_enabled: enabled,
+    });
     execute({
       ruleId: rule.id,
       messagingChannelId: channelId,
@@ -653,14 +671,18 @@ function RuleToggle({
             name={`rule-${rule.id}-${channelId}`}
             enabled={enabled}
             disabled={isExecuting}
-            onChange={(value) =>
+            onChange={(value) => {
+              analytics.captureAction("rule_channel_toggled", {
+                enabled: value,
+                action_type: value ? defaultActionType : currentActionType,
+              });
               execute({
                 ruleId: rule.id,
                 messagingChannelId: channelId,
                 enabled: value,
                 actionType: value ? defaultActionType : undefined,
-              })
-            }
+              });
+            }}
           />
         </div>
       </ItemActions>
@@ -691,6 +713,7 @@ function FeatureRouteToggle({
   onUpdate: () => void;
   disabled?: boolean;
 }) {
+  const analytics = useProductAnalytics("channels");
   const { execute, status } = useAction(
     updateMessagingFeatureRouteAction.bind(null, emailAccountId),
     {
@@ -736,6 +759,10 @@ function FeatureRouteToggle({
             disabled={disabled || status === "executing"}
             onChange={(enabled) => {
               if (disabled) return;
+              analytics.captureAction("feature_route_toggled", {
+                purpose,
+                enabled,
+              });
               execute({ channelId: messagingChannelId, purpose, enabled });
             }}
           />

--- a/apps/web/app/(app)/[emailAccountId]/clean/IntroStep.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/IntroStep.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { useStep } from "@/app/(app)/[emailAccountId]/clean/useStep";
 import { CleanAction } from "@/generated/prisma/enums";
 import { PremiumAlertWithData } from "@/components/PremiumAlert";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 export function IntroStep({
   unhandledCount,
@@ -16,6 +17,7 @@ export function IntroStep({
   cleanAction: CleanAction;
 }) {
   const { onNext } = useStep();
+  const analytics = useProductAnalytics("deep_clean");
 
   return (
     <div>
@@ -52,7 +54,16 @@ export function IntroStep({
         )}
 
         <div className="mt-6">
-          <Button onClick={onNext} disabled={unhandledCount === null}>
+          <Button
+            onClick={() => {
+              analytics.captureAction("deep_clean_started", {
+                clean_action: cleanAction,
+                unhandled_count: unhandledCount,
+              });
+              onNext();
+            }}
+            disabled={unhandledCount === null}
+          >
             Next
           </Button>
         </div>

--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -66,6 +66,7 @@ import type { AttachmentPreviewItem } from "@/app/api/user/drive/preview/attachm
 import { LoadingContent } from "@/components/LoadingContent";
 import { getEmailUrlForMessage } from "@/utils/url";
 import { AlertBasic } from "@/components/Alert";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 type SetupPhase = "setup" | "loading-attachments" | "preview" | "starting";
 
@@ -79,6 +80,7 @@ type FilingState = {
 
 export function DriveSetup() {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics("attachments");
   const { data: connectionsData } = useDriveConnections();
   const {
     data: foldersData,
@@ -103,6 +105,10 @@ export function DriveSetup() {
   const { data: attachmentsData, isLoading: attachmentsLoading } =
     useFilingPreviewAttachments(shouldFetchAttachments, {
       onSuccess: (data) => {
+        analytics.captureAction("auto_file_preview_completed", {
+          attachment_count: data.attachments.length,
+          no_attachments_found: data.noAttachmentsFound,
+        });
         // Initialize states and trigger filing for each attachment
         const initial: Record<string, FilingState> = {};
         for (const att of data.attachments) {
@@ -116,11 +122,15 @@ export function DriveSetup() {
             .then((result) => {
               const resultData = result?.data;
               if (result?.serverError) {
+                analytics.captureAction("auto_file_preview_item_failed", {
+                  reason: "server_error",
+                });
                 setFilingStates((prev) => ({
                   ...prev,
                   [key]: { status: "error", error: result.serverError },
                 }));
               } else if (resultData?.skipped) {
+                analytics.captureAction("auto_file_preview_item_skipped");
                 setFilingStates((prev) => ({
                   ...prev,
                   [key]: {
@@ -130,11 +140,15 @@ export function DriveSetup() {
                   },
                 }));
               } else if (resultData) {
+                analytics.captureAction("auto_file_preview_item_filed");
                 setFilingStates((prev) => ({
                   ...prev,
                   [key]: { status: "filed", result: resultData },
                 }));
               } else {
+                analytics.captureAction("auto_file_preview_item_failed", {
+                  reason: "unknown",
+                });
                 setFilingStates((prev) => ({
                   ...prev,
                   [key]: { status: "error", error: "Unknown error" },
@@ -142,6 +156,9 @@ export function DriveSetup() {
               }
             })
             .catch((err) => {
+              analytics.captureAction("auto_file_preview_item_failed", {
+                reason: "exception",
+              });
               setFilingStates((prev) => ({
                 ...prev,
                 [key]: {
@@ -154,6 +171,7 @@ export function DriveSetup() {
         setFilingStates(initial);
       },
       onError: (err) => {
+        analytics.captureAction("auto_file_preview_failed");
         toastError({
           title: "Error fetching preview",
           description:
@@ -174,10 +192,15 @@ export function DriveSetup() {
   }, [userPhase, attachmentsLoading, attachmentsData]);
 
   const handlePreviewClick = useCallback(() => {
+    analytics.captureAction("auto_file_preview_started", {
+      folder_count: foldersData?.savedFolders.length ?? 0,
+      has_connection: Boolean(connection),
+    });
     setUserPhase("previewing");
-  }, []);
+  }, [analytics, connection, foldersData?.savedFolders.length]);
 
   const handleStartFiling = useCallback(async () => {
+    analytics.captureAction("auto_file_enable_started");
     setUserPhase("starting");
     try {
       const result = await updateFilingEnabledAction(emailAccountId, {
@@ -185,6 +208,9 @@ export function DriveSetup() {
       });
 
       if (result?.serverError) {
+        analytics.captureAction("auto_file_enable_failed", {
+          reason: "server_error",
+        });
         toastError({
           title: "Error starting auto-filing",
           description: result.serverError,
@@ -193,9 +219,13 @@ export function DriveSetup() {
         return;
       }
 
+      analytics.captureAction("auto_file_enabled");
       toastSuccess({ description: "Auto-filing started!" });
       await mutateEmail();
     } catch (error) {
+      analytics.captureAction("auto_file_enable_failed", {
+        reason: "exception",
+      });
       toastError({
         title: "Error starting auto-filing",
         description:
@@ -205,7 +235,7 @@ export function DriveSetup() {
       });
       setUserPhase("previewing");
     }
-  }, [emailAccountId, mutateEmail]);
+  }, [analytics, emailAccountId, mutateEmail]);
 
   return (
     <div className="mx-auto max-w-2xl py-8">
@@ -432,6 +462,7 @@ function FilingRow({
   userEmail: string;
   provider: string;
 }) {
+  const analytics = useProductAnalytics("attachments");
   const [correctedPath, setCorrectedPath] = useState<string | null>(null);
   const [isMoving, setIsMoving] = useState(false);
   const [vote, setVote] = useState<boolean | null>(null);
@@ -453,6 +484,7 @@ function FilingRow({
           targetFolderId: folder.folderId,
           targetFolderPath: folder.folderPath,
         });
+        analytics.captureAction("auto_file_preview_item_moved");
         setCorrectedPath(folder.folderPath);
         toastSuccess({ description: `Moved to ${folder.folderName}` });
       } catch {
@@ -462,7 +494,7 @@ function FilingRow({
         setIsMoving(false);
       }
     },
-    [emailAccountId, filingState.result?.filingId],
+    [analytics, emailAccountId, filingState.result?.filingId],
   );
 
   const handleCorrectClick = useCallback(async () => {
@@ -478,8 +510,19 @@ function FilingRow({
     if (result?.serverError) {
       setVote(null);
       toastError({ description: "Failed to submit feedback" });
+    } else {
+      analytics.captureAction("auto_file_preview_feedback_submitted", {
+        feedback_positive: true,
+        item_status: filingState.status,
+      });
     }
-  }, [emailAccountId, filingState.result?.filingId, filingState.filingId]);
+  }, [
+    analytics,
+    emailAccountId,
+    filingState.filingId,
+    filingState.result?.filingId,
+    filingState.status,
+  ]);
 
   const handleWrongClick = useCallback(async () => {
     const filingId = filingState.result?.filingId;
@@ -494,8 +537,18 @@ function FilingRow({
     if (result?.serverError) {
       setVote(null);
       toastError({ description: "Failed to submit feedback" });
+    } else {
+      analytics.captureAction("auto_file_preview_feedback_submitted", {
+        feedback_positive: false,
+        item_status: filingState.status,
+      });
     }
-  }, [emailAccountId, filingState.result?.filingId]);
+  }, [
+    analytics,
+    emailAccountId,
+    filingState.result?.filingId,
+    filingState.status,
+  ]);
 
   const handleSkippedWrongClick = useCallback(async () => {
     const filingId = filingState.filingId;
@@ -510,8 +563,13 @@ function FilingRow({
     if (result?.serverError) {
       setVote(null);
       toastError({ description: "Failed to submit feedback" });
+    } else {
+      analytics.captureAction("auto_file_preview_feedback_submitted", {
+        feedback_positive: false,
+        item_status: filingState.status,
+      });
     }
-  }, [emailAccountId, filingState.filingId]);
+  }, [analytics, emailAccountId, filingState.filingId, filingState.status]);
 
   const isFiled = filingState.status === "filed";
   const isSkipped = filingState.status === "skipped";
@@ -645,6 +703,7 @@ function SetupFolderSelection({
   mutateFolders: () => void;
   isLoading: boolean;
 }) {
+  const analytics = useProductAnalytics("attachments");
   // Optimistic state for folder selection
   const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
     () => new Set(savedFolders.map((f) => f.folderId)),
@@ -676,6 +735,9 @@ function SetupFolderSelection({
       });
 
       if (isChecked) {
+        analytics.captureAction("auto_file_folder_selected", {
+          saved_folder_count: optimisticFolderIds.size + 1,
+        });
         const result = await addFilingFolderAction(emailAccountId, {
           folderId: folder.id,
           folderName: folder.name,
@@ -698,6 +760,9 @@ function SetupFolderSelection({
           mutateFolders();
         }
       } else {
+        analytics.captureAction("auto_file_folder_removed", {
+          saved_folder_count: Math.max(optimisticFolderIds.size - 1, 0),
+        });
         const result = await removeFilingFolderAction(emailAccountId, {
           folderId: folder.id,
         });
@@ -718,7 +783,7 @@ function SetupFolderSelection({
         }
       }
     },
-    [emailAccountId, mutateFolders],
+    [analytics, emailAccountId, mutateFolders, optimisticFolderIds.size],
   );
 
   const rootFolders = useMemo(() => {
@@ -834,6 +899,7 @@ function SetupRulesForm({
   phase: SetupPhase;
   onPreviewClick: () => void;
 }) {
+  const analytics = useProductAnalytics("attachments");
   const {
     register,
     handleSubmit,
@@ -866,17 +932,30 @@ function SetupRulesForm({
       const result = await updateFilingPromptAction(emailAccountId, data);
 
       if (result?.serverError) {
+        analytics.captureAction("auto_file_prompt_save_failed", {
+          reason: "server_error",
+        });
         toastError({
           title: "Error saving rules",
           description: result.serverError,
         });
       } else {
+        analytics.captureAction("auto_file_prompt_saved", {
+          has_existing_prompt: Boolean(initialPrompt),
+        });
         mutateEmail();
         // Trigger preview after successful save
         onPreviewClick();
       }
     },
-    [canPreview, emailAccountId, mutateEmail, onPreviewClick],
+    [
+      analytics,
+      canPreview,
+      emailAccountId,
+      initialPrompt,
+      mutateEmail,
+      onPreviewClick,
+    ],
   );
 
   return (

--- a/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
@@ -27,6 +27,7 @@ import { fetchWithAccount } from "@/utils/fetch";
 import { RequestAccessDialog } from "./RequestAccessDialog";
 import { truncate } from "@/utils/string";
 import { Notice } from "@/components/Notice";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 interface IntegrationRowProps {
   integration: GetIntegrationsResponse["integrations"][number];
@@ -38,6 +39,7 @@ export function IntegrationRow({
   onConnectionChange,
 }: IntegrationRowProps) {
   const { emailAccountId } = useAccount();
+  const analytics = useProductAnalytics("integrations");
   const [disconnecting, setDisconnecting] = useState(false);
   const [expandedTools, setExpandedTools] = useState(false);
 
@@ -51,7 +53,16 @@ export function IntegrationRow({
   const tools = conn?.tools || [];
 
   const handleConnect = async () => {
+    analytics.captureAction("integration_connect_started", {
+      integration: integration.name,
+      auth_type: integration.authType,
+    });
+
     if (integration.authType === "api-token") {
+      analytics.captureAction("integration_connect_failed", {
+        integration: integration.name,
+        reason: "unsupported_auth_type",
+      });
       toastError({
         title: "Error connecting to integration",
         description: "API token connections are not supported yet",
@@ -72,6 +83,10 @@ export function IntegrationRow({
       const data: GetMcpAuthUrlResponse = await response.json();
       window.location.href = data.url;
     } catch (error) {
+      analytics.captureAction("integration_connect_failed", {
+        integration: integration.name,
+        reason: "auth_url_error",
+      });
       console.error(
         `Failed to initiate ${integration.name} connection:`,
         error,
@@ -86,6 +101,10 @@ export function IntegrationRow({
 
   const handleToggle = async (enabled: boolean) => {
     if (!connectionId) return;
+    analytics.captureAction("integration_toggled", {
+      integration: integration.name,
+      enabled,
+    });
 
     try {
       const result = await toggleMcpConnectionAction(emailAccountId, {
@@ -113,6 +132,11 @@ export function IntegrationRow({
   };
 
   const handleToggleTool = async (toolId: string, isEnabled: boolean) => {
+    analytics.captureAction("integration_tool_toggled", {
+      integration: integration.name,
+      enabled: isEnabled,
+    });
+
     try {
       const result = await toggleMcpToolAction(emailAccountId, {
         toolId,
@@ -147,6 +171,9 @@ export function IntegrationRow({
 
     if (!connectionId) return;
 
+    analytics.captureAction("integration_disconnect_started", {
+      integration: integration.name,
+    });
     setDisconnecting(true);
 
     try {
@@ -160,6 +187,9 @@ export function IntegrationRow({
           description: result.serverError,
         });
       } else {
+        analytics.captureAction("integration_disconnected", {
+          integration: integration.name,
+        });
         toastSuccess({
           title: "Disconnected successfully",
           description: `Disconnected from ${integration.displayName}`,
@@ -225,7 +255,15 @@ export function IntegrationRow({
               variant="ghost"
               size="sm"
               className="flex items-center gap-1"
-              onClick={() => setExpandedTools(!expandedTools)}
+              onClick={() => {
+                analytics.captureAction("integration_tools_toggled", {
+                  integration: integration.name,
+                  expanded: !expandedTools,
+                  enabled_tool_count: toolsCount,
+                  total_tool_count: totalTools,
+                });
+                setExpandedTools(!expandedTools);
+              }}
             >
               {expandedTools ? (
                 <ChevronDown className="h-4 w-4" />
@@ -263,7 +301,15 @@ export function IntegrationRow({
               <DropdownMenuContent align="end">
                 {tools.length > 0 && (
                   <DropdownMenuItem
-                    onClick={() => setExpandedTools(!expandedTools)}
+                    onClick={() => {
+                      analytics.captureAction("integration_tools_toggled", {
+                        integration: integration.name,
+                        expanded: !expandedTools,
+                        enabled_tool_count: toolsCount,
+                        total_tool_count: totalTools,
+                      });
+                      setExpandedTools(!expandedTools);
+                    }}
                     className="sm:hidden"
                   >
                     {expandedTools ? "Hide tools" : "Manage tools"}

--- a/apps/web/app/(app)/[emailAccountId]/onboarding-brief/StepConnectCalendar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding-brief/StepConnectCalendar.tsx
@@ -45,6 +45,7 @@ export function StepConnectCalendar({ onNext }: { onNext: () => void }) {
           </>
         ) : (
           <ConnectCalendar
+            analyticsPage="meeting_briefs"
             onboardingReturnPath={prefixPath(
               emailAccountId,
               "/onboarding-brief?step=2",

--- a/apps/web/app/(app)/[emailAccountId]/stats/Stats.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/Stats.tsx
@@ -20,6 +20,7 @@ import { LayoutGrid } from "lucide-react";
 import { DatePickerWithRange } from "@/components/DatePickerWithRange";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { CardBasic } from "@/components/ui/card";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 const selectOptions = [
   { label: "Last week", value: "7" },
@@ -31,6 +32,7 @@ const selectOptions = [
 const defaultSelected = selectOptions[1];
 
 export function Stats() {
+  const analytics = useProductAnalytics("analytics");
   const [dateDropdown, setDateDropdown] = useState<string>(
     defaultSelected.label,
   );
@@ -50,6 +52,10 @@ export function Stats() {
   const onSetDateDropdown = useCallback(
     (option: { label: string; value: string }) => {
       const { label, value } = option;
+      analytics.captureAction("analytics_date_range_changed", {
+        range_label: label,
+        range_days: Number.parseInt(value),
+      });
       setDateDropdown(label);
 
       if (value === "7") {
@@ -60,7 +66,7 @@ export function Stats() {
         setPeriod("month");
       }
     },
-    [period],
+    [analytics, period],
   );
 
   const { isLoading, onLoad } = useStatLoader();
@@ -95,22 +101,42 @@ export function Stats() {
             {
               label: "Day",
               checked: period === "day",
-              setChecked: () => setPeriod("day"),
+              setChecked: () => {
+                analytics.captureAction("analytics_grouping_changed", {
+                  period: "day",
+                });
+                setPeriod("day");
+              },
             },
             {
               label: "Week",
               checked: period === "week",
-              setChecked: () => setPeriod("week"),
+              setChecked: () => {
+                analytics.captureAction("analytics_grouping_changed", {
+                  period: "week",
+                });
+                setPeriod("week");
+              },
             },
             {
               label: "Month",
               checked: period === "month",
-              setChecked: () => setPeriod("month"),
+              setChecked: () => {
+                analytics.captureAction("analytics_grouping_changed", {
+                  period: "month",
+                });
+                setPeriod("month");
+              },
             },
             {
               label: "Year",
               checked: period === "year",
-              setChecked: () => setPeriod("year"),
+              setChecked: () => {
+                analytics.captureAction("analytics_grouping_changed", {
+                  period: "year",
+                });
+                setPeriod("year");
+              },
             },
           ]}
         />

--- a/apps/web/components/SideNavMenu.tsx
+++ b/apps/web/components/SideNavMenu.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import type { ComponentProps } from "react";
 import type { LucideIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -10,6 +12,13 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { Badge } from "@/components/ui/badge";
+import {
+  getAppPageFromNavItem,
+  getAppPageFromPathname,
+  getAppPageProperties,
+  PRODUCT_ANALYTICS_EVENTS,
+  APP_PAGES,
+} from "@/utils/analytics/product";
 
 type NavItem = {
   name: string;
@@ -31,6 +40,9 @@ export function SideNavMenu({
   activeHref: string;
 }) {
   const { closeMobileSidebar } = useSidebar();
+  const pathname = usePathname();
+  const posthog = usePostHog();
+  const currentAppPage = getAppPageFromPathname(pathname);
 
   return (
     <SidebarMenu>
@@ -45,7 +57,23 @@ export function SideNavMenu({
           >
             <Link
               href={item.href}
-              onClick={() => closeMobileSidebar("left-sidebar")}
+              onClick={() => {
+                const destinationAppPage = getAppPageFromNavItem({
+                  name: item.name,
+                  href: item.href,
+                });
+
+                posthog.capture(PRODUCT_ANALYTICS_EVENTS.navigationClicked, {
+                  ...getAppPageProperties(currentAppPage),
+                  destination_page: destinationAppPage,
+                  destination_page_label: destinationAppPage
+                    ? APP_PAGES[destinationAppPage].label
+                    : undefined,
+                  nav_item: item.name,
+                  nav_href_type: getNavHrefType(item.href),
+                });
+                closeMobileSidebar("left-sidebar");
+              }}
             >
               <item.icon />
               <span>{item.name}</span>
@@ -65,4 +93,10 @@ export function SideNavMenu({
       ))}
     </SidebarMenu>
   );
+}
+
+function getNavHrefType(href: string) {
+  if (href.startsWith("?")) return "query";
+  if (href.startsWith("http")) return "external";
+  return "internal";
 }

--- a/apps/web/components/TabSelect.tsx
+++ b/apps/web/components/TabSelect.tsx
@@ -14,6 +14,7 @@ import { LayoutGroup, motion } from "motion/react";
 import Link from "next/link";
 import { type Dispatch, type SetStateAction, useId } from "react";
 import { ArrowUpRight } from "lucide-react";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 const tabSelectButtonVariants = cva("p-4 transition-colors duration-75", {
   variants: {
@@ -54,6 +55,7 @@ export function TabSelect<T extends string>({
   className?: string;
 }) {
   const layoutGroupId = useId();
+  const analytics = useProductAnalytics();
 
   return (
     <div className={cn("flex text-sm", className)}>
@@ -70,7 +72,14 @@ export function TabSelect<T extends string>({
             >
               <button
                 type="button"
-                {...(onSelect && !href && { onClick: () => onSelect(id) })}
+                onClick={() => {
+                  analytics.captureAction("tab_selected", {
+                    tab: id,
+                    tab_label: label,
+                    has_href: Boolean(href),
+                  });
+                  if (onSelect && !href) onSelect(id);
+                }}
                 className={cn(
                   tabSelectButtonVariants({ variant }),
                   target === "_blank" && "group flex items-center gap-1.5",

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -33,6 +33,7 @@ import { useSession } from "@/utils/auth-client";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
 import type { MessageContext } from "@/app/api/chat/validation";
+import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB
 const MAX_FILES = 5;
@@ -44,6 +45,7 @@ const ACCEPTED_IMAGE_TYPES = [
 ];
 
 export function Chat({ open }: { open: boolean }) {
+  const analytics = useProductAnalytics("assistant_chat");
   const {
     chat,
     chatId,
@@ -121,10 +123,15 @@ export function Chat({ open }: { open: boolean }) {
       const results = await Promise.all(filesToProcess.map(readFileAsDataUrl));
       const valid = results.filter((a): a is Attachment => a !== undefined);
 
+      analytics.captureAction("chat_attachments_added", {
+        requested_file_count: files.length,
+        accepted_file_count: valid.length,
+        existing_attachment_count: attachments.length,
+      });
       setAttachments((prev) => [...prev, ...valid]);
       setUploadQueue([]);
     },
-    [attachments.length, readFileAsDataUrl, setAttachments],
+    [analytics, attachments.length, readFileAsDataUrl, setAttachments],
   );
 
   const handleFileChange = useCallback(
@@ -170,6 +177,12 @@ export function Chat({ open }: { open: boolean }) {
       onSubmit={(e) => {
         e.preventDefault();
         if (hasContent && status === "ready") {
+          analytics.captureAction("chat_message_submitted", {
+            has_text: input.trim().length > 0,
+            attachment_count: attachments.length,
+            has_context: Boolean(context),
+            message_count: messages.length,
+          });
           handleSubmit();
           setLocalStorageInput("");
         }
@@ -223,7 +236,12 @@ export function Chat({ open }: { open: boolean }) {
             variant="ghost"
             size="icon"
             className="size-9 rounded-full text-muted-foreground hover:text-foreground"
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() => {
+              analytics.captureAction("chat_attach_button_clicked", {
+                attachment_count: attachments.length,
+              });
+              fileInputRef.current?.click();
+            }}
             disabled={attachments.length >= MAX_FILES}
           >
             <PaperclipIcon className="size-4" />
@@ -242,6 +260,9 @@ export function Chat({ open }: { open: boolean }) {
           className="h-9 w-9 rounded-full bg-blue-500 text-white hover:bg-blue-600"
           onClick={(e) => {
             if (status === "streaming" || status === "submitted") {
+              analytics.captureAction("chat_generation_stopped", {
+                status,
+              });
               e.preventDefault();
               stop();
               setMessages((messages) => messages);
@@ -288,6 +309,9 @@ export function Chat({ open }: { open: boolean }) {
           firstName={firstName}
           inputArea={inputArea}
           onSuggestionClick={(text) => {
+            analytics.captureAction("chat_suggestion_clicked", {
+              suggestion_index: CHAT_EXAMPLES.indexOf(text),
+            });
             chat.sendMessage({
               role: "user",
               parts: [{ type: "text", text }],

--- a/apps/web/hooks/useProductAnalytics.ts
+++ b/apps/web/hooks/useProductAnalytics.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import {
+  getAppPageFromPathname,
+  getAppPageProperties,
+  PRODUCT_ANALYTICS_EVENTS,
+  type AppPage,
+  type ProductAnalyticsAction,
+} from "@/utils/analytics/product";
+
+type AppPageActionProperties = Record<string, unknown>;
+
+export function useProductAnalytics(page?: AppPage) {
+  const posthog = usePostHog();
+  const pathname = usePathname();
+  const inferredPage = page ?? getAppPageFromPathname(pathname);
+
+  return useMemo(
+    () => ({
+      captureAction: (
+        action: ProductAnalyticsAction,
+        properties?: AppPageActionProperties,
+      ) => {
+        if (!inferredPage) return;
+
+        posthog.capture(PRODUCT_ANALYTICS_EVENTS.pageAction, {
+          ...getAppPageProperties(inferredPage),
+          action,
+          ...properties,
+        });
+      },
+    }),
+    [inferredPage, posthog],
+  );
+}

--- a/apps/web/providers/PostHogProvider.tsx
+++ b/apps/web/providers/PostHogProvider.tsx
@@ -7,6 +7,10 @@ import { useSession } from "@/utils/auth-client";
 import { usePathname, useSearchParams } from "next/navigation";
 import { env } from "@/env";
 import { useAccount } from "@/providers/EmailAccountProvider";
+import {
+  getAppPageViewProperties,
+  PRODUCT_ANALYTICS_EVENTS,
+} from "@/utils/analytics/product";
 
 // based on: https://posthog.com/docs/libraries/next-js
 
@@ -23,6 +27,14 @@ export function PostHogPageview() {
       posthog.capture("$pageview", {
         $current_url: url,
       });
+
+      const appPageProperties = getAppPageViewProperties({
+        pathname,
+        searchParams,
+      });
+      if (appPageProperties) {
+        posthog.capture(PRODUCT_ANALYTICS_EVENTS.pageViewed, appPageProperties);
+      }
     }
   }, [pathname, searchParams]);
 

--- a/apps/web/utils/analytics/product.ts
+++ b/apps/web/utils/analytics/product.ts
@@ -1,0 +1,211 @@
+export const PRODUCT_ANALYTICS_EVENTS = {
+  pageViewed: "app_page_viewed",
+  navigationClicked: "app_navigation_clicked",
+  pageAction: "app_page_action",
+} as const;
+
+export const PRODUCT_ANALYTICS_ACTIONS = {
+  chat: {
+    attachButtonClicked: "chat_attach_button_clicked",
+    attachmentsAdded: "chat_attachments_added",
+    generationStopped: "chat_generation_stopped",
+    messageSubmitted: "chat_message_submitted",
+    suggestionClicked: "chat_suggestion_clicked",
+  },
+  navigation: {
+    tabSelected: "tab_selected",
+  },
+  channels: {
+    channelConnectStarted: "channel_connect_started",
+    channelDisconnected: "channel_disconnected",
+    channelLinkCodeCreated: "channel_link_code_created",
+    featureRouteToggled: "feature_route_toggled",
+    ruleChannelModeChanged: "rule_channel_mode_changed",
+    ruleChannelToggled: "rule_channel_toggled",
+  },
+  calendars: {
+    bookingLinkSaved: "calendar_booking_link_saved",
+    bookingLinkSaveStarted: "calendar_booking_link_save_started",
+    connectFailed: "calendar_connect_failed",
+    connectStarted: "calendar_connect_started",
+    connectStartFailed: "calendar_connect_start_failed",
+    timezoneSaved: "calendar_timezone_saved",
+    timezoneSaveStarted: "calendar_timezone_save_started",
+  },
+  meetingBriefs: {
+    emailDeliverySaved: "meeting_briefs_email_delivery_saved",
+    emailDeliveryToggled: "meeting_briefs_email_delivery_toggled",
+    enabledSaved: "meeting_briefs_enabled_saved",
+    enableStarted: "meeting_briefs_enable_started",
+    toggled: "meeting_briefs_toggled",
+  },
+  bulkUnsubscribe: {
+    bulkCompleted: "bulk_unsubscribe_completed",
+    bulkStarted: "bulk_unsubscribe_started",
+    senderCompleted: "unsubscribe_sender_completed",
+    senderFailed: "unsubscribe_sender_failed",
+    senderStarted: "unsubscribe_sender_started",
+  },
+  bulkArchive: {
+    actionChanged: "bulk_archive_action_changed",
+    categorizationCompleted: "bulk_archive_categorization_completed",
+    setupDialogToggled: "bulk_archive_setup_dialog_toggled",
+  },
+  autoFile: {
+    enabled: "auto_file_enabled",
+    enableFailed: "auto_file_enable_failed",
+    enableStarted: "auto_file_enable_started",
+    folderRemoved: "auto_file_folder_removed",
+    folderSelected: "auto_file_folder_selected",
+    previewFailed: "auto_file_preview_failed",
+    previewFeedbackSubmitted: "auto_file_preview_feedback_submitted",
+    previewItemFailed: "auto_file_preview_item_failed",
+    previewItemFiled: "auto_file_preview_item_filed",
+    previewItemMoved: "auto_file_preview_item_moved",
+    previewItemSkipped: "auto_file_preview_item_skipped",
+    previewCompleted: "auto_file_preview_completed",
+    previewStarted: "auto_file_preview_started",
+    promptSaveFailed: "auto_file_prompt_save_failed",
+    promptSaved: "auto_file_prompt_saved",
+  },
+  integrations: {
+    connectFailed: "integration_connect_failed",
+    connectStarted: "integration_connect_started",
+    disconnected: "integration_disconnected",
+    disconnectStarted: "integration_disconnect_started",
+    toggled: "integration_toggled",
+    toolsToggled: "integration_tools_toggled",
+    toolToggled: "integration_tool_toggled",
+  },
+  analytics: {
+    dateRangeChanged: "analytics_date_range_changed",
+    groupingChanged: "analytics_grouping_changed",
+  },
+  deepClean: {
+    started: "deep_clean_started",
+  },
+} as const;
+
+export const APP_PAGES = {
+  mail: { label: "Mail", area: "mail" },
+  assistant_chat: { label: "Chat", area: "manage" },
+  automation: { label: "Assistant", area: "manage" },
+  channels: { label: "Channels", area: "manage" },
+  bulk_unsubscribe: { label: "Bulk Unsubscribe", area: "cleanup" },
+  bulk_archive: { label: "Bulk Archive", area: "cleanup" },
+  analytics: { label: "Analytics", area: "cleanup" },
+  deep_clean: { label: "Deep Clean", area: "cleanup" },
+  meeting_briefs: { label: "Meeting Briefs", area: "more" },
+  attachments: { label: "Attachments", area: "more" },
+  calendars: { label: "Calendars", area: "more" },
+  integrations: { label: "Integrations", area: "more" },
+} as const;
+
+export type AppPage = keyof typeof APP_PAGES;
+export type ProductAnalyticsAction = StringLeaf<
+  typeof PRODUCT_ANALYTICS_ACTIONS
+>;
+
+const APP_ROUTE_SEGMENTS: Array<{ segment: string; page: AppPage }> = [
+  { segment: "mail", page: "mail" },
+  { segment: "compose", page: "mail" },
+  { segment: "assistant", page: "assistant_chat" },
+  { segment: "automation", page: "automation" },
+  { segment: "channels", page: "channels" },
+  { segment: "bulk-unsubscribe", page: "bulk_unsubscribe" },
+  { segment: "bulk-archive", page: "bulk_archive" },
+  { segment: "quick-bulk-archive", page: "bulk_archive" },
+  { segment: "stats", page: "analytics" },
+  { segment: "clean", page: "deep_clean" },
+  { segment: "briefs", page: "meeting_briefs" },
+  { segment: "drive", page: "attachments" },
+  { segment: "calendars", page: "calendars" },
+  { segment: "integrations", page: "integrations" },
+];
+
+const NAV_ITEM_PAGES: Record<string, AppPage> = {
+  Inbox: "mail",
+  Drafts: "mail",
+  Sent: "mail",
+  Archived: "mail",
+  Personal: "mail",
+  Social: "mail",
+  Updates: "mail",
+  Forums: "mail",
+  Promotions: "mail",
+  Chat: "assistant_chat",
+  Assistant: "automation",
+  Channels: "channels",
+  "Bulk Unsubscribe": "bulk_unsubscribe",
+  "Bulk Archive": "bulk_archive",
+  Analytics: "analytics",
+  "Deep Clean": "deep_clean",
+  "Meeting Briefs": "meeting_briefs",
+  Attachments: "attachments",
+  Calendars: "calendars",
+  Integrations: "integrations",
+};
+
+export function getAppPageFromPathname(
+  pathname: string | null | undefined,
+): AppPage | null {
+  if (!pathname) return null;
+
+  const segments = pathname.split("/").filter(Boolean);
+  const route = APP_ROUTE_SEGMENTS.find(({ segment }) =>
+    segments.includes(segment),
+  );
+
+  return route?.page ?? null;
+}
+
+export function getAppPageFromNavItem({
+  name,
+  href,
+}: {
+  name: string;
+  href: string;
+}): AppPage | null {
+  if (NAV_ITEM_PAGES[name]) return NAV_ITEM_PAGES[name];
+
+  const hrefPath = href.startsWith("?") ? null : href.split("?")[0];
+  return getAppPageFromPathname(hrefPath);
+}
+
+export function getAppPageProperties(page: AppPage | null) {
+  if (!page) return {};
+
+  const config = APP_PAGES[page];
+  return {
+    app_page: page,
+    app_page_label: config.label,
+    app_area: config.area,
+  };
+}
+
+export function getAppPageViewProperties({
+  pathname,
+  searchParams,
+}: {
+  pathname: string | null | undefined;
+  searchParams?: Pick<URLSearchParams, "get"> | null;
+}) {
+  const page = getAppPageFromPathname(pathname);
+  if (!page) return null;
+
+  const tab = searchParams?.get("tab") || undefined;
+  const mailType = searchParams?.get("type") || undefined;
+
+  return {
+    ...getAppPageProperties(page),
+    route: pathname,
+    ...(tab ? { tab } : {}),
+    ...(mailType ? { mail_type: mailType } : {}),
+  };
+}
+
+type StringLeaf<T> = T extends string
+  ? T
+  : T extends Record<string, unknown>
+    ? StringLeaf<T[keyof T]>
+    : never;


### PR DESCRIPTION
Adds shared product analytics helpers and app page metadata for PostHog events. Tracks app page views, navigation clicks, tab selections, and key user actions across chat, channels, calendars, attachments, integrations, cleanup, analytics, and meeting brief flows. Event properties are limited to non-sensitive metadata such as counts, providers, state, and outcomes.