### PR TITLE
assistant: Refine rule editor layout and section styling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleDialog.tsx
@@ -73,7 +73,7 @@ export function RuleDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="max-h-[90vh] max-w-4xl overflow-y-auto"
+        className="max-h-[90vh] max-w-3xl overflow-y-auto"
         aria-describedby={undefined}
       >
         <DialogHeader className={ruleId ? "sr-only" : ""}>

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -16,8 +16,8 @@ import {
   PencilIcon,
   TrashIcon,
   MailIcon,
-  BotIcon,
-  ChevronDownIcon,
+  ZapIcon,
+  ChevronRightIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
@@ -405,7 +405,7 @@ export function RuleForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-10">
         {isSubmitted && formErrors.length > 0 && (
           <div className="mt-4">
             <AlertError
@@ -446,6 +446,7 @@ export function RuleForm({
           icon={MailIcon}
           color="blue"
           title="When I get an email"
+          className="!mt-6"
           errors={
             errors.conditions?.root?.message ? (
               <AlertError
@@ -470,9 +471,9 @@ export function RuleForm({
         </RuleSectionCard>
 
         <RuleSectionCard
-          icon={BotIcon}
+          icon={ZapIcon}
           color="green"
-          title="Then:"
+          title="Then"
           errors={
             actionErrors.length > 0 ? (
               <AlertError
@@ -520,10 +521,10 @@ export function RuleForm({
               type="button"
               className="flex w-full items-center gap-2 py-2 text-sm font-medium text-left text-muted-foreground hover:text-foreground transition-colors"
             >
-              <ChevronDownIcon
+              <ChevronRightIcon
                 className={cn(
                   "size-4 transition-transform",
-                  isAdvancedOpen && "rotate-180",
+                  isAdvancedOpen && "rotate-90",
                 )}
               />
               Advanced options
@@ -652,7 +653,7 @@ export function RuleForm({
           </CollapsibleContent>
         </Collapsible>
 
-        <div className="flex justify-end space-x-2">
+        <div className="flex justify-end space-x-2 !mt-6">
           {onCancel && (
             <Button variant="outline" size="sm" onClick={onCancel}>
               Cancel

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -15,7 +15,7 @@ import { env } from "@/env";
 import {
   PencilIcon,
   TrashIcon,
-  MailIcon,
+  InboxIcon,
   ZapIcon,
   ChevronRightIcon,
 } from "lucide-react";
@@ -443,7 +443,7 @@ export function RuleForm({
         </div>
 
         <RuleSectionCard
-          icon={MailIcon}
+          icon={InboxIcon}
           color="blue"
           title="When I get an email"
           className="!mt-6"

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleSectionCard.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleSectionCard.tsx
@@ -1,4 +1,3 @@
-import { Card } from "@/components/ui/card";
 import { TypographyH3 } from "@/components/Typography";
 import { cn } from "@/utils";
 
@@ -8,30 +7,30 @@ export function RuleSectionCard({
   title,
   errors,
   children,
+  className,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   color: "blue" | "green";
   title: string;
   errors?: React.ReactNode;
   children: React.ReactNode;
+  className?: string;
 }) {
   return (
-    <Card className="rounded-lg p-4">
-      <div>
-        <div className="flex items-center gap-3">
-          <Icon
-            className={cn("size-5", {
-              "text-blue-600 dark:text-blue-400": color === "blue",
-              "text-green-600 dark:text-green-400": color === "green",
-            })}
-          />
-          <TypographyH3 className="text-base">{title}</TypographyH3>
-        </div>
-
-        {errors && <div className="mt-2">{errors}</div>}
-
-        {children && <div className="mt-4 space-y-2">{children}</div>}
+    <div className={className}>
+      <div className="flex items-center gap-3">
+        <Icon
+          className={cn("size-5", {
+            "text-blue-600 dark:text-blue-400": color === "blue",
+            "text-green-600 dark:text-green-400": color === "green",
+          })}
+        />
+        <TypographyH3 className="text-base">{title}</TypographyH3>
       </div>
-    </Card>
+
+      {errors && <div className="mt-2">{errors}</div>}
+
+      {children && <div className="mt-4 space-y-2">{children}</div>}
+    </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleSteps.tsx
@@ -23,11 +23,12 @@ export function RuleSteps({
         <Tooltip hide={!addButtonTooltip} content={addButtonTooltip || ""}>
           <span>
             <Button
-              variant="ghost"
+              variant="outline"
               size="sm"
               onClick={onAdd}
               disabled={addButtonDisabled}
               Icon={PlusIcon}
+              className="border-dashed text-muted-foreground hover:text-foreground"
             >
               {addButtonLabel}
             </Button>


### PR DESCRIPTION
## Summary
- Drop the outer Card chrome from the When/Then sections so the rule editor reads as a flat dialog instead of nested cards.
- Narrow the dialog (max-w-3xl), bump section spacing, and pull the title and bottom buttons closer to their adjacent sections.
- Tighten copy and icons: drop the colon from "Then", swap the bot icon for a lightning bolt.
- Switch add-row buttons (Add Condition / Add Action) to a dashed-outline tertiary style so they don't compete with the primary section content.

## Test plan
- [ ] Open a rule (existing and new); confirm flat layout, narrower dialog, and dashed Add Condition / Add Action buttons
- [ ] Verify the Then section now shows a lightning bolt and reads "Then" with no colon

🤖 Generated with [Claude Code](https://claude.com/claude-code)