### PR TITLE
Show read percentage as progress bar in bulk unsubscriber

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -16,7 +16,10 @@ import {
 import type { RowProps } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
 import { ButtonCheckbox } from "@/components/ButtonCheckbox";
 import { DomainIcon } from "@/components/charts/DomainIcon";
+import { Progress } from "@/components/ui/progress";
 import { extractDomainFromEmail } from "@/utils/email";
+
+const LOW_READ_THRESHOLD = 30;
 
 export function BulkUnsubscribeDesktop({
   tableRows,
@@ -136,9 +139,20 @@ export function BulkUnsubscribeRowDesktop({
         <span className="font-medium text-foreground/80">{item.value}</span>
       </TableCell>
       <TableCell className="whitespace-nowrap" data-label="Read">
-        <span className="font-medium text-foreground/80">
-          {Math.round(readPercentage)}%
-        </span>
+        <div className="flex items-center gap-2">
+          <Progress
+            value={readPercentage}
+            className="h-1.5 w-16 bg-muted"
+            innerClassName={
+              readPercentage < LOW_READ_THRESHOLD
+                ? "bg-amber-400"
+                : "bg-slate-300 dark:bg-slate-500"
+            }
+          />
+          <span className="font-medium text-foreground/80">
+            {Math.round(readPercentage)}%
+          </span>
+        </div>
       </TableCell>
       <TableCell className="w-auto sm:w-[196px] p-1" data-cell="actions">
         <div className="flex justify-end items-center gap-2">


### PR DESCRIPTION
## Summary
- Render the Read column in the bulk unsubscriber table as a small progress bar alongside the percentage.
- Highlight low engagement (read rate under 30%) in amber so candidates for unsubscribing stand out.

## Test plan
- [ ] Open the Bulk Unsubscriber and confirm the Read column shows a progress bar that scales with the percentage.
- [ ] Confirm rows under 30% read rate render in amber and other rows render in the muted slate color.
- [ ] Verify the layout still looks correct on mobile, where the cell collapses into the inline "Read:" row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)