### PR TITLE
tabs: Sync archived label rules

### DIFF
--- a/apps/web/utils/rule/mapRulesToExtensionTabs.test.ts
+++ b/apps/web/utils/rule/mapRulesToExtensionTabs.test.ts
@@ -98,7 +98,7 @@ describe("mapRulesToExtensionTabs", () => {
     ]);
   });
 
-  it("skips labels for archived rules", () => {
+  it("syncs archived label rules with label-only queries", () => {
     const rules = [
       getRule("archive newsletters", [
         getAction({ label: "Newsletter" }),
@@ -108,6 +108,13 @@ describe("mapRulesToExtensionTabs", () => {
     ];
 
     expect(mapRulesToExtensionTabs(rules)).toEqual([
+      {
+        type: "add_custom",
+        label: "Newsletter",
+        icon: "🏷️",
+        query: "label:newsletter",
+        displayLabel: "Newsletter",
+      },
       {
         type: "enable_default",
         tabId: "github",

--- a/apps/web/utils/rule/mapRulesToExtensionTabs.ts
+++ b/apps/web/utils/rule/mapRulesToExtensionTabs.ts
@@ -49,9 +49,10 @@ export function mapRulesToExtensionTabs(rules: RulesResponse): SyncTab[] {
 
   for (const rule of rules) {
     if (!rule.enabled) continue;
-    if (rule.actions.some((action) => action.type === ActionType.ARCHIVE))
-      continue;
 
+    const archivesMessages = rule.actions.some(
+      (action) => action.type === ActionType.ARCHIVE,
+    );
     for (const action of rule.actions) {
       if (action.type !== ActionType.LABEL || !action.label) continue;
 
@@ -65,18 +66,19 @@ export function mapRulesToExtensionTabs(rules: RulesResponse): SyncTab[] {
       if (seenLabels.has(dedupeKey)) continue;
       seenLabels.add(dedupeKey);
 
-      if (defaultTab) {
+      if (defaultTab && !archivesMessages) {
         tabs.push({
           type: "enable_default",
           tabId: defaultTab.tabId,
           displayLabel: defaultTab.label,
         });
       } else {
+        const queryPrefix = archivesMessages ? "" : "in:inbox ";
         tabs.push({
           type: "add_custom",
           label,
           icon: "🏷️",
-          query: `in:inbox label:${labelToGmailSlug(label)}`,
+          query: `${queryPrefix}label:${labelToGmailSlug(label)}`,
           displayLabel: label,
         });
       }


### PR DESCRIPTION
Updates tab sync so enabled label rules that also archive messages are still available as custom tabs. Archived label rules now use label-only queries so the synced tabs can find messages outside the inbox. Adds a focused unit test for the archived label-rule mapping.