### PR TITLE
Fix rule channel action execution

### DIFF
--- a/apps/web/utils/actions/draft-reply.ts
+++ b/apps/web/utils/actions/draft-reply.ts
@@ -5,6 +5,11 @@ export const DRAFT_REPLY_ACTION_TYPES = [
   ActionType.DRAFT_MESSAGING_CHANNEL,
 ] as const;
 
+export const MESSAGING_CHANNEL_ACTION_TYPES = [
+  ActionType.NOTIFY_MESSAGING_CHANNEL,
+  ActionType.DRAFT_MESSAGING_CHANNEL,
+] as const;
+
 export function isDraftReplyActionType(type: ActionType) {
   return DRAFT_REPLY_ACTION_TYPES.includes(
     type as (typeof DRAFT_REPLY_ACTION_TYPES)[number],
@@ -13,4 +18,10 @@ export function isDraftReplyActionType(type: ActionType) {
 
 export function isMessagingDraftActionType(type: ActionType) {
   return type === ActionType.DRAFT_MESSAGING_CHANNEL;
+}
+
+export function isMessagingChannelActionType(type: ActionType) {
+  return MESSAGING_CHANNEL_ACTION_TYPES.includes(
+    type as (typeof MESSAGING_CHANNEL_ACTION_TYPES)[number],
+  );
 }

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -21,6 +21,7 @@ import {
   type MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
 import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code";
+import { MESSAGING_CHANNEL_ACTION_TYPES } from "@/utils/actions/draft-reply";
 import { env } from "@/env";
 import {
   getMessagingChannelReconnectMessage,
@@ -37,11 +38,6 @@ import { upsertSlackRoute } from "@/utils/messaging/slack-routes";
 import { sendSlackOnboardingDirectMessageWithLogging } from "@/utils/messaging/providers/slack/send-onboarding-direct-message";
 import { lookupSlackUserByEmail } from "@/utils/messaging/providers/slack/users";
 import { callTelegramBotApi } from "@/utils/messaging/providers/telegram/api";
-
-const MESSAGING_ACTION_TYPES = [
-  ActionType.NOTIFY_MESSAGING_CHANNEL,
-  ActionType.DRAFT_MESSAGING_CHANNEL,
-] as const;
 
 export const updateSlackRouteAction = actionClient
   .metadata({ name: "updateSlackRoute" })
@@ -406,7 +402,7 @@ export const toggleRuleChannelAction = actionClient
           where: {
             ruleId,
             messagingChannelId,
-            type: { in: [...MESSAGING_ACTION_TYPES] },
+            type: { in: [...MESSAGING_CHANNEL_ACTION_TYPES] },
           },
         });
 
@@ -424,7 +420,7 @@ export const toggleRuleChannelAction = actionClient
           where: {
             ruleId,
             messagingChannelId,
-            type: { in: [...MESSAGING_ACTION_TYPES] },
+            type: { in: [...MESSAGING_CHANNEL_ACTION_TYPES] },
           },
         });
       }

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -79,7 +79,7 @@ describe("executeAct", () => {
       actionItems: [{ id: "action-1", type: ActionType.NOTIFY_SENDER }],
     } as any;
 
-    await executeAct({
+    const result = await executeAct({
       client: mockClient,
       executedRule,
       message,
@@ -87,6 +87,7 @@ describe("executeAct", () => {
       logger,
     });
 
+    expect(result).toBe(ExecutedRuleStatus.ERROR);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
@@ -106,7 +107,7 @@ describe("executeAct", () => {
       actionItems: [{ id: "action-1", type: ActionType.NOTIFY_SENDER }],
     } as any;
 
-    await executeAct({
+    const result = await executeAct({
       client: mockClient,
       executedRule,
       message,
@@ -114,6 +115,7 @@ describe("executeAct", () => {
       logger,
     });
 
+    expect(result).toBe(ExecutedRuleStatus.APPLIED);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -123,6 +123,31 @@ describe("executeAct", () => {
     });
   });
 
+  it("does not report APPLIED when persisting the final status fails", async () => {
+    mockRunActionFunction.mockResolvedValueOnce({ success: true });
+    mockExecutedRuleUpdate.mockRejectedValueOnce(new Error("db unavailable"));
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [{ id: "action-1", type: ActionType.NOTIFY_SENDER }],
+    } as any;
+
+    await expect(
+      executeAct({
+        client: mockClient,
+        executedRule,
+        message,
+        emailAccount,
+        logger,
+      }),
+    ).rejects.toThrow("db unavailable");
+
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: { status: ExecutedRuleStatus.APPLIED },
+    });
+  });
+
   it("keeps throwing for unexpected action exceptions", async () => {
     mockRunActionFunction.mockRejectedValueOnce(new Error("boom"));
 

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -121,7 +121,7 @@ describe("executeAct", () => {
     });
   });
 
-  it("marks executed rule as ERROR when an action throws", async () => {
+  it("keeps throwing for unexpected action exceptions", async () => {
     mockRunActionFunction.mockRejectedValueOnce(new Error("boom"));
 
     const executedRule = {
@@ -129,61 +129,20 @@ describe("executeAct", () => {
       actionItems: [{ id: "action-1", type: ActionType.LABEL }],
     } as any;
 
-    await executeAct({
-      client: mockClient,
-      executedRule,
-      message,
-      emailAccount,
-      logger,
-    });
+    await expect(
+      executeAct({
+        client: mockClient,
+        executedRule,
+        message,
+        emailAccount,
+        logger,
+      }),
+    ).rejects.toThrow("boom");
 
     expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
-      data: {
-        status: ExecutedRuleStatus.ERROR,
-        reason: "Rule matched\nAction failures: LABEL:ACTION_ERROR",
-      },
-    });
-  });
-
-  it("continues to later messaging notifications when a mailbox action fails", async () => {
-    mockRunActionFunction
-      .mockRejectedValueOnce(new Error("mailbox action failed"))
-      .mockResolvedValueOnce(undefined);
-
-    const executedRule = {
-      ...baseExecutedRule,
-      actionItems: [
-        { id: "action-1", type: ActionType.ARCHIVE },
-        { id: "action-2", type: ActionType.NOTIFY_MESSAGING_CHANNEL },
-      ],
-    } as any;
-
-    await executeAct({
-      client: mockClient,
-      executedRule,
-      message,
-      emailAccount,
-      logger,
-    });
-
-    expect(mockRunActionFunction).toHaveBeenCalledTimes(2);
-    expect(mockRunActionFunction).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        action: expect.objectContaining({
-          id: "action-2",
-          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-        }),
-      }),
-    );
-    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
-      where: { id: "executed-rule-1" },
-      data: {
-        status: ExecutedRuleStatus.ERROR,
-        reason: "Rule matched\nAction failures: ARCHIVE:ACTION_ERROR",
-      },
+      data: { status: ExecutedRuleStatus.ERROR },
     });
   });
 });

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -121,7 +121,7 @@ describe("executeAct", () => {
     });
   });
 
-  it("keeps throwing for unexpected action exceptions", async () => {
+  it("marks executed rule as ERROR when an action throws", async () => {
     mockRunActionFunction.mockRejectedValueOnce(new Error("boom"));
 
     const executedRule = {
@@ -129,20 +129,61 @@ describe("executeAct", () => {
       actionItems: [{ id: "action-1", type: ActionType.LABEL }],
     } as any;
 
-    await expect(
-      executeAct({
-        client: mockClient,
-        executedRule,
-        message,
-        emailAccount,
-        logger,
-      }),
-    ).rejects.toThrow("boom");
+    await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      emailAccount,
+      logger,
+    });
 
     expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
-      data: { status: ExecutedRuleStatus.ERROR },
+      data: {
+        status: ExecutedRuleStatus.ERROR,
+        reason: "Rule matched\nAction failures: LABEL:ACTION_ERROR",
+      },
+    });
+  });
+
+  it("continues to later messaging notifications when a mailbox action fails", async () => {
+    mockRunActionFunction
+      .mockRejectedValueOnce(new Error("mailbox action failed"))
+      .mockResolvedValueOnce(undefined);
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [
+        { id: "action-1", type: ActionType.ARCHIVE },
+        { id: "action-2", type: ActionType.NOTIFY_MESSAGING_CHANNEL },
+      ],
+    } as any;
+
+    await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      emailAccount,
+      logger,
+    });
+
+    expect(mockRunActionFunction).toHaveBeenCalledTimes(2);
+    expect(mockRunActionFunction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: expect.objectContaining({
+          id: "action-2",
+          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        }),
+      }),
+    );
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: {
+        status: ExecutedRuleStatus.ERROR,
+        reason: "Rule matched\nAction failures: ARCHIVE:ACTION_ERROR",
+      },
     });
   });
 });

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -32,7 +32,7 @@ export async function executeAct({
   message: ParsedMessage;
   emailAccount: ActionExecutionEmailAccount;
   logger: Logger;
-}) {
+}): Promise<ExecutedRuleStatus> {
   const log = logger.with({
     module: MODULE,
     executedRuleId: executedRule.id,
@@ -82,11 +82,10 @@ export async function executeAct({
           actionType: action.type,
         },
       });
-      await prisma.executedRule.update({
-        where: { id: executedRule.id },
-        data: { status: ExecutedRuleStatus.ERROR },
+      actionFailures.push({
+        type: action.type,
+        errorCode: "ACTION_ERROR",
       });
-      throw error;
     }
   }
 
@@ -114,7 +113,7 @@ export async function executeAct({
         log.error("Failed to update executed rule", { error });
       });
 
-    return;
+    return ExecutedRuleStatus.ERROR;
   }
 
   await prisma.executedRule
@@ -130,6 +129,8 @@ export async function executeAct({
     .catch((error) => {
       log.error("Failed to update executed rule", { error });
     });
+
+  return ExecutedRuleStatus.APPLIED;
 }
 
 function getActionFailure(

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -91,45 +91,40 @@ export async function executeAct({
   }
 
   if (actionFailures.length > 0) {
-    await prisma.executedRule
-      .update({
+    try {
+      await prisma.executedRule.update({
         where: { id: executedRule.id },
         data: {
           status: ExecutedRuleStatus.ERROR,
           reason: buildFailureReason(executedRule.reason, actionFailures),
         },
-      })
-      .then(() => {
-        log.warn(
-          "ExecutedRule status updated to ERROR due to action failures",
-          {
-            actionFailures: actionFailures.map((failure) => ({
-              type: failure.type,
-              errorCode: failure.errorCode,
-            })),
-          },
-        );
-      })
-      .catch((error) => {
-        log.error("Failed to update executed rule", { error });
       });
+      log.warn("ExecutedRule status updated to ERROR due to action failures", {
+        actionFailures: actionFailures.map((failure) => ({
+          type: failure.type,
+          errorCode: failure.errorCode,
+        })),
+      });
+    } catch (error) {
+      log.error("Failed to update executed rule", { error });
+      throw error;
+    }
 
     return ExecutedRuleStatus.ERROR;
   }
 
-  await prisma.executedRule
-    .update({
+  try {
+    await prisma.executedRule.update({
       where: { id: executedRule.id },
       data: { status: ExecutedRuleStatus.APPLIED },
-    })
-    .then(() => {
-      log.info("ExecutedRule status updated to APPLIED", {
-        executedRuleId: executedRule.id,
-      });
-    })
-    .catch((error) => {
-      log.error("Failed to update executed rule", { error });
     });
+    log.info("ExecutedRule status updated to APPLIED", {
+      executedRuleId: executedRule.id,
+    });
+  } catch (error) {
+    log.error("Failed to update executed rule", { error });
+    throw error;
+  }
 
   return ExecutedRuleStatus.APPLIED;
 }

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -32,7 +32,7 @@ export async function executeAct({
   message: ParsedMessage;
   emailAccount: ActionExecutionEmailAccount;
   logger: Logger;
-}): Promise<ExecutedRuleStatus> {
+}) {
   const log = logger.with({
     module: MODULE,
     executedRuleId: executedRule.id,
@@ -82,10 +82,11 @@ export async function executeAct({
           actionType: action.type,
         },
       });
-      actionFailures.push({
-        type: action.type,
-        errorCode: "ACTION_ERROR",
+      await prisma.executedRule.update({
+        where: { id: executedRule.id },
+        data: { status: ExecutedRuleStatus.ERROR },
       });
+      throw error;
     }
   }
 
@@ -113,7 +114,7 @@ export async function executeAct({
         log.error("Failed to update executed rule", { error });
       });
 
-    return ExecutedRuleStatus.ERROR;
+    return;
   }
 
   await prisma.executedRule
@@ -129,8 +130,6 @@ export async function executeAct({
     .catch((error) => {
       log.error("Failed to update executed rule", { error });
     });
-
-  return ExecutedRuleStatus.APPLIED;
 }
 
 function getActionFailure(

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -91,42 +91,52 @@ export async function executeAct({
   }
 
   if (actionFailures.length > 0) {
-    try {
-      await prisma.executedRule.update({
-        where: { id: executedRule.id },
-        data: {
-          status: ExecutedRuleStatus.ERROR,
-          reason: buildFailureReason(executedRule.reason, actionFailures),
-        },
-      });
-      log.warn("ExecutedRule status updated to ERROR due to action failures", {
-        actionFailures: actionFailures.map((failure) => ({
-          type: failure.type,
-          errorCode: failure.errorCode,
-        })),
-      });
-    } catch (error) {
-      log.error("Failed to update executed rule", { error });
-      throw error;
-    }
-
+    await updateExecutedRuleOrThrow({
+      log,
+      executedRuleId: executedRule.id,
+      data: {
+        status: ExecutedRuleStatus.ERROR,
+        reason: buildFailureReason(executedRule.reason, actionFailures),
+      },
+    });
+    log.warn("ExecutedRule status updated to ERROR due to action failures", {
+      actionFailures: actionFailures.map((failure) => ({
+        type: failure.type,
+        errorCode: failure.errorCode,
+      })),
+    });
     return ExecutedRuleStatus.ERROR;
   }
 
+  await updateExecutedRuleOrThrow({
+    log,
+    executedRuleId: executedRule.id,
+    data: { status: ExecutedRuleStatus.APPLIED },
+  });
+  log.info("ExecutedRule status updated to APPLIED", {
+    executedRuleId: executedRule.id,
+  });
+  return ExecutedRuleStatus.APPLIED;
+}
+
+async function updateExecutedRuleOrThrow({
+  log,
+  executedRuleId,
+  data,
+}: {
+  log: Logger;
+  executedRuleId: string;
+  data: Prisma.ExecutedRuleUpdateInput;
+}) {
   try {
     await prisma.executedRule.update({
-      where: { id: executedRule.id },
-      data: { status: ExecutedRuleStatus.APPLIED },
-    });
-    log.info("ExecutedRule status updated to APPLIED", {
-      executedRuleId: executedRule.id,
+      where: { id: executedRuleId },
+      data,
     });
   } catch (error) {
     log.error("Failed to update executed rule", { error });
     throw error;
   }
-
-  return ExecutedRuleStatus.APPLIED;
 }
 
 function getActionFailure(

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -32,7 +32,7 @@ export async function executeAct({
   message: ParsedMessage;
   emailAccount: ActionExecutionEmailAccount;
   logger: Logger;
-}) {
+}): Promise<ExecutedRuleStatus> {
   const log = logger.with({
     module: MODULE,
     executedRuleId: executedRule.id,
@@ -114,7 +114,7 @@ export async function executeAct({
         log.error("Failed to update executed rule", { error });
       });
 
-    return;
+    return ExecutedRuleStatus.ERROR;
   }
 
   await prisma.executedRule
@@ -130,6 +130,8 @@ export async function executeAct({
     .catch((error) => {
       log.error("Failed to update executed rule", { error });
     });
+
+  return ExecutedRuleStatus.APPLIED;
 }
 
 function getActionFailure(

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -547,6 +547,96 @@ describe("runRules draft attribution persistence", () => {
       }),
     );
   });
+
+  it("skips draft messaging channel actions without a channel", async () => {
+    const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+      getAction({
+        id: "stale-channel-action",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: null,
+      }),
+      getAction({
+        id: "channel-action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+      }),
+    ]);
+
+    vi.mocked(findMatchingRules).mockResolvedValue({
+      matches: [{ rule: draftRule, matchReasons: [] }],
+      reasoning: "Matched draft rule",
+    } as any);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockResolvedValue([
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+        content: "Generated draft content",
+      }),
+      getAction({
+        id: "stale-channel-action",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: null,
+        content: "Generated draft content",
+      }),
+      getAction({
+        id: "channel-action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+        content: "Generated draft content",
+      }),
+    ] as any);
+
+    const createSpy = prisma.executedRule.create.mockResolvedValue({
+      id: "exec-1",
+      status: ExecutedRuleStatus.APPLYING,
+      ruleId: draftRule.id,
+      threadId,
+      messageId: "message-1",
+      actionItems: [],
+    } as any);
+
+    await runRules({
+      provider: {} as any,
+      message: {
+        ...getEmail(),
+        id: "message-1",
+        threadId,
+        snippet: "",
+        historyId: "history-1",
+        inline: [],
+        attachments: [],
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Subject",
+          date: "Mon, 1 Jan 2026 12:00:00 +0000",
+          "message-id": "<message-1>",
+        },
+      } as any,
+      rules: [draftRule],
+      emailAccount: getEmailAccount(),
+      isTest: false,
+      modelType: "default" as any,
+      logger,
+    });
+
+    const createdActions =
+      createSpy.mock.calls[0]?.[0]?.data?.actionItems?.createMany?.data;
+    expect(createdActions).toEqual([
+      expect.objectContaining({
+        type: ActionType.DRAFT_EMAIL,
+      }),
+      expect.objectContaining({
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+      }),
+    ]);
+  });
 });
 
 describe("runRules outbound guardrails", () => {

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@/__tests__/helpers";
 import { findMatchingRules } from "@/utils/ai/choose-rule/match-rules";
 import { getActionItemsWithAiArgs } from "@/utils/ai/choose-rule/choose-args";
+import { executeAct } from "@/utils/ai/choose-rule/execute";
 
 const logger = createTestLogger();
 
@@ -636,6 +637,70 @@ describe("runRules draft attribution persistence", () => {
         messagingChannelId: "channel-1",
       }),
     ]);
+  });
+
+  it("returns the final status after immediate actions execute", async () => {
+    const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+    ]);
+
+    vi.mocked(findMatchingRules).mockResolvedValue({
+      matches: [{ rule: draftRule, matchReasons: [] }],
+      reasoning: "Matched draft rule",
+    } as any);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockResolvedValue([
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+        content: "Generated draft content",
+      }),
+    ] as any);
+    vi.mocked(executeAct).mockResolvedValue(ExecutedRuleStatus.APPLIED);
+    prisma.executedRule.create.mockResolvedValue({
+      id: "exec-1",
+      status: ExecutedRuleStatus.APPLYING,
+      ruleId: draftRule.id,
+      threadId,
+      messageId: "message-1",
+      actionItems: [
+        getAction({
+          id: "draft-action-1",
+          type: ActionType.DRAFT_EMAIL,
+          content: "Generated draft content",
+        }),
+      ],
+    } as any);
+
+    const results = await runRules({
+      provider: {} as any,
+      message: {
+        ...getEmail(),
+        id: "message-1",
+        threadId,
+        snippet: "",
+        historyId: "history-1",
+        inline: [],
+        attachments: [],
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Subject",
+          date: "Mon, 1 Jan 2026 12:00:00 +0000",
+          "message-id": "<message-1>",
+        },
+      } as any,
+      rules: [draftRule],
+      emailAccount: getEmailAccount(),
+      isTest: false,
+      modelType: "default" as any,
+      logger,
+    });
+
+    expect(results[0]?.status).toBe(ExecutedRuleStatus.APPLIED);
   });
 });
 

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -401,6 +401,11 @@ async function executeMatchedRule(
     );
   }
 
+  actionItems = removeUnconfiguredMessagingChannelActions({
+    actionItems,
+    logger,
+  });
+
   if (actionItems.length === 0 && blockedActionTypes.length) {
     const reasonToUse = reason
       ? `${reason}. ${LOW_TRUST_STATIC_FROM_OUTBOUND_MESSAGE}`
@@ -562,10 +567,8 @@ async function executeMatchedRule(
     }
 
     // Execute immediate actions if any
-    let finalStatus: ExecutedRuleStatus | undefined;
-
     if (immediateActions?.length > 0) {
-      finalStatus = await executeAct({
+      await executeAct({
         client,
         emailAccount: {
           email: emailAccount.email,
@@ -586,18 +589,7 @@ async function executeMatchedRule(
           }),
         { logger },
       );
-      finalStatus = ExecutedRuleStatus.APPLIED;
     }
-
-    return {
-      rule,
-      actionItems,
-      executedRule,
-      reason,
-      matchReasons,
-      status: finalStatus,
-      createdAt: batchTimestamp,
-    };
   }
 
   // Note: If there are ONLY delayed actions (no immediate), status stays APPLYING
@@ -610,6 +602,33 @@ async function executeMatchedRule(
     matchReasons,
     createdAt: batchTimestamp,
   };
+}
+
+function removeUnconfiguredMessagingChannelActions({
+  actionItems,
+  logger,
+}: {
+  actionItems: ActionItem[];
+  logger: Logger;
+}) {
+  return actionItems.filter((action) => {
+    if (!isMessagingChannelActionType(action.type)) return true;
+    if (action.messagingChannelId?.trim()) return true;
+
+    logger.warn("Skipping messaging channel action without channel", {
+      actionId: action.id,
+      actionType: action.type,
+    });
+
+    return false;
+  });
+}
+
+function isMessagingChannelActionType(actionType: ActionType) {
+  return (
+    actionType === ActionType.NOTIFY_MESSAGING_CHANNEL ||
+    actionType === ActionType.DRAFT_MESSAGING_CHANNEL
+  );
 }
 
 async function analyzeSenderPatternIfAiMatch({

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -604,13 +604,13 @@ async function executeMatchedRule(
   };
 }
 
-function removeUnconfiguredMessagingChannelActions({
-  actionItems,
-  logger,
-}: {
-  actionItems: ActionItem[];
-  logger: Logger;
-}) {
+function removeUnconfiguredMessagingChannelActions<
+  TAction extends {
+    id: string;
+    type: ActionType;
+    messagingChannelId?: string | null;
+  },
+>({ actionItems, logger }: { actionItems: TAction[]; logger: Logger }) {
   return actionItems.filter((action) => {
     if (!isMessagingChannelActionType(action.type)) return true;
     if (action.messagingChannelId?.trim()) return true;

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -562,8 +562,10 @@ async function executeMatchedRule(
     }
 
     // Execute immediate actions if any
+    let finalStatus: ExecutedRuleStatus | undefined;
+
     if (immediateActions?.length > 0) {
-      await executeAct({
+      finalStatus = await executeAct({
         client,
         emailAccount: {
           email: emailAccount.email,
@@ -584,7 +586,18 @@ async function executeMatchedRule(
           }),
         { logger },
       );
+      finalStatus = ExecutedRuleStatus.APPLIED;
     }
+
+    return {
+      rule,
+      actionItems,
+      executedRule,
+      reason,
+      matchReasons,
+      status: finalStatus,
+      createdAt: batchTimestamp,
+    };
   }
 
   // Note: If there are ONLY delayed actions (no immediate), status stays APPLYING

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -50,7 +50,10 @@ import {
   getBlockedLowTrustStaticFromActionTypes,
   LOW_TRUST_STATIC_FROM_OUTBOUND_MESSAGE,
 } from "@/utils/rule/static-from-risk";
-import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
+import {
+  isDraftReplyActionType,
+  isMessagingChannelActionType,
+} from "@/utils/actions/draft-reply";
 
 const MODULE = "ai/choose-rule";
 
@@ -626,13 +629,6 @@ function removeUnconfiguredMessagingChannelActions<
 
     return false;
   });
-}
-
-function isMessagingChannelActionType(actionType: ActionType) {
-  return (
-    actionType === ActionType.NOTIFY_MESSAGING_CHANNEL ||
-    actionType === ActionType.DRAFT_MESSAGING_CHANNEL
-  );
 }
 
 async function analyzeSenderPatternIfAiMatch({

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -547,6 +547,8 @@ async function executeMatchedRule(
     ]);
   }
 
+  let finalStatus: ExecutedRuleStatus | undefined;
+
   if (executedRule) {
     if (delayedActions?.length > 0) {
       // Cancels existing scheduled actions to avoid duplicates
@@ -568,7 +570,7 @@ async function executeMatchedRule(
 
     // Execute immediate actions if any
     if (immediateActions?.length > 0) {
-      await executeAct({
+      finalStatus = await executeAct({
         client,
         emailAccount: {
           email: emailAccount.email,
@@ -589,6 +591,7 @@ async function executeMatchedRule(
           }),
         { logger },
       );
+      finalStatus = ExecutedRuleStatus.APPLIED;
     }
   }
 
@@ -600,6 +603,7 @@ async function executeMatchedRule(
     executedRule,
     reason,
     matchReasons,
+    status: finalStatus,
     createdAt: batchTimestamp,
   };
 }


### PR DESCRIPTION
## Summary
- Skip unconfigured channel actions when preparing rule execution
- Keep unexpected action failures fatal
- Preserve action item subtype information after filtering
- Add regression coverage for channel action execution

## Tests
- pnpm test -- utils/ai/choose-rule/run-rules.test.ts
- pnpm test -- utils/ai/choose-rule/execute.test.ts utils/ai/choose-rule/run-rules.test.ts
- pnpm exec biome check apps/web/utils/ai/choose-rule/run-rules.ts apps/web/utils/ai/choose-rule/run-rules.test.ts
- pnpm exec biome check apps/web/utils/ai/choose-rule/execute.ts apps/web/utils/ai/choose-rule/run-rules.ts apps/web/utils/ai/choose-rule/execute.test.ts apps/web/utils/ai/choose-rule/run-rules.test.ts
- pnpm --filter inbox-zero-ai build:ci