### PR TITLE
bulk unsubscribe: Fix sender display names

### DIFF
--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -98,7 +98,7 @@ async function getEmailMessages(
         email: from,
         fromName: email.fromName,
         minFromName: email.minFromName,
-        maxFromName: email.maxFromName,
+        maxFromName: email.fromName,
       }),
       value: email.count,
       inboxEmails: email.inboxEmails,
@@ -124,7 +124,6 @@ type NewsletterCountResult = {
   from: string;
   fromName: string | null;
   minFromName: string | null;
-  maxFromName: string | null;
   count: number;
   inboxEmails: number;
   readEmails: number;
@@ -135,7 +134,6 @@ type NewsletterCountRawResult = {
   from: string;
   fromName: string | null;
   minFromName: string | null;
-  maxFromName: string | null;
   count: number;
   inboxEmails: number;
   readEmails: number;
@@ -221,7 +219,6 @@ async function getNewsletterCounts(
         "from",
         MAX(NULLIF("fromName", '')) as "fromName",
         MIN(NULLIF("fromName", '')) as "minFromName",
-        MAX(NULLIF("fromName", '')) as "maxFromName",
         COUNT(*)::int as "count",
         SUM(CASE WHEN inbox = true THEN 1 ELSE 0 END)::int as "inboxEmails",
         SUM(CASE WHEN read = true THEN 1 ELSE 0 END)::int as "readEmails",
@@ -243,7 +240,6 @@ async function getNewsletterCounts(
       from: result.from,
       fromName: result.fromName,
       minFromName: result.minFromName,
-      maxFromName: result.maxFromName,
       count: result.count,
       inboxEmails: result.inboxEmails,
       readEmails: result.readEmails,

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withEmailProvider } from "@/utils/middleware";
-import { extractEmailAddress } from "@/utils/email";
+import {
+  extractEmailAddress,
+  getNewsletterSenderDisplayName,
+} from "@/utils/email";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { Prisma } from "@/generated/prisma/client";
@@ -91,7 +94,12 @@ async function getEmailMessages(
     const from = extractEmailAddress(email.from);
     return {
       name: from,
-      fromName: email.fromName || "",
+      fromName: getNewsletterSenderDisplayName({
+        email: from,
+        fromName: email.fromName,
+        minFromName: email.minFromName,
+        maxFromName: email.maxFromName,
+      }),
       value: email.count,
       inboxEmails: email.inboxEmails,
       readEmails: email.readEmails,
@@ -115,6 +123,8 @@ async function getEmailMessages(
 type NewsletterCountResult = {
   from: string;
   fromName: string | null;
+  minFromName: string | null;
+  maxFromName: string | null;
   count: number;
   inboxEmails: number;
   readEmails: number;
@@ -124,6 +134,8 @@ type NewsletterCountResult = {
 type NewsletterCountRawResult = {
   from: string;
   fromName: string | null;
+  minFromName: string | null;
+  maxFromName: string | null;
   count: number;
   inboxEmails: number;
   readEmails: number;
@@ -207,7 +219,9 @@ async function getNewsletterCounts(
     WITH email_message_stats AS (
       SELECT 
         "from",
-        MAX("fromName") as "fromName",
+        MAX(NULLIF("fromName", '')) as "fromName",
+        MIN(NULLIF("fromName", '')) as "minFromName",
+        MAX(NULLIF("fromName", '')) as "maxFromName",
         COUNT(*)::int as "count",
         SUM(CASE WHEN inbox = true THEN 1 ELSE 0 END)::int as "inboxEmails",
         SUM(CASE WHEN read = true THEN 1 ELSE 0 END)::int as "readEmails",
@@ -228,6 +242,8 @@ async function getNewsletterCounts(
     return results.map((result) => ({
       from: result.from,
       fromName: result.fromName,
+      minFromName: result.minFromName,
+      maxFromName: result.maxFromName,
       count: result.count,
       inboxEmails: result.inboxEmails,
       readEmails: result.readEmails,

--- a/apps/web/utils/email.test.ts
+++ b/apps/web/utils/email.test.ts
@@ -9,6 +9,7 @@ import {
   participant,
   normalizeEmailAddress,
   formatEmailWithName,
+  getNewsletterSenderDisplayName,
 } from "./email";
 
 describe("email utils", () => {
@@ -532,6 +533,68 @@ describe("email utils", () => {
       expect(formatEmailWithName("Support", "support+tag@example.com")).toBe(
         "Support <support+tag@example.com>",
       );
+    });
+  });
+
+  describe("getNewsletterSenderDisplayName", () => {
+    it("keeps normal sender display names", () => {
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "updates@example.com",
+          fromName: "Example Updates",
+          minFromName: "Example Updates",
+          maxFromName: "Example Updates",
+        }),
+      ).toBe("Example Updates");
+    });
+
+    it("uses the sender domain when one address has multiple display names", () => {
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "notifications@github.com",
+          fromName: "Some Person",
+          minFromName: "Another Person",
+          maxFromName: "Some Person",
+        }),
+      ).toBe("github.com");
+
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "invitations@linkedin.com",
+          fromName: "Some Person",
+          minFromName: "Another Person",
+          maxFromName: "Some Person",
+        }),
+      ).toBe("linkedin.com");
+
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "messaging-digest-noreply@linkedin.com",
+          fromName: "Some Person via LinkedIn",
+          minFromName: "Another Person via LinkedIn",
+          maxFromName: "Some Person via LinkedIn",
+        }),
+      ).toBe("linkedin.com");
+    });
+
+    it("keeps the selected display name when min and max names match", () => {
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "notifications@example.com",
+          fromName: "Example",
+          minFromName: "Example",
+          maxFromName: "Example",
+        }),
+      ).toBe("Example");
+    });
+
+    it("falls back to an empty display name when no name is available", () => {
+      expect(
+        getNewsletterSenderDisplayName({
+          email: "updates@example.com",
+          fromName: null,
+        }),
+      ).toBe("");
     });
   });
 });

--- a/apps/web/utils/email.ts
+++ b/apps/web/utils/email.ts
@@ -154,6 +154,26 @@ export function formatEmailWithName(
   return `${name} <${address}>`;
 }
 
+export function getNewsletterSenderDisplayName({
+  email,
+  fromName,
+  minFromName,
+  maxFromName,
+}: {
+  email: string;
+  fromName?: string | null;
+  minFromName?: string | null;
+  maxFromName?: string | null;
+}) {
+  const hasMultipleDisplayNames =
+    !!minFromName && !!maxFromName && minFromName !== maxFromName;
+  const domain = extractDomainFromEmail(email);
+
+  if (hasMultipleDisplayNames && domain) return domain;
+
+  return fromName?.trim() || "";
+}
+
 // Public email providers where we should search by full email address
 // For company domains, we search by domain to catch emails from different people at same company
 export const PUBLIC_EMAIL_DOMAINS = new Set([


### PR DESCRIPTION
Updates sender display names so grouped sender rows use the sender domain when one sender address has multiple display names.

- Adds generic display-name normalization for newsletter sender rows.
- Extends the newsletter stats query with min/max display-name aggregates.
- Adds focused unit coverage for stable and unstable display names.