### PR TITLE
Fix BlogLayout footer touching edge and overlapping nav

### DIFF
--- a/apps/web/components/layouts/BlogLayout.tsx
+++ b/apps/web/components/layouts/BlogLayout.tsx
@@ -19,7 +19,7 @@ export function BlogLayout(props: { children: React.ReactNode }) {
       <div className="mt-20">
         <Footer
           variant="simple"
-          className="mx-auto w-full max-w-screen-xl px-0"
+          className="mx-auto w-full max-w-screen-xl px-6 lg:px-8"
         />
       </div>
     </div>

--- a/apps/web/components/new-landing/sections/Footer.tsx
+++ b/apps/web/components/new-landing/sections/Footer.tsx
@@ -33,7 +33,7 @@ const selfHostedFooter = {
 export function Footer({ className, variant = "default" }: FooterProps) {
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) {
     return (
-      <footer className="relative z-50 border-t border-[#E7E7E7A3] bg-cover bg-center bg-no-repeat overflow-hidden">
+      <footer className="border-t border-[#E7E7E7A3] bg-cover bg-center bg-no-repeat overflow-hidden">
         <div className={cn("overflow-hidden px-6 py-12 lg:px-8", className)}>
           <div className="flex flex-wrap justify-center gap-x-6 gap-y-2">
             {selfHostedFooter.resources.map((item) => (
@@ -77,7 +77,12 @@ export function Footer({ className, variant = "default" }: FooterProps) {
   }
 
   return (
-    <footer className="relative z-50 border-t border-[#E7E7E7A3] bg-cover bg-center bg-no-repeat overflow-hidden">
+    <footer
+      className={cn(
+        "border-t border-[#E7E7E7A3] bg-cover bg-center bg-no-repeat overflow-hidden",
+        variant === "default" && "relative z-50",
+      )}
+    >
       {variant === "default" ? <UnicornScene className="opacity-15" /> : null}
       <div
         className={cn("overflow-hidden px-6 py-20 sm:py-24 lg:px-8", className)}


### PR DESCRIPTION
## Summary
- BlogLayout passed `px-0` to `Footer`, which overrode the default `px-6 lg:px-8` via tailwind-merge — content went flush to the viewport edge on case-studies, blog posts, and alternatives pages.
- `Footer`'s outer element had `relative z-50`, which is only needed for the `default` variant's absolutely-positioned `UnicornScene`. In the `simple` variant (used by `BlogLayout`) it just put the footer above the sticky `BlogHeader` (`z-30`), causing the footer to render over the nav on scroll.
- Bumps marketing submodule for case-studies metadata title fix (`Customer Stories | Inbox Zero` → `Case Studies | Inbox Zero` for site-wide consistency).

## Test plan
- [ ] Visit `/case-studies` — footer has horizontal padding, doesn't touch edge.
- [ ] Scroll to bottom of `/case-studies` — sticky header stays above footer content; no overlap.
- [ ] Spot-check a blog post and an alternatives page (also use `BlogLayout`) — same behavior.
- [ ] Visit homepage / other landing pages using the `default` Footer variant — `UnicornScene` still renders correctly with `relative z-50` intact.
- [ ] Verify `/case-studies` `<title>` reads `Case Studies | Inbox Zero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)