### PR TITLE
Fix draft signature context

### DIFF
--- a/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
+++ b/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
@@ -197,28 +197,6 @@ describe("aiDraftReply formatting", () => {
     expect(result).toBe("Hmmm, let me think about that. Sounds good!!!");
   });
 
-  it("keeps the core reply prompt instructions", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "Merci pour votre message.",
-      },
-    });
-
-    await aiDraftReply(getDraftParams());
-
-    const [callArgs] = mockGenerateObject.mock.calls.at(-1)!;
-
-    expect(callArgs.system).toContain(
-      "Write the reply in the same language as the latest message in the thread.",
-    );
-    expect(callArgs.system).toContain(
-      "If a clickable link is necessary, use markdown links in the format [Label](https://example.com/path) or [Label](mailto:name@example.com).",
-    );
-    expect(callArgs.prompt).toContain(
-      "IMPORTANT: You are writing an email as user@example.com. Write the reply from their perspective.",
-    );
-  });
-
   it("includes learned reply memories when provided", async () => {
     mockGenerateObject.mockResolvedValueOnce({
       object: {

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -57,6 +57,7 @@ const getUserPrompt = ({
   mcpContext,
   meetingContext,
   attachmentContext,
+  hasConfiguredSignature,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: EmailAccountWithAI;
@@ -70,6 +71,7 @@ const getUserPrompt = ({
   mcpContext: string | null;
   meetingContext: string | null;
   attachmentContext: string | null;
+  hasConfiguredSignature: boolean;
 }) => {
   const userAbout = emailAccount.about
     ? `Context about the user:
@@ -169,6 +171,10 @@ ${attachmentContext}
 Mention attached documents only when useful and only if this section is present.
 `
     : "";
+  const signatureContext = hasConfiguredSignature
+    ? `The user's email account already has a configured signature that will be appended after this draft. Do not write any closing, sign-off, name, title, contact details, or signature block.
+`
+    : "";
 
   return `${userAbout}
 ${relevantKnowledge}
@@ -177,6 +183,7 @@ ${historicalContext}
 ${precedentHistoryContext}
 ${writingStylePrompt}
 ${learnedWritingStylePrompt}
+${signatureContext}
 ${schedulingContext}
 ${mcpToolsContext}
 ${upcomingMeetingsContext}
@@ -222,6 +229,7 @@ export async function aiDraftReplyWithConfidence({
   mcpContext,
   meetingContext,
   attachmentContext = null,
+  hasConfiguredSignature = false,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: EmailAccountWithAI;
@@ -235,6 +243,7 @@ export async function aiDraftReplyWithConfidence({
   mcpContext: string | null;
   meetingContext: string | null;
   attachmentContext?: string | null;
+  hasConfiguredSignature?: boolean;
 }): Promise<DraftReplyResult> {
   logger.info("Drafting email reply", {
     messageCount: messages.length,
@@ -271,6 +280,7 @@ export async function aiDraftReplyWithConfidence({
     mcpContext,
     meetingContext,
     attachmentContext,
+    hasConfiguredSignature,
   });
 
   const modelOptions = getModel(emailAccount.user, "draft");
@@ -324,6 +334,7 @@ export async function aiDraftReply({
   mcpContext,
   meetingContext,
   attachmentContext = null,
+  hasConfiguredSignature = false,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: EmailAccountWithAI;
@@ -337,6 +348,7 @@ export async function aiDraftReply({
   mcpContext: string | null;
   meetingContext: string | null;
   attachmentContext?: string | null;
+  hasConfiguredSignature?: boolean;
 }) {
   const result = await aiDraftReplyWithConfidence({
     messages,
@@ -351,6 +363,7 @@ export async function aiDraftReply({
     mcpContext,
     meetingContext,
     attachmentContext,
+    hasConfiguredSignature,
   });
 
   return result.reply;

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -341,6 +341,35 @@ describe("fetchMessagesAndGenerateDraft - AI content escaping", () => {
     expect(result).toBe("");
   });
 
+  it("passes configured signature state into draft generation", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Received the invoices. I will forward them for processing.",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+    });
+    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue(
+      createMockEmailAccountSettings({
+        signature: "<p>User Name<br>Team Lead</p>",
+      }),
+    );
+
+    const result = await fetchMessagesAndGenerateDraft(
+      createMockEmailAccount(),
+      "thread-1",
+      createMockClient(),
+      createMockMessage(),
+      logger,
+    );
+
+    expect(result).toBe(
+      "Received the invoices. I will forward them for processing.\n\n<p>User Name<br>Team Lead</p>",
+    );
+    expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConfiguredSignature: true,
+      }),
+    );
+  });
+
   it("converts AI link markup into provider-ready draft content for the reply-tracker flow", async () => {
     vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
       reply:

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -273,7 +273,7 @@ async function generateDraftContent(
     emailHistoryContext,
     calendarAvailability,
     writingStyle,
-    learnedWritingStyle,
+    emailAccountSettings,
     mcpResult,
     upcomingMeetings,
     emailHistorySummary,
@@ -300,7 +300,7 @@ async function generateDraftContent(
     getWritingStyle({ emailAccountId: emailAccount.id }),
     prisma.emailAccount.findUnique({
       where: { id: emailAccount.id },
-      select: { learnedWritingStyle: true },
+      select: { learnedWritingStyle: true, signature: true },
     }),
     mcpAgent({ emailAccount, messages }),
     getMeetingContext({
@@ -389,7 +389,8 @@ async function generateDraftContent(
     emailHistoryContext,
     calendarAvailability,
     writingStyle,
-    learnedWritingStyle: learnedWritingStyle?.learnedWritingStyle ?? null,
+    learnedWritingStyle: emailAccountSettings?.learnedWritingStyle ?? null,
+    hasConfiguredSignature: !!emailAccountSettings?.signature?.trim(),
     mcpContext: mcpResult?.response || null,
     meetingContext,
     attachmentContext: attachmentSelection.attachmentContext,


### PR DESCRIPTION
Passes configured signature state into reply draft generation so generated drafts can avoid adding extra closings when an account signature is appended.

Removes a low-value prompt wording assertion and adds focused regression coverage.

Tests: pnpm --filter inbox-zero-ai test --run utils/reply-tracker/generate-draft.test.ts utils/ai/reply/draft-reply.formatting.test.ts