### PR TITLE
Dedupe draft entries in rule actions hover card

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
@@ -14,8 +14,11 @@ import { useRuleDialog } from "@/app/(app)/[emailAccountId]/assistant/RuleDialog
 import { ThreadSkipHint } from "@/app/(app)/[emailAccountId]/assistant/ThreadSkipHint";
 import { LearnedPatternExclusionHint } from "@/app/(app)/[emailAccountId]/assistant/LearnedPatternExclusionHint";
 import type { RunRulesResult } from "@/utils/ai/choose-rule/run-rules";
-import { sortActionsByPriority } from "@/utils/action-sort";
-import { getActionDisplay, getActionIcon } from "@/utils/action-display";
+import {
+  getActionDisplay,
+  getActionIcon,
+  getVisibleActions,
+} from "@/utils/action-display";
 import { getActionColor } from "@/components/PlanBadge";
 import { useAccount } from "@/providers/EmailAccountProvider";
 
@@ -210,7 +213,7 @@ function Actions({
 }) {
   return (
     <div className="flex flex-col gap-2 flex-wrap">
-      {sortActionsByPriority(actions).map((action) => {
+      {getVisibleActions(actions).map((action) => {
         const Icon = getActionIcon(action.type);
         const fields = [
           { key: "to", value: action.to },

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -42,8 +42,11 @@ import { useAction } from "next-safe-action/hooks";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
 import type { RulesResponse } from "@/app/api/user/rules/route";
-import { sortActionsByPriority } from "@/utils/action-sort";
-import { getActionDisplay, getActionIcon } from "@/utils/action-display";
+import {
+  getActionDisplay,
+  getActionIcon,
+  getVisibleActions,
+} from "@/utils/action-display";
 import { RuleDialog } from "./RuleDialog";
 import { useDialogState } from "@/hooks/useDialogState";
 import { useChat } from "@/providers/ChatProvider";
@@ -418,17 +421,6 @@ export function ActionBadges({
         );
       })}
     </div>
-  );
-}
-
-function getVisibleActions<T extends { type: ActionType }>(actions: T[]): T[] {
-  const sortedActions = sortActionsByPriority(actions);
-  const hasEmailDraft = sortedActions.some(
-    (action) => action.type === "DRAFT_EMAIL",
-  );
-
-  return sortedActions.filter(
-    (action) => !(action.type === "DRAFT_MESSAGING_CHANNEL" && hasEmailDraft),
   );
 }
 

--- a/apps/web/utils/action-display.tsx
+++ b/apps/web/utils/action-display.tsx
@@ -1,5 +1,6 @@
 import { ActionType } from "@/generated/prisma/enums";
 import { getEmailTerminology } from "@/utils/terminology";
+import { sortActionsByPriority } from "@/utils/action-sort";
 import {
   ArchiveIcon,
   BellIcon,
@@ -15,6 +16,24 @@ import {
   NewspaperIcon,
 } from "lucide-react";
 import { truncate } from "@/utils/string";
+
+/**
+ * Hide messaging-channel draft entries when an email draft already exists,
+ * so users don't see "Draft Reply" repeated once per connected chat app.
+ */
+export function getVisibleActions<T extends { type: ActionType }>(
+  actions: T[],
+): T[] {
+  const sortedActions = sortActionsByPriority(actions);
+  const hasEmailDraft = sortedActions.some(
+    (action) => action.type === ActionType.DRAFT_EMAIL,
+  );
+
+  return sortedActions.filter(
+    (action) =>
+      !(action.type === ActionType.DRAFT_MESSAGING_CHANNEL && hasEmailDraft),
+  );
+}
 
 export function getActionDisplay(
   action: {


### PR DESCRIPTION
## Summary
- Hides `DRAFT_MESSAGING_CHANNEL` rows when a `DRAFT_EMAIL` action exists, so the rule results hover no longer shows "Draft Reply" once per connected chat app.
- Lifts the existing rules-table filter into a shared `getVisibleActions` helper in `action-display.tsx` and reuses it in the hover card.

## Test plan
- [ ] Open the assistant results panel for a rule that has both an email draft and a chat-app draft notification; verify only one "Draft Reply" entry shows.
- [ ] Confirm the rules table list still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)