### PR TITLE
Add Outlook participant search diagnostics

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -604,6 +604,47 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
   });
 });
 
+describe("OutlookProvider.getThreadsWithParticipant", () => {
+  it("logs broad search and exact participant match counts", async () => {
+    const participantEmail = "participant@example.com";
+    const unrelatedMessage = createMessage({
+      id: "unrelated-message",
+      conversationId: "thread-unrelated",
+    });
+    const client = createMockOutlookClient([], {
+      responsesByApiPath: {
+        "/me/messages": ({ search }) => {
+          if (search) {
+            return {
+              value: [unrelatedMessage],
+              "@odata.nextLink": "https://graph.example.com/next-page",
+            };
+          }
+          return { value: [] };
+        },
+      },
+    });
+    const logger = createMockLogger();
+    const provider = new OutlookProvider(client, logger);
+
+    const threads = await provider.getThreadsWithParticipant({
+      participantEmail,
+      maxThreads: 1,
+    });
+
+    expect(threads).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Outlook participant search completed",
+      {
+        rawMessageCount: 1,
+        exactParticipantMessageCount: 0,
+        threadCount: 0,
+        hasMorePages: true,
+      },
+    );
+  });
+});
+
 function createMockOutlookClient(
   messages: Message[],
   options?: {
@@ -611,7 +652,11 @@ function createMockOutlookClient(
     folderIdCache?: Record<string, string> | null;
     responsesByApiPath?: Record<
       string,
-      { value: Message[]; "@odata.nextLink"?: string }
+      | { value: Message[]; "@odata.nextLink"?: string }
+      | ((request: { filter?: string; search?: string }) => {
+          value: Message[];
+          "@odata.nextLink"?: string;
+        })
     >;
   },
 ) {
@@ -623,19 +668,30 @@ function createMockOutlookClient(
     getClient: () => ({
       api: (apiPath: string) => {
         let filterValue: string | undefined;
+        let searchValue: string | undefined;
         const request = {
           filter: (value: string) => {
             filterValue = value;
             return request;
           },
+          search: (value: string) => {
+            searchValue = value;
+            return request;
+          },
           select: () => request,
+          expand: () => request,
           top: () => request,
           orderby: () => request,
           get: async () => {
-            requestLog.push({ apiPath, filter: filterValue });
-            return (
-              options?.responsesByApiPath?.[apiPath] || { value: messages }
-            );
+            requestLog.push({
+              apiPath,
+              filter: filterValue,
+            });
+            const response = options?.responsesByApiPath?.[apiPath];
+            if (typeof response === "function") {
+              return response({ filter: filterValue, search: searchValue });
+            }
+            return response || { value: messages };
           },
         };
 
@@ -652,6 +708,19 @@ function createMockOutlookClient(
     },
     getRequestLog: () => requestLog,
   } as any;
+}
+
+function createMockLogger() {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+    with: vi.fn(),
+  };
+  logger.with.mockReturnValue(logger);
+  return logger as any;
 }
 
 function createMessage(input: {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1192,6 +1192,7 @@ export class OutlookProvider implements EmailProvider {
     maxThreads?: number;
   }): Promise<EmailThread[]> {
     const { participantEmail, maxThreads = 5 } = options;
+    const maxSearchResults = Math.min(20, Math.max(10, maxThreads * 4));
 
     // IMPORTANT:
     // Microsoft Graph does not reliably support filtering Messages by recipient collections
@@ -1201,40 +1202,27 @@ export class OutlookProvider implements EmailProvider {
     const sanitizedEmail = sanitizeKqlValue(participantEmail);
     const searchQuery = `participants:${sanitizedEmail}`;
 
-    const { messages } = await queryBatchMessages(
+    const { messages, nextPageToken } = await queryBatchMessages(
       this.client,
       {
         searchQuery,
-        maxResults: Math.min(20, Math.max(10, maxThreads * 4)),
+        maxResults: maxSearchResults,
       },
       this.logger,
     );
 
     const participantLower = participantEmail.toLowerCase().trim();
-
-    const relevant = messages.filter((m) => {
-      const h = m.headers;
-
-      const fromEmail = extractEmailAddress(h.from || "").toLowerCase();
-      if (fromEmail === participantLower) return true;
-
-      const toAddresses = splitRecipientList(h.to || "")
-        .map((addr) => extractEmailAddress(addr).toLowerCase())
-        .filter(Boolean);
-      if (toAddresses.includes(participantLower)) return true;
-
-      const ccAddresses = splitRecipientList(h.cc || "")
-        .map((addr) => extractEmailAddress(addr).toLowerCase())
-        .filter(Boolean);
-      if (ccAddresses.includes(participantLower)) return true;
-
-      return false;
-    });
+    const relevant = filterMessagesForParticipant(messages, participantLower);
 
     // Extract unique conversationIds (thread IDs) from parsed messages
-    const conversationIds = Array.from(
-      new Set(relevant.map((m) => m.threadId).filter(Boolean)),
-    ).slice(0, maxThreads);
+    const conversationIds = getUniqueThreadIds(relevant, maxThreads);
+
+    this.logger.info("Outlook participant search completed", {
+      rawMessageCount: messages.length,
+      exactParticipantMessageCount: relevant.length,
+      threadCount: conversationIds.length,
+      hasMorePages: !!nextPageToken,
+    });
 
     if (conversationIds.length === 0) {
       return [];
@@ -1253,7 +1241,6 @@ export class OutlookProvider implements EmailProvider {
       } catch (error) {
         this.logger.warn("Failed to fetch thread messages for conversationId", {
           conversationId,
-          participantEmail,
           error,
           // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
           errorCode: (error as any)?.code,
@@ -2036,6 +2023,39 @@ function resolveOutlookFolderId(
 ): string | undefined {
   const folderKey = LABEL_TO_FOLDER_KEY[labelId.toUpperCase()];
   return folderKey ? folderIds[folderKey] : undefined;
+}
+
+function filterMessagesForParticipant(
+  messages: ParsedMessage[],
+  participantLower: string,
+): ParsedMessage[] {
+  return messages.filter((message) => {
+    const headers = message.headers;
+
+    const fromEmail = extractEmailAddress(headers.from || "").toLowerCase();
+    if (fromEmail === participantLower) return true;
+
+    const toAddresses = splitRecipientList(headers.to || "")
+      .map((addr) => extractEmailAddress(addr).toLowerCase())
+      .filter(Boolean);
+    if (toAddresses.includes(participantLower)) return true;
+
+    const ccAddresses = splitRecipientList(headers.cc || "")
+      .map((addr) => extractEmailAddress(addr).toLowerCase())
+      .filter(Boolean);
+    if (ccAddresses.includes(participantLower)) return true;
+
+    return false;
+  });
+}
+
+function getUniqueThreadIds(
+  messages: ParsedMessage[],
+  maxThreads: number,
+): string[] {
+  return Array.from(
+    new Set(messages.map((message) => message.threadId).filter(Boolean)),
+  ).slice(0, maxThreads);
 }
 
 function getRequiredOutlookThreadLabelIds({


### PR DESCRIPTION
Adds diagnostics for Outlook participant history retrieval used by meeting context generation.

- Logs aggregate broad-search counts, exact participant matches, resulting thread count, and whether Graph returned another page.
- Avoids adding new public or log-visible private participant details.
- Adds a regression test for the diagnostic counts when broad search returns messages that do not exactly match the participant.

Validation: pnpm --filter inbox-zero-ai test --run utils/email/microsoft.test.ts