### PR TITLE
assistant: Refine rule guidance

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -746,8 +746,7 @@ export function buildResolvedSystemPrompt({
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.
 - Prefer updating an existing rule over creating an overlapping duplicate. Do not create semantic duplicates like "Notification" and "Notifications".
-- Use updateRuleState to disable, enable, or delete rules. Never remove all actions as a proxy for disabling or deleting a rule.
-- Deleting a rule requires UI confirmation. If updateRuleState returns requiresConfirmation, explain that deletion is pending confirmation and nothing has been deleted yet.
+- Use updateRuleState to disable, enable, or delete rules.
 - If multiple fetched rules are similar, ask the user which one to update instead of guessing.
 - Use short concise rule names and real sender or domain values. Ask when required data is missing.
 - Rules can use {{variables}} in action fields to insert AI-generated content.`,

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
@@ -25,7 +25,7 @@ export const updateRuleActionsTool = ({
 }) =>
   tool({
     description:
-      "Update the actions of an existing rule. This replaces the existing actions. Do not use this tool to remove, disable, or delete a rule; use updateRuleState instead. SEND_EMAIL and FORWARD require an explicit recipient in fields.to; use REPLY for inbound auto-responses.",
+      "Update the actions of an existing rule. This replaces the existing actions. SEND_EMAIL and FORWARD require an explicit recipient in fields.to; use REPLY for inbound auto-responses.",
     inputSchema: z.object({
       ruleName: z.string().describe("The name of the rule to update"),
       actions: z

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
@@ -23,7 +23,7 @@ export const updateRuleStateTool = ({
 }) =>
   tool({
     description:
-      "Enable, disable, or request deletion of an existing rule. Use this for rule removal or pausing. Do not clear a rule's actions as a substitute for disabling or deleting it. Deleting a rule returns a pending confirmation payload; the rule is not deleted until the user confirms in the UI. If deletion returns requiresConfirmation, explain that deletion is pending confirmation and nothing has been deleted yet. Default/system rules cannot be deleted; disable them instead.",
+      "Enable, disable, or request deletion of an existing rule. Use this when the user wants to turn a rule on or off, pause it, remove it, or delete it. Delete requests return requiresConfirmation; explain that deletion is pending and no rule has been deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
     inputSchema: z.object({
       ruleName: z.string().describe("The exact name of the rule to update"),
       operation: ruleStateOperationSchema.describe(

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
@@ -23,7 +23,7 @@ export const updateRuleStateTool = ({
 }) =>
   tool({
     description:
-      "Enable, disable, or request deletion of an existing rule. Use this for rule removal or pausing. Do not clear a rule's actions as a substitute for disabling or deleting it. Deleting a rule returns a pending confirmation payload; the rule is not deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
+      "Enable, disable, or request deletion of an existing rule. Use this for rule removal or pausing. Do not clear a rule's actions as a substitute for disabling or deleting it. Deleting a rule returns a pending confirmation payload; the rule is not deleted until the user confirms in the UI. If deletion returns requiresConfirmation, explain that deletion is pending confirmation and nothing has been deleted yet. Default/system rules cannot be deleted; disable them instead.",
     inputSchema: z.object({
       ruleName: z.string().describe("The exact name of the rule to update"),
       operation: ruleStateOperationSchema.describe(


### PR DESCRIPTION
Refine assistant rule-management guidance after the prior rule-state change.

- Keep general rule routing concise in the system prompt.
- Move delete-confirmation response guidance into the rule-state tool description.
- Remove redundant rule-action tool wording.