### PR TITLE
assistant: Fix build type error

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -1921,11 +1921,7 @@ function ToolEmailRows({ emails }: { emails: ToolEmailRow[] }) {
     <EmailLookupProvider value={lookup}>
       <div className="overflow-hidden">
         {uniqueEmails.map((email) => (
-          <InlineEmailCard
-            key={email.threadId}
-            threadid={email.threadId}
-            action="none"
-          />
+          <InlineEmailCard key={email.threadId} threadid={email.threadId} />
         ))}
       </div>
     </EmailLookupProvider>


### PR DESCRIPTION
Fixes a build type error in the assistant tool renderer.

- Removes an unsupported prop from an inline component render
- Keeps the component API unchanged