### PR TITLE
assistant: Handle inaccessible chat files

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -585,6 +585,7 @@ function getEmailCapabilitiesPolicy({
     "- When replying to a thread, write the reply in the same language as the latest message in the thread.",
     '- When the user asks to forward an existing email, activate "forward" and use forwardEmail with a messageId from searchInbox results. Do not recreate forwards with sendEmail.',
     "- When the user asks to reply to an existing email, use replyEmail with a messageId from searchInbox results. Do not recreate replies with sendEmail.",
+    "- Chat-uploaded files are not available as outgoing email attachments. If the user asks to send, forward, or attach a file from chat, explain that this is unsupported and do not call sendEmail, replyEmail, or forwardEmail for that file.",
     "- Only send emails when the user clearly asks to send now.",
     '- After calling these tools, briefly say the email is ready in the pending email card for review and send. Do not mention card position like "below" or "above". Do not ask follow-up questions about CC, BCC, or whether to proceed because the UI handles confirmation.',
     "- After sendEmail, replyEmail, or forwardEmail, do not also render email widgets for that same action in the text; the pending email card is already the UI for it.",

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -106,7 +106,9 @@ const NEGATIVE_REACTION_ALIASES = new Set([
   "heavy_multiplication_x",
 ]);
 const UNSUPPORTED_MESSAGING_ATTACHMENT_MESSAGE =
-  "I can process images, but I can't access other file types (documents, videos, audio) sent here yet. I can still draft the email text if you share what to write.";
+  "I can process images, but I can't access or email other file types (documents, videos, audio) sent here yet. Share the contents as text if you want me to draft an email about them.";
+const UNSUPPORTED_MESSAGING_ATTACHMENT_MODEL_CONTEXT =
+  "Hidden context: The latest messaging input included one or more unsupported non-image file attachments. Their contents are unavailable, and they cannot be attached to outgoing emails from chat.";
 
 const SLACK_ASSISTANT_SUGGESTED_PROMPTS = [
   { title: "Inbox summary", message: "Summarize what needs attention today." },
@@ -651,6 +653,18 @@ async function processMessagingAssistantMessage({
       role: "user",
       parts: userParts,
     };
+    const modelUserMessage: UIMessage = context.hasUnsupportedAttachments
+      ? {
+          ...newUserMessage,
+          parts: [
+            {
+              type: "text" as const,
+              text: UNSUPPORTED_MESSAGING_ATTACHMENT_MODEL_CONTEXT,
+            },
+            ...newUserMessage.parts,
+          ],
+        }
+      : newUserMessage;
 
     await prisma.chatMessage.upsert({
       where: { id: userMessageId },
@@ -702,7 +716,7 @@ async function processMessagingAssistantMessage({
       const result = await aiProcessAssistantChat({
         messages: await convertToModelMessages([
           ...existingMessages,
-          newUserMessage,
+          modelUserMessage,
         ]),
         emailAccountId: context.emailAccountId,
         user: emailAccountUser,


### PR DESCRIPTION
Updates assistant chat behavior so unsupported messaging file uploads are treated as inaccessible when preparing email actions. Adds model-visible context for omitted non-image chat files and keeps the user-facing guidance clear.\n\nTests: pnpm --filter inbox-zero-ai exec vitest run __tests__/ai-assistant-chat.test.ts; pnpm --filter inbox-zero-ai exec vitest run utils/messaging/chat-sdk/bot.test.ts