### PR TITLE
Fix draft reply content consistency

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -477,6 +477,14 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           replyToMessageId: sourceMessage.id,
         });
 
+        const siblingDraftActionState = {
+          id: "email-draft-action-edit-send",
+          draftId: createdDraft.id,
+          subject: `Re: ${subject}`,
+          content: "Initial draft body.",
+          wasDraftSent: false,
+        };
+
         const slackActionState = {
           id: "draft-action-edit-send",
           type: ActionType.DRAFT_MESSAGING_CHANNEL,
@@ -507,6 +515,13 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
             rule: {
               systemType: null,
             },
+            actionItems: [
+              {
+                id: siblingDraftActionState.id,
+                draftId: siblingDraftActionState.draftId,
+                subject: siblingDraftActionState.subject,
+              },
+            ],
           },
           messagingChannel: {
             id: "channel-1",
@@ -524,14 +539,6 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
               },
             ],
           },
-        };
-
-        const siblingDraftActionState = {
-          id: "email-draft-action-edit-send",
-          draftId: createdDraft.id,
-          subject: `Re: ${subject}`,
-          content: "Initial draft body.",
-          wasDraftSent: false,
         };
 
         prisma.executedAction.findUnique.mockImplementation(
@@ -1111,6 +1118,7 @@ function getNotificationContext({
       rule: {
         systemType: null,
       },
+      actionItems: [],
     },
     messagingChannel: messagingChannelId
       ? {

--- a/apps/web/utils/ai/choose-rule/choose-args.test.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.test.ts
@@ -273,17 +273,22 @@ describe("combineActionsWithAiArgs", () => {
       expect(result[0].content).toBe(fullDraft);
     });
 
-    it("still processes template content when a separate draft exists", () => {
+    it("uses one generated draft for every draft reply action", () => {
       const actions = [
         createMockAction({
           id: "3",
           type: ActionType.DRAFT_EMAIL,
+          content: null,
+        }),
+        createMockAction({
+          id: "4",
+          type: ActionType.DRAFT_MESSAGING_CHANNEL,
           content: "Hello {{name}}, {{message}}",
         }),
       ];
 
       const aiArgs = {
-        "DRAFT_EMAIL-3": {
+        "DRAFT_MESSAGING_CHANNEL-4": {
           content: {
             var1: "Alice",
             var2: "I hope this email finds you well.",
@@ -297,9 +302,10 @@ describe("combineActionsWithAiArgs", () => {
         "Some other draft",
       );
 
-      expect(result[0].content).toBe(
-        "Hello Alice, I hope this email finds you well.",
-      );
+      expect(result.map((action) => action.content)).toEqual([
+        "Some other draft",
+        "Some other draft",
+      ]);
     });
   });
 

--- a/apps/web/utils/ai/choose-rule/choose-args.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.ts
@@ -153,7 +153,7 @@ export function combineActionsWithAiArgs(
   return actions.map((action) => {
     const updatedAction: ActionWithDraftAttribution = { ...action };
 
-    // Add draft content to DRAFT_EMAIL actions if available
+    // Add draft content to draft reply actions if available
     if (draft && isDraftReplyActionType(action.type)) {
       updatedAction.content = draft;
       updatedAction.draftModelProvider = draftAttribution?.provider ?? null;
@@ -180,8 +180,9 @@ export function combineActionsWithAiArgs(
 
     // Merge variables for each field that has AI-generated content
     for (const [field, vars] of Object.entries(aiAction)) {
-      // Skip content field only if the action originally had no content and we've already set a draft
-      if (field === "content" && draft && !action.content) continue;
+      if (field === "content" && draft && isDraftReplyActionType(action.type)) {
+        continue;
+      }
 
       // Only process fields that we know can contain template strings
       if (

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -132,13 +132,13 @@ describe("handleRuleNotificationAction", () => {
         type: ActionType.DRAFT_MESSAGING_CHANNEL,
         content:
           'Thanks for the note.\n\nTry opening the &quot;Test&quot; tab.\n\nDrafted by <a href="https://getinboxzero.com/?ref=ABC">Inbox Zero</a>.',
+        mailboxDraftAction: {
+          id: "draft-action-1",
+          draftId: "draft-1",
+          subject: "Re: Test subject",
+        },
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue({
-      id: "draft-action-1",
-      draftId: "draft-1",
-      subject: "Re: Test subject",
-    } as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const editMessage = vi.fn().mockResolvedValue(undefined);
@@ -252,13 +252,13 @@ describe("handleRuleNotificationAction", () => {
             },
           ],
         },
+        mailboxDraftAction: {
+          id: "draft-action-1",
+          draftId: "draft-1",
+          subject: "Re: Test subject",
+        },
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue({
-      id: "draft-action-1",
-      draftId: "draft-1",
-      subject: "Re: Test subject",
-    } as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const editMessage = vi.fn().mockResolvedValue(undefined);
@@ -369,13 +369,13 @@ describe("handleRuleNotificationAction", () => {
             },
           ],
         },
+        mailboxDraftAction: {
+          id: "draft-action-1",
+          draftId: "draft-1",
+          subject: "Re: Test subject",
+        },
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue({
-      id: "draft-action-1",
-      draftId: "draft-1",
-      subject: "Re: Test subject",
-    } as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const editMessage = vi.fn().mockResolvedValue(undefined);
@@ -666,7 +666,6 @@ describe("sendMessagingRuleNotification", () => {
         content: "Draft body",
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const { sendMessagingRuleNotification } = await import(
@@ -705,6 +704,111 @@ describe("sendMessagingRuleNotification", () => {
     });
   });
 
+  it("previews the synced mailbox draft for Slack draft notifications", async () => {
+    const provider = {
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Mailbox draft body",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Mailbox draft body",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Messaging draft body",
+        mailboxDraftAction: {
+          id: "draft-action-1",
+          draftId: "draft-1",
+          subject: "Re: Test subject",
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(provider.getDraft).toHaveBeenCalledWith("draft-1");
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Mailbox draft body");
+    expect(serializedBlocks).not.toContain("Messaging draft body");
+  });
+
+  it("falls back to stored draft content when synced mailbox draft lookup fails", async () => {
+    mockCreateEmailProvider.mockRejectedValue(new Error("provider failed"));
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Messaging draft body",
+        mailboxDraftAction: {
+          id: "draft-action-1",
+          draftId: "draft-1",
+          subject: "Re: Test subject",
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Messaging draft body");
+  });
+
   it("adds an Open in Outlook button for Slack draft notifications on Microsoft accounts", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
@@ -714,7 +818,6 @@ describe("sendMessagingRuleNotification", () => {
         accountProvider: "microsoft",
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const { sendMessagingRuleNotification } = await import(
@@ -754,7 +857,6 @@ describe("sendMessagingRuleNotification", () => {
         accountProvider: "imap",
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const { sendMessagingRuleNotification } = await import(
@@ -791,7 +893,6 @@ describe("sendMessagingRuleNotification", () => {
         content: null,
       }) as never,
     );
-    prisma.executedAction.findFirst.mockResolvedValue(null as never);
     prisma.executedAction.update.mockResolvedValue({} as never);
 
     const { sendMessagingRuleNotification } = await import(
@@ -1513,6 +1614,7 @@ function getNotificationContext({
   accountProvider = "google",
   messagingMessageId = null,
   messagingMessageStatus = null,
+  mailboxDraftAction = null,
 }: {
   id: string;
   type: ActionType;
@@ -1535,6 +1637,11 @@ function getNotificationContext({
   accountProvider?: "google" | "microsoft" | "imap";
   messagingMessageId?: string | null;
   messagingMessageStatus?: MessagingMessageStatus | null;
+  mailboxDraftAction?: {
+    id: string;
+    draftId: string;
+    subject: string | null;
+  } | null;
 }) {
   const defaultRoutes =
     messagingChannel?.routes ??
@@ -1587,6 +1694,7 @@ function getNotificationContext({
       rule: {
         systemType: null,
       },
+      actionItems: mailboxDraftAction ? [mailboxDraftAction] : [],
     },
     messagingChannel: messagingChannel
       ? {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -281,11 +281,16 @@ async function sendSlackRuleNotificationWithContext({
     return { delivered: false, kind: "none" };
   }
 
+  const draftContent = await getNotificationDraftContent({
+    context,
+    logger,
+  });
+
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
-    draftContent: context.content,
+    draftContent,
     format: "slack",
   });
 
@@ -372,11 +377,16 @@ async function sendLinkedRuleNotification({
     return { delivered: false, kind: "none" };
   }
 
+  const draftContent = await getNotificationDraftContent({
+    context,
+    logger,
+  });
+
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
-    draftContent: context.content,
+    draftContent,
     format: "plain",
   });
   const text = buildMessagingRuleNotificationText({
@@ -464,11 +474,16 @@ async function sendTelegramRuleNotificationWithContext({
     return { delivered: false, kind: "none" };
   }
 
+  const draftContent = await getNotificationDraftContent({
+    context,
+    logger,
+  });
+
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
-    draftContent: context.content,
+    draftContent,
     format: "plain",
   });
 
@@ -611,25 +626,22 @@ export async function handleSlackRuleNotificationModalSubmit({
     return { action: "close" };
   }
 
-  const siblingDraftAction = await getSiblingEmailDraftAction({
-    executedActionId: context.id,
-    executedRuleId: context.executedRule.id,
-  });
+  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
 
-  if (siblingDraftAction?.draftId) {
+  if (mailboxDraftAction?.draftId) {
     try {
       const provider = await createProviderForContext(context, logger);
 
-      await provider.updateDraft(siblingDraftAction.draftId, {
+      await provider.updateDraft(mailboxDraftAction.draftId, {
         messageHtml: convertNewlinesToBr(escapeHtml(nextContent)),
-        ...(siblingDraftAction.subject
-          ? { subject: siblingDraftAction.subject }
+        ...(mailboxDraftAction.subject
+          ? { subject: mailboxDraftAction.subject }
           : {}),
       });
     } catch (error) {
       logger.warn("Failed to sync edited Slack draft back to email draft", {
         executedActionId: context.id,
-        siblingDraftActionId: siblingDraftAction.id,
+        mailboxDraftActionId: mailboxDraftAction.id,
         error,
       });
     }
@@ -638,7 +650,7 @@ export async function handleSlackRuleNotificationModalSubmit({
   await prisma.executedAction.updateMany({
     where: {
       id: {
-        in: [context.id, siblingDraftAction?.id].filter(Boolean) as string[],
+        in: [context.id, mailboxDraftAction?.id].filter(Boolean) as string[],
       },
     },
     data: {
@@ -740,16 +752,13 @@ async function handleDraftSend({
 
   const provider = await createProviderForContext(context, logger);
 
-  const siblingDraftAction = await getSiblingEmailDraftAction({
-    executedActionId: context.id,
-    executedRuleId: context.executedRule.id,
-  });
+  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
 
   try {
     const finalDraftContent = await getEditableDraftContent({
       context,
       provider,
-      siblingDraftAction,
+      mailboxDraftAction,
     });
     const sourceMessageSummary = await getSourceMessageSummaryForProvider({
       context,
@@ -763,8 +772,8 @@ async function handleDraftSend({
       format: "slack",
     });
 
-    if (siblingDraftAction?.draftId) {
-      await provider.sendDraft(siblingDraftAction.draftId);
+    if (mailboxDraftAction?.draftId) {
+      await provider.sendDraft(mailboxDraftAction.draftId);
     } else {
       const sourceMessage = await provider.getMessage(
         context.executedRule.messageId,
@@ -827,9 +836,9 @@ async function handleDraftSend({
       },
     });
 
-    if (siblingDraftAction?.id) {
+    if (mailboxDraftAction?.id) {
       await prisma.executedAction.update({
-        where: { id: siblingDraftAction.id },
+        where: { id: mailboxDraftAction.id },
         data: {
           wasDraftSent: true,
         },
@@ -920,14 +929,11 @@ async function handleDraftEdit({
 
   const provider = await createProviderForContext(context, logger);
 
-  const siblingDraftAction = await getSiblingEmailDraftAction({
-    executedActionId: context.id,
-    executedRuleId: context.executedRule.id,
-  });
+  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
   const initialContent = await getEditableDraftContent({
     context,
     provider,
-    siblingDraftAction,
+    mailboxDraftAction,
   });
 
   await event.openModal({
@@ -1249,6 +1255,22 @@ async function getNotificationContext(executedActionId: string) {
               systemType: true,
             },
           },
+          actionItems: {
+            where: {
+              id: { not: executedActionId },
+              type: ActionType.DRAFT_EMAIL,
+              draftId: { not: null },
+            },
+            select: {
+              id: true,
+              draftId: true,
+              subject: true,
+            },
+            orderBy: {
+              createdAt: "asc",
+            },
+            take: 1,
+          },
         },
       },
       messagingChannel: {
@@ -1273,43 +1295,24 @@ async function getNotificationContext(executedActionId: string) {
   });
 }
 
-async function getSiblingEmailDraftAction({
-  executedActionId,
-  executedRuleId,
-}: {
-  executedActionId: string;
-  executedRuleId: string;
-}) {
-  return prisma.executedAction.findFirst({
-    where: {
-      executedRuleId,
-      id: { not: executedActionId },
-      type: ActionType.DRAFT_EMAIL,
-      draftId: { not: null },
-    },
-    select: {
-      id: true,
-      draftId: true,
-      subject: true,
-    },
-    orderBy: {
-      createdAt: "asc",
-    },
-  });
+function getMailboxDraftActionForMessagingDraft(context: NotificationContext) {
+  return context.executedRule.actionItems?.[0] ?? null;
 }
 
 async function getEditableDraftContent({
   context,
   provider,
-  siblingDraftAction,
+  mailboxDraftAction,
 }: {
   context: NotificationContext;
   provider: Awaited<ReturnType<typeof createEmailProvider>>;
-  siblingDraftAction: Awaited<ReturnType<typeof getSiblingEmailDraftAction>>;
+  mailboxDraftAction: Awaited<
+    ReturnType<typeof getMailboxDraftActionForMessagingDraft>
+  >;
 }) {
-  if (siblingDraftAction?.draftId) {
+  if (mailboxDraftAction?.draftId) {
     try {
-      const latestDraft = await provider.getDraft(siblingDraftAction.draftId);
+      const latestDraft = await provider.getDraft(mailboxDraftAction.draftId);
       if (latestDraft) {
         const text = extractDraftPlainText(latestDraft).trim();
         if (text) return text;
@@ -1320,6 +1323,40 @@ async function getEditableDraftContent({
   }
 
   return context.content || "";
+}
+
+async function getNotificationDraftContent({
+  context,
+  logger,
+}: {
+  context: NotificationContext;
+  logger: Logger;
+}) {
+  if (!isDraftReplyActionType(context.type)) return context.content;
+
+  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
+
+  if (!mailboxDraftAction?.draftId) return context.content;
+
+  try {
+    const provider = await createProviderForContext(context, logger);
+
+    return await getEditableDraftContent({
+      context,
+      provider,
+      mailboxDraftAction,
+    });
+  } catch (error) {
+    logger.warn(
+      "Failed to load synced mailbox draft for notification preview",
+      {
+        executedActionId: context.id,
+        mailboxDraftActionId: mailboxDraftAction.id,
+        error,
+      },
+    );
+    return context.content;
+  }
 }
 
 async function getSourceMessageSummary(


### PR DESCRIPTION
Ensures draft reply actions share the same generated content across delivery surfaces.

- Prevents draft reply action content from being overwritten by separate generated template output once a shared draft exists.
- Uses the synced mailbox draft as the source of truth when rendering messaging previews.
- Adds regression coverage for shared draft generation and messaging preview consistency.