### PR TITLE
tests: Add OAuth callback state coverage

### DIFF
--- a/apps/web/app/api/mcp/[integration]/callback/route.test.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.test.ts
@@ -124,6 +124,34 @@ describe("mcp callback route", () => {
     expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
   });
 
+  it("rejects a signed callback state that does not match the browser state cookie", async () => {
+    const attackerState = generateSignedOAuthState({
+      userId: "attacker-user",
+      emailAccountId: "attacker-email-account",
+      type: "notion-mcp",
+    });
+    const victimState = generateSignedOAuthState({
+      userId: "victim-user",
+      emailAccountId: "victim-email-account",
+      type: "notion-mcp",
+    });
+
+    const response = await GET(
+      createRequest({
+        queryState: attackerState,
+        cookieState: victimState,
+      }),
+      params,
+    );
+
+    const location = response.headers.get("location");
+    expect(location).toContain("/integrations");
+    expect(location).toContain("error=invalid_state");
+    expect(prisma.emailAccount.findFirst).not.toHaveBeenCalled();
+    expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    expect(mockSyncMcpTools).not.toHaveBeenCalled();
+  });
+
   it("accepts a matching signed state and continues the OAuth flow", async () => {
     const state = generateSignedOAuthState({
       userId: "user-123",

--- a/apps/web/app/api/slack/callback/route.test.ts
+++ b/apps/web/app/api/slack/callback/route.test.ts
@@ -190,6 +190,28 @@ describe("slack callback route", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects a signed callback state that does not match the browser state cookie", async () => {
+    const attackerState = createSignedState("attacker-account");
+    const victimState = createSignedState("victim-account");
+
+    const response = await GET(
+      createRequest(
+        `http://localhost:3000/api/slack/callback?code=valid-auth-code&state=${encodeURIComponent(attackerState)}`,
+        victimState,
+      ),
+    );
+
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.pathname).toBe("/channels");
+    expect(location.searchParams.get("error")).toBe("connection_failed");
+    expect(location.searchParams.get("error_reason")).toBe("invalid_state");
+    expect(mockGetOAuthCodeResult).not.toHaveBeenCalled();
+    expect(mockAcquireOAuthCodeLock).not.toHaveBeenCalled();
+    expect(prisma.messagingChannel.upsert).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("redirects Slack OAuth failures back to the account channels page", async () => {
     const state = createSignedState("account-789");
 


### PR DESCRIPTION
Adds regression coverage for OAuth callbacks when the signed URL state does not match the browser state cookie.

- Covers MCP callback handling before account lookup, token exchange, or sync.
- Covers Slack callback handling before lock acquisition, token exchange, or database writes.