### PR TITLE
feat(digest): fall back to user's email provider when Resend is not configured

### DIFF
--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -327,6 +327,7 @@ async function sendEmail({
       ruleNames: Object.fromEntries(ruleNameMap),
       itemsByRule: executedRulesByRule,
       logger,
+      emailProvider,
     });
 
     logger.info("Digest sent");

--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -1,5 +1,5 @@
 import { env } from "@/env";
-import { sendDigestEmail } from "@inboxzero/resend";
+import { sendDigestEmail, renderDigestEmailHtml } from "@inboxzero/resend";
 import {
   MessagingProvider,
   MessagingRoutePurpose,
@@ -10,6 +10,7 @@ import {
   DIGEST_MAX_ITEMS_PER_RULE,
   formatDigestDate,
 } from "@/utils/digest/format";
+import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import {
   resolveSlackRouteDestination,
@@ -33,6 +34,7 @@ export async function sendDigest({
   ruleNames,
   itemsByRule,
   logger,
+  emailProvider,
 }: {
   emailAccountId: string;
   userEmail: string;
@@ -41,6 +43,13 @@ export async function sendDigest({
   ruleNames: Record<string, string>;
   itemsByRule: ItemsByRule;
   logger: Logger;
+  /**
+   * Optional. When set and `RESEND_API_KEY` is not configured, the digest
+   * email is delivered via the user's own provider (Outlook/Gmail) so the
+   * user receives it in their own inbox. Without this, no-Resend deployments
+   * will throw on email delivery.
+   */
+  emailProvider?: EmailProvider;
 }): Promise<void> {
   logger = logger.with({ emailAccountId, userEmail });
 
@@ -82,6 +91,7 @@ export async function sendDigest({
         ruleNames,
         itemsByRule,
         logger,
+        emailProvider,
       }),
     );
   }
@@ -167,6 +177,7 @@ async function sendDigestViaEmail({
   ruleNames,
   itemsByRule,
   logger,
+  emailProvider,
 }: {
   emailAccountId: string;
   userEmail: string;
@@ -175,21 +186,45 @@ async function sendDigestViaEmail({
   ruleNames: Record<string, string>;
   itemsByRule: ItemsByRule;
   logger: Logger;
+  emailProvider?: EmailProvider;
 }) {
-  logger.info("Sending digest via email");
-  await sendDigestEmail({
-    from: env.RESEND_FROM_EMAIL,
+  const emailProps = {
+    baseUrl: env.NEXT_PUBLIC_BASE_URL,
+    unsubscribeToken,
+    date,
+    ruleNames,
+    ...itemsByRule,
+    emailAccountId,
+  };
+
+  // Prefer Resend when configured (matches existing behavior).
+  if (env.RESEND_API_KEY) {
+    logger.info("Sending digest via Resend");
+    await sendDigestEmail({
+      from: env.RESEND_FROM_EMAIL,
+      to: userEmail,
+      emailProps,
+    });
+    logger.info("Digest email sent via Resend");
+    return;
+  }
+
+  // Fallback: deliver via the user's own email provider so self-hosted
+  // deployments without Resend still receive their digests.
+  if (!emailProvider) {
+    throw new Error(
+      "Cannot send digest email: RESEND_API_KEY is not configured and no email provider was supplied for fallback delivery",
+    );
+  }
+
+  logger.info("Sending digest via user's email provider (Resend not configured)");
+  const { subject, html } = await renderDigestEmailHtml(emailProps);
+  await emailProvider.sendEmailWithHtml({
     to: userEmail,
-    emailProps: {
-      baseUrl: env.NEXT_PUBLIC_BASE_URL,
-      unsubscribeToken,
-      date,
-      ruleNames,
-      ...itemsByRule,
-      emailAccountId,
-    },
+    subject,
+    messageHtml: html,
   });
-  logger.info("Digest email sent");
+  logger.info("Digest email sent via user's email provider");
 }
 
 async function sendDigestViaSlack({

--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -157,6 +157,20 @@ export const sendDigestEmail = async ({
     ],
   });
 
+/**
+ * Render the digest email to a subject line and HTML body string.
+ * Used when delivering the digest via the user's own email provider
+ * (Outlook/Gmail) instead of Resend — for self-hosted deployments
+ * that don't have RESEND_API_KEY configured.
+ */
+export const renderDigestEmailHtml = async (
+  emailProps: DigestEmailProps,
+): Promise<{ subject: string; html: string }> => {
+  const subject = generateDigestSubject(emailProps);
+  const html = await render(<DigestEmail {...emailProps} />);
+  return { subject, html };
+};
+
 export const sendInvitationEmail = async ({
   from,
   to,


### PR DESCRIPTION
## Problem
Self-hosted Inbox Zero deployments often skip Resend — they don't want a paid service, can't sign a BAA for HIPAA contexts, or just don't need transactional email beyond the digest. Today the digest pipeline is hard-wired to Resend, so those deployments either silently lose digests (current behavior) or have to disable the digest feature entirely.

## Fix
Add an opt-in fallback: when `RESEND_API_KEY` is unset, deliver the digest via the user's own email provider (Outlook/Gmail). The user receives their digest in their own inbox — same address they're already authenticated against.

### Behavior matrix
| `RESEND_API_KEY` | `EmailProvider` passed | Result |
|---|---|---|
| set | (any) | Send via Resend (unchanged) |
| unset | yes | Send via user's mailbox (new) |
| unset | no | Throw with clear error message |

## Implementation
- **`packages/resend/src/send.tsx`** — new exported helper `renderDigestEmailHtml(props)` returning `{ subject, html }`. Reuses the existing `DigestEmail` React template + `generateDigestSubject` so there's only one source of truth for digest formatting.
- **`apps/web/utils/digest/send-digest.ts`** — `sendDigest` accepts an optional `EmailProvider`. Inside `sendDigestViaEmail`, branches on `env.RESEND_API_KEY` and falls back to `provider.sendEmailWithHtml(...)` when Resend isn't configured.
- **`apps/web/app/api/resend/digest/route.ts`** — passes the already-constructed `EmailProvider` (line 131-135) into `sendDigest`.

## Risk
- **No impact on Resend users.** The Resend path is preferred whenever \`RESEND_API_KEY\` is set.
- **No new OAuth scopes.** The fallback uses \`sendEmailWithHtml\`, which is already on the \`EmailProvider\` abstraction (both Outlook and Gmail implement it for AI-drafted replies).
- The new path doesn't return Resend-style tags / message-IDs — that's intentional, it's a different delivery channel.

## Testing
Manual:
1. Unset \`RESEND_API_KEY\`, set \`NEXT_PUBLIC_DIGEST_ENABLED=true\`, trigger \`POST /api/resend/digest\` for an Outlook account.
2. Confirm the user receives the digest in their own inbox.
3. Set \`RESEND_API_KEY\` again — confirm Resend is still used (existing path).

Pairs nicely with a separate small fix that makes \`sendEmail\` throw instead of silently returning \`Promise.resolve()\` when Resend isn't configured (will open as a separate PR), but this PR is independent and useful on its own.