### PR TITLE
reply: Calibrate draft confidence scoring

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -395,6 +395,60 @@ Also, what model or provider does the assistant use by default?`,
       );
     });
 
+    describe("confidence calibration", () => {
+      test(
+        "missing business context is not high confidence",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Dana Lee <dana@clientcorp.com>",
+                to: emailAccount.email,
+                subject: "Security questionnaire",
+                content: `Hi,
+
+Could you send the final security questionnaire answers today and confirm whether the DPA redlines are approved?
+
+Thanks,
+Dana`,
+              }),
+              date: new Date("2026-03-15T12:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass = result.confidence !== "HIGH_CONFIDENCE";
+          const testName = "missing business context confidence";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "STANDARD or ALL_EMAILS because the draft lacks facts needed to answer",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not be marked high confidence without questionnaire or DPA facts.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+    });
+
     describe("punctuation defaults", () => {
       test(
         "does not use em dash when writing style does not ask for it",

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 7;
+export const DRAFT_PIPELINE_VERSION = 8;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -199,7 +199,7 @@ const draftSchema = z.object({
   confidence: z
     .nativeEnum(DraftReplyConfidence)
     .describe(
-      "Required value: ALL_EMAILS, STANDARD, or HIGH_CONFIDENCE. Use ALL_EMAILS when uncertain or context is missing, STANDARD for solid drafts with minor uncertainty, and HIGH_CONFIDENCE only when intent and response are clear.",
+      "Required value: ALL_EMAILS, STANDARD, or HIGH_CONFIDENCE. Use ALL_EMAILS when uncertain, context is missing, or the draft must ask/check/follow up because requested facts are unavailable. Use STANDARD for solid drafts with minor uncertainty. Use HIGH_CONFIDENCE only when the sender's intent and the complete factual response are clear from the provided context.",
     ),
 });
 
@@ -433,7 +433,7 @@ Do not suggest specific times. Acknowledge the request and suggest alternatives 
     parts.push(`Available time slots:
 ${times}
 
-${calendarBookingLink ? "Lead with the booking link, then optionally suggest a few of these times as alternatives." : "When the sender is asking to schedule, respond concretely using these time slots. If they appear stale relative to today's date, say that and ask for updated availability instead of ignoring the scheduling request."} Format suggested times as a bulleted list.`);
+${calendarBookingLink ? "Lead with the booking link, then optionally suggest a few of these times as alternatives." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Format suggested times as a bulleted list.`);
   }
 
   if (parts.length === 0) return "";


### PR DESCRIPTION
Calibrates draft reply confidence so under-contexted drafts are not marked high confidence while still allowing a draft to be produced.

- Adds eval coverage for missing-context confidence scoring.
- Tightens scheduling guidance for provided future availability.
- Bumps the draft pipeline version for attribution.