### PR TITLE
test: Fix inline email card tests after dropdown refactor

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 
-import React, { createElement, type ReactNode } from "react";
+import React, { createElement, type MouseEvent, type ReactNode } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssistantInlineEmailResponse } from "@/components/assistant-chat/assistant-inline-email-response";
@@ -41,6 +41,51 @@ vi.mock("@/utils/actions/mail", () => ({
 
 vi.mock("@/hooks/useThread", () => ({
   useThread: (...args: unknown[]) => mockUseThread(...args),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({
+    children,
+    "aria-label": ariaLabel,
+  }: {
+    children?: ReactNode;
+    "aria-label"?: string;
+  }) =>
+    createElement(
+      "button",
+      { type: "button", "aria-label": ariaLabel },
+      children,
+    ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    disabled,
+    asChild,
+  }: {
+    children?: ReactNode;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+    disabled?: boolean;
+    asChild?: boolean;
+  }) => {
+    if (asChild) return <>{children}</>;
+    return createElement(
+      "button",
+      {
+        type: "button",
+        disabled,
+        role: "menuitem",
+        onClick: (event: MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          onClick?.(event);
+        },
+      },
+      children,
+    );
+  },
 }));
 
 afterEach(() => {
@@ -97,7 +142,7 @@ describe("AssistantInlineEmailResponse", () => {
         "google",
       ),
     );
-    expect(screen.getByRole("button", { name: "Archive" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Archive/ })).toBeTruthy();
   });
 
   it("renders inline email detail views", () => {

--- a/apps/web/components/assistant-chat/inline-email-card.test.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.test.tsx
@@ -109,6 +109,51 @@ vi.mock("@/components/email-list/EmailAttachments", () => ({
   EmailAttachments: () => <div>Attachments</div>,
 }));
 
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({
+    children,
+    "aria-label": ariaLabel,
+  }: {
+    children?: ReactNode;
+    "aria-label"?: string;
+  }) =>
+    createElement(
+      "button",
+      { type: "button", "aria-label": ariaLabel },
+      children,
+    ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    disabled,
+    asChild,
+  }: {
+    children?: ReactNode;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+    disabled?: boolean;
+    asChild?: boolean;
+  }) => {
+    if (asChild) return <>{children}</>;
+    return createElement(
+      "button",
+      {
+        type: "button",
+        disabled,
+        role: "menuitem",
+        onClick: (event: MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          onClick?.(event);
+        },
+      },
+      children,
+    );
+  },
+}));
+
 afterEach(() => {
   cleanup();
 });
@@ -175,7 +220,7 @@ describe("InlineEmailCard", () => {
     render(
       createElement(
         InlineEmailCard,
-        { id: "user-content-19cdca06580b38e9", action: "archive" },
+        { id: "user-content-19cdca06580b38e9" },
         "Follow up",
       ),
     );
@@ -189,7 +234,7 @@ describe("InlineEmailCard", () => {
       ),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Archive/ }));
 
     await waitFor(() => {
       expect(mockArchiveThreadAction).toHaveBeenCalledWith("account-1", {
@@ -231,30 +276,24 @@ describe("InlineEmailCard", () => {
       error: null,
     });
 
-    render(
-      <InlineEmailCard threadid="thread-1" action="none">
-        Second
-      </InlineEmailCard>,
-    );
+    render(<InlineEmailCard threadid="thread-1">Second</InlineEmailCard>);
 
-    fireEvent.click(screen.getByText("Subject Two"));
+    fireEvent.click(screen.getByRole("button", { name: /Second/ }));
 
-    expect(screen.getByText("Rendered Subject")).toBeTruthy();
+    expect(screen.getByText("Rendered plain body")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Show details/ }));
+
     expect(screen.getByText("From:")).toBeTruthy();
     expect(
       screen.getByText("Sender Two <sender-two@example.com>"),
     ).toBeTruthy();
-    expect(screen.getByText("Rendered plain body")).toBeTruthy();
   });
 
-  it("shows the archive action even when action is none", () => {
-    render(
-      <InlineEmailCard threadid="thread-1" action="none">
-        Second
-      </InlineEmailCard>,
-    );
+  it("renders the archive action in the row menu", () => {
+    render(<InlineEmailCard threadid="thread-1">Second</InlineEmailCard>);
 
-    expect(screen.getByRole("button", { name: "Archive" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Archive/ })).toBeTruthy();
   });
 
   it("renders the preview when message headers are missing", () => {
@@ -280,15 +319,10 @@ describe("InlineEmailCard", () => {
       error: null,
     });
 
-    render(
-      <InlineEmailCard threadid="thread-1" action="none">
-        Second
-      </InlineEmailCard>,
-    );
+    render(<InlineEmailCard threadid="thread-1">Second</InlineEmailCard>);
 
-    fireEvent.click(screen.getByText("Subject Two"));
+    fireEvent.click(screen.getByRole("button", { name: /Second/ }));
 
-    expect(screen.getByText("Fallback Subject")).toBeTruthy();
     expect(screen.getByText("Fallback body")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

PR #2393 moved the per-row archive / mark-read / open-in-email actions into a `DropdownMenu` and removed the `action` prop, but didn't update the existing component tests, leaving 6 tests failing on `main`:

- `inline-email-card.test.tsx` — 5 failures (Archive button no longer rendered inline; Subject hidden when card has summary children; details panel now opt-in; etc.)
- `assistant-inline-email-response.test.tsx` — 1 failure (Archive lookup, link only rendered inside the dropdown)

## Fix

Mock `@/components/ui/dropdown-menu` in both test files so menu items render inline (the tests don't need to exercise Radix portal/open semantics — they only verify the button + action behavior). Update assertions to the new structure: `menuitem` role for archive, expand-card-by-clicking-the-row instead of by clicking the subject, and click "Show details" to assert the details panel renders.

## Test plan

- [x] `pnpm test components/assistant-chat/inline-email-card.test.tsx` — 8/8 pass
- [x] `pnpm test components/assistant-chat/assistant-inline-email-response.test.tsx` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)