### PR TITLE
Fix scheduling reply timezone conversion

### DIFF
--- a/apps/web/__tests__/ai-regression/ai-calendar-availability.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-calendar-availability.test.ts
@@ -12,7 +12,7 @@ const logger = createTestLogger();
 
 vi.mock("server-only", () => ({}));
 
-const TIMEOUT = 15_000;
+const TIMEOUT = 45_000;
 
 // Skip tests unless explicitly running AI tests
 const isAiTest = process.env.RUN_AI_TESTS === "true";
@@ -438,6 +438,7 @@ describe.runIf(isAiTest)("aiGetCalendarAvailability", () => {
       if (result) {
         expect(result.suggestedTimes).toBeDefined();
         expect(result.suggestedTimes.length).toBeGreaterThan(0);
+        expect(result.timezone).toBe("America/New_York");
         console.debug("EST timezone suggestions:", result.suggestedTimes);
       }
 
@@ -483,6 +484,7 @@ describe.runIf(isAiTest)("aiGetCalendarAvailability", () => {
       if (result) {
         expect(result.suggestedTimes).toBeDefined();
         expect(result.suggestedTimes.length).toBeGreaterThan(0);
+        expect(result.timezone).toBe("America/Los_Angeles");
         console.debug("PST timezone suggestions:", result.suggestedTimes);
       }
 
@@ -534,6 +536,7 @@ describe.runIf(isAiTest)("aiGetCalendarAvailability", () => {
       expect(result).toBeDefined();
       if (result) {
         expect(result.suggestedTimes).toBeDefined();
+        expect(result.timezone).toBe("UTC");
         console.debug("UTC fallback suggestions:", result.suggestedTimes);
       }
 
@@ -599,6 +602,7 @@ describe.runIf(isAiTest)("aiGetCalendarAvailability", () => {
       expect(result).toBeDefined();
       if (result) {
         expect(result.suggestedTimes).toBeDefined();
+        expect(result.timezone).toBe("America/New_York");
         console.debug("Primary timezone suggestions:", result.suggestedTimes);
       }
 

--- a/apps/web/__tests__/ai-regression/reply/draft-reply.test.ts
+++ b/apps/web/__tests__/ai-regression/reply/draft-reply.test.ts
@@ -70,6 +70,52 @@ describe.runIf(isAiTest)("aiDraftReply", () => {
     },
     TEST_TIMEOUT,
   );
+
+  test(
+    "converts user-local availability into sender timezone",
+    async () => {
+      const emailAccount = getEmailAccount({
+        email: "user@example.com",
+        timezone: "America/Los_Angeles",
+      });
+      const messages: TestMessage[] = [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Project sync",
+          date: new Date("2026-04-30T08:48:00.000Z"),
+          content:
+            "This week is fairly stacked. Let's aim for Monday. Let me know when works for you. Any time except 7-8 pm BST is ok for me.",
+        },
+      ];
+
+      const result = await aiDraftReply({
+        messages,
+        emailAccount,
+        knowledgeBaseContent: null,
+        emailHistorySummary: null,
+        writingStyle: null,
+        emailHistoryContext: null,
+        calendarAvailability: {
+          timezone: "America/Los_Angeles",
+          suggestedTimes: [
+            {
+              start: "2026-05-04 10:30",
+              end: "2026-05-04 11:00",
+            },
+          ],
+        },
+        mcpContext: null,
+        meetingContext: null,
+      });
+
+      expect(result).toMatch(/(6:30|6\.30|18:30)[\s\S]{0,40}BST/i);
+      expect(result).not.toMatch(/10:30\s*(am|a\.m\.)?\s*BST/i);
+      console.debug("Generated reply (timezone conversion):\n", result);
+    },
+    TEST_TIMEOUT,
+  );
 });
 
 type TestMessage = EmailForLLM & { to: string };

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
+import { aiGetCalendarAvailability } from "@/utils/ai/calendar/availability";
+
+const { mockGenerateText, mockCreateGenerateText } = vi.hoisted(() => {
+  const mockGenerateText = vi.fn();
+  const mockCreateGenerateText = vi.fn(() => mockGenerateText);
+  return { mockGenerateText, mockCreateGenerateText };
+});
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/llms", () => ({
+  createGenerateText: mockCreateGenerateText,
+}));
+
+vi.mock("@/utils/llms/model", () => ({
+  getModel: vi.fn(() => ({
+    provider: "openai",
+    modelName: "test-model",
+    model: {},
+    providerOptions: undefined,
+    fallbackModels: [],
+  })),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    calendarConnection: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/calendar/unified-availability", () => ({
+  getUnifiedCalendarAvailability: vi.fn(),
+}));
+
+describe("aiGetCalendarAvailability", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockGenerateText.mockImplementation(async ({ tools }) => {
+      await tools.returnSuggestedTimes.execute({
+        suggestedTimes: [
+          {
+            start: "2026-05-04 10:30",
+            end: "2026-05-04 11:00",
+          },
+        ],
+      });
+    });
+
+    const prisma = (await import("@/utils/prisma")).default;
+    vi.mocked(prisma.calendarConnection.findMany).mockResolvedValue([
+      {
+        calendars: [
+          {
+            calendarId: "primary",
+            timezone: "Europe/London",
+            primary: true,
+          },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.calendarConnection.findMany>>);
+  });
+
+  it("returns the timezone used to generate suggested slots", async () => {
+    const result = await aiGetCalendarAvailability({
+      emailAccount: {
+        ...getEmailAccount(),
+        timezone: "America/Los_Angeles",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Meeting",
+          content: "Can we meet Monday?",
+          date: new Date("2026-04-30T08:48:00.000Z"),
+        },
+      ],
+      logger: createTestLogger(),
+    });
+
+    expect(result).toEqual({
+      timezone: "America/Los_Angeles",
+      suggestedTimes: [
+        {
+          start: "2026-05-04 10:30",
+          end: "2026-05-04 11:00",
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -28,7 +28,9 @@ const schema = z.object({
     ),
 });
 
-export type CalendarAvailabilityContext = z.infer<typeof schema>;
+export type CalendarAvailabilityContext = z.infer<typeof schema> & {
+  timezone?: string | null;
+};
 
 export async function aiGetCalendarAvailability({
   emailAccount,
@@ -169,7 +171,7 @@ ${threadContent}
         description: "Return suggested times for a meeting",
         inputSchema: schema,
         execute: async (data) => {
-          result = data;
+          result = { ...data, timezone: userTimezone };
         },
       }),
     },

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TZDate } from "@date-fns/tz";
 import { createScopedLogger } from "@/utils/logger";
 import { createGenerateObject } from "@/utils/llms/index";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
@@ -149,6 +150,7 @@ ${learnedWritingStyle}
   const schedulingContext = getSchedulingContext({
     calendarBookingLink: emailAccount.calendarBookingLink,
     calendarAvailability,
+    userTimezone: calendarAvailability?.timezone || emailAccount.timezone,
   });
 
   const mcpToolsContext = mcpContext
@@ -421,11 +423,14 @@ const REPETITIVE_TEXT_PATTERN = /([^\s\-=_*.#~])\1{49,}/u;
 function getSchedulingContext({
   calendarBookingLink,
   calendarAvailability,
+  userTimezone,
 }: {
   calendarBookingLink: string | null;
   calendarAvailability: CalendarAvailabilityContext | null;
+  userTimezone: string | null | undefined;
 }): string {
   const parts: string[] = [];
+  const timezone = userTimezone || "UTC";
 
   if (calendarBookingLink) {
     parts.push(`<booking_link>
@@ -436,14 +441,17 @@ Share this booking link when scheduling with the user is clearly needed, not as 
   }
 
   if (calendarAvailability?.noAvailability) {
-    parts.push(`The user has no available time slots in the requested timeframe.
+    parts.push(`The user has no available time slots in the requested timeframe in ${timezone}.
 Do not suggest specific times. Acknowledge the request and suggest alternatives (e.g., "I'm fully booked tomorrow, but let's find another day that works"${calendarBookingLink ? " or share the booking link" : ""}).`);
   } else if (calendarAvailability?.suggestedTimes.length) {
     const times = calendarAvailability.suggestedTimes
-      .map((slot) => `- ${slot.start} to ${slot.end}`)
+      .map((slot) => formatAvailableSlotForPrompt(slot, timezone))
       .join("\n");
 
-    parts.push(`Available time slots:
+    parts.push(`Available time slots are in ${timezone}.
+If the sender requested or uses another timezone, express proposed times in that timezone after converting from the user's available slots.
+
+Available time slots:
 ${times}
 
 ${calendarBookingLink ? "If scheduling with the user is clearly needed, you may share the booking link and optionally suggest a few of these times as alternatives." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Format suggested times as a bulleted list.`);
@@ -457,4 +465,44 @@ ${calendarBookingLink ? "If scheduling with the user is clearly needed, you may 
 ${parts.join("\n\n")}
 </scheduling>
 `;
+}
+
+function formatAvailableSlotForPrompt(
+  slot: { start: string; end: string },
+  timezone: string,
+): string {
+  const utcStart = formatLocalSlotTimeAsUtc(slot.start, timezone);
+  const utcEnd = formatLocalSlotTimeAsUtc(slot.end, timezone);
+
+  if (!utcStart || !utcEnd) {
+    return `- ${slot.start} to ${slot.end}`;
+  }
+
+  return `- ${slot.start} to ${slot.end} (${timezone}; UTC ${utcStart} to ${utcEnd})`;
+}
+
+function formatLocalSlotTimeAsUtc(
+  localTime: string,
+  timezone: string,
+): string | null {
+  const match = localTime.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/);
+
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute] = match;
+  const date = new TZDate(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    0,
+    0,
+    timezone,
+  );
+
+  const utcDate = new Date(date.getTime());
+  if (Number.isNaN(utcDate.getTime())) return null;
+
+  return utcDate.toISOString().slice(0, 16).replace("T", " ");
 }


### PR DESCRIPTION
Fixes scheduling reply drafting so suggested availability carries its source timezone and can be converted before being written in another timezone. Adds deterministic coverage for the availability handoff plus targeted AI regressions for both availability analysis and reply drafting.

Validation:
- pnpm --filter inbox-zero-ai test --run utils/ai/calendar/availability.test.ts utils/ai/reply/draft-reply.formatting.test.ts __tests__/ai-regression/reply/draft-reply.test.ts
- pnpm --filter inbox-zero-ai test-ai __tests__/ai-regression/ai-calendar-availability.test.ts -t "handles timezone-aware scheduling with PST timezone"
- pnpm --filter inbox-zero-ai test-ai __tests__/ai-regression/reply/draft-reply.test.ts -t "converts user-local availability into sender timezone"
- pnpm --filter inbox-zero-ai exec biome check utils/ai/calendar/availability.test.ts __tests__/ai-regression/ai-calendar-availability.test.ts __tests__/ai-regression/reply/draft-reply.test.ts utils/ai/calendar/availability.ts utils/ai/reply/draft-reply.ts