### PR TITLE
assistant: Note when drafts also deliver to chat

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -605,6 +605,10 @@ export function RuleForm({
                   onChange={(channelId) => {
                     setValue("notifyMessagingChannelId", channelId);
                   }}
+                  hasDraftToChat={watch("actions")?.some(
+                    (action) =>
+                      action.type === ActionType.DRAFT_MESSAGING_CHANNEL,
+                  )}
                 />
 
                 {!!rule.id && (
@@ -726,12 +730,14 @@ function NotifyChannelRow({
   emailAccountId,
   value,
   onChange,
+  hasDraftToChat,
 }: {
   channels: GetMessagingChannelsResponse["channels"];
   availableProviders: GetMessagingChannelsResponse["availableProviders"];
   emailAccountId: string;
   value: string | null;
   onChange: (channelId: string | null) => void;
+  hasDraftToChat?: boolean;
 }) {
   const router = useRouter();
   const connectedChannels = getConnectedRuleNotificationChannels(channels);
@@ -746,12 +752,16 @@ function NotifyChannelRow({
     !connectedChannels.some((channel) => channel.id === selectedChannel.id);
 
   const channelsPath = prefixPath(emailAccountId, "/channels");
+  const draftsNote = hasDraftToChat
+    ? "Drafts also go to chat — configured in actions above."
+    : undefined;
 
   if (!hasChannels && !showDisconnectedOption) {
     return (
       <AdvancedRow
         title="Notify in chat"
         description="Send a message when this rule matches."
+        note={draftsNote}
       >
         <Button asChild variant="outline" size="sm">
           <Link href={channelsPath}>Connect</Link>
@@ -775,6 +785,7 @@ function NotifyChannelRow({
     <AdvancedRow
       title="Notify in chat"
       description="Send a message when this rule matches."
+      note={draftsNote}
     >
       <Select
         value={value ?? "off"}
@@ -834,18 +845,23 @@ function AdvancedRow({
   title,
   description,
   children,
+  note,
 }: {
   title: string;
   description: string;
   children: ReactNode;
+  note?: ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-3">
-      <div>
-        <p className="text-sm font-medium">{title}</p>
-        <p className="text-sm text-muted-foreground">{description}</p>
+    <div className="px-4 py-3 space-y-2">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium">{title}</p>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        <div className="shrink-0">{children}</div>
       </div>
-      <div className="shrink-0">{children}</div>
+      {note ? <p className="text-xs text-muted-foreground">{note}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- The rule editor's "Notify in chat" row already shows the notify destination, but said "Off" even when the rule had draft-to-chat actions configured, which read as "no chat output at all."
- Added a small caption underneath the row that surfaces when the rule has any draft-to-chat action: "Drafts also go to chat — configured in actions above."
- Extended `AdvancedRow` with an optional `note` slot so other advanced rows can opt in to this same kind of supplemental hint without breaking the divider layout.

## Test plan
- [ ] On a rule with no chat actions: row shows just title/description/select, no caption.
- [ ] On a rule with one or more `DRAFT_MESSAGING_CHANNEL` actions: caption appears under the row regardless of the notify select state (Off, channel, Connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)