### PR TITLE
reply memory: Improve learned style summaries

### DIFF
--- a/apps/web/__tests__/eval/reply-memory.test.ts
+++ b/apps/web/__tests__/eval/reply-memory.test.ts
@@ -662,83 +662,69 @@ Thanks,`,
     test(
       "summarizes repeated preference evidence into a prompt-ready learned writing style",
       async () => {
+        const conciseStyleEvidence = [
+          {
+            title: "concise tone",
+            content: "Keep replies short and remove filler.",
+            draftText:
+              "Hi there! Thanks so much for checking in. I just wanted to let you know that I got your note and will take a look soon.",
+            sentText: "Got it. I will review and get back to you.",
+          },
+          {
+            title: "low ceremony",
+            content: "Skip greetings and sign-offs for routine replies.",
+            draftText:
+              "Hi! Thanks again for the follow-up. I appreciate the reminder and will send an update shortly. Best,",
+            sentText: "I will send an update shortly.",
+          },
+          {
+            title: "plain wording",
+            content:
+              "Prefer plain declarative phrasing over warm filler in status updates.",
+            draftText:
+              "I just wanted to let you know that I am still on track and hope to have more to share very soon.",
+            sentText: "Still on track. I will share more soon.",
+          },
+        ];
         const learnedWritingStyle = await aiSummarizeLearnedWritingStyle({
-          preferenceMemoryEvidence: buildPreferenceMemoryEvidence([
-            {
-              title: "concise tone",
-              content: "Keep replies short and remove filler.",
-              draftText:
-                "Hi there! Thanks so much for checking in. I just wanted to let you know that I got your note and will take a look soon.",
-              sentText: "Got it. I will review and get back to you.",
-            },
-            {
-              title: "low ceremony",
-              content: "Skip greetings and sign-offs for routine replies.",
-              draftText:
-                "Hi! Thanks again for the follow-up. I appreciate the reminder and will send an update shortly. Best,",
-              sentText: "I will send an update shortly.",
-            },
-            {
-              title: "plain wording",
-              content:
-                "Prefer plain declarative phrasing over warm filler in status updates.",
-              draftText:
-                "I just wanted to let you know that I am still on track and hope to have more to share very soon.",
-              sentText: "Still on track. I will share more soon.",
-            },
-          ]),
+          preferenceMemoryEvidence:
+            buildPreferenceMemoryEvidence(conciseStyleEvidence),
           emailAccount: replyMemoryEmailAccount,
         });
+        const hasActionableShape =
+          learnedWritingStyle.includes("Actionable rules:") &&
+          learnedWritingStyle.includes("Before/after patterns:") &&
+          /one|1|sentence|brief|short|terse/i.test(learnedWritingStyle) &&
+          /greeting|sign[- ]?off|ceremony/i.test(learnedWritingStyle);
 
         const judgeResult = await judgeBinary({
           input: [
             "## Style Evidence",
-            buildPreferenceMemoryEvidence([
-              {
-                title: "concise tone",
-                content: "Keep replies short and remove filler.",
-                draftText:
-                  "Hi there! Thanks so much for checking in. I just wanted to let you know that I got your note and will take a look soon.",
-                sentText: "Got it. I will review and get back to you.",
-              },
-              {
-                title: "low ceremony",
-                content: "Skip greetings and sign-offs for routine replies.",
-                draftText:
-                  "Hi! Thanks again for the follow-up. I appreciate the reminder and will send an update shortly. Best,",
-                sentText: "I will send an update shortly.",
-              },
-              {
-                title: "plain wording",
-                content:
-                  "Prefer plain declarative phrasing over warm filler in status updates.",
-                draftText:
-                  "I just wanted to let you know that I am still on track and hope to have more to share very soon.",
-                sentText: "Still on track. I will share more soon.",
-              },
-            ]),
+            buildPreferenceMemoryEvidence(conciseStyleEvidence),
           ].join("\n"),
           output: learnedWritingStyle,
           expected:
-            "A compact learned writing style summary that captures brevity, low ceremony, and plain wording without copying full email text.",
+            "A compact learned writing style summary with actionable drafting constraints and short before/after patterns. It should capture brevity, low ceremony, and plain wording without copying full email text.",
           criterion: {
             name: "Learned writing style summary quality",
             description:
-              "The summary should distill repeated evidence into an account-level style guide with concise patterns and short representative edits, not raw quotes or one-off instructions.",
+              "The summary should distill repeated evidence into an account-level style guide with concrete instructions that can change future drafts, such as sentence count, greeting/sign-off habits, filler removal, and concise before/after patterns.",
           },
           judgeUserAi: getEvalJudgeUserAi(),
         });
-        const pass = judgeResult.pass;
+        const pass = hasActionableShape && judgeResult.pass;
 
         evalReporter.record({
           testName: "learned style summary quality",
           model: model.label,
           pass,
-          expected: "prompt-ready learned writing style summary",
+          expected:
+            "actionable learned writing style with before/after patterns",
           actual: formatJudgeActual(learnedWritingStyle, judgeResult),
           criteria: [judgeResult],
         });
 
+        expect(hasActionableShape).toBe(true);
         expect(judgeResult.pass).toBe(true);
       },
       TIMEOUT,

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 8;
+export const DRAFT_PIPELINE_VERSION = 9;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/summarize-learned-writing-style.ts
+++ b/apps/web/utils/ai/reply/summarize-learned-writing-style.ts
@@ -41,16 +41,17 @@ Summarize the user's learned writing style from this preference evidence.`;
 function getSystemPrompt() {
   return `You maintain a compact learned writing-style summary for an email user based on accumulated preference memories from prior draft edits.
 
-Return a concise prompt-ready style guide that helps draft future emails.
+Return a concise prompt-ready style guide that helps draft future emails match the user's edits.
 
 Rules:
 - Summarize repeated style patterns, not one-off instructions.
+- Make the guidance operational. Prefer concrete constraints such as sentence count, whether to use greetings/sign-offs, how many questions or next steps to include, how much explanation to add, and how warm or plain the tone should be.
 - Focus on directness, verbosity, greeting habits, sign-off habits, paragraph structure, formatting, and how much filler the user removes.
 - Keep it under 1500 characters.
 - Include two sections exactly:
-  1. "Observed patterns:" with 2-5 bullets
-  2. "Representative edits:" with 2-3 short bullets
-- Representative edits should be short paraphrases of draft-to-send changes, not full email quotes.
+  1. "Actionable rules:" with 3-6 bullets
+  2. "Before/after patterns:" with 2-3 short bullets
+- Before/after patterns should be compact, sanitized examples that show how the user tends to compress drafts. Use short paraphrases, not full email quotes.
 - Do not mention names, email addresses, company names, phone numbers, dates, links, or other identifying details.
 - This learned summary is advisory and should complement, not replace, explicit user-written style settings.`;
 }


### PR DESCRIPTION
## Summary
- Make learned writing style summaries more actionable with concrete drafting constraints
- Include compact before/after patterns in learned style summaries
- Add eval assertions for the new summary shape and bump draft attribution version

## Test plan
- [x] pnpm --filter inbox-zero-ai test utils/ai/reply/reply-memory.test.ts utils/ai/reply/draft-reply.formatting.test.ts --run
- [x] EVAL_MODELS=gpt-5.4-mini pnpm --filter inbox-zero-ai test-ai eval/reply-memory -t "learned writing style"