### PR TITLE
Fix email forward preview subject prefix

### DIFF
--- a/apps/web/components/assistant-chat/helpers.test.ts
+++ b/apps/web/components/assistant-chat/helpers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getPendingEmailSubjectPrefix } from "@/components/assistant-chat/helpers";
+
+describe("getPendingEmailSubjectPrefix", () => {
+  it("uses the forward prefix for pending forwarded emails", () => {
+    expect(getPendingEmailSubjectPrefix("forward_email")).toBe("Fwd: ");
+  });
+
+  it("uses the reply prefix for pending replies", () => {
+    expect(getPendingEmailSubjectPrefix("reply_email")).toBe("Re: ");
+  });
+
+  it("does not prefix new outbound emails", () => {
+    expect(getPendingEmailSubjectPrefix("send_email")).toBe("");
+  });
+});

--- a/apps/web/components/assistant-chat/helpers.ts
+++ b/apps/web/components/assistant-chat/helpers.ts
@@ -6,6 +6,8 @@ import type {
   CustomUIDataTypes,
 } from "@/components/assistant-chat/types";
 
+type PendingEmailActionType = "send_email" | "reply_email" | "forward_email";
+
 export function convertToUIMessages(chat: GetChatResponse): ChatMessage[] {
   return (
     chat?.messages.map((message) => ({
@@ -17,4 +19,12 @@ export function convertToUIMessages(chat: GetChatResponse): ChatMessage[] {
       // },
     })) || []
   );
+}
+
+export function getPendingEmailSubjectPrefix(
+  actionType: PendingEmailActionType,
+) {
+  if (actionType === "reply_email") return "Re: ";
+  if (actionType === "forward_email") return "Fwd: ";
+  return "";
 }

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -76,6 +76,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { getPendingEmailSubjectPrefix } from "@/components/assistant-chat/helpers";
 
 export type ThreadLookup = EmailLookup;
 
@@ -681,7 +682,7 @@ function EmailActionResult({
           <div className="flex items-center gap-2 border-b px-4 py-2.5">
             <FieldLabel>Subject</FieldLabel>
             <span className="truncate text-sm font-medium text-foreground">
-              {actionType !== "send_email" ? "Re: " : ""}
+              {getPendingEmailSubjectPrefix(actionType)}
               {displaySubject}
             </span>
           </div>


### PR DESCRIPTION
Fixes the pending email preview subject prefix for forwarded messages while preserving reply and new-email behavior.

- Added a small helper for pending email subject prefixes.
- Updated the assistant email preview card to use the helper.
- Added regression coverage for forward, reply, and new email prefixes.

Tests: pnpm test --run components/assistant-chat/helpers.test.ts components/assistant-chat/tools.search-inbox-result.test.tsx