### PR TITLE
Fix stale draft cleanup

### DIFF
--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -3,6 +3,7 @@ import {
   handlePreviousDraftDeletion,
   extractDraftPlainText,
   stripQuotedContent,
+  stripQuotedHtmlContent,
   isDraftUnmodified,
 } from "@/utils/ai/choose-rule/draft-management";
 import prisma from "@/utils/prisma";
@@ -550,6 +551,18 @@ describe("stripQuotedContent", () => {
   });
 });
 
+describe("stripQuotedHtmlContent", () => {
+  it("removes Gmail quote containers without reading localized header text", () => {
+    const html = `<div dir="ltr">My reply</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender a écrit:<br></div><blockquote class="gmail_quote"><div>Quoted content</div></blockquote></div>`;
+
+    const result = stripQuotedHtmlContent(html);
+
+    expect(result).toContain("My reply");
+    expect(result).not.toContain("Le lun.");
+    expect(result).not.toContain("Quoted content");
+  });
+});
+
 describe("isDraftUnmodified", () => {
   const logger = createTestLogger();
 
@@ -639,6 +652,40 @@ describe("isDraftUnmodified", () => {
       labelIds: [],
       inline: [],
       bodyContentType: "html",
+    };
+
+    const result = isDraftUnmodified({
+      originalContent,
+      currentDraft,
+      logger,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("should compare Gmail drafts using structural HTML when available", () => {
+    const originalContent =
+      'My reply\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.';
+    const currentDraft: ParsedMessage = {
+      id: "msg-123",
+      threadId: "thread-456",
+      textPlain:
+        "My reply\n\nDrafted by Inbox Zero [http://localhost:3000/?ref=ABC].\n\nLe lun. 27 avr. 2026, Sender a écrit:\nQuoted content",
+      textHtml:
+        '<div dir="ltr">My reply<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender a écrit:<br></div><blockquote class="gmail_quote"><div>Quoted content</div></blockquote></div>',
+      subject: "subject",
+      date: new Date().toISOString(),
+      snippet: "snippet",
+      historyId: "12345",
+      internalDate: "1234567890",
+      headers: {
+        from: "test@example.com",
+        to: "recipient@example.com",
+        subject: "Test",
+        date: "Mon, 1 Jan 2024 12:00:00 +0000",
+      },
+      labelIds: [],
+      inline: [],
     };
 
     const result = isDraftUnmodified({

--- a/apps/web/utils/ai/choose-rule/draft-management.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.ts
@@ -1,3 +1,4 @@
+import { load } from "cheerio";
 import prisma from "@/utils/prisma";
 import { ActionType } from "@/generated/prisma/enums";
 import type { ExecutedRule } from "@/generated/prisma/client";
@@ -54,7 +55,7 @@ export async function handlePreviousDraftDeletion({
       previousDraftAction.draftId,
     );
 
-    if (!currentDraftDetails?.textPlain) {
+    if (!currentDraftDetails?.textPlain && !currentDraftDetails?.textHtml) {
       logger.warn(
         "Could not fetch current draft details or content, skipping deletion.",
         { previousDraftId: previousDraftAction.draftId },
@@ -126,12 +127,27 @@ export function extractDraftPlainText(draft: ParsedMessage): string {
   if (draft.bodyContentType === "html") {
     return draft.textPlain
       ? convertEmailHtmlToText({
-          htmlText: draft.textPlain,
+          htmlText: stripQuotedHtmlContent(draft.textPlain),
           includeLinks: false,
         })
       : "";
   }
   return draft.textPlain || "";
+}
+
+export function stripQuotedHtmlContent(html: string): string {
+  const $ = load(html, null, false);
+
+  $(
+    [
+      ".gmail_quote_container",
+      ".gmail_quote",
+      ".gmail_attr",
+      "blockquote[type='cite']",
+    ].join(", "),
+  ).remove();
+
+  return $.root().html() || html;
 }
 
 /**
@@ -169,7 +185,8 @@ export function isDraftUnmodified({
   currentDraft: ParsedMessage;
   logger: Logger;
 }): boolean {
-  const currentText = extractDraftPlainText(currentDraft);
+  const { text: currentText, source: comparisonSource } =
+    extractDraftComparisonText(currentDraft);
   const currentReplyContent = stripQuotedContent(currentText);
 
   const originalWithBr = originalContent.replace(/\n/g, "<br>");
@@ -178,11 +195,43 @@ export function isDraftUnmodified({
     includeLinks: false,
   });
   const originalContentTrimmed = originalContentPlain.trim();
+  const isUnmodified = originalContentTrimmed === currentReplyContent;
+
+  logger.info("Checked draft unmodified status", {
+    comparisonSource,
+    hasTextHtml: !!currentDraft.textHtml,
+    hasTextPlain: !!currentDraft.textPlain,
+    bodyContentType: currentDraft.bodyContentType,
+    originalLength: originalContentTrimmed.length,
+    currentLength: currentReplyContent.length,
+    isUnmodified,
+  });
 
   logger.trace("Comparing draft content", {
+    comparisonSource,
     original: originalContentTrimmed,
     current: currentReplyContent,
   });
 
-  return originalContentTrimmed === currentReplyContent;
+  return isUnmodified;
+}
+
+function extractDraftComparisonText(draft: ParsedMessage): {
+  text: string;
+  source: "textHtml" | "textPlain";
+} {
+  if (draft.textHtml) {
+    return {
+      text: convertEmailHtmlToText({
+        htmlText: stripQuotedHtmlContent(draft.textHtml),
+        includeLinks: false,
+      }),
+      source: "textHtml",
+    };
+  }
+
+  return {
+    text: extractDraftPlainText(draft),
+    source: "textPlain",
+  };
 }

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -1,7 +1,7 @@
 import prisma from "@/utils/prisma";
 import { ActionType } from "@/generated/prisma/enums";
 import { createEmailProvider } from "@/utils/email/provider";
-import { calculateSimilarity } from "@/utils/similarity-score";
+import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import type { Logger } from "@/utils/logger";
 
 const STALE_DAYS = 3;
@@ -70,9 +70,15 @@ export async function cleanupAIDraftsForAccount({
         continue;
       }
 
-      const similarityScore = calculateSimilarity(action.content, draftDetails);
+      const isUnmodified = action.content
+        ? isDraftUnmodified({
+            originalContent: action.content,
+            currentDraft: draftDetails,
+            logger,
+          })
+        : false;
 
-      if (similarityScore !== 1.0) {
+      if (!isUnmodified) {
         skippedModified++;
         continue;
       }

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -3,7 +3,7 @@ import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import { ActionType } from "@/generated/prisma/enums";
-import { trackSentDraftStatus } from "./draft-tracking";
+import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
@@ -12,6 +12,9 @@ vi.mock("@/utils/prisma-retry", () => ({
 }));
 vi.mock("@/utils/similarity-score", () => ({
   calculateSimilarity: vi.fn(),
+}));
+vi.mock("@/utils/ai/choose-rule/draft-management", () => ({
+  isDraftUnmodified: vi.fn(),
 }));
 vi.mock("@/utils/ai/reply/reply-memory", () => ({
   isMeaningfulDraftEdit: vi.fn(),
@@ -25,6 +28,7 @@ vi.mock("@/utils/messaging/rule-notifications", () => ({
 }));
 
 import { calculateSimilarity } from "@/utils/similarity-score";
+import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import {
   isMeaningfulDraftEdit,
   saveDraftSendLogReplyMemory,
@@ -167,6 +171,85 @@ describe("trackSentDraftStatus", () => {
   });
 });
 
+describe("cleanupThreadAIDrafts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.executedAction.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([]);
+  });
+
+  it("deletes stale drafts only when the generated reply is unchanged", async () => {
+    const draftDetails = createDraftMessage({
+      textPlain: "Generated reply\n\nOn Monday wrote:\n> Quote",
+    });
+    vi.mocked(prisma.executedAction.findMany).mockResolvedValue([
+      {
+        id: "action-1",
+        draftId: "draft-1",
+        content: "Generated reply",
+      },
+    ] as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.93);
+    vi.mocked(isDraftUnmodified).mockReturnValue(true);
+
+    const provider = {
+      getDraft: vi.fn().mockResolvedValue(draftDetails),
+      deleteDraft: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await cleanupThreadAIDrafts({
+      threadId: "thread-1",
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+      excludeMessageId: "message-2",
+    });
+
+    expect(isDraftUnmodified).toHaveBeenCalledWith({
+      originalContent: "Generated reply",
+      currentDraft: draftDetails,
+      logger,
+    });
+    expect(provider.deleteDraft).toHaveBeenCalledWith("draft-1");
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: { wasDraftSent: false },
+    });
+  });
+
+  it("keeps stale drafts when the generated reply was edited", async () => {
+    vi.mocked(prisma.executedAction.findMany).mockResolvedValue([
+      {
+        id: "action-1",
+        draftId: "draft-1",
+        content: "Generated reply",
+      },
+    ] as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(1);
+    vi.mocked(isDraftUnmodified).mockReturnValue(false);
+
+    const provider = {
+      getDraft: vi.fn().mockResolvedValue(
+        createDraftMessage({
+          textPlain: "Generated reply\n\nUser edit",
+        }),
+      ),
+      deleteDraft: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await cleanupThreadAIDrafts({
+      threadId: "thread-1",
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+      excludeMessageId: "message-2",
+    });
+
+    expect(provider.deleteDraft).not.toHaveBeenCalled();
+    expect(prisma.executedAction.update).not.toHaveBeenCalled();
+  });
+});
+
 function createSentMessage(): ParsedMessage {
   return {
     id: "sent-1",
@@ -181,5 +264,28 @@ function createSentMessage(): ParsedMessage {
     },
     textPlain: "Please include pricing for seat counts.",
     textHtml: "<p>Please include pricing for seat counts.</p>",
+  } as ParsedMessage;
+}
+
+function createDraftMessage({
+  textPlain,
+  textHtml,
+}: {
+  textPlain?: string;
+  textHtml?: string;
+}): ParsedMessage {
+  return {
+    id: "draft-message-1",
+    threadId: "thread-1",
+    internalDate: "1710000000000",
+    headers: {
+      from: "user@example.com",
+      to: "sales@example.com",
+      subject: "Re: Pricing question",
+      date: "2026-03-17T10:10:00.000Z",
+      "message-id": "<draft-message-1@example.com>",
+    },
+    textPlain,
+    textHtml,
   } as ParsedMessage;
 }

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -4,6 +4,7 @@ import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/prisma";
 import { withPrismaRetry } from "@/utils/prisma-retry";
 import { calculateSimilarity } from "@/utils/similarity-score";
+import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import {
@@ -269,7 +270,13 @@ export async function cleanupThreadAIDrafts({
             action.content,
             draftDetails,
           );
-          const isUnmodified = similarityScore === 1.0;
+          const isUnmodified = action.content
+            ? isDraftUnmodified({
+                originalContent: action.content,
+                currentDraft: draftDetails,
+                logger,
+              })
+            : false;
 
           logger.info("Checked existing draft for modification", {
             ...actionLoggerOptions,

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -195,6 +195,20 @@ On Mon, Jan 1, 2024 at 10:00 AM Sender <sender@example.com> wrote:
       expect(score).toBe(1.0);
     });
 
+    it("should strip converted Gmail HTML quote blocks before comparing drafts", () => {
+      const storedContent = `Checking on this now.
+
+Drafted by <a href="https://www.getinboxzero.com/?ref=ABC123">Inbox Zero</a>.`;
+      const gmailMessage = {
+        ...createParsedMessage(""),
+        textPlain: undefined,
+        textHtml: `<div dir="ltr">Checking on this now.<br><br>Drafted by <a href="https://www.getinboxzero.com/?ref=ABC123">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender &lt;<a href="mailto:sender@example.com">sender@example.com</a>&gt; a écrit:<br></div><blockquote class="gmail_quote"><div dir="ltr">Previous message</div></blockquote></div>`,
+      };
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(1.0);
+    });
+
     it.each([
       { emoji: "👋", hex: "&#x1F44B;", name: "waving hand" },
       { emoji: "😀", hex: "&#x1F600;", name: "grinning face" },

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -1,6 +1,9 @@
 import * as stringSimilarity from "string-similarity";
 import { convertEmailHtmlToText, parseReply } from "@/utils/mail";
-import { stripQuotedContent } from "@/utils/ai/choose-rule/draft-management";
+import {
+  stripQuotedContent,
+  stripQuotedHtmlContent,
+} from "@/utils/ai/choose-rule/draft-management";
 import type { ParsedMessage } from "@/utils/types";
 
 const HTML_TAG_NAMES = [
@@ -31,7 +34,7 @@ const HTML_TAG_PATTERN = new RegExp(
 function normalizeForOutlook(content: string): string {
   const withBr = content.replace(/\n/g, "<br>");
   const plainText = convertEmailHtmlToText({
-    htmlText: withBr,
+    htmlText: stripQuotedHtmlContent(withBr),
     includeLinks: false,
   });
   return stripQuotedContent(plainText).toLowerCase().trim();
@@ -66,13 +69,13 @@ function decodeHtmlEntities(text: string): string {
 function normalizeForGmail(content: string): string {
   const plainText = looksLikeHtmlContent(content)
     ? convertEmailHtmlToText({
-        htmlText: content.replace(/\n/g, "<br>"),
+        htmlText: stripQuotedHtmlContent(content.replace(/\n/g, "<br>")),
         includeLinks: false,
       })
     : content;
   const reply = parseReply(plainText);
   const decoded = decodeHtmlEntities(reply);
-  return decoded.toLowerCase().trim();
+  return stripQuotedContent(decoded).toLowerCase().trim();
 }
 
 /**
@@ -101,7 +104,7 @@ export function calculateSimilarity(
   } else {
     // ParsedMessage - check bodyContentType to determine normalization strategy
     const isOutlook = providerMessage.bodyContentType === "html";
-    const text = providerMessage.textPlain || providerMessage.textHtml || "";
+    const text = providerMessage.textHtml || providerMessage.textPlain || "";
 
     if (isOutlook) {
       // Outlook: use HTML-aware normalization for both


### PR DESCRIPTION
Updates draft cleanup to delete stale generated drafts only when the extracted provider draft reply exactly matches the generated reply body.

- Uses structural quote stripping for provider HTML quote blocks instead of relying on localized quote-header text
- Applies the exact unmodified-draft comparator to thread and account cleanup paths
- Keeps similarity scoring for diagnostics and send-log comparison

Tests: pnpm --filter inbox-zero-ai test utils/similarity-score.test.ts utils/ai/choose-rule/draft-management.test.ts utils/reply-tracker/draft-tracking.test.ts --run