### PR TITLE
messaging: Show draft attachment summaries

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -77,3 +77,4 @@ gh pr create --title "<title>" --body "<body>" && gh pr comment $(gh pr view --j
 
 Display the returned PR URL as a markdown link on its own line, formatted as: `[PR #<number>](<url>)` so it's clickable.
 Display the name of the branch you created.
+In the final response, include a concise performance impact note for the PR, covering added runtime work, database/network calls, and hot-path risk when relevant.

--- a/apps/web/prisma/migrations/20260430181500_add_selected_action_attachments/migration.sql
+++ b/apps/web/prisma/migrations/20260430181500_add_selected_action_attachments/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ExecutedAction" ADD COLUMN "selectedAttachments" JSONB;
+ALTER TABLE "ScheduledAction" ADD COLUMN "selectedAttachments" JSONB;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -612,6 +612,7 @@ model ExecutedAction {
   folderName        String?
   folderId          String?
   staticAttachments Json? // AttachmentSourceInput[] — explicit files to attach for email actions
+  selectedAttachments Json? // SelectedAttachment[] — AI-selected files for this specific execution
 
   // additional fields as a result of the action
   draftId              String? // Gmail draft ID created by DRAFT_EMAIL action
@@ -652,6 +653,7 @@ model ScheduledAction {
   folderId          String?
   scheduledId       String?
   staticAttachments Json? // AttachmentSourceInput[] — explicit files to attach for email actions
+  selectedAttachments Json? // SelectedAttachment[] — AI-selected files for this specific execution
 
   executedAt       DateTime?
   executedActionId String?   @unique

--- a/apps/web/utils/action-item.test.ts
+++ b/apps/web/utils/action-item.test.ts
@@ -342,6 +342,25 @@ describe("sanitizeActionFields", () => {
 
       expect(result.staticAttachments).toEqual(attachments);
     });
+
+    it("preserves selected attachments", () => {
+      const selectedAttachments = [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-3",
+          filename: "brief.pdf",
+          mimeType: "application/pdf",
+        },
+      ];
+
+      const result = sanitizeActionFields({
+        type: ActionType.DRAFT_EMAIL,
+        content: "Draft Content",
+        selectedAttachments,
+      });
+
+      expect(result.selectedAttachments).toEqual(selectedAttachments);
+    });
   });
 
   describe("DRAFT_MESSAGING_CHANNEL action", () => {
@@ -384,6 +403,26 @@ describe("sanitizeActionFields", () => {
       });
 
       expect(result.staticAttachments).toEqual(attachments);
+    });
+
+    it("preserves selected attachments", () => {
+      const selectedAttachments = [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-4",
+          filename: "brief.pdf",
+          mimeType: "application/pdf",
+        },
+      ];
+
+      const result = sanitizeActionFields({
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+        content: "Draft Content",
+        selectedAttachments,
+      });
+
+      expect(result.selectedAttachments).toEqual(selectedAttachments);
     });
   });
 

--- a/apps/web/utils/action-item.ts
+++ b/apps/web/utils/action-item.ts
@@ -1,5 +1,6 @@
 import { ActionType } from "@/generated/prisma/enums";
 import type { Action, ExecutedAction, Prisma } from "@/generated/prisma/client";
+import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
 
 const DRAFT_REPLY_FIELDS = [
   { name: "subject" as const, label: "Subject", expandable: true },
@@ -180,13 +181,15 @@ type ActionFieldsSelection = {
   folderId: string | null;
   delayInMinutes: number | null;
   staticAttachments?: Prisma.JsonValue;
+  selectedAttachments?: Prisma.JsonValue;
 };
 
 type SanitizableActionFields = Partial<
-  Omit<ActionFieldsSelection, "staticAttachments">
+  Omit<ActionFieldsSelection, "staticAttachments" | "selectedAttachments">
 > & {
   type: ActionType;
   staticAttachments?: Prisma.JsonValue | null;
+  selectedAttachments?: Prisma.JsonValue | null;
 };
 
 export function sanitizeActionFields(
@@ -214,6 +217,9 @@ export function sanitizeActionFields(
     delayInMinutes: action.delayInMinutes || null,
     staticAttachments: supportsStaticAttachments
       ? (action.staticAttachments ?? undefined)
+      : undefined,
+    selectedAttachments: isDraftReplyActionType(action.type)
+      ? (action.selectedAttachments ?? undefined)
       : undefined,
   };
 

--- a/apps/web/utils/ai/action-attachments.test.ts
+++ b/apps/web/utils/ai/action-attachments.test.ts
@@ -1,19 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  AttachmentSourceType,
-  DraftReplyConfidence,
-} from "@/generated/prisma/enums";
+import { AttachmentSourceType } from "@/generated/prisma/enums";
 import { resolveActionAttachments } from "@/utils/ai/action-attachments";
 import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
-import { getReplyWithConfidence } from "@/utils/redis/reply";
-import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/utils/prisma");
-vi.mock("@/utils/redis/reply", () => ({
-  getReplyWithConfidence: vi.fn(),
-}));
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   resolveDraftAttachments: vi.fn(),
 }));
@@ -51,13 +42,9 @@ describe("resolveActionAttachments", () => {
         contentType: "application/pdf",
       },
     ]);
-    vi.mocked(prisma.attachmentSource.findFirst).mockResolvedValue({
-      id: "as-1",
-    } as any);
-    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
   });
 
-  it("returns early without hitting Prisma when there are no static attachments and AI selection is disabled", async () => {
+  it("returns early when there are no static attachments and AI selection is disabled", async () => {
     const result = await resolveActionAttachments({
       email: email as any,
       emailAccount,
@@ -68,43 +55,37 @@ describe("resolveActionAttachments", () => {
     });
 
     expect(result).toEqual([]);
-    expect(prisma.attachmentSource.findFirst).not.toHaveBeenCalled();
     expect(resolveDraftAttachments).not.toHaveBeenCalled();
   });
 
-  it("returns early when AI selection is on but the executed rule has no ruleId", async () => {
+  it("returns early when AI selection is on but no selected attachments were persisted", async () => {
     const result = await resolveActionAttachments({
       email: email as any,
       emailAccount,
-      executedRule: { ruleId: null } as any,
+      executedRule: executedRule as any,
       logger,
       staticAttachments: null,
       includeAiSelectedAttachments: true,
     });
 
     expect(result).toEqual([]);
-    expect(prisma.attachmentSource.findFirst).not.toHaveBeenCalled();
+    expect(resolveDraftAttachments).not.toHaveBeenCalled();
   });
 
   it("dedupes static and draft-selected attachments by drive connection and file id before resolving", async () => {
-    vi.mocked(getReplyWithConfidence).mockResolvedValue({
-      reply: "r",
-      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
-      attachments: [
-        {
-          driveConnectionId: "d1",
-          fileId: "f1",
-          filename: "from-cache.pdf",
-          mimeType: "application/pdf",
-        },
-      ],
-    });
-
     await resolveActionAttachments({
       email: email as any,
       emailAccount,
       executedRule: executedRule as any,
       logger,
+      selectedAttachments: [
+        {
+          driveConnectionId: "d1",
+          fileId: "f1",
+          filename: "from-selected.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
       staticAttachments: [
         {
           driveConnectionId: "d1",
@@ -131,16 +112,22 @@ describe("resolveActionAttachments", () => {
     ).toHaveLength(1);
   });
 
-  it("skips resolveDraftAttachments when the draft cache is empty and there are no static attachments", async () => {
-    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
-
+  it("ignores persisted AI selections when AI selection is disabled for the action", async () => {
     const result = await resolveActionAttachments({
       email: email as any,
       emailAccount,
       executedRule: executedRule as any,
       logger,
       staticAttachments: null,
-      includeAiSelectedAttachments: true,
+      selectedAttachments: [
+        {
+          driveConnectionId: "d1",
+          fileId: "f1",
+          filename: "from-selected.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+      includeAiSelectedAttachments: false,
     });
 
     expect(result).toEqual([]);

--- a/apps/web/utils/ai/action-attachments.ts
+++ b/apps/web/utils/ai/action-attachments.ts
@@ -2,9 +2,9 @@ import { AttachmentSourceType } from "@/generated/prisma/enums";
 import {
   type SelectedAttachment,
   attachmentSourceInputSchema,
+  selectedAttachmentSchema,
 } from "@/utils/attachments/source-schema";
 import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
-import prisma from "@/utils/prisma";
 import type {
   ActionExecutionEmailAccount,
   ActionItem,
@@ -12,7 +12,6 @@ import type {
   ExecutedRuleForAction,
 } from "@/utils/ai/types";
 import type { Logger } from "@/utils/logger";
-import { getReplyWithConfidence } from "@/utils/redis/reply";
 
 export async function resolveActionAttachments({
   email,
@@ -20,6 +19,7 @@ export async function resolveActionAttachments({
   executedRule,
   logger,
   staticAttachments,
+  selectedAttachments,
   includeAiSelectedAttachments,
 }: {
   email: EmailForAction;
@@ -27,35 +27,29 @@ export async function resolveActionAttachments({
   executedRule: ExecutedRuleForAction;
   logger: Logger;
   staticAttachments?: ActionItem["staticAttachments"];
+  selectedAttachments?: ActionItem["selectedAttachments"];
   includeAiSelectedAttachments: boolean;
 }) {
   const staticSelectedAttachments = parseStaticAttachments(staticAttachments);
+  const aiSelectedAttachments = includeAiSelectedAttachments
+    ? parseSelectedAttachments(selectedAttachments)
+    : [];
 
   if (
     staticSelectedAttachments.length === 0 &&
-    (!includeAiSelectedAttachments || !executedRule.ruleId)
+    aiSelectedAttachments.length === 0
   ) {
     return [];
   }
 
-  const [aiSelectedAttachments, staticSelected] = await Promise.all([
-    includeAiSelectedAttachments
-      ? getDraftSelectedAttachments({
-          email,
-          emailAccountId: emailAccount.id,
-          executedRule,
-          logger,
-        })
-      : Promise.resolve([]),
-    Promise.resolve(staticSelectedAttachments),
-  ]);
-
   const allSelected = [
     ...new Map(
-      [...aiSelectedAttachments, ...staticSelected].map((attachment) => [
-        `${attachment.driveConnectionId}:${attachment.fileId}`,
-        attachment,
-      ]),
+      [...aiSelectedAttachments, ...staticSelectedAttachments].map(
+        (attachment) => [
+          `${attachment.driveConnectionId}:${attachment.fileId}`,
+          attachment,
+        ],
+      ),
     ).values(),
   ];
 
@@ -79,43 +73,6 @@ export async function resolveActionAttachments({
   return attachments;
 }
 
-async function getDraftSelectedAttachments({
-  email,
-  emailAccountId,
-  executedRule,
-  logger,
-}: {
-  email: EmailForAction;
-  emailAccountId: string;
-  executedRule: ExecutedRuleForAction;
-  logger: Logger;
-}): Promise<SelectedAttachment[]> {
-  if (!executedRule.ruleId) return [];
-
-  const attachmentSource = await prisma.attachmentSource.findFirst({
-    where: { ruleId: executedRule.ruleId },
-    select: { id: true },
-  });
-
-  if (!attachmentSource) return [];
-
-  const cachedDraft = await getReplyWithConfidence({
-    emailAccountId,
-    messageId: email.id,
-    ruleId: executedRule.ruleId,
-  });
-
-  if (cachedDraft) {
-    return cachedDraft.attachments ?? [];
-  }
-
-  logger.warn("Draft attachment cache missing, skipping attachments", {
-    messageId: email.id,
-    ruleId: executedRule.ruleId,
-  });
-  return [];
-}
-
 function parseStaticAttachments(raw: unknown): SelectedAttachment[] {
   if (!raw || !Array.isArray(raw) || raw.length === 0) return [];
 
@@ -131,4 +88,11 @@ function parseStaticAttachments(raw: unknown): SelectedAttachment[] {
       filename: item.name,
       mimeType: "application/pdf",
     }));
+}
+
+function parseSelectedAttachments(raw: unknown): SelectedAttachment[] {
+  if (!raw || !Array.isArray(raw) || raw.length === 0) return [];
+
+  const parsed = selectedAttachmentSchema.array().safeParse(raw);
+  return parsed.success ? parsed.data : [];
 }

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -1,16 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ActionType,
-  AttachmentSourceType,
-  DraftReplyConfidence,
-} from "@/generated/prisma/enums";
+import { ActionType, AttachmentSourceType } from "@/generated/prisma/enums";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import { runActionFunction } from "@/utils/ai/actions";
 import {
   resolveDraftAttachments,
   selectDraftAttachmentsForRule,
 } from "@/utils/attachments/draft-attachments";
-import { getReplyWithConfidence } from "@/utils/redis/reply";
 import {
   getMessagingRuleNotificationResult,
   sendMessagingRuleNotification,
@@ -19,10 +14,6 @@ import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 vi.mock("server-only", () => ({}));
-
-vi.mock("@/utils/redis/reply", () => ({
-  getReplyWithConfidence: vi.fn().mockResolvedValue(null),
-}));
 
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   resolveDraftAttachments: vi.fn().mockResolvedValue([]),
@@ -42,9 +33,6 @@ vi.mock("@/utils/messaging/rule-notifications", () => ({
 
 vi.mock("@/utils/prisma", () => ({
   default: {
-    attachmentSource: {
-      findFirst: vi.fn().mockResolvedValue({ id: "attachment-source-1" }),
-    },
     executedAction: {
       update: vi.fn().mockResolvedValue({}),
     },
@@ -77,9 +65,6 @@ describe("runActionFunction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(prisma.attachmentSource.findFirst).mockResolvedValue({
-      id: "attachment-source-1",
-    });
     vi.mocked(prisma.executedAction.update).mockResolvedValue({});
     vi.mocked(getMessagingRuleNotificationResult).mockResolvedValue({
       delivered: true,
@@ -90,19 +75,6 @@ describe("runActionFunction", () => {
   it("passes resolved drive attachments into draft creation", async () => {
     const client = createMockEmailProvider();
 
-    vi.mocked(getReplyWithConfidence).mockResolvedValue({
-      reply: "Attached the requested PDF.",
-      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
-      attachments: [
-        {
-          driveConnectionId: "drive-1",
-          fileId: "file-1",
-          filename: "lease.pdf",
-          mimeType: "application/pdf",
-          reason: "Matched the requested property",
-        },
-      ],
-    });
     vi.mocked(resolveDraftAttachments).mockResolvedValue([
       {
         filename: "lease.pdf",
@@ -118,6 +90,15 @@ describe("runActionFunction", () => {
         id: "action-1",
         type: ActionType.DRAFT_EMAIL,
         content: "Attached the requested PDF.",
+        selectedAttachments: [
+          {
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+            filename: "lease.pdf",
+            mimeType: "application/pdf",
+            reason: "Matched the requested property",
+          },
+        ],
       },
       emailAccount,
       executedRule: {
@@ -127,16 +108,6 @@ describe("runActionFunction", () => {
         ruleId: "rule-1",
       } as any,
       logger,
-    });
-
-    expect(getReplyWithConfidence).toHaveBeenCalledWith({
-      emailAccountId: "account-1",
-      messageId: "message-1",
-      ruleId: "rule-1",
-    });
-    expect(prisma.attachmentSource.findFirst).toHaveBeenCalledWith({
-      where: { ruleId: "rule-1" },
-      select: { id: true },
     });
 
     expect(resolveDraftAttachments).toHaveBeenCalledWith({
@@ -170,10 +141,8 @@ describe("runActionFunction", () => {
     );
   });
 
-  it("skips draft attachments when the rule cache is missing", async () => {
+  it("skips draft attachments when no selected attachments were persisted", async () => {
     const client = createMockEmailProvider();
-
-    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
 
     await runActionFunction({
       client,
@@ -438,7 +407,6 @@ describe("runActionFunction", () => {
       logger,
     });
 
-    expect(getReplyWithConfidence).not.toHaveBeenCalled();
     expect(resolveDraftAttachments).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       userId: "user-1",
@@ -506,7 +474,6 @@ describe("runActionFunction", () => {
       logger,
     });
 
-    expect(getReplyWithConfidence).not.toHaveBeenCalled();
     expect(resolveDraftAttachments).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       userId: "user-1",
@@ -535,9 +502,8 @@ describe("runActionFunction", () => {
     );
   });
 
-  it("skips cache lookup when drafts have no attachment sources", async () => {
+  it("does not try to resolve attachments when drafts have no selected attachments", async () => {
     const client = createMockEmailProvider();
-    vi.mocked(prisma.attachmentSource.findFirst).mockResolvedValue(null);
 
     await runActionFunction({
       client,
@@ -557,12 +523,7 @@ describe("runActionFunction", () => {
       logger,
     });
 
-    expect(getReplyWithConfidence).not.toHaveBeenCalled();
     expect(resolveDraftAttachments).not.toHaveBeenCalled();
-    expect(prisma.attachmentSource.findFirst).toHaveBeenCalledWith({
-      where: { ruleId: "rule-1" },
-      select: { id: true },
-    });
     expect(client.draftEmail).toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -212,6 +212,7 @@ const draft: ActionFunction<{
     executedRule,
     logger,
     staticAttachments: args.staticAttachments,
+    selectedAttachments: args.selectedAttachments,
     includeAiSelectedAttachments: true,
   });
 
@@ -321,6 +322,7 @@ const reply: ActionFunction<{
     executedRule,
     logger,
     staticAttachments: args.staticAttachments,
+    selectedAttachments: args.selectedAttachments,
     includeAiSelectedAttachments: false,
   });
 
@@ -359,6 +361,7 @@ const send_email: ActionFunction<{
     executedRule,
     logger,
     staticAttachments: args.staticAttachments,
+    selectedAttachments: args.selectedAttachments,
     includeAiSelectedAttachments: false,
   });
 

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -172,6 +172,7 @@ const draft: ActionFunction<{
   cc?: string | null;
   bcc?: string | null;
   staticAttachments?: ActionItem["staticAttachments"];
+  selectedAttachments?: ActionItem["selectedAttachments"];
 }> = async ({ client, email, args, emailAccount, executedRule, logger }) => {
   if (env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED) return;
 
@@ -322,7 +323,6 @@ const reply: ActionFunction<{
     executedRule,
     logger,
     staticAttachments: args.staticAttachments,
-    selectedAttachments: args.selectedAttachments,
     includeAiSelectedAttachments: false,
   });
 
@@ -361,7 +361,6 @@ const send_email: ActionFunction<{
     executedRule,
     logger,
     staticAttachments: args.staticAttachments,
-    selectedAttachments: args.selectedAttachments,
     includeAiSelectedAttachments: false,
   });
 

--- a/apps/web/utils/ai/choose-rule/choose-args.test.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.test.ts
@@ -273,6 +273,39 @@ describe("combineActionsWithAiArgs", () => {
       expect(result[0].content).toBe(fullDraft);
     });
 
+    it("carries selected attachments with generated draft actions", () => {
+      const actions = [
+        createMockAction({
+          id: "2",
+          type: ActionType.DRAFT_EMAIL,
+          content: null,
+        }),
+      ];
+      const selectedAttachments = [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-1",
+          filename: "attachment.pdf",
+          mimeType: "application/pdf",
+        },
+      ];
+
+      const result = combineActionsWithAiArgs(
+        actions,
+        undefined,
+        "Generated draft",
+        null,
+        null,
+        null,
+        selectedAttachments,
+      );
+
+      expect(result[0]).toMatchObject({
+        content: "Generated draft",
+        selectedAttachments,
+      });
+    });
+
     it("uses one generated draft for every draft reply action", () => {
       const actions = [
         createMockAction({

--- a/apps/web/utils/ai/choose-rule/choose-args.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.ts
@@ -19,6 +19,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { DraftAttribution } from "@/utils/ai/reply/draft-attribution";
 import type { DraftContextMetadata } from "@/utils/ai/reply/draft-context-metadata";
 import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
+import type { SelectedAttachment } from "@/utils/attachments/source-schema";
 
 const MODULE = "choose-args";
 
@@ -31,6 +32,7 @@ type DraftAttributionFields = {
   draftModelName?: string | null;
   draftPipelineVersion?: number | null;
   draftContextMetadata?: DraftContextMetadata | null;
+  selectedAttachments?: SelectedAttachment[] | null;
 };
 
 export type ActionWithDraftAttribution = Action & DraftAttributionFields;
@@ -63,6 +65,7 @@ export async function getActionItemsWithAiArgs({
   let draftConfidence: DraftReplyConfidence | null = null;
   let draftAttribution: DraftAttribution | null = null;
   let draftContextMetadata: DraftContextMetadata | null = null;
+  let selectedAttachments: SelectedAttachment[] | null = null;
 
   if (draftReplyActions.length) {
     try {
@@ -86,6 +89,7 @@ export async function getActionItemsWithAiArgs({
       draftConfidence = draftResult.confidence;
       draftAttribution = draftResult.attribution;
       draftContextMetadata = draftResult.draftContextMetadata ?? null;
+      selectedAttachments = draftResult.attachments ?? null;
 
       log.info("Draft generated", {
         email: emailAccount.email,
@@ -127,6 +131,7 @@ export async function getActionItemsWithAiArgs({
     draftAttribution,
     aiArgsAttribution,
     draftContextMetadata,
+    selectedAttachments,
   );
   const filteredActions = filterIncompleteDraftActions(combinedActions);
 
@@ -147,6 +152,7 @@ export function combineActionsWithAiArgs(
   draftAttribution: DraftAttribution | null = null,
   aiArgsAttribution: DraftAttribution | null = null,
   draftContextMetadata: DraftContextMetadata | null = null,
+  selectedAttachments: SelectedAttachment[] | null = null,
 ): ActionWithDraftAttribution[] {
   if (!aiArgs && !draft) return actions as ActionWithDraftAttribution[];
 
@@ -161,6 +167,7 @@ export function combineActionsWithAiArgs(
       updatedAction.draftPipelineVersion =
         draftAttribution?.pipelineVersion ?? null;
       updatedAction.draftContextMetadata = draftContextMetadata;
+      updatedAction.selectedAttachments = selectedAttachments;
     }
 
     // Process AI args if available

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -423,6 +423,14 @@ describe("runRules draft attribution persistence", () => {
         draftModelProvider: "openai",
         draftModelName: "gpt-5.1",
         draftPipelineVersion: 1,
+        selectedAttachments: [
+          {
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+            filename: "attachment.pdf",
+            mimeType: "application/pdf",
+          },
+        ],
       } as any,
     ]);
 
@@ -470,6 +478,12 @@ describe("runRules draft attribution persistence", () => {
         draftModelProvider: "openai",
         draftModelName: "gpt-5.1",
         draftPipelineVersion: 1,
+        selectedAttachments: [
+          expect.objectContaining({
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+          }),
+        ],
       }),
     ]);
   });

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -480,6 +480,10 @@ async function executeMatchedRule(
                       item.staticAttachments != null
                         ? (item.staticAttachments as Prisma.InputJsonValue)
                         : undefined,
+                    selectedAttachments:
+                      item.selectedAttachments != null
+                        ? (item.selectedAttachments as Prisma.InputJsonValue)
+                        : undefined,
                     draftModelProvider: item.draftModelProvider ?? null,
                     draftModelName: item.draftModelName ?? null,
                     draftPipelineVersion: isDraftReplyActionType(item.type)

--- a/apps/web/utils/ai/types.ts
+++ b/apps/web/utils/ai/types.ts
@@ -34,6 +34,7 @@ export type ActionItem = {
   folderId?: ExecutedAction["folderId"];
   delayInMinutes?: number | null;
   staticAttachments?: ExecutedAction["staticAttachments"];
+  selectedAttachments?: ExecutedAction["selectedAttachments"];
 };
 
 export type ActionExecutionEmailAccount = Pick<

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -3,7 +3,6 @@ import prisma from "@/utils/__mocks__/prisma";
 import {
   ActionType,
   AttachmentSourceType,
-  DraftReplyConfidence,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -11,13 +10,9 @@ import {
 } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
-import { getReplyWithConfidence } from "@/utils/redis/reply";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/redis/reply", () => ({
-  getReplyWithConfidence: vi.fn(),
-}));
 
 const mockCreateEmailProvider = vi.fn();
 const mockSendAutomationMessage = vi.fn();
@@ -83,7 +78,6 @@ describe("handleRuleNotificationAction", () => {
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
     mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
-    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
   });
 
   it("keeps the draft preview visible after sending from Slack", async () => {
@@ -709,7 +703,6 @@ describe("sendMessagingRuleNotification", () => {
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
     mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
-    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
   });
 
   it("adds an Open in Gmail button for Slack draft notifications on Google accounts", async () => {
@@ -823,27 +816,20 @@ describe("sendMessagingRuleNotification", () => {
   });
 
   it("mentions AI-selected attachments in Slack draft notifications", async () => {
-    vi.mocked(getReplyWithConfidence).mockResolvedValue({
-      reply: "Draft body",
-      confidence: DraftReplyConfidence.STANDARD,
-      attribution: null,
-      draftContextMetadata: null,
-      attachments: [
-        {
-          driveConnectionId: "drive-1",
-          fileId: "file-1",
-          filename: "certificate.pdf",
-          mimeType: "application/pdf",
-          reason: "requested certificate",
-        },
-      ],
-    });
-
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
         id: "action-1",
         type: ActionType.DRAFT_MESSAGING_CHANNEL,
         content: "Draft body",
+        selectedAttachments: [
+          {
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+            filename: "certificate.pdf",
+            mimeType: "application/pdf",
+            reason: "requested certificate",
+          },
+        ],
       }) as never,
     );
     prisma.executedAction.update.mockResolvedValue({} as never);
@@ -1418,27 +1404,20 @@ describe("sendMessagingRuleNotification", () => {
   });
 
   it("mentions AI-selected attachments in Telegram draft notifications", async () => {
-    vi.mocked(getReplyWithConfidence).mockResolvedValue({
-      reply: "Draft body",
-      confidence: DraftReplyConfidence.STANDARD,
-      attribution: null,
-      draftContextMetadata: null,
-      attachments: [
-        {
-          driveConnectionId: "drive-1",
-          fileId: "file-1",
-          filename: "certificate.pdf",
-          mimeType: "application/pdf",
-          reason: "requested certificate",
-        },
-      ],
-    });
-
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
         id: "action-1",
         type: ActionType.DRAFT_MESSAGING_CHANNEL,
         content: "Draft body",
+        selectedAttachments: [
+          {
+            driveConnectionId: "drive-1",
+            fileId: "file-1",
+            filename: "certificate.pdf",
+            mimeType: "application/pdf",
+            reason: "requested certificate",
+          },
+        ],
         messagingChannel: {
           id: "channel-1",
           provider: MessagingProvider.TELEGRAM,
@@ -2089,6 +2068,7 @@ function getNotificationContext({
   messagingMessageStatus = null,
   mailboxDraftAction = null,
   staticAttachments = null,
+  selectedAttachments = null,
 }: {
   id: string;
   type: ActionType;
@@ -2117,6 +2097,7 @@ function getNotificationContext({
     subject: string | null;
   } | null;
   staticAttachments?: unknown;
+  selectedAttachments?: unknown;
 }) {
   const defaultRoutes =
     messagingChannel?.routes ??
@@ -2150,6 +2131,7 @@ function getNotificationContext({
     bcc: null,
     draftId: null,
     staticAttachments,
+    selectedAttachments,
     messagingChannelId: "channel-1",
     messagingMessageId,
     messagingMessageStatus,

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   ActionType,
+  AttachmentSourceType,
+  DraftReplyConfidence,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -9,9 +11,13 @@ import {
 } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
+import { getReplyWithConfidence } from "@/utils/redis/reply";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/redis/reply", () => ({
+  getReplyWithConfidence: vi.fn(),
+}));
 
 const mockCreateEmailProvider = vi.fn();
 const mockSendAutomationMessage = vi.fn();
@@ -77,6 +83,7 @@ describe("handleRuleNotificationAction", () => {
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
     mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
+    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
   });
 
   it("keeps the draft preview visible after sending from Slack", async () => {
@@ -702,6 +709,7 @@ describe("sendMessagingRuleNotification", () => {
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
     mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
+    vi.mocked(getReplyWithConfidence).mockResolvedValue(null);
   });
 
   it("adds an Open in Gmail button for Slack draft notifications on Google accounts", async () => {
@@ -812,6 +820,103 @@ describe("sendMessagingRuleNotification", () => {
 
     expect(serializedBlocks).toContain("Mailbox draft body");
     expect(serializedBlocks).not.toContain("Messaging draft body");
+  });
+
+  it("mentions AI-selected attachments in Slack draft notifications", async () => {
+    vi.mocked(getReplyWithConfidence).mockResolvedValue({
+      reply: "Draft body",
+      confidence: DraftReplyConfidence.STANDARD,
+      attribution: null,
+      draftContextMetadata: null,
+      attachments: [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-1",
+          filename: "certificate.pdf",
+          mimeType: "application/pdf",
+          reason: "requested certificate",
+        },
+      ],
+    });
+
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Attachments:");
+    expect(serializedBlocks).toContain("certificate.pdf");
+  });
+
+  it("mentions configured attachments in Slack draft notifications", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        staticAttachments: [
+          {
+            driveConnectionId: "drive-1",
+            name: "quote.pdf",
+            sourceId: "file-1",
+            sourcePath: null,
+            type: AttachmentSourceType.FILE,
+          },
+        ],
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Attachments:");
+    expect(serializedBlocks).toContain("quote.pdf");
   });
 
   it("falls back to stored draft content when synced mailbox draft lookup fails", async () => {
@@ -1310,6 +1415,74 @@ describe("sendMessagingRuleNotification", () => {
         messagingMessageStatus: MessagingMessageStatus.SENT,
       },
     });
+  });
+
+  it("mentions AI-selected attachments in Telegram draft notifications", async () => {
+    vi.mocked(getReplyWithConfidence).mockResolvedValue({
+      reply: "Draft body",
+      confidence: DraftReplyConfidence.STANDARD,
+      attribution: null,
+      draftContextMetadata: null,
+      attachments: [
+        {
+          driveConnectionId: "drive-1",
+          fileId: "file-1",
+          filename: "certificate.pdf",
+          mimeType: "application/pdf",
+          reason: "requested certificate",
+        },
+      ],
+    });
+
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockTelegramPostMessage).toHaveBeenCalledTimes(1);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const serializedCard = JSON.stringify(card);
+
+    expect(serializedCard).toContain("Attachments:");
+    expect(serializedCard).toContain("certificate.pdf");
   });
 
   it("renders decoded email previews in Telegram draft notification cards", async () => {
@@ -1915,6 +2088,7 @@ function getNotificationContext({
   messagingMessageId = null,
   messagingMessageStatus = null,
   mailboxDraftAction = null,
+  staticAttachments = null,
 }: {
   id: string;
   type: ActionType;
@@ -1942,6 +2116,7 @@ function getNotificationContext({
     draftId: string;
     subject: string | null;
   } | null;
+  staticAttachments?: unknown;
 }) {
   const defaultRoutes =
     messagingChannel?.routes ??
@@ -1974,7 +2149,7 @@ function getNotificationContext({
     cc: null,
     bcc: null,
     draftId: null,
-    staticAttachments: null,
+    staticAttachments,
     messagingChannelId: "channel-1",
     messagingMessageId,
     messagingMessageStatus,

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -67,8 +67,10 @@ import {
 } from "@/utils/messaging/providers/telegram/format";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
-import { attachmentSourceInputSchema } from "@/utils/attachments/source-schema";
-import { getReplyWithConfidence } from "@/utils/redis/reply";
+import {
+  attachmentSourceInputSchema,
+  selectedAttachmentSchema,
+} from "@/utils/attachments/source-schema";
 
 const DRAFT_PREVIEW_MAX_CHARS = 900;
 const SUMMARY_PREVIEW_MAX_CHARS = 2000;
@@ -869,6 +871,7 @@ async function sendDraftReplyFromNotification({
       } as ExecutedRule,
       logger,
       staticAttachments: context.staticAttachments,
+      selectedAttachments: context.selectedAttachments,
       includeAiSelectedAttachments: true,
     });
 
@@ -1308,6 +1311,7 @@ async function getNotificationContext(executedActionId: string) {
       bcc: true,
       draftId: true,
       staticAttachments: true,
+      selectedAttachments: true,
       messagingChannelId: true,
       messagingMessageId: true,
       messagingMessageStatus: true,
@@ -1450,28 +1454,13 @@ async function getNotificationDraftAttachmentNames({
   const staticAttachmentNames = getStaticDraftAttachmentNames(
     context.staticAttachments,
   );
-  const ruleId = context.executedRule.ruleId;
-  if (!ruleId) return staticAttachmentNames;
+  const selectedAttachmentNames = getSelectedDraftAttachmentNames(
+    context.selectedAttachments,
+    logger,
+    context.id,
+  );
 
-  try {
-    const cachedDraft = await getReplyWithConfidence({
-      emailAccountId: context.executedRule.emailAccount.id,
-      messageId: context.executedRule.messageId,
-      ruleId,
-    });
-
-    return [
-      ...(cachedDraft?.attachments?.map((attachment) => attachment.filename) ??
-        []),
-      ...staticAttachmentNames,
-    ];
-  } catch (error) {
-    logger.warn("Failed to load draft attachment names for notification", {
-      executedActionId: context.id,
-      error,
-    });
-    return staticAttachmentNames;
-  }
+  return [...selectedAttachmentNames, ...staticAttachmentNames];
 }
 
 function getStaticDraftAttachmentNames(raw: unknown) {
@@ -1483,6 +1472,24 @@ function getStaticDraftAttachmentNames(raw: unknown) {
   return parsed.data
     .filter((attachment) => attachment.type === AttachmentSourceType.FILE)
     .map((attachment) => attachment.name);
+}
+
+function getSelectedDraftAttachmentNames(
+  raw: unknown,
+  logger: Logger,
+  executedActionId: string,
+) {
+  if (!raw || !Array.isArray(raw) || raw.length === 0) return [];
+
+  const parsed = selectedAttachmentSchema.array().safeParse(raw);
+  if (!parsed.success) {
+    logger.warn("Skipping invalid selected attachment metadata", {
+      executedActionId,
+    });
+    return [];
+  }
+
+  return parsed.data.map((attachment) => attachment.filename);
 }
 
 async function getSourceMessageSummaryForProvider({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -294,7 +294,7 @@ async function sendSlackRuleNotificationWithContext({
     context,
     logger,
   });
-  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+  const draftAttachmentNames = getNotificationDraftAttachmentNames({
     context,
     logger,
   });
@@ -395,7 +395,7 @@ async function sendLinkedRuleNotification({
     context,
     logger,
   });
-  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+  const draftAttachmentNames = getNotificationDraftAttachmentNames({
     context,
     logger,
   });
@@ -497,7 +497,7 @@ async function sendTelegramRuleNotificationWithContext({
     context,
     logger,
   });
-  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+  const draftAttachmentNames = getNotificationDraftAttachmentNames({
     context,
     logger,
   });
@@ -834,7 +834,7 @@ async function sendDraftReplyFromNotification({
     context,
     provider,
   });
-  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+  const draftAttachmentNames = getNotificationDraftAttachmentNames({
     context,
     logger,
   });
@@ -1442,7 +1442,7 @@ async function getNotificationDraftContent({
   }
 }
 
-async function getNotificationDraftAttachmentNames({
+function getNotificationDraftAttachmentNames({
   context,
   logger,
 }: {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -25,6 +25,7 @@ import {
 } from "@/utils/messaging/providers/slack/format";
 import {
   ActionType,
+  AttachmentSourceType,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -66,9 +67,12 @@ import {
 } from "@/utils/messaging/providers/telegram/format";
 import { getMessagingRoute } from "@/utils/messaging/routes";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
+import { attachmentSourceInputSchema } from "@/utils/attachments/source-schema";
+import { getReplyWithConfidence } from "@/utils/redis/reply";
 
 const DRAFT_PREVIEW_MAX_CHARS = 900;
 const SUMMARY_PREVIEW_MAX_CHARS = 2000;
+const MAX_DRAFT_ATTACHMENT_NAMES = 5;
 const RULE_DRAFT_SEND_ACTION_ID = "rule_draft_send";
 const RULE_DRAFT_EDIT_ACTION_ID = "rule_draft_edit";
 const RULE_DRAFT_DISMISS_ACTION_ID = "rule_draft_dismiss";
@@ -288,12 +292,17 @@ async function sendSlackRuleNotificationWithContext({
     context,
     logger,
   });
+  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+    context,
+    logger,
+  });
 
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
     draftContent,
+    draftAttachmentNames,
     format: "slack",
   });
 
@@ -384,12 +393,17 @@ async function sendLinkedRuleNotification({
     context,
     logger,
   });
+  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+    context,
+    logger,
+  });
 
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
     draftContent,
+    draftAttachmentNames,
     format: "plain",
   });
   const text = buildMessagingRuleNotificationText({
@@ -481,12 +495,17 @@ async function sendTelegramRuleNotificationWithContext({
     context,
     logger,
   });
+  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+    context,
+    logger,
+  });
 
   const content = buildNotificationContent({
     actionType: context.type,
     email,
     systemType: context.executedRule.rule?.systemType ?? null,
     draftContent,
+    draftAttachmentNames,
     format: "plain",
   });
 
@@ -813,11 +832,16 @@ async function sendDraftReplyFromNotification({
     context,
     provider,
   });
+  const draftAttachmentNames = await getNotificationDraftAttachmentNames({
+    context,
+    logger,
+  });
   const notificationContent = buildNotificationContent({
     actionType: context.type,
     email: sourceMessageSummary,
     systemType: context.executedRule.rule?.systemType ?? null,
     draftContent: finalDraftContent,
+    draftAttachmentNames,
     format:
       context.messagingChannel?.provider === MessagingProvider.SLACK
         ? "slack"
@@ -1414,6 +1438,53 @@ async function getNotificationDraftContent({
   }
 }
 
+async function getNotificationDraftAttachmentNames({
+  context,
+  logger,
+}: {
+  context: NotificationContext;
+  logger: Logger;
+}) {
+  if (!isDraftReplyActionType(context.type)) return [];
+
+  const staticAttachmentNames = getStaticDraftAttachmentNames(
+    context.staticAttachments,
+  );
+  const ruleId = context.executedRule.ruleId;
+  if (!ruleId) return staticAttachmentNames;
+
+  try {
+    const cachedDraft = await getReplyWithConfidence({
+      emailAccountId: context.executedRule.emailAccount.id,
+      messageId: context.executedRule.messageId,
+      ruleId,
+    });
+
+    return [
+      ...(cachedDraft?.attachments?.map((attachment) => attachment.filename) ??
+        []),
+      ...staticAttachmentNames,
+    ];
+  } catch (error) {
+    logger.warn("Failed to load draft attachment names for notification", {
+      executedActionId: context.id,
+      error,
+    });
+    return staticAttachmentNames;
+  }
+}
+
+function getStaticDraftAttachmentNames(raw: unknown) {
+  if (!raw || !Array.isArray(raw) || raw.length === 0) return [];
+
+  const parsed = attachmentSourceInputSchema.array().safeParse(raw);
+  if (!parsed.success) return [];
+
+  return parsed.data
+    .filter((attachment) => attachment.type === AttachmentSourceType.FILE)
+    .map((attachment) => attachment.name);
+}
+
 async function getSourceMessageSummaryForProvider({
   context,
   provider,
@@ -1440,12 +1511,14 @@ function buildNotificationContent({
   email,
   systemType,
   draftContent,
+  draftAttachmentNames,
   format,
 }: {
   actionType: ActionType;
   email: NotificationEmailPreview;
   systemType: SystemType | string | null;
   draftContent?: string | null;
+  draftAttachmentNames?: string[];
   format: NotificationContentFormat;
 }): NotificationContent {
   if (isDraftReplyActionType(actionType)) {
@@ -1480,6 +1553,13 @@ function buildNotificationContent({
       details.push(`💬 *They wrote:*\n${preview}`);
     }
     details.push(`✍️ *I drafted a reply for you:*\n${draftPreview}`);
+    const attachmentSummary = buildDraftAttachmentSummary(
+      draftAttachmentNames,
+      { format },
+    );
+    if (attachmentSummary) {
+      details.push(`📎 *Attachments:* ${attachmentSummary}`);
+    }
 
     return {
       title: "New email — reply drafted",
@@ -1683,6 +1763,28 @@ function buildDraftPreview(
     format === "slack" ? preview : stripSlackFormatting(preview),
     DRAFT_PREVIEW_MAX_CHARS,
   );
+}
+
+function buildDraftAttachmentSummary(
+  attachmentNames: string[] | null | undefined,
+  { format }: { format: NotificationContentFormat },
+) {
+  const uniqueNames = [
+    ...new Set(
+      (attachmentNames ?? [])
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0),
+    ),
+  ];
+  if (uniqueNames.length === 0) return null;
+
+  const visibleNames = uniqueNames
+    .slice(0, MAX_DRAFT_ATTACHMENT_NAMES)
+    .map((name) => formatNotificationText(name, format));
+  const hiddenCount = uniqueNames.length - visibleNames.length;
+  const suffix = hiddenCount > 0 ? ` and ${hiddenCount} more` : "";
+
+  return `${visibleNames.join(", ")}${suffix}`;
 }
 
 function buildNotificationCardBody(content: NotificationContent): CardChild[] {

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -63,6 +63,7 @@ export async function executeScheduledAction(
       bcc: scheduledAction.bcc,
       url: scheduledAction.url,
       staticAttachments: scheduledAction.staticAttachments,
+      selectedAttachments: scheduledAction.selectedAttachments,
     };
 
     const executedAction = await executeDelayedAction({
@@ -174,6 +175,7 @@ async function executeDelayedAction({
       bcc: actionItem.bcc,
       url: actionItem.url,
       staticAttachments: actionItem.staticAttachments ?? undefined,
+      selectedAttachments: actionItem.selectedAttachments ?? undefined,
       executedRuleId: scheduledAction.executedRuleId,
     },
   });

--- a/apps/web/utils/scheduled-actions/scheduler.ts
+++ b/apps/web/utils/scheduled-actions/scheduler.ts
@@ -68,6 +68,7 @@ export async function createScheduledAction({
         folderName: actionItem.folderName,
         folderId: actionItem.folderId,
         staticAttachments: actionItem.staticAttachments ?? undefined,
+        selectedAttachments: actionItem.selectedAttachments ?? undefined,
       },
     });
 


### PR DESCRIPTION
Adds attachment summaries to draft notification messages when files are selected for a draft reply.

- Includes configured and AI-selected draft attachment names in messaging notifications.
- Adds regression coverage for Slack and Telegram draft notification cards.