### PR TITLE
reply memory: Avoid public domain scopes

### DIFF
--- a/apps/web/utils/ai/reply/extract-reply-memories.ts
+++ b/apps/web/utils/ai/reply/extract-reply-memories.ts
@@ -5,7 +5,7 @@ import {
 } from "@/generated/prisma/enums";
 import type { ReplyMemory } from "@/generated/prisma/client";
 import { getUserInfoPrompt } from "@/utils/ai/helpers";
-import { extractDomainFromEmail } from "@/utils/email";
+import { extractDomainFromEmail, PUBLIC_EMAIL_DOMAINS } from "@/utils/email";
 import { createGenerateObject } from "@/utils/llms";
 import { getModel } from "@/utils/llms/model";
 import { isDefined } from "@/utils/types";
@@ -73,6 +73,7 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
   }
 
   const senderDomain = extractDomainFromEmail(normalizedSenderEmail);
+  const allowDomainScope = !isPublicEmailDomain(senderDomain);
   const prompt = getPrompt({
     senderEmail: normalizedSenderEmail,
     senderDomain,
@@ -95,7 +96,7 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
 
   const result = await generateObject({
     ...modelOptions,
-    system: getSystemPrompt(),
+    system: getSystemPrompt({ allowDomainScope }),
     prompt,
     schema: replyMemorySchema,
   });
@@ -128,6 +129,13 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
       if (
         newMemory.scopeType === ReplyMemoryScopeType.TOPIC &&
         !newMemory.scopeValue.length
+      ) {
+        return null;
+      }
+
+      if (
+        newMemory.scopeType === ReplyMemoryScopeType.DOMAIN &&
+        !allowDomainScope
       ) {
         return null;
       }
@@ -232,7 +240,16 @@ function normalizeMemoryText(value: string) {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
-function getSystemPrompt() {
+function getSystemPrompt({ allowDomainScope }: { allowDomainScope: boolean }) {
+  const domainScopePrompt = allowDomainScope
+    ? `- DOMAIN: applies to one sender domain
+`
+    : "";
+  const domainRulePrompt = allowDomainScope
+    ? `- For DOMAIN scope, use the exact sender domain from the context.
+`
+    : "- DOMAIN scope is unavailable because the sender domain is a public email provider. Use SENDER for sender-specific rules, GLOBAL for broad account rules, or TOPIC for reusable topics.\n";
+
   return `You analyze how a user edits AI-generated email reply drafts and turn durable patterns into reusable drafting memories.
 
 Return only memories that are likely to help with future drafts.
@@ -245,7 +262,7 @@ Memory kinds:
 Scopes:
 - GLOBAL: applies broadly to the user's replies
 - SENDER: applies to one sender email address
-- DOMAIN: applies to one sender domain
+${domainScopePrompt.trimEnd()}
 - TOPIC: applies to a reusable topic or subject area
 
 Rules:
@@ -262,7 +279,7 @@ Rules:
 - Use PREFERENCE for stable tone, length, formatting, or phrasing preferences.
 - For GLOBAL scope, leave scopeValue empty.
 - For SENDER scope, use the exact sender email from the context.
-- For DOMAIN scope, use the exact sender domain from the context.
+${domainRulePrompt.trimEnd()}
 - For TOPIC scope, use a short stable topic phrase such as "pricing" or "refunds".
 - Always include a scopeValue field. Use an empty string for GLOBAL scope.
 - If an existing memory already captures the same durable idea, return its id in matchingExistingMemoryId and set newMemory to null.
@@ -271,4 +288,8 @@ Rules:
 - Be conservative about matching existing memories. Only match when the existing memory clearly already covers the same durable idea.
 - Work language-agnostically. The memories may be written in any language.
 - If nothing durable was learned, return an empty array.`;
+}
+
+function isPublicEmailDomain(domain: string) {
+  return PUBLIC_EMAIL_DOMAINS.has(domain.trim().toLowerCase());
 }

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -223,6 +223,46 @@ describe("reply-memory", () => {
     );
   });
 
+  it("does not retrieve domain-scoped reply memories for public email domains", async () => {
+    vi.mocked(prisma.replyMemory.findMany)
+      .mockResolvedValueOnce([
+        createReplyMemory({
+          id: "sender-memory",
+          content: "Use the sender-specific instruction.",
+          kind: ReplyMemoryKind.FACT,
+          scopeType: ReplyMemoryScopeType.SENDER,
+          scopeValue: "customer@gmail.com",
+        }),
+      ] as any)
+      .mockResolvedValueOnce([
+        createReplyMemory({
+          id: "global-memory",
+          content: "Use the global instruction.",
+          kind: ReplyMemoryKind.PROCEDURE,
+          scopeType: ReplyMemoryScopeType.GLOBAL,
+        }),
+      ] as any);
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as any);
+
+    const result = await getReplyMemoriesForPrompt({
+      emailAccountId: "account-1",
+      senderEmail: "customer@gmail.com",
+      emailContent: "Can you help with my event?",
+      logger,
+    });
+
+    expect(result.selectedMemories).toHaveLength(2);
+    expect(prisma.replyMemory.findMany).toHaveBeenCalledTimes(2);
+    expect(prisma.replyMemory.findMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          scopeType: ReplyMemoryScopeType.DOMAIN,
+          scopeValue: "gmail.com",
+        }),
+      }),
+    );
+  });
+
   it("keeps sender memories ahead of newer global memories when retrieval is capped", async () => {
     vi.mocked(prisma.replyMemory.findMany)
       .mockResolvedValueOnce([
@@ -1228,6 +1268,62 @@ describe("reply-memory", () => {
       logger,
     });
 
+    expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
+  });
+
+  it("skips domain memories for public email domains", async () => {
+    vi.mocked(prisma.draftSendLog.updateMany).mockResolvedValue({
+      count: 0,
+    });
+    vi.mocked(prisma.draftSendLog.findMany).mockResolvedValue([
+      createDraftSendLog({
+        replyMemorySentText: "Use the portal link for signup issues.",
+      }),
+    ] as any);
+    vi.mocked(prisma.replyMemory.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.replyMemory.upsert).mockResolvedValue(
+      createReplyMemory({}) as any,
+    );
+    vi.mocked(prisma.draftSendLog.update).mockResolvedValue({} as any);
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        memories: [
+          newReplyMemoryDecision({
+            content: "For signup issues, send the portal link.",
+            kind: ReplyMemoryKind.PROCEDURE,
+            scopeType: ReplyMemoryScopeType.DOMAIN,
+            scopeValue: "gmail.com",
+          }),
+        ],
+      },
+    });
+
+    const provider = {
+      getMessage: vi
+        .fn()
+        .mockResolvedValue(
+          createSourceMessage({ from: "Customer <customer@gmail.com>" }),
+        ),
+    };
+
+    await syncReplyMemoriesFromDraftSendLogs({
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+    });
+
+    expect(prisma.replyMemory.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.not.arrayContaining([
+            {
+              scopeType: ReplyMemoryScopeType.DOMAIN,
+              scopeValue: "gmail.com",
+            },
+          ]),
+        }),
+      }),
+    );
     expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
   });
 

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -1441,6 +1441,52 @@ describe("reply-memory", () => {
     ]);
   });
 
+  it("does not offer or return domain-scoped memories for public email domains", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        memories: [
+          newReplyMemoryDecision({
+            content: "For signup issues, send the portal link.",
+            kind: ReplyMemoryKind.PROCEDURE,
+            scopeType: ReplyMemoryScopeType.DOMAIN,
+            scopeValue: "gmail.com",
+          }),
+        ],
+      },
+    });
+
+    const result = await aiExtractReplyMemoriesFromDraftEdit({
+      emailAccount: {
+        id: "account-1",
+        userId: "user-1",
+        email: "user@example.com",
+        about: null,
+        multiRuleSelectionEnabled: false,
+        timezone: "UTC",
+        calendarBookingLink: null,
+        name: "User",
+        user: {
+          aiProvider: null,
+          aiModel: null,
+          aiApiKey: null,
+        },
+        account: {
+          provider: "google",
+        },
+      } as any,
+      incomingEmailContent: "I cannot sign up for the event.",
+      draftText: "Try again later.",
+      sentText: "Please log in to the portal and try signing up again.",
+      senderEmail: "customer@gmail.com",
+      existingMemories: [],
+    });
+
+    const systemPrompt = mockGenerateObject.mock.calls[0]?.[0]?.system;
+    expect(systemPrompt).not.toContain("- DOMAIN: applies");
+    expect(systemPrompt).toContain("DOMAIN scope is unavailable");
+    expect(result).toEqual([]);
+  });
+
   it("caps extracted reply memories at the per-edit limit", async () => {
     mockGenerateObject.mockResolvedValue({
       object: {

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -3,7 +3,11 @@ import {
   ReplyMemoryScopeType,
 } from "@/generated/prisma/enums";
 import type { Prisma, ReplyMemory } from "@/generated/prisma/client";
-import { extractDomainFromEmail, extractEmailAddress } from "@/utils/email";
+import {
+  extractDomainFromEmail,
+  extractEmailAddress,
+  PUBLIC_EMAIL_DOMAINS,
+} from "@/utils/email";
 import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { Logger } from "@/utils/logger";
@@ -179,7 +183,7 @@ export async function getReplyMemoriesForPrompt({
             scopeValue: normalizedSenderEmail,
           })
         : Promise.resolve([]),
-      senderDomain
+      senderDomain && !isPublicEmailDomain(senderDomain)
         ? fetchReplyMemoriesByScope({
             emailAccountId,
             kinds: PROMPTABLE_REPLY_MEMORY_KINDS,
@@ -461,6 +465,13 @@ async function processReplyMemoryDraftSendLog({
       senderDomain,
     });
 
+    if (
+      normalizedMemory.scopeType === ReplyMemoryScopeType.DOMAIN &&
+      isPublicEmailDomain(normalizedScopeValue)
+    ) {
+      continue;
+    }
+
     // Non-global memories need a concrete scope target to be retrievable.
     if (
       normalizedMemory.scopeType !== ReplyMemoryScopeType.GLOBAL &&
@@ -695,7 +706,7 @@ function getReplyMemoryScopes({
           },
         ]
       : []),
-    ...(senderDomain
+    ...(senderDomain && !isPublicEmailDomain(senderDomain)
       ? [
           {
             scopeType: ReplyMemoryScopeType.DOMAIN,
@@ -834,6 +845,10 @@ function getNormalizedReplyMemoryScopeValue({
     case ReplyMemoryScopeType.TOPIC:
       return memory.scopeValue.trim().toLowerCase();
   }
+}
+
+function isPublicEmailDomain(domain: string) {
+  return PUBLIC_EMAIL_DOMAINS.has(domain.trim().toLowerCase());
 }
 
 function formatPreferenceMemoryEvidence(


### PR DESCRIPTION
Prevents reply memories from using public email domains as reusable domain scopes.

- Skips domain-scoped retrieval for public email providers
- Skips creating domain-scoped reply memories for public email providers
- Adds focused coverage for retrieval and learning behavior

Validation:
- pnpm --filter inbox-zero-ai test utils/ai/reply/reply-memory.test.ts --run