### PR TITLE
fix: Exclude calendar attachments from filing

### DIFF
--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -6,7 +6,7 @@ import {
   getMockParsedMessage,
 } from "@/__tests__/mocks/email-provider.mock";
 import { createScopedLogger } from "@/utils/logger";
-import { processAttachment } from "./filing-engine";
+import { getFilableAttachments, processAttachment } from "./filing-engine";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
@@ -146,6 +146,55 @@ describe("processAttachment", () => {
   });
 });
 
+describe("getFilableAttachments", () => {
+  it("excludes calendar invite attachments", () => {
+    const documentAttachment = createAttachment({
+      attachmentId: "attachment-1",
+      filename: "itinerary.pdf",
+      mimeType: "application/pdf",
+    });
+    const calendarInvite = createAttachment({
+      attachmentId: "attachment-2",
+      filename: "invite.ics",
+      mimeType: "text/calendar",
+    });
+    const calendarInviteWithGenericMimeType = createAttachment({
+      attachmentId: "attachment-3",
+      filename: "meeting.ics",
+      mimeType: "application/octet-stream",
+    });
+
+    const message = getMockParsedMessage({
+      attachments: [
+        documentAttachment,
+        calendarInvite,
+        calendarInviteWithGenericMimeType,
+      ],
+    });
+
+    expect(getFilableAttachments(message)).toEqual([documentAttachment]);
+  });
+
+  it("excludes calendar attachments even when the filename is generic", () => {
+    const documentAttachment = createAttachment({
+      attachmentId: "attachment-1",
+      filename: "agenda.txt",
+      mimeType: "text/plain",
+    });
+    const calendarInvite = createAttachment({
+      attachmentId: "attachment-2",
+      filename: "attachment.dat",
+      mimeType: "text/calendar",
+    });
+
+    const message = getMockParsedMessage({
+      attachments: [documentAttachment, calendarInvite],
+    });
+
+    expect(getFilableAttachments(message)).toEqual([documentAttachment]);
+  });
+});
+
 function setupSuccessfulFiling({
   confidence,
   filingConfirmationSendEmail = true,
@@ -205,5 +254,28 @@ function setupSuccessfulFiling({
     emailProvider,
     message,
     uploadFile,
+  };
+}
+
+function createAttachment({
+  attachmentId,
+  filename,
+  mimeType,
+}: {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+}) {
+  return {
+    attachmentId,
+    filename,
+    headers: {
+      "content-description": "",
+      "content-id": "",
+      "content-transfer-encoding": "base64",
+      "content-type": mimeType,
+    },
+    mimeType,
+    size: 128,
   };
 }

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -202,18 +202,11 @@ function setupSuccessfulFiling({
   confidence: number;
   filingConfirmationSendEmail?: boolean;
 }) {
-  const attachment = {
+  const attachment = createAttachment({
     attachmentId: "attachment-1",
     filename: "invoice.pdf",
-    headers: {
-      "content-description": "",
-      "content-id": "",
-      "content-transfer-encoding": "base64",
-      "content-type": "application/pdf",
-    },
     mimeType: "application/pdf",
-    size: 128,
-  };
+  });
   const message = getMockParsedMessage({
     attachments: [attachment],
     headers: {

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -337,10 +337,13 @@ export async function processAttachment({
  * Get all filable attachments from a message.
  * All attachment types are supported - text-extractable files (PDF, DOCX, TXT)
  * get full content analysis, while other types (images, spreadsheets, etc.)
- * are filed based on filename and email metadata.
+ * are filed based on filename and email metadata. Calendar invite artifacts are
+ * excluded because they describe the email event rather than a user document.
  */
 export function getFilableAttachments(message: ParsedMessage): Attachment[] {
-  return message.attachments || [];
+  return (message.attachments || []).filter(
+    (attachment) => !isCalendarInviteAttachment(attachment),
+  );
 }
 
 // ============================================================================
@@ -414,4 +417,18 @@ function resolveFolderTarget(
     folderPath: analysis.folderPath || "Inbox Zero Filed",
     needsToCreateFolder: true,
   };
+}
+
+function isCalendarInviteAttachment(attachment: Attachment): boolean {
+  const filename = attachment.filename.toLowerCase();
+  const mimeType = attachment.mimeType.toLowerCase();
+  const contentType = attachment.headers["content-type"].toLowerCase();
+
+  return (
+    filename.endsWith(".ics") ||
+    mimeType === "text/calendar" ||
+    mimeType === "application/ics" ||
+    contentType.startsWith("text/calendar") ||
+    contentType.startsWith("application/ics")
+  );
 }

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -14,6 +14,7 @@ import {
 } from "@/utils/drive/filing-notifications";
 import { sendFilingMessagingNotifications } from "@/utils/drive/filing-messaging-notifications";
 import { extractEmailAddress } from "@/utils/email";
+import { isCalendarInviteAttachment } from "@/utils/parse/calender-event";
 
 // ============================================================================
 // Types
@@ -417,18 +418,4 @@ function resolveFolderTarget(
     folderPath: analysis.folderPath || "Inbox Zero Filed",
     needsToCreateFolder: true,
   };
-}
-
-function isCalendarInviteAttachment(attachment: Attachment): boolean {
-  const filename = attachment.filename.toLowerCase();
-  const mimeType = attachment.mimeType.toLowerCase();
-  const contentType = attachment.headers["content-type"].toLowerCase();
-
-  return (
-    filename.endsWith(".ics") ||
-    mimeType === "text/calendar" ||
-    mimeType === "application/ics" ||
-    contentType.startsWith("text/calendar") ||
-    contentType.startsWith("application/ics")
-  );
 }

--- a/apps/web/utils/parse/calender-event.ts
+++ b/apps/web/utils/parse/calender-event.ts
@@ -1,4 +1,4 @@
-import type { ParsedMessage } from "@/utils/types";
+import type { Attachment, ParsedMessage } from "@/utils/types";
 
 interface CalendarEventInfo {
   endDate?: Date | null;
@@ -280,23 +280,23 @@ export function getCalendarEventStatus(
 /** High-confidence calendar detection for preset rule matching (bypasses AI). */
 export function isCalendarInvite(email: ParsedMessage): boolean {
   return (
-    hasIcsAttachment(email) ||
-    hasCalendarMimeType(email) ||
+    email.attachments?.some(isCalendarInviteAttachment) === true ||
     hasICalendarContent(email)
   );
 }
 
-function hasCalendarMimeType(email: ParsedMessage): boolean {
-  if (!email.attachments || email.attachments.length === 0) {
-    return false;
-  }
+export function isCalendarInviteAttachment(attachment: Attachment): boolean {
+  const filename = attachment.filename?.toLowerCase() ?? "";
+  if (filename.endsWith(".ics")) return true;
 
-  return email.attachments.some(
-    (attachment) =>
-      attachment.mimeType?.toLowerCase() === "text/calendar" ||
-      attachment.headers?.["content-type"]
-        ?.toLowerCase()
-        .includes("text/calendar"),
+  const mimeType = attachment.mimeType?.toLowerCase() ?? "";
+  if (mimeType === "text/calendar" || mimeType === "application/ics")
+    return true;
+
+  const contentType = attachment.headers?.["content-type"]?.toLowerCase() ?? "";
+  return (
+    contentType.startsWith("text/calendar") ||
+    contentType.startsWith("application/ics")
   );
 }
 


### PR DESCRIPTION
Prevents system-generated calendar attachment artifacts from being considered for automatic document filing.

- Filters calendar-style attachments before filing and preview
- Adds regression coverage for filename and MIME-type filtering

Validation:
- pnpm test --run utils/drive/filing-engine.test.ts
- pnpm check