### PR TITLE
messaging: Align Slack notification actions

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -796,9 +796,14 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(message).toBeDefined();
       expect(message?.text).toContain("Email notification");
       expect(message?.text).toContain(`*Subject:* ${subject}`);
-      expect(getActionLabels(postArgs?.blocks)).toEqual(
-        expect.arrayContaining(["Archive", "Mark read"]),
-      );
+      expect(getActionLabels(postArgs?.blocks)).toEqual([
+        "Archive",
+        "Mark read",
+        "Delete",
+        "Spam",
+        "Open in Gmail",
+        "Dismiss",
+      ]);
     });
 
     test("sendMessagingRuleNotification replies in a thread for later actions on the same email thread", async () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -501,6 +501,52 @@ describe("handleRuleNotificationAction", () => {
     );
   });
 
+  it("dismisses Slack notification messages", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      actionId: "rule_draft_dismiss",
+      value: "action-1",
+      user: { userId: "user-1" },
+      raw: { team: { id: "team-1" } },
+      threadId: "slack-thread-1",
+      messageId: "slack-message-1",
+      adapter: { name: "slack", editMessage },
+      thread: { postEphemeral: vi.fn() },
+    } as any;
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger: createScopedLogger("test"),
+    });
+
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.DISMISSED,
+      },
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editMessage.mock.calls[0][2])).toContain(
+      "Email notification",
+    );
+    expect(JSON.stringify(editMessage.mock.calls[0][2])).toContain(
+      "Dismissed.",
+    );
+  });
+
   it("rejects unsupported Slack More menu selections before loading context", async () => {
     const postEphemeral = vi.fn().mockResolvedValue(undefined);
     const event = {
@@ -885,7 +931,7 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedBlocks).not.toContain("Open in Outlook");
   });
 
-  it("puts destructive Slack notification actions behind a More menu", async () => {
+  it("shows consistent standalone Slack notification actions", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
         id: "action-1",
@@ -922,31 +968,87 @@ describe("sendMessagingRuleNotification", () => {
     const buttonLabels = elements
       .filter((element: { type: string }) => element.type === "button")
       .map((element: { text: { text: string } }) => element.text.text);
-    const moreMenu = elements.find(
-      (element: { action_id: string }) =>
-        element.action_id === "rule_notify_more",
+
+    expect(buttonLabels).toEqual([
+      "Archive",
+      "Mark read",
+      "Delete",
+      "Spam",
+      "Open in Gmail",
+      "Dismiss",
+    ]);
+    expect(elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "button",
+          action_id: "rule_notify_trash",
+          value: "action-1",
+          style: "danger",
+        }),
+        expect.objectContaining({
+          type: "button",
+          action_id: "rule_notify_mark_spam",
+          value: "action-1",
+          style: "danger",
+        }),
+        expect.objectContaining({
+          type: "button",
+          action_id: expect.stringContaining("mail.google.com"),
+          url: "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
+        }),
+        expect.objectContaining({
+          type: "button",
+          action_id: "rule_draft_dismiss",
+          value: "action-1",
+        }),
+      ]),
+    );
+    expect(elements).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "static_select",
+        }),
+      ]),
+    );
+  });
+
+  it("uses the full plain text body for Slack notification previews", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
     );
 
-    expect(buttonLabels).toEqual(["Archive", "Mark read"]);
-    expect(moreMenu).toEqual(
-      expect.objectContaining({
-        type: "static_select",
-        placeholder: {
-          type: "plain_text",
-          text: "More actions",
+    const longBody = "Full body ".repeat(80).trim();
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
         },
-        options: [
-          expect.objectContaining({
-            text: { type: "plain_text", text: "Delete" },
-            value: "rule_notify_trash:action-1",
-          }),
-          expect.objectContaining({
-            text: { type: "plain_text", text: "Spam" },
-            value: "rule_notify_mark_spam:action-1",
-          }),
-        ],
-      }),
-    );
+        snippet: "Short snippet",
+        textPlain: longBody,
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain(longBody);
+    expect(serializedBlocks).not.toContain("Short snippet");
   });
 
   it("delivers Teams notifications through the linked messaging fallback", async () => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1092,6 +1092,45 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedBlocks).not.toContain("image.png");
   });
 
+  it("prefers converted HTML over plain text for Slack notification previews", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Short snippet",
+        textPlain: "Plain fallback body",
+        textHtml: "<p>Rendered HTML body</p>",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Rendered HTML body");
+    expect(serializedBlocks).not.toContain("Plain fallback body");
+    expect(serializedBlocks).not.toContain("Short snippet");
+  });
+
   it("delivers Teams notifications through the linked messaging fallback", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1051,6 +1051,47 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedBlocks).not.toContain("Short snippet");
   });
 
+  it("converts HTML-only emails for Slack notification previews", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        content: null,
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Short snippet",
+        textHtml:
+          '<div><p>HTML only body</p><p>Second line</p><img src="image.png" /></div>',
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("HTML only body");
+    expect(serializedBlocks).toContain("Second line");
+    expect(serializedBlocks).not.toContain("Short snippet");
+    expect(serializedBlocks).not.toContain("<p>");
+    expect(serializedBlocks).not.toContain("image.png");
+  });
+
   it("delivers Teams notifications through the linked messaging fallback", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -5,8 +5,6 @@ import {
   Card,
   CardText,
   LinkButton,
-  Select,
-  SelectOption,
   type ActionEvent,
   type CardElement,
   type CardChild,
@@ -567,7 +565,7 @@ export async function handleRuleNotificationAction({
       await handleDraftEdit({ context, event, logger });
       return;
     case RULE_DRAFT_DISMISS_ACTION_ID:
-      await handleDraftDismiss({ context, event, logger });
+      await handleDismissNotification({ context, event, logger });
       return;
     case RULE_NOTIFY_ARCHIVE_ACTION_ID:
       await handleArchiveNotification({ context, event, logger });
@@ -953,7 +951,7 @@ async function handleDraftEdit({
   });
 }
 
-async function handleDraftDismiss({
+async function handleDismissNotification({
   context,
   event,
   logger,
@@ -966,7 +964,9 @@ async function handleDraftDismiss({
     await postNotificationFeedback({
       event,
       logger,
-      text: "That draft has already been handled.",
+      text: isDraftReplyActionType(context.type)
+        ? "That draft has already been handled."
+        : "That notification has already been handled.",
     });
     return;
   }
@@ -982,7 +982,11 @@ async function handleDraftDismiss({
     event.threadId,
     event.messageId,
     buildTerminalCard({
-      title: "Draft reply",
+      title: isDraftReplyActionType(context.type)
+        ? "Draft reply"
+        : getInfoNotificationTitle(
+            context.executedRule.rule?.systemType ?? null,
+          ),
       message: "Dismissed.",
     }),
   );
@@ -1517,26 +1521,23 @@ function buildNotificationCard({
               label: "Mark read",
               value: actionId,
             }),
-            Select({
-              id: RULE_NOTIFY_MORE_ACTION_ID,
-              label: "More",
-              placeholder: "More actions",
-              options: [
-                SelectOption({
-                  label: "Delete",
-                  value: getMoreNotificationActionValue({
-                    actionId,
-                    selectedActionId: RULE_NOTIFY_TRASH_ACTION_ID,
-                  }),
-                }),
-                SelectOption({
-                  label: "Spam",
-                  value: getMoreNotificationActionValue({
-                    actionId,
-                    selectedActionId: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
-                  }),
-                }),
-              ],
+            Button({
+              id: RULE_NOTIFY_TRASH_ACTION_ID,
+              label: "Delete",
+              style: "danger",
+              value: actionId,
+            }),
+            Button({
+              id: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
+              label: "Spam",
+              style: "danger",
+              value: actionId,
+            }),
+            ...(openLink ? [LinkButton(openLink)] : []),
+            Button({
+              id: RULE_DRAFT_DISMISS_ACTION_ID,
+              label: "Dismiss",
+              value: actionId,
             }),
           ],
     ),
@@ -1559,16 +1560,6 @@ function buildTerminalCard({
     title,
     children: [CardText(message)],
   });
-}
-
-function getMoreNotificationActionValue({
-  actionId,
-  selectedActionId,
-}: {
-  actionId: string;
-  selectedActionId: string;
-}) {
-  return `${selectedActionId}:${actionId}`;
 }
 
 function buildTelegramNotificationCard({
@@ -1678,7 +1669,7 @@ function buildEmailSummary(email: {
 }
 
 function buildEmailPreview(email: { snippet: string; textPlain?: string }) {
-  const rawPreview = email.snippet || email.textPlain || "";
+  const rawPreview = email.textPlain || email.snippet || "";
   const preview = escapeSlackText(
     removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
   );

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -45,6 +45,7 @@ import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-ad
 import { resolveActionAttachments } from "@/utils/ai/action-attachments";
 import { quotePlainTextContent } from "@/utils/email/quoted-plain-text";
 import { formatReplySubject } from "@/utils/email/subject";
+import { emailToContent } from "@/utils/mail";
 import { extractDraftPlainText } from "@/utils/ai/choose-rule/draft-management";
 import type { ParsedMessage } from "@/utils/types";
 import he from "he";
@@ -1668,8 +1669,21 @@ function buildEmailSummary(email: {
   ].join("\n");
 }
 
-function buildEmailPreview(email: { snippet: string; textPlain?: string }) {
-  const rawPreview = email.textPlain || email.snippet || "";
+function buildEmailPreview(email: {
+  snippet: string;
+  textPlain?: string;
+  textHtml?: string;
+}) {
+  const rawPreview =
+    email.textPlain ||
+    (email.textHtml
+      ? emailToContent(
+          { textHtml: email.textHtml, textPlain: "", snippet: "" },
+          { maxLength: 0 },
+        )
+      : "") ||
+    email.snippet ||
+    "";
   const preview = escapeSlackText(
     removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
   );

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1674,16 +1674,7 @@ function buildEmailPreview(email: {
   textPlain?: string;
   textHtml?: string;
 }) {
-  const rawPreview =
-    email.textPlain ||
-    (email.textHtml
-      ? emailToContent(
-          { textHtml: email.textHtml, textPlain: "", snippet: "" },
-          { maxLength: 0 },
-        )
-      : "") ||
-    email.snippet ||
-    "";
+  const rawPreview = emailToContent(email, { maxLength: 0 });
   const preview = escapeSlackText(
     removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
   );


### PR DESCRIPTION
Aligns Slack notification cards so generic notifications expose the same common controls as draft notifications.

- Shows destructive actions, provider open links, and dismiss as standalone controls.
- Uses the full plain text preview when available.
- Covers the behavior with unit and emulator-backed tests.