### PR TITLE
Fix disconnected channel selection state

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -1066,14 +1066,12 @@ function MessagingChannelField({
       control={control}
       name={`actions.${index}.messagingChannelId`}
       render={({ field, fieldState }) => {
-        const isSelectedChannelAvailable =
+        const isSelectedChannelConnected =
           !field.value ||
           messagingChannels.some((channel) => channel.id === field.value);
-        const value = isSelectedChannelAvailable
-          ? (field.value ?? (includeEmailOption ? "email" : undefined))
-          : includeEmailOption
-            ? "email"
-            : undefined;
+        const value =
+          (isSelectedChannelConnected ? field.value : null) ??
+          (includeEmailOption ? "email" : undefined);
 
         return (
           <div className="space-y-2">

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -233,13 +233,15 @@ function ActionCard({
 
   const delayValue = watch(`actions.${index}.delayInMinutes`);
   const delayEnabled = !!delayValue;
+  const connectedMessagingChannels =
+    getConnectedRuleNotificationChannels(messagingChannels);
   const selectedMessagingChannelIds = getDraftReplyMessagingChannelIds({
     primaryAction,
     draftMessagingActions,
   });
   const selectedMessagingChannels = selectedMessagingChannelIds
     .map((channelId) =>
-      messagingChannels.find(
+      connectedMessagingChannels.find(
         (messagingChannel) => messagingChannel.id === channelId,
       ),
     )
@@ -249,7 +251,7 @@ function ActionCard({
   const selectedMessagingChannel = selectedMessagingChannels[0];
   const draftReplyGroupIndexes = [index, ...draftMessagingIndexes];
   const draftReplyDelivery: DraftReplyDelivery =
-    selectedMessagingChannelIds.length === 0
+    selectedMessagingChannels.length === 0
       ? "EMAIL"
       : primaryAction?.type === ActionType.DRAFT_MESSAGING_CHANNEL
         ? "MESSAGING"
@@ -658,8 +660,6 @@ function ActionCard({
     />
   ) : null;
 
-  const connectedMessagingChannels =
-    getConnectedRuleNotificationChannels(messagingChannels);
   const canConnectMessagingApp = availableMessagingProviders.length > 0;
 
   const deliveryField = isMessagingNotification ? (
@@ -668,7 +668,6 @@ function ActionCard({
       index={index}
       label="Send to"
       messagingChannels={connectedMessagingChannels}
-      selectedChannel={selectedMessagingChannel}
     />
   ) : null;
 
@@ -950,15 +949,6 @@ function DraftReplyReviewChannelsSection({
     selectedMessagingChannelIds: string[];
   }) => void;
 }) {
-  const availableChannels = [...connectedChannels];
-  for (const selectedChannel of selectedChannels) {
-    if (
-      !availableChannels.some((channel) => channel.id === selectedChannel.id)
-    ) {
-      availableChannels.push(selectedChannel);
-    }
-  }
-
   const includeEmail = delivery !== "MESSAGING";
   const selectedMessagingChannelIds = selectedChannels.map(
     (channel) => channel.id,
@@ -999,7 +989,7 @@ function DraftReplyReviewChannelsSection({
           </div>
         </div>
 
-        {availableChannels.map((channel) => {
+        {connectedChannels.map((channel) => {
           const channelLabel = formatDraftReplyReviewChannelLabel(channel);
           const isSelectedChannel = selectedMessagingChannelIds.includes(
             channel.id,
@@ -1064,26 +1054,26 @@ function MessagingChannelField({
   label,
   includeEmailOption = false,
   messagingChannels,
-  selectedChannel,
 }: {
   control: Control<CreateRuleBody>;
   index: number;
   label: string;
   includeEmailOption?: boolean;
   messagingChannels: MessagingChannelOption[];
-  selectedChannel?: MessagingChannelOption;
 }) {
   return (
     <FormField
       control={control}
       name={`actions.${index}.messagingChannelId`}
       render={({ field, fieldState }) => {
-        const value = field.value ?? (includeEmailOption ? "email" : undefined);
-        const showDisconnectedOption =
-          !!selectedChannel &&
-          !messagingChannels.some(
-            (channel) => channel.id === selectedChannel.id,
-          );
+        const isSelectedChannelAvailable =
+          !field.value ||
+          messagingChannels.some((channel) => channel.id === field.value);
+        const value = isSelectedChannelAvailable
+          ? (field.value ?? (includeEmailOption ? "email" : undefined))
+          : includeEmailOption
+            ? "email"
+            : undefined;
 
         return (
           <div className="space-y-2">
@@ -1114,12 +1104,6 @@ function MessagingChannelField({
                     {formatMessagingDestinationLabel(channel)}
                   </SelectItem>
                 ))}
-                {showDisconnectedOption && selectedChannel ? (
-                  <SelectItem value={selectedChannel.id}>
-                    {formatMessagingDestinationLabel(selectedChannel)}{" "}
-                    (Disconnected)
-                  </SelectItem>
-                ) : null}
               </SelectContent>
             </Select>
             {fieldState.error?.message ? (

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -566,6 +566,12 @@ function createMessagingChannel({
     targetLabel: null,
     isDm: false,
   };
+  const savedRuleNotificationDestination = {
+    enabled: true,
+    targetId: `${id}-route`,
+    targetLabel: teamName,
+    isDm: false,
+  };
 
   return {
     id,
@@ -576,7 +582,7 @@ function createMessagingChannel({
     canSendAsDm: false,
     actions: [],
     destinations: {
-      ruleNotifications: disabledDestination,
+      ruleNotifications: savedRuleNotificationDestination,
       scheduledCheckIns: disabledDestination,
       meetingBriefs: disabledDestination,
       documentFilings: disabledDestination,

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -419,6 +419,76 @@ describe("RuleForm", () => {
     expect(screen.getByText("Telegram DM")).toBeTruthy();
   });
 
+  it("does not show disconnected draft reply destinations as selected options", () => {
+    mockUseMessagingChannels.mockReturnValue({
+      data: {
+        channels: [
+          createMessagingChannel({
+            id: "cmessagingchannel1234567890123",
+            provider: "SLACK",
+            teamName: "Workspace",
+            teamId: "team-1",
+          }),
+          createMessagingChannel({
+            id: "cmessagingchannel1234567890456",
+            provider: "TELEGRAM",
+            teamName: "Telegram DM",
+            teamId: "chat-1",
+          }),
+        ],
+        availableProviders: ["SLACK", "TELEGRAM"],
+      },
+    });
+
+    render(
+      <RuleForm
+        alwaysEditMode
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Draft reply rule",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-email",
+              type: ActionType.DRAFT_EMAIL,
+              content: { value: "" },
+            },
+            {
+              id: "action-slack",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: "cmessagingchannel1234567890123",
+              content: { value: "" },
+            },
+            {
+              id: "action-telegram",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: "cmessagingchannel1234567890456",
+              content: { value: "" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("Draft to")).toHaveLength(1);
+    expect(screen.getByText("Email")).toBeTruthy();
+    expect(screen.queryByText(/Disconnected/)).toBeNull();
+  });
+
   it("preserves the original action order when saving an unchanged rule", async () => {
     const view = render(
       <RuleForm
@@ -478,3 +548,40 @@ describe("RuleForm", () => {
     });
   });
 });
+
+function createMessagingChannel({
+  id,
+  provider,
+  teamName,
+  teamId,
+}: {
+  id: string;
+  provider: "SLACK" | "TELEGRAM";
+  teamName: string;
+  teamId: string;
+}) {
+  const disabledDestination = {
+    enabled: false,
+    targetId: null,
+    targetLabel: null,
+    isDm: false,
+  };
+
+  return {
+    id,
+    provider,
+    teamName,
+    teamId,
+    isConnected: false,
+    canSendAsDm: false,
+    actions: [],
+    destinations: {
+      ruleNotifications: disabledDestination,
+      scheduledCheckIns: disabledDestination,
+      meetingBriefs: disabledDestination,
+      documentFilings: disabledDestination,
+      digests: disabledDestination,
+      followUps: disabledDestination,
+    },
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -744,19 +744,17 @@ function NotifyChannelRow({
   const hasChannels = connectedChannels.length > 0;
   const canConnect = availableProviders.length > 0;
 
-  if (!hasChannels && !canConnect && !value) return null;
-
-  const selectedChannel = channels.find((c) => c.id === value);
-  const showDisconnectedOption =
-    !!selectedChannel &&
-    !connectedChannels.some((channel) => channel.id === selectedChannel.id);
+  if (!hasChannels && !canConnect) return null;
+  const selectedChannelIsConnected =
+    !value || connectedChannels.some((channel) => channel.id === value);
+  const selectValue = selectedChannelIsConnected ? (value ?? "off") : "off";
 
   const channelsPath = prefixPath(emailAccountId, "/channels");
   const draftsNote = hasDraftToChat
     ? "Drafts also go to chat — configured in actions above."
     : undefined;
 
-  if (!hasChannels && !showDisconnectedOption) {
+  if (!hasChannels) {
     return (
       <AdvancedRow
         title="Notify in chat"
@@ -788,7 +786,7 @@ function NotifyChannelRow({
       note={draftsNote}
     >
       <Select
-        value={value ?? "off"}
+        value={selectValue}
         onValueChange={(next) => {
           if (next === CONNECT_SENTINEL) {
             router.push(channelsPath);
@@ -822,11 +820,6 @@ function NotifyChannelRow({
                   {formatMessagingDestinationLabel(channel)}
                 </SelectItem>
               ))}
-          {showDisconnectedOption && selectedChannel ? (
-            <SelectItem value={selectedChannel.id}>
-              {formatMessagingDestinationLabel(selectedChannel)} (Disconnected)
-            </SelectItem>
-          ) : null}
           {canConnect ? (
             <>
               <SelectSeparator />


### PR DESCRIPTION
Fix rule editor delivery controls so unavailable chat destinations are no longer shown as selected options.

- Filter draft-reply delivery choices to connected notification channels.
- Reset unavailable chat notification selects to an off/default display state.
- Add a regression test for disconnected saved destinations.