### PR TITLE
Fix attachment filing webhook flow

### DIFF
--- a/apps/web/app/api/outlook/webhook/process-history.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.test.ts
@@ -280,7 +280,7 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     );
   });
 
-  it("learns from Outlook label removal when rule already exists", async () => {
+  it("learns from Outlook label removal and continues shared processing when rule already exists", async () => {
     const inboxMessage = getMockParsedMessage({
       id: "message-123",
       threadId: "thread-123",
@@ -307,7 +307,12 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
       emailAccountId: "account-123",
       logger,
     });
-    expect(processHistoryItem).not.toHaveBeenCalled();
+    expect(processHistoryItem).toHaveBeenCalledWith(
+      { messageId: "message-123", message: inboxMessage },
+      expect.objectContaining({
+        provider: mockProvider,
+      }),
+    );
   });
 
   describe("error handling", () => {

--- a/apps/web/app/api/outlook/webhook/process-history.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.ts
@@ -161,8 +161,7 @@ export async function processHistoryForUser({
               extra: { operation: "learn-outlook-label-removal" },
             }),
           );
-          logger.info("Skipping. Rule already exists.");
-          return NextResponse.json({ ok: true });
+          logger.info("Skipping rules. Rule already exists.");
         }
 
         // Pass pre-fetched message to avoid refetching

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -64,6 +64,14 @@ describe("processAttachment", () => {
       wasAsked: data.wasAsked,
       folderPath: data.folderPath,
     }));
+    prisma.documentFiling.update.mockImplementation(
+      async ({ data, where }: any) => ({
+        id: where.id,
+        status: data.status,
+        wasAsked: data.wasAsked,
+        folderPath: data.folderPath,
+      }),
+    );
     prisma.documentFiling.findFirst.mockResolvedValue(null);
 
     vi.mocked(extractTextFromDocument).mockResolvedValue({
@@ -189,7 +197,7 @@ describe("processAttachment", () => {
     expect(analyzeDocument).not.toHaveBeenCalled();
   });
 
-  it("retries an attachment that only has an error filing record", async () => {
+  it("retries an error filing record without creating a duplicate row", async () => {
     prisma.documentFiling.findFirst.mockResolvedValue({
       id: "filing-error",
       filename: "invoice.pdf",
@@ -217,6 +225,14 @@ describe("processAttachment", () => {
     expect(result.success).toBe(true);
     expect(uploadFile).toHaveBeenCalled();
     expect(analyzeDocument).toHaveBeenCalled();
+    expect(prisma.documentFiling.create).not.toHaveBeenCalled();
+    expect(prisma.documentFiling.update).toHaveBeenCalledWith({
+      where: { id: "filing-error" },
+      data: expect.objectContaining({
+        status: "FILED",
+        fileId: "drive-file-1",
+      }),
+    });
   });
 });
 

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -188,6 +188,36 @@ describe("processAttachment", () => {
     expect(uploadFile).not.toHaveBeenCalled();
     expect(analyzeDocument).not.toHaveBeenCalled();
   });
+
+  it("retries an attachment that only has an error filing record", async () => {
+    prisma.documentFiling.findFirst.mockResolvedValue({
+      id: "filing-error",
+      filename: "invoice.pdf",
+      folderPath: "Invoices",
+      fileId: null,
+      status: "ERROR",
+      wasAsked: false,
+      confidence: null,
+      reasoning: "Previous attempt failed",
+      driveConnection: { provider: "google" },
+    } as any);
+    const { attachment, emailAccount, emailProvider, message, uploadFile } =
+      setupSuccessfulFiling({
+        confidence: 0.95,
+      });
+
+    const result = await processAttachment({
+      attachment,
+      emailAccount,
+      emailProvider,
+      logger,
+      message,
+    });
+
+    expect(result.success).toBe(true);
+    expect(uploadFile).toHaveBeenCalled();
+    expect(analyzeDocument).toHaveBeenCalled();
+  });
 });
 
 function setupSuccessfulFiling({

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -64,6 +64,7 @@ describe("processAttachment", () => {
       wasAsked: data.wasAsked,
       folderPath: data.folderPath,
     }));
+    prisma.documentFiling.findFirst.mockResolvedValue(null);
 
     vi.mocked(extractTextFromDocument).mockResolvedValue({
       text: "Quarterly invoice",
@@ -143,6 +144,49 @@ describe("processAttachment", () => {
         userEmail: "user@test.com",
       }),
     );
+  });
+
+  it("does not upload an attachment that already has a filing record", async () => {
+    prisma.documentFiling.findFirst.mockResolvedValue({
+      id: "filing-existing",
+      filename: "invoice.pdf",
+      folderPath: "Invoices",
+      fileId: "drive-file-existing",
+      status: "FILED",
+      wasAsked: false,
+      confidence: 0.95,
+      reasoning: "Already filed",
+      driveConnection: { provider: "google" },
+    } as any);
+    const { attachment, emailAccount, emailProvider, message, uploadFile } =
+      setupSuccessfulFiling({
+        confidence: 0.95,
+      });
+
+    const result = await processAttachment({
+      attachment,
+      emailAccount,
+      emailProvider,
+      logger,
+      message,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      filing: {
+        id: "filing-existing",
+        filename: "invoice.pdf",
+        folderPath: "Invoices",
+        fileId: "drive-file-existing",
+        wasAsked: false,
+        confidence: 0.95,
+        provider: "google",
+      },
+      filingId: "filing-existing",
+    });
+    expect(emailProvider.getAttachment).not.toHaveBeenCalled();
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(analyzeDocument).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -113,7 +113,11 @@ export async function processAttachment({
         status: existingFiling.status,
       });
 
-      if (existingFiling.status === "PREVIEW") {
+      if (existingFiling.status === "ERROR") {
+        log.info("Retrying attachment after previous filing error", {
+          filingId: existingFiling.id,
+        });
+      } else if (existingFiling.status === "PREVIEW") {
         return {
           success: false,
           skipped: true,
@@ -122,21 +126,21 @@ export async function processAttachment({
             "Document doesn't match filing preferences",
           filingId: existingFiling.id,
         };
+      } else {
+        return {
+          success: true,
+          filing: {
+            id: existingFiling.id,
+            filename: existingFiling.filename,
+            folderPath: existingFiling.folderPath,
+            fileId: existingFiling.fileId,
+            wasAsked: existingFiling.wasAsked,
+            confidence: existingFiling.confidence,
+            provider: existingFiling.driveConnection.provider,
+          },
+          filingId: existingFiling.id,
+        };
       }
-
-      return {
-        success: true,
-        filing: {
-          id: existingFiling.id,
-          filename: existingFiling.filename,
-          folderPath: existingFiling.folderPath,
-          fileId: existingFiling.fileId,
-          wasAsked: existingFiling.wasAsked,
-          confidence: existingFiling.confidence,
-          provider: existingFiling.driveConnection.provider,
-        },
-        filingId: existingFiling.id,
-      };
     }
 
     // Get all connected drives

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -107,6 +107,7 @@ export async function processAttachment({
       },
     });
 
+    let retryFilingId: string | null = null;
     if (existingFiling) {
       log.info("Attachment already has a filing record", {
         filingId: existingFiling.id,
@@ -117,6 +118,7 @@ export async function processAttachment({
         log.info("Retrying attachment after previous filing error", {
           filingId: existingFiling.id,
         });
+        retryFilingId = existingFiling.id;
       } else if (existingFiling.status === "PREVIEW") {
         return {
           success: false,
@@ -227,20 +229,23 @@ export async function processAttachment({
     if (analysis.action === "skip") {
       log.info("AI decided to skip this document");
 
-      // Create a DocumentFiling record for skipped items (for audit trail and feedback)
-      const skipFiling = await prisma.documentFiling.create({
-        data: {
-          messageId: message.id,
-          attachmentId: attachment.attachmentId,
-          filename: attachment.filename,
-          folderPath: "",
-          status: "PREVIEW", // PREVIEW = AI decided to skip (not user rejection)
-          reasoning: analysis.reasoning,
-          confidence: analysis.confidence,
-          driveConnectionId: driveConnections[0].id,
-          emailAccountId: emailAccount.id,
-        },
-      });
+      const skipFilingData = {
+        messageId: message.id,
+        attachmentId: attachment.attachmentId,
+        filename: attachment.filename,
+        folderPath: "",
+        status: "PREVIEW" as const, // PREVIEW = AI decided to skip (not user rejection)
+        reasoning: analysis.reasoning,
+        confidence: analysis.confidence,
+        driveConnectionId: driveConnections[0].id,
+        emailAccountId: emailAccount.id,
+      };
+      const skipFiling = retryFilingId
+        ? await prisma.documentFiling.update({
+            where: { id: retryFilingId },
+            data: skipFilingData,
+          })
+        : await prisma.documentFiling.create({ data: skipFilingData });
 
       log.info("Skip record created", { filingId: skipFiling.id });
 
@@ -296,23 +301,27 @@ export async function processAttachment({
       fileId = uploadedFile.id;
     }
 
-    // Step 9: Create DocumentFiling record
-    const filing = await prisma.documentFiling.create({
-      data: {
-        messageId: message.id,
-        attachmentId: attachment.attachmentId,
-        filename: attachment.filename,
-        folderId: targetFolderId,
-        folderPath: targetFolderPath,
-        fileId,
-        reasoning: analysis.reasoning,
-        confidence: analysis.confidence,
-        status: shouldAsk ? "PENDING" : "FILED",
-        wasAsked: shouldAsk,
-        driveConnectionId: driveConnection.id,
-        emailAccountId: emailAccount.id,
-      },
-    });
+    // Step 9: Create or replace DocumentFiling record
+    const filingData = {
+      messageId: message.id,
+      attachmentId: attachment.attachmentId,
+      filename: attachment.filename,
+      folderId: targetFolderId,
+      folderPath: targetFolderPath,
+      fileId,
+      reasoning: analysis.reasoning,
+      confidence: analysis.confidence,
+      status: shouldAsk ? ("PENDING" as const) : ("FILED" as const),
+      wasAsked: shouldAsk,
+      driveConnectionId: driveConnection.id,
+      emailAccountId: emailAccount.id,
+    };
+    const filing = retryFilingId
+      ? await prisma.documentFiling.update({
+          where: { id: retryFilingId },
+          data: filingData,
+        })
+      : await prisma.documentFiling.create({ data: filingData });
 
     log.info("Filing record created", {
       filingId: filing.id,

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -84,6 +84,61 @@ export async function processAttachment({
       return { success: false, error: "Filing not enabled" };
     }
 
+    const existingFiling = await prisma.documentFiling.findFirst({
+      where: {
+        emailAccountId: emailAccount.id,
+        messageId: message.id,
+        attachmentId: attachment.attachmentId,
+      },
+      select: {
+        id: true,
+        filename: true,
+        folderPath: true,
+        fileId: true,
+        status: true,
+        wasAsked: true,
+        confidence: true,
+        reasoning: true,
+        driveConnection: {
+          select: {
+            provider: true,
+          },
+        },
+      },
+    });
+
+    if (existingFiling) {
+      log.info("Attachment already has a filing record", {
+        filingId: existingFiling.id,
+        status: existingFiling.status,
+      });
+
+      if (existingFiling.status === "PREVIEW") {
+        return {
+          success: false,
+          skipped: true,
+          skipReason:
+            existingFiling.reasoning ||
+            "Document doesn't match filing preferences",
+          filingId: existingFiling.id,
+        };
+      }
+
+      return {
+        success: true,
+        filing: {
+          id: existingFiling.id,
+          filename: existingFiling.filename,
+          folderPath: existingFiling.folderPath,
+          fileId: existingFiling.fileId,
+          wasAsked: existingFiling.wasAsked,
+          confidence: existingFiling.confidence,
+          provider: existingFiling.driveConnection.provider,
+        },
+        filingId: existingFiling.id,
+      };
+    }
+
     // Get all connected drives
     const driveConnections = await prisma.driveConnection.findMany({
       where: {

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -8,6 +8,7 @@ import {
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
 
 vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({
@@ -38,6 +39,12 @@ vi.mock("@/utils/ai/choose-rule/run-rules", () => ({
 vi.mock("@/utils/reply-tracker/handle-outbound", () => ({
   handleOutboundMessage: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/utils/drive/filing-engine", () => ({
+  getFilableAttachments: vi.fn((message) => message.attachments ?? []),
+  processAttachment: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+import { processAttachment } from "@/utils/drive/filing-engine";
 
 const logger = createTestLogger();
 
@@ -346,6 +353,53 @@ describe("Provider Edge Cases", () => {
 
       expect(provider.getMessage).not.toHaveBeenCalled();
       expect(handleOutboundMessage).toHaveBeenCalled();
+    });
+
+    it("still processes attachments when rules were already run for the message", async () => {
+      vi.mocked(prisma.executedRule.findFirst).mockResolvedValue({
+        id: "executed-rule-1",
+      } as any);
+
+      const attachment = {
+        attachmentId: "attachment-1",
+        filename: "invoice.pdf",
+        mimeType: "application/pdf",
+        size: 123,
+      };
+      const message = getMockParsedMessage({
+        id: "msg-123",
+        threadId: "thread-123",
+        labelIds: ["INBOX"],
+        attachments: [attachment],
+      });
+      const provider = createMockEmailProvider({
+        getMessage: vi.fn().mockResolvedValue(message),
+        isSentMessage: vi.fn().mockReturnValue(false),
+      });
+      const emailAccount = {
+        ...getDefaultEmailAccount(),
+        filingEnabled: true,
+        filingPrompt: "File invoices",
+      };
+
+      await processHistoryItem(
+        { messageId: "msg-123", threadId: "thread-123" },
+        {
+          ...baseOptions,
+          provider,
+          hasAiAccess: true,
+          hasAutomationRules: true,
+          emailAccount,
+        },
+      );
+
+      expect(processAttachment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachment,
+          emailProvider: provider,
+          message,
+        }),
+      );
     });
   });
 });

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/__tests__/mocks/email-provider.mock";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
+import { processAttachment } from "@/utils/drive/filing-engine";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 
@@ -43,8 +44,6 @@ vi.mock("@/utils/drive/filing-engine", () => ({
   getFilableAttachments: vi.fn((message) => message.attachments ?? []),
   processAttachment: vi.fn().mockResolvedValue({ success: true }),
 }));
-
-import { processAttachment } from "@/utils/drive/filing-engine";
 
 const logger = createTestLogger();
 

--- a/apps/web/utils/webhook/process-history-item.ts
+++ b/apps/web/utils/webhook/process-history-item.ts
@@ -93,8 +93,7 @@ export async function processHistoryItem(
       : null;
 
     if (hasExistingRule) {
-      logger.info("Skipping. Rule already exists.");
-      return;
+      logger.info("Skipping rules. Rule already exists.");
     }
 
     const isForFilebot = isFilebotEmail({
@@ -192,7 +191,7 @@ export async function processHistoryItem(
 
     logger.info("Pre-rules check", { hasAutomationRules, hasAiAccess });
 
-    if (hasAutomationRules && hasAiAccess) {
+    if (!hasExistingRule && hasAutomationRules && hasAiAccess) {
       logger.info("Running rules...");
 
       await runRules({


### PR DESCRIPTION
Ensures attachment filing still runs when message rule execution has already been recorded. Adds a duplicate filing guard so repeated webhook processing reuses existing filing records instead of re-uploading files. Updates webhook and filing-engine tests for the rule-dedupe and duplicate-filing paths.