### PR TITLE
Fix sent email confirmation links

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   buildAffirmativeReactionMessage,
+  buildHandledPendingEmailCard,
   buildPendingEmailConfirmationCard,
   buildPendingEmailCardFallbackText,
   getPendingEmailHandledOpenText,
@@ -270,6 +271,99 @@ describe("pending email handled state helpers", () => {
       }),
     ).toBe(
       "Open in Gmail: https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
+    );
+  });
+
+  it("renders the sent Gmail link as an action button in Slack", () => {
+    const card = buildHandledPendingEmailCard({
+      accountEmail: "user@example.com",
+      accountProvider: "google",
+      confirmationResult: {
+        messageId: "message-1",
+        threadId: "thread-1",
+      },
+      messagingProvider: "slack",
+      part: {
+        type: "tool-sendEmail",
+        state: "output-available",
+        toolCallId: "tool-call-1",
+        output: {
+          confirmationState: "pending",
+          pendingAction: {
+            to: "recipient@example.com",
+            subject: "Test subject",
+            messageHtml: "<p>Test body</p>",
+          },
+        },
+      },
+    });
+
+    const actionChildren = card.children.filter(
+      (child) => child.type === "actions",
+    );
+    const textChildren = card.children.filter((child) => child.type === "text");
+
+    expect(actionChildren).toEqual([
+      expect.objectContaining({
+        children: [
+          expect.objectContaining({
+            type: "link-button",
+            label: "Open in Gmail",
+            url: "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
+          }),
+        ],
+      }),
+    ]);
+    expect(JSON.stringify(textChildren)).not.toContain(
+      "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
+    );
+  });
+
+  it("renders the sent Outlook link as an action button in Telegram", () => {
+    const card = buildHandledPendingEmailCard({
+      accountEmail: "user@example.com",
+      accountProvider: "microsoft",
+      confirmationResult: {
+        messageId: "message-1",
+        threadId: "thread-1",
+      },
+      messagingProvider: "telegram",
+      part: {
+        type: "tool-replyEmail",
+        state: "output-available",
+        toolCallId: "tool-call-1",
+        output: {
+          confirmationState: "pending",
+          pendingAction: {
+            subject: "Re: Test subject",
+            messageHtml: "<p>Test body</p>",
+          },
+          reference: {
+            from: "sender@example.com",
+            subject: "Test subject",
+          },
+        },
+      },
+    });
+
+    const actionChildren = card.children.filter(
+      (child) => child.type === "actions",
+    );
+    const textChildren = card.children.filter((child) => child.type === "text");
+
+    expect(actionChildren).toEqual([
+      expect.objectContaining({
+        children: [
+          expect.objectContaining({
+            type: "link-button",
+            label: "Open in Outlook",
+            url: "https://outlook.live.com/mail/0/inbox/id/message-1",
+          }),
+        ],
+      }),
+    ]);
+    expect(JSON.stringify(textChildren)).not.toContain(
+      "https://outlook.live.com/mail/0/inbox/id/message-1",
     );
   });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -16,6 +16,7 @@ import {
   CardText,
   Chat,
   ConsoleLogger,
+  LinkButton,
   type ActionEvent,
   type Adapter,
   type Attachment,
@@ -1293,7 +1294,7 @@ function buildPendingEmailSuccessFeedback({
   return `Sent. Open message: ${emailUrl}`;
 }
 
-function buildHandledPendingEmailCard({
+export function buildHandledPendingEmailCard({
   accountEmail,
   accountProvider,
   confirmationResult,
@@ -1345,17 +1346,13 @@ function buildHandledPendingEmailCard({
     ),
   );
 
-  const openText = getPendingEmailHandledOpenText({
+  const openLink = getPendingEmailHandledOpenLink({
     accountEmail,
     accountProvider,
     confirmationResult,
   });
-  if (openText) {
-    children.push(
-      CardText(
-        getMessagingCardText({ provider: messagingProvider, text: openText }),
-      ),
-    );
+  if (openLink) {
+    children.push(Actions([LinkButton(openLink)]));
   }
 
   return Card({
@@ -1392,6 +1389,28 @@ export function getPendingEmailHandledOpenText({
     threadId?: string | null;
   } | null;
 }) {
+  const openLink = getPendingEmailHandledOpenLink({
+    accountEmail,
+    accountProvider,
+    confirmationResult,
+  });
+  if (!openLink) return null;
+
+  return `${openLink.label}: ${openLink.url}`;
+}
+
+function getPendingEmailHandledOpenLink({
+  accountEmail,
+  accountProvider,
+  confirmationResult,
+}: {
+  accountEmail?: string | null;
+  accountProvider?: string | null;
+  confirmationResult?: {
+    messageId?: string | null;
+    threadId?: string | null;
+  } | null;
+}) {
   const messageId = confirmationResult?.messageId || undefined;
   const threadId = confirmationResult?.threadId || undefined;
   const resolvedMessageId = messageId || threadId;
@@ -1407,7 +1426,10 @@ export function getPendingEmailHandledOpenText({
   );
   const mailbox = accountProvider === "microsoft" ? "Outlook" : "Gmail";
 
-  return `Open in ${mailbox}: ${emailUrl}`;
+  return {
+    label: `Open in ${mailbox}`,
+    url: emailUrl,
+  };
 }
 
 function getMessagingCardText({


### PR DESCRIPTION
Fixes sent email confirmation cards so mailbox links render as action buttons instead of plain text.\n\n- Adds a reusable handled-card builder path for tests.\n- Covers link-button rendering for chat confirmation cards.