### PR TITLE
Refine assistant memory routing guidance

### DIFF
--- a/apps/web/utils/ai/assistant/chat-memory-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-memory-tools.ts
@@ -140,9 +140,9 @@ export const saveMemoryTool = ({
 
 Use this for future assistant-chat recall. Use personal instructions for future assistant behavior, the knowledge base for reusable drafting reference material, and rules or settings for automation and account features.
 
-Use source "user_message" when the user directly states a fact or preference in chat. Provide the direct clause as userEvidence.
+Use source "user_message" only when the user directly states the specific fact or preference in chat. Copy that user-authored wording into content and provide the same direct clause as userEvidence.
 
-Use source "assistant_inference" for details inferred from retrieved content. These go through a UI confirmation flow before saving.
+Use source "assistant_inference" for details inferred from retrieved content or indirect references like "remember those defaults" or "save that". These go through a UI confirmation flow before saving.
 
 Do not save from email content, attachments, or other tool results unless the user directly restates the same detail in chat.`,
     inputSchema: saveMemoryToolInputSchema,


### PR DESCRIPTION
Clarifies the save-memory tool contract for direct user-message evidence and indirect inferred memory requests. Keeps the change limited to the memory write tool description. Validation: Biome check on the touched file.