### PR TITLE
chat: Reset state on account switch

### DIFF
--- a/apps/web/providers/ChatProvider.test.tsx
+++ b/apps/web/providers/ChatProvider.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatProvider, useChat } from "./ChatProvider";
+
+const {
+  mockSetMessages,
+  mockSetQueryState,
+  mockUseChatMessages,
+  mockUseSWRConfig,
+  mockConvertToUIMessages,
+  mockCaptureException,
+  accountState,
+  queryState,
+} = vi.hoisted(() => ({
+  mockSetMessages: vi.fn(),
+  mockSetQueryState: vi.fn(),
+  mockUseChatMessages: vi.fn(),
+  mockUseSWRConfig: vi.fn(),
+  mockConvertToUIMessages: vi.fn(),
+  mockCaptureException: vi.fn(),
+  accountState: {
+    emailAccountId: "account-a",
+  },
+  queryState: {
+    initialChatId: "chat-from-account-a" as string | null,
+  },
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    id: "new-chat-id",
+    messages: [],
+    status: "ready",
+    setMessages: mockSetMessages,
+    sendMessage: vi.fn(),
+    stop: vi.fn(),
+    regenerate: vi.fn(),
+  }),
+}));
+
+vi.mock("ai", () => ({
+  DefaultChatTransport: class DefaultChatTransport {},
+}));
+
+vi.mock("nuqs", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    parseAsString: {},
+    useQueryState: () => {
+      const [value, setValue] = React.useState<string | null>(
+        queryState.initialChatId,
+      );
+
+      return [
+        value,
+        (nextValue: string | null) => {
+          mockSetQueryState(nextValue);
+          setValue(nextValue);
+        },
+      ] as const;
+    },
+  };
+});
+
+vi.mock("swr", () => ({
+  useSWRConfig: () => mockUseSWRConfig(),
+}));
+
+vi.mock("@/hooks/useChatMessages", () => ({
+  useChatMessages: (chatId: string | null) => mockUseChatMessages(chatId),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => ({
+    emailAccountId: accountState.emailAccountId,
+  }),
+}));
+
+vi.mock("@/components/assistant-chat/helpers", () => ({
+  convertToUIMessages: mockConvertToUIMessages,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: mockCaptureException,
+}));
+
+describe("ChatProvider account changes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    accountState.emailAccountId = "account-a";
+    queryState.initialChatId = "chat-from-account-a";
+    mockUseSWRConfig.mockReturnValue({ mutate: vi.fn() });
+    mockUseChatMessages.mockImplementation((chatId: string | null) =>
+      chatId
+        ? {
+            data: {
+              messages: [
+                {
+                  id: "message-from-account-a",
+                  role: "user",
+                  parts: [{ type: "text", text: "Old chat" }],
+                },
+              ],
+            },
+          }
+        : { data: undefined },
+    );
+    mockConvertToUIMessages.mockReturnValue([
+      {
+        id: "message-from-account-a",
+        role: "user",
+        parts: [{ type: "text", text: "Old chat" }],
+      },
+    ]);
+  });
+
+  it("clears the active chat when the selected email account changes", async () => {
+    let latestContext: ReturnType<typeof useChat> | undefined;
+
+    function Consumer() {
+      latestContext = useChat();
+      return null;
+    }
+
+    const { rerender } = renderWithProvider(<Consumer />);
+
+    await waitFor(() => {
+      expect(latestContext?.chatId).toBe("chat-from-account-a");
+    });
+
+    accountState.emailAccountId = "account-b";
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.chatId).toBeNull();
+    });
+    expect(mockSetQueryState).toHaveBeenCalledWith(null);
+    expect(mockSetMessages).toHaveBeenLastCalledWith([]);
+  });
+});
+
+function renderWithProvider(children: React.ReactNode) {
+  return render(<ChatProvider>{children}</ChatProvider>);
+}

--- a/apps/web/providers/ChatProvider.tsx
+++ b/apps/web/providers/ChatProvider.tsx
@@ -66,6 +66,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const inlineActionsRef = useRef(inlineActions);
   const pendingInlineActionsRef = useRef<InlineEmailAction[] | null>(null);
   const previousChatIdRef = useRef(chatId);
+  const previousEmailAccountIdRef = useRef<string | null>(null);
 
   const { data } = useChatMessages(chatId);
   const persistedMessageIds = useMemo(
@@ -147,6 +148,26 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     pendingInlineActionsRef.current = null;
     setInlineActions([]);
   }, [chatId]);
+
+  useEffect(() => {
+    if (!emailAccountId) return;
+
+    if (previousEmailAccountIdRef.current === null) {
+      previousEmailAccountIdRef.current = emailAccountId;
+      return;
+    }
+
+    if (previousEmailAccountIdRef.current === emailAccountId) return;
+
+    previousEmailAccountIdRef.current = emailAccountId;
+    pendingInlineActionsRef.current = null;
+    setChatId(null);
+    chat.setMessages([]);
+    setInput("");
+    setContext(null);
+    setAttachments([]);
+    setInlineActions([]);
+  }, [chat.setMessages, emailAccountId, setChatId]);
 
   const sendMessageParts = useCallback(
     async (


### PR DESCRIPTION
Resets the active chat state when the selected email account changes so stale conversations are not reused across accounts.\n\n- Clears chat id, messages, input, context, attachments, and pending inline actions on account changes\n- Adds a provider regression test for account-scoped chat reset\n\nTested with: `cd apps/web && pnpm test --run providers/ChatProvider.test.tsx`