### PR TITLE
Fix messaging notification formatting

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1312,6 +1312,67 @@ describe("sendMessagingRuleNotification", () => {
     });
   });
 
+  it("sends Telegram draft notification cards without raw markdown-sensitive text", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "cmabcdef1234567890123456",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Use the account_name tag and keep *exact* wording.",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "cmabcdef1234567890123456",
+      email: {
+        headers: {
+          from: "Sender_Name <sender@example.com>",
+          subject: "Question about [billing]_status",
+        },
+        snippet: "Can you review item_name before 5 * 6?",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockTelegramPostMessage).toHaveBeenCalledTimes(1);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const cardText = (
+      card as { children?: Array<{ content?: string }> }
+    ).children
+      ?.map((child) => child.content ?? "")
+      .join("\n");
+
+    expect(card).not.toMatchObject({ title: expect.any(String) });
+    expect(JSON.stringify(card)).not.toContain("**");
+    expect(cardText).not.toContain("*They wrote:*");
+    expect(cardText).not.toContain("Sender_Name");
+    expect(cardText).toContain("Sender\\_Name");
+    expect(cardText).toContain("\\[billing]");
+    expect(cardText).toContain("5 \\* 6");
+  });
+
   it("skips linked notifications when provider routing data is incomplete", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1317,7 +1317,7 @@ describe("sendMessagingRuleNotification", () => {
       getNotificationContext({
         id: "cmabcdef1234567890123456",
         type: ActionType.DRAFT_MESSAGING_CHANNEL,
-        content: "Use the account_name tag and keep *exact* wording.",
+        content: String.raw`Use the C:\labels\account_name tag and keep *exact* wording.`,
         messagingChannel: {
           id: "channel-1",
           provider: MessagingProvider.TELEGRAM,
@@ -1371,6 +1371,7 @@ describe("sendMessagingRuleNotification", () => {
     expect(cardText).toContain("Sender\\_Name");
     expect(cardText).toContain("\\[billing]");
     expect(cardText).toContain("5 \\* 6");
+    expect(cardText).toContain(String.raw`C:\\labels\\account\_name`);
   });
 
   it("skips linked notifications when provider routing data is incomplete", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1643,7 +1643,7 @@ function sanitizeTelegramNotificationContent(
 }
 
 function escapeTelegramCardMarkdown(text: string) {
-  return text.replace(/([_*`[])/g, "\\$1");
+  return text.replace(/([\\_*`[])/g, "\\$1");
 }
 
 function buildHandledNotificationCard({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -60,6 +60,7 @@ import {
   isOperationalSlackChannel,
 } from "@/utils/messaging/channel-validity";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
+import { markdownToTelegramText } from "@/utils/messaging/providers/telegram/format";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 
@@ -1607,7 +1608,9 @@ function buildTelegramNotificationCard({
   content: NotificationContent;
   openLink?: NotificationOpenLink | null;
 }): CardElement {
-  const children = buildNotificationCardBody(content);
+  const children = buildNotificationCardBody(
+    sanitizeTelegramNotificationContent(content),
+  );
   children.push(
     Actions([
       Button({
@@ -1621,9 +1624,26 @@ function buildTelegramNotificationCard({
   );
 
   return Card({
-    title: content.title,
     children,
   });
+}
+
+function sanitizeTelegramNotificationContent(
+  content: NotificationContent,
+): NotificationContent {
+  return {
+    title: escapeTelegramCardMarkdown(content.title),
+    summary: escapeTelegramCardMarkdown(
+      markdownToTelegramText(content.summary),
+    ),
+    details: content.details?.map((detail) =>
+      escapeTelegramCardMarkdown(markdownToTelegramText(detail)),
+    ),
+  };
+}
+
+function escapeTelegramCardMarkdown(text: string) {
+  return text.replace(/([_*`[])/g, "\\$1");
 }
 
 function buildHandledNotificationCard({


### PR DESCRIPTION
Fixes a messaging notification formatting edge case that could prevent delivery for one provider.

- Sanitizes provider-specific notification card text before delivery
- Adds a regression test for markdown-sensitive notification content

Validation:
- pnpm --filter inbox-zero-ai test --run utils/messaging/rule-notifications.test.ts
- pnpm --filter inbox-zero-ai exec biome check utils/messaging/rule-notifications.ts utils/messaging/rule-notifications.test.ts