### PR TITLE
stats: Harden query parameterization

### DIFF
--- a/apps/web/app/api/user/stats/by-period/controller.test.ts
+++ b/apps/web/app/api/user/stats/by-period/controller.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/prisma";
+import { getStatsByPeriod } from "./controller";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+describe("getStatsByPeriod", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+  });
+
+  it("passes the period as a query parameter", async () => {
+    await getStatsByPeriod({
+      emailAccountId: "email-account-1",
+      period: "month",
+    });
+
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+
+    const queryArgs = vi.mocked(prisma.$queryRaw).mock.calls[0];
+
+    expect(queryArgs).toContain("month");
+    expect(JSON.stringify(queryArgs)).not.toContain("'month'");
+  });
+});

--- a/apps/web/app/api/user/stats/by-period/controller.test.ts
+++ b/apps/web/app/api/user/stats/by-period/controller.test.ts
@@ -10,17 +10,24 @@ describe("getStatsByPeriod", () => {
     vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
   });
 
-  it("passes the period as a query parameter", async () => {
+  it("keeps the period out of raw SQL if validation is bypassed", async () => {
+    const maliciousPeriod = 'month\'); DROP TABLE "EmailMessage"; --';
+
     await getStatsByPeriod({
       emailAccountId: "email-account-1",
-      period: "month",
+      period: maliciousPeriod as never,
     });
 
     expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
 
     const queryArgs = vi.mocked(prisma.$queryRaw).mock.calls[0];
+    const [queryStrings, ...queryValues] = queryArgs as [
+      readonly string[],
+      ...unknown[],
+    ];
+    const rawSqlText = queryStrings.join("");
 
-    expect(queryArgs).toContain("month");
-    expect(JSON.stringify(queryArgs)).not.toContain("'month'");
+    expect(rawSqlText).not.toContain(maliciousPeriod);
+    expect(queryValues).toContain(maliciousPeriod);
   });
 });

--- a/apps/web/app/api/user/stats/by-period/controller.ts
+++ b/apps/web/app/api/user/stats/by-period/controller.ts
@@ -40,10 +40,9 @@ async function getEmailStatsByPeriod(
       ? Prisma.sql` AND ${Prisma.join(dateConditions, " AND ")}`
       : Prisma.sql``;
 
-  // Convert period and dateFormat to string literals in PostgreSQL
   return prisma.$queryRaw<StatsResult[]>`
     SELECT
-      DATE_TRUNC(${Prisma.raw(`'${period}'`)}, date) AS "startOfPeriod",
+      DATE_TRUNC(${period}, date) AS "startOfPeriod",
       COUNT(*) AS "totalCount",
       SUM(CASE WHEN inbox = true THEN 1 ELSE 0 END) AS "inboxCount",
       SUM(CASE WHEN inbox = false THEN 1 ELSE 0 END) AS "notInbox",


### PR DESCRIPTION
Parameterizes the period value in the stats aggregation query instead of embedding it through raw SQL. Adds a focused unit test that verifies the period is passed as a query parameter.\n\nValidation: pnpm test --run app/api/user/stats/by-period/controller.test.ts; pnpm exec biome check app/api/user/stats/by-period/controller.ts app/api/user/stats/by-period/controller.test.ts; git diff --check.