### PR TITLE
fix: throw when Resend is not configured

### DIFF
--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -48,8 +48,7 @@ const sendEmail = async ({
   baseUrl: string;
 }) => {
   if (!resend) {
-    console.log(RESEND_NOT_CONFIGURED_MESSAGE);
-    return Promise.resolve();
+    throw new Error(RESEND_NOT_CONFIGURED_MESSAGE);
   }
 
   const text = await render(react, { plainText: true });


### PR DESCRIPTION
## Problem
`sendEmail` in `packages/resend/src/send.tsx` returns `Promise.resolve()` when `RESEND_API_KEY` is unset, which means callers cannot distinguish "delivery failed because Resend isn't configured" from "delivery succeeded".

This causes a real data-loss bug in `apps/web/app/api/resend/digest/route.ts`: pending digests are marked `SENT` and their content `[REDACTED]` even though no email was ever sent. Self-hosters without a Resend account silently lose their digest history.

## Fix
Throw an error instead. Existing callers wrap `sendEmail` / `sendDigestEmail` in try/catch (see `route.ts:368`) and will correctly mark `FAILED`.

## Risk
Other callers of `sendEmail` (summary, invitation, reconnection, action-required, meeting-briefing) currently no-op silently when Resend isn't configured. After this change, those will throw — surfacing the misconfiguration rather than hiding it. Any caller without try/catch will surface the error, which is the desired behavior for a self-hosted deployment that hasn't configured Resend.

`sendColdEmailNotification` has its own separate Resend check (line 287-290 / 294-297 in some refactors) and is unaffected.

## Companion PR
Pairs nicely with #2459 which adds an Outlook/Gmail fallback so digests actually deliver when Resend isn't configured. This PR alone is still useful — it converts a silent data-loss bug into a loud failure.