### PR TITLE
admin: Add response time loading

### DIFF
--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -74,7 +74,7 @@ export function createMockEmailProvider(
     // Message retrieval
     getSentMessages: vi.fn().mockResolvedValue([]),
     getInboxMessages: vi.fn().mockResolvedValue([defaultMessage]),
-    getSentMessageIds: vi.fn().mockResolvedValue([]),
+    getSentMessageIds: vi.fn().mockResolvedValue({ messages: [] }),
     getSentThreadsExcluding: vi.fn().mockResolvedValue([]),
     getDrafts: vi.fn().mockResolvedValue([]),
     getMessagesWithPagination: vi

--- a/apps/web/app/(app)/admin/AdminUserControls.tsx
+++ b/apps/web/app/(app)/admin/AdminUserControls.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useAction } from "next-safe-action/hooks";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
@@ -15,12 +16,16 @@ import {
   adminWatchEmailsAction,
   adminDisableAllRulesAction,
   adminCleanupDraftsAction,
+  adminLoadResponseTimeDataAction,
 } from "@/utils/actions/admin";
 import { adminCheckPermissionsAction } from "@/utils/actions/permissions";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { getActionErrorMessage } from "@/utils/error";
 
 export const AdminUserControls = () => {
+  const [responseTimeMaxSentMessages, setResponseTimeMaxSentMessages] =
+    useState(500);
+
   const { execute: processHistory, isExecuting: isProcessing } = useAction(
     adminProcessHistoryAction,
     {
@@ -120,6 +125,21 @@ export const AdminUserControls = () => {
       },
     },
   );
+  const { execute: loadResponseTimes, isExecuting: isLoadingResponseTimes } =
+    useAction(adminLoadResponseTimeDataAction, {
+      onSuccess: (result) => {
+        toastSuccess({
+          title: "Response times loaded",
+          description: `Analyzed ${result.data?.emailsAnalyzed ?? 0} email(s) with a cap of ${result.data?.maxEmailsCap ?? responseTimeMaxSentMessages}`,
+        });
+      },
+      onError: (error) => {
+        toastError({
+          title: "Error loading response times",
+          description: getActionErrorMessage(error.error),
+        });
+      },
+    });
   const { execute: deleteAccount, isExecuting: isDeleting } = useAction(
     adminDeleteAccountAction,
     {
@@ -155,7 +175,20 @@ export const AdminUserControls = () => {
         registerProps={register("email", { required: true })}
         error={errors.email}
       />
-      <div className="flex gap-2">
+      <Input
+        type="number"
+        name="responseTimeMaxSentMessages"
+        label="Response time sent messages"
+        min={1}
+        max={2000}
+        step={50}
+        registerProps={{
+          value: responseTimeMaxSentMessages,
+          onChange: (event) =>
+            setResponseTimeMaxSentMessages(Number(event.target.value)),
+        }}
+      />
+      <div className="flex flex-wrap gap-2">
         <Button
           variant="outline"
           loading={isProcessing}
@@ -200,6 +233,18 @@ export const AdminUserControls = () => {
           }}
         >
           Cleanup Drafts
+        </Button>
+        <Button
+          variant="outline"
+          loading={isLoadingResponseTimes}
+          onClick={() => {
+            loadResponseTimes({
+              email: getValues("email"),
+              maxSentMessages: responseTimeMaxSentMessages,
+            });
+          }}
+        >
+          Load Response Times
         </Button>
         <Button
           variant="destructive"

--- a/apps/web/app/(app)/admin/AdminUserControls.tsx
+++ b/apps/web/app/(app)/admin/AdminUserControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { type ChangeEvent, useState } from "react";
 import { useAction } from "next-safe-action/hooks";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
@@ -184,7 +184,7 @@ export const AdminUserControls = () => {
         step={50}
         registerProps={{
           value: responseTimeMaxSentMessages,
-          onChange: (event) =>
+          onChange: (event: ChangeEvent<HTMLInputElement>) =>
             setResponseTimeMaxSentMessages(Number(event.target.value)),
         }}
       />

--- a/apps/web/app/api/user/stats/response-time/calculate.test.ts
+++ b/apps/web/app/api/user/stats/response-time/calculate.test.ts
@@ -6,8 +6,12 @@ import {
 } from "./calculate";
 import { getMockMessage as getMockMessageHelper } from "../../../../../__tests__/helpers";
 import { createTestLogger } from "@/__tests__/helpers";
+import { sleep } from "@/utils/sleep";
 
 vi.mock("server-only", () => ({}));
+vi.mock("@/utils/sleep", () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
 
 const logger = createTestLogger();
 
@@ -16,6 +20,7 @@ describe("Response Time Stats", () => {
     let mockEmailProvider: any;
 
     beforeEach(() => {
+      vi.mocked(sleep).mockClear();
       mockEmailProvider = {
         getThreadMessages: vi.fn(),
         isSentMessage: (message: any) =>
@@ -150,6 +155,39 @@ describe("Response Time Stats", () => {
       expect(result.responseTimes).toHaveLength(1);
       expect(result.responseTimes[0].responseTimeMins).toBe(30); // 30 mins
       // T2 is ignored because lastReceivedMessage is nullified after T1
+    });
+
+    it("paces provider requests when a delay is configured", async () => {
+      const t0 = new Date("2024-01-01T10:00:00Z");
+      const t1 = new Date("2024-01-01T10:30:00Z");
+
+      mockEmailProvider.getThreadMessages.mockImplementation(
+        async (threadId: string) => [
+          {
+            ...getMockMessageHelper({ id: `received-${threadId}`, threadId }),
+            internalDate: t0.toISOString(),
+          },
+          {
+            ...getMockMessageHelper({ id: `sent-${threadId}`, threadId }),
+            internalDate: t1.toISOString(),
+            labelIds: ["SENT"],
+          },
+        ],
+      );
+
+      await calculateResponseTimes(
+        [
+          { id: "sent-t1", threadId: "t1" },
+          { id: "sent-t2", threadId: "t2" },
+          { id: "sent-t3", threadId: "t3" },
+        ],
+        mockEmailProvider,
+        logger,
+        { providerRequestDelayMs: 250 },
+      );
+
+      expect(sleep).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledWith(250);
     });
 
     it("should fallback to id check if SENT label not found", async () => {

--- a/apps/web/app/api/user/stats/response-time/calculate.ts
+++ b/apps/web/app/api/user/stats/response-time/calculate.ts
@@ -1,6 +1,7 @@
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import type { ResponseTime } from "@/generated/prisma/client";
+import { sleep } from "@/utils/sleep";
 
 export type ResponseTimeEntry = Pick<
   ResponseTime,
@@ -56,6 +57,7 @@ export async function calculateResponseTimes(
   sentMessages: { id: string; threadId: string }[],
   emailProvider: EmailProvider,
   logger: Logger,
+  options: { providerRequestDelayMs?: number } = {},
 ): Promise<{
   responseTimes: ResponseTimeEntry[];
   processedThreadsCount: number;
@@ -63,12 +65,18 @@ export async function calculateResponseTimes(
   const responseTimes: ResponseTimeEntry[] = [];
   const processedThreads = new Set<string>();
   const sentMessageIds = new Set(sentMessages.map((m) => m.id));
+  let providerRequests = 0;
 
   for (const sentMsg of sentMessages) {
     if (!sentMsg.threadId || processedThreads.has(sentMsg.threadId)) continue;
     processedThreads.add(sentMsg.threadId);
 
     try {
+      if (providerRequests > 0 && options.providerRequestDelayMs) {
+        await sleep(options.providerRequestDelayMs);
+      }
+      providerRequests++;
+
       const threadMessages = await emailProvider.getThreadMessages(
         sentMsg.threadId,
       );

--- a/apps/web/app/api/user/stats/response-time/controller.test.ts
+++ b/apps/web/app/api/user/stats/response-time/controller.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/prisma";
+import { createTestLogger } from "@/__tests__/helpers";
+import { getResponseTimeStats } from "./controller";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+const logger = createTestLogger();
+
+describe("getResponseTimeStats", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.responseTime.createMany).mockResolvedValue({
+      count: 0,
+    } as never);
+  });
+
+  it("paginates sent messages when the cap is greater than one page", async () => {
+    const firstPage = buildSentMessages(0, 50);
+    const secondPage = buildSentMessages(50, 10);
+    const allMessages = [...firstPage, ...secondPage];
+
+    const getSentMessageIds = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: firstPage,
+        nextPageToken: "next-page",
+      })
+      .mockResolvedValueOnce({
+        messages: secondPage,
+      });
+
+    vi.mocked(prisma.responseTime.findMany).mockResolvedValue(
+      allMessages.map((message, index) => ({
+        threadId: message.threadId,
+        sentMessageId: message.id,
+        receivedMessageId: `received-${index}`,
+        receivedAt: new Date("2026-01-01T09:00:00.000Z"),
+        sentAt: new Date(
+          `2026-01-01T10:${String(index).padStart(2, "0")}:00.000Z`,
+        ),
+        responseTimeMins: index + 1,
+      })) as never,
+    );
+
+    const result = await getResponseTimeStats({
+      emailAccountId: "email-account-1",
+      emailProvider: {
+        getSentMessageIds,
+      } as never,
+      logger,
+      maxSentMessages: 60,
+    });
+
+    expect(getSentMessageIds).toHaveBeenCalledTimes(2);
+    expect(getSentMessageIds).toHaveBeenNthCalledWith(1, {
+      maxResults: 50,
+      after: undefined,
+      before: undefined,
+      pageToken: undefined,
+    });
+    expect(getSentMessageIds).toHaveBeenNthCalledWith(2, {
+      maxResults: 10,
+      after: undefined,
+      before: undefined,
+      pageToken: "next-page",
+    });
+    expect(result.emailsAnalyzed).toBe(60);
+    expect(result.maxEmailsCap).toBe(60);
+  });
+});
+
+function buildSentMessages(start: number, count: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const value = start + index;
+
+    return {
+      id: `sent-${value}`,
+      threadId: `thread-${value}`,
+    };
+  });
+}

--- a/apps/web/app/api/user/stats/response-time/controller.test.ts
+++ b/apps/web/app/api/user/stats/response-time/controller.test.ts
@@ -2,14 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 import { getResponseTimeStats } from "./controller";
+import { sleep } from "@/utils/sleep";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/sleep", () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
 
 const logger = createTestLogger();
 
 describe("getResponseTimeStats", () => {
   beforeEach(() => {
+    vi.mocked(sleep).mockClear();
     vi.mocked(prisma.responseTime.createMany).mockResolvedValue({
       count: 0,
     } as never);
@@ -67,6 +72,48 @@ describe("getResponseTimeStats", () => {
     });
     expect(result.emailsAnalyzed).toBe(60);
     expect(result.maxEmailsCap).toBe(60);
+  });
+
+  it("paces paginated sent-message lookups when a delay is configured", async () => {
+    const firstPage = buildSentMessages(0, 50);
+    const secondPage = buildSentMessages(50, 10);
+    const allMessages = [...firstPage, ...secondPage];
+
+    const getSentMessageIds = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: firstPage,
+        nextPageToken: "next-page",
+      })
+      .mockResolvedValueOnce({
+        messages: secondPage,
+      });
+
+    vi.mocked(prisma.responseTime.findMany).mockResolvedValue(
+      allMessages.map((message, index) => ({
+        threadId: message.threadId,
+        sentMessageId: message.id,
+        receivedMessageId: `received-${index}`,
+        receivedAt: new Date("2026-01-01T09:00:00.000Z"),
+        sentAt: new Date(
+          `2026-01-01T10:${String(index).padStart(2, "0")}:00.000Z`,
+        ),
+        responseTimeMins: index + 1,
+      })) as never,
+    );
+
+    await getResponseTimeStats({
+      emailAccountId: "email-account-1",
+      emailProvider: {
+        getSentMessageIds,
+      } as never,
+      logger,
+      maxSentMessages: 60,
+      providerRequestDelayMs: 250,
+    });
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(250);
   });
 });
 

--- a/apps/web/app/api/user/stats/response-time/controller.ts
+++ b/apps/web/app/api/user/stats/response-time/controller.ts
@@ -3,6 +3,7 @@ import { format } from "date-fns/format";
 import { startOfWeek } from "date-fns/startOfWeek";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
+import { sleep } from "@/utils/sleep";
 import {
   calculateResponseTimes,
   calculateSummaryStats,
@@ -16,6 +17,7 @@ import type { ResponseTimeQuery } from "@/app/api/user/stats/response-time/valid
 
 const DEFAULT_MAX_SENT_MESSAGES = 50;
 const SENT_MESSAGES_PAGE_SIZE = 50;
+const ADMIN_PROVIDER_REQUEST_DELAY_MS = 250;
 
 type SentMessage = SentMessagePage["messages"][number];
 
@@ -41,16 +43,19 @@ export async function getResponseTimeStats({
   emailProvider,
   logger,
   maxSentMessages = DEFAULT_MAX_SENT_MESSAGES,
+  providerRequestDelayMs = 0,
 }: ResponseTimeQuery & {
   emailAccountId: string;
   emailProvider: EmailProvider;
   logger: Logger;
   maxSentMessages?: number;
+  providerRequestDelayMs?: number;
 }): Promise<ResponseTimeResponse> {
   // 1. Fetch sent message IDs (lightweight - just id and threadId)
   const sentMessages = await getSentMessagesForResponseTimes({
     emailProvider,
     maxSentMessages,
+    providerRequestDelayMs,
     ...(fromDate ? { after: new Date(fromDate) } : {}),
     ...(toDate ? { before: new Date(toDate) } : {}),
   });
@@ -93,6 +98,7 @@ export async function getResponseTimeStats({
       uncachedMessages,
       emailProvider,
       logger,
+      { providerRequestDelayMs },
     );
 
     // 5. Store new calculations to DB
@@ -151,18 +157,26 @@ async function getSentMessagesForResponseTimes({
   maxSentMessages,
   after,
   before,
+  providerRequestDelayMs,
 }: {
   emailProvider: EmailProvider;
   maxSentMessages: number;
   after?: Date;
   before?: Date;
+  providerRequestDelayMs: number;
 }): Promise<SentMessage[]> {
   const sentMessages: SentMessage[] = [];
   let pageToken: string | undefined;
+  let providerRequests = 0;
 
   do {
     const remaining = maxSentMessages - sentMessages.length;
     if (remaining <= 0) break;
+
+    if (providerRequests > 0 && providerRequestDelayMs) {
+      await sleep(providerRequestDelayMs);
+    }
+    providerRequests++;
 
     const page = await emailProvider.getSentMessageIds({
       maxResults: Math.min(remaining, SENT_MESSAGES_PAGE_SIZE),
@@ -227,4 +241,8 @@ function getEmptyStats(maxSentMessages: number): ResponseTimeResponse {
     emailsAnalyzed: 0,
     maxEmailsCap: maxSentMessages,
   };
+}
+
+export function getAdminResponseTimeProviderDelayMs() {
+  return ADMIN_PROVIDER_REQUEST_DELAY_MS;
 }

--- a/apps/web/app/api/user/stats/response-time/controller.ts
+++ b/apps/web/app/api/user/stats/response-time/controller.ts
@@ -1,4 +1,4 @@
-import type { EmailProvider } from "@/utils/email/types";
+import type { EmailProvider, SentMessagePage } from "@/utils/email/types";
 import { format } from "date-fns/format";
 import { startOfWeek } from "date-fns/startOfWeek";
 import type { Logger } from "@/utils/logger";
@@ -14,7 +14,10 @@ import {
 } from "./calculate";
 import type { ResponseTimeQuery } from "@/app/api/user/stats/response-time/validation";
 
-const MAX_SENT_MESSAGES = 50;
+const DEFAULT_MAX_SENT_MESSAGES = 50;
+const SENT_MESSAGES_PAGE_SIZE = 50;
+
+type SentMessage = SentMessagePage["messages"][number];
 
 interface TrendEntry {
   count: number;
@@ -37,20 +40,23 @@ export async function getResponseTimeStats({
   emailAccountId,
   emailProvider,
   logger,
+  maxSentMessages = DEFAULT_MAX_SENT_MESSAGES,
 }: ResponseTimeQuery & {
   emailAccountId: string;
   emailProvider: EmailProvider;
   logger: Logger;
+  maxSentMessages?: number;
 }): Promise<ResponseTimeResponse> {
   // 1. Fetch sent message IDs (lightweight - just id and threadId)
-  const sentMessages = await emailProvider.getSentMessageIds({
-    maxResults: MAX_SENT_MESSAGES,
+  const sentMessages = await getSentMessagesForResponseTimes({
+    emailProvider,
+    maxSentMessages,
     ...(fromDate ? { after: new Date(fromDate) } : {}),
     ...(toDate ? { before: new Date(toDate) } : {}),
   });
 
   if (!sentMessages.length) {
-    return getEmptyStats();
+    return getEmptyStats(maxSentMessages);
   }
 
   const sentMessageIds = sentMessages.map((m) => m.id);
@@ -122,7 +128,7 @@ export async function getResponseTimeStats({
   });
 
   if (allEntries.length === 0) {
-    return getEmptyStats();
+    return getEmptyStats(maxSentMessages);
   }
 
   // 7. Calculate derived statistics
@@ -136,8 +142,42 @@ export async function getResponseTimeStats({
     distribution,
     trend,
     emailsAnalyzed: allEntries.length,
-    maxEmailsCap: MAX_SENT_MESSAGES,
+    maxEmailsCap: maxSentMessages,
   };
+}
+
+async function getSentMessagesForResponseTimes({
+  emailProvider,
+  maxSentMessages,
+  after,
+  before,
+}: {
+  emailProvider: EmailProvider;
+  maxSentMessages: number;
+  after?: Date;
+  before?: Date;
+}): Promise<SentMessage[]> {
+  const sentMessages: SentMessage[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const remaining = maxSentMessages - sentMessages.length;
+    if (remaining <= 0) break;
+
+    const page = await emailProvider.getSentMessageIds({
+      maxResults: Math.min(remaining, SENT_MESSAGES_PAGE_SIZE),
+      after,
+      before,
+      pageToken,
+    });
+
+    if (page.messages.length === 0) break;
+
+    sentMessages.push(...page.messages);
+    pageToken = page.nextPageToken;
+  } while (pageToken && sentMessages.length < maxSentMessages);
+
+  return sentMessages.slice(0, maxSentMessages);
 }
 
 function calculateTrend(responseTimes: ResponseTimeEntry[]): TrendEntry[] {
@@ -167,7 +207,7 @@ function calculateTrend(responseTimes: ResponseTimeEntry[]): TrendEntry[] {
     .sort((a, b) => a.periodDate.getTime() - b.periodDate.getTime());
 }
 
-function getEmptyStats(): ResponseTimeResponse {
+function getEmptyStats(maxSentMessages: number): ResponseTimeResponse {
   return {
     summary: {
       medianResponseTime: 0,
@@ -185,6 +225,6 @@ function getEmptyStats(): ResponseTimeResponse {
     },
     trend: [],
     emailsAnalyzed: 0,
-    maxEmailsCap: MAX_SENT_MESSAGES,
+    maxEmailsCap: maxSentMessages,
   };
 }

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -71,7 +71,7 @@ export const createMockEmailProvider = (
   }),
   getSentMessages: vi.fn().mockResolvedValue([]),
   getInboxMessages: vi.fn().mockResolvedValue([]),
-  getSentMessageIds: vi.fn().mockResolvedValue([]),
+  getSentMessageIds: vi.fn().mockResolvedValue({ messages: [] }),
   getSentThreadsExcluding: vi.fn().mockResolvedValue([]),
   getThreadMessages: vi.fn().mockResolvedValue([]),
   getThreadMessagesInInbox: vi.fn().mockResolvedValue([]),

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -18,11 +18,13 @@ import {
   getLabelsBody,
   watchEmailsBody,
   getUserInfoBody,
+  loadResponseTimeDataBody,
   disableAllRulesBody,
   cleanupDraftsBody,
 } from "@/utils/actions/admin.validation";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import { cleanupAIDraftsForAccount } from "@/utils/ai/draft-cleanup";
+import { getResponseTimeStats } from "@/app/api/user/stats/response-time/controller";
 
 export const adminProcessHistoryAction = adminActionClient
   .metadata({ name: "adminProcessHistory" })
@@ -419,6 +421,60 @@ export const adminGetUserInfoAction = adminActionClient
       })),
     };
   });
+
+export const adminLoadResponseTimeDataAction = adminActionClient
+  .metadata({ name: "adminLoadResponseTimeData" })
+  .inputSchema(loadResponseTimeDataBody)
+  .action(
+    async ({ parsedInput: { email, maxSentMessages }, ctx: { logger } }) => {
+      const emailAccount = await prisma.emailAccount.findUnique({
+        where: { email: email.toLowerCase() },
+        select: {
+          id: true,
+          account: {
+            select: {
+              provider: true,
+            },
+          },
+        },
+      });
+
+      if (!emailAccount) {
+        throw new SafeError("Email account not found");
+      }
+
+      const emailProvider = await createEmailProvider({
+        emailAccountId: emailAccount.id,
+        provider: emailAccount.account.provider,
+        logger,
+      });
+
+      logger.info("Starting admin response time data load", {
+        emailAccountId: emailAccount.id,
+        maxSentMessages,
+      });
+
+      const result = await getResponseTimeStats({
+        emailAccountId: emailAccount.id,
+        emailProvider,
+        logger,
+        maxSentMessages,
+      });
+
+      logger.info("Finished admin response time data load", {
+        emailAccountId: emailAccount.id,
+        emailsAnalyzed: result.emailsAnalyzed,
+        maxSentMessages,
+      });
+
+      return {
+        emailsAnalyzed: result.emailsAnalyzed,
+        maxEmailsCap: result.maxEmailsCap,
+        averageResponseTime: result.summary.averageResponseTime,
+        medianResponseTime: result.summary.medianResponseTime,
+      };
+    },
+  );
 
 export const adminDisableAllRulesAction = adminActionClient
   .metadata({ name: "adminDisableAllRules" })

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -24,7 +24,10 @@ import {
 } from "@/utils/actions/admin.validation";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import { cleanupAIDraftsForAccount } from "@/utils/ai/draft-cleanup";
-import { getResponseTimeStats } from "@/app/api/user/stats/response-time/controller";
+import {
+  getAdminResponseTimeProviderDelayMs,
+  getResponseTimeStats,
+} from "@/app/api/user/stats/response-time/controller";
 
 export const adminProcessHistoryAction = adminActionClient
   .metadata({ name: "adminProcessHistory" })
@@ -459,6 +462,7 @@ export const adminLoadResponseTimeDataAction = adminActionClient
         emailProvider,
         logger,
         maxSentMessages,
+        providerRequestDelayMs: getAdminResponseTimeProviderDelayMs(),
       });
 
       logger.info("Finished admin response time data load", {

--- a/apps/web/utils/actions/admin.validation.ts
+++ b/apps/web/utils/actions/admin.validation.ts
@@ -26,6 +26,12 @@ export const getUserInfoBody = z.object({
 });
 export type GetUserInfoBody = z.infer<typeof getUserInfoBody>;
 
+export const loadResponseTimeDataBody = z.object({
+  email: z.string().trim().email("Valid email address is required"),
+  maxSentMessages: z.coerce.number().int().min(1).max(2000).default(500),
+});
+export type LoadResponseTimeDataBody = z.infer<typeof loadResponseTimeDataBody>;
+
 export const disableAllRulesBody = z.object({
   email: z.string().trim().email("Valid email address is required"),
 });

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -117,9 +117,9 @@ describe("confirmAssistantEmailAction", () => {
       messageId: "",
       threadId: "thr-1",
     });
-    const getSentMessageIds = vi
-      .fn()
-      .mockResolvedValue([{ id: "msg-from-sent", threadId: "thr-1" }]);
+    const getSentMessageIds = vi.fn().mockResolvedValue({
+      messages: [{ id: "msg-from-sent", threadId: "thr-1" }],
+    });
     vi.mocked(createEmailProvider).mockResolvedValue({
       sendEmailWithHtml,
       getSentMessageIds,
@@ -168,10 +168,12 @@ describe("confirmAssistantEmailAction", () => {
         messageId: "",
         threadId: "thr-1",
       }),
-      getSentMessageIds: vi.fn().mockResolvedValue([
-        { id: "msg-1", threadId: "thr-1" },
-        { id: "msg-2", threadId: "thr-1" },
-      ]),
+      getSentMessageIds: vi.fn().mockResolvedValue({
+        messages: [
+          { id: "msg-1", threadId: "thr-1" },
+          { id: "msg-2", threadId: "thr-1" },
+        ],
+      }),
     } as any);
 
     const result = await confirmAssistantEmailAction(
@@ -217,7 +219,9 @@ describe("confirmAssistantEmailAction", () => {
     const getSentMessageIds = vi
       .fn()
       .mockRejectedValueOnce(new Error("temporary failure"))
-      .mockResolvedValueOnce([{ id: "msg-from-sent", threadId: "thr-1" }]);
+      .mockResolvedValueOnce({
+        messages: [{ id: "msg-from-sent", threadId: "thr-1" }],
+      });
     vi.mocked(createEmailProvider).mockResolvedValue({
       sendEmailWithHtml: vi.fn().mockResolvedValue({
         messageId: "",
@@ -287,9 +291,9 @@ describe("confirmAssistantEmailAction", () => {
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessage: vi.fn().mockResolvedValue(sourceMessage),
       replyToEmail,
-      getSentMessageIds: vi
-        .fn()
-        .mockResolvedValue([{ id: "reply-message-2", threadId: "thread-1" }]),
+      getSentMessageIds: vi.fn().mockResolvedValue({
+        messages: [{ id: "reply-message-2", threadId: "thread-1" }],
+      }),
     } as any);
 
     const result = await confirmAssistantEmailAction(
@@ -348,9 +352,9 @@ describe("confirmAssistantEmailAction", () => {
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessage: vi.fn().mockResolvedValue(sourceMessage),
       forwardEmail,
-      getSentMessageIds: vi
-        .fn()
-        .mockResolvedValue([{ id: "forward-message-2", threadId: "thread-1" }]),
+      getSentMessageIds: vi.fn().mockResolvedValue({
+        messages: [{ id: "forward-message-2", threadId: "thread-1" }],
+      }),
     } as any);
 
     const result = await confirmAssistantEmailAction(

--- a/apps/web/utils/actions/assistant-chat.ts
+++ b/apps/web/utils/actions/assistant-chat.ts
@@ -1171,13 +1171,13 @@ async function resolveSentMessageId({
     attempt++
   ) {
     try {
-      const sentMessageIds = await emailProvider.getSentMessageIds({
+      const sentMessagePage = await emailProvider.getSentMessageIds({
         maxResults: 20,
         after: sentAfterWithLookback,
         before: new Date(),
       });
 
-      const matchingThreadIds = sentMessageIds.filter(
+      const matchingThreadIds = sentMessagePage.messages.filter(
         (sentMessage) => sentMessage.threadId === threadId,
       );
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -72,6 +72,7 @@ import type {
   EmailLabel,
   EmailFilter,
   EmailSignature,
+  SentMessagePage,
 } from "@/utils/email/types";
 import { createScopedLogger, type Logger } from "@/utils/logger";
 import { getGmailSignatures } from "@/utils/gmail/signature-settings";
@@ -230,8 +231,9 @@ export class GmailProvider implements EmailProvider {
     maxResults: number;
     after?: Date;
     before?: Date;
-  }): Promise<{ id: string; threadId: string }[]> {
-    const { maxResults, after, before } = options;
+    pageToken?: string;
+  }): Promise<SentMessagePage> {
+    const { maxResults, after, before, pageToken } = options;
 
     let query = `label:${GmailLabel.SENT}`;
     if (after) {
@@ -241,13 +243,19 @@ export class GmailProvider implements EmailProvider {
       query += ` before:${Math.floor(before.getTime() / 1000) + 1}`;
     }
 
-    const response = await getMessages(this.client, { query, maxResults });
+    const response = await getMessages(this.client, {
+      query,
+      maxResults,
+      pageToken,
+    });
 
-    return (
-      response.messages
-        ?.filter((m) => m.id && m.threadId)
-        .map((m) => ({ id: m.id!, threadId: m.threadId! })) || []
-    );
+    return {
+      messages: response.messages.map((m) => ({
+        id: m.id,
+        threadId: m.threadId,
+      })),
+      nextPageToken: response.nextPageToken,
+    };
   }
 
   async getSentThreadsExcluding(options: {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -60,6 +60,7 @@ import type {
   EmailLabel,
   EmailFilter,
   EmailSignature,
+  SentMessagePage,
 } from "@/utils/email/types";
 import { unwatchOutlook, watchOutlook } from "@/utils/outlook/watch";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
@@ -295,41 +296,48 @@ export class OutlookProvider implements EmailProvider {
     maxResults: number;
     after?: Date;
     before?: Date;
-  }): Promise<{ id: string; threadId: string }[]> {
-    const { maxResults, after, before } = options;
+    pageToken?: string;
+  }): Promise<SentMessagePage> {
+    const { maxResults, after, before, pageToken } = options;
 
-    const filters: string[] = [];
-    if (after) {
-      filters.push(`sentDateTime ge ${after.toISOString()}`);
-    }
-    if (before) {
-      filters.push(`sentDateTime le ${before.toISOString()}`);
-    }
+    const buildRequest = () => {
+      // pageToken is the full @odata.nextLink URL, which already encodes
+      // top/skip/filter from the original request.
+      if (pageToken?.startsWith("http")) {
+        return this.client.getClient().api(pageToken);
+      }
 
-    let request = this.client
-      .getClient()
-      .api("/me/mailFolders('sentitems')/messages")
-      .select("id,conversationId")
-      .top(maxResults)
-      .orderby("sentDateTime desc");
+      const filters: string[] = [];
+      if (after) filters.push(`sentDateTime ge ${after.toISOString()}`);
+      if (before) filters.push(`sentDateTime le ${before.toISOString()}`);
 
-    if (filters.length) {
-      request = request.filter(filters.join(" and "));
-    }
+      let request = this.client
+        .getClient()
+        .api("/me/mailFolders('sentitems')/messages")
+        .select("id,conversationId")
+        .top(maxResults)
+        .orderby("sentDateTime desc");
 
-    const response = await withOutlookRetry(() => request.get(), this.logger);
+      if (filters.length) {
+        request = request.filter(filters.join(" and "));
+      }
 
-    return (
-      response.value
-        ?.filter(
-          (m: { id?: string; conversationId?: string }) =>
-            m.id && m.conversationId,
-        )
-        .map((m: { id: string; conversationId: string }) => ({
-          id: m.id,
-          threadId: m.conversationId,
-        })) || []
-    );
+      return request;
+    };
+
+    const response: {
+      value?: { id?: string; conversationId?: string }[];
+      "@odata.nextLink"?: string;
+    } = await withOutlookRetry(() => buildRequest().get(), this.logger);
+
+    return {
+      messages: (response.value || []).flatMap((m) =>
+        m.id && m.conversationId
+          ? [{ id: m.id, threadId: m.conversationId }]
+          : [],
+      ),
+      nextPageToken: response["@odata.nextLink"],
+    };
   }
 
   async getSentThreadsExcluding(options: {

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -42,6 +42,11 @@ export interface EmailSignature {
   signature: string;
 }
 
+export interface SentMessagePage {
+  messages: { id: string; threadId: string }[];
+  nextPageToken?: string;
+}
+
 export interface EmailProvider {
   archiveMessage(messageId: string): Promise<void>;
   archiveThread(threadId: string, ownerEmail: string): Promise<void>;
@@ -173,7 +178,8 @@ export interface EmailProvider {
     maxResults: number;
     after?: Date;
     before?: Date;
-  }): Promise<{ id: string; threadId: string }[]>;
+    pageToken?: string;
+  }): Promise<SentMessagePage>;
   getSentMessages(maxResults?: number): Promise<ParsedMessage[]>;
   getSentThreadsExcluding(options: {
     excludeToEmails?: string[];


### PR DESCRIPTION
Adds an admin action and UI control to preload response time data with a configurable sent-message cap.

- Updates response-time stats loading to paginate sent-message IDs beyond the default cap.
- Updates the email provider contract and existing sent-message lookup tests for paginated results.
- Validation: targeted Vitest runs passed; `pnpm check` completed with an existing unrelated warning.