### PR TITLE
follow-ups: Add Mark done button to Slack nudge

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -286,6 +286,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         daysSinceSent: 4,
         snippet: "Wanted to check whether the redlines have landed.",
         threadLink: "https://mail.example.com/thread/awaiting",
+        trackerId: "tracker-awaiting",
       });
 
       await sendFollowUpReminderToSlack({
@@ -298,6 +299,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         daysSinceSent: 1,
         snippet: "Could you walk me through the SSO setup?",
         threadLink: "https://mail.example.com/thread/needs-reply",
+        trackerId: "tracker-needs-reply",
       });
 
       const history = await emulatorClient.conversations.history({
@@ -343,6 +345,109 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(needsReplyBlocks).toContain(
         "Could you walk me through the SSO setup?",
       );
+    });
+
+    test("Mark done click resolves the tracker and confirms via ephemeral", async () => {
+      const { sendFollowUpReminderToSlack } = await import(
+        "@/utils/messaging/providers/slack/send"
+      );
+      const { ThreadTrackerType } = await import("@/generated/prisma/enums");
+      const { FOLLOW_UP_MARK_DONE_ACTION_ID, handleFollowUpReminderAction } =
+        await import("@/utils/follow-up/follow-up-actions");
+      const postMessageSpy = vi.spyOn(emulatorClient.chat, "postMessage");
+
+      const trackerId = "tracker-mark-done";
+
+      await sendFollowUpReminderToSlack({
+        accessToken: "emulator-token",
+        channelId: notifChannelId,
+        subject: "Pricing question",
+        counterpartyName: "Sam Prospect",
+        counterpartyEmail: "sam@prospect.com",
+        trackerType: ThreadTrackerType.AWAITING,
+        daysSinceSent: 5,
+        snippet: "Following up on the quote we sent.",
+        threadLink: "https://mail.example.com/thread/mark-done",
+        trackerId,
+      });
+
+      // Read the rendered Mark done button payload from what was actually
+      // posted to Slack — this catches drift between renderer and handler.
+      const postedCall = postMessageSpy.mock.calls.find((c) =>
+        c[0].text?.includes("Pricing question"),
+      );
+      expect(postedCall).toBeDefined();
+      const buttons = ((postedCall![0].blocks as unknown[]) ?? []).flatMap(
+        (block) => {
+          if (
+            block &&
+            typeof block === "object" &&
+            "type" in block &&
+            (block as { type: string }).type === "actions" &&
+            "elements" in block &&
+            Array.isArray((block as { elements: unknown[] }).elements)
+          ) {
+            return (block as { elements: unknown[] }).elements;
+          }
+          return [];
+        },
+      );
+      const markDoneButton = buttons.find(
+        (b: any) => b?.action_id === FOLLOW_UP_MARK_DONE_ACTION_ID,
+      ) as { action_id: string; value: string; text: { text: string } };
+      expect(markDoneButton).toBeDefined();
+      expect(markDoneButton.text.text).toBe("Mark done");
+      expect(markDoneButton.value).toBe(trackerId);
+
+      // Mock the prisma lookups the handler relies on.
+      prisma.threadTracker.findUnique.mockResolvedValue({
+        id: trackerId,
+        resolved: false,
+        emailAccountId: "account-1",
+      } as never);
+      prisma.messagingChannel.findFirst.mockResolvedValue({
+        id: "channel-1",
+      } as never);
+      prisma.threadTracker.update.mockResolvedValue({} as never);
+
+      const postEphemeral = vi.fn().mockResolvedValue(undefined);
+      const post = vi.fn().mockResolvedValue(undefined);
+
+      await handleFollowUpReminderAction({
+        event: {
+          actionId: markDoneButton.action_id,
+          value: markDoneButton.value,
+          user: { userId: "U_USER" },
+          raw: { team: { id: "T_TEAM" } },
+          threadId: postedCall![0].channel ?? notifChannelId,
+          messageId: "1700000000.000100",
+          adapter: { name: "slack" },
+          thread: { postEphemeral, post },
+        } as any,
+        logger,
+      });
+
+      // Auth lookup scoped to tracker's account, slack, the click team and user.
+      expect(prisma.messagingChannel.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            emailAccountId: "account-1",
+            teamId: "T_TEAM",
+            providerUserId: "U_USER",
+            isConnected: true,
+          }),
+        }),
+      );
+
+      // Tracker flipped to resolved.
+      expect(prisma.threadTracker.update).toHaveBeenCalledWith({
+        where: { id: trackerId },
+        data: { resolved: true },
+      });
+
+      // User saw an ephemeral confirmation.
+      expect(postEphemeral).toHaveBeenCalled();
+      expect(postEphemeral.mock.calls[0]?.[1]).toMatch(/done/i);
     });
 
     test("addReaction/removeReaction manages processing indicator", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -526,6 +526,7 @@ async function processFollowUpsForType({
                 emailAddress: emailAccount.email,
                 provider: providerName,
               }) ?? undefined,
+            trackerId: tracker.id,
             logger: threadLogger,
           });
         } catch (notifyError) {

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { MessagingProvider } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+import {
+  FOLLOW_UP_MARK_DONE_ACTION_ID,
+  handleFollowUpReminderAction,
+} from "./follow-up-actions";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+const logger = createScopedLogger("follow-up-actions-test");
+
+function makeEvent(
+  overrides: Partial<{
+    actionId: string;
+    value: string | undefined;
+    teamId: string | null;
+    userId: string;
+  }> = {},
+) {
+  const postEphemeral = vi.fn().mockResolvedValue(undefined);
+  const post = vi.fn().mockResolvedValue(undefined);
+  const value = "value" in overrides ? overrides.value : "tracker-1";
+  const event = {
+    actionId: overrides.actionId ?? FOLLOW_UP_MARK_DONE_ACTION_ID,
+    value,
+    user: { userId: overrides.userId ?? "U_USER" },
+    raw:
+      overrides.teamId === null
+        ? {}
+        : { team: { id: overrides.teamId ?? "T_TEAM" } },
+    threadId: "ts-1",
+    messageId: "ts-1",
+    adapter: { name: "slack" } as any,
+    thread: { postEphemeral, post } as any,
+    triggerId: undefined,
+    openModal: vi.fn(),
+  };
+  return { event: event as any, postEphemeral, post };
+}
+
+describe("handleFollowUpReminderAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the tracker as resolved when team and user match", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: false,
+      emailAccountId: "account-1",
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: "channel-1",
+    } as any);
+    prisma.threadTracker.update.mockResolvedValue({} as any);
+
+    const { event, postEphemeral } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.update).toHaveBeenCalledWith({
+      where: { id: "tracker-1" },
+      data: { resolved: true },
+    });
+    expect(postEphemeral).toHaveBeenCalled();
+    const text = postEphemeral.mock.calls[0]?.[1];
+    expect(typeof text).toBe("string");
+    expect(text).toMatch(/done/i);
+  });
+
+  it("scopes the channel auth lookup to the tracker's email account, slack, the slack team and the clicker", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: false,
+      emailAccountId: "account-1",
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: "channel-1",
+    } as any);
+    prisma.threadTracker.update.mockResolvedValue({} as any);
+
+    const { event } = makeEvent({ teamId: "T_REAL", userId: "U_REAL" });
+    await handleFollowUpReminderAction({ event, logger });
+
+    const call = prisma.messagingChannel.findFirst.mock.calls[0]?.[0];
+    expect(call?.where).toMatchObject({
+      emailAccountId: "account-1",
+      provider: MessagingProvider.SLACK,
+      teamId: "T_REAL",
+      providerUserId: "U_REAL",
+      isConnected: true,
+    });
+  });
+
+  it("rejects when no matching Slack channel is found (different team or user)", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: false,
+      emailAccountId: "account-1",
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue(null);
+
+    const { event, postEphemeral } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.update).not.toHaveBeenCalled();
+    expect(postEphemeral).toHaveBeenCalled();
+  });
+
+  it("no-ops when the tracker no longer exists", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue(null);
+
+    const { event, postEphemeral } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.messagingChannel.findFirst).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.update).not.toHaveBeenCalled();
+    expect(postEphemeral).toHaveBeenCalled();
+  });
+
+  it("no-ops when the tracker is already resolved", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: true,
+      emailAccountId: "account-1",
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: "channel-1",
+    } as any);
+
+    const { event, postEphemeral } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.update).not.toHaveBeenCalled();
+    expect(postEphemeral).toHaveBeenCalled();
+  });
+
+  it("ignores actions with the wrong action ID", async () => {
+    const { event } = makeEvent({ actionId: "rule_draft_send" });
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("ignores events with no tracker id", async () => {
+    const { event, postEphemeral } = makeEvent({ value: undefined });
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.findUnique).not.toHaveBeenCalled();
+    expect(postEphemeral).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/follow-up/follow-up-actions.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.ts
@@ -1,0 +1,107 @@
+import type { ActionEvent } from "chat";
+import { MessagingProvider } from "@/generated/prisma/enums";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+export const FOLLOW_UP_MARK_DONE_ACTION_ID = "follow_up_mark_done";
+
+export const FOLLOW_UP_REMINDER_ACTION_IDS = [
+  FOLLOW_UP_MARK_DONE_ACTION_ID,
+] as const;
+
+export async function handleFollowUpReminderAction({
+  event,
+  logger,
+}: {
+  event: ActionEvent;
+  logger: Logger;
+}): Promise<void> {
+  if (event.actionId !== FOLLOW_UP_MARK_DONE_ACTION_ID) return;
+
+  const trackerId = event.value?.trim();
+  if (!trackerId) return;
+
+  const tracker = await prisma.threadTracker.findUnique({
+    where: { id: trackerId },
+    select: { id: true, resolved: true, emailAccountId: true },
+  });
+
+  if (!tracker) {
+    await postFeedback(event, logger, "That follow-up is no longer active.");
+    return;
+  }
+
+  const teamId = getSlackTeamId(event.raw);
+  const channel = teamId
+    ? await prisma.messagingChannel.findFirst({
+        where: {
+          emailAccountId: tracker.emailAccountId,
+          provider: MessagingProvider.SLACK,
+          teamId,
+          providerUserId: event.user.userId,
+          isConnected: true,
+        },
+        select: { id: true },
+      })
+    : null;
+
+  if (!channel) {
+    await postFeedback(
+      event,
+      logger,
+      "You don't have permission to act on this follow-up.",
+    );
+    return;
+  }
+
+  if (tracker.resolved) {
+    await postFeedback(event, logger, "This follow-up is already done.");
+    return;
+  }
+
+  await prisma.threadTracker.update({
+    where: { id: trackerId },
+    data: { resolved: true },
+  });
+
+  await postFeedback(
+    event,
+    logger,
+    "Marked done. We won't follow up on this thread again.",
+  );
+}
+
+async function postFeedback(
+  event: ActionEvent,
+  logger: Logger,
+  text: string,
+): Promise<void> {
+  const thread = event.thread;
+  if (!thread) return;
+
+  if (event.adapter.name === "slack") {
+    try {
+      await thread.postEphemeral(event.user, text, { fallbackToDM: false });
+      return;
+    } catch (error) {
+      logger.warn("Failed to post follow-up feedback (slack ephemeral)", {
+        actionId: event.actionId,
+        error,
+      });
+    }
+  }
+
+  try {
+    await thread.post(text);
+  } catch (error) {
+    logger.warn("Failed to post follow-up feedback", {
+      actionId: event.actionId,
+      error,
+    });
+  }
+}
+
+function getSlackTeamId(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return null;
+  return (raw as { team?: { id?: string } }).team?.id || null;
+}

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -36,6 +36,7 @@ const baseArgs = {
   daysSinceSent: 3,
   snippet: "Following up on the items we discussed.",
   threadLink: "https://mail.example/thread",
+  trackerId: "tracker-1",
   logger,
 };
 

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -41,6 +41,7 @@ type FollowUpNotificationContent = {
   daysSinceSent: number;
   snippet?: string;
   threadLink?: string;
+  trackerId: string;
 };
 
 export async function getFollowUpNotificationChannels(

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -52,6 +52,10 @@ import {
   isHelpCommand,
 } from "@/utils/messaging/prompt-commands";
 import {
+  FOLLOW_UP_REMINDER_ACTION_IDS,
+  handleFollowUpReminderAction,
+} from "@/utils/follow-up/follow-up-actions";
+import {
   handleRuleNotificationAction,
   handleSlackRuleNotificationModalSubmit,
   RULE_NOTIFICATION_ACTION_IDS,
@@ -465,6 +469,14 @@ function registerMessagingHandlers({
   bot.onAction([...RULE_NOTIFICATION_ACTION_IDS], async (event) => {
     const handlerLogger = getHandlerLogger();
     await handleRuleNotificationAction({
+      event,
+      logger: handlerLogger,
+    });
+  });
+
+  bot.onAction([...FOLLOW_UP_REMINDER_ACTION_IDS], async (event) => {
+    const handlerLogger = getHandlerLogger();
+    await handleFollowUpReminderAction({
       event,
       logger: handlerLogger,
     });

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ThreadTrackerType } from "@/generated/prisma/enums";
+import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "@/utils/follow-up/follow-up-actions";
 import { buildFollowUpReminderBlocks } from "./follow-up-reminder";
 
 const baseAwaitingParams = {
@@ -10,6 +11,7 @@ const baseAwaitingParams = {
   daysSinceSent: 4,
   snippet: "Following up on the proposal we sent last week.",
   threadLink: "https://mail.example.com/thread/awaiting",
+  trackerId: "tracker-abc123",
 };
 
 const baseNeedsReplyParams = {
@@ -83,6 +85,33 @@ describe("buildFollowUpReminderBlocks", () => {
   it("includes the thread link as an action button", () => {
     const json = blocksJson(baseAwaitingParams);
     expect(json).toContain("https://mail.example.com/thread/awaiting");
+  });
+
+  it("renders a Mark done button carrying the tracker id", () => {
+    const blocks = buildFollowUpReminderBlocks(baseAwaitingParams);
+    const buttons = blocks.flatMap((block) =>
+      block.type === "actions" && Array.isArray((block as any).elements)
+        ? (block as any).elements
+        : [],
+    );
+    const markDone = buttons.find(
+      (el: any) =>
+        el?.type === "button" &&
+        el?.action_id === FOLLOW_UP_MARK_DONE_ACTION_ID,
+    );
+    expect(markDone).toBeDefined();
+    expect(markDone.text.text).toBe("Mark done");
+    expect(markDone.value).toBe("tracker-abc123");
+  });
+
+  it("renders the Mark done button even without a thread link", () => {
+    const blocks = buildFollowUpReminderBlocks({
+      ...baseAwaitingParams,
+      threadLink: undefined,
+    });
+    const json = JSON.stringify(blocks);
+    expect(json).toContain(FOLLOW_UP_MARK_DONE_ACTION_ID);
+    expect(json).toContain("Mark done");
   });
 
   it("escapes Slack-sensitive characters in subject, name, and snippet", () => {

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -1,7 +1,8 @@
-import type { KnownBlock, Block } from "@slack/types";
+import type { ActionsBlock, Button, KnownBlock, Block } from "@slack/types";
 import type { ThreadTrackerType } from "@/generated/prisma/enums";
 import { escapeSlackText } from "@/utils/messaging/providers/slack/format";
 import { getFollowUpCopy, truncateSnippet } from "@/utils/follow-up/copy";
+import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "@/utils/follow-up/follow-up-actions";
 import { pluralize } from "@/utils/string";
 
 export type FollowUpReminderBlocksParams = {
@@ -12,6 +13,7 @@ export type FollowUpReminderBlocksParams = {
   daysSinceSent: number;
   snippet?: string;
   threadLink?: string;
+  trackerId: string;
 };
 
 export function buildFollowUpReminderBlocks({
@@ -22,6 +24,7 @@ export function buildFollowUpReminderBlocks({
   daysSinceSent,
   snippet,
   threadLink,
+  trackerId,
 }: FollowUpReminderBlocksParams): (KnownBlock | Block)[] {
   const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
   const sentenceVerb = `${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`;
@@ -56,18 +59,25 @@ export function buildFollowUpReminderBlocks({
     });
   }
 
+  const actionElements: Button[] = [];
   if (threadLink) {
-    blocks.push({
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "Open thread", emoji: true },
-          url: threadLink,
-        },
-      ],
+    actionElements.push({
+      type: "button",
+      text: { type: "plain_text", text: "Open thread", emoji: true },
+      url: threadLink,
     });
   }
+  actionElements.push({
+    type: "button",
+    action_id: FOLLOW_UP_MARK_DONE_ACTION_ID,
+    text: { type: "plain_text", text: "Mark done", emoji: true },
+    value: trackerId,
+  });
+  const actionsBlock: ActionsBlock = {
+    type: "actions",
+    elements: actionElements,
+  };
+  blocks.push(actionsBlock);
 
   blocks.push({
     type: "context",


### PR DESCRIPTION
## Summary
- Render a Mark done button on the follow-up nudge so the recipient can resolve a thread directly from Slack.
- New `handleFollowUpReminderAction` handler authorizes via the connected Slack messaging channel (matching team and clicker), flips the tracker's `resolved` flag, and confirms with an ephemeral reply.
- Wire the handler into `chat-sdk/bot.ts` alongside the existing rule-notification action handlers.

## Auth model
The handler only resolves a tracker if there is a connected Slack channel for the tracker's email account where:
- `teamId` matches the Slack team the click came from
- `providerUserId` matches the Slack user who clicked
- `isConnected: true`

Otherwise the click receives an ephemeral "you don't have permission" reply and no DB write happens.

## Test plan
- [x] `pnpm test utils/follow-up/follow-up-actions.test.ts` (7 new unit tests covering happy path, scoped channel auth, rejected auth, missing tracker, already-resolved, wrong action id, missing tracker id)
- [x] `pnpm test utils/messaging/providers/slack/messages/follow-up-reminder.test.ts` (2 new button-rendering tests)
- [x] `pnpm test utils/messaging utils/follow-up app/api/follow-up-reminders` (221 tests pass)
- [x] `pnpm exec next build` (compiles + type-checks clean)

## Out of scope
Snooze and Draft-a-reply buttons. Snooze in particular needs a `snoozedUntil` field on `ThreadTracker` and a corresponding skip in `processFollowUpsForType`, so it's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)