### PR TITLE
rules: Block duplicate sender rules

### DIFF
--- a/apps/web/utils/actions/rule.test.ts
+++ b/apps/web/utils/actions/rule.test.ts
@@ -159,6 +159,7 @@ describe("updateRuleAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(createEmailProvider).mockResolvedValue({} as any);
+    prisma.rule.findMany.mockResolvedValue([]);
   });
 
   it("scopes the rule update to the bound email account", async () => {

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -834,6 +834,8 @@ function mapActionToSanitizedFields(action: {
 }
 
 function handleRuleError(error: unknown, logger: Logger) {
+  if (error instanceof SafeError) throw error;
+
   if (isDuplicateError(error, "name")) {
     throw new SafeError("Rule name already exists");
   }

--- a/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
@@ -1,16 +1,16 @@
 import { type InferUITool, tool } from "ai";
-import { GroupItemType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import { createRuleSchema } from "@/utils/ai/rule/create-rule-schema";
-import prisma from "@/utils/prisma";
 import {
   createRule,
   outboundActionsNeedChatRiskConfirmation,
 } from "@/utils/rule/rule";
-import { splitEmailPatterns } from "@/utils/rule/email-from-pattern";
+import {
+  findSenderOnlyOverlapConflict,
+  formatSenderOnlyOverlapError,
+} from "@/utils/rule/sender-scope-overlap";
 import {
   buildCreateRuleSchemaFromChatToolInput,
-  type ChatCreateRuleToolInvocation,
   trackRuleToolCall,
 } from "./shared";
 
@@ -34,13 +34,18 @@ export const createRuleTool = ({
       try {
         const overlapConflict = await findSenderOnlyOverlapConflict({
           emailAccountId,
-          condition,
+          rule: {
+            instructions: condition.aiInstructions,
+            from: condition.static?.from,
+            to: condition.static?.to,
+            subject: condition.static?.subject,
+          },
         });
 
         if (overlapConflict) {
           return {
             success: false,
-            error: `Cannot create this rule because it overlaps the existing "${overlapConflict.ruleName}" rule on sender scope ${overlapConflict.overlappingSenders.join(", ")}. Update the existing rule instead of creating a duplicate.`,
+            error: formatSenderOnlyOverlapError(overlapConflict),
             conflictingRuleName: overlapConflict.ruleName,
             overlappingSenders: overlapConflict.overlappingSenders,
           };
@@ -85,208 +90,3 @@ export const createRuleTool = ({
   });
 
 export type CreateRuleTool = InferUITool<ReturnType<typeof createRuleTool>>;
-
-async function findSenderOnlyOverlapConflict({
-  emailAccountId,
-  condition,
-}: {
-  emailAccountId: string;
-  condition: ChatCreateRuleToolInvocation["condition"];
-}) {
-  if (
-    condition.aiInstructions ||
-    condition.static?.to ||
-    condition.static?.subject ||
-    !condition.static?.from
-  ) {
-    return null;
-  }
-
-  const proposedPatterns = parseSenderScopePatterns(condition.static.from);
-  if (!proposedPatterns.length) return null;
-
-  const existingRules = await prisma.rule.findMany({
-    where: {
-      emailAccountId,
-      enabled: true,
-      from: { not: null },
-    },
-    select: {
-      name: true,
-      instructions: true,
-      from: true,
-      to: true,
-      subject: true,
-      group: {
-        select: {
-          items: {
-            where: {
-              type: GroupItemType.FROM,
-            },
-            select: {
-              value: true,
-              exclude: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  for (const existingRule of existingRules) {
-    if (
-      existingRule.instructions ||
-      existingRule.to ||
-      existingRule.subject ||
-      !existingRule.from
-    ) {
-      continue;
-    }
-
-    const overlappingSenders = getOverlappingSenderScopes(
-      proposedPatterns,
-      parseSenderScopePatterns(existingRule.from),
-      getExcludedSenderScopePatterns(existingRule.group?.items ?? []),
-      getIncludedSenderScopePatterns(existingRule.group?.items ?? []),
-    );
-
-    if (!overlappingSenders.length) continue;
-
-    return {
-      ruleName: existingRule.name,
-      overlappingSenders,
-    };
-  }
-
-  return null;
-}
-
-function getOverlappingSenderScopes(
-  left: SenderScopePattern[],
-  right: SenderScopePattern[],
-  rightExcluded: SenderScopePattern[] = [],
-  rightIncluded: SenderScopePattern[] = [],
-) {
-  const overlaps = new Set<string>();
-
-  for (const leftPattern of left) {
-    if (
-      rightIncluded.some((includedPattern) =>
-        senderScopesOverlap(leftPattern, includedPattern),
-      )
-    ) {
-      overlaps.add(leftPattern.raw);
-      continue;
-    }
-
-    for (const rightPattern of right) {
-      if (!senderScopesOverlap(leftPattern, rightPattern)) continue;
-      if (isSenderScopeFullyExcluded(leftPattern, rightExcluded)) continue;
-      overlaps.add(leftPattern.raw);
-    }
-  }
-
-  return [...overlaps];
-}
-
-type SenderScopePattern =
-  | {
-      kind: "domain";
-      value: string;
-      raw: string;
-    }
-  | {
-      kind: "email";
-      value: string;
-      raw: string;
-    };
-
-function parseSenderScopePatterns(value: string) {
-  return splitEmailPatterns(value)
-    .map(normalizeSenderScopePattern)
-    .filter((pattern): pattern is SenderScopePattern => Boolean(pattern));
-}
-
-function normalizeSenderScopePattern(value: string): SenderScopePattern | null {
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) return null;
-
-  if (normalized.startsWith("@")) {
-    const domain = normalized.slice(1);
-    return domain
-      ? {
-          kind: "domain",
-          value: domain,
-          raw: normalized,
-        }
-      : null;
-  }
-
-  if (normalized.includes("@")) {
-    return {
-      kind: "email",
-      value: normalized,
-      raw: normalized,
-    };
-  }
-
-  return {
-    kind: "domain",
-    value: normalized,
-    raw: normalized,
-  };
-}
-
-function senderScopesOverlap(
-  left: SenderScopePattern,
-  right: SenderScopePattern,
-) {
-  if (left.kind === "email" && right.kind === "email") {
-    return left.value === right.value;
-  }
-
-  if (left.kind === "domain" && right.kind === "domain") {
-    return left.value === right.value;
-  }
-
-  if (left.kind === "email" && right.kind === "domain") {
-    return left.value.endsWith(`@${right.value}`);
-  }
-
-  return right.value.endsWith(`@${left.value}`);
-}
-
-function isSenderScopeFullyExcluded(
-  pattern: SenderScopePattern,
-  excludedPatterns: SenderScopePattern[],
-) {
-  if (!excludedPatterns.length) return false;
-
-  if (pattern.kind === "email") {
-    return excludedPatterns.some((excludedPattern) =>
-      senderScopesOverlap(pattern, excludedPattern),
-    );
-  }
-
-  return excludedPatterns.some(
-    (excludedPattern) =>
-      excludedPattern.kind === "domain" &&
-      excludedPattern.value === pattern.value,
-  );
-}
-
-function getExcludedSenderScopePatterns(
-  items: Array<{ value: string; exclude: boolean }>,
-) {
-  return items
-    .filter((item) => item.exclude)
-    .flatMap((item) => parseSenderScopePatterns(item.value));
-}
-
-function getIncludedSenderScopePatterns(
-  items: Array<{ value: string; exclude: boolean }>,
-) {
-  return items
-    .filter((item) => !item.exclude)
-    .flatMap((item) => parseSenderScopePatterns(item.value));
-}

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -73,6 +73,7 @@ describe("deleteRule", () => {
       level: "low",
       message: "safe",
     });
+    prisma.rule.findMany.mockResolvedValue([]);
   });
 
   it("deletes the group first and relies on cascade delete for grouped rules", async () => {
@@ -135,6 +136,7 @@ describe("outbound action guardrails", () => {
       level: "low",
       message: "safe",
     });
+    prisma.rule.findMany.mockResolvedValue([]);
   });
 
   it("rejects creating a low-trust from rule with FORWARD", async () => {
@@ -236,6 +238,76 @@ describe("outbound action guardrails", () => {
     );
 
     expect(prisma.rule.create).not.toHaveBeenCalled();
+  });
+
+  it("allows sender-only rules when an overlapping existing rule is grouped", async () => {
+    const existingGroupedRule = {
+      name: "Existing grouped rule",
+      instructions: null,
+      from: "@example.com",
+      to: null,
+      subject: null,
+      body: null,
+      groupId: "group-id",
+      group: { items: [] },
+    };
+
+    prisma.rule.findMany.mockImplementation(async (args) => {
+      const select = (args as { select?: Record<string, unknown> }).select;
+
+      return [
+        {
+          name: existingGroupedRule.name,
+          instructions: existingGroupedRule.instructions,
+          from: existingGroupedRule.from,
+          to: existingGroupedRule.to,
+          subject: existingGroupedRule.subject,
+          body: existingGroupedRule.body,
+          groupId: select?.groupId ? existingGroupedRule.groupId : undefined,
+          group: existingGroupedRule.group,
+        },
+      ] as never;
+    });
+    prisma.rule.create.mockResolvedValue({
+      id: "new-rule-id",
+      actions: [],
+      group: null,
+    } as any);
+
+    await expect(
+      createRule({
+        result: {
+          name: "New sender rule",
+          condition: {
+            aiInstructions: null,
+            conditionalOperator: null,
+            static: {
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+            },
+          },
+          actions: [
+            {
+              type: ActionType.ARCHIVE,
+              fields: null,
+              delayInMinutes: null,
+            },
+          ],
+        },
+        emailAccountId: "email-account-id",
+        provider: "gmail",
+        runOnThreads: true,
+        logger,
+      }),
+    ).resolves.toMatchObject({ id: "new-rule-id" });
+
+    expect(prisma.rule.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ groupId: true }),
+      }),
+    );
+    expect(prisma.rule.create).toHaveBeenCalled();
   });
 
   it("rejects updating a low-trust from rule before mapping action fields", async () => {
@@ -524,6 +596,7 @@ describe("replaceRuleWithResolvedActions", () => {
       level: "low",
       message: "safe",
     });
+    prisma.rule.findMany.mockResolvedValue([]);
   });
 
   it("deletes the previous learned pattern group when the rule is detached from it", async () => {
@@ -584,6 +657,7 @@ describe("rule history snapshots", () => {
       level: "low",
       message: "safe",
     });
+    prisma.rule.findMany.mockResolvedValue([]);
   });
 
   it("writes history when updating instructions", async () => {

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, GroupItemType } from "@/generated/prisma/enums";
 import { createEmailProvider } from "@/utils/email/provider";
 import { WEBHOOK_ACTION_DISABLED_MESSAGE } from "@/utils/webhook-action";
 import { getActionRiskLevel } from "@/utils/risk";
@@ -177,6 +177,65 @@ describe("outbound action guardrails", () => {
 
     expect(prisma.rule.create).not.toHaveBeenCalled();
     expect(createEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating a duplicate sender-only rule", async () => {
+    prisma.rule.findMany.mockResolvedValue([
+      {
+        name: "Existing sender rule",
+        instructions: null,
+        from: "sender@example.com",
+        to: null,
+        subject: null,
+        body: null,
+        group: {
+          items: [
+            {
+              value: "sender@example.com",
+              exclude: false,
+              type: GroupItemType.FROM,
+            },
+          ],
+        },
+      },
+    ] as any);
+    prisma.rule.create.mockResolvedValue({
+      id: "new-rule-id",
+      actions: [],
+      group: null,
+    } as any);
+
+    await expect(
+      createRule({
+        result: {
+          name: "Duplicate sender rule",
+          condition: {
+            aiInstructions: null,
+            conditionalOperator: null,
+            static: {
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+            },
+          },
+          actions: [
+            {
+              type: ActionType.ARCHIVE,
+              fields: null,
+              delayInMinutes: null,
+            },
+          ],
+        },
+        emailAccountId: "email-account-id",
+        provider: "gmail",
+        runOnThreads: true,
+        logger,
+      }),
+    ).rejects.toThrow(
+      'Cannot create this rule because it overlaps the existing "Existing sender rule" rule',
+    );
+
+    expect(prisma.rule.create).not.toHaveBeenCalled();
   });
 
   it("rejects updating a low-trust from rule before mapping action fields", async () => {
@@ -392,6 +451,14 @@ describe("outbound action guardrails", () => {
   });
 
   it("scopes partial rule updates to the email account", async () => {
+    prisma.rule.findUnique.mockResolvedValue({
+      instructions: "old instructions",
+      from: null,
+      to: null,
+      subject: null,
+      body: null,
+      groupId: null,
+    } as any);
     prisma.rule.update.mockResolvedValue({
       id: "rule-id",
       actions: [],
@@ -480,7 +547,7 @@ describe("replaceRuleWithResolvedActions", () => {
 
     expect(prisma.rule.findUnique).toHaveBeenCalledWith({
       where: { id: "rule-id", emailAccountId: "email-account-id" },
-      select: { groupId: true },
+      select: expect.objectContaining({ groupId: true }),
     });
     expect(prisma.group.deleteMany).toHaveBeenCalledWith({
       where: { id: "old-group-id", emailAccountId: "email-account-id" },

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -157,14 +157,7 @@ export async function partialUpdateRule({
   if (hasRuleScopeUpdate(data)) {
     const existingRule = await prisma.rule.findUnique({
       where: { id: ruleId, emailAccountId },
-      select: {
-        instructions: true,
-        from: true,
-        to: true,
-        subject: true,
-        body: true,
-        groupId: true,
-      },
+      select: RULE_SCOPE_SELECT,
     });
 
     if (!existingRule) throw new Error("Rule not found");
@@ -172,18 +165,7 @@ export async function partialUpdateRule({
     await assertNoSenderOnlyOverlap({
       emailAccountId,
       excludeRuleId: ruleId,
-      rule: {
-        instructions: getUpdatedRuleScopeValue(
-          data,
-          existingRule,
-          "instructions",
-        ),
-        from: getUpdatedRuleScopeValue(data, existingRule, "from"),
-        to: getUpdatedRuleScopeValue(data, existingRule, "to"),
-        subject: getUpdatedRuleScopeValue(data, existingRule, "subject"),
-        body: getUpdatedRuleScopeValue(data, existingRule, "body"),
-        groupId: getUpdatedRuleScopeValue(data, existingRule, "groupId"),
-      },
+      rule: mergeRuleScope(data, existingRule),
     });
   }
 
@@ -303,48 +285,24 @@ export async function replaceRuleWithResolvedActions({
   emailAccountId,
   data,
   actions,
-  skipSenderOnlyOverlapCheck = false,
 }: {
   ruleId: string;
   emailAccountId: string;
   data: RuleRecordData;
   actions: RuleActionCreateData[];
-  skipSenderOnlyOverlapCheck?: boolean;
 }): Promise<RuleWithRelations> {
   assertWebhookActionsAllowed(actions);
 
   const existingRule = await prisma.rule.findUnique({
     where: { id: ruleId, emailAccountId },
-    select: {
-      instructions: true,
-      from: true,
-      to: true,
-      subject: true,
-      body: true,
-      groupId: true,
-    },
+    select: RULE_SCOPE_SELECT,
   });
 
-  if (!skipSenderOnlyOverlapCheck) {
-    await assertNoSenderOnlyOverlap({
-      emailAccountId,
-      excludeRuleId: ruleId,
-      rule: existingRule
-        ? {
-            instructions: getUpdatedRuleScopeValue(
-              data,
-              existingRule,
-              "instructions",
-            ),
-            from: getUpdatedRuleScopeValue(data, existingRule, "from"),
-            to: getUpdatedRuleScopeValue(data, existingRule, "to"),
-            subject: getUpdatedRuleScopeValue(data, existingRule, "subject"),
-            body: getUpdatedRuleScopeValue(data, existingRule, "body"),
-            groupId: getUpdatedRuleScopeValue(data, existingRule, "groupId"),
-          }
-        : data,
-    });
-  }
+  await assertNoSenderOnlyOverlap({
+    emailAccountId,
+    excludeRuleId: ruleId,
+    rule: existingRule ? mergeRuleScope(data, existingRule) : data,
+  });
 
   validateLowTrustStaticFromOutboundActions({
     from: data.from,
@@ -755,22 +713,6 @@ type RuleScopeKey =
   | "body"
   | "groupId";
 
-function hasRuleScopeUpdate(data: Partial<Rule>) {
-  return RULE_SCOPE_KEYS.some((key) => hasOwn(data, key));
-}
-
-function getUpdatedRuleScopeValue<
-  T extends Record<RuleScopeKey, string | null>,
->(data: Partial<Rule>, existingRule: T, key: RuleScopeKey) {
-  return hasOwn(data, key)
-    ? ((data[key] as string | null | undefined) ?? null)
-    : existingRule[key];
-}
-
-function hasOwn<T extends object>(object: T, key: PropertyKey) {
-  return Object.hasOwn(object, key);
-}
-
 const RULE_SCOPE_KEYS = [
   "instructions",
   "from",
@@ -778,7 +720,34 @@ const RULE_SCOPE_KEYS = [
   "subject",
   "body",
   "groupId",
-] satisfies RuleScopeKey[];
+] as const satisfies RuleScopeKey[];
+
+const RULE_SCOPE_SELECT = {
+  instructions: true,
+  from: true,
+  to: true,
+  subject: true,
+  body: true,
+  groupId: true,
+} as const;
+
+function hasRuleScopeUpdate(data: Partial<Rule>) {
+  return RULE_SCOPE_KEYS.some((key) => Object.hasOwn(data, key));
+}
+
+function mergeRuleScope<T extends Record<RuleScopeKey, string | null>>(
+  data: Partial<Rule>,
+  existingRule: T,
+): Record<RuleScopeKey, string | null> {
+  return Object.fromEntries(
+    RULE_SCOPE_KEYS.map((key) => [
+      key,
+      Object.hasOwn(data, key)
+        ? ((data[key] as string | null | undefined) ?? null)
+        : existingRule[key],
+    ]),
+  ) as Record<RuleScopeKey, string | null>;
+}
 
 function validateLowTrustStaticFromOutboundActions({
   from,

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -30,6 +30,7 @@ import {
   ensureWebhookActionEnabled,
   hasWebhookAction,
 } from "@/utils/webhook-action";
+import { assertNoSenderOnlyOverlap } from "@/utils/rule/sender-scope-overlap";
 
 type CreateRuleEnablement =
   | { source: "default" }
@@ -144,7 +145,7 @@ async function updateRuleAndQueueHistory({
   return rule;
 }
 
-export function partialUpdateRule({
+export async function partialUpdateRule({
   ruleId,
   emailAccountId,
   data,
@@ -153,6 +154,39 @@ export function partialUpdateRule({
   emailAccountId: string;
   data: Partial<Rule>;
 }) {
+  if (hasRuleScopeUpdate(data)) {
+    const existingRule = await prisma.rule.findUnique({
+      where: { id: ruleId, emailAccountId },
+      select: {
+        instructions: true,
+        from: true,
+        to: true,
+        subject: true,
+        body: true,
+        groupId: true,
+      },
+    });
+
+    if (!existingRule) throw new Error("Rule not found");
+
+    await assertNoSenderOnlyOverlap({
+      emailAccountId,
+      excludeRuleId: ruleId,
+      rule: {
+        instructions: getUpdatedRuleScopeValue(
+          data,
+          existingRule,
+          "instructions",
+        ),
+        from: getUpdatedRuleScopeValue(data, existingRule, "from"),
+        to: getUpdatedRuleScopeValue(data, existingRule, "to"),
+        subject: getUpdatedRuleScopeValue(data, existingRule, "subject"),
+        body: getUpdatedRuleScopeValue(data, existingRule, "body"),
+        groupId: getUpdatedRuleScopeValue(data, existingRule, "groupId"),
+      },
+    });
+  }
+
   return updateRuleAndQueueHistory({
     ruleId,
     emailAccountId,
@@ -216,12 +250,18 @@ export async function createRuleWithResolvedActions({
   emailAccountId,
   data,
   actions,
+  skipSenderOnlyOverlapCheck = false,
 }: {
   emailAccountId: string;
   data: RuleRecordData & { name: string };
   actions: RuleActionCreateData[];
+  skipSenderOnlyOverlapCheck?: boolean;
 }): Promise<RuleWithRelations> {
   assertWebhookActionsAllowed(actions);
+
+  if (!skipSenderOnlyOverlapCheck) {
+    await assertNoSenderOnlyOverlap({ emailAccountId, rule: data });
+  }
 
   validateLowTrustStaticFromOutboundActions({
     from: data.from,
@@ -263,13 +303,48 @@ export async function replaceRuleWithResolvedActions({
   emailAccountId,
   data,
   actions,
+  skipSenderOnlyOverlapCheck = false,
 }: {
   ruleId: string;
   emailAccountId: string;
   data: RuleRecordData;
   actions: RuleActionCreateData[];
+  skipSenderOnlyOverlapCheck?: boolean;
 }): Promise<RuleWithRelations> {
   assertWebhookActionsAllowed(actions);
+
+  const existingRule = await prisma.rule.findUnique({
+    where: { id: ruleId, emailAccountId },
+    select: {
+      instructions: true,
+      from: true,
+      to: true,
+      subject: true,
+      body: true,
+      groupId: true,
+    },
+  });
+
+  if (!skipSenderOnlyOverlapCheck) {
+    await assertNoSenderOnlyOverlap({
+      emailAccountId,
+      excludeRuleId: ruleId,
+      rule: existingRule
+        ? {
+            instructions: getUpdatedRuleScopeValue(
+              data,
+              existingRule,
+              "instructions",
+            ),
+            from: getUpdatedRuleScopeValue(data, existingRule, "from"),
+            to: getUpdatedRuleScopeValue(data, existingRule, "to"),
+            subject: getUpdatedRuleScopeValue(data, existingRule, "subject"),
+            body: getUpdatedRuleScopeValue(data, existingRule, "body"),
+            groupId: getUpdatedRuleScopeValue(data, existingRule, "groupId"),
+          }
+        : data,
+    });
+  }
 
   validateLowTrustStaticFromOutboundActions({
     from: data.from,
@@ -277,11 +352,6 @@ export async function replaceRuleWithResolvedActions({
   });
 
   validateWebhookUrlsInActions(actions);
-
-  const existingRule = await prisma.rule.findUnique({
-    where: { id: ruleId, emailAccountId },
-    select: { groupId: true },
-  });
 
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
@@ -343,6 +413,16 @@ export async function createRule({
 
     assertWebhookActionsAllowed(result.actions);
 
+    await assertNoSenderOnlyOverlap({
+      emailAccountId,
+      rule: {
+        instructions: result.condition.aiInstructions,
+        from: result.condition.static?.from,
+        to: result.condition.static?.to,
+        subject: result.condition.static?.subject,
+      },
+    });
+
     validateLowTrustStaticFromOutboundActions({
       from: result.condition.static?.from,
       actionTypes: result.actions.map((action) => action.type),
@@ -380,6 +460,7 @@ export async function createRule({
         subject: result.condition.static?.subject,
       },
       actions: mappedActions,
+      skipSenderOnlyOverlapCheck: true,
     });
 
     queueRuleHistory({ rule, triggerType: "created" });
@@ -665,6 +746,39 @@ function shouldEnable(
   );
   return riskLevels.every((level) => level === "low");
 }
+
+type RuleScopeKey =
+  | "instructions"
+  | "from"
+  | "to"
+  | "subject"
+  | "body"
+  | "groupId";
+
+function hasRuleScopeUpdate(data: Partial<Rule>) {
+  return RULE_SCOPE_KEYS.some((key) => hasOwn(data, key));
+}
+
+function getUpdatedRuleScopeValue<
+  T extends Record<RuleScopeKey, string | null>,
+>(data: Partial<Rule>, existingRule: T, key: RuleScopeKey) {
+  return hasOwn(data, key)
+    ? ((data[key] as string | null | undefined) ?? null)
+    : existingRule[key];
+}
+
+function hasOwn<T extends object>(object: T, key: PropertyKey) {
+  return Object.hasOwn(object, key);
+}
+
+const RULE_SCOPE_KEYS = [
+  "instructions",
+  "from",
+  "to",
+  "subject",
+  "body",
+  "groupId",
+] satisfies RuleScopeKey[];
 
 function validateLowTrustStaticFromOutboundActions({
   from,

--- a/apps/web/utils/rule/sender-scope-overlap.ts
+++ b/apps/web/utils/rule/sender-scope-overlap.ts
@@ -1,0 +1,254 @@
+import { GroupItemType } from "@/generated/prisma/enums";
+import { SafeError } from "@/utils/error";
+import prisma from "@/utils/prisma";
+import { splitEmailPatterns } from "@/utils/rule/email-from-pattern";
+
+type SenderOnlyRuleScope = {
+  instructions?: string | null;
+  from?: string | null;
+  to?: string | null;
+  subject?: string | null;
+  body?: string | null;
+  groupId?: string | null;
+};
+
+type SenderOnlyOverlapConflict = {
+  ruleName: string;
+  overlappingSenders: string[];
+};
+
+export async function assertNoSenderOnlyOverlap({
+  emailAccountId,
+  rule,
+  excludeRuleId,
+}: {
+  emailAccountId: string;
+  rule: SenderOnlyRuleScope;
+  excludeRuleId?: string;
+}) {
+  const conflict = await findSenderOnlyOverlapConflict({
+    emailAccountId,
+    rule,
+    excludeRuleId,
+  });
+
+  if (!conflict) return;
+
+  throw new SafeError(formatSenderOnlyOverlapError(conflict), 400);
+}
+
+export async function findSenderOnlyOverlapConflict({
+  emailAccountId,
+  rule,
+  excludeRuleId,
+}: {
+  emailAccountId: string;
+  rule: SenderOnlyRuleScope;
+  excludeRuleId?: string;
+}): Promise<SenderOnlyOverlapConflict | null> {
+  if (!isSenderOnlyScope(rule)) return null;
+
+  const proposedPatterns = parseSenderScopePatterns(rule.from);
+  if (!proposedPatterns.length) return null;
+
+  const existingRules =
+    (await prisma.rule.findMany({
+      where: {
+        emailAccountId,
+        enabled: true,
+        from: { not: null },
+        ...(excludeRuleId && { id: { not: excludeRuleId } }),
+      },
+      select: {
+        name: true,
+        instructions: true,
+        from: true,
+        to: true,
+        subject: true,
+        body: true,
+        group: {
+          select: {
+            items: {
+              where: {
+                type: GroupItemType.FROM,
+              },
+              select: {
+                value: true,
+                exclude: true,
+              },
+            },
+          },
+        },
+      },
+    })) ?? [];
+
+  for (const existingRule of existingRules) {
+    if (!isSenderOnlyScope(existingRule)) continue;
+
+    const overlappingSenders = getOverlappingSenderScopes(
+      proposedPatterns,
+      parseSenderScopePatterns(existingRule.from),
+      getExcludedSenderScopePatterns(existingRule.group?.items ?? []),
+      getIncludedSenderScopePatterns(existingRule.group?.items ?? []),
+    );
+
+    if (!overlappingSenders.length) continue;
+
+    return {
+      ruleName: existingRule.name,
+      overlappingSenders,
+    };
+  }
+
+  return null;
+}
+
+export function formatSenderOnlyOverlapError({
+  ruleName,
+  overlappingSenders,
+}: SenderOnlyOverlapConflict) {
+  return `Cannot create this rule because it overlaps the existing "${ruleName}" rule on sender scope ${overlappingSenders.join(", ")}. Update the existing rule instead of creating a duplicate.`;
+}
+
+function isSenderOnlyScope(
+  rule: SenderOnlyRuleScope,
+): rule is SenderOnlyRuleScope & { from: string } {
+  return Boolean(
+    rule.from &&
+      !rule.instructions &&
+      !rule.to &&
+      !rule.subject &&
+      !rule.body &&
+      !rule.groupId,
+  );
+}
+
+function getOverlappingSenderScopes(
+  left: SenderScopePattern[],
+  right: SenderScopePattern[],
+  rightExcluded: SenderScopePattern[] = [],
+  rightIncluded: SenderScopePattern[] = [],
+) {
+  const overlaps = new Set<string>();
+
+  for (const leftPattern of left) {
+    if (
+      rightIncluded.some((includedPattern) =>
+        senderScopesOverlap(leftPattern, includedPattern),
+      )
+    ) {
+      overlaps.add(leftPattern.raw);
+      continue;
+    }
+
+    for (const rightPattern of right) {
+      if (!senderScopesOverlap(leftPattern, rightPattern)) continue;
+      if (isSenderScopeFullyExcluded(leftPattern, rightExcluded)) continue;
+      overlaps.add(leftPattern.raw);
+    }
+  }
+
+  return [...overlaps];
+}
+
+type SenderScopePattern =
+  | {
+      kind: "domain";
+      value: string;
+      raw: string;
+    }
+  | {
+      kind: "email";
+      value: string;
+      raw: string;
+    };
+
+function parseSenderScopePatterns(value: string) {
+  return splitEmailPatterns(value)
+    .map(normalizeSenderScopePattern)
+    .filter((pattern): pattern is SenderScopePattern => Boolean(pattern));
+}
+
+function normalizeSenderScopePattern(value: string): SenderScopePattern | null {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+
+  if (normalized.startsWith("@")) {
+    const domain = normalized.slice(1);
+    return domain
+      ? {
+          kind: "domain",
+          value: domain,
+          raw: normalized,
+        }
+      : null;
+  }
+
+  if (normalized.includes("@")) {
+    return {
+      kind: "email",
+      value: normalized,
+      raw: normalized,
+    };
+  }
+
+  return {
+    kind: "domain",
+    value: normalized,
+    raw: normalized,
+  };
+}
+
+function senderScopesOverlap(
+  left: SenderScopePattern,
+  right: SenderScopePattern,
+) {
+  if (left.kind === "email" && right.kind === "email") {
+    return left.value === right.value;
+  }
+
+  if (left.kind === "domain" && right.kind === "domain") {
+    return left.value === right.value;
+  }
+
+  if (left.kind === "email" && right.kind === "domain") {
+    return left.value.endsWith(`@${right.value}`);
+  }
+
+  return right.value.endsWith(`@${left.value}`);
+}
+
+function isSenderScopeFullyExcluded(
+  pattern: SenderScopePattern,
+  excludedPatterns: SenderScopePattern[],
+) {
+  if (!excludedPatterns.length) return false;
+
+  if (pattern.kind === "email") {
+    return excludedPatterns.some((excludedPattern) =>
+      senderScopesOverlap(pattern, excludedPattern),
+    );
+  }
+
+  return excludedPatterns.some(
+    (excludedPattern) =>
+      excludedPattern.kind === "domain" &&
+      excludedPattern.value === pattern.value,
+  );
+}
+
+function getExcludedSenderScopePatterns(
+  items: Array<{ value: string; exclude: boolean }>,
+) {
+  return items
+    .filter((item) => item.exclude)
+    .flatMap((item) => parseSenderScopePatterns(item.value));
+}
+
+function getIncludedSenderScopePatterns(
+  items: Array<{ value: string; exclude: boolean }>,
+) {
+  return items
+    .filter((item) => !item.exclude)
+    .flatMap((item) => parseSenderScopePatterns(item.value));
+}

--- a/apps/web/utils/rule/sender-scope-overlap.ts
+++ b/apps/web/utils/rule/sender-scope-overlap.ts
@@ -51,36 +51,36 @@ export async function findSenderOnlyOverlapConflict({
   const proposedPatterns = parseSenderScopePatterns(rule.from);
   if (!proposedPatterns.length) return null;
 
-  const existingRules =
-    (await prisma.rule.findMany({
-      where: {
-        emailAccountId,
-        enabled: true,
-        from: { not: null },
-        ...(excludeRuleId && { id: { not: excludeRuleId } }),
-      },
-      select: {
-        name: true,
-        instructions: true,
-        from: true,
-        to: true,
-        subject: true,
-        body: true,
-        group: {
-          select: {
-            items: {
-              where: {
-                type: GroupItemType.FROM,
-              },
-              select: {
-                value: true,
-                exclude: true,
-              },
+  const existingRules = await prisma.rule.findMany({
+    where: {
+      emailAccountId,
+      enabled: true,
+      from: { not: null },
+      ...(excludeRuleId && { id: { not: excludeRuleId } }),
+    },
+    select: {
+      name: true,
+      instructions: true,
+      from: true,
+      to: true,
+      subject: true,
+      body: true,
+      groupId: true,
+      group: {
+        select: {
+          items: {
+            where: {
+              type: GroupItemType.FROM,
+            },
+            select: {
+              value: true,
+              exclude: true,
             },
           },
         },
       },
-    })) ?? [];
+    },
+  });
 
   for (const existingRule of existingRules) {
     if (!isSenderOnlyScope(existingRule)) continue;


### PR DESCRIPTION
Centralizes duplicate sender-scope validation so all rule creation and update paths apply the same guard.

- Reuses the shared overlap helper from chat rule creation.
- Preserves safe validation messages for server actions.
- Adds regression coverage for duplicate sender-only rule creation.

Tests: pnpm test --run utils/rule/rule.test.ts utils/ai/assistant/chat-rule-tools.test.ts utils/actions/rule.test.ts