### PR TITLE
email labels: Fix archive badge display

### DIFF
--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -13,10 +13,8 @@ import { Badge } from "@/components/ui/badge";
 import { useEmail } from "@/providers/EmailProvider";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useMemo } from "react";
-import { isDefined } from "@/utils/types";
 import { isGoogleProvider } from "@/utils/email/provider-types";
-import { getRuleLabel } from "@/utils/rule/consts";
-import { SystemType } from "@/generated/prisma/enums";
+import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
 
 const MAX_VISIBLE_LABELS = 2;
 
@@ -47,48 +45,16 @@ export function EmailMessageCell({
   const { provider } = useAccount();
   const { showEmail } = useDisplayedEmail();
 
-  const labelsToDisplay = useMemo(() => {
-    const labels = labelIds
-      ?.map((idOrName) => {
-        // First try to find by ID
-        let label = userLabels[idOrName];
-
-        // If not found by ID, try to find by name
-        if (!label) {
-          const foundLabel = Object.values(userLabels).find(
-            (l) => l.name.toLowerCase() === idOrName.toLowerCase(),
-          );
-          if (foundLabel) {
-            label = foundLabel;
-          }
-        }
-
-        if (!label) return null;
-        return { id: label.id, name: label.name };
-      })
-      .filter(isDefined)
-      .filter((label) => {
-        if (filterReplyTrackerLabels) {
-          if (
-            label.name === getRuleLabel(SystemType.TO_REPLY) ||
-            label.name === getRuleLabel(SystemType.AWAITING_REPLY)
-          ) {
-            return false;
-          }
-        }
-
-        if (label.name.includes("/")) {
-          return false;
-        }
-        return true;
-      });
-
-    if (labelIds && !labelIds.includes("INBOX")) {
-      labels?.unshift({ id: "ARCHIVE", name: "Archived" });
-    }
-
-    return labels;
-  }, [labelIds, userLabels, filterReplyTrackerLabels]);
+  const labelsToDisplay = useMemo(
+    () =>
+      getEmailMessageCellLabels({
+        labelIds,
+        userLabels,
+        filterReplyTrackerLabels,
+        provider,
+      }),
+    [labelIds, userLabels, filterReplyTrackerLabels, provider],
+  );
 
   const showIcons = !hideViewEmailButton && isGoogleProvider(provider);
   const visibleLabels = labelsToDisplay?.slice(0, MAX_VISIBLE_LABELS) ?? [];

--- a/apps/web/components/EmailMessageCellLabels.test.ts
+++ b/apps/web/components/EmailMessageCellLabels.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { getEmailMessageCellLabels } from "./EmailMessageCellLabels";
+
+describe("getEmailMessageCellLabels", () => {
+  it("does not infer Outlook sent mail as archived just because it is outside the inbox", () => {
+    const labels = getEmailMessageCellLabels({
+      labelIds: ["SENT", "Awaiting Reply"],
+      userLabels: {
+        awaitingReply: {
+          id: "awaitingReply",
+          name: "Awaiting Reply",
+        },
+      },
+      provider: "microsoft",
+    });
+
+    expect(labels).toEqual([{ id: "awaitingReply", name: "Awaiting Reply" }]);
+  });
+
+  it("shows archived for Outlook messages in the archive folder", () => {
+    const labels = getEmailMessageCellLabels({
+      labelIds: ["ARCHIVE", "label-newsletter"],
+      userLabels: {
+        "label-newsletter": {
+          id: "label-newsletter",
+          name: "Newsletter",
+        },
+      },
+      provider: "microsoft",
+    });
+
+    expect(labels).toEqual([
+      { id: "ARCHIVE", name: "Archived" },
+      { id: "label-newsletter", name: "Newsletter" },
+    ]);
+  });
+
+  it("keeps Gmail archive inference for messages without the inbox label", () => {
+    const labels = getEmailMessageCellLabels({
+      labelIds: ["label-newsletter"],
+      userLabels: {
+        "label-newsletter": {
+          id: "label-newsletter",
+          name: "Newsletter",
+        },
+      },
+      provider: "google",
+    });
+
+    expect(labels).toEqual([
+      { id: "ARCHIVE", name: "Archived" },
+      { id: "label-newsletter", name: "Newsletter" },
+    ]);
+  });
+});

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -1,4 +1,4 @@
-import type { EmailLabels } from "@/providers/email-label-types";
+import type { EmailLabel, EmailLabels } from "@/providers/email-label-types";
 import {
   isGoogleProvider,
   isMicrosoftProvider,
@@ -6,11 +6,13 @@ import {
 import { isDefined } from "@/utils/types";
 import { getRuleLabel } from "@/utils/rule/consts";
 import { SystemType } from "@/generated/prisma/enums";
+import { GmailLabel } from "@/utils/gmail/label";
+import { OutlookLabel } from "@/utils/outlook/constants";
 
-export type EmailMessageCellLabel = {
-  id: string;
-  name: string;
-};
+export type EmailMessageCellLabel = Pick<EmailLabel, "id" | "name">;
+
+const TO_REPLY_LABEL = getRuleLabel(SystemType.TO_REPLY);
+const AWAITING_REPLY_LABEL = getRuleLabel(SystemType.AWAITING_REPLY);
 
 export function getEmailMessageCellLabels({
   labelIds,
@@ -25,29 +27,22 @@ export function getEmailMessageCellLabels({
 }): EmailMessageCellLabel[] | undefined {
   const labels = labelIds
     ?.map((idOrName) => {
-      let label = userLabels[idOrName];
-
-      if (!label) {
-        const foundLabel = Object.values(userLabels).find(
+      const label =
+        userLabels[idOrName] ??
+        Object.values(userLabels).find(
           (l) => l.name.toLowerCase() === idOrName.toLowerCase(),
         );
-        if (foundLabel) {
-          label = foundLabel;
-        }
-      }
 
       if (!label) return null;
       return { id: label.id, name: label.name };
     })
     .filter(isDefined)
     .filter((label) => {
-      if (filterReplyTrackerLabels) {
-        if (
-          label.name === getRuleLabel(SystemType.TO_REPLY) ||
-          label.name === getRuleLabel(SystemType.AWAITING_REPLY)
-        ) {
-          return false;
-        }
+      if (
+        filterReplyTrackerLabels &&
+        (label.name === TO_REPLY_LABEL || label.name === AWAITING_REPLY_LABEL)
+      ) {
+        return false;
       }
 
       if (label.name.includes("/")) {
@@ -57,7 +52,7 @@ export function getEmailMessageCellLabels({
     });
 
   if (shouldShowArchivedLabel({ labelIds, provider, labels })) {
-    labels?.unshift({ id: "ARCHIVE", name: "Archived" });
+    labels?.unshift({ id: OutlookLabel.ARCHIVE, name: "Archived" });
   }
 
   return labels;
@@ -73,14 +68,14 @@ function shouldShowArchivedLabel({
   labels?: EmailMessageCellLabel[];
 }) {
   if (!labelIds) return false;
-  if (labels?.some((label) => label.id === "ARCHIVE")) return false;
+  if (labels?.some((label) => label.id === OutlookLabel.ARCHIVE)) return false;
 
   if (isGoogleProvider(provider)) {
-    return !labelIds.includes("INBOX");
+    return !labelIds.includes(GmailLabel.INBOX);
   }
 
   if (isMicrosoftProvider(provider)) {
-    return labelIds.includes("ARCHIVE");
+    return labelIds.includes(OutlookLabel.ARCHIVE);
   }
 
   return false;

--- a/apps/web/components/EmailMessageCellLabels.ts
+++ b/apps/web/components/EmailMessageCellLabels.ts
@@ -1,0 +1,87 @@
+import type { EmailLabels } from "@/providers/email-label-types";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
+import { isDefined } from "@/utils/types";
+import { getRuleLabel } from "@/utils/rule/consts";
+import { SystemType } from "@/generated/prisma/enums";
+
+export type EmailMessageCellLabel = {
+  id: string;
+  name: string;
+};
+
+export function getEmailMessageCellLabels({
+  labelIds,
+  userLabels,
+  filterReplyTrackerLabels,
+  provider,
+}: {
+  labelIds?: string[];
+  userLabels: EmailLabels;
+  filterReplyTrackerLabels?: boolean;
+  provider?: string | null;
+}): EmailMessageCellLabel[] | undefined {
+  const labels = labelIds
+    ?.map((idOrName) => {
+      let label = userLabels[idOrName];
+
+      if (!label) {
+        const foundLabel = Object.values(userLabels).find(
+          (l) => l.name.toLowerCase() === idOrName.toLowerCase(),
+        );
+        if (foundLabel) {
+          label = foundLabel;
+        }
+      }
+
+      if (!label) return null;
+      return { id: label.id, name: label.name };
+    })
+    .filter(isDefined)
+    .filter((label) => {
+      if (filterReplyTrackerLabels) {
+        if (
+          label.name === getRuleLabel(SystemType.TO_REPLY) ||
+          label.name === getRuleLabel(SystemType.AWAITING_REPLY)
+        ) {
+          return false;
+        }
+      }
+
+      if (label.name.includes("/")) {
+        return false;
+      }
+      return true;
+    });
+
+  if (shouldShowArchivedLabel({ labelIds, provider, labels })) {
+    labels?.unshift({ id: "ARCHIVE", name: "Archived" });
+  }
+
+  return labels;
+}
+
+function shouldShowArchivedLabel({
+  labelIds,
+  provider,
+  labels,
+}: {
+  labelIds?: string[];
+  provider?: string | null;
+  labels?: EmailMessageCellLabel[];
+}) {
+  if (!labelIds) return false;
+  if (labels?.some((label) => label.id === "ARCHIVE")) return false;
+
+  if (isGoogleProvider(provider)) {
+    return !labelIds.includes("INBOX");
+  }
+
+  if (isMicrosoftProvider(provider)) {
+    return labelIds.includes("ARCHIVE");
+  }
+
+  return false;
+}


### PR DESCRIPTION
Uses provider-aware email label display logic so archive badges are only inferred where the provider model supports that inference.

- Moves email-cell label selection into a focused helper.
- Adds unit coverage for provider-specific archive badge behavior.

Tests: `cd apps/web && pnpm test --run components/EmailMessageCellLabels.test.ts`