### PR TITLE
messaging: Normalize reaction-only chat input

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -88,11 +88,15 @@ describe("normalizeMessagingAssistantText", () => {
 });
 
 describe("normalizeMessagingUserText", () => {
-  it("leaves emoji-only messages unchanged", () => {
-    expect(normalizeMessagingUserText({ text: "👍🏽" })).toBe("👍🏽");
-    expect(normalizeMessagingUserText({ text: ":thumbsup:" })).toBe(
-      ":thumbsup:",
-    );
+  it("converts emoji-only affirmative messages into plain yes", () => {
+    expect(normalizeMessagingUserText({ text: "👍🏽" })).toBe("yes");
+    expect(normalizeMessagingUserText({ text: ":thumbsup:" })).toBe("yes");
+  });
+
+  it("converts emoji-only negative messages into plain no", () => {
+    expect(normalizeMessagingUserText({ text: "❌" })).toBe("no");
+    expect(normalizeMessagingUserText({ text: "👎" })).toBe("no");
+    expect(normalizeMessagingUserText({ text: ":thumbsdown:" })).toBe("no");
   });
 
   it("does not treat plain words as emoji aliases", () => {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -89,6 +89,15 @@ const AFFIRMATIVE_REACTION_ALIASES = new Set([
   "check",
   "heavy_check_mark",
 ]);
+const NEGATIVE_REACTION_EMOJI_TOKENS = new Set(["👎", "❌", "✖", "✕", "☒"]);
+const NEGATIVE_REACTION_ALIASES = new Set([
+  "-1",
+  "thumbsdown",
+  "thumbs_down",
+  "x",
+  "negative_squared_cross_mark",
+  "heavy_multiplication_x",
+]);
 const UNSUPPORTED_MESSAGING_ATTACHMENT_MESSAGE =
   "I can process images, but I can't access other file types (documents, videos, audio) sent here yet. I can still draft the email text if you share what to write.";
 
@@ -2592,7 +2601,10 @@ export function buildAffirmativeReactionMessage({
 }
 
 export function normalizeMessagingUserText({ text }: { text: string }) {
-  return text.trim();
+  const trimmed = text.trim();
+  const emojiResponse = getEmojiOnlyUserResponse(trimmed);
+
+  return emojiResponse ?? trimmed;
 }
 
 export function buildPendingEmailCardFallbackText(normalizedText: string) {
@@ -2621,14 +2633,54 @@ function isAffirmativeReactionToken(token: string) {
   const trimmed = token.trim();
   if (!trimmed) return false;
 
-  const alias = trimmed.toLowerCase();
-  if (AFFIRMATIVE_REACTION_ALIASES.has(alias)) return true;
+  if (isAffirmativeReactionAlias(trimmed)) return true;
 
-  const normalized = alias
+  return isAffirmativeReactionEmoji(trimmed);
+}
+
+function getEmojiOnlyUserResponse(text: string): "yes" | "no" | null {
+  if (!text) return null;
+
+  const slackAlias = getSlackEmojiAlias(text);
+  if (slackAlias) {
+    if (isAffirmativeReactionAlias(slackAlias)) return "yes";
+    if (isNegativeReactionAlias(slackAlias)) return "no";
+    return null;
+  }
+
+  if (isAffirmativeReactionEmoji(text)) return "yes";
+  if (isNegativeReactionEmoji(text)) return "no";
+
+  return null;
+}
+
+function getSlackEmojiAlias(text: string): string | null {
+  const match = /^:([A-Za-z0-9_+-]+):$/.exec(text);
+  return match?.[1] ?? null;
+}
+
+function isAffirmativeReactionAlias(token: string) {
+  return AFFIRMATIVE_REACTION_ALIASES.has(token.trim().toLowerCase());
+}
+
+function isNegativeReactionAlias(token: string) {
+  return NEGATIVE_REACTION_ALIASES.has(token.trim().toLowerCase());
+}
+
+function isAffirmativeReactionEmoji(token: string) {
+  return AFFIRMATIVE_REACTION_EMOJI_TOKENS.has(normalizeReactionEmoji(token));
+}
+
+function isNegativeReactionEmoji(token: string) {
+  return NEGATIVE_REACTION_EMOJI_TOKENS.has(normalizeReactionEmoji(token));
+}
+
+function normalizeReactionEmoji(token: string) {
+  return token
+    .trim()
+    .toLowerCase()
     .replaceAll("\uFE0F", "")
     .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, "");
-
-  return AFFIRMATIVE_REACTION_EMOJI_TOKENS.has(normalized);
 }
 
 function getMessagingAssistantPostPayload({


### PR DESCRIPTION
Normalizes reaction-only messaging input to yes/no before assistant processing. Adds unit coverage for affirmative and negative reaction-only messages while preserving regular text and plain words.

Tests: `cd apps/web && pnpm test --run utils/messaging/chat-sdk/bot.test.ts`; `cd apps/web && pnpm exec biome check utils/messaging/chat-sdk/bot.ts utils/messaging/chat-sdk/bot.test.ts`