### PR TITLE
Fix messaging notification rendering

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1312,6 +1312,62 @@ describe("sendMessagingRuleNotification", () => {
     });
   });
 
+  it("renders decoded email previews in Telegram draft notification cards", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet:
+          "Quoted reply said A &gt; B, C &lt; D, and Tom &amp; Jerry replied.",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const serializedCard = JSON.stringify(card);
+
+    expect(serializedCard).toContain(
+      "Quoted reply said A > B, C < D, and Tom & Jerry replied.",
+    );
+    expect(serializedCard).not.toContain("&gt;");
+    expect(serializedCard).not.toContain("&lt;");
+    expect(serializedCard).not.toContain("&amp;");
+  });
+
   it("skips linked notifications when provider routing data is incomplete", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -814,7 +814,10 @@ async function sendDraftReplyFromNotification({
     email: sourceMessageSummary,
     systemType: context.executedRule.rule?.systemType ?? null,
     draftContent: finalDraftContent,
-    format: "slack",
+    format:
+      context.messagingChannel?.provider === MessagingProvider.SLACK
+        ? "slack"
+        : "plain",
   });
 
   if (mailboxDraftAction?.draftId) {
@@ -1442,22 +1445,25 @@ function buildNotificationContent({
   format: NotificationContentFormat;
 }): NotificationContent {
   if (isDraftReplyActionType(actionType)) {
-    const senderName = escapeSlackText(
+    const senderName = formatNotificationText(
       extractNameFromEmail(email.headers.from),
+      format,
     );
-    const senderEmail = escapeSlackText(
+    const senderEmail = formatNotificationText(
       extractEmailAddress(email.headers.from),
+      format,
     );
     const senderDisplay =
       senderEmail && senderName !== senderEmail
         ? `${senderName} (${senderEmail})`
         : senderName;
-    const subject = escapeSlackText(
+    const subject = formatNotificationText(
       truncate(he.decode(email.headers.subject), 80),
+      format,
     );
 
-    const emailPreview = buildEmailPreview(email);
-    const draftPreview = buildDraftPreview(draftContent);
+    const emailPreview = buildEmailPreview(email, { format });
+    const draftPreview = buildDraftPreview(draftContent, { format });
 
     const summary = `📩 You got an email from *${senderDisplay}* about "${subject}".`;
 
@@ -1489,7 +1495,7 @@ function buildNotificationContent({
         ? `When: ${calendarEvent.eventDateString}`
         : null,
       calendarEvent.organizer ? `Organizer: ${calendarEvent.organizer}` : null,
-      buildEmailPreview(email),
+      buildEmailPreview(email, { format }),
     ].filter(Boolean);
 
     return {
@@ -1504,7 +1510,7 @@ function buildNotificationContent({
     details: [
       buildNotificationDetailSection({
         label: "Preview",
-        value: buildEmailPreview(email),
+        value: buildEmailPreview(email, { format }),
       }),
     ].filter(Boolean) as string[],
   };
@@ -1647,11 +1653,17 @@ function buildHandledNotificationCard({
   });
 }
 
-function buildDraftPreview(content?: string | null) {
+function buildDraftPreview(
+  content?: string | null,
+  { format = "slack" }: { format?: NotificationContentFormat } = {},
+) {
   if (!content?.trim()) return "No draft preview available.";
 
+  const preview = removeExcessiveWhitespace(
+    richTextToSlackMrkdwn(he.decode(content)),
+  ).trim();
   return truncate(
-    removeExcessiveWhitespace(richTextToSlackMrkdwn(he.decode(content))).trim(),
+    format === "slack" ? preview : stripSlackFormatting(preview),
     DRAFT_PREVIEW_MAX_CHARS,
   );
 }
@@ -1704,18 +1716,33 @@ function buildEmailSummary(email: {
   ].join("\n");
 }
 
-function buildEmailPreview(email: {
-  snippet: string;
-  textPlain?: string;
-  textHtml?: string;
-}) {
+function buildEmailPreview(
+  email: {
+    snippet: string;
+    textPlain?: string;
+    textHtml?: string;
+  },
+  {
+    format = "slack",
+  }: {
+    format?: NotificationContentFormat;
+  } = {},
+) {
   const rawPreview = emailToContent(email, { maxLength: 0 });
-  const preview = escapeSlackText(
+  const preview = formatNotificationText(
     removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
+    format,
   );
   if (!preview) return null;
 
   return truncate(preview, SUMMARY_PREVIEW_MAX_CHARS);
+}
+
+function formatNotificationText(
+  text: string,
+  format: NotificationContentFormat,
+) {
+  return format === "slack" ? escapeSlackText(text) : text;
 }
 
 function buildNotificationDetailSection({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1654,8 +1654,8 @@ function buildHandledNotificationCard({
 }
 
 function buildDraftPreview(
-  content?: string | null,
-  { format = "slack" }: { format?: NotificationContentFormat } = {},
+  content: string | null | undefined,
+  { format }: { format: NotificationContentFormat },
 ) {
   if (!content?.trim()) return "No draft preview available.";
 
@@ -1722,11 +1722,7 @@ function buildEmailPreview(
     textPlain?: string;
     textHtml?: string;
   },
-  {
-    format = "slack",
-  }: {
-    format?: NotificationContentFormat;
-  } = {},
+  { format }: { format: NotificationContentFormat },
 ) {
   const rawPreview = emailToContent(email, { maxLength: 0 });
   const preview = formatNotificationText(


### PR DESCRIPTION
Fixes non-Slack messaging notification rendering so decoded email preview text is shown in plain-format cards while Slack keeps its provider-specific escaping. Adds regression coverage for encoded entity handling in notification cards.

Tests:
- cd apps/web && pnpm test --run utils/messaging/rule-notifications.test.ts
- pnpm exec ultracite check apps/web/utils/messaging/rule-notifications.ts apps/web/utils/messaging/rule-notifications.test.ts