### PR TITLE
Fix assistant rule rename handling

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -423,13 +423,16 @@ describe("aiProcessAssistantChat", () => {
         .success,
     ).toBe(false);
     expect(
-      args.tools.updateRuleActions.inputSchema.safeParse(
-        getWebhookRuleActionsInput(),
-      ).success,
+      args.tools.updateRule.inputSchema.safeParse({
+        ruleName: "Webhook",
+        updates: {
+          actions: getWebhookRuleActionsInput().actions,
+        },
+      }).success,
     ).toBe(false);
   });
 
-  it("accepts sparse rule action fields for createRule and updateRuleActions", async () => {
+  it("accepts sparse rule action fields for createRule and updateRule", async () => {
     const tools = await captureToolSet(true);
 
     expect(
@@ -460,52 +463,58 @@ describe("aiProcessAssistantChat", () => {
     ).toBe(true);
 
     expect(
-      tools.updateRuleActions.inputSchema.safeParse({
+      tools.updateRule.inputSchema.safeParse({
         ruleName: "Finance",
-        actions: [
-          {
-            type: ActionType.LABEL,
-            fields: {
-              label: "Finance",
+        updates: {
+          actions: [
+            {
+              type: ActionType.LABEL,
+              fields: {
+                label: "Finance",
+              },
+              delayInMinutes: null,
             },
-            delayInMinutes: null,
-          },
-          {
-            type: ActionType.ARCHIVE,
-            fields: {},
-            delayInMinutes: null,
-          },
-        ],
+            {
+              type: ActionType.ARCHIVE,
+              fields: {},
+              delayInMinutes: null,
+            },
+          ],
+        },
       }).success,
     ).toBe(true);
   });
 
-  it("rejects updateRuleActions payloads that omit required action fields", async () => {
+  it("rejects updateRule payloads that omit required action fields", async () => {
     const tools = await captureToolSet(true);
 
     expect(
-      tools.updateRuleActions.inputSchema.safeParse({
+      tools.updateRule.inputSchema.safeParse({
         ruleName: "Finance",
-        actions: [
-          {
-            type: ActionType.LABEL,
-            fields: {},
-            delayInMinutes: null,
-          },
-        ],
+        updates: {
+          actions: [
+            {
+              type: ActionType.LABEL,
+              fields: {},
+              delayInMinutes: null,
+            },
+          ],
+        },
       }).success,
     ).toBe(false);
 
     expect(
-      tools.updateRuleActions.inputSchema.safeParse({
+      tools.updateRule.inputSchema.safeParse({
         ruleName: "Webhook",
-        actions: [
-          {
-            type: ActionType.CALL_WEBHOOK,
-            fields: {},
-            delayInMinutes: null,
-          },
-        ],
+        updates: {
+          actions: [
+            {
+              type: ActionType.CALL_WEBHOOK,
+              fields: {},
+              delayInMinutes: null,
+            },
+          ],
+        },
       }).success,
     ).toBe(false);
   });
@@ -516,32 +525,36 @@ describe("aiProcessAssistantChat", () => {
     const microsoftTools = await captureToolSet(true, "microsoft");
 
     expect(
-      googleTools.updateRuleActions.inputSchema.safeParse({
+      googleTools.updateRule.inputSchema.safeParse({
         ruleName: "Finance",
-        actions: [
-          {
-            type: ActionType.MOVE_FOLDER,
-            fields: {
-              folderName: "Archive",
+        updates: {
+          actions: [
+            {
+              type: ActionType.MOVE_FOLDER,
+              fields: {
+                folderName: "Archive",
+              },
+              delayInMinutes: null,
             },
-            delayInMinutes: null,
-          },
-        ],
+          ],
+        },
       }).success,
     ).toBe(false);
 
     expect(
-      microsoftTools.updateRuleActions.inputSchema.safeParse({
+      microsoftTools.updateRule.inputSchema.safeParse({
         ruleName: "Finance",
-        actions: [
-          {
-            type: ActionType.MOVE_FOLDER,
-            fields: {
-              folderName: "Archive",
+        updates: {
+          actions: [
+            {
+              type: ActionType.MOVE_FOLDER,
+              fields: {
+                folderName: "Archive",
+              },
+              delayInMinutes: null,
             },
-            delayInMinutes: null,
-          },
-        ],
+          ],
+        },
       }).success,
     ).toBe(true);
   });
@@ -1152,10 +1165,12 @@ describe("aiProcessAssistantChat", () => {
   it("requires reading rules immediately before updating rule conditions", async () => {
     const tools = await captureToolSet(true, "google");
 
-    const result = await tools.updateRuleConditions.execute({
+    const result = await tools.updateRule.execute({
       ruleName: "To Reply",
-      condition: {
-        aiInstructions: "Updated instructions",
+      updates: {
+        condition: {
+          aiInstructions: "Updated instructions",
+        },
       },
     });
 
@@ -1199,6 +1214,7 @@ describe("aiProcessAssistantChat", () => {
       id: "rule-1",
       name: "To Reply",
       updatedAt: new Date("2026-02-13T10:00:00.000Z"),
+      enabled: true,
       emailAccount: {
         rulesRevision: 2,
       },
@@ -1207,6 +1223,7 @@ describe("aiProcessAssistantChat", () => {
       to: null,
       subject: null,
       conditionalOperator: "AND",
+      actions: [],
     });
     mockPrisma.rule.update.mockResolvedValue({
       id: "rule-1",
@@ -1235,10 +1252,12 @@ describe("aiProcessAssistantChat", () => {
     expect(freshRuleContext?.content).toContain('"name": "To Reply"');
     expect(onRulesStateExposed).toHaveBeenCalledWith(2);
 
-    const result = await args.tools.updateRuleConditions.execute({
+    const result = await args.tools.updateRule.execute({
       ruleName: "To Reply",
-      condition: {
-        aiInstructions: "Updated instructions",
+      updates: {
+        condition: {
+          aiInstructions: "Updated instructions",
+        },
       },
     });
 
@@ -1400,10 +1419,12 @@ describe("aiProcessAssistantChat", () => {
       conditionalOperator: "AND",
     });
 
-    const result = await tools.updateRuleConditions.execute({
+    const result = await tools.updateRule.execute({
       ruleName: "To Reply",
-      condition: {
-        aiInstructions: "Updated instructions",
+      updates: {
+        condition: {
+          aiInstructions: "Updated instructions",
+        },
       },
     });
 

--- a/apps/web/__tests__/ai-regression/ai-assistant-chat-send-disabled-regression.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-assistant-chat-send-disabled-regression.test.ts
@@ -217,24 +217,26 @@ describe.runIf(isAiTest)(
           }),
         );
 
-        const updateWithoutRead = await args.tools.updateRuleActions.execute({
+        const updateWithoutRead = await args.tools.updateRule.execute({
           ruleName: "DraftDemo",
-          actions: [
-            {
-              type: ActionType.DRAFT_EMAIL,
-              fields: {
-                to: "demoinboxzero@outlook.com",
-                subject: "test draft",
-                content: "hey, just testing out this email draft!",
-                label: null,
-                cc: null,
-                bcc: null,
-                webhookUrl: null,
-                folderName: null,
+          updates: {
+            actions: [
+              {
+                type: ActionType.DRAFT_EMAIL,
+                fields: {
+                  to: "demoinboxzero@outlook.com",
+                  subject: "test draft",
+                  content: "hey, just testing out this email draft!",
+                  label: null,
+                  cc: null,
+                  bcc: null,
+                  webhookUrl: null,
+                  folderName: null,
+                },
+                delayInMinutes: null,
               },
-              delayInMinutes: null,
-            },
-          ],
+            ],
+          },
         });
 
         expect(updateWithoutRead.success).toBe(false);

--- a/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from "ai";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, type LogicalOperator } from "@/generated/prisma/enums";
 import type { getEmailAccount } from "@/__tests__/helpers";
 import type { MessageContext } from "@/app/api/chat/validation";
 import { writeEvalDebugArtifact } from "@/__tests__/eval/debug-artifacts";
@@ -21,6 +21,25 @@ export type UpdateRuleActionsInput = {
     } | null;
     delayInMinutes?: number | null;
   }>;
+};
+
+export type UpdateRuleInput = {
+  ruleName: string;
+  updates: {
+    name?: string;
+    enabled?: boolean;
+    condition?: {
+      aiInstructions?: string;
+      clearAiInstructions?: true;
+      static?: {
+        from?: string | null;
+        to?: string | null;
+        subject?: string | null;
+      } | null;
+      conditionalOperator?: LogicalOperator | null;
+    };
+    actions?: UpdateRuleActionsInput["actions"];
+  };
 };
 
 export type AssistantChatTrace = {
@@ -182,6 +201,79 @@ export function isUpdateRuleActionsInput(
   };
 
   return typeof value.ruleName === "string" && Array.isArray(value.actions);
+}
+
+export function isUpdateRuleInput(input: unknown): input is UpdateRuleInput {
+  if (!input || typeof input !== "object") return false;
+
+  const value = input as {
+    ruleName?: unknown;
+    updates?: unknown;
+  };
+
+  return (
+    typeof value.ruleName === "string" &&
+    typeof value.updates === "object" &&
+    value.updates !== null
+  );
+}
+
+export function getLastRuleActionsUpdate(toolCalls: RecordedToolCall[]) {
+  for (let index = toolCalls.length - 1; index >= 0; index -= 1) {
+    const toolCall = toolCalls[index];
+    if (toolCall.toolName !== "updateRule") continue;
+    if (!isUpdateRuleInput(toolCall.input)) continue;
+    if (!toolCall.input.updates.actions) continue;
+
+    return {
+      index,
+      ruleName: toolCall.input.ruleName,
+      actions: toolCall.input.updates.actions,
+    };
+  }
+
+  return null;
+}
+
+export function getLastRuleConditionUpdate(toolCalls: RecordedToolCall[]) {
+  for (let index = toolCalls.length - 1; index >= 0; index -= 1) {
+    const toolCall = toolCalls[index];
+    if (toolCall.toolName !== "updateRule") continue;
+    if (!isUpdateRuleInput(toolCall.input)) continue;
+    if (!toolCall.input.updates.condition) continue;
+
+    return {
+      index,
+      ruleName: toolCall.input.ruleName,
+      condition: toolCall.input.updates.condition,
+    };
+  }
+
+  return null;
+}
+
+export type UpdateRuleConditionsInput = {
+  ruleName: string;
+  condition: {
+    aiInstructions?: string | null;
+  };
+};
+
+export function isUpdateRuleConditionsInput(
+  input: unknown,
+): input is UpdateRuleConditionsInput {
+  if (!input || typeof input !== "object") return false;
+
+  const value = input as {
+    ruleName?: unknown;
+    condition?: unknown;
+  };
+
+  return (
+    typeof value.ruleName === "string" &&
+    typeof value.condition === "object" &&
+    value.condition !== null
+  );
 }
 
 export function hasActionType(

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-action-preservation.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-action-preservation.test.ts
@@ -2,10 +2,9 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
-  getLastMatchingToolCall,
+  getLastRuleActionsUpdate,
   hasActionType,
   hasLabelAction,
-  isUpdateRuleActionsInput,
   summarizeRecordedToolCalls,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
@@ -166,11 +165,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const archive = updateCall?.actions.find(
               (a) => a.type === ActionType.ARCHIVE,
@@ -209,11 +204,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const archives =
               updateCall?.actions.filter(
@@ -259,11 +250,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const pass =
               !!updateCall &&
@@ -297,11 +284,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const archive = updateCall?.actions.find(
               (a) => a.type === ActionType.ARCHIVE,
@@ -351,11 +334,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const archives =
               updateCall?.actions.filter(
@@ -398,11 +377,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const archives =
               updateCall?.actions.filter(

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
@@ -2,10 +2,9 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
+  getLastRuleActionsUpdate,
   hasActionType,
   hasLabelAction,
-  isUpdateRuleActionsInput,
-  getLastMatchingToolCall,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -163,20 +162,12 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
-            const updateCallIndex = getLastToolCallIndex(
-              toolCalls,
-              "updateRuleActions",
-            );
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const pass =
               !!updateCall &&
               updateCall.ruleName === "Notification" &&
-              hasRuleReadBeforeUpdate(toolCalls, updateCallIndex) &&
+              hasRuleReadBeforeUpdate(toolCalls, updateCall.index) &&
               !toolCalls.some(
                 (toolCall) => toolCall.toolName === "createRule",
               ) &&
@@ -208,11 +199,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleActions",
-              isUpdateRuleActionsInput,
-            )?.input;
+            const updateCall = getLastRuleActionsUpdate(toolCalls);
 
             const pass =
               !!updateCall &&

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-condition-updates.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-condition-updates.test.ts
@@ -2,9 +2,11 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
-  getLastMatchingToolCall,
+  getLastRuleConditionUpdate,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
+  isUpdateRuleConditionsInput,
+  isUpdateRuleInput,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   describeEvalMatrix,
@@ -164,15 +166,7 @@ describe.runIf(shouldRunEval)(
               ],
             });
 
-            const updateCall = getLastMatchingToolCall(
-              toolCalls,
-              "updateRuleConditions",
-              isUpdateRuleConditionsInput,
-            )?.input;
-            const updateCallIndex = getLastToolCallIndex(
-              toolCalls,
-              "updateRuleConditions",
-            );
+            const updateCall = getLastRuleConditionUpdate(toolCalls);
             const judgeResult = updateCall
               ? await judgeEvalOutput({
                   input:
@@ -192,7 +186,7 @@ describe.runIf(shouldRunEval)(
               !!updateCall &&
               !!judgeResult?.pass &&
               updateCall.ruleName === "To Reply" &&
-              hasRuleReadBeforeUpdate(toolCalls, updateCallIndex) &&
+              hasRuleReadBeforeUpdate(toolCalls, updateCall.index) &&
               !toolCalls.some(
                 (toolCall) => toolCall.toolName === "createRule",
               ) &&
@@ -244,30 +238,6 @@ async function runAssistantChat({
   };
 }
 
-type UpdateRuleConditionsInput = {
-  ruleName: string;
-  condition: {
-    aiInstructions?: string | null;
-  };
-};
-
-function isUpdateRuleConditionsInput(
-  input: unknown,
-): input is UpdateRuleConditionsInput {
-  if (!input || typeof input !== "object") return false;
-
-  const value = input as {
-    ruleName?: unknown;
-    condition?: unknown;
-  };
-
-  return (
-    typeof value.ruleName === "string" &&
-    !!value.condition &&
-    typeof value.condition === "object"
-  );
-}
-
 function summarizeToolCall(toolCall: RecordedToolCall) {
   if (isUpdateRuleConditionsInput(toolCall.input)) {
     return (
@@ -276,6 +246,17 @@ function summarizeToolCall(toolCall: RecordedToolCall) {
       toolCall.input.ruleName +
       ", aiInstructions=" +
       truncate(toolCall.input.condition.aiInstructions) +
+      ")"
+    );
+  }
+
+  if (isUpdateRuleInput(toolCall.input)) {
+    return (
+      toolCall.toolName +
+      "(ruleName=" +
+      toolCall.input.ruleName +
+      ", aiInstructions=" +
+      truncate(toolCall.input.updates.condition?.aiInstructions) +
       ")"
     );
   }

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
@@ -130,6 +130,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat rule creation", () => {
     configureRuleEvalProvider({
       mockCreateEmailProvider,
       ruleRows: defaultRuleRows,
+      includeCreateLabel: true,
     });
   });
 

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
@@ -2,10 +2,9 @@ import type { ModelMessage } from "ai";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   captureAssistantChatToolCalls,
+  getLastRuleActionsUpdate,
   hasActionType,
   hasLabelAction,
-  isUpdateRuleActionsInput,
-  getLastMatchingToolCall,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -342,11 +341,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat overlap exceptions", () => {
             context: buildFixRuleContext(),
           });
 
-          const updateActionsCall = getLastMatchingToolCall(
-            toolCalls,
-            "updateRuleActions",
-            isUpdateRuleActionsInput,
-          )?.input;
+          const updateActionsCall = getLastRuleActionsUpdate(toolCalls);
 
           const pass =
             !!updateActionsCall &&

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
@@ -1,0 +1,660 @@
+import type { ModelMessage } from "ai";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  captureAssistantChatToolCalls,
+  getLastMatchingToolCall,
+  isUpdateRuleInput,
+  summarizeRecordedToolCalls,
+  type RecordedToolCall,
+  type UpdateRuleInput,
+} from "@/__tests__/eval/assistant-chat-eval-utils";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import {
+  buildDefaultSystemRuleRows,
+  configureRuleEvalPrisma,
+  configureRuleEvalProvider,
+  configureRuleMutationMocks,
+} from "@/__tests__/eval/assistant-chat-rule-eval-test-utils";
+import type { getEmailAccount } from "@/__tests__/helpers";
+import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+
+// pnpm test-ai eval/assistant-chat-rule-editing-patch-semantics
+// Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing-patch-semantics
+
+vi.mock("server-only", () => ({}));
+
+const shouldRunEval = shouldRunEvalTests();
+const TIMEOUT = 240_000;
+const evalReporter = createEvalReporter();
+const logger = createScopedLogger(
+  "eval-assistant-chat-rule-editing-patch-semantics",
+);
+const ruleUpdatedAt = new Date("2026-03-13T00:00:00.000Z");
+const renamedRuleName = "Cat label";
+const customRuleName = "Cat updates";
+const conditionOnlyRuleName = "Vendor Alerts";
+const staticConditionRuleName = "Vendor Billing";
+const defaultRuleRows = buildDefaultSystemRuleRows(ruleUpdatedAt);
+const patchRuleRows = [
+  ...defaultRuleRows,
+  {
+    id: "cat-updates-rule-id",
+    name: customRuleName,
+    instructions: "Emails about cats.",
+    updatedAt: ruleUpdatedAt,
+    from: null,
+    to: null,
+    subject: null,
+    conditionalOperator: LogicalOperator.AND,
+    enabled: true,
+    runOnThreads: true,
+    systemType: null,
+    actions: [
+      {
+        type: ActionType.LABEL,
+        content: null,
+        label: "cat-label",
+        to: null,
+        cc: null,
+        bcc: null,
+        subject: null,
+        url: null,
+        folderName: null,
+      },
+    ],
+  },
+  {
+    id: "vendor-alerts-rule-id",
+    name: conditionOnlyRuleName,
+    instructions: "Important product and account alerts.",
+    updatedAt: ruleUpdatedAt,
+    from: "alerts@vendor.example",
+    to: null,
+    subject: null,
+    conditionalOperator: LogicalOperator.AND,
+    enabled: true,
+    runOnThreads: true,
+    systemType: null,
+    actions: [
+      {
+        type: ActionType.LABEL,
+        content: null,
+        label: "Vendor Alerts",
+        to: null,
+        cc: null,
+        bcc: null,
+        subject: null,
+        url: null,
+        folderName: null,
+      },
+    ],
+  },
+  {
+    id: "vendor-billing-rule-id",
+    name: staticConditionRuleName,
+    instructions: "Billing notices, invoices, and account payment updates.",
+    updatedAt: ruleUpdatedAt,
+    from: "billing@vendor.example",
+    to: null,
+    subject: "invoice",
+    conditionalOperator: LogicalOperator.AND,
+    enabled: true,
+    runOnThreads: true,
+    systemType: null,
+    actions: [
+      {
+        type: ActionType.LABEL,
+        content: null,
+        label: "Vendor Billing",
+        to: null,
+        cc: null,
+        bcc: null,
+        subject: null,
+        url: null,
+        folderName: null,
+      },
+    ],
+  },
+];
+const about = "My name is Test User, and I manage a company inbox.";
+
+const {
+  mockCreateRule,
+  mockPartialUpdateRule,
+  mockUpdateRuleActions,
+  mockSetRuleEnabled,
+  mockSaveLearnedPatterns,
+  mockCreateEmailProvider,
+  mockPosthogCaptureEvent,
+  mockRedis,
+  mockUnsubscribeSenderAndMark,
+} = vi.hoisted(() => ({
+  mockCreateRule: vi.fn(),
+  mockPartialUpdateRule: vi.fn(),
+  mockUpdateRuleActions: vi.fn(),
+  mockSetRuleEnabled: vi.fn(),
+  mockSaveLearnedPatterns: vi.fn(),
+  mockCreateEmailProvider: vi.fn(),
+  mockPosthogCaptureEvent: vi.fn(),
+  mockRedis: {
+    set: vi.fn(),
+    rpush: vi.fn(),
+    hincrby: vi.fn(),
+    expire: vi.fn(),
+    keys: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    llen: vi.fn().mockResolvedValue(0),
+    lrange: vi.fn().mockResolvedValue([]),
+  },
+  mockUnsubscribeSenderAndMark: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/rule", async (importOriginal) => {
+  const { buildRuleModuleMutationMock } = await import(
+    "@/__tests__/eval/assistant-chat-rule-eval-test-utils"
+  );
+
+  return buildRuleModuleMutationMock({
+    importOriginal: () => importOriginal<typeof import("@/utils/rule/rule")>(),
+    mockCreateRule,
+    mockPartialUpdateRule,
+    mockUpdateRuleActions,
+    mockSetRuleEnabled,
+  });
+});
+
+vi.mock("@/utils/rule/learned-patterns", () => ({
+  saveLearnedPatterns: mockSaveLearnedPatterns,
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: mockCreateEmailProvider,
+}));
+
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: mockPosthogCaptureEvent,
+  getPosthogLlmClient: () => null,
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: mockRedis,
+}));
+
+vi.mock("@/utils/senders/unsubscribe", () => ({
+  unsubscribeSenderAndMark: mockUnsubscribeSenderAndMark,
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_EMAIL_SEND_ENABLED: true,
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+describe.runIf(shouldRunEval)(
+  "Eval: assistant chat rule editing patch semantics",
+  () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      configureRuleMutationMocks({
+        mockCreateRule,
+        mockPartialUpdateRule,
+        mockUpdateRuleActions,
+        mockSetRuleEnabled,
+        mockSaveLearnedPatterns,
+      });
+
+      configureRuleEvalPrisma({
+        about,
+        ruleRows: patchRuleRows,
+      });
+
+      configureRuleEvalProvider({
+        mockCreateEmailProvider,
+        ruleRows: patchRuleRows,
+      });
+    });
+
+    describeEvalMatrix(
+      "assistant-chat rule editing patch semantics",
+      (model, emailAccount) => {
+        test(
+          "renames an existing rule without creating or deleting rules",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: `Rename my "${customRuleName}" rule to "${renamedRuleName}".`,
+                },
+              ],
+            });
+
+            const updateRuleCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const updateRuleIndex = getLastToolCallIndex(
+              toolCalls,
+              "updateRule",
+            );
+
+            const pass =
+              !!updateRuleCall &&
+              updateRuleCall.ruleName === customRuleName &&
+              updateRuleCall.updates?.name === renamedRuleName &&
+              !("condition" in updateRuleCall.updates) &&
+              !("actions" in updateRuleCall.updates) &&
+              hasRuleReadBeforeUpdate(toolCalls, updateRuleIndex) &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "rename existing rule with patch update",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "action-only update preserves existing conditions and name",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "Change my Notification rule so those emails are marked read too.",
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === "Notification" &&
+              !!patchCall.updates?.actions &&
+              !("name" in patchCall.updates) &&
+              !("condition" in patchCall.updates) &&
+              patchHasActionType(patchCall, ActionType.MARK_READ) &&
+              patchHasLabelAction(patchCall, "Notification");
+
+            evalReporter.record({
+              testName: "action patch preserves non-action fields",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "condition-only update preserves existing actions and name",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "If I am CC'd on an email, it should not be marked To Reply.",
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === "To Reply" &&
+              !!patchCall.updates?.condition &&
+              !("name" in patchCall.updates) &&
+              !("actions" in patchCall.updates) &&
+              getPatchConditionInstructions(patchCall)
+                .toLowerCase()
+                .includes("cc");
+
+            evalReporter.record({
+              testName: "condition patch preserves non-condition fields",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "clears one static condition without clearing instructions or actions",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    'Remove the sender restriction from my "Vendor Alerts" rule, but keep its instructions and actions.',
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === conditionOnlyRuleName &&
+              !!patchCall.updates?.condition &&
+              !("name" in patchCall.updates) &&
+              !("actions" in patchCall.updates) &&
+              getPatchConditionStaticFrom(patchCall) === null &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "explicit condition clear preserves other fields",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "clears one static field without clearing sibling static fields",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: `For my "${staticConditionRuleName}" rule, remove the subject restriction but keep the sender restriction.`,
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === staticConditionRuleName &&
+              !!patchCall.updates?.condition &&
+              !("name" in patchCall.updates) &&
+              !("actions" in patchCall.updates) &&
+              getPatchConditionStaticSubject(patchCall) === null &&
+              preservesStaticSender(patchCall, "billing@vendor.example") &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "clear one static field preserves sibling fields",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "renames and updates actions in one patch without touching conditions",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: `Rename "${customRuleName}" to "${renamedRuleName}" and also mark matching emails as read.`,
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === customRuleName &&
+              patchCall.updates?.name === renamedRuleName &&
+              !!patchCall.updates.actions &&
+              !("condition" in patchCall.updates) &&
+              patchHasActionType(patchCall, ActionType.MARK_READ) &&
+              patchHasLabelAction(patchCall, "cat-label") &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "combined name and action patch",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "replaces a label action instead of adding a second label",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: `Change the "${customRuleName}" rule to use the Notification label instead of cat-label. Do not keep the old cat-label action.`,
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === customRuleName &&
+              !!patchCall.updates.actions &&
+              !("name" in patchCall.updates) &&
+              !("condition" in patchCall.updates) &&
+              patchHasLabelAction(patchCall, "Notification") &&
+              !patchHasLabelAction(patchCall, "cat-label") &&
+              countLabelActions(patchCall) === 1 &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "replace label action without adding duplicate",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "updates conditions and actions together without renaming",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content:
+                    "Change my Notification rule to only catch system alerts and mark those emails read too.",
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === "Notification" &&
+              !("name" in patchCall.updates) &&
+              !!patchCall.updates.condition &&
+              !!patchCall.updates.actions &&
+              getPatchConditionInstructions(patchCall)
+                .toLowerCase()
+                .includes("system alert") &&
+              patchHasActionType(patchCall, ActionType.MARK_READ) &&
+              patchHasLabelAction(patchCall, "Notification") &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "combined condition and action patch",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
+          "pauses a rule through the unified update patch",
+          async () => {
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: "Pause my Marketing rule for now.",
+                },
+              ],
+            });
+
+            const patchCall = getLastUpdateRuleCall(toolCalls)?.input;
+            const pass =
+              !!patchCall &&
+              patchCall.ruleName === "Marketing" &&
+              patchCall.updates.enabled === false &&
+              !("name" in patchCall.updates) &&
+              !("condition" in patchCall.updates) &&
+              !("actions" in patchCall.updates) &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "pause uses enabled patch",
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+      },
+    );
+
+    afterAll(() => {
+      evalReporter.printReport();
+    });
+  },
+);
+
+async function runAssistantChat({
+  emailAccount,
+  messages,
+}: {
+  emailAccount: ReturnType<typeof getEmailAccount>;
+  messages: ModelMessage[];
+}) {
+  const toolCalls = await captureAssistantChatToolCalls({
+    messages,
+    emailAccount,
+    logger,
+  });
+
+  return {
+    toolCalls,
+    actual: summarizeRecordedToolCalls(
+      toolCalls,
+      (toolCall) => toolCall.toolName,
+    ),
+  };
+}
+
+function getLastUpdateRuleCall(toolCalls: RecordedToolCall[]) {
+  return getLastMatchingToolCall(toolCalls, "updateRule", isUpdateRuleInput);
+}
+
+function patchHasActionType(input: UpdateRuleInput, actionType: ActionType) {
+  return input.updates.actions?.some((action) => action.type === actionType);
+}
+
+function patchHasLabelAction(input: UpdateRuleInput, label: string) {
+  return input.updates.actions?.some(
+    (action) =>
+      action.type === ActionType.LABEL && action.fields?.label === label,
+  );
+}
+
+function getPatchConditionInstructions(input: UpdateRuleInput) {
+  return input.updates.condition?.aiInstructions ?? "";
+}
+
+function getPatchConditionStaticFrom(input: UpdateRuleInput) {
+  return input.updates.condition?.static?.from;
+}
+
+function getPatchConditionStaticSubject(input: UpdateRuleInput) {
+  return input.updates.condition?.static?.subject;
+}
+
+function preservesStaticSender(input: UpdateRuleInput, expectedSender: string) {
+  const from = input.updates.condition?.static?.from;
+  return from === undefined || from === expectedSender;
+}
+
+function countLabelActions(input: UpdateRuleInput) {
+  return (
+    input.updates.actions?.filter((action) => action.type === ActionType.LABEL)
+      .length ?? 0
+  );
+}
+
+function hasNoCreateDeleteOrLegacyRuleMutations(toolCalls: RecordedToolCall[]) {
+  return !toolCalls.some((toolCall) =>
+    [
+      "createRule",
+      "updateRuleState",
+      "updateRuleActions",
+      "updateRuleConditions",
+      "updateLearnedPatterns",
+    ].includes(toolCall.toolName),
+  );
+}
+
+function getLastToolCallIndex(toolCalls: RecordedToolCall[], toolName: string) {
+  return toolCalls.findLastIndex((toolCall) => toolCall.toolName === toolName);
+}
+
+function hasRuleReadBeforeUpdate(
+  toolCalls: RecordedToolCall[],
+  updateCallIndex: number,
+) {
+  if (updateCallIndex < 0) return false;
+
+  return (
+    getLastToolCallIndex(
+      toolCalls.slice(0, updateCallIndex),
+      "getUserRulesAndSettings",
+    ) >= 0
+  );
+}

--- a/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
@@ -21,6 +21,7 @@ type RuleMutationMocks = {
   mockCreateRule: AnyMock;
   mockPartialUpdateRule: AnyMock;
   mockUpdateRuleActions: AnyMock;
+  mockSetRuleEnabled?: AnyMock;
 };
 
 export function buildDefaultSystemRuleRows(updatedAt: Date) {
@@ -70,16 +71,19 @@ export function configureRuleMutationMocks({
   mockPartialUpdateRule,
   mockUpdateRuleActions,
   mockSaveLearnedPatterns,
+  mockSetRuleEnabled,
 }: {
   mockCreateRule: AnyMock;
   mockPartialUpdateRule: AnyMock;
   mockUpdateRuleActions: AnyMock;
   mockSaveLearnedPatterns: AnyMock;
+  mockSetRuleEnabled?: AnyMock;
 }) {
   mockCreateRule.mockResolvedValue({ id: "created-rule-id" });
   mockPartialUpdateRule.mockResolvedValue({ id: "updated-rule-id" });
   mockUpdateRuleActions.mockResolvedValue({ id: "updated-rule-id" });
   mockSaveLearnedPatterns.mockResolvedValue({ success: true });
+  mockSetRuleEnabled?.mockResolvedValue({ id: "updated-rule-id" });
 }
 
 export function configureRuleEvalPrisma({
@@ -221,6 +225,7 @@ export async function buildRuleModuleMutationMock({
   mockCreateRule,
   mockPartialUpdateRule,
   mockUpdateRuleActions,
+  mockSetRuleEnabled,
 }: RuleMutationMocks & {
   importOriginal: () => Promise<typeof import("@/utils/rule/rule")>;
 }) {
@@ -231,6 +236,7 @@ export async function buildRuleModuleMutationMock({
     createRule: mockCreateRule,
     partialUpdateRule: mockPartialUpdateRule,
     updateRuleActions: mockUpdateRuleActions,
+    ...(mockSetRuleEnabled ? { setRuleEnabled: mockSetRuleEnabled } : {}),
   };
 }
 

--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -25,6 +25,7 @@ import {
   SendEmailResult,
   UpdatePersonalInstructions,
   UpdatedLearnedPatterns,
+  UpdatedRule,
   UpdatedRuleActions,
   UpdatedRuleConditions,
   UpdatedRuleState,
@@ -425,6 +426,25 @@ export function MessagePart({
           updatedActions={getOutputField(output, "updatedActions")}
         />
       );
+    }
+  }
+
+  if (part.type === "tool-updateRule") {
+    const { toolCallId, state } = part;
+    if (state === "input-available") {
+      return (
+        <BasicToolInfo
+          key={toolCallId}
+          text={`Updating rule "${part.input.ruleName}"...`}
+        />
+      );
+    }
+    if (state === "output-available") {
+      const { output } = part;
+      if (isOutputWithError(output)) {
+        return renderToolError(toolCallId, output);
+      }
+      return <UpdatedRule key={toolCallId} args={part.input} output={output} />;
     }
   }
 

--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -47,6 +47,22 @@ interface MessagePartProps {
   threadLookup: ThreadLookup;
 }
 
+type LegacyRuleToolPart =
+  | {
+      type: "tool-updateRuleConditions";
+      toolCallId: string;
+      state: string;
+      input: Parameters<typeof UpdatedRuleConditions>[0]["args"];
+      output?: unknown;
+    }
+  | {
+      type: "tool-updateRuleActions";
+      toolCallId: string;
+      state: string;
+      input: Parameters<typeof UpdatedRuleActions>[0]["args"];
+      output?: unknown;
+    };
+
 function ErrorToolCard({ error }: { error: string }) {
   return <div className="text-xs text-muted-foreground">Error: {error}</div>;
 }
@@ -365,18 +381,23 @@ export function MessagePart({
     }
   }
 
-  if (part.type === "tool-updateRuleConditions") {
-    const { toolCallId, state } = part;
+  // These tools are no longer exposed to the assistant; updateRule replaces
+  // them. Keep render-only support so older persisted chat messages still show
+  // their historical tool cards instead of falling through to raw JSON.
+  const legacyRulePart = part as unknown as LegacyRuleToolPart;
+
+  if (legacyRulePart.type === "tool-updateRuleConditions") {
+    const { toolCallId, state } = legacyRulePart;
     if (state === "input-available") {
       return (
         <BasicToolInfo
           key={toolCallId}
-          text={`Updating rule "${part.input.ruleName}" conditions...`}
+          text={`Updating rule "${legacyRulePart.input.ruleName}" conditions...`}
         />
       );
     }
     if (state === "output-available") {
-      const { output } = part;
+      const { output } = legacyRulePart;
       if (isOutputWithError(output)) {
         return renderToolError(toolCallId, output);
       }
@@ -388,7 +409,7 @@ export function MessagePart({
       return (
         <UpdatedRuleConditions
           key={toolCallId}
-          args={part.input}
+          args={legacyRulePart.input}
           ruleId={ruleId}
           originalConditions={getOutputField(output, "originalConditions")}
           updatedConditions={getOutputField(output, "updatedConditions")}
@@ -397,18 +418,18 @@ export function MessagePart({
     }
   }
 
-  if (part.type === "tool-updateRuleActions") {
-    const { toolCallId, state } = part;
+  if (legacyRulePart.type === "tool-updateRuleActions") {
+    const { toolCallId, state } = legacyRulePart;
     if (state === "input-available") {
       return (
         <BasicToolInfo
           key={toolCallId}
-          text={`Updating rule "${part.input.ruleName}" actions...`}
+          text={`Updating rule "${legacyRulePart.input.ruleName}" actions...`}
         />
       );
     }
     if (state === "output-available") {
-      const { output } = part;
+      const { output } = legacyRulePart;
       if (isOutputWithError(output)) {
         return renderToolError(toolCallId, output);
       }
@@ -420,7 +441,7 @@ export function MessagePart({
       return (
         <UpdatedRuleActions
           key={toolCallId}
-          args={part.input}
+          args={legacyRulePart.input}
           ruleId={ruleId}
           originalActions={getOutputField(output, "originalActions")}
           updatedActions={getOutputField(output, "updatedActions")}

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -13,6 +13,10 @@ import type {
   UpdateRuleConditionsTool,
 } from "@/utils/ai/assistant/tools/rules/update-rule-conditions-tool";
 import type {
+  UpdateRuleOutput,
+  UpdateRuleTool,
+} from "@/utils/ai/assistant/tools/rules/update-rule-tool";
+import type {
   UpdateRuleStateOutput,
   UpdateRuleStateTool,
 } from "@/utils/ai/assistant/tools/rules/update-rule-state-tool";
@@ -1247,6 +1251,80 @@ export function UpdatedRuleActions({
             />
           </ViewChangesCollapsible>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function UpdatedRule({
+  args,
+  output,
+  preview,
+}: {
+  args: UpdateRuleTool["input"];
+  output: UpdateRuleOutput;
+  preview?: boolean;
+}) {
+  const ruleId = output.ruleId;
+  const title = output.updatedName || args.updates.name || args.ruleName;
+  const conditionText = args.updates.condition
+    ? buildConditionText(args.updates.condition)
+    : null;
+  const actions = args.updates.actions;
+
+  return (
+    <Card>
+      <RuleToolCardHeader
+        title={title}
+        actions={
+          preview ? (
+            <RuleActionsPreview />
+          ) : ruleId ? (
+            <RuleActions ruleId={ruleId} />
+          ) : null
+        }
+      />
+
+      <CardContent className="space-y-3 px-4 py-3.5">
+        {args.updates.name && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">Name</FieldLabel>
+            <p>{args.updates.name}</p>
+          </div>
+        )}
+
+        {conditionText && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">When</FieldLabel>
+            <p>{conditionText}</p>
+          </div>
+        )}
+
+        {args.updates.enabled !== undefined && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">Status</FieldLabel>
+            <p>{args.updates.enabled ? "Enabled" : "Disabled"}</p>
+          </div>
+        )}
+
+        {actions && (
+          <div className="flex gap-4 text-sm">
+            <FieldLabel className="pt-0.5">Then</FieldLabel>
+            <ActionBadgeList actions={actions} />
+          </div>
+        )}
+
+        {output.originalName &&
+          output.updatedName &&
+          output.originalName !== output.updatedName && (
+            <ViewChangesCollapsible>
+              <CollapsibleDiffContent
+                title="Name:"
+                originalText={output.originalName}
+                updatedText={output.updatedName}
+              />
+            </ViewChangesCollapsible>
+          )}
       </CardContent>
     </Card>
   );

--- a/apps/web/components/assistant-chat/types.ts
+++ b/apps/web/components/assistant-chat/types.ts
@@ -8,6 +8,7 @@ import type { UpdatePersonalInstructionsTool } from "@/utils/ai/assistant/tools/
 import type { UpdateLearnedPatternsTool } from "@/utils/ai/assistant/tools/rules/update-learned-patterns-tool";
 import type { UpdateRuleActionsTool } from "@/utils/ai/assistant/tools/rules/update-rule-actions-tool";
 import type { UpdateRuleConditionsTool } from "@/utils/ai/assistant/tools/rules/update-rule-conditions-tool";
+import type { UpdateRuleTool } from "@/utils/ai/assistant/tools/rules/update-rule-tool";
 import type { UpdateRuleStateTool } from "@/utils/ai/assistant/tools/rules/update-rule-state-tool";
 import type { GetAssistantCapabilitiesTool } from "@/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool";
 import type { UpdateAssistantSettingsTool } from "@/utils/ai/assistant/tools/settings/update-assistant-settings-tool";
@@ -52,6 +53,7 @@ export type ChatTools = {
   getRuleExecutionForMessage: GetRuleExecutionForMessageTool;
   getLearnedPatterns: GetLearnedPatternsTool;
   createRule: CreateRuleTool;
+  updateRule: UpdateRuleTool;
   updateRuleConditions: UpdateRuleConditionsTool;
   updateRuleActions: UpdateRuleActionsTool;
   updateRuleState: UpdateRuleStateTool;

--- a/apps/web/components/assistant-chat/types.ts
+++ b/apps/web/components/assistant-chat/types.ts
@@ -6,8 +6,6 @@ import type { GetRuleExecutionForMessageTool } from "@/utils/ai/assistant/tools/
 import type { GetUserRulesAndSettingsTool } from "@/utils/ai/assistant/tools/rules/get-user-rules-and-settings-tool";
 import type { UpdatePersonalInstructionsTool } from "@/utils/ai/assistant/tools/rules/update-personal-instructions-tool";
 import type { UpdateLearnedPatternsTool } from "@/utils/ai/assistant/tools/rules/update-learned-patterns-tool";
-import type { UpdateRuleActionsTool } from "@/utils/ai/assistant/tools/rules/update-rule-actions-tool";
-import type { UpdateRuleConditionsTool } from "@/utils/ai/assistant/tools/rules/update-rule-conditions-tool";
 import type { UpdateRuleTool } from "@/utils/ai/assistant/tools/rules/update-rule-tool";
 import type { UpdateRuleStateTool } from "@/utils/ai/assistant/tools/rules/update-rule-state-tool";
 import type { GetAssistantCapabilitiesTool } from "@/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool";
@@ -54,8 +52,6 @@ export type ChatTools = {
   getLearnedPatterns: GetLearnedPatternsTool;
   createRule: CreateRuleTool;
   updateRule: UpdateRuleTool;
-  updateRuleConditions: UpdateRuleConditionsTool;
-  updateRuleActions: UpdateRuleActionsTool;
   updateRuleState: UpdateRuleStateTool;
   updateLearnedPatterns: UpdateLearnedPatternsTool;
   updatePersonalInstructions: UpdatePersonalInstructionsTool;

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import { createRuleTool } from "./tools/rules/create-rule-tool";
+import { updateRuleTool } from "./tools/rules/update-rule-tool";
 import { updateRuleStateTool } from "./tools/rules/update-rule-state-tool";
 
 vi.mock("server-only", () => ({}));
@@ -13,11 +14,13 @@ vi.mock("server-only", () => ({}));
 const {
   mockCreateRule,
   mockOutboundActionsNeedChatRiskConfirmation,
+  mockPartialUpdateRule,
   mockPrisma,
   mockSetRuleEnabled,
 } = vi.hoisted(() => ({
   mockCreateRule: vi.fn(),
   mockOutboundActionsNeedChatRiskConfirmation: vi.fn(),
+  mockPartialUpdateRule: vi.fn(),
   mockSetRuleEnabled: vi.fn(),
   mockPrisma: {
     rule: {
@@ -39,6 +42,7 @@ vi.mock("@/utils/rule/rule", async (importOriginal) => {
     createRule: mockCreateRule,
     outboundActionsNeedChatRiskConfirmation:
       mockOutboundActionsNeedChatRiskConfirmation,
+    partialUpdateRule: mockPartialUpdateRule,
     setRuleEnabled: mockSetRuleEnabled,
   };
 });
@@ -120,6 +124,60 @@ describe("createRuleTool overlap guard", () => {
 
     expect(result).toEqual({ success: true, ruleId: "new-rule-id" });
     expect(mockCreateRule).toHaveBeenCalledOnce();
+  });
+});
+
+describe("updateRuleTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPartialUpdateRule.mockResolvedValue({ id: "rule-id" });
+    mockPrisma.rule.findUnique.mockResolvedValue({
+      id: "rule-id",
+      name: "Vendor Billing",
+      enabled: true,
+      updatedAt: new Date("2026-04-27T00:00:00.000Z"),
+      emailAccount: { rulesRevision: 3 },
+      instructions: "Billing notices.",
+      from: "billing@vendor.example",
+      to: null,
+      subject: "invoice",
+      conditionalOperator: "AND",
+      actions: [],
+    });
+  });
+
+  it("preserves omitted static fields when patching one static condition", async () => {
+    const result = await updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["Vendor Billing", "2026-04-27T00:00:00.000Z"],
+        ]),
+      }),
+    }).execute({
+      ruleName: "Vendor Billing",
+      updates: {
+        condition: {
+          static: {
+            subject: null,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPartialUpdateRule).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      data: {
+        subject: null,
+      },
+    });
   });
 });
 

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -163,6 +163,7 @@ describe("updateRuleTool", () => {
       ruleName: "Vendor Billing",
       updates: {
         condition: {
+          conditionalOperator: null,
           static: {
             subject: null,
           },

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -17,8 +17,7 @@ import { getRuleExecutionForMessageTool } from "./tools/rules/get-rule-execution
 import { getUserRulesAndSettingsTool } from "./tools/rules/get-user-rules-and-settings-tool";
 import { updatePersonalInstructionsTool } from "./tools/rules/update-personal-instructions-tool";
 import { updateLearnedPatternsTool } from "./tools/rules/update-learned-patterns-tool";
-import { updateRuleActionsTool } from "./tools/rules/update-rule-actions-tool";
-import { updateRuleConditionsTool } from "./tools/rules/update-rule-conditions-tool";
+import { updateRuleTool } from "./tools/rules/update-rule-tool";
 import { updateRuleStateTool } from "./tools/rules/update-rule-state-tool";
 import { getAssistantCapabilitiesTool } from "./tools/settings/get-assistant-capabilities-tool";
 import { updateAssistantSettingsTool } from "./tools/settings/update-assistant-settings-tool";
@@ -251,8 +250,7 @@ export async function aiProcessAssistantChat({
     getRuleExecutionForMessage: getRuleExecutionForMessageTool(toolOptions),
     getLearnedPatterns: getLearnedPatternsTool(toolOptions),
     createRule: createRuleTool(toolOptions),
-    updateRuleConditions: updateRuleConditionsTool(toolOptions),
-    updateRuleActions: updateRuleActionsTool(toolOptions),
+    updateRule: updateRuleTool(toolOptions),
     updateRuleState: updateRuleStateTool(toolOptions),
     updateLearnedPatterns: updateLearnedPatternsTool(toolOptions),
     updatePersonalInstructions: updatePersonalInstructionsTool(toolOptions),
@@ -755,7 +753,7 @@ export function buildResolvedSystemPrompt({
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.
 - Prefer updating an existing rule over creating an overlapping duplicate. Do not create semantic duplicates like "Notification" and "Notifications".
-- Use updateRuleState to disable, enable, or delete rules.
+- For direct requests to change an existing rule's behavior, read rules then use the relevant rule update tool. Do not ask for another confirmation unless multiple rules are similar or required data is missing.
 - If multiple fetched rules are similar, ask the user which one to update instead of guessing.
 - Use short concise rule names and real sender or domain values. Ask when required data is missing.
 - Rules can use {{variables}} in action fields to insert AI-generated content.`,

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -203,7 +203,7 @@ export async function aiProcessAssistantChat({
                 .join("\n")}\n\n` +
               `Expected outcome: ${formatFixRuleExpectedOutcome(context)}` +
               (isConversationStatusFixContext(context, expectedFixSystemType)
-                ? "\n\nThis fix is about conversation status classification. Prefer updating conversation rule instructions with updateRuleConditions (for example, To Reply/FYI rules)."
+                ? "\n\nThis fix is about conversation status classification. Prefer updating conversation rule instructions with updateRule (for example, To Reply/FYI rules)."
                 : ""),
           },
         ]

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
@@ -23,11 +23,11 @@ export const updateRuleStateTool = ({
 }) =>
   tool({
     description:
-      "Enable, disable, or request deletion of an existing rule. Use this when the user wants to turn a rule on or off, pause it, remove it, or delete it. Delete requests return requiresConfirmation; explain that deletion is pending and no rule has been deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
+      "Request deletion of an existing rule. Use updateRule with updates.enabled for enable, disable, pause, or resume. Delete requests return requiresConfirmation; explain that deletion is pending and no rule has been deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
     inputSchema: z.object({
       ruleName: z.string().describe("The exact name of the rule to update"),
       operation: ruleStateOperationSchema.describe(
-        "enable turns the rule on, disable turns the rule off, delete asks the user to confirm deleting the rule.",
+        "delete asks the user to confirm deleting the rule. Use updateRule for enable or disable.",
       ),
     }),
     execute: async ({ ruleName, operation }) => {

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -338,7 +338,7 @@ function buildConditionUpdateData(condition: PatchCondition) {
     data.instructions = condition.aiInstructions;
   }
 
-  if ("conditionalOperator" in condition && condition.conditionalOperator) {
+  if (condition.conditionalOperator) {
     data.conditionalOperator = condition.conditionalOperator;
   }
 

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -1,0 +1,360 @@
+import { type InferUITool, tool } from "ai";
+import { z } from "zod";
+import { LogicalOperator } from "@/generated/prisma/enums";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { filterNullProperties } from "@/utils";
+import {
+  createRuleActionSchema,
+  type RuleAction,
+} from "@/utils/ai/rule/create-rule-schema";
+import { isDuplicateError } from "@/utils/prisma-helpers";
+import { isMicrosoftProvider } from "@/utils/email/provider-types";
+import {
+  partialUpdateRule,
+  setRuleEnabled,
+  updateRuleActions,
+} from "@/utils/rule/rule";
+import {
+  AI_INSTRUCTIONS_PROMPT_DESCRIPTION,
+  INVALID_STATIC_FROM_MESSAGE,
+  isInvalidStaticFromValue,
+  STATIC_FROM_CONDITION_DESCRIPTION,
+} from "@/utils/ai/rule/rule-condition-descriptions";
+import { hideToolErrorFromUser } from "../../tool-error-visibility";
+import type { RuleReadState } from "../../chat-rule-state";
+import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+
+export const updateRuleTool = ({
+  email,
+  emailAccountId,
+  provider,
+  logger,
+  getRuleReadState,
+}: {
+  email: string;
+  emailAccountId: string;
+  provider: string;
+  logger: Logger;
+  getRuleReadState?: () => RuleReadState | null;
+}) =>
+  tool({
+    description:
+      "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: only fields included in updates are changed, and omitted fields are preserved. Use updates.name to rename a rule. Use updates.enabled to enable, disable, pause, or resume a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use updates.actions to replace the full action list; when changing actions, include every action that should remain. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
+    inputSchema: z
+      .object({
+        ruleName: z.string().describe("The exact current name of the rule."),
+        updates: z
+          .object({
+            name: z
+              .string()
+              .trim()
+              .min(1)
+              .optional()
+              .describe("The new rule name, when renaming the rule."),
+            enabled: z
+              .boolean()
+              .optional()
+              .describe(
+                "Whether the rule should be enabled. Use false for pause/disable, true for enable/resume.",
+              ),
+            condition: createPatchConditionSchema().optional(),
+            actions: z
+              .array(createRuleActionSchema(provider))
+              .min(1, "Rules must have at least one action.")
+              .optional()
+              .describe(
+                "The full replacement list of actions. Include existing actions that should remain.",
+              ),
+          })
+          .refine((updates) => Object.keys(updates).length > 0, {
+            message: "At least one update field is required.",
+          }),
+      })
+      .describe("Patch update for an existing rule."),
+    execute: async ({ ruleName, updates }) => {
+      trackRuleToolCall({ tool: "update_rule", email, logger });
+      try {
+        const readValidationError = validateRuleWasReadRecently({
+          ruleName,
+          getRuleReadState,
+        });
+
+        if (readValidationError) {
+          return hideToolErrorFromUser({
+            success: false,
+            error: readValidationError,
+          });
+        }
+
+        const rule = await prisma.rule.findUnique({
+          where: { name_emailAccountId: { name: ruleName, emailAccountId } },
+          select: {
+            id: true,
+            name: true,
+            enabled: true,
+            updatedAt: true,
+            instructions: true,
+            from: true,
+            to: true,
+            subject: true,
+            conditionalOperator: true,
+            emailAccount: {
+              select: {
+                rulesRevision: true,
+              },
+            },
+            actions: {
+              select: {
+                type: true,
+                content: true,
+                label: true,
+                to: true,
+                cc: true,
+                bcc: true,
+                subject: true,
+                url: true,
+                folderName: true,
+                delayInMinutes: true,
+              },
+            },
+          },
+        });
+
+        if (!rule) {
+          return {
+            success: false,
+            error:
+              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
+          };
+        }
+
+        const staleReadError = validateRuleWasReadRecently({
+          ruleName,
+          getRuleReadState,
+          currentRulesRevision: rule.emailAccount.rulesRevision,
+          currentRuleUpdatedAt: rule.updatedAt,
+        });
+        if (staleReadError) {
+          return hideToolErrorFromUser({
+            success: false,
+            error: staleReadError,
+          });
+        }
+
+        const originalConditions = {
+          aiInstructions: rule.instructions,
+          static: filterNullProperties({
+            from: rule.from,
+            to: rule.to,
+            subject: rule.subject,
+          }),
+          conditionalOperator: rule.conditionalOperator,
+        };
+        const originalActions = rule.actions.map((action) => ({
+          type: action.type,
+          fields: filterNullProperties({
+            label: action.label,
+            content: action.content,
+            to: action.to,
+            cc: action.cc,
+            bcc: action.bcc,
+            subject: action.subject,
+            webhookUrl: action.url,
+            ...(isMicrosoftProvider(provider) && {
+              folderName: action.folderName,
+            }),
+          }),
+          delayInMinutes: action.delayInMinutes,
+        }));
+
+        if (updates.name || updates.condition) {
+          await partialUpdateRule({
+            ruleId: rule.id,
+            emailAccountId,
+            data: {
+              ...(updates.name && { name: updates.name }),
+              ...(updates.condition &&
+                buildConditionUpdateData(updates.condition)),
+            },
+          });
+        }
+
+        if (updates.actions) {
+          await updateRuleActions({
+            ruleId: rule.id,
+            actions: updates.actions.map((action) => ({
+              type: action.type,
+              fields: {
+                label: action.fields?.label ?? null,
+                to: action.fields?.to ?? null,
+                cc: action.fields?.cc ?? null,
+                bcc: action.fields?.bcc ?? null,
+                subject: action.fields?.subject ?? null,
+                content: action.fields?.content ?? null,
+                webhookUrl: action.fields?.webhookUrl ?? null,
+                ...(isMicrosoftProvider(provider) && {
+                  folderName: action.fields?.folderName ?? null,
+                }),
+              },
+              delayInMinutes: action.delayInMinutes ?? null,
+            })),
+            provider,
+            emailAccountId,
+            logger,
+          });
+        }
+
+        if (updates.enabled !== undefined && updates.enabled !== rule.enabled) {
+          await setRuleEnabled({
+            ruleId: rule.id,
+            emailAccountId,
+            enabled: updates.enabled,
+          });
+        }
+
+        return {
+          success: true,
+          ruleId: rule.id,
+          originalName: rule.name,
+          updatedName: updates.name ?? rule.name,
+          originalEnabled: rule.enabled,
+          updatedEnabled: updates.enabled ?? rule.enabled,
+          originalConditions,
+          updatedConditions: updates.condition,
+          originalActions,
+          updatedActions: updates.actions,
+        };
+      } catch (error) {
+        logger.error("Failed to update rule", { error, ruleName });
+
+        if (isDuplicateError(error, "name")) {
+          return {
+            success: false,
+            error:
+              "No rule was updated. Another rule already uses that name. Ask the user for a different name.",
+          };
+        }
+
+        return {
+          success: false,
+          error: "Failed to update rule",
+        };
+      }
+    },
+  });
+
+export type UpdateRuleTool = InferUITool<ReturnType<typeof updateRuleTool>>;
+
+export type UpdateRuleOutput = {
+  success: boolean;
+  ruleId?: string;
+  error?: string;
+  originalName?: string;
+  updatedName?: string;
+  originalEnabled?: boolean;
+  updatedEnabled?: boolean;
+  originalConditions?: {
+    aiInstructions: string | null;
+    static?: Record<string, string | null>;
+    conditionalOperator: string | null;
+  };
+  updatedConditions?: PatchCondition;
+  originalActions?: Array<{
+    type: string;
+    fields: Record<string, string | null>;
+    delayInMinutes?: number | null;
+  }>;
+  updatedActions?: RuleAction[];
+};
+
+type PatchCondition = {
+  aiInstructions?: string;
+  clearAiInstructions?: true;
+  static?: {
+    from?: string | null;
+    to?: string | null;
+    subject?: string | null;
+  } | null;
+  conditionalOperator?: LogicalOperator | null;
+};
+
+function createPatchConditionSchema() {
+  return z
+    .object({
+      aiInstructions: z
+        .string()
+        .trim()
+        .min(1)
+        .optional()
+        .describe(
+          `${AI_INSTRUCTIONS_PROMPT_DESCRIPTION} Omit this field to preserve existing instructions.`,
+        ),
+      clearAiInstructions: z
+        .literal(true)
+        .optional()
+        .describe(
+          "Set to true only when the user explicitly asks to remove the semantic AI instructions from this rule.",
+        ),
+      static: z
+        .object({
+          from: z
+            .string()
+            .transform((v) => (v?.trim() ? v : null))
+            .nullable()
+            .optional()
+            .refine((value) => !isInvalidStaticFromValue(value), {
+              message: INVALID_STATIC_FROM_MESSAGE,
+            })
+            .describe(STATIC_FROM_CONDITION_DESCRIPTION),
+          to: z.string().nullish(),
+          subject: z.string().nullish(),
+        })
+        .nullish()
+        .describe(
+          "Static condition fields to patch. Omit fields to preserve them. Set a field to null only when the user explicitly asks to clear it.",
+        ),
+      conditionalOperator: z
+        .enum([LogicalOperator.AND, LogicalOperator.OR])
+        .nullish(),
+    })
+    .describe(
+      "Condition patch. Omitted condition fields are preserved; null clears fields only when explicit.",
+    );
+}
+
+function buildConditionUpdateData(condition: PatchCondition) {
+  const data: {
+    instructions?: string | null;
+    from?: string | null;
+    to?: string | null;
+    subject?: string | null;
+    conditionalOperator?: LogicalOperator;
+  } = {};
+
+  if (condition.clearAiInstructions) {
+    data.instructions = null;
+  } else if ("aiInstructions" in condition) {
+    data.instructions = condition.aiInstructions;
+  }
+
+  if ("conditionalOperator" in condition && condition.conditionalOperator) {
+    data.conditionalOperator = condition.conditionalOperator;
+  }
+
+  if ("static" in condition) {
+    if (condition.static === null) {
+      data.from = null;
+      data.to = null;
+      data.subject = null;
+    } else if (condition.static) {
+      if ("from" in condition.static) data.from = condition.static.from ?? null;
+      if ("to" in condition.static) data.to = condition.static.to ?? null;
+      if ("subject" in condition.static) {
+        data.subject = condition.static.subject ?? null;
+      }
+    }
+  }
+
+  return data;
+}

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -156,10 +156,41 @@ export type CreateOrUpdateRuleSchema = CreateRuleSchema & {
 
 function createActionObjectSchema(type: ActionType, fields: z.ZodTypeAny) {
   return z.object({
-    type: z.literal(type),
+    type: z.literal(type).describe(getActionTypeDescription(type)),
     fields,
     delayInMinutes: delayInMinutesLlmSchema,
   });
+}
+
+function getActionTypeDescription(type: ActionType) {
+  switch (type) {
+    case ActionType.DRAFT_EMAIL:
+      return "Draft a reply to the matching inbound email without sending it. Use this for draft reply requests.";
+    case ActionType.REPLY:
+      return "Send a reply to the matching inbound email. Do not use this for draft reply requests.";
+    case ActionType.SEND_EMAIL:
+      return "Send a new outbound email. Do not use this for draft reply requests.";
+    case ActionType.FORWARD:
+      return "Forward the matching email.";
+    case ActionType.LABEL:
+      return "Apply a label to the matching email.";
+    case ActionType.ARCHIVE:
+      return "Archive the matching email.";
+    case ActionType.MARK_READ:
+      return "Mark the matching email as read.";
+    case ActionType.STAR:
+      return "Star the matching email.";
+    case ActionType.MARK_SPAM:
+      return "Mark the matching email as spam.";
+    case ActionType.DIGEST:
+      return "Include the matching email in a digest.";
+    case ActionType.CALL_WEBHOOK:
+      return "Call a webhook for the matching email.";
+    case ActionType.MOVE_FOLDER:
+      return "Move the matching email to a folder.";
+    default:
+      return "Action type to apply to the matching email.";
+  }
 }
 
 function createOptionalActionFieldsSchema(provider: string) {


### PR DESCRIPTION
Fixes assistant rule renames so existing rules are updated instead of replaced with new rules.

- Adds a dedicated rule rename tool with stale-state validation and duplicate-name handling.
- Wires chat UI rendering/types for rename tool results.
- Adds unit and AI eval coverage for rename behavior.