### PR TITLE
assistant: Make rule advanced section a collapsible

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -50,7 +50,10 @@ import { MutedText } from "@/components/Typography";
 import { BRAND_NAME } from "@/utils/branding";
 import { ActionAttachmentsField } from "@/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
-import { getMessagingProviderName } from "@/utils/messaging/platforms";
+import {
+  getConnectAppLabel,
+  getMessagingProviderName,
+} from "@/utils/messaging/platforms";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
 import type { GetMessagingChannelsResponse } from "@/app/api/user/messaging-channels/route";
 import { prefixPath } from "@/utils/path";
@@ -740,6 +743,7 @@ function ActionCard({
         delivery={draftReplyDelivery}
         selectedChannels={selectedMessagingChannels}
         connectedChannels={connectedMessagingChannels}
+        availableProviders={availableMessagingProviders}
         errorMessage={deliveryErrorMessage}
         onChange={handleDraftReplyDeliveryChange}
       />
@@ -901,7 +905,7 @@ function ActionCard({
                 <div className="flex flex-wrap gap-2">
                   <Button asChild size="sm" variant="outline">
                     <Link href={prefixPath(emailAccountId, "/channels")}>
-                      Connect app
+                      {getConnectAppLabel(availableMessagingProviders)}
                     </Link>
                   </Button>
                 </div>
@@ -931,6 +935,7 @@ function DraftReplyReviewChannelsSection({
   delivery,
   selectedChannels,
   connectedChannels,
+  availableProviders,
   errorMessage,
   onChange,
 }: {
@@ -938,6 +943,7 @@ function DraftReplyReviewChannelsSection({
   delivery: DraftReplyDelivery;
   selectedChannels: MessagingChannelOption[];
   connectedChannels: MessagingChannelOption[];
+  availableProviders: MessagingProviderOption[];
   errorMessage?: string;
   onChange: (value: {
     includeEmail: boolean;
@@ -1042,7 +1048,7 @@ function DraftReplyReviewChannelsSection({
       {!hasConnectedMessagingDestination ? (
         <Button asChild size="sm" variant="outline" className="w-fit">
           <Link href={prefixPath(emailAccountId, "/channels")}>
-            Connect app
+            {getConnectAppLabel(availableProviders)}
           </Link>
         </Button>
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -743,7 +743,7 @@ function ActionCard({
         delivery={draftReplyDelivery}
         selectedChannels={selectedMessagingChannels}
         connectedChannels={connectedMessagingChannels}
-        availableProviders={availableMessagingProviders}
+        connectAppLabel={getConnectAppLabel(availableMessagingProviders)}
         errorMessage={deliveryErrorMessage}
         onChange={handleDraftReplyDeliveryChange}
       />
@@ -935,7 +935,7 @@ function DraftReplyReviewChannelsSection({
   delivery,
   selectedChannels,
   connectedChannels,
-  availableProviders,
+  connectAppLabel,
   errorMessage,
   onChange,
 }: {
@@ -943,7 +943,7 @@ function DraftReplyReviewChannelsSection({
   delivery: DraftReplyDelivery;
   selectedChannels: MessagingChannelOption[];
   connectedChannels: MessagingChannelOption[];
-  availableProviders: MessagingProviderOption[];
+  connectAppLabel: string;
   errorMessage?: string;
   onChange: (value: {
     includeEmail: boolean;
@@ -1048,7 +1048,7 @@ function DraftReplyReviewChannelsSection({
       {!hasConnectedMessagingDestination ? (
         <Button asChild size="sm" variant="outline" className="w-fit">
           <Link href={prefixPath(emailAccountId, "/channels")}>
-            {getConnectAppLabel(availableProviders)}
+            {connectAppLabel}
           </Link>
         </Button>
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -530,121 +530,125 @@ export function RuleForm({
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="rounded-md border divide-y">
-              <AdvancedRow
-                title="Apply to threads"
-                description="Run on every reply in a conversation, not just the first message."
-              >
-                <Tooltip
-                  content="This can't be changed for this rule type."
-                  hide={allowMultipleConditions(rule.systemType)}
-                >
-                  <span>
-                    <Toggle
-                      name="runOnThreads"
-                      enabled={watch("runOnThreads") || false}
-                      onChange={(enabled) => {
-                        setValue("runOnThreads", enabled);
-                      }}
-                      disabled={!allowMultipleConditions(rule.systemType)}
-                    />
-                  </span>
-                </Tooltip>
-              </AdvancedRow>
-
-              {env.NEXT_PUBLIC_DIGEST_ENABLED && (
+            {isAdvancedOpen ? (
+              <div className="rounded-md border divide-y">
                 <AdvancedRow
-                  title="Include in digest"
-                  description="Show matched emails in your digest summary."
-                >
-                  <Toggle
-                    name="digest"
-                    enabled={watch("digest") || false}
-                    onChange={(enabled) => {
-                      setValue("digest", enabled);
-                    }}
-                  />
-                </AdvancedRow>
-              )}
-
-              {!!rule.id && (
-                <AdvancedRow
-                  title="Learned patterns"
-                  description="Patterns inferred from your corrections."
+                  title="Apply to threads"
+                  description="Run on every reply in a conversation, not just the first message."
                 >
                   <Tooltip
-                    content="Learned patterns aren't available for this rule type."
-                    hide={!isConversationStatusType(rule.systemType)}
+                    content="This can't be changed for this rule type."
+                    hide={allowMultipleConditions(rule.systemType)}
                   >
                     <span>
-                      <LearnedPatternsDialog
-                        ruleId={rule.id}
-                        groupId={rule.groupId || null}
-                        disabled={isConversationStatusType(rule.systemType)}
-                        label="View"
+                      <Toggle
+                        name="runOnThreads"
+                        enabled={watch("runOnThreads") || false}
+                        onChange={(enabled) => {
+                          setValue("runOnThreads", enabled);
+                        }}
+                        disabled={!allowMultipleConditions(rule.systemType)}
                       />
                     </span>
                   </Tooltip>
                 </AdvancedRow>
-              )}
 
-              {rule.id && !rule.systemType && (
-                <AdvancedRow
-                  title="Delete rule"
-                  description="Permanently remove this rule."
-                >
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    Icon={TrashIcon}
-                    loading={isDeleting}
-                    disabled={isSubmitting}
-                    onClick={async () => {
-                      const yes = confirm(
-                        "Are you sure you want to delete this rule?",
-                      );
-                      if (yes) {
-                        try {
-                          setIsDeleting(true);
-                          const result = await deleteRuleAction(
-                            emailAccountId,
-                            {
-                              id: rule.id!,
-                            },
-                          );
-                          if (result?.serverError) {
-                            toastError({
-                              description: result.serverError,
-                            });
-                          } else {
-                            toastSuccess({
-                              description: "The rule has been deleted.",
-                            });
-
-                            if (isDialog && onSuccess) {
-                              onSuccess();
-                            }
-
-                            router.push(
-                              prefixPath(
-                                emailAccountId,
-                                "/automation?tab=rules",
-                              ),
-                            );
-                          }
-                        } catch {
-                          toastError({ description: "Failed to delete rule." });
-                        } finally {
-                          setIsDeleting(false);
-                        }
-                      }
-                    }}
+                {env.NEXT_PUBLIC_DIGEST_ENABLED && (
+                  <AdvancedRow
+                    title="Include in digest"
+                    description="Show matched emails in your digest summary."
                   >
-                    Delete
-                  </Button>
-                </AdvancedRow>
-              )}
-            </div>
+                    <Toggle
+                      name="digest"
+                      enabled={watch("digest") || false}
+                      onChange={(enabled) => {
+                        setValue("digest", enabled);
+                      }}
+                    />
+                  </AdvancedRow>
+                )}
+
+                {!!rule.id && (
+                  <AdvancedRow
+                    title="Learned patterns"
+                    description="Patterns inferred from your corrections."
+                  >
+                    <Tooltip
+                      content="Learned patterns aren't available for this rule type."
+                      hide={!isConversationStatusType(rule.systemType)}
+                    >
+                      <span>
+                        <LearnedPatternsDialog
+                          ruleId={rule.id}
+                          groupId={rule.groupId || null}
+                          disabled={isConversationStatusType(rule.systemType)}
+                          label="View"
+                        />
+                      </span>
+                    </Tooltip>
+                  </AdvancedRow>
+                )}
+
+                {rule.id && !rule.systemType && (
+                  <AdvancedRow
+                    title="Delete rule"
+                    description="Permanently remove this rule."
+                  >
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      Icon={TrashIcon}
+                      loading={isDeleting}
+                      disabled={isSubmitting}
+                      onClick={async () => {
+                        const yes = confirm(
+                          "Are you sure you want to delete this rule?",
+                        );
+                        if (yes) {
+                          try {
+                            setIsDeleting(true);
+                            const result = await deleteRuleAction(
+                              emailAccountId,
+                              {
+                                id: rule.id!,
+                              },
+                            );
+                            if (result?.serverError) {
+                              toastError({
+                                description: result.serverError,
+                              });
+                            } else {
+                              toastSuccess({
+                                description: "The rule has been deleted.",
+                              });
+
+                              if (isDialog && onSuccess) {
+                                onSuccess();
+                              }
+
+                              router.push(
+                                prefixPath(
+                                  emailAccountId,
+                                  "/automation?tab=rules",
+                                ),
+                              );
+                            }
+                          } catch {
+                            toastError({
+                              description: "Failed to delete rule.",
+                            });
+                          } finally {
+                            setIsDeleting(false);
+                          }
+                        }
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  </AdvancedRow>
+                )}
+              </div>
+            ) : null}
           </CollapsibleContent>
         </Collapsible>
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import { type SubmitHandler, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -11,7 +17,7 @@ import {
   TrashIcon,
   MailIcon,
   BotIcon,
-  SettingsIcon,
+  ChevronDownIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
@@ -28,7 +34,7 @@ import {
   createRuleBody,
 } from "@/utils/actions/rule.validation";
 import { Toggle } from "@/components/Toggle";
-import { TooltipExplanation } from "@/components/TooltipExplanation";
+import { Tooltip } from "@/components/Tooltip";
 import { useLabels } from "@/hooks/useLabels";
 import { useMessagingChannels } from "@/hooks/useMessagingChannels";
 import { AlertError } from "@/components/Alert";
@@ -37,13 +43,12 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
 import { getEmailTerminology } from "@/utils/terminology";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Form } from "@/components/ui/form";
+import { cn } from "@/utils";
 import { getActionIcon } from "@/utils/action-display";
 import { useFolders } from "@/hooks/useFolders";
 import { isConversationStatusType } from "@/utils/reply-tracker/conversation-status-config";
@@ -390,6 +395,7 @@ export function RuleForm({
 
   const [isNameEditMode, setIsNameEditMode] = useState(alwaysEditMode);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
 
   const toggleNameEditMode = useCallback(() => {
     if (!alwaysEditMode) {
@@ -439,7 +445,7 @@ export function RuleForm({
         <RuleSectionCard
           icon={MailIcon}
           color="blue"
-          title="When you get an email"
+          title="When I get an email"
           errors={
             errors.conditions?.root?.message ? (
               <AlertError
@@ -508,62 +514,85 @@ export function RuleForm({
           />
         </RuleSectionCard>
 
-        <div className="flex justify-between items-center">
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="outline" size="sm" Icon={SettingsIcon}>
-                Advanced Settings
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-lg">
-              <DialogHeader>
-                <DialogTitle>Advanced Settings</DialogTitle>
-              </DialogHeader>
-              <div className="space-y-4">
-                <div className="flex items-center space-x-2">
-                  <Toggle
-                    name="runOnThreads"
-                    labelRight="Apply to threads"
-                    enabled={watch("runOnThreads") || false}
-                    onChange={(enabled) => {
-                      setValue("runOnThreads", enabled);
-                    }}
-                    disabled={!allowMultipleConditions(rule.systemType)}
-                  />
-
-                  <ThreadsExplanation size="md" />
-                </div>
-
-                {env.NEXT_PUBLIC_DIGEST_ENABLED && (
-                  <div className="flex items-center space-x-2">
+        <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 py-2 text-sm font-medium text-left text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ChevronDownIcon
+                className={cn(
+                  "size-4 transition-transform",
+                  isAdvancedOpen && "rotate-180",
+                )}
+              />
+              Advanced options
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="rounded-md border divide-y">
+              <AdvancedRow
+                title="Apply to threads"
+                description="Run on every reply in a conversation, not just the first message."
+              >
+                <Tooltip
+                  content="This can't be changed for this rule type."
+                  hide={allowMultipleConditions(rule.systemType)}
+                >
+                  <span>
                     <Toggle
-                      name="digest"
-                      labelRight="Include in daily digest"
-                      enabled={watch("digest") || false}
+                      name="runOnThreads"
+                      enabled={watch("runOnThreads") || false}
                       onChange={(enabled) => {
-                        setValue("digest", enabled);
+                        setValue("runOnThreads", enabled);
                       }}
+                      disabled={!allowMultipleConditions(rule.systemType)}
                     />
+                  </span>
+                </Tooltip>
+              </AdvancedRow>
 
-                    <TooltipExplanation
-                      size="md"
-                      side="right"
-                      text="When enabled you will receive a summary of the emails that match this rule in your digest email."
-                    />
-                  </div>
-                )}
+              {env.NEXT_PUBLIC_DIGEST_ENABLED && (
+                <AdvancedRow
+                  title="Include in digest"
+                  description="Show matched emails in your digest summary."
+                >
+                  <Toggle
+                    name="digest"
+                    enabled={watch("digest") || false}
+                    onChange={(enabled) => {
+                      setValue("digest", enabled);
+                    }}
+                  />
+                </AdvancedRow>
+              )}
 
-                {!!rule.id && (
-                  <div className="flex">
-                    <LearnedPatternsDialog
-                      ruleId={rule.id}
-                      groupId={rule.groupId || null}
-                      disabled={isConversationStatusType(rule.systemType)}
-                    />
-                  </div>
-                )}
+              {!!rule.id && (
+                <AdvancedRow
+                  title="Learned patterns"
+                  description="Patterns inferred from your corrections."
+                >
+                  <Tooltip
+                    content="Learned patterns aren't available for this rule type."
+                    hide={!isConversationStatusType(rule.systemType)}
+                  >
+                    <span>
+                      <LearnedPatternsDialog
+                        ruleId={rule.id}
+                        groupId={rule.groupId || null}
+                        disabled={isConversationStatusType(rule.systemType)}
+                        label="View"
+                      />
+                    </span>
+                  </Tooltip>
+                </AdvancedRow>
+              )}
 
-                {rule.id && !rule.systemType && (
+              {rule.id && !rule.systemType && (
+                <AdvancedRow
+                  title="Delete rule"
+                  description="Permanently remove this rule."
+                >
                   <Button
                     size="sm"
                     variant="outline"
@@ -611,54 +640,58 @@ export function RuleForm({
                       }
                     }}
                   >
-                    Delete rule
+                    Delete
                   </Button>
-                )}
+                </AdvancedRow>
+              )}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
 
-                {rule.id && rule.systemType && (
-                  <p className="text-sm text-muted-foreground">
-                    Default rules can be disabled from the rules list.
-                  </p>
-                )}
-              </div>
-            </DialogContent>
-          </Dialog>
+        <div className="flex justify-end space-x-2">
+          {onCancel && (
+            <Button variant="outline" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
 
-          <div className="flex space-x-2">
-            {onCancel && (
-              <Button variant="outline" size="sm" onClick={onCancel}>
-                Cancel
-              </Button>
-            )}
-
-            {rule.id ? (
-              <Button
-                type="submit"
-                size="sm"
-                loading={isSubmitting}
-                disabled={isDeleting}
-              >
-                Save
-              </Button>
-            ) : (
-              <Button type="submit" size="sm" loading={isSubmitting}>
-                Create
-              </Button>
-            )}
-          </div>
+          {rule.id ? (
+            <Button
+              type="submit"
+              size="sm"
+              loading={isSubmitting}
+              disabled={isDeleting}
+            >
+              Save
+            </Button>
+          ) : (
+            <Button type="submit" size="sm" loading={isSubmitting}>
+              Create
+            </Button>
+          )}
         </div>
       </form>
     </Form>
   );
 }
 
-function ThreadsExplanation({ size }: { size: "sm" | "md" }) {
+function AdvancedRow({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
   return (
-    <TooltipExplanation
-      size={size}
-      side="right"
-      text="When enabled, this rule can apply to the first email and any subsequent replies in a conversation. When disabled, it can only apply to the first email."
-    />
+    <div className="flex items-center justify-between gap-4 px-4 py-3">
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/group/LearnedPatterns.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/group/LearnedPatterns.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { useAction } from "next-safe-action/hooks";
-import { BrainIcon } from "lucide-react";
 import { ViewLearnedPatterns } from "@/app/(app)/[emailAccountId]/assistant/group/ViewLearnedPatterns";
 import {
   Dialog,
@@ -23,10 +22,12 @@ export function LearnedPatternsDialog({
   ruleId,
   groupId,
   disabled,
+  label = "View learned patterns",
 }: {
   ruleId: string;
   groupId: string | null;
   disabled?: boolean;
+  label?: string;
 }) {
   const { emailAccountId } = useAccount();
 
@@ -60,7 +61,6 @@ export function LearnedPatternsDialog({
         <Button
           variant="outline"
           size="sm"
-          Icon={BrainIcon}
           disabled={disabled}
           onClick={async () => {
             if (!ruleId) return;
@@ -70,7 +70,7 @@ export function LearnedPatternsDialog({
             execute({ ruleId });
           }}
         >
-          View learned patterns
+          {label}
         </Button>
       </DialogTrigger>
 

--- a/apps/web/utils/messaging/platforms.ts
+++ b/apps/web/utils/messaging/platforms.ts
@@ -12,3 +12,13 @@ export function getMessagingProviderName(
 ): string {
   return PROVIDER_NAMES[provider.toUpperCase() as MessagingProvider];
 }
+
+export function getConnectAppLabel(
+  providers: ReadonlyArray<MessagingProvider | MessagingPlatform>,
+): string {
+  const names = providers.map(getMessagingProviderName);
+  if (names.length === 0) return "Connect app";
+  if (names.length === 1) return `Connect ${names[0]}`;
+  if (names.length === 2) return `Connect ${names[0]} or ${names[1]}`;
+  return `Connect ${names.slice(0, -1).join(", ")}, or ${names.at(-1)}`;
+}


### PR DESCRIPTION
## Summary
- Replace the rule form's "Advanced Settings" dialog with an inline collapsible "Advanced options" section.
- Add tooltips on disabled controls (Apply to threads, View learned patterns) explaining why they're locked for the current rule type.
- Drop the brain icon from the learned patterns trigger and let callers customize its label.
- Make the "Connect app" button name the providers enabled in env (e.g. "Connect Slack or Telegram").
- Tighten copy: "When I get an email", "Include in digest", and remove the redundant default-rule notice.

## Test plan
- [ ] Open a rule (regular, cold email, and reply tracker), verify advanced section expands/collapses and tooltips show on disabled toggles
- [ ] With only Slack env vars set, verify "Connect app" reads "Connect Slack"; with Slack + Telegram, "Connect Slack or Telegram"

🤖 Generated with [Claude Code](https://claude.com/claude-code)