### PR TITLE
Fix email action confirmation race

### DIFF
--- a/apps/web/app/api/chat/confirm-email-action/route.test.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.test.ts
@@ -87,6 +87,7 @@ describe("confirm email action route", () => {
     expect(mockConfirmAssistantEmailActionForAccount).toHaveBeenCalledWith({
       ...body,
       waitForPersistence: true,
+      persistenceWaitMs: 10_000,
       emailAccountId: "email-account-1",
       logger: request.logger,
       provider: "google",

--- a/apps/web/app/api/chat/confirm-email-action/route.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.ts
@@ -5,6 +5,7 @@ import { withEmailAccount } from "@/utils/middleware";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 
 export const maxDuration = 120;
+const MOBILE_PENDING_ACTION_PERSIST_WAIT_MS = 10_000;
 
 // Mobile clients call this endpoint directly; web uses the server action path.
 export const POST = withEmailAccount(
@@ -36,6 +37,7 @@ export const POST = withEmailAccount(
       actionType: data.actionType,
       contentOverride: data.contentOverride,
       waitForPersistence: true,
+      persistenceWaitMs: MOBILE_PENDING_ACTION_PERSIST_WAIT_MS,
       emailAccountId,
       provider: user.account.provider,
       logger: request.logger,

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -808,6 +808,65 @@ describe("confirmAssistantEmailAction", () => {
     expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps waiting when mobile confirmation reaches the server before persistence finishes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    (prisma.emailAccount.findUnique as any).mockResolvedValueOnce({
+      name: "Owner",
+      email: "owner@example.com",
+    });
+
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "assistant-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildProcessingSendPart()],
+    } as any);
+    prisma.chatMessage.findMany.mockImplementation(() =>
+      Promise.resolve(
+        Date.now() >= 4000
+          ? ([
+              {
+                id: "assistant-message-1",
+                chatId: "chat-1",
+                updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+                parts: [buildPendingSendPart()],
+              },
+            ] as any)
+          : ([] as any),
+      ),
+    );
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sendEmailWithHtml = vi.fn().mockResolvedValue({
+      messageId: "msg-1",
+      threadId: "thr-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      sendEmailWithHtml,
+    } as any);
+
+    const resultPromise = confirmAssistantEmailActionForAccount({
+      chatId: "chat-1",
+      toolCallId: "tool-1",
+      actionType: "send_email",
+      waitForPersistence: true,
+      persistenceWaitMs: 10_000,
+      emailAccountId: "ea_1",
+      provider: "google",
+      logger: createScopedLogger("test/assistant-email-confirmation"),
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.confirmationState).toBe("confirmed");
+    expect(sendEmailWithHtml).toHaveBeenCalledTimes(1);
+  });
+
   it("waits for pending email persistence in the web confirmation action", async () => {
     vi.useFakeTimers();
 

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -139,6 +139,7 @@ export async function confirmAssistantEmailActionForAccount({
   actionType,
   contentOverride,
   waitForPersistence,
+  persistenceWaitMs,
   emailAccountId,
   provider,
   logger,
@@ -149,6 +150,7 @@ export async function confirmAssistantEmailActionForAccount({
   actionType: AssistantPendingEmailActionType;
   contentOverride?: string;
   waitForPersistence?: boolean;
+  persistenceWaitMs?: number;
   emailAccountId: string;
   provider: string;
   logger: Logger;
@@ -160,6 +162,7 @@ export async function confirmAssistantEmailActionForAccount({
     actionType,
     emailAccountId,
     waitForPersistence,
+    persistenceWaitMs,
     logger,
   });
 
@@ -956,6 +959,7 @@ async function reservePendingAssistantEmailAction({
   actionType,
   emailAccountId,
   waitForPersistence,
+  persistenceWaitMs,
   logger,
 }: {
   chatId: string;
@@ -964,12 +968,13 @@ async function reservePendingAssistantEmailAction({
   actionType: AssistantPendingEmailActionType;
   emailAccountId: string;
   waitForPersistence?: boolean;
+  persistenceWaitMs?: number;
   logger: Logger;
 }) {
   const matchEmailParts = (parts: unknown) =>
     !!findPendingAssistantEmailPart({ parts, toolCallId, actionType });
   const waitForPersistenceMs = waitForPersistence
-    ? PENDING_ACTION_PERSIST_WAIT_MS
+    ? (persistenceWaitMs ?? PENDING_ACTION_PERSIST_WAIT_MS)
     : undefined;
 
   const chatMessage = await findChatMessageForPendingAction({


### PR DESCRIPTION
Fixes a race where email action confirmation can arrive before the pending assistant message has finished persisting.

- Allows the direct confirmation endpoint to wait longer for pending action persistence.
- Keeps the shared confirmation default unchanged unless a caller overrides it.
- Adds regression coverage for delayed persistence during confirmation.