### PR TITLE
history: Group entries by thread

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ExternalLinkIcon } from "lucide-react";
-import { useMemo } from "react";
+import { ChevronRightIcon, ExternalLinkIcon } from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
 import { LoadingContent } from "@/components/LoadingContent";
 import type { GetExecutedRulesResponse } from "@/app/api/user/executed-rules/history/route";
@@ -34,6 +34,9 @@ import { DateCell } from "@/app/(app)/[emailAccountId]/assistant/DateCell";
 import { isGoogleProvider } from "@/utils/email/provider-types";
 import { getEmailUrlForMessage } from "@/utils/url";
 
+type HistoryMessage =
+  GetExecutedRulesResponse["results"][number]["messages"][number];
+
 export function History() {
   const [page] = useQueryState("page", parseAsInteger.withDefault(1));
   const [ruleId] = useQueryState("ruleId", parseAsString.withDefault("all"));
@@ -42,7 +45,10 @@ export function History() {
   const results = data?.results ?? [];
   const totalPages = data?.totalPages ?? 1;
   const messageIds = useMemo(
-    () => results.map((result) => result.messageId),
+    () =>
+      results.flatMap((thread) =>
+        thread.messages.map((message) => message.messageId),
+      ),
     [results],
   );
   const { data: messagesData, isLoading: isMessagesLoading } = useMessagesBatch(
@@ -94,6 +100,21 @@ function HistoryTable({
 }) {
   const { userEmail } = useAccount();
   const { setInput } = useChat();
+  const [expandedThreadIds, setExpandedThreadIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  function toggleThread(threadId: string) {
+    setExpandedThreadIds((current) => {
+      const next = new Set(current);
+      if (next.has(threadId)) {
+        next.delete(threadId);
+      } else {
+        next.add(threadId);
+      }
+      return next;
+    });
+  }
 
   return (
     <div>
@@ -105,36 +126,111 @@ function HistoryTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {data.map((er) => {
-            const message = messagesById[er.messageId];
+          {data.map((thread) => {
+            const latestMessage = thread.messages[0];
+            if (!latestMessage) return null;
+
+            const message = messagesById[latestMessage.messageId];
             const isMessageLoading = !message && messagesLoading;
+            const canExpand = thread.messages.length > 1;
+            const isExpanded = expandedThreadIds.has(thread.threadId);
 
             return (
-              <TableRow key={er.messageId}>
-                <TableCell>
-                  <EmailCell
-                    message={message}
-                    messageId={er.messageId}
-                    threadId={er.threadId}
-                    userEmail={userEmail}
-                    createdAt={er.executedRules[0]?.createdAt}
-                    isMessageLoading={isMessageLoading}
-                  />
-                  {!er.executedRules[0]?.automated && (
-                    <Badge color="yellow" className="mt-2">
-                      Applied manually
-                    </Badge>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <RuleCell
-                    executedRules={er.executedRules}
-                    message={message}
-                    setInput={setInput}
-                    isMessageLoading={isMessageLoading}
-                  />
-                </TableCell>
-              </TableRow>
+              <Fragment key={thread.threadId}>
+                <TableRow>
+                  <TableCell>
+                    <div className="flex items-start gap-2">
+                      {canExpand ? (
+                        <Button
+                          variant="ghost"
+                          size="iconSm"
+                          className="mt-1"
+                          aria-label={
+                            isExpanded ? "Collapse thread" : "Expand thread"
+                          }
+                          onClick={() => toggleThread(thread.threadId)}
+                        >
+                          <ChevronRightIcon
+                            className={`size-4 transition-transform ${
+                              isExpanded ? "rotate-90" : ""
+                            }`}
+                          />
+                        </Button>
+                      ) : (
+                        <div className="w-8 shrink-0" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <EmailCell
+                          message={message}
+                          messageId={latestMessage.messageId}
+                          threadId={thread.threadId}
+                          userEmail={userEmail}
+                          createdAt={latestMessage.executedRules[0]?.createdAt}
+                          isMessageLoading={isMessageLoading}
+                        />
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {thread.messages.length > 1 && (
+                            <Badge color="blue">
+                              {thread.messages.length} messages handled
+                            </Badge>
+                          )}
+                          {!latestMessage.executedRules[0]?.automated && (
+                            <Badge color="yellow">Applied manually</Badge>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <RuleCell
+                      executedRules={latestMessage.executedRules}
+                      message={message}
+                      setInput={setInput}
+                      isMessageLoading={isMessageLoading}
+                    />
+                  </TableCell>
+                </TableRow>
+
+                {isExpanded &&
+                  thread.messages.map((threadMessage) => {
+                    const innerMessage = messagesById[threadMessage.messageId];
+                    const isInnerMessageLoading =
+                      !innerMessage && messagesLoading;
+
+                    return (
+                      <TableRow
+                        key={`${thread.threadId}-${threadMessage.messageId}`}
+                        className="bg-muted/30 hover:bg-muted/50"
+                      >
+                        <TableCell className="pl-14">
+                          <EmailCell
+                            message={innerMessage}
+                            messageId={threadMessage.messageId}
+                            threadId={thread.threadId}
+                            userEmail={userEmail}
+                            createdAt={
+                              threadMessage.executedRules[0]?.createdAt
+                            }
+                            isMessageLoading={isInnerMessageLoading}
+                          />
+                          {!threadMessage.executedRules[0]?.automated && (
+                            <Badge color="yellow" className="mt-2">
+                              Applied manually
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <RuleCell
+                            executedRules={threadMessage.executedRules}
+                            message={innerMessage}
+                            setInput={setInput}
+                            isMessageLoading={isInnerMessageLoading}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+              </Fragment>
             );
           })}
         </TableBody>
@@ -157,7 +253,7 @@ function EmailCell({
   threadId: string;
   messageId: string;
   userEmail: string;
-  createdAt: Date;
+  createdAt?: Date | string;
   isMessageLoading: boolean;
 }) {
   return (
@@ -172,7 +268,7 @@ function EmailCell({
             <span className="text-muted-foreground">Email unavailable</span>
           )}
         </div>
-        <DateCell createdAt={createdAt} />
+        {createdAt && <DateCell createdAt={new Date(createdAt)} />}
       </div>
       <div className="mt-1 flex items-center font-medium">
         {message ? (
@@ -213,7 +309,7 @@ function RuleCell({
   setInput,
   isMessageLoading,
 }: {
-  executedRules: GetExecutedRulesResponse["results"][number]["executedRules"];
+  executedRules: HistoryMessage["executedRules"];
   message?: ParsedMessage;
   setInput: (input: string) => void;
   isMessageLoading: boolean;

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useCallback, useState, useRef, useMemo } from "react";
+import {
+  Fragment,
+  useCallback,
+  useState,
+  useRef,
+  useMemo,
+  type ReactNode,
+} from "react";
 import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 import { parseAsBoolean, useQueryState } from "nuqs";
 import PQueue from "p-queue";
 import {
   BookOpenCheckIcon,
+  ChevronRightIcon,
   SparklesIcon,
   PenSquareIcon,
   PauseIcon,
@@ -36,12 +44,14 @@ import { useChat } from "@/providers/ChatProvider";
 import { MutedText } from "@/components/Typography";
 import { createClientLogger } from "@/utils/logger-client";
 import { isDefined } from "@/utils/types";
+import { Badge } from "@/components/Badge";
 import {
   getSelectionMetadataTraceDetails,
   summarizeSelectionMetadata,
 } from "@/utils/ai/choose-rule/selection-metadata-summary";
 
 type Message = MessagesResponse["messages"][number];
+type MessageThread = { threadId: string; messages: Message[] };
 
 const logger = createClientLogger("automation-test");
 
@@ -88,18 +98,15 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
   // Check if we have more data to load
   const hasMore = data?.[data.length - 1]?.nextPageToken != null;
 
-  // filter out messages in same thread
-  // only keep the most recent message in each thread
-  const messages = useMemo(() => {
-    const threadIds = new Set();
+  const messageThreads = useMemo(() => {
     const messages = data?.flatMap((page) => page.messages) || [];
-    return messages.filter((message) => {
-      // works because messages are sorted by date descending
-      if (threadIds.has(message.threadId)) return false;
-      threadIds.add(message.threadId);
-      return true;
-    });
+    return groupMessagesByThread(messages);
   }, [data]);
+
+  const messages = useMemo(
+    () => messageThreads.flatMap((thread) => thread.messages),
+    [messageThreads],
+  );
 
   const { data: rules } = useSWR<RulesResponse>("/api/user/rules");
   const { emailAccountId, userEmail } = useAccount();
@@ -128,7 +135,22 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
   const [resultsMap, setResultsMap] = useState<
     Record<string, RunRulesResult[]>
   >({});
+  const [expandedThreadIds, setExpandedThreadIds] = useState<Set<string>>(
+    new Set(),
+  );
   const handledThreadsRef = useRef(new Set<string>());
+
+  function toggleThread(threadId: string) {
+    setExpandedThreadIds((current) => {
+      const next = new Set(current);
+      if (next.has(threadId)) {
+        next.delete(threadId);
+      } else {
+        next.add(threadId);
+      }
+      return next;
+    });
+  }
 
   // Merge existing rules with results
   const allResults = useMemo(() => {
@@ -316,24 +338,77 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
       )}
 
       <LoadingContent loading={isLoading} error={error}>
-        {messages.length === 0 ? (
+        {messageThreads.length === 0 ? (
           <MutedText className="p-4 text-center">No emails found</MutedText>
         ) : (
           <Card>
             <Table>
               <TableBody>
-                {messages.map((message) => (
-                  <ProcessRulesRow
-                    key={message.id}
-                    message={message}
-                    userEmail={userEmail}
-                    isRunning={isRunning[message.id]}
-                    results={allResults[message.id]}
-                    onRun={(rerun) => onRun(message, rerun)}
-                    testMode={testMode}
-                    setInput={setInput}
-                  />
-                ))}
+                {messageThreads.map((thread) => {
+                  const latestMessage = thread.messages[0];
+                  if (!latestMessage) return null;
+
+                  const canExpand = thread.messages.length > 1;
+                  const isExpanded = expandedThreadIds.has(thread.threadId);
+
+                  return (
+                    <Fragment key={thread.threadId}>
+                      <ProcessRulesRow
+                        message={latestMessage}
+                        userEmail={userEmail}
+                        isRunning={isRunning[latestMessage.id]}
+                        results={allResults[latestMessage.id]}
+                        onRun={(rerun) => onRun(latestMessage, rerun)}
+                        testMode={testMode}
+                        setInput={setInput}
+                        leading={
+                          canExpand ? (
+                            <Button
+                              variant="ghost"
+                              size="iconSm"
+                              aria-label={
+                                isExpanded ? "Collapse thread" : "Expand thread"
+                              }
+                              onClick={() => toggleThread(thread.threadId)}
+                            >
+                              <ChevronRightIcon
+                                className={cn(
+                                  "size-4 transition-transform",
+                                  isExpanded && "rotate-90",
+                                )}
+                              />
+                            </Button>
+                          ) : (
+                            <div className="w-8 shrink-0" />
+                          )
+                        }
+                        summary={
+                          thread.messages.length > 1 ? (
+                            <Badge color="blue">
+                              {thread.messages.length} messages in thread
+                            </Badge>
+                          ) : null
+                        }
+                      />
+
+                      {isExpanded &&
+                        thread.messages.map((message) => (
+                          <ProcessRulesRow
+                            key={`${thread.threadId}-${message.id}`}
+                            message={message}
+                            userEmail={userEmail}
+                            isRunning={isRunning[message.id]}
+                            results={allResults[message.id]}
+                            onRun={(rerun) => onRun(message, rerun)}
+                            testMode={testMode}
+                            setInput={setInput}
+                            className="bg-muted/30 hover:bg-muted/50"
+                            cellClassName="pl-14"
+                          />
+                        ))}
+                    </Fragment>
+                  );
+                })}
               </TableBody>
             </Table>
 
@@ -384,6 +459,10 @@ function ProcessRulesRow({
   onRun,
   testMode,
   setInput,
+  leading,
+  summary,
+  className,
+  cellClassName,
 }: {
   message: Message;
   userEmail: string;
@@ -392,25 +471,34 @@ function ProcessRulesRow({
   onRun: (rerun?: boolean) => void;
   testMode: boolean;
   setInput: (input: string) => void;
+  leading?: ReactNode;
+  summary?: ReactNode;
+  className?: string;
+  cellClassName?: string;
 }) {
   return (
     <TableRow
-      className={
-        isRunning ? "animate-pulse bg-blue-50 dark:bg-blue-950/20" : undefined
-      }
+      className={cn(
+        isRunning && "animate-pulse bg-blue-50 dark:bg-blue-950/20",
+        className,
+      )}
     >
-      <TableCell>
+      <TableCell className={cellClassName}>
         <div className="flex items-center justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <EmailMessageCell
-              sender={message.headers.from}
-              subject={message.headers.subject}
-              snippet={message.snippet}
-              userEmail={userEmail}
-              threadId={message.threadId}
-              messageId={message.id}
-              labelIds={message.labelIds}
-            />
+          <div className="flex min-w-0 flex-1 items-start gap-2">
+            {leading}
+            <div className="min-w-0 flex-1">
+              <EmailMessageCell
+                sender={message.headers.from}
+                subject={message.headers.subject}
+                snippet={message.snippet}
+                userEmail={userEmail}
+                threadId={message.threadId}
+                messageId={message.id}
+                labelIds={message.labelIds}
+              />
+              {summary && <div className="mt-2 flex flex-wrap">{summary}</div>}
+            </div>
           </div>
           <div className="ml-4 flex shrink-0 items-center gap-1">
             {results ? (
@@ -449,4 +537,22 @@ function ProcessRulesRow({
       </TableCell>
     </TableRow>
   );
+}
+
+function groupMessagesByThread(messages: Message[]): MessageThread[] {
+  const threadsById = new Map<string, MessageThread>();
+
+  for (const message of messages) {
+    const thread = threadsById.get(message.threadId);
+    if (thread) {
+      thread.messages.push(message);
+    } else {
+      threadsById.set(message.threadId, {
+        threadId: message.threadId,
+        messages: [message],
+      });
+    }
+  }
+
+  return Array.from(threadsById.values());
 }

--- a/apps/web/app/api/user/executed-rules/history/route.ts
+++ b/apps/web/app/api/user/executed-rules/history/route.ts
@@ -50,59 +50,84 @@ async function getExecutedRules({
     ruleId: ruleId === "all" || ruleId === "skipped" ? undefined : ruleId,
   };
 
-  const [executedRules, total] = await Promise.all([
-    prisma.executedRule.findMany({
+  const [threadGroups, totalThreadGroups] = await Promise.all([
+    prisma.executedRule.groupBy({
+      by: ["threadId"],
       where,
+      _max: { createdAt: true },
+      orderBy: { _max: { createdAt: "desc" } },
       take: LIMIT,
       skip: (page - 1) * LIMIT,
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        messageId: true,
-        threadId: true,
-        actionItems: true,
-        status: true,
-        reason: true,
-        matchMetadata: true,
-        automated: true,
-        createdAt: true,
-        rule: {
-          select: {
-            id: true,
-            name: true,
-            systemType: true,
-            instructions: true,
-            groupId: true,
-            from: true,
-            to: true,
-            subject: true,
-            body: true,
-            conditionalOperator: true,
-            group: { select: { name: true } },
-          },
-        },
-      },
     }),
-    prisma.executedRule.count({ where }),
+    prisma.executedRule.groupBy({ by: ["threadId"], where }),
   ]);
 
-  const executedRulesByMessageId = groupBy(executedRules, (er) => er.messageId);
+  const threadIds = threadGroups.map((group) => group.threadId);
 
-  const results = Object.entries(executedRulesByMessageId)
-    .filter(([, groupedExecutedRules]) => groupedExecutedRules.length > 0)
-    .map(([messageId, groupedExecutedRules]) => ({
-      messageId,
-      threadId: groupedExecutedRules[0].threadId,
-      executedRules: groupedExecutedRules.map((executedRule) => ({
-        ...executedRule,
-        matchMetadata:
-          serializedMatchMetadataSchema.safeParse(executedRule.matchMetadata)
-            .data ?? null,
-      })),
-    }));
+  const executedRules = threadIds.length
+    ? await prisma.executedRule.findMany({
+        where: { ...where, threadId: { in: threadIds } },
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          messageId: true,
+          threadId: true,
+          actionItems: true,
+          status: true,
+          reason: true,
+          matchMetadata: true,
+          automated: true,
+          createdAt: true,
+          rule: {
+            select: {
+              id: true,
+              name: true,
+              systemType: true,
+              instructions: true,
+              groupId: true,
+              from: true,
+              to: true,
+              subject: true,
+              body: true,
+              conditionalOperator: true,
+              group: { select: { name: true } },
+            },
+          },
+        },
+      })
+    : [];
+
+  const executedRulesByThreadId = groupBy(executedRules, (er) => er.threadId);
+
+  const results = threadIds
+    .map((threadId) => {
+      const threadExecutedRules = executedRulesByThreadId[threadId] ?? [];
+      const executedRulesByMessageId = groupBy(
+        threadExecutedRules,
+        (er) => er.messageId,
+      );
+
+      return {
+        threadId,
+        messages: Object.entries(executedRulesByMessageId)
+          .filter(([, groupedExecutedRules]) => groupedExecutedRules.length > 0)
+          .map(([messageId, groupedExecutedRules]) => ({
+            messageId,
+            threadId,
+            executedRules: groupedExecutedRules.map((executedRule) => ({
+              ...executedRule,
+              matchMetadata:
+                serializedMatchMetadataSchema.safeParse(
+                  executedRule.matchMetadata,
+                ).data ?? null,
+            })),
+          })),
+      };
+    })
+    .filter((thread) => thread.messages.length > 0);
 
   return {
     results,
-    totalPages: Math.ceil(total / LIMIT),
+    totalPages: Math.ceil(totalThreadGroups.length / LIMIT),
   };
 }


### PR DESCRIPTION
Groups automation history and test results by thread so related messages stay together. Adds expandable rows that keep the default view compact while exposing per-message handling details.

- Changes history pagination to use thread groups
- Groups Test tab messages by thread with expandable per-message rows
- Keeps per-message rule actions, fix controls, and rerun/test controls available