### PR TITLE
follow-ups: Clearer Slack nudge messages

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -280,9 +280,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         accessToken: "emulator-token",
         channelId: notifChannelId,
         subject: "Contract terms",
-        counterparty: "jane@partner.com",
+        counterpartyName: "Jane Partner",
+        counterpartyEmail: "jane@partner.com",
         trackerType: ThreadTrackerType.AWAITING,
         daysSinceSent: 4,
+        snippet: "Wanted to check whether the redlines have landed.",
         threadLink: "https://mail.example.com/thread/awaiting",
       });
 
@@ -290,9 +292,11 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         accessToken: "emulator-token",
         channelId: notifChannelId,
         subject: "Onboarding questions",
-        counterparty: "alex@customer.com",
+        counterpartyName: "Alex Customer",
+        counterpartyEmail: "alex@customer.com",
         trackerType: ThreadTrackerType.NEEDS_REPLY,
         daysSinceSent: 1,
+        snippet: "Could you walk me through the SSO setup?",
         threadLink: "https://mail.example.com/thread/needs-reply",
       });
 
@@ -317,18 +321,28 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const awaitingBlocks = JSON.stringify(awaitingCall![0].blocks);
       expect(awaitingBlocks).toContain("Follow-up nudge");
+      expect(awaitingBlocks).toContain("they haven't replied");
       expect(awaitingBlocks).toContain("sent 4 days ago");
-      // AWAITING: the user emailed jane — preposition must be "to", not "from"
-      expect(awaitingBlocks).toContain("to _jane@partner.com_");
-      expect(awaitingBlocks).not.toContain("from _jane@partner.com_");
+      expect(awaitingBlocks).toContain("Jane Partner");
+      expect(awaitingBlocks).toContain("jane@partner.com");
+      // AWAITING: the user emailed Jane — preposition must be "to", not "from"
+      expect(awaitingBlocks).toContain("to *Jane Partner*");
+      expect(awaitingBlocks).not.toContain("from *Jane Partner*");
+      expect(awaitingBlocks).toContain(
+        "Wanted to check whether the redlines have landed.",
+      );
       expect(awaitingBlocks).toContain(
         "https://mail.example.com/thread/awaiting",
       );
 
       const needsReplyBlocks = JSON.stringify(needsReplyCall![0].blocks);
-      expect(needsReplyBlocks).toContain("Reply needed");
+      expect(needsReplyBlocks).toContain("Follow-up nudge");
+      expect(needsReplyBlocks).toContain("you haven't replied");
       expect(needsReplyBlocks).toContain("received 1 day ago");
-      expect(needsReplyBlocks).toContain("from _alex@customer.com_");
+      expect(needsReplyBlocks).toContain("from *Alex Customer*");
+      expect(needsReplyBlocks).toContain(
+        "Could you walk me through the SSO setup?",
+      );
     });
 
     test("addReaction/removeReaction manages processing indicator", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -688,7 +688,8 @@ describe("processAccountFollowUps - dedup logic", () => {
     expect(sendFollowUpNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         subject: "Pricing follow-up",
-        counterparty: "Alex Partner",
+        counterpartyName: "Alex Partner",
+        counterpartyEmail: "alex@partner.com",
         trackerType: ThreadTrackerType.AWAITING,
       }),
     );
@@ -744,7 +745,8 @@ describe("processAccountFollowUps - dedup logic", () => {
     expect(sendFollowUpNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         subject: "Customer reply needed",
-        counterparty: "Morgan Customer",
+        counterpartyName: "Morgan Customer",
+        counterpartyEmail: "morgan@customer.com",
         trackerType: ThreadTrackerType.NEEDS_REPLY,
       }),
     );
@@ -786,7 +788,8 @@ describe("processAccountFollowUps - dedup logic", () => {
     expect(sendFollowUpNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         subject: "Missing recipient header",
-        counterparty: "someone",
+        counterpartyName: "someone",
+        counterpartyEmail: "",
         trackerType: ThreadTrackerType.AWAITING,
       }),
     );

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -33,7 +33,11 @@ import {
 } from "@/utils/reply-tracker/label-helpers";
 import { getRuleLabel } from "@/utils/rule/consts";
 import { internalDateToDate } from "@/utils/date";
-import { extractNameFromEmail, isSameEmailAddress } from "@/utils/email";
+import {
+  extractEmailAddress,
+  extractNameFromEmail,
+  isSameEmailAddress,
+} from "@/utils/email";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 import { env } from "@/env";
@@ -501,16 +505,20 @@ async function processFollowUpsForType({
         // the ledger to skip next run. Retrying would burn provider rate
         // limits (Gmail re-labeling, Slack API) if a channel is misconfigured.
         try {
-          await sendFollowUpNotification({
-            channels: notificationChannels,
-            subject: lastMessage.subject || "(no subject)",
-            counterparty: resolveFollowUpCounterparty({
+          const { name: counterpartyName, email: counterpartyEmail } =
+            resolveFollowUpCounterparty({
               trackerType,
               fromHeader: lastMessage.headers.from,
               toHeader: lastMessage.headers.to,
-            }),
+            });
+          await sendFollowUpNotification({
+            channels: notificationChannels,
+            subject: lastMessage.subject || "(no subject)",
+            counterpartyName,
+            counterpartyEmail,
             trackerType,
             daysSinceSent: Math.max(1, differenceInDays(now, messageDate)),
+            snippet: lastMessage.snippet || undefined,
             threadLink:
               getEmailUrlForOptionalMessage({
                 messageId: lastMessage.id,
@@ -692,10 +700,12 @@ function resolveFollowUpCounterparty({
   trackerType: ThreadTrackerType;
   fromHeader: string;
   toHeader: string;
-}) {
+}): { name: string; email: string } {
   // AWAITING: user emailed someone — return the recipient.
   // NEEDS_REPLY: someone emailed the user — return the sender.
   const header =
     trackerType === ThreadTrackerType.AWAITING ? toHeader : fromHeader;
-  return extractNameFromEmail(header || "") || header || "someone";
+  const email = extractEmailAddress(header || "") || header || "";
+  const name = extractNameFromEmail(header || "") || email || "someone";
+  return { name, email };
 }

--- a/apps/web/utils/follow-up/copy.ts
+++ b/apps/web/utils/follow-up/copy.ts
@@ -1,0 +1,19 @@
+import { ThreadTrackerType } from "@/generated/prisma/enums";
+
+const SNIPPET_MAX_CHARS = 280;
+
+export function getFollowUpCopy(trackerType: ThreadTrackerType) {
+  const isAwaiting = trackerType === ThreadTrackerType.AWAITING;
+  return {
+    isAwaiting,
+    directionLine: isAwaiting ? "they haven't replied" : "you haven't replied",
+    preposition: isAwaiting ? "to" : "from",
+    verb: isAwaiting ? "sent" : "received",
+  };
+}
+
+export function truncateSnippet(snippet: string): string {
+  const collapsed = snippet.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= SNIPPET_MAX_CHARS) return collapsed;
+  return `${collapsed.slice(0, SNIPPET_MAX_CHARS - 1).trimEnd()}…`;
+}

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -30,9 +30,11 @@ const logger = createScopedLogger("send-follow-up-test");
 
 const baseArgs = {
   subject: "Project update",
-  counterparty: "Alex",
+  counterpartyName: "Alex Tester",
+  counterpartyEmail: "alex@example.com",
   trackerType: ThreadTrackerType.AWAITING,
   daysSinceSent: 3,
+  snippet: "Following up on the items we discussed.",
   threadLink: "https://mail.example/thread",
   logger,
 };

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -2,7 +2,7 @@ import {
   MessagingProvider,
   MessagingRoutePurpose,
   type MessagingRouteTargetType,
-  ThreadTrackerType,
+  type ThreadTrackerType,
 } from "@/generated/prisma/enums";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 import type { Logger } from "@/utils/logger";
@@ -16,6 +16,8 @@ import {
 } from "@/utils/messaging/routes";
 import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import prisma from "@/utils/prisma";
+import { pluralize } from "@/utils/string";
+import { getFollowUpCopy, truncateSnippet } from "@/utils/follow-up/copy";
 
 export type FollowUpNotificationChannel = {
   id: string;
@@ -29,6 +31,16 @@ export type FollowUpNotificationChannel = {
     targetType: MessagingRouteTargetType;
     targetId: string;
   }>;
+};
+
+type FollowUpNotificationContent = {
+  subject: string;
+  counterpartyName: string;
+  counterpartyEmail: string;
+  trackerType: ThreadTrackerType;
+  daysSinceSent: number;
+  snippet?: string;
+  threadLink?: string;
 };
 
 export async function getFollowUpNotificationChannels(
@@ -56,19 +68,10 @@ export async function getFollowUpNotificationChannels(
 
 export async function sendFollowUpNotification({
   channels,
-  subject,
-  counterparty,
-  trackerType,
-  daysSinceSent,
-  threadLink,
   logger,
-}: {
+  ...content
+}: FollowUpNotificationContent & {
   channels: FollowUpNotificationChannel[];
-  subject: string;
-  counterparty: string;
-  trackerType: ThreadTrackerType;
-  daysSinceSent: number;
-  threadLink?: string;
   logger: Logger;
 }): Promise<void> {
   const deliveryPromises: Promise<void>[] = [];
@@ -97,11 +100,7 @@ export async function sendFollowUpNotification({
           sendFollowUpViaSlack({
             accessToken: channel.accessToken,
             route,
-            subject,
-            counterparty,
-            trackerType,
-            daysSinceSent,
-            threadLink,
+            content,
             logger,
           }),
         );
@@ -109,14 +108,10 @@ export async function sendFollowUpNotification({
       case MessagingProvider.TEAMS:
       case MessagingProvider.TELEGRAM:
         deliveryPromises.push(
-          sendFollowUpViaMessagingApp({
+          sendAutomationMessage({
             channel,
             route,
-            subject,
-            counterparty,
-            trackerType,
-            daysSinceSent,
-            threadLink,
+            text: formatFollowUpText(content),
             logger,
           }),
         );
@@ -139,20 +134,12 @@ export async function sendFollowUpNotification({
 async function sendFollowUpViaSlack({
   accessToken,
   route,
-  subject,
-  counterparty,
-  trackerType,
-  daysSinceSent,
-  threadLink,
+  content,
   logger,
 }: {
   accessToken: string;
   route: { targetId: string; targetType: MessagingRouteTargetType };
-  subject: string;
-  counterparty: string;
-  trackerType: ThreadTrackerType;
-  daysSinceSent: number;
-  threadLink?: string;
+  content: FollowUpNotificationContent;
   logger: Logger;
 }) {
   const destination = await resolveSlackRouteDestination({
@@ -168,77 +155,28 @@ async function sendFollowUpViaSlack({
   await sendFollowUpReminderToSlack({
     accessToken,
     channelId: destination,
-    subject,
-    counterparty,
-    trackerType,
-    daysSinceSent,
-    threadLink,
-  });
-}
-
-async function sendFollowUpViaMessagingApp({
-  channel,
-  route,
-  subject,
-  counterparty,
-  trackerType,
-  daysSinceSent,
-  threadLink,
-  logger,
-}: {
-  channel: {
-    provider: MessagingProvider;
-    accessToken: string | null;
-    teamId: string | null;
-    providerUserId: string | null;
-  };
-  route: { targetId: string; targetType: MessagingRouteTargetType };
-  subject: string;
-  counterparty: string;
-  trackerType: ThreadTrackerType;
-  daysSinceSent: number;
-  threadLink?: string;
-  logger: Logger;
-}) {
-  await sendAutomationMessage({
-    channel,
-    route,
-    text: formatFollowUpText({
-      subject,
-      counterparty,
-      trackerType,
-      daysSinceSent,
-      threadLink,
-    }),
-    logger,
+    ...content,
   });
 }
 
 function formatFollowUpText({
   subject,
-  counterparty,
+  counterpartyName,
+  counterpartyEmail,
   trackerType,
   daysSinceSent,
+  snippet,
   threadLink,
-}: {
-  subject: string;
-  counterparty: string;
-  trackerType: ThreadTrackerType;
-  daysSinceSent: number;
-  threadLink?: string;
-}): string {
-  const isAwaiting = trackerType === ThreadTrackerType.AWAITING;
-  const header = isAwaiting ? "Follow-up nudge" : "Reply needed";
-  const dayLabel = daysSinceSent === 1 ? "day" : "days";
-  const verb = isAwaiting ? "sent" : "received";
-  const preposition = isAwaiting ? "to" : "from";
+}: FollowUpNotificationContent): string {
+  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
 
   const lines = [
-    header,
+    `Follow-up nudge — ${directionLine}`,
     subject,
-    `${preposition} ${counterparty} · ${verb} ${daysSinceSent} ${dayLabel} ago`,
+    `${preposition} ${counterpartyName} <${counterpartyEmail}> · ${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
   ];
 
+  if (snippet) lines.push(`> ${truncateSnippet(snippet)}`);
   if (threadLink) lines.push(`Open: ${threadLink}`);
 
   return lines.join("\n");

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -74,7 +74,7 @@ export async function sendFollowUpNotification({
   channels: FollowUpNotificationChannel[];
   logger: Logger;
 }): Promise<void> {
-  const deliveryPromises: Promise<void>[] = [];
+  const deliveryPromises: Promise<unknown>[] = [];
 
   for (const channel of channels) {
     const route = getMessagingRoute(

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { ThreadTrackerType } from "@/generated/prisma/enums";
+import { buildFollowUpReminderBlocks } from "./follow-up-reminder";
+
+const baseAwaitingParams = {
+  subject: "Quote follow-up",
+  counterpartyName: "Test Counterparty",
+  counterpartyEmail: "test@example.com",
+  trackerType: ThreadTrackerType.AWAITING,
+  daysSinceSent: 4,
+  snippet: "Following up on the proposal we sent last week.",
+  threadLink: "https://mail.example.com/thread/awaiting",
+};
+
+const baseNeedsReplyParams = {
+  ...baseAwaitingParams,
+  trackerType: ThreadTrackerType.NEEDS_REPLY,
+  daysSinceSent: 1,
+  snippet: "Could you share pricing details when you get a chance?",
+  threadLink: "https://mail.example.com/thread/needs-reply",
+};
+
+function blocksJson(params: Parameters<typeof buildFollowUpReminderBlocks>[0]) {
+  return JSON.stringify(buildFollowUpReminderBlocks(params));
+}
+
+describe("buildFollowUpReminderBlocks", () => {
+  it("AWAITING: surfaces direction (they haven't replied) in the message", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("they haven't replied");
+    expect(json).not.toContain("you haven't replied");
+  });
+
+  it("NEEDS_REPLY: surfaces direction (you haven't replied) in the message", () => {
+    const json = blocksJson(baseNeedsReplyParams);
+    expect(json).toContain("you haven't replied");
+    expect(json).not.toContain("they haven't replied");
+  });
+
+  it("renders the counterparty name and email together", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("Test Counterparty");
+    expect(json).toContain("test@example.com");
+  });
+
+  it("AWAITING: prefixes the counterparty with 'to'", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("to ");
+    expect(json).not.toContain("from Test Counterparty");
+  });
+
+  it("NEEDS_REPLY: prefixes the counterparty with 'from'", () => {
+    const json = blocksJson(baseNeedsReplyParams);
+    expect(json).toContain("from ");
+    expect(json).not.toContain("to Test Counterparty");
+  });
+
+  it("renders 'sent N days ago' for AWAITING", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("sent 4 days ago");
+  });
+
+  it("renders 'received N day ago' for NEEDS_REPLY (singular)", () => {
+    const json = blocksJson(baseNeedsReplyParams);
+    expect(json).toContain("received 1 day ago");
+  });
+
+  it("includes the message snippet so the user knows what the thread is about", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("Following up on the proposal we sent last week.");
+  });
+
+  it("omits the snippet block when no snippet is provided", () => {
+    const json = blocksJson({ ...baseAwaitingParams, snippet: undefined });
+    expect(json).not.toContain("Following up on");
+  });
+
+  it("renders the subject as the headline", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("Quote follow-up");
+  });
+
+  it("includes the thread link as an action button", () => {
+    const json = blocksJson(baseAwaitingParams);
+    expect(json).toContain("https://mail.example.com/thread/awaiting");
+  });
+
+  it("escapes Slack-sensitive characters in subject, name, and snippet", () => {
+    const json = blocksJson({
+      ...baseAwaitingParams,
+      subject: "Q1 <plan> & review",
+      counterpartyName: "A&B Partners",
+      snippet: "<script> tag in body",
+    });
+    expect(json).toContain("Q1 &lt;plan&gt; &amp; review");
+    expect(json).toContain("A&amp;B Partners");
+    expect(json).toContain("&lt;script&gt; tag in body");
+  });
+});

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -1,46 +1,60 @@
 import type { KnownBlock, Block } from "@slack/types";
-import { ThreadTrackerType } from "@/generated/prisma/enums";
+import type { ThreadTrackerType } from "@/generated/prisma/enums";
 import { escapeSlackText } from "@/utils/messaging/providers/slack/format";
+import { getFollowUpCopy, truncateSnippet } from "@/utils/follow-up/copy";
+import { pluralize } from "@/utils/string";
 
 export type FollowUpReminderBlocksParams = {
   subject: string;
-  counterparty: string;
+  counterpartyName: string;
+  counterpartyEmail: string;
   trackerType: ThreadTrackerType;
   daysSinceSent: number;
+  snippet?: string;
   threadLink?: string;
 };
 
 export function buildFollowUpReminderBlocks({
   subject,
-  counterparty,
+  counterpartyName,
+  counterpartyEmail,
   trackerType,
   daysSinceSent,
+  snippet,
   threadLink,
 }: FollowUpReminderBlocksParams): (KnownBlock | Block)[] {
-  const isAwaiting = trackerType === ThreadTrackerType.AWAITING;
-  const headerText = isAwaiting ? "Follow-up nudge" : "Reply needed";
+  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
+  const sentenceVerb = `${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`;
 
-  const dayLabel = daysSinceSent === 1 ? "day" : "days";
-  const sentenceVerb = isAwaiting
-    ? `sent ${daysSinceSent} ${dayLabel} ago`
-    : `received ${daysSinceSent} ${dayLabel} ago`;
-  // AWAITING: the user emailed `counterparty` — they are the recipient.
-  // NEEDS_REPLY: `counterparty` emailed the user — they are the sender.
-  const preposition = isAwaiting ? "to" : "from";
+  const counterpartyMarkdown = `${preposition} *${escapeSlackText(counterpartyName)}* \`<${escapeSlackText(counterpartyEmail)}>\``;
 
   const blocks: (KnownBlock | Block)[] = [
     {
       type: "header",
-      text: { type: "plain_text", text: headerText, emoji: true },
+      text: { type: "plain_text", text: "Follow-up nudge", emoji: true },
+    },
+    {
+      type: "context",
+      elements: [{ type: "mrkdwn", text: `_${directionLine}_` }],
     },
     {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${escapeSlackText(subject)}*\n${preposition} _${escapeSlackText(counterparty)}_ · ${sentenceVerb}`,
+        text: `*${escapeSlackText(subject)}*\n${counterpartyMarkdown} · ${sentenceVerb}`,
       },
     },
   ];
+
+  if (snippet) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `> ${escapeSlackText(truncateSnippet(snippet))}`,
+      },
+    });
+  }
 
   if (threadLink) {
     blocks.push({

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -164,24 +164,14 @@ export type SlackFollowUpReminderParams = FollowUpReminderBlocksParams & {
 export async function sendFollowUpReminderToSlack({
   accessToken,
   channelId,
-  subject,
-  counterparty,
-  trackerType,
-  daysSinceSent,
-  threadLink,
+  ...blockParams
 }: SlackFollowUpReminderParams): Promise<void> {
   const client = createSlackClient(accessToken);
-  const blocks = buildFollowUpReminderBlocks({
-    subject,
-    counterparty,
-    trackerType,
-    daysSinceSent,
-    threadLink,
-  });
+  const blocks = buildFollowUpReminderBlocks(blockParams);
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: `Follow-up: ${subject}`,
+    text: `Follow-up: ${blockParams.subject}`,
   });
 }
 


### PR DESCRIPTION
## Summary
- Add a direction subline to follow-up nudges (`they haven't replied` vs `you haven't replied`) so it's obvious at a glance which side owes a reply.
- Render the counterparty as a name plus email instead of a bare address.
- Quote a snippet of the last message so the recipient knows why the thread is being surfaced.
- Match the new shape on the plain-text Teams/Telegram path.

## Before / after (AWAITING)

Before:
```
Follow-up nudge
Re: Quote follow-up
to test@example.com · sent 4 days ago
[Open thread]
```

After:
```
Follow-up nudge
_they haven't replied_
*Quote follow-up*
to *Test Counterparty* `<test@example.com>` · sent 4 days ago
> Following up on the proposal we sent last week.
[Open thread]
```

## Test plan
- [x] `pnpm test utils/messaging/providers/slack/messages/follow-up-reminder.test.ts` (12 new unit tests)
- [x] `pnpm test utils/follow-up/send-follow-up-notification.test.ts`
- [x] `pnpm test app/api/follow-up-reminders/process.test.ts`
- [ ] Spot-check via the Slack notification integration test (`RUN_INTEGRATION_TESTS=true pnpm test-integration slack-notifications`)

## Out of scope
Interactive Mark done / Snooze 3 days / Draft buttons (and the `snoozedUntil` schema field) — left for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)