### PR TITLE
assistant: Flatten rule step nesting

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ConditionSteps.tsx
@@ -332,7 +332,7 @@ export function ConditionSteps({
 
         return (
           <div
-            className={`pl-3 ${shouldIndent ? "ml-14" : ""}`}
+            className={shouldIndent ? "ml-14" : undefined}
             key={condition.id}
           >
             <RuleStep

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleSteps.tsx
@@ -1,4 +1,3 @@
-import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { PlusIcon } from "lucide-react";
 import { Tooltip } from "@/components/Tooltip";
@@ -18,7 +17,7 @@ export function RuleSteps({
   addButtonTooltip?: string;
 }) {
   return (
-    <Card className="p-4 space-y-2 border-none shadow-none bg-gray-50 dark:bg-gray-900">
+    <div className="space-y-2">
       {children}
       <div>
         <Tooltip hide={!addButtonTooltip} content={addButtonTooltip || ""}>
@@ -35,6 +34,6 @@ export function RuleSteps({
           </span>
         </Tooltip>
       </div>
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Drop the gray inner Card wrapper around rule conditions/actions in the rule editor.
- Remove the leading left padding on each step so its content aligns with the section title.

## Test plan
- [ ] Open a rule (existing and new) and verify the conditions/actions sit directly inside the outer section card with no nested gray panel and no extra left indent

🤖 Generated with [Claude Code](https://claude.com/claude-code)