### PR TITLE
Fix messaging draft confirmation cards

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   buildAffirmativeReactionMessage,
+  buildPendingEmailConfirmationCard,
   buildPendingEmailCardFallbackText,
   getPendingEmailHandledOpenText,
   getPendingEmailHandledStatus,
@@ -190,6 +191,64 @@ describe("buildPendingEmailCardFallbackText", () => {
     const input =
       "This draft is pending confirmation.\n\nI couldn't show the Send button right now. Ask me to prepare the draft again.";
     expect(buildPendingEmailCardFallbackText(input)).toBe(input);
+  });
+});
+
+describe("buildPendingEmailConfirmationCard", () => {
+  it("escapes Telegram Markdown control characters in pending email cards", () => {
+    const card = buildPendingEmailConfirmationCard({
+      chatMessageId: "chat-message-1",
+      part: {
+        type: "tool-sendEmail",
+        state: "output-available",
+        toolCallId: "tool-call-1",
+        output: {
+          confirmationState: "pending",
+          pendingAction: {
+            to: "first_last@outlook.com",
+            subject: "Plan [draft]",
+            messageHtml: "<p>Use foo_bar *soon* [ok]</p>",
+          },
+        },
+      },
+      provider: "telegram",
+    });
+
+    const textChildren = card.children
+      .filter((child) => child.type === "text")
+      .map((child) => child.content);
+
+    expect(textChildren[0]).toContain("first\\_last@outlook.com");
+    expect(textChildren[0]).toContain("Plan \\[draft]");
+    expect(textChildren[1]).toContain("foo\\_bar \\*soon\\* \\[ok]");
+  });
+
+  it("leaves non-Telegram pending email card text unchanged", () => {
+    const card = buildPendingEmailConfirmationCard({
+      chatMessageId: "chat-message-1",
+      part: {
+        type: "tool-sendEmail",
+        state: "output-available",
+        toolCallId: "tool-call-1",
+        output: {
+          confirmationState: "pending",
+          pendingAction: {
+            to: "first_last@outlook.com",
+            subject: "Plan [draft]",
+            messageHtml: "<p>Use foo_bar *soon* [ok]</p>",
+          },
+        },
+      },
+      provider: "slack",
+    });
+
+    const textChildren = card.children
+      .filter((child) => child.type === "text")
+      .map((child) => child.content);
+
+    expect(textChildren[0]).toContain("first_last@outlook.com");
+    expect(textChildren[0]).toContain("Plan [draft]");
+    expect(textChildren[1]).toContain("foo_bar *soon* [ok]");
   });
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -978,6 +978,7 @@ async function handlePendingEmailConfirmAction({
         confirmationResult: confirmation.confirmationResult,
         event,
         logger,
+        messagingProvider: provider,
         part: pendingToolPart,
       }))
     ) {
@@ -1019,6 +1020,36 @@ async function postPendingEmailCard({
   logger: Logger;
 }): Promise<boolean> {
   const actionType = pendingActionTypeFromToolPartType(part.type);
+
+  try {
+    await thread.post(
+      buildPendingEmailConfirmationCard({
+        chatMessageId,
+        part,
+        provider,
+      }),
+    );
+    return true;
+  } catch (error) {
+    logger.warn("Failed to post messaging pending email confirmation card", {
+      error,
+      provider,
+      actionType,
+    });
+    return false;
+  }
+}
+
+export function buildPendingEmailConfirmationCard({
+  chatMessageId,
+  part,
+  provider,
+}: {
+  chatMessageId: string;
+  part: PendingEmailToolPart;
+  provider: SupportedPlatform;
+}) {
+  const actionType = pendingActionTypeFromToolPartType(part.type);
   const value = createPendingEmailActionToken({
     actionType,
     chatMessageId,
@@ -1038,9 +1069,13 @@ async function postPendingEmailCard({
   });
   const preview = buildPendingEmailPreview(part);
 
-  const cardChildren: CardChild[] = [CardText(summary)];
+  const cardChildren: CardChild[] = [
+    CardText(getMessagingCardText({ provider, text: summary })),
+  ];
   if (preview) {
-    cardChildren.push(CardText(preview));
+    cardChildren.push(
+      CardText(getMessagingCardText({ provider, text: preview })),
+    );
   }
   cardChildren.push(
     Actions([
@@ -1053,22 +1088,10 @@ async function postPendingEmailCard({
     ]),
   );
 
-  try {
-    await thread.post(
-      Card({
-        title: "Review draft",
-        children: cardChildren,
-      }),
-    );
-    return true;
-  } catch (error) {
-    logger.warn("Failed to post messaging pending email confirmation card", {
-      error,
-      provider,
-      actionType,
-    });
-    return false;
-  }
+  return Card({
+    title: "Review draft",
+    children: cardChildren,
+  });
 }
 
 async function replacePendingEmailConfirmationCard({
@@ -1077,6 +1100,7 @@ async function replacePendingEmailConfirmationCard({
   confirmationResult,
   event,
   logger,
+  messagingProvider,
   part,
 }: {
   accountEmail?: string | null;
@@ -1087,6 +1111,7 @@ async function replacePendingEmailConfirmationCard({
   } | null;
   event: ActionEvent;
   logger: Logger;
+  messagingProvider: SupportedPlatform;
   part: PendingEmailToolPart;
 }) {
   try {
@@ -1097,6 +1122,7 @@ async function replacePendingEmailConfirmationCard({
         accountEmail,
         accountProvider,
         confirmationResult,
+        messagingProvider,
         part,
       }),
     );
@@ -1254,6 +1280,7 @@ function buildHandledPendingEmailCard({
   accountEmail,
   accountProvider,
   confirmationResult,
+  messagingProvider,
   part,
 }: {
   accountEmail?: string | null;
@@ -1262,6 +1289,7 @@ function buildHandledPendingEmailCard({
     messageId?: string | null;
     threadId?: string | null;
   } | null;
+  messagingProvider: SupportedPlatform;
   part: PendingEmailToolPart;
 }) {
   const actionType = pendingActionTypeFromToolPartType(part.type);
@@ -1277,14 +1305,27 @@ function buildHandledPendingEmailCard({
     referenceSubject,
   });
   const preview = buildPendingEmailPreview(part);
-  const children: CardChild[] = [CardText(summary)];
+  const children: CardChild[] = [
+    CardText(
+      getMessagingCardText({ provider: messagingProvider, text: summary }),
+    ),
+  ];
 
   if (preview) {
-    children.push(CardText(preview));
+    children.push(
+      CardText(
+        getMessagingCardText({ provider: messagingProvider, text: preview }),
+      ),
+    );
   }
 
   children.push(
-    CardText(`Status: ${getPendingEmailHandledStatus(actionType)}`),
+    CardText(
+      getMessagingCardText({
+        provider: messagingProvider,
+        text: `Status: ${getPendingEmailHandledStatus(actionType)}`,
+      }),
+    ),
   );
 
   const openText = getPendingEmailHandledOpenText({
@@ -1293,7 +1334,11 @@ function buildHandledPendingEmailCard({
     confirmationResult,
   });
   if (openText) {
-    children.push(CardText(openText));
+    children.push(
+      CardText(
+        getMessagingCardText({ provider: messagingProvider, text: openText }),
+      ),
+    );
   }
 
   return Card({
@@ -1346,6 +1391,22 @@ export function getPendingEmailHandledOpenText({
   const mailbox = accountProvider === "microsoft" ? "Outlook" : "Gmail";
 
   return `Open in ${mailbox}: ${emailUrl}`;
+}
+
+function getMessagingCardText({
+  provider,
+  text,
+}: {
+  provider: SupportedPlatform;
+  text: string;
+}) {
+  if (provider !== "telegram") return text;
+
+  return escapeTelegramMarkdownText(text);
+}
+
+function escapeTelegramMarkdownText(text: string) {
+  return text.replace(/([\\_*`[])/g, "\\$1");
 }
 
 function getSlackTeamIdFromActionRaw(raw: unknown): string | null {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -45,7 +45,10 @@ import { consumeMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code-c
 import type { MessagingPlatform } from "@/utils/messaging/platforms";
 import { buildPendingEmailPreview } from "@/utils/messaging/pending-email-preview";
 import { markdownToSlackMrkdwn } from "@/utils/messaging/providers/slack/format";
-import { markdownToTelegramText } from "@/utils/messaging/providers/telegram/format";
+import {
+  escapeTelegramMarkdown,
+  markdownToTelegramText,
+} from "@/utils/messaging/providers/telegram/format";
 import {
   expandPromptCommand,
   getHelpText,
@@ -1402,11 +1405,7 @@ function getMessagingCardText({
 }) {
   if (provider !== "telegram") return text;
 
-  return escapeTelegramMarkdownText(text);
-}
-
-function escapeTelegramMarkdownText(text: string) {
-  return text.replace(/([\\_*`[])/g, "\\$1");
+  return escapeTelegramMarkdown(text);
 }
 
 function getSlackTeamIdFromActionRaw(raw: unknown): string | null {

--- a/apps/web/utils/messaging/providers/telegram/format.ts
+++ b/apps/web/utils/messaging/providers/telegram/format.ts
@@ -1,3 +1,7 @@
+export function escapeTelegramMarkdown(text: string): string {
+  return text.replace(/([\\_*`[])/g, "\\$1");
+}
+
 export function markdownToTelegramText(text: string): string {
   const normalized = text
     .replace(/\r\n/g, "\n")

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -60,7 +60,10 @@ import {
   isOperationalSlackChannel,
 } from "@/utils/messaging/channel-validity";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
-import { markdownToTelegramText } from "@/utils/messaging/providers/telegram/format";
+import {
+  escapeTelegramMarkdown,
+  markdownToTelegramText,
+} from "@/utils/messaging/providers/telegram/format";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 
@@ -1632,18 +1635,12 @@ function sanitizeTelegramNotificationContent(
   content: NotificationContent,
 ): NotificationContent {
   return {
-    title: escapeTelegramCardMarkdown(content.title),
-    summary: escapeTelegramCardMarkdown(
-      markdownToTelegramText(content.summary),
-    ),
+    title: escapeTelegramMarkdown(content.title),
+    summary: escapeTelegramMarkdown(markdownToTelegramText(content.summary)),
     details: content.details?.map((detail) =>
-      escapeTelegramCardMarkdown(markdownToTelegramText(detail)),
+      escapeTelegramMarkdown(markdownToTelegramText(detail)),
     ),
   };
-}
-
-function escapeTelegramCardMarkdown(text: string) {
-  return text.replace(/([\\_*`[])/g, "\\$1");
 }
 
 function buildHandledNotificationCard({


### PR DESCRIPTION
Fixes pending draft confirmation cards by escaping platform-specific markdown before sending interactive messages.

- Applies safe text formatting for messaging confirmation cards
- Adds regression coverage for card text escaping and non-affected providers

Tested with `cd apps/web && pnpm test --run utils/messaging/chat-sdk/bot.test.ts`.