### PR TITLE
docs: Update testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Do not run `dev` or `build` unless explicitly asked
 - Run `pnpm install` before running tests or build if not already done
 - Before writing or updating tests, review `.claude/skills/testing/SKILL.md`.
+- For core bug-fix tasks, default to TDD when practical (red/green/refactor); AI prompt improvements should generally be backed by evals too, and TDD is often useful there as well.
 - When adding a new workspace package, add its `package.json` COPY line to `docker/Dockerfile.prod` and `docker/Dockerfile.local`.
 
 ## Code Style


### PR DESCRIPTION
Adds guidance to default to TDD when practical for core bug-fix work. Also notes that AI prompt improvements should generally be backed by evals.