### PR TITLE
Fix Gmail sent message filtering

### DIFF
--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -100,6 +100,58 @@ describe("GmailProvider.getLatestMessageInThread", () => {
   });
 });
 
+describe("GmailProvider.getSentMessageIds", () => {
+  it("filters sent messages with Gmail labelIds and second-accurate date bounds", async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: {
+        messages: [{ id: "message-1", threadId: "thread-1" }],
+        nextPageToken: "next-page",
+      },
+    });
+    const provider = new GmailProvider({
+      users: { messages: { list } },
+    } as any);
+
+    const result = await provider.getSentMessageIds({
+      maxResults: 50,
+      after: new Date("2026-03-31T12:00:00.000Z"),
+      before: new Date("2026-04-30T17:00:00.000Z"),
+      pageToken: "page-1",
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      userId: "me",
+      maxResults: 50,
+      q: "after:1774958399 before:1777568401",
+      pageToken: "page-1",
+      labelIds: [GmailLabel.SENT],
+    });
+    expect(result).toEqual({
+      messages: [{ id: "message-1", threadId: "thread-1" }],
+      nextPageToken: "next-page",
+    });
+  });
+
+  it("omits the Gmail search query when no date range is provided", async () => {
+    const list = vi.fn().mockResolvedValue({ data: { messages: [] } });
+    const provider = new GmailProvider({
+      users: { messages: { list } },
+    } as any);
+
+    await provider.getSentMessageIds({
+      maxResults: 50,
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      userId: "me",
+      maxResults: 50,
+      q: undefined,
+      pageToken: undefined,
+      labelIds: [GmailLabel.SENT],
+    });
+  });
+});
+
 describe("GmailProvider.getLabels", () => {
   it("returns visible user labels by default", async () => {
     vi.spyOn(gmailLabelModule, "getLabels").mockResolvedValue([

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -235,18 +235,19 @@ export class GmailProvider implements EmailProvider {
   }): Promise<SentMessagePage> {
     const { maxResults, after, before, pageToken } = options;
 
-    let query = `label:${GmailLabel.SENT}`;
+    const queryParts: string[] = [];
     if (after) {
-      query += ` after:${Math.floor(after.getTime() / 1000) - 1}`;
+      queryParts.push(`after:${Math.floor(after.getTime() / 1000) - 1}`);
     }
     if (before) {
-      query += ` before:${Math.floor(before.getTime() / 1000) + 1}`;
+      queryParts.push(`before:${Math.floor(before.getTime() / 1000) + 1}`);
     }
 
     const response = await getMessages(this.client, {
-      query,
+      query: queryParts.join(" ") || undefined,
       maxResults,
       pageToken,
+      labelIds: [GmailLabel.SENT],
     });
 
     return {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -140,6 +140,34 @@ describe("OutlookProvider.getLatestMessageInThread", () => {
   });
 });
 
+describe("OutlookProvider.getSentMessageIds", () => {
+  it("queries sent items with sentDateTime bounds", async () => {
+    const client = createMockOutlookClient([
+      createMessage({
+        id: "message-1",
+        conversationId: "thread-1",
+      }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    const result = await provider.getSentMessageIds({
+      maxResults: 50,
+      after: new Date("2026-03-31T12:00:00.000Z"),
+      before: new Date("2026-04-30T17:00:00.000Z"),
+    });
+
+    expect(client.getRequestLog()).toContainEqual({
+      apiPath: "/me/mailFolders('sentitems')/messages",
+      filter:
+        "sentDateTime ge 2026-03-31T12:00:00.000Z and sentDateTime le 2026-04-30T17:00:00.000Z",
+    });
+    expect(result).toEqual({
+      messages: [{ id: "message-1", threadId: "thread-1" }],
+      nextPageToken: undefined,
+    });
+  });
+});
+
 describe("OutlookProvider.getThreadsWithQuery", () => {
   it("filters returned threads by explicit labelIds", async () => {
     getFolderIdsMock.mockResolvedValue({


### PR DESCRIPTION
Fixes Gmail sent-message lookup by using the API label filter for sent messages while keeping second-accurate date bounds.\n\nAdds unit coverage for date-scoped and unscoped sent-message lookup requests.