### PR TITLE
ui: Improve AI chat email card readability

### DIFF
--- a/apps/web/components/Tooltip.tsx
+++ b/apps/web/components/Tooltip.tsx
@@ -13,6 +13,7 @@ interface TooltipProps {
   content?: string;
   contentComponent?: React.ReactNode;
   hide?: boolean;
+  side?: "top" | "right" | "bottom" | "left";
 }
 
 export const Tooltip = ({
@@ -20,6 +21,7 @@ export const Tooltip = ({
   content,
   contentComponent,
   hide,
+  side,
 }: TooltipProps) => {
   // Make tooltip work on mobile with a click
   const [isOpen, setIsOpen] = useState(false);
@@ -32,7 +34,7 @@ export const Tooltip = ({
         <TooltipTrigger asChild onClick={() => setIsOpen(!isOpen)}>
           {children}
         </TooltipTrigger>
-        <TooltipContent>
+        <TooltipContent side={side}>
           {contentComponent || <p className="max-w-xs">{content}</p>}
         </TooltipContent>
       </ShadcnTooltip>

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -13,7 +13,7 @@ type AssistantInlineEmailResponseProps = ComponentProps<typeof Streamdown>;
 
 const allowedTags = {
   emails: [],
-  email: ["id", "threadid"],
+  email: ["id", "threadid", "index"],
   "email-detail": ["id", "threadid"],
 };
 const components = {

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -7,6 +7,7 @@ import {
   isValidElement,
   useState,
   useContext,
+  useMemo,
   cloneElement,
   type ReactNode,
 } from "react";
@@ -75,6 +76,10 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
   );
   const [readThreadIds, setReadThreadIds] = useState<Set<string>>(
     () => new Set(),
+  );
+  const numberedChildren = useMemo(
+    () => numberInlineEmailCards(children),
+    [children],
   );
   const threadIds = normalizeInlineEmailThreadIds(collectThreadIds(children));
   const remainingArchiveThreadIds = threadIds.filter(
@@ -270,7 +275,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
               </Tooltip>
             </div>
           )}
-          {numberInlineEmailCards(children)}
+          {numberedChildren}
         </div>
       )}
     </InlineEmailListContext.Provider>
@@ -310,7 +315,6 @@ export function InlineEmailCard({
 }: {
   id?: string;
   threadid?: string;
-  action?: string;
   index?: number | string;
   children?: ReactNode;
 }) {
@@ -383,6 +387,7 @@ export function InlineEmailCard({
   }
 
   const isDone = actionState === "done" || isArchived;
+  const markReadComplete = isMarkedRead || markReadState === "done";
   const showArchive = Boolean(threadId);
   const hasSummary = !!children;
 
@@ -435,13 +440,9 @@ export function InlineEmailCard({
                   {extractNameFromEmail(meta.from)}
                 </span>
               </Tooltip>
-              {meta.subject ? (
-                <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-                  {meta.subject}
-                </span>
-              ) : (
-                <span className="min-w-0 flex-1" />
-              )}
+              <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+                {meta.subject}
+              </span>
               <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                 {formatShortDate(new Date(meta.date), { lowercase: true })}
               </span>
@@ -483,21 +484,15 @@ export function InlineEmailCard({
                   </DropdownMenuItem>
                 ) : null}
                 <DropdownMenuItem
-                  disabled={
-                    isMarkedRead ||
-                    markReadState === "loading" ||
-                    markReadState === "done"
-                  }
+                  disabled={markReadComplete || markReadState === "loading"}
                   onClick={handleMarkRead}
                 >
-                  {isMarkedRead || markReadState === "done" ? (
+                  {markReadComplete ? (
                     <CheckIcon className="mr-2 size-4" />
                   ) : (
                     <MailOpenIcon className="mr-2 size-4" />
                   )}
-                  {isMarkedRead || markReadState === "done"
-                    ? "Marked read"
-                    : "Mark as read"}
+                  {markReadComplete ? "Marked read" : "Mark as read"}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -51,6 +51,9 @@ type ActionState = "idle" | "loading" | "done";
 const iconButtonClass =
   "inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50";
 
+const iconIndicatorClass =
+  "inline-flex h-7 w-7 items-center justify-center text-muted-foreground";
+
 type InlineEmailListState = {
   archivedThreadIds: Set<string>;
   readThreadIds: Set<string>;
@@ -275,7 +278,7 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
 }
 
 function numberInlineEmailCards(children: ReactNode): ReactNode {
-  let positional = 0;
+  let nextIndex = 0;
   return Children.map(children, (child) => {
     if (
       !isValidElement<{
@@ -287,9 +290,15 @@ function numberInlineEmailCards(children: ReactNode): ReactNode {
       return child;
     }
     if (!resolveInlineEmailThreadId(child.props)) return child;
-    positional += 1;
-    if (child.props.index !== undefined) return child;
-    return cloneElement(child, { index: positional });
+    if (child.props.index !== undefined) {
+      const explicit = Number(child.props.index);
+      if (Number.isFinite(explicit)) {
+        nextIndex = Math.max(nextIndex, explicit);
+      }
+      return child;
+    }
+    nextIndex += 1;
+    return cloneElement(child, { index: nextIndex });
   });
 }
 
@@ -310,12 +319,14 @@ export function InlineEmailCard({
   const inlineEmailActionContext = useInlineEmailActionContext();
   const { emailAccountId, provider, userEmail } = useAccount();
   const [actionState, setActionState] = useState<ActionState>("idle");
+  const [markReadState, setMarkReadState] = useState<ActionState>("idle");
   const [expanded, setExpanded] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
   const threadId = resolveInlineEmailThreadId({ id, threadid });
 
   const meta = threadId ? emailLookup.get(threadId) : undefined;
   const isArchived = !!threadId && !!listState?.archivedThreadIds.has(threadId);
+  const isMarkedRead = !!threadId && !!listState?.readThreadIds.has(threadId);
 
   const externalUrl = threadId
     ? getEmailUrlForMessage(
@@ -349,7 +360,8 @@ export function InlineEmailCard({
   }
 
   async function handleMarkRead() {
-    if (!threadId) return;
+    if (!threadId || markReadState !== "idle") return;
+    setMarkReadState("loading");
     try {
       const result = await markReadThreadAction(emailAccountId, {
         threadId,
@@ -357,13 +369,16 @@ export function InlineEmailCard({
       });
       if (result?.serverError) {
         toastError({ description: result.serverError });
+        setMarkReadState("idle");
         return;
       }
       listState?.markRead([threadId]);
       inlineEmailActionContext?.queueAction("mark_read_threads", [threadId]);
       toastSuccess({ description: "Marked as read" });
+      setMarkReadState("done");
     } catch {
       toastError({ description: "Failed to mark as read" });
+      setMarkReadState("idle");
     }
   }
 
@@ -445,9 +460,22 @@ export function InlineEmailCard({
                     {isDone ? "Archived" : "Archive"}
                   </DropdownMenuItem>
                 ) : null}
-                <DropdownMenuItem onClick={handleMarkRead}>
-                  <MailOpenIcon className="mr-2 size-4" />
-                  Mark as read
+                <DropdownMenuItem
+                  disabled={
+                    isMarkedRead ||
+                    markReadState === "loading" ||
+                    markReadState === "done"
+                  }
+                  onClick={handleMarkRead}
+                >
+                  {isMarkedRead || markReadState === "done" ? (
+                    <CheckIcon className="mr-2 size-4" />
+                  ) : (
+                    <MailOpenIcon className="mr-2 size-4" />
+                  )}
+                  {isMarkedRead || markReadState === "done"
+                    ? "Marked read"
+                    : "Mark as read"}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
@@ -475,7 +503,7 @@ export function InlineEmailCard({
           ) : null}
 
           {threadId ? (
-            <span className={iconButtonClass} aria-hidden="true">
+            <span className={iconIndicatorClass} aria-hidden="true">
               {expanded ? (
                 <ChevronDownIcon className="size-3.5" />
               ) : (

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -384,13 +384,14 @@ export function InlineEmailCard({
 
   const isDone = actionState === "done" || isArchived;
   const showArchive = Boolean(threadId);
+  const hasSummary = !!children;
 
   return (
     <div>
       <div
         role={threadId ? "button" : undefined}
         tabIndex={threadId ? 0 : undefined}
-        className={`group flex items-center gap-2 border-b border-border/40 py-3 pl-2 pr-3 text-sm last:border-b-0 ${threadId ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
+        className={`group flex items-center gap-2 border-b border-border/40 pl-2 pr-3 text-sm last:border-b-0 ${hasSummary ? "py-3" : "py-1.5"} ${threadId ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
         onClick={() => threadId && setExpanded(!expanded)}
         onKeyDown={(e) => {
           if (threadId && (e.key === "Enter" || e.key === " ")) {
@@ -406,25 +407,46 @@ export function InlineEmailCard({
         ) : null}
 
         {meta ? (
-          <div className="min-w-0 flex-1">
-            {children ? (
+          hasSummary ? (
+            <div className="min-w-0 flex-1">
               <div className="text-sm text-foreground">{children}</div>
-            ) : null}
-            <div className="mt-1 truncate text-xs text-muted-foreground">
+              <div className="mt-1 truncate text-xs text-muted-foreground">
+                <Tooltip
+                  content={extractEmailAddress(meta.from) || meta.from}
+                  side="right"
+                >
+                  <span className="font-medium">
+                    {extractNameFromEmail(meta.from)}
+                  </span>
+                </Tooltip>
+                {" · "}
+                <span className="tabular-nums">
+                  {formatShortDate(new Date(meta.date), { lowercase: true })}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-3">
               <Tooltip
                 content={extractEmailAddress(meta.from) || meta.from}
                 side="right"
               >
-                <span className="font-medium">
+                <span className="w-40 shrink-0 truncate text-sm font-medium">
                   {extractNameFromEmail(meta.from)}
                 </span>
               </Tooltip>
-              {" · "}
-              <span className="tabular-nums">
+              {meta.subject ? (
+                <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+                  {meta.subject}
+                </span>
+              ) : (
+                <span className="min-w-0 flex-1" />
+              )}
+              <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                 {formatShortDate(new Date(meta.date), { lowercase: true })}
               </span>
             </div>
-          </div>
+          )
         ) : (
           <span className="min-w-0 flex-1 truncate">{children}</span>
         )}

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, {
+import {
   Children,
   createContext,
   useEffect,
   isValidElement,
   useState,
   useContext,
+  cloneElement,
   type ReactNode,
 } from "react";
 import {
@@ -15,8 +16,16 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
+  InfoIcon,
   MailOpenIcon,
+  MoreVerticalIcon,
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useEmailLookup } from "@/components/assistant-chat/email-lookup-context";
 import { useInlineEmailActionContext } from "@/components/assistant-chat/inline-email-action-context";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -27,15 +36,20 @@ import {
 import { normalizeInlineEmailThreadIds } from "@/utils/ai/assistant/inline-email-actions";
 import { getEmailUrlForMessage } from "@/utils/url";
 import { formatShortDate } from "@/utils/date";
+import { extractEmailAddress, extractNameFromEmail } from "@/utils/email";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/Tooltip";
 import { EmailAttachments } from "@/components/email-list/EmailAttachments";
-import { EmailDetails } from "@/components/email-list/EmailDetails";
 import { HtmlEmail, PlainEmail } from "@/components/email-list/EmailContents";
+import { EmailDetails } from "@/components/email-list/EmailDetails";
 import { useThread } from "@/hooks/useThread";
+import { LoadingMiniSpinner } from "@/components/Loading";
 
 type ActionState = "idle" | "loading" | "done";
+
+const iconButtonClass =
+  "inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50";
 
 type InlineEmailListState = {
   archivedThreadIds: Set<string>;
@@ -253,21 +267,42 @@ export function InlineEmailList({ children }: { children?: ReactNode }) {
               </Tooltip>
             </div>
           )}
-          {children}
+          {numberInlineEmailCards(children)}
         </div>
       )}
     </InlineEmailListContext.Provider>
   );
 }
 
+function numberInlineEmailCards(children: ReactNode): ReactNode {
+  let positional = 0;
+  return Children.map(children, (child) => {
+    if (
+      !isValidElement<{
+        id?: string;
+        threadid?: string;
+        index?: number | string;
+      }>(child)
+    ) {
+      return child;
+    }
+    if (!resolveInlineEmailThreadId(child.props)) return child;
+    positional += 1;
+    if (child.props.index !== undefined) return child;
+    return cloneElement(child, { index: positional });
+  });
+}
+
 export function InlineEmailCard({
   id,
   threadid,
+  index,
   children,
 }: {
   id?: string;
   threadid?: string;
   action?: string;
+  index?: number | string;
   children?: ReactNode;
 }) {
   const emailLookup = useEmailLookup();
@@ -276,12 +311,11 @@ export function InlineEmailCard({
   const { emailAccountId, provider, userEmail } = useAccount();
   const [actionState, setActionState] = useState<ActionState>("idle");
   const [expanded, setExpanded] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
   const threadId = resolveInlineEmailThreadId({ id, threadid });
 
   const meta = threadId ? emailLookup.get(threadId) : undefined;
   const isArchived = !!threadId && !!listState?.archivedThreadIds.has(threadId);
-  const isMarkedRead = !!threadId && !!listState?.readThreadIds.has(threadId);
-  const isUnread = !!meta?.isUnread && !isMarkedRead && !isArchived;
 
   const externalUrl = threadId
     ? getEmailUrlForMessage(
@@ -292,8 +326,7 @@ export function InlineEmailCard({
       )
     : null;
 
-  async function handleArchive(e: React.MouseEvent) {
-    e.stopPropagation();
+  async function handleArchive() {
     if (!threadId || actionState !== "idle") return;
     setActionState("loading");
     try {
@@ -315,6 +348,25 @@ export function InlineEmailCard({
     }
   }
 
+  async function handleMarkRead() {
+    if (!threadId) return;
+    try {
+      const result = await markReadThreadAction(emailAccountId, {
+        threadId,
+        read: true,
+      });
+      if (result?.serverError) {
+        toastError({ description: result.serverError });
+        return;
+      }
+      listState?.markRead([threadId]);
+      inlineEmailActionContext?.queueAction("mark_read_threads", [threadId]);
+      toastSuccess({ description: "Marked as read" });
+    } catch {
+      toastError({ description: "Failed to mark as read" });
+    }
+  }
+
   const isDone = actionState === "done" || isArchived;
   const showArchive = Boolean(threadId);
 
@@ -323,7 +375,7 @@ export function InlineEmailCard({
       <div
         role={threadId ? "button" : undefined}
         tabIndex={threadId ? 0 : undefined}
-        className={`group flex items-center border-b border-border/40 px-3 py-2 text-sm last:border-b-0 ${threadId ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
+        className={`group flex items-center gap-2 border-b border-border/40 py-3 pl-2 pr-3 text-sm last:border-b-0 ${threadId ? "cursor-pointer" : ""} ${isDone ? "bg-muted/30 line-through opacity-50" : "hover:bg-muted/50"}`}
         onClick={() => threadId && setExpanded(!expanded)}
         onKeyDown={(e) => {
           if (threadId && (e.key === "Enter" || e.key === " ")) {
@@ -332,90 +384,111 @@ export function InlineEmailCard({
           }
         }}
       >
-        {threadId && (
-          <div className="mr-1 flex w-4 shrink-0 justify-center text-muted-foreground">
-            {expanded ? (
-              <ChevronDownIcon className="size-3.5" />
-            ) : (
-              <ChevronRightIcon className="size-3.5" />
-            )}
-          </div>
-        )}
+        {index !== undefined ? (
+          <span className="w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+            {index}.
+          </span>
+        ) : null}
 
         {meta ? (
-          <>
-            <div className="flex w-4 shrink-0 justify-center">
-              {isUnread ? (
-                <div className="size-2 rounded-full bg-blue-500" />
-              ) : null}
-            </div>
-
-            <span
-              className={`w-40 shrink-0 truncate pr-3 text-xs ${isUnread ? "font-semibold" : ""}`}
-            >
-              {meta.from}
-            </span>
-
-            <span className="min-w-0 flex-1 truncate">
-              <span className={isUnread ? "font-medium" : ""}>
-                {meta.subject}
-              </span>
-              {children ? (
-                <span className="ml-2 text-muted-foreground/60">
-                  {" "}
-                  — {children}
+          <div className="min-w-0 flex-1">
+            {children ? (
+              <div className="text-sm text-foreground">{children}</div>
+            ) : null}
+            <div className="mt-1 truncate text-xs text-muted-foreground">
+              <Tooltip
+                content={extractEmailAddress(meta.from) || meta.from}
+                side="right"
+              >
+                <span className="font-medium">
+                  {extractNameFromEmail(meta.from)}
                 </span>
-              ) : null}
-            </span>
-
-            <span className="shrink-0 px-2 text-xs text-muted-foreground">
-              {formatShortDate(new Date(meta.date), { lowercase: true })}
-            </span>
-          </>
+              </Tooltip>
+              {" · "}
+              <span className="tabular-nums">
+                {formatShortDate(new Date(meta.date), { lowercase: true })}
+              </span>
+            </div>
+          </div>
         ) : (
           <span className="min-w-0 flex-1 truncate">{children}</span>
         )}
 
-        <div
-          className="flex shrink-0 items-center gap-1"
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
-          {externalUrl ? (
-            <Tooltip content="Open in email">
-              <a
-                href={externalUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-              >
-                <ExternalLinkIcon className="size-3.5" />
-              </a>
-            </Tooltip>
+        <div className="flex shrink-0 items-center gap-0.5">
+          {threadId ? (
+            <DropdownMenu>
+              <Tooltip content="More actions">
+                <DropdownMenuTrigger
+                  className={iconButtonClass}
+                  aria-label="More actions"
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.stopPropagation();
+                    }
+                  }}
+                >
+                  <MoreVerticalIcon className="size-3.5" />
+                </DropdownMenuTrigger>
+              </Tooltip>
+              <DropdownMenuContent align="end" className="w-48">
+                {showArchive ? (
+                  <DropdownMenuItem
+                    disabled={isDone || actionState === "loading"}
+                    onClick={handleArchive}
+                  >
+                    {isDone ? (
+                      <CheckIcon className="mr-2 size-4" />
+                    ) : (
+                      <ArchiveIcon className="mr-2 size-4" />
+                    )}
+                    {isDone ? "Archived" : "Archive"}
+                  </DropdownMenuItem>
+                ) : null}
+                <DropdownMenuItem onClick={handleMarkRead}>
+                  <MailOpenIcon className="mr-2 size-4" />
+                  Mark as read
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => {
+                    setShowDetails((v) => !v);
+                    if (!expanded) setExpanded(true);
+                  }}
+                >
+                  <InfoIcon className="mr-2 size-4" />
+                  {showDetails ? "Hide details" : "Show details"}
+                </DropdownMenuItem>
+                {externalUrl ? (
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={externalUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLinkIcon className="mr-2 size-4" />
+                      Open in email
+                    </a>
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : null}
 
-          {showArchive ? (
-            isDone ? (
-              <span className="flex items-center gap-1 px-2 text-xs text-muted-foreground">
-                <CheckIcon className="size-3" />
-                Archived
-              </span>
-            ) : (
-              <Button
-                variant="outline"
-                size="xs"
-                loading={actionState === "loading"}
-                onClick={handleArchive}
-                Icon={ArchiveIcon}
-              >
-                Archive
-              </Button>
-            )
+          {threadId ? (
+            <span className={iconButtonClass} aria-hidden="true">
+              {expanded ? (
+                <ChevronDownIcon className="size-3.5" />
+              ) : (
+                <ChevronRightIcon className="size-3.5" />
+              )}
+            </span>
           ) : null}
         </div>
       </div>
 
-      {expanded && threadId && <EmailPreview threadId={threadId} />}
+      {expanded && threadId && (
+        <EmailPreview threadId={threadId} showDetails={showDetails} />
+      )}
     </div>
   );
 }
@@ -500,15 +573,19 @@ function collectThreadIds(children: ReactNode): string[] {
 function EmailPreview({
   threadId,
   compact = false,
+  showDetails = false,
 }: {
   threadId: string;
   compact?: boolean;
+  showDetails?: boolean;
 }) {
   const { data, isLoading, error } = useThread({ id: threadId });
 
   if (isLoading) {
     return (
-      <div className="px-3 py-2 text-xs text-muted-foreground">Loading…</div>
+      <div className="flex justify-center px-3 py-4 text-muted-foreground">
+        <LoadingMiniSpinner />
+      </div>
     );
   }
 
@@ -529,7 +606,6 @@ function EmailPreview({
   }
 
   const lastMessage = data.thread.messages[data.thread.messages.length - 1];
-  const hasMultipleMessages = data.thread.messages.length > 1;
 
   const body = (
     <>
@@ -552,36 +628,17 @@ function EmailPreview({
   );
 
   if (compact) {
-    return (
-      <div className="max-h-[32rem] overflow-auto">
-        {hasMultipleMessages ? (
-          <div className="border-b px-4 py-2 text-xs text-muted-foreground">
-            Showing the latest message in this thread.
-          </div>
-        ) : null}
-        <div className="px-4 py-3">{body}</div>
-      </div>
-    );
+    return <div className="max-h-[32rem] overflow-auto px-4 py-3">{body}</div>;
   }
 
   return (
-    <div className="max-h-[32rem] overflow-auto border-t bg-muted/20 p-4">
-      <article className="rounded-lg bg-background p-4 shadow-sm">
-        <div className="mb-4">
-          <div className="text-sm font-semibold text-foreground">
-            {lastMessage.headers?.subject || lastMessage.subject}
-          </div>
-          {hasMultipleMessages ? (
-            <div className="mt-1 text-xs text-muted-foreground">
-              Showing the latest message in this thread.
-            </div>
-          ) : null}
+    <div className="max-h-[32rem] overflow-auto border-t bg-muted/20 px-4 py-3">
+      {showDetails ? (
+        <div className="mb-3">
+          <EmailDetails message={lastMessage} />
         </div>
-
-        <EmailDetails message={lastMessage} />
-
-        {body}
-      </article>
+      ) : null}
+      {body}
     </div>
   );
 }

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -281,7 +281,7 @@ export function ManageInboxResult({
       )}
 
       {resolvedThreads && resolvedThreads.length > 0 && (
-        <div className="-mx-4">
+        <div className="-mx-4 -my-3.5">
           <ToolEmailRows emails={resolvedThreads} />
         </div>
       )}

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -159,6 +159,7 @@ function getIframeHtml(
       }
       body {
         background-color: white;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       }
       table { max-width: 100% !important; overflow-x: auto; }
       img { max-width: 100% !important; height: auto; }
@@ -184,9 +185,11 @@ function getIframeHtml(
       table { max-width: 100% !important; overflow-x: auto; }
       img { max-width: 100% !important; height: auto; }
 
-      /* Base styles with low specificity - only apply to completely unstyled content */
-      body:not([style]):not([bgcolor]) {
+      /* Base styles - apply our font as a baseline; inline styles on inner elements still win */
+      body {
         font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      }
+      body:not([style]):not([bgcolor]) {
         margin: 0;
         color: hsl(var(--foreground));
         background-color: hsl(var(--background));

--- a/apps/web/components/email-list/EmailContents.tsx
+++ b/apps/web/components/email-list/EmailContents.tsx
@@ -15,6 +15,7 @@ const IMAGE_PROXY_ORIGIN = IMAGE_PROXY_BASE_URL
   : null;
 const IMAGE_PROXY_ENABLED = Boolean(IMAGE_PROXY_BASE_URL);
 const IMAGE_PROXY_RENDER_ROUTE = "/api/email/render-html";
+const SANS_FONT_STACK = `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`;
 
 export function HtmlEmail({ html }: { html: string }) {
   const sanitizedHtml = useMemo(() => sanitize(html), [html]);
@@ -159,7 +160,7 @@ function getIframeHtml(
       }
       body {
         background-color: white;
-        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-family: ${SANS_FONT_STACK};
       }
       table { max-width: 100% !important; overflow-x: auto; }
       img { max-width: 100% !important; height: auto; }
@@ -187,7 +188,7 @@ function getIframeHtml(
 
       /* Base styles - apply our font as a baseline; inline styles on inner elements still win */
       body {
-        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-family: ${SANS_FONT_STACK};
       }
       body:not([style]):not([bgcolor]) {
         margin: 0;

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -791,20 +791,17 @@ function getFormattingRules(responseSurface: "web" | "messaging") {
 - Ask at most one follow-up question at the end of a response.
 
 Inline email cards:
-- When presenting emails for triage or inbox summary, use <email> tags wrapped in an <emails> container to render an interactive inbox-style table.
+- For triage or inbox summary, render <email> tags inside an <emails> container.
 - Format:
 <emails>
 <email index="1" threadid="THREAD_ID">Brief context</email>
 <email index="2" threadid="THREAD_ID">Brief context</email>
 </emails>
-- Always include an index attribute on each <email>, starting at 1 in the first <emails> block and continuing to count across every subsequent <emails> block in the same response (so a response with two blocks of 4 emails each is numbered 1–8, not 1–4 twice). The user may reference items by number ("archive #6"); the explicit index lets you map a referenced number back to its threadid in later turns even if the visible list changes.
-- To show one email or thread in detail, use:
-<email-detail threadid="THREAD_ID">Brief context</email-detail>
-- The threadid attribute must be a threadId from searchInbox results. Do not use the HTML id attribute.
-- Each inline email row always shows the standard archive action automatically. Do not add an action attribute to control it.
-- The inner text is your brief context or recommendation. Default to a single sentence. Use 2 sentences only when the email is complex or has multiple distinct parts that affect how the user should act. Never pad — if one sentence captures the gist, stop.
-- The UI automatically resolves the full email metadata (sender, subject, date) from the thread ID, so do NOT repeat those details in the tag content.
-- Use a separate <emails> block per category group, with a markdown header (##) before each block.
-- Use <emails> for grouped list views and <email-detail> when you want to show a single email or thread in detail.
-- Only use email widgets when they add clarity, not for every search result.`;
+- Number every <email> starting from 1, continuing across blocks within the same response (two groups of 4 are 1–8, not 1–4 twice). The index lets you map "#6" back to its threadid in later turns even if the list changes.
+- For a single email or thread, use <email-detail threadid="THREAD_ID">Brief context</email-detail>.
+- The threadid must be a threadId from searchInbox results (not the HTML id).
+- Inner text is your brief context or recommendation. Default to one sentence; use two only when the email has multiple parts that change how the user should act. Never pad.
+- The UI resolves sender, subject, and date from the threadId — don't repeat them.
+- Group <emails> blocks under markdown ## headers when triage has categories.
+- Only render email widgets when they add clarity, not for every search result.`;
 }

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -794,13 +794,15 @@ Inline email cards:
 - When presenting emails for triage or inbox summary, use <email> tags wrapped in an <emails> container to render an interactive inbox-style table.
 - Format:
 <emails>
-<email threadid="THREAD_ID">Brief context</email>
+<email index="1" threadid="THREAD_ID">Brief context</email>
+<email index="2" threadid="THREAD_ID">Brief context</email>
 </emails>
+- Always include an index attribute on each <email>, starting at 1 in the first <emails> block and continuing to count across every subsequent <emails> block in the same response (so a response with two blocks of 4 emails each is numbered 1–8, not 1–4 twice). The user may reference items by number ("archive #6"); the explicit index lets you map a referenced number back to its threadid in later turns even if the visible list changes.
 - To show one email or thread in detail, use:
 <email-detail threadid="THREAD_ID">Brief context</email-detail>
 - The threadid attribute must be a threadId from searchInbox results. Do not use the HTML id attribute.
 - Each inline email row always shows the standard archive action automatically. Do not add an action attribute to control it.
-- The inner text is your brief context or recommendation (e.g. "Subscription cancellation — confirm and outline next steps").
+- The inner text is your brief context or recommendation. Default to a single sentence. Use 2 sentences only when the email is complex or has multiple distinct parts that affect how the user should act. Never pad — if one sentence captures the gist, stop.
 - The UI automatically resolves the full email metadata (sender, subject, date) from the thread ID, so do NOT repeat those details in the tag content.
 - Use a separate <emails> block per category group, with a markdown header (##) before each block.
 - Use <emails> for grouped list views and <email-detail> when you want to show a single email or thread in detail.


### PR DESCRIPTION
## Summary
- Reworks the inline email cards rendered by the AI chat (`<emails>` + `<email>`) so the AI summary is the headline and sender/date is a small attribution line beneath it. Drops the duplicated subject from the row.
- Adds explicit numbering: each `<email>` accepts an `index` attribute (with positional fallback). System prompt instructs the AI to number globally across a response so users can reference items by number across turns.
- Right-side actions consolidated into a vertical-kebab menu (Archive, Mark as read, Show details, Open in email) with a chevron disclosure for inline expand. Icons share a common style; archived state shows a check.
- Compacts the expanded email view: drops the duplicate subject heading and the "showing latest message" hint; sender details (From/To/CC/BCC/Date) move behind a kebab toggle.
- Font fallback fix in the email iframe: the heavy-styling branch now also sets the system font on `body`, so emails with minor inline styling no longer fall back to the browser default serif.
- Tooltip wrapper accepts an optional `side` prop so callers can position tooltips around tight rows.
- AI prompt also instructs single-sentence summaries by default, with a second sentence only where complexity warrants it.

## Test plan
- [ ] Trigger a triage prompt that returns multiple `<emails>` blocks; confirm rows show numbered AI summaries with sender · date attribution and global numbering across blocks.
- [ ] Hover sender name; confirm tooltip shows the full email address to the side.
- [ ] Open the kebab menu on a row: verify Archive, Mark as read, Show details, Open in email behave correctly; confirm Show details auto-expands the row and toggles the gray details box.
- [ ] Click chevron / row body to expand; confirm only the email body renders by default with system font, and that emails containing inline styles like `style="font-size: 1em"` no longer fall back to serif.
- [ ] Confirm dropdown menu does not also toggle row expand (event propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)