### PR TITLE
messaging: Hide quoted draft preview text

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -755,7 +755,8 @@ describe("sendMessagingRuleNotification", () => {
       getDraft: vi.fn().mockResolvedValue({
         id: "draft-1",
         threadId: "thread-1",
-        textPlain: "Mailbox draft body",
+        textPlain:
+          "Mailbox draft body\n\nDrafted by Inbox Zero.\n\nOn Thu, 30 Apr 2026 at 19:04, Sender <sender@example.com> wrote:\n\n> Quoted body that should be hidden.",
         subject: "Re: Test subject",
         date: new Date().toISOString(),
         snippet: "Mailbox draft body",
@@ -811,7 +812,10 @@ describe("sendMessagingRuleNotification", () => {
     const serializedBlocks = JSON.stringify(args.blocks);
 
     expect(serializedBlocks).toContain("Mailbox draft body");
+    expect(serializedBlocks).toContain("Drafted by Inbox Zero.");
     expect(serializedBlocks).not.toContain("Messaging draft body");
+    expect(serializedBlocks).not.toContain("Quoted body that should be hidden");
+    expect(serializedBlocks).not.toContain("On Thu, 30 Apr 2026");
   });
 
   it("falls back to stored draft content when synced mailbox draft lookup fails", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -46,7 +46,10 @@ import { resolveActionAttachments } from "@/utils/ai/action-attachments";
 import { quotePlainTextContent } from "@/utils/email/quoted-plain-text";
 import { formatReplySubject } from "@/utils/email/subject";
 import { emailToContent } from "@/utils/mail";
-import { extractDraftPlainText } from "@/utils/ai/choose-rule/draft-management";
+import {
+  extractDraftPlainText,
+  stripQuotedContent,
+} from "@/utils/ai/choose-rule/draft-management";
 import type { ParsedMessage } from "@/utils/types";
 import he from "he";
 import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
@@ -1369,7 +1372,7 @@ async function getEditableDraftContent({
     try {
       const latestDraft = await provider.getDraft(mailboxDraftAction.draftId);
       if (latestDraft) {
-        const text = extractDraftPlainText(latestDraft).trim();
+        const text = stripQuotedContent(extractDraftPlainText(latestDraft));
         if (text) return text;
       }
     } catch {
@@ -1377,7 +1380,7 @@ async function getEditableDraftContent({
     }
   }
 
-  return context.content || "";
+  return stripQuotedContent(context.content || "");
 }
 
 async function getNotificationDraftContent({
@@ -1676,9 +1679,9 @@ function buildDraftPreview(
 ) {
   if (!content?.trim()) return "No draft preview available.";
 
-  const preview = removeExcessiveWhitespace(
-    richTextToSlackMrkdwn(he.decode(content)),
-  ).trim();
+  const preview = stripQuotedContent(
+    removeExcessiveWhitespace(richTextToSlackMrkdwn(he.decode(content))).trim(),
+  );
   return truncate(
     format === "slack" ? preview : stripSlackFormatting(preview),
     DRAFT_PREVIEW_MAX_CHARS,


### PR DESCRIPTION
Strips quoted reply content before messaging draft previews are shown.

- Reuses the existing quote stripping helper for synced and stored draft content.
- Adds regression coverage for quoted text in draft notification previews.

Tests: pnpm test --run utils/messaging/rule-notifications.test.ts