### PR TITLE
Fix Outlook draft recipient overrides

### DIFF
--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -642,6 +642,81 @@ describe("forwardEmail", () => {
 });
 
 describe("draftEmail", () => {
+  it("uses explicit recipient override when drafting a follow-up from a sent message", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: true }));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({ id: "draft-1" }) as Message);
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await draftEmail(
+      client,
+      {
+        id: "message-1",
+        threadId: "conversation-1",
+        headers: {
+          from: "Owner Name <owner@example.com>",
+          to: "Recipient Name <recipient@example.com>",
+          subject: "Original subject",
+          date: "2026-01-01T12:00:00.000Z",
+        },
+        rawRecipients: {
+          from: {
+            emailAddress: {
+              address: "owner@example.com",
+              name: "Owner Name",
+            },
+          },
+          toRecipients: [
+            {
+              emailAddress: {
+                address: "recipient@example.com",
+                name: "Recipient Name",
+              },
+            },
+          ],
+          ccRecipients: [],
+        },
+        textPlain: "Original body",
+        textHtml: "<p>Original body</p>",
+      } as EmailForAction,
+      {
+        to: "Recipient Name <recipient@example.com>",
+        content: "Draft body",
+      },
+      "owner@example.com",
+      createScopedLogger("outlook-mail-test"),
+    );
+
+    expect(updateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toRecipients: [
+          {
+            emailAddress: {
+              address: "recipient@example.com",
+              name: "Recipient Name",
+            },
+          },
+        ],
+      }),
+    );
+  });
+
   it("clears default reply-all CC and BCC recipients when no recipients are requested", async () => {
     const getOriginalReadStatus = vi.fn(async () => ({ isRead: true }));
     const createReplyAllDraft = vi.fn(

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -289,13 +289,26 @@ export async function draftEmail(
     userEmail,
   );
 
-  // Use raw recipients if available (Outlook), otherwise parse from string (Gmail)
-  const toRecipient = originalEmail.rawRecipients?.from || {
+  const overrideToRecipient = args.to
+    ? {
+        emailAddress: {
+          address: extractEmailAddress(recipients.to),
+          name: extractNameFromEmail(recipients.to),
+        },
+      }
+    : undefined;
+
+  const fallbackToRecipient = {
     emailAddress: {
       address: extractEmailAddress(recipients.to),
       name: extractNameFromEmail(recipients.to),
     },
   };
+
+  const toRecipient =
+    overrideToRecipient ??
+    originalEmail.rawRecipients?.from ??
+    fallbackToRecipient;
 
   // Build CC list from reply-all and args
   const ccAddresses = mergeAndDedupeRecipients(recipients.cc, args.cc);


### PR DESCRIPTION
Fixes Outlook draft creation so explicit recipient overrides take precedence over provider metadata.\n\nAdds a regression test for follow-up drafts created from sent messages.\n\nVerified with the focused Outlook mail test and formatter check.