### PR TITLE
messaging: Send edited drafts from modal

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -673,6 +673,32 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
         expect(postedMessage?.text).toContain("Initial draft body.");
 
+        const openModal = vi.fn().mockResolvedValue(undefined);
+        await handleRuleNotificationAction({
+          event: {
+            actionId: "rule_draft_edit",
+            value: slackActionState.id,
+            user: { userId: "user-1" },
+            raw: { team: { id: "team-1" } },
+            adapter: { name: "slack" },
+            openModal,
+            thread: { postEphemeral: vi.fn() },
+          } as any,
+          logger,
+        });
+
+        expect(openModal).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submitLabel: "Send reply",
+          }),
+        );
+
+        const draftBeforeSend = await gmailHarness.provider.getDraft(
+          createdDraft.id,
+        );
+        const sentMessageId = draftBeforeSend?.id;
+        expect(sentMessageId).toBeDefined();
+
         const editResponse = await handleSlackRuleNotificationModalSubmit({
           event: {
             privateMetadata: slackActionState.id,
@@ -694,60 +720,22 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         });
 
         expect(editResponse).toEqual({ action: "close" });
-
-        const updatedDraft = await gmailHarness.provider.getDraft(
-          createdDraft.id,
-        );
-        const updatedDraftText =
-          updatedDraft?.textPlain || updatedDraft?.textHtml || "";
-        const sentMessageId = updatedDraft?.id;
-
-        expect(updatedDraftText).toContain(editedContent);
-        expect(sentMessageId).toBeDefined();
         expect(slackActionState.messagingMessageStatus).toBe(
-          MessagingMessageStatus.DRAFT_EDITED,
+          MessagingMessageStatus.DRAFT_SENT,
         );
+        expect(slackActionState.wasDraftSent).toBe(true);
+        expect(siblingDraftActionState.wasDraftSent).toBe(true);
+        expect(
+          await gmailHarness.provider.getDraft(createdDraft.id),
+        ).toBeNull();
 
         const editedSlackMessage = await findMessageBySubject({
           channelId: notifChannelId,
           subject,
         });
 
+        expect(editedSlackMessage?.text).toContain("Reply sent.");
         expect(editedSlackMessage?.text).toContain(editedContent);
-
-        await handleRuleNotificationAction({
-          event: {
-            actionId: "rule_draft_send",
-            value: slackActionState.id,
-            user: { userId: "user-1" },
-            raw: { team: { id: "team-1" } },
-            threadId: postedMessage!.ts!,
-            messageId: postedMessage!.ts!,
-            adapter: {
-              editMessage: (
-                _threadId: string,
-                messageId: string,
-                card: unknown,
-              ) =>
-                updateSlackCardMessage({
-                  channelId: notifChannelId,
-                  messageId,
-                  card,
-                }),
-            },
-            thread: { postEphemeral: vi.fn() },
-          } as any,
-          logger,
-        });
-
-        expect(
-          await gmailHarness.provider.getDraft(createdDraft.id),
-        ).toBeNull();
-        expect(slackActionState.messagingMessageStatus).toBe(
-          MessagingMessageStatus.DRAFT_SENT,
-        );
-        expect(slackActionState.wasDraftSent).toBe(true);
-        expect(siblingDraftActionState.wasDraftSent).toBe(true);
 
         const sentReply = await gmailHarness.provider.getMessage(
           sentMessageId!,
@@ -757,13 +745,6 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         expect(sentReply.textPlain || sentReply.textHtml || "").toContain(
           editedContent,
         );
-
-        const handledSlackMessage = await findMessageBySubject({
-          channelId: notifChannelId,
-          subject,
-        });
-
-        expect(handledSlackMessage?.text).toContain("Reply sent.");
       } finally {
         await gmailHarness.emulator.close();
       }

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -763,8 +763,9 @@ async function handleDraftSend({
     const result = await sendDraftReplyFromNotification({
       context,
       logger,
-      editMessage: (card) =>
-        event.adapter.editMessage(event.threadId, event.messageId, card),
+      editMessage: async (card) => {
+        await event.adapter.editMessage(event.threadId, event.messageId, card);
+      },
     });
 
     if (result === "draft_unavailable") {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -643,6 +643,13 @@ export async function handleSlackRuleNotificationModalSubmit({
         mailboxDraftActionId: mailboxDraftAction.id,
         error,
       });
+      return {
+        action: "errors",
+        errors: {
+          [SLACK_DRAFT_EDIT_FIELD_ID]:
+            "I couldn't update that draft. Please try again.",
+        },
+      };
     }
   }
 
@@ -657,30 +664,33 @@ export async function handleSlackRuleNotificationModalSubmit({
     },
   });
 
-  await prisma.executedAction.update({
-    where: { id: context.id },
-    data: {
-      messagingMessageStatus: MessagingMessageStatus.DRAFT_EDITED,
-    },
-  });
+  try {
+    await sendDraftReplyFromNotification({
+      context: { ...context, content: nextContent },
+      logger,
+      editMessage: async (card) => {
+        if (event.relatedMessage) {
+          await event.relatedMessage.edit(card);
+          return;
+        }
 
-  const content = buildNotificationContent({
-    actionType: context.type,
-    email: await getSourceMessageSummary(context, logger),
-    systemType: context.executedRule.rule?.systemType ?? null,
-    draftContent: nextContent,
-    format: "slack",
-  });
-
-  if (event.relatedMessage) {
-    await event.relatedMessage.edit(
-      buildNotificationCard({
-        actionId: context.id,
-        actionType: context.type,
-        content,
-        openLink: getNotificationOpenLink(context),
-      }),
-    );
+        logger.warn("Slack draft modal submitted without related message", {
+          executedActionId: context.id,
+        });
+      },
+    });
+  } catch (error) {
+    logger.warn("Failed to send edited Slack draft notification reply", {
+      executedActionId: context.id,
+      error,
+    });
+    return {
+      action: "errors",
+      errors: {
+        [SLACK_DRAFT_EDIT_FIELD_ID]:
+          "I couldn't send that draft. Please try again.",
+      },
+    };
   }
 
   return { action: "close" };
@@ -749,110 +759,21 @@ async function handleDraftSend({
     return;
   }
 
-  const provider = await createProviderForContext(context, logger);
-
-  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
-
   try {
-    const finalDraftContent = await getEditableDraftContent({
+    const result = await sendDraftReplyFromNotification({
       context,
-      provider,
-      mailboxDraftAction,
-    });
-    const sourceMessageSummary = await getSourceMessageSummaryForProvider({
-      context,
-      provider,
-    });
-    const notificationContent = buildNotificationContent({
-      actionType: context.type,
-      email: sourceMessageSummary,
-      systemType: context.executedRule.rule?.systemType ?? null,
-      draftContent: finalDraftContent,
-      format: "slack",
+      logger,
+      editMessage: (card) =>
+        event.adapter.editMessage(event.threadId, event.messageId, card),
     });
 
-    if (mailboxDraftAction?.draftId) {
-      await provider.sendDraft(mailboxDraftAction.draftId);
-    } else {
-      const sourceMessage = await provider.getMessage(
-        context.executedRule.messageId,
-      );
-      const attachments = await resolveActionAttachments({
-        email: sourceMessage,
-        emailAccount: {
-          email: context.executedRule.emailAccount.email,
-          id: context.executedRule.emailAccount.id,
-          userId: context.executedRule.emailAccount.userId,
-        },
-        executedRule: {
-          id: context.executedRule.id,
-          threadId: context.executedRule.threadId,
-          emailAccountId: context.executedRule.emailAccount.id,
-          ruleId: context.executedRule.ruleId,
-        } as ExecutedRule,
+    if (result === "draft_unavailable") {
+      await postNotificationFeedback({
+        event,
         logger,
-        staticAttachments: context.staticAttachments,
-        includeAiSelectedAttachments: true,
-      });
-
-      const content = context.content?.trim();
-      if (!content) {
-        await expireNotificationCard({
-          event,
-          logger,
-          actionId: context.id,
-          title: "Draft unavailable",
-          message: "This draft is no longer available.",
-        });
-        return;
-      }
-
-      const formattedFrom = await getFormattedSenderAddress({
-        emailAccountId: context.executedRule.emailAccount.id,
-        fallbackEmail: context.executedRule.emailAccount.email,
-      });
-
-      await provider.sendEmailWithHtml(
-        buildNotificationReplySendBody({
-          sourceMessage,
-          fallbackThreadId: context.executedRule.threadId,
-          to: context.to,
-          cc: context.cc,
-          bcc: context.bcc,
-          subject: context.subject,
-          content,
-          formattedFrom,
-          attachments: serializeMailAttachments(attachments),
-        }),
-      );
-    }
-
-    await prisma.executedAction.update({
-      where: { id: context.id },
-      data: {
-        messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
-        wasDraftSent: true,
-      },
-    });
-
-    if (mailboxDraftAction?.id) {
-      await prisma.executedAction.update({
-        where: { id: mailboxDraftAction.id },
-        data: {
-          wasDraftSent: true,
-        },
+        text: "This draft is no longer available.",
       });
     }
-
-    await event.adapter.editMessage(
-      event.threadId,
-      event.messageId,
-      buildHandledNotificationCard({
-        content: notificationContent,
-        openLink: getNotificationOpenLink(context),
-        status: "Reply sent.",
-      }),
-    );
   } catch (error) {
     logger.warn("Failed to send Slack draft notification reply", {
       executedActionId: context.id,
@@ -864,6 +785,126 @@ async function handleDraftSend({
       text: "I couldn't send that draft. Please try again.",
     });
   }
+}
+
+async function sendDraftReplyFromNotification({
+  context,
+  logger,
+  editMessage,
+}: {
+  context: NotificationContext;
+  logger: Logger;
+  editMessage: (card: CardElement) => Promise<void>;
+}): Promise<"sent" | "draft_unavailable"> {
+  const provider = await createProviderForContext(context, logger);
+
+  const mailboxDraftAction = getMailboxDraftActionForMessagingDraft(context);
+  const finalDraftContent = await getEditableDraftContent({
+    context,
+    provider,
+    mailboxDraftAction,
+  });
+  const sourceMessageSummary = await getSourceMessageSummaryForProvider({
+    context,
+    provider,
+  });
+  const notificationContent = buildNotificationContent({
+    actionType: context.type,
+    email: sourceMessageSummary,
+    systemType: context.executedRule.rule?.systemType ?? null,
+    draftContent: finalDraftContent,
+    format: "slack",
+  });
+
+  if (mailboxDraftAction?.draftId) {
+    await provider.sendDraft(mailboxDraftAction.draftId);
+  } else {
+    const sourceMessage = await provider.getMessage(
+      context.executedRule.messageId,
+    );
+    const attachments = await resolveActionAttachments({
+      email: sourceMessage,
+      emailAccount: {
+        email: context.executedRule.emailAccount.email,
+        id: context.executedRule.emailAccount.id,
+        userId: context.executedRule.emailAccount.userId,
+      },
+      executedRule: {
+        id: context.executedRule.id,
+        threadId: context.executedRule.threadId,
+        emailAccountId: context.executedRule.emailAccount.id,
+        ruleId: context.executedRule.ruleId,
+      } as ExecutedRule,
+      logger,
+      staticAttachments: context.staticAttachments,
+      includeAiSelectedAttachments: true,
+    });
+
+    const content = context.content?.trim();
+    if (!content) {
+      await prisma.executedAction.update({
+        where: { id: context.id },
+        data: {
+          messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+        },
+      });
+
+      await editMessage(
+        buildTerminalCard({
+          title: "Draft unavailable",
+          message: "This draft is no longer available.",
+        }),
+      );
+
+      return "draft_unavailable";
+    }
+
+    const formattedFrom = await getFormattedSenderAddress({
+      emailAccountId: context.executedRule.emailAccount.id,
+      fallbackEmail: context.executedRule.emailAccount.email,
+    });
+
+    await provider.sendEmailWithHtml(
+      buildNotificationReplySendBody({
+        sourceMessage,
+        fallbackThreadId: context.executedRule.threadId,
+        to: context.to,
+        cc: context.cc,
+        bcc: context.bcc,
+        subject: context.subject,
+        content,
+        formattedFrom,
+        attachments: serializeMailAttachments(attachments),
+      }),
+    );
+  }
+
+  await prisma.executedAction.update({
+    where: { id: context.id },
+    data: {
+      messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+      wasDraftSent: true,
+    },
+  });
+
+  if (mailboxDraftAction?.id) {
+    await prisma.executedAction.update({
+      where: { id: mailboxDraftAction.id },
+      data: {
+        wasDraftSent: true,
+      },
+    });
+  }
+
+  await editMessage(
+    buildHandledNotificationCard({
+      content: notificationContent,
+      openLink: getNotificationOpenLink(context),
+      status: "Reply sent.",
+    }),
+  );
+
+  return "sent";
 }
 
 export function buildNotificationReplySendBody({
@@ -939,6 +980,7 @@ async function handleDraftEdit({
     type: "modal",
     callbackId: SLACK_DRAFT_EDIT_MODAL_ID,
     title: "Edit draft",
+    submitLabel: "Send reply",
     privateMetadata: context.id,
     children: [
       {
@@ -1362,14 +1404,6 @@ async function getNotificationDraftContent({
     );
     return context.content;
   }
-}
-
-async function getSourceMessageSummary(
-  context: NotificationContext,
-  logger: Logger,
-) {
-  const provider = await createProviderForContext(context, logger);
-  return getSourceMessageSummaryForProvider({ context, provider });
 }
 
 async function getSourceMessageSummaryForProvider({
@@ -1999,39 +2033,6 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
       },
     );
   }
-}
-
-async function expireNotificationCard({
-  event,
-  logger,
-  actionId,
-  title,
-  message,
-}: {
-  event: ActionEvent;
-  logger: Logger;
-  actionId: string;
-  title: string;
-  message: string;
-}) {
-  await prisma.executedAction.update({
-    where: { id: actionId },
-    data: {
-      messagingMessageStatus: MessagingMessageStatus.EXPIRED,
-    },
-  });
-
-  await event.adapter.editMessage(
-    event.threadId,
-    event.messageId,
-    buildTerminalCard({ title, message }),
-  );
-
-  await postNotificationFeedback({
-    event,
-    logger,
-    text: message,
-  });
 }
 
 async function postNotificationFeedback({


### PR DESCRIPTION
Updates the messaging draft edit modal so submitting it sends the edited draft immediately instead of requiring a second action.

- Reuses the notification send path for modal submissions and card actions.
- Adds integration coverage for the modal submit label and edit-and-send flow.

Tests: pnpm --filter inbox-zero-ai test-integration slack-notifications; pnpm check apps/web/utils/messaging/rule-notifications.ts apps/web/__tests__/integration/slack-notifications.test.ts