### PR TITLE
Fix messaging follow-up link rendering

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -691,6 +691,7 @@ describe("processAccountFollowUps - dedup logic", () => {
         counterpartyName: "Alex Partner",
         counterpartyEmail: "alex@partner.com",
         trackerType: ThreadTrackerType.AWAITING,
+        threadLinkLabel: "Open in Outlook",
       }),
     );
   });

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -38,6 +38,10 @@ import {
   extractNameFromEmail,
   isSameEmailAddress,
 } from "@/utils/email";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 import { env } from "@/env";
@@ -526,6 +530,7 @@ async function processFollowUpsForType({
                 emailAddress: emailAccount.email,
                 provider: providerName,
               }) ?? undefined,
+            threadLinkLabel: getThreadLinkLabel(providerName),
             trackerId: tracker.id,
             logger: threadLogger,
           });
@@ -709,4 +714,10 @@ function resolveFollowUpCounterparty({
   const email = extractEmailAddress(header || "") || header || "";
   const name = extractNameFromEmail(header || "") || email || "someone";
   return { name, email };
+}
+
+function getThreadLinkLabel(provider: string) {
+  if (isGoogleProvider(provider)) return "Open in Gmail";
+  if (isMicrosoftProvider(provider)) return "Open in Outlook";
+  return "Open thread";
 }

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -16,6 +16,9 @@ import {
 } from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 
+const mockTelegramOpenDm = vi.fn();
+const mockTelegramPostMessage = vi.fn();
+
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({ default: {} }));
 vi.mock("@/utils/messaging/providers/slack/send", () => ({
@@ -24,6 +27,16 @@ vi.mock("@/utils/messaging/providers/slack/send", () => ({
 }));
 vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: vi.fn(),
+}));
+vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
+  getMessagingAdapterRegistry: () => ({
+    typedAdapters: {
+      telegram: {
+        openDM: (...args: unknown[]) => mockTelegramOpenDm(...args),
+        postMessage: (...args: unknown[]) => mockTelegramPostMessage(...args),
+      },
+    },
+  }),
 }));
 
 const logger = createScopedLogger("send-follow-up-test");
@@ -72,10 +85,28 @@ const teamsChannel: FollowUpNotificationChannel = {
   ],
 };
 
+const telegramChannel: FollowUpNotificationChannel = {
+  id: "channel-3",
+  provider: MessagingProvider.TELEGRAM,
+  isConnected: true,
+  accessToken: null,
+  teamId: "telegram-chat-1",
+  providerUserId: "telegram-user-id",
+  routes: [
+    {
+      purpose: MessagingRoutePurpose.FOLLOW_UPS,
+      targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+      targetId: "telegram-chat-1",
+    },
+  ],
+};
+
 describe("sendFollowUpNotification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (resolveSlackRouteDestination as any).mockResolvedValue("C1");
+    mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
+    mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
 
   it("no-ops when no channels are provided", async () => {
@@ -89,9 +120,31 @@ describe("sendFollowUpNotification", () => {
     expect(sendFollowUpReminderToSlack).toHaveBeenCalledTimes(1);
   });
 
-  it("delivers to Teams/Telegram via automation adapter", async () => {
+  it("delivers to Teams via automation adapter", async () => {
     await sendFollowUpNotification({ channels: [teamsChannel], ...baseArgs });
     expect(sendAutomationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers Telegram follow-ups with a thread link button instead of raw URL text", async () => {
+    const threadLink = "https://outlook.live.com/mail/0/inbox/id/thread-1";
+
+    await sendFollowUpNotification({
+      channels: [telegramChannel],
+      ...baseArgs,
+      threadLink,
+      threadLinkLabel: "Open in Outlook",
+    });
+
+    expect(sendAutomationMessage).not.toHaveBeenCalled();
+    expect(mockTelegramOpenDm).toHaveBeenCalledWith("telegram-chat-1");
+    expect(mockTelegramPostMessage).toHaveBeenCalledTimes(1);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const serializedCard = JSON.stringify(card);
+    expect(serializedCard).toContain("Follow-up nudge");
+    expect(serializedCard).toContain("Open in Outlook");
+    expect(serializedCard).toContain(threadLink);
+    expect(serializedCard).not.toContain(`Open: ${threadLink}`);
   });
 
   it("fans out across multiple channels in parallel", async () => {

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -183,7 +183,8 @@ async function sendFollowUpViaTelegram({
   content: FollowUpNotificationContent;
   logger: Logger;
 }) {
-  const destination = resolveTelegramRouteDestination({ channel, route });
+  const destination =
+    route.targetId || channel.teamId || channel.providerUserId;
 
   if (!destination) {
     logger.warn("No Telegram destination resolved for follow-up notification");
@@ -265,14 +266,4 @@ function buildTelegramFollowUpCard({
     title: "Follow-up nudge",
     children,
   });
-}
-
-function resolveTelegramRouteDestination({
-  channel,
-  route,
-}: {
-  channel: FollowUpNotificationChannel;
-  route: { targetId: string; targetType: MessagingRouteTargetType };
-}) {
-  return route.targetId || channel.teamId || channel.providerUserId;
 }

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -1,3 +1,4 @@
+import { Actions, Card, CardText, LinkButton, type CardChild } from "chat";
 import {
   MessagingProvider,
   MessagingRoutePurpose,
@@ -10,6 +11,7 @@ import {
   resolveSlackRouteDestination,
   sendFollowUpReminderToSlack,
 } from "@/utils/messaging/providers/slack/send";
+import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 import {
   getMessagingRoute,
   getMessagingRouteWhere,
@@ -41,6 +43,7 @@ type FollowUpNotificationContent = {
   daysSinceSent: number;
   snippet?: string;
   threadLink?: string;
+  threadLinkLabel?: string;
   trackerId: string;
 };
 
@@ -107,12 +110,21 @@ export async function sendFollowUpNotification({
         );
         break;
       case MessagingProvider.TEAMS:
-      case MessagingProvider.TELEGRAM:
         deliveryPromises.push(
           sendAutomationMessage({
             channel,
             route,
             text: formatFollowUpText(content),
+            logger,
+          }),
+        );
+        break;
+      case MessagingProvider.TELEGRAM:
+        deliveryPromises.push(
+          sendFollowUpViaTelegram({
+            channel,
+            route,
+            content,
             logger,
           }),
         );
@@ -160,6 +172,36 @@ async function sendFollowUpViaSlack({
   });
 }
 
+async function sendFollowUpViaTelegram({
+  channel,
+  route,
+  content,
+  logger,
+}: {
+  channel: FollowUpNotificationChannel;
+  route: { targetId: string; targetType: MessagingRouteTargetType };
+  content: FollowUpNotificationContent;
+  logger: Logger;
+}) {
+  const destination = resolveTelegramRouteDestination({ channel, route });
+
+  if (!destination) {
+    logger.warn("No Telegram destination resolved for follow-up notification");
+    return;
+  }
+
+  const telegramAdapter = getMessagingAdapterRegistry().typedAdapters.telegram;
+  if (!telegramAdapter) {
+    throw new Error("Telegram adapter is not configured");
+  }
+
+  const threadId = await telegramAdapter.openDM(destination);
+  await telegramAdapter.postMessage(
+    threadId,
+    buildTelegramFollowUpCard(content),
+  );
+}
+
 function formatFollowUpText({
   subject,
   counterpartyName,
@@ -181,4 +223,56 @@ function formatFollowUpText({
   if (threadLink) lines.push(`Open: ${threadLink}`);
 
   return lines.join("\n");
+}
+
+function buildTelegramFollowUpCard({
+  subject,
+  counterpartyName,
+  counterpartyEmail,
+  trackerType,
+  daysSinceSent,
+  snippet,
+  threadLink,
+  threadLinkLabel,
+}: FollowUpNotificationContent) {
+  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
+  const children: CardChild[] = [
+    CardText(
+      [
+        directionLine,
+        subject,
+        `${preposition} ${counterpartyName} <${counterpartyEmail}> · ${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
+      ].join("\n\n"),
+    ),
+  ];
+
+  if (snippet) {
+    children.push(CardText(`> ${truncateSnippet(snippet)}`));
+  }
+
+  if (threadLink) {
+    children.push(
+      Actions([
+        LinkButton({
+          label: threadLinkLabel ?? "Open thread",
+          url: threadLink,
+        }),
+      ]),
+    );
+  }
+
+  return Card({
+    title: "Follow-up nudge",
+    children,
+  });
+}
+
+function resolveTelegramRouteDestination({
+  channel,
+  route,
+}: {
+  channel: FollowUpNotificationChannel;
+  route: { targetId: string; targetType: MessagingRouteTargetType };
+}) {
+  return route.targetId || channel.teamId || channel.providerUserId;
 }


### PR DESCRIPTION
Updates follow-up messaging so thread links can render as structured buttons instead of raw URLs.

- Adds provider-specific link labels for thread open actions.
- Adds tests for button rendering and label propagation.

Tests: pnpm --filter inbox-zero-ai test --run utils/follow-up/send-follow-up-notification.test.ts app/api/follow-up-reminders/process.test.ts