### PR TITLE
gmail: Fix email watch setup edge case

### DIFF
--- a/apps/web/utils/gmail/retry.test.ts
+++ b/apps/web/utils/gmail/retry.test.ts
@@ -139,6 +139,21 @@ describe("Gmail retry helpers", () => {
       expect(result.isServerError).toBe(false);
       expect(result.isFailedPrecondition).toBe(true);
     });
+
+    it("should not retry duplicate Gmail push client errors", () => {
+      const errorInfo = {
+        status: 400,
+        reason: "failedPrecondition",
+        errorMessage:
+          "Only one user push notification client allowed per developer (call /stop then try again)",
+      };
+      const result = isRetryableError(errorInfo);
+
+      expect(result.retryable).toBe(false);
+      expect(result.isRateLimit).toBe(false);
+      expect(result.isServerError).toBe(false);
+      expect(result.isFailedPrecondition).toBe(false);
+    });
   });
 
   describe("calculateRetryDelay", () => {

--- a/apps/web/utils/gmail/retry.ts
+++ b/apps/web/utils/gmail/retry.ts
@@ -152,6 +152,7 @@ export function isRetryableError(errorInfo: ErrorInfo): {
   isFailedPrecondition: boolean;
 } {
   const { status, reason, errorMessage, googleErrorStatus } = errorInfo;
+  const hasExistingPushClient = isExistingGmailPushClientError(errorInfo);
 
   // Broad rate-limit detection: 429, 403 + known reasons, or well-known messages
   const isRateLimit =
@@ -178,6 +179,7 @@ export function isRetryableError(errorInfo: ErrorInfo): {
     );
 
   const isFailedPrecondition =
+    !hasExistingPushClient &&
     status === 400 &&
     (String(reason).toLowerCase() === "failedprecondition" ||
       /precondition check failed/i.test(errorMessage));
@@ -192,6 +194,18 @@ export function isRetryableError(errorInfo: ErrorInfo): {
     isServerError,
     isFailedPrecondition,
   };
+}
+
+export function isExistingGmailPushClientError(errorInfo: {
+  errorMessage: string;
+  status?: number;
+}): boolean {
+  return (
+    errorInfo.status === 400 &&
+    /only one user push notification client allowed per developer/i.test(
+      errorInfo.errorMessage,
+    )
+  );
 }
 
 /**

--- a/apps/web/utils/gmail/watch.test.ts
+++ b/apps/web/utils/gmail/watch.test.ts
@@ -14,9 +14,14 @@ vi.mock("@/env", () => ({
   env: envMock,
 }));
 
-vi.mock("@/utils/gmail/retry", () => ({
-  withGmailRetry: (...args: unknown[]) => withGmailRetryMock(...args),
-}));
+vi.mock("@/utils/gmail/retry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/gmail/retry")>();
+
+  return {
+    ...actual,
+    withGmailRetry: (...args: unknown[]) => withGmailRetryMock(...args),
+  };
+});
 
 import { watchGmail } from "./watch";
 
@@ -47,11 +52,13 @@ describe("watchGmail", () => {
   });
 
   it("registers the watch when the verification token is configured", async () => {
+    const stopMock = vi.fn().mockResolvedValue({});
     const watchMock = vi.fn().mockResolvedValue({
       data: { expiration: "123" },
     });
     const gmail = {
       users: {
+        stop: stopMock,
         watch: watchMock,
       },
     } as any;
@@ -61,6 +68,7 @@ describe("watchGmail", () => {
     });
 
     expect(withGmailRetryMock).toHaveBeenCalledTimes(1);
+    expect(stopMock).not.toHaveBeenCalled();
     expect(watchMock).toHaveBeenCalledWith({
       userId: "me",
       requestBody: {
@@ -73,11 +81,13 @@ describe("watchGmail", () => {
 
   it("allows intentionally-empty verification tokens", async () => {
     envMock.GOOGLE_PUBSUB_VERIFICATION_TOKEN = "";
+    const stopMock = vi.fn().mockResolvedValue({});
     const watchMock = vi.fn().mockResolvedValue({
       data: { expiration: "123" },
     });
     const gmail = {
       users: {
+        stop: stopMock,
         watch: watchMock,
       },
     } as any;
@@ -87,6 +97,43 @@ describe("watchGmail", () => {
     });
 
     expect(withGmailRetryMock).toHaveBeenCalledTimes(1);
+    expect(stopMock).not.toHaveBeenCalled();
     expect(watchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the existing Gmail watch and retries when another push client blocks setup", async () => {
+    const duplicatePushClientError = Object.assign(
+      new Error(
+        "Only one user push notification client allowed per developer (call /stop then try again)",
+      ),
+      { status: 400 },
+    );
+    const stopMock = vi.fn().mockResolvedValue({});
+    const watchMock = vi
+      .fn()
+      .mockRejectedValueOnce(duplicatePushClientError)
+      .mockResolvedValueOnce({
+        data: { expiration: "123" },
+      });
+    const gmail = {
+      users: {
+        stop: stopMock,
+        watch: watchMock,
+      },
+    } as any;
+
+    await expect(watchGmail(gmail)).resolves.toEqual({
+      expiration: "123",
+    });
+
+    expect(withGmailRetryMock).toHaveBeenCalledTimes(3);
+    expect(stopMock).toHaveBeenCalledWith({ userId: "me" });
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(watchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      stopMock.mock.invocationCallOrder[0],
+    );
+    expect(stopMock.mock.invocationCallOrder[0]).toBeLessThan(
+      watchMock.mock.invocationCallOrder[1],
+    );
   });
 });

--- a/apps/web/utils/gmail/watch.ts
+++ b/apps/web/utils/gmail/watch.ts
@@ -1,7 +1,11 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import { GmailLabel } from "./label";
 import { env } from "@/env";
-import { withGmailRetry } from "@/utils/gmail/retry";
+import {
+  extractErrorInfo,
+  isExistingGmailPushClientError,
+  withGmailRetry,
+} from "@/utils/gmail/retry";
 
 export async function watchGmail(gmail: gmail_v1.Gmail) {
   if (env.GOOGLE_PUBSUB_VERIFICATION_TOKEN == null) {
@@ -10,6 +14,21 @@ export async function watchGmail(gmail: gmail_v1.Gmail) {
     );
   }
 
+  try {
+    return await startGmailWatch(gmail);
+  } catch (error) {
+    if (!isExistingGmailPushClientError(extractErrorInfo(error))) throw error;
+
+    await unwatchGmail(gmail);
+    return await startGmailWatch(gmail);
+  }
+}
+
+export async function unwatchGmail(gmail: gmail_v1.Gmail) {
+  await withGmailRetry(() => gmail.users.stop({ userId: "me" }));
+}
+
+async function startGmailWatch(gmail: gmail_v1.Gmail) {
   const res = await withGmailRetry(() =>
     gmail.users.watch({
       userId: "me",
@@ -22,8 +41,4 @@ export async function watchGmail(gmail: gmail_v1.Gmail) {
   );
 
   return res.data;
-}
-
-export async function unwatchGmail(gmail: gmail_v1.Gmail) {
-  await withGmailRetry(() => gmail.users.stop({ userId: "me" }));
 }


### PR DESCRIPTION
Retries Gmail watch setup once by stopping an existing push client only when that provider error occurs.

- Keeps ordinary watch renewals on the existing path.
- Treats the duplicate push-client response as non-retryable in the generic retry helper.
- Adds focused unit coverage for watch recovery and retry classification.

Tests: cd apps/web && pnpm test --run utils/gmail/watch.test.ts utils/gmail/retry.test.ts