### PR TITLE
Tint low read rate progress bar and text in amber

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -102,6 +102,7 @@ export function BulkUnsubscribeRowDesktop({
   readPercentage,
 }: RowProps) {
   const domain = extractDomainFromEmail(item.name) || item.name;
+  const isLowReadRate = readPercentage < LOW_READ_THRESHOLD;
 
   return (
     <TableRow
@@ -145,17 +146,20 @@ export function BulkUnsubscribeRowDesktop({
             value={readPercentage}
             className={cn(
               "h-1.5 w-16",
-              readPercentage < LOW_READ_THRESHOLD
-                ? "bg-amber-100 dark:bg-amber-950"
-                : "bg-muted",
+              isLowReadRate ? "bg-amber-100 dark:bg-amber-950" : "bg-muted",
             )}
             innerClassName={
-              readPercentage < LOW_READ_THRESHOLD
-                ? "bg-amber-400"
-                : "bg-slate-300 dark:bg-slate-500"
+              isLowReadRate ? "bg-amber-400" : "bg-slate-300 dark:bg-slate-500"
             }
           />
-          <span className="font-medium text-foreground/80">
+          <span
+            className={cn(
+              "font-medium",
+              isLowReadRate
+                ? "text-amber-600 dark:text-amber-400"
+                : "text-foreground/80",
+            )}
+          >
             {Math.round(readPercentage)}%
           </span>
         </div>

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -18,6 +18,7 @@ import { ButtonCheckbox } from "@/components/ButtonCheckbox";
 import { DomainIcon } from "@/components/charts/DomainIcon";
 import { Progress } from "@/components/ui/progress";
 import { extractDomainFromEmail } from "@/utils/email";
+import { cn } from "@/utils";
 
 const LOW_READ_THRESHOLD = 30;
 
@@ -142,7 +143,12 @@ export function BulkUnsubscribeRowDesktop({
         <div className="flex items-center gap-2">
           <Progress
             value={readPercentage}
-            className="h-1.5 w-16 bg-muted"
+            className={cn(
+              "h-1.5 w-16",
+              readPercentage < LOW_READ_THRESHOLD
+                ? "bg-amber-100 dark:bg-amber-950"
+                : "bg-muted",
+            )}
             innerClassName={
               readPercentage < LOW_READ_THRESHOLD
                 ? "bg-amber-400"


### PR DESCRIPTION
## Summary
- When the read percentage is under 30% in the bulk unsubscriber, the progress track now uses a soft amber background and the percentage text renders in amber so low-engagement senders stand out at a glance.

## Test plan
- [ ] Open the Bulk Unsubscriber and confirm rows under 30% show an amber bar (light amber track, deeper amber fill) and amber percentage text.
- [ ] Confirm rows at 30% and above keep the muted slate styling.
- [ ] Verify both light and dark mode look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)