### PR TITLE
assistant: Redesign test and history rows

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -1,23 +1,15 @@
 "use client";
 
-import Link from "next/link";
-import { ExternalLinkIcon } from "lucide-react";
-import { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 import { useQueryState, parseAsInteger, parseAsString } from "nuqs";
+import { format, isToday, isYesterday } from "date-fns";
 import { LoadingContent } from "@/components/LoadingContent";
 import type { GetExecutedRulesResponse } from "@/app/api/user/executed-rules/history/route";
 import { AlertBasic } from "@/components/Alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { TablePagination } from "@/components/TablePagination";
 import { Badge } from "@/components/Badge";
 import { RulesSelect } from "@/app/(app)/[emailAccountId]/assistant/RulesSelect";
@@ -25,14 +17,12 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { useChat } from "@/providers/ChatProvider";
 import { useExecutedRules } from "@/hooks/useExecutedRules";
 import { useMessagesBatch } from "@/hooks/useMessagesBatch";
-import { decodeSnippet } from "@/utils/gmail/decode";
 import type { ParsedMessage } from "@/utils/types";
-import { ViewEmailButton } from "@/components/ViewEmailButton";
+import { EmailMessageCell } from "@/components/EmailMessageCell";
 import { FixWithChat } from "@/app/(app)/[emailAccountId]/assistant/FixWithChat";
 import { ResultsDisplay } from "@/app/(app)/[emailAccountId]/assistant/ResultDisplay";
-import { DateCell } from "@/app/(app)/[emailAccountId]/assistant/DateCell";
-import { isGoogleProvider } from "@/utils/email/provider-types";
-import { getEmailUrlForMessage } from "@/utils/url";
+
+type ExecutedRuleResult = GetExecutedRulesResponse["results"][number];
 
 export function History() {
   const [page] = useQueryState("page", parseAsInteger.withDefault(1));
@@ -94,49 +84,55 @@ function HistoryTable({
 }) {
   const { userEmail } = useAccount();
   const { setInput } = useChat();
+  const groups = useMemo(() => groupByDate(data), [data]);
 
   return (
     <div>
       <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Email</TableHead>
-            <TableHead className="text-right">Rule</TableHead>
-          </TableRow>
-        </TableHeader>
         <TableBody>
-          {data.map((er) => {
-            const message = messagesById[er.messageId];
-            const isMessageLoading = !message && messagesLoading;
-
-            return (
-              <TableRow key={er.messageId}>
-                <TableCell>
-                  <EmailCell
-                    message={message}
-                    messageId={er.messageId}
-                    threadId={er.threadId}
-                    userEmail={userEmail}
-                    createdAt={er.executedRules[0]?.createdAt}
-                    isMessageLoading={isMessageLoading}
-                  />
-                  {!er.executedRules[0]?.automated && (
-                    <Badge color="yellow" className="mt-2">
-                      Applied manually
-                    </Badge>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <RuleCell
-                    executedRules={er.executedRules}
-                    message={message}
-                    setInput={setInput}
-                    isMessageLoading={isMessageLoading}
-                  />
+          {groups.map((group) => (
+            <Fragment key={group.key}>
+              <TableRow className="hover:bg-transparent">
+                <TableCell
+                  colSpan={2}
+                  className="bg-muted/40 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  {formatDateGroupLabel(group.date)}
                 </TableCell>
               </TableRow>
-            );
-          })}
+              {group.items.map((er) => {
+                const message = messagesById[er.messageId];
+                const isMessageLoading = !message && messagesLoading;
+
+                return (
+                  <TableRow key={er.messageId}>
+                    <TableCell>
+                      <EmailCell
+                        message={message}
+                        messageId={er.messageId}
+                        threadId={er.threadId}
+                        userEmail={userEmail}
+                        isMessageLoading={isMessageLoading}
+                      />
+                      {!er.executedRules[0]?.automated && (
+                        <Badge color="yellow" className="mt-2">
+                          Applied manually
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <RuleCell
+                        executedRules={er.executedRules}
+                        message={message}
+                        setInput={setInput}
+                        isMessageLoading={isMessageLoading}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </Fragment>
+          ))}
         </TableBody>
       </Table>
 
@@ -150,60 +146,40 @@ function EmailCell({
   threadId,
   messageId,
   userEmail,
-  createdAt,
   isMessageLoading,
 }: {
   message?: ParsedMessage;
   threadId: string;
   messageId: string;
   userEmail: string;
-  createdAt: Date;
   isMessageLoading: boolean;
 }) {
+  if (message) {
+    return (
+      <EmailMessageCell
+        sender={message.headers.from}
+        subject={message.headers.subject}
+        snippet={message.snippet}
+        userEmail={userEmail}
+        threadId={threadId}
+        messageId={messageId}
+        labelIds={message.labelIds}
+      />
+    );
+  }
+
+  if (isMessageLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-80" />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-1 flex-col justify-center">
-      <div className="flex items-center justify-between">
-        <div className="font-semibold">
-          {message ? (
-            message.headers.from
-          ) : isMessageLoading ? (
-            <Skeleton className="h-5 w-48" />
-          ) : (
-            <span className="text-muted-foreground">Email unavailable</span>
-          )}
-        </div>
-        <DateCell createdAt={createdAt} />
-      </div>
-      <div className="mt-1 flex items-center font-medium">
-        {message ? (
-          <span>{message.headers.subject}</span>
-        ) : isMessageLoading ? (
-          <Skeleton className="h-4 w-64" />
-        ) : (
-          <span className="text-muted-foreground">Subject unavailable</span>
-        )}
-        <OpenInGmailButton
-          messageId={messageId}
-          threadId={threadId}
-          userEmail={userEmail}
-        />
-        <ViewEmailButton
-          threadId={threadId}
-          messageId={messageId}
-          size="xs"
-          className="ml-2"
-        />
-      </div>
-      <div className="mt-1 text-muted-foreground">
-        {message ? (
-          decodeSnippet(message.snippet)
-        ) : isMessageLoading ? (
-          <Skeleton className="h-4 w-80" />
-        ) : (
-          "Preview unavailable"
-        )}
-      </div>
-    </div>
+    <span className="text-sm text-muted-foreground">Email unavailable</span>
   );
 }
 
@@ -240,35 +216,35 @@ function RuleCell({
   );
 }
 
-function OpenInGmailButton({
-  messageId,
-  threadId,
-  userEmail,
-}: {
-  messageId: string;
-  threadId: string;
-  userEmail: string;
-}) {
-  const { provider } = useAccount();
-
-  if (!isGoogleProvider(provider)) {
-    return null;
-  }
-
-  return (
-    <Link
-      href={getEmailUrlForMessage(messageId, threadId, userEmail, provider)}
-      target="_blank"
-      className="ml-2 text-muted-foreground hover:text-foreground"
-    >
-      <ExternalLinkIcon className="h-4 w-4" />
-    </Link>
-  );
-}
-
 function mapMessagesById(messages: ParsedMessage[]) {
   return messages.reduce<Record<string, ParsedMessage>>((acc, message) => {
     acc[message.id] = message;
     return acc;
   }, {});
+}
+
+function groupByDate(items: ExecutedRuleResult[]) {
+  const groups: { key: string; date: Date; items: ExecutedRuleResult[] }[] = [];
+  for (const item of items) {
+    const createdAt = item.executedRules[0]?.createdAt;
+    const date = createdAt ? new Date(createdAt) : null;
+    const key = date ? format(date, "yyyy-MM-dd") : "unknown";
+    const last = groups[groups.length - 1];
+    if (last?.key === key) {
+      last.items.push(item);
+    } else {
+      groups.push({ key, date: date ?? new Date(0), items: [item] });
+    }
+  }
+  return groups;
+}
+
+function formatDateGroupLabel(date: Date) {
+  if (date.getTime() === 0) return "Unknown date";
+  if (isToday(date)) return "Today";
+  if (isYesterday(date)) return "Yesterday";
+  if (date.getFullYear() === new Date().getFullYear()) {
+    return format(date, "EEEE, MMM d");
+  }
+  return format(date, "EEEE, MMM d, yyyy");
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/History.tsx
@@ -224,7 +224,11 @@ function mapMessagesById(messages: ParsedMessage[]) {
 }
 
 function groupByDate(items: ExecutedRuleResult[]) {
-  const groups: { key: string; date: Date; items: ExecutedRuleResult[] }[] = [];
+  const groups: {
+    key: string;
+    date: Date | null;
+    items: ExecutedRuleResult[];
+  }[] = [];
   for (const item of items) {
     const createdAt = item.executedRules[0]?.createdAt;
     const date = createdAt ? new Date(createdAt) : null;
@@ -233,14 +237,14 @@ function groupByDate(items: ExecutedRuleResult[]) {
     if (last?.key === key) {
       last.items.push(item);
     } else {
-      groups.push({ key, date: date ?? new Date(0), items: [item] });
+      groups.push({ key, date, items: [item] });
     }
   }
   return groups;
 }
 
-function formatDateGroupLabel(date: Date) {
-  if (date.getTime() === 0) return "Unknown date";
+function formatDateGroupLabel(date: Date | null) {
+  if (!date) return "Unknown date";
   if (isToday(date)) return "Today";
   if (isYesterday(date)) return "Yesterday";
   if (date.getFullYear() === new Date().getFullYear()) {

--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, MailIcon } from "lucide-react";
 import Link from "next/link";
-import { MessageText } from "@/components/Typography";
 import { getEmailUrlForMessage } from "@/utils/url";
 import { decodeSnippet } from "@/utils/gmail/decode";
-import { ViewEmailButton } from "@/components/ViewEmailButton";
+import { Tooltip } from "@/components/Tooltip";
+import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
 import { useThread } from "@/hooks/useThread";
 import { snippetRemoveReply } from "@/utils/gmail/snippet";
 import { extractNameFromEmail } from "@/utils/email";
@@ -41,6 +41,7 @@ export function EmailMessageCell({
 }) {
   const { userLabels } = useEmail();
   const { provider } = useAccount();
+  const { showEmail } = useDisplayedEmail();
 
   const labelsToDisplay = useMemo(() => {
     const labels = labelIds
@@ -85,16 +86,48 @@ export function EmailMessageCell({
     return labels;
   }, [labelIds, userLabels, filterReplyTrackerLabels]);
 
+  const showIcons = !hideViewEmailButton && isGoogleProvider(provider);
+  const visibleLabels = labelsToDisplay?.slice(0, MAX_VISIBLE_LABELS) ?? [];
+  const overflowLabels = labelsToDisplay?.slice(MAX_VISIBLE_LABELS) ?? [];
+
   return (
-    <div className="min-w-0 break-words">
-      <MessageText className="flex items-center">
-        <span className="max-w-[300px] truncate">
+    <div className="min-w-0 break-words text-sm text-slate-700 dark:text-foreground">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="order-1 max-w-[240px] shrink-0 truncate font-semibold">
           {extractNameFromEmail(sender)}
         </span>
-        {!hideViewEmailButton && isGoogleProvider(provider) && (
-          <>
+        <span className="order-4 min-w-0 max-w-full basis-full truncate sm:order-2 sm:max-w-md sm:basis-auto">
+          {subject}
+        </span>
+        {visibleLabels.length > 0 && (
+          <div className="order-5 flex shrink-0 items-center gap-1 sm:order-3">
+            {visibleLabels.map((label) => (
+              <Badge
+                variant="outline"
+                key={label.id}
+                className="max-w-[140px] truncate font-normal text-muted-foreground"
+              >
+                {label.name}
+              </Badge>
+            ))}
+            {overflowLabels.length > 0 && (
+              <Tooltip content={overflowLabels.map((l) => l.name).join(", ")}>
+                <span>
+                  <Badge
+                    variant="outline"
+                    className="font-normal text-muted-foreground"
+                  >
+                    +{overflowLabels.length}
+                  </Badge>
+                </span>
+              </Tooltip>
+            )}
+          </div>
+        )}
+        {showIcons && (
+          <div className="order-2 ml-auto flex shrink-0 items-center gap-2 text-muted-foreground sm:order-4 sm:ml-0">
             <Link
-              className="ml-2 hover:text-foreground"
+              className="hover:text-foreground"
               href={getEmailUrlForMessage(
                 messageId,
                 threadId,
@@ -102,34 +135,31 @@ export function EmailMessageCell({
                 provider,
               )}
               target="_blank"
+              aria-label="Open in Gmail"
             >
               <ExternalLinkIcon className="h-4 w-4" />
             </Link>
-            <ViewEmailButton
-              threadId={threadId}
-              messageId={messageId}
-              size="xs"
-              className="ml-1.5"
-            />
-          </>
+            <Tooltip content="View email">
+              <button
+                type="button"
+                className="hover:text-foreground"
+                onClick={() => showEmail({ threadId, messageId })}
+                aria-label="View email"
+              >
+                <MailIcon className="h-4 w-4" />
+              </button>
+            </Tooltip>
+          </div>
         )}
-        {labelsToDisplay && labelsToDisplay.length > 0 && (
-          <span className="ml-2 flex flex-wrap items-center gap-1">
-            {labelsToDisplay.map((label) => (
-              <Badge variant="secondary" key={label.id}>
-                {label.name}
-              </Badge>
-            ))}
-          </span>
-        )}
-      </MessageText>
-      <MessageText className="mt-1 truncate font-bold">{subject}</MessageText>
-      <MessageText className="mt-1 line-clamp-2 break-all">
+      </div>
+      <p className="mt-1 line-clamp-2 max-w-2xl break-all text-sm text-muted-foreground">
         {snippetRemoveReply(decodeSnippet(snippet)).trim()}
-      </MessageText>
+      </p>
     </div>
   );
 }
+
+const MAX_VISIBLE_LABELS = 2;
 
 export function EmailMessageCellWithData({
   sender,

--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -18,6 +18,8 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { getRuleLabel } from "@/utils/rule/consts";
 import { SystemType } from "@/generated/prisma/enums";
 
+const MAX_VISIBLE_LABELS = 2;
+
 export function EmailMessageCell({
   sender,
   userEmail,
@@ -158,8 +160,6 @@ export function EmailMessageCell({
     </div>
   );
 }
-
-const MAX_VISIBLE_LABELS = 2;
 
 export function EmailMessageCellWithData({
   sender,


### PR DESCRIPTION
## Summary
- Inline subject after sender in the assistant Test and History tabs; replace the bordered mail button with a plain icon and move icons + labels (with `+N` overflow tooltip) to the right of the row.
- History tab now groups rows by date with section headers (Today / Yesterday / dated), drops the Date column and table header, and uses a shared `EmailMessageCell` instead of duplicating row markup.
- On mobile, the subject wraps to its own line and icons stay anchored to the right of the sender row for readability.

## Test plan
- [ ] Test tab: rows render with sender → subject → labels → icons; snippet on second line.
- [ ] History tab: rows group under date headers; pagination still works; loading/error/missing-email states render.
- [ ] Resize to mobile width: subject drops to its own row, icons remain inline with sender.
- [ ] Hover the `+N` chip when an email has more than two labels — tooltip lists the hidden ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)