### PR TITLE
QA: Fix URL extraction for markdown links in draft-reply eval

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -749,7 +749,7 @@ function hasExactUrl(text: string, expectedUrl: string): boolean {
 }
 
 function extractUrls(text: string): string[] {
-  return (text.match(/https?:\/\/[^\s<>"']+/g) ?? []).map((url) =>
+  return (text.match(/https?:\/\/[^\s<>"'()[\]]+/g) ?? []).map((url) =>
     url.replace(/[),.?!;:]+$/g, ""),
   );
 }


### PR DESCRIPTION
## Summary
Follow-up from QA on PR #2452. The `extractUrls` helper added in #2452 didn't handle markdown link syntax like `[https://x](https://x)` — the regex `/https?:\/\/[^\s<>\"']+/g` greedily captures the whole `https://x](https://x)` token, so URL normalization fails and `hasExactUrl` returns false even when the link is present.

This caused a false-negative failure in the new `explicit support preference may include booking link` eval: the model correctly included the booking link in markdown form, but the helper missed it.

Fix: exclude `()`, `[]` from the URL match class so markdown link syntax is split into two separate URLs.

## Test plan
- [x] Re-ran `pnpm --filter inbox-zero-ai test-ai __tests__/eval/draft-reply.test.ts` with `EVAL_MODELS=gemini-3.1-flash-lite` — booking-link tests now pass deterministically when the model includes the link
- [x] Verified extractor output on the failing reply: now returns `["https://cal.example.com/founder", "https://cal.example.com/founder"]` instead of one mashed token

🤖 Generated with [Claude Code](https://claude.com/claude-code)