### PR TITLE
auth: Add SSO integration coverage

### DIFF
--- a/apps/web/__tests__/integration/sso-okta.test.ts
+++ b/apps/web/__tests__/integration/sso-okta.test.ts
@@ -1,0 +1,190 @@
+import { createEmulator, type Emulator } from "emulate";
+import { NextRequest } from "next/server";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { discoverOIDCConfig, type OIDCConfig } from "@better-auth/sso";
+import prisma from "@/utils/__mocks__/prisma";
+import { GET } from "@/app/api/sso/signin/route";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@inboxzero/loops", () => ({
+  createContact: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/resend", () => ({
+  createContact: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/tinybird", () => ({
+  publishArchive: vi.fn().mockResolvedValue(undefined),
+  publishDelete: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/tinybird-ai-analytics", () => ({
+  publishAiCall: vi.fn().mockResolvedValue(undefined),
+}));
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
+const TEST_PORT = 4121;
+const PROVIDER_ID = "okta-provider";
+const ORGANIZATION_SLUG = "okta-test-org";
+const ORGANIZATION_ID = "org_okta_test";
+const USER_EMAIL = "user@example.com";
+const CLIENT_ID = "okta-sso-client";
+const CLIENT_SECRET = "okta-sso-secret";
+const CALLBACK_URL =
+  "http://localhost:3000/api/auth/sso/callback/okta-provider";
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "Okta SSO integration",
+  { timeout: 30_000 },
+  () => {
+    let emulator: Emulator;
+    let oidcConfig: OIDCConfig;
+
+    beforeAll(async () => {
+      emulator = await createEmulator({
+        service: "okta",
+        port: TEST_PORT,
+        seed: {
+          okta: {
+            users: [
+              {
+                okta_id: "00u_okta_user_1",
+                login: USER_EMAIL,
+                email: USER_EMAIL,
+                first_name: "Test",
+                last_name: "User",
+              },
+            ],
+            authorization_servers: [
+              {
+                id: "default",
+                name: "default",
+                audiences: ["api://default"],
+              },
+            ],
+            oauth_clients: [
+              {
+                client_id: CLIENT_ID,
+                client_secret: CLIENT_SECRET,
+                name: "Inbox Zero SSO",
+                redirect_uris: [CALLBACK_URL],
+                auth_server_id: "default",
+                token_endpoint_auth_method: "client_secret_post",
+              },
+            ],
+          },
+        },
+      });
+
+      const issuer = `${emulator.url}/oauth2/default`;
+      const discoveredConfig = await discoverOIDCConfig({
+        issuer,
+        isTrustedOrigin: (url) => url.startsWith(emulator.url),
+      });
+
+      oidcConfig = {
+        ...discoveredConfig,
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        pkce: true,
+        scopes: ["openid", "email", "profile"],
+        mapping: {
+          id: "sub",
+          email: "email",
+          emailVerified: "email_verified",
+          name: "name",
+        },
+      };
+    });
+
+    afterAll(async () => {
+      await emulator?.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      prisma.ssoProvider.findFirst.mockImplementation(async (args) => {
+        const where = args?.where as
+          | {
+              organization?: { slug?: string };
+              providerId?: { equals?: string } | string;
+            }
+          | undefined;
+
+        if (where?.organization?.slug === ORGANIZATION_SLUG) {
+          return { providerId: PROVIDER_ID } as never;
+        }
+
+        const providerId =
+          typeof where?.providerId === "string"
+            ? where.providerId
+            : where?.providerId?.equals;
+
+        if (providerId === PROVIDER_ID) {
+          return {
+            id: "sso_provider_1",
+            issuer: oidcConfig.issuer,
+            oidcConfig: JSON.stringify(oidcConfig),
+            samlConfig: null,
+            providerId: PROVIDER_ID,
+            organizationId: ORGANIZATION_ID,
+            domain: "example.com",
+          } as never;
+        }
+
+        return null;
+      });
+
+      prisma.verificationToken.create.mockImplementation(
+        async ({ data }) => data as never,
+      );
+    });
+
+    test("starts SSO with an Okta OIDC provider", async () => {
+      const request = new NextRequest(
+        `http://localhost/api/sso/signin?${new URLSearchParams({
+          email: USER_EMAIL,
+          organizationSlug: ORGANIZATION_SLUG,
+        })}`,
+      );
+
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.providerId).toBe(PROVIDER_ID);
+
+      const redirectUrl = new URL(body.redirectUrl);
+      expect(redirectUrl.origin).toBe(emulator.url);
+      expect(redirectUrl.pathname).toBe("/oauth2/default/v1/authorize");
+      expect(redirectUrl.searchParams.get("client_id")).toBe(CLIENT_ID);
+      expect(redirectUrl.searchParams.get("redirect_uri")).toBe(CALLBACK_URL);
+      expect(redirectUrl.searchParams.get("response_type")).toBe("code");
+      expect(redirectUrl.searchParams.get("login_hint")).toBe(USER_EMAIL);
+      expect(redirectUrl.searchParams.get("scope")?.split(" ")).toEqual([
+        "openid",
+        "email",
+        "profile",
+      ]);
+      expect(redirectUrl.searchParams.get("code_challenge")).toBeTruthy();
+      expect(redirectUrl.searchParams.get("code_challenge_method")).toBe(
+        "S256",
+      );
+
+      const oktaResponse = await fetch(body.redirectUrl);
+      const oktaHtml = await oktaResponse.text();
+
+      expect(oktaResponse.status).toBe(200);
+      expect(oktaHtml).toContain("Sign in with Okta");
+      expect(oktaHtml).toContain(USER_EMAIL);
+    });
+  },
+);

--- a/apps/web/app/api/sso/signin/route.test.ts
+++ b/apps/web/app/api/sso/signin/route.test.ts
@@ -1,5 +1,18 @@
 // Mock server-only as per testing guidelines
 vi.mock("server-only", () => ({}));
+vi.mock("@inboxzero/loops", () => ({
+  createContact: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/resend", () => ({
+  createContact: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/tinybird", () => ({
+  publishArchive: vi.fn().mockResolvedValue(undefined),
+  publishDelete: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@inboxzero/tinybird-ai-analytics", () => ({
+  publishAiCall: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Mock the auth config
 vi.mock("@/utils/auth", () => ({
@@ -112,6 +125,8 @@ describe("SSO Signin Route", () => {
         body: {
           providerId: "test-provider-id",
           callbackURL: "/accounts",
+          email: "user@example.com",
+          loginHint: "user@example.com",
         },
       });
 
@@ -281,6 +296,8 @@ describe("SSO Signin Route", () => {
         body: {
           providerId: "test-provider",
           callbackURL: "/accounts",
+          email: "user@example.com",
+          loginHint: "user@example.com",
         },
       });
     });

--- a/apps/web/app/api/sso/signin/route.ts
+++ b/apps/web/app/api/sso/signin/route.ts
@@ -47,6 +47,8 @@ export const GET = withError("sso/signin", async (request) => {
     body: {
       providerId: provider.providerId,
       callbackURL: "/accounts",
+      email,
+      loginHint: email,
     },
   });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -224,7 +224,7 @@
     "cross-env": "10.1.0",
     "dotenv": "17.4.2",
     "dotenv-cli": "11.0.0",
-    "emulate": "npm:@inbox-zero/emulate@0.4.5",
+    "emulate": "npm:@inbox-zero/emulate@0.5.0",
     "jsdom": "27.3.0",
     "postcss": "8.5.6",
     "serwist": "9.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
 
   apps/web:
     dependencies:
@@ -665,8 +665,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       emulate:
-        specifier: npm:@inbox-zero/emulate@0.4.5
-        version: '@inbox-zero/emulate@0.4.5(hono@4.12.10)'
+        specifier: npm:@inbox-zero/emulate@0.5.0
+        version: '@inbox-zero/emulate@0.5.0(hono@4.12.10)'
       jsdom:
         specifier: 27.3.0
         version: 27.3.0
@@ -737,7 +737,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/cli:
     dependencies:
@@ -756,7 +756,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/image-proxy:
     dependencies:
@@ -775,7 +775,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/loops:
     dependencies:
@@ -3094,8 +3094,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -3267,8 +3267,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inbox-zero/emulate@0.4.5':
-    resolution: {integrity: sha512-xd6HANmTYlx32wDGf6GI3DztfdsHC8zzwrtJtXeET7WDe1vfHOhTiyKrZl2BYh5nS71PTihqXx5nE+sYLu55qA==}
+  '@inbox-zero/emulate@0.5.0':
+    resolution: {integrity: sha512-9yziFx3e6WSmaHebTveEj0Jcgz2CKPD4n9M7AqSUaXDuv7pTuWgAnYssL/ozRdJTufy1/d3NZUe9ZR9Iez34GA==}
     hasBin: true
 
   '@inquirer/ansi@1.0.2':
@@ -13099,6 +13099,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -15376,7 +15381,7 @@ snapshots:
     dependencies:
       hono: 4.12.10
 
-  '@hono/node-server@1.19.9(hono@4.12.10)':
+  '@hono/node-server@1.19.14(hono@4.12.10)':
     dependencies:
       hono: 4.12.10
 
@@ -15491,12 +15496,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inbox-zero/emulate@0.4.5(hono@4.12.10)':
+  '@inbox-zero/emulate@0.5.0(hono@4.12.10)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.10)
+      '@hono/node-server': 1.19.14(hono@4.12.10)
       commander: 14.0.3
       picocolors: 1.1.1
-      yaml: 2.8.3
+      yaml: 2.8.4
     transitivePeerDependencies:
       - hono
 
@@ -19967,7 +19972,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -19985,6 +19990,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -20013,7 +20026,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.3.0)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -26853,6 +26866,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.50.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.4
+
   vitest-mock-extended@4.0.0(typescript@6.0.3)(vitest@4.1.4):
     dependencies:
       ts-essentials: 10.1.1(typescript@6.0.3)
@@ -26890,10 +26919,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -26910,7 +26939,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -27182,6 +27211,8 @@ snapshots:
   yaml@2.8.2: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.8.4: {}
 
   yn@3.1.1:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
 - "@inboxzero/*"
+- "@inbox-zero/emulate"
 
 # pnpm 10 blocks install scripts by default. Only packages listed here may run them.
 onlyBuiltDependencies:


### PR DESCRIPTION
Updates the emulator dependency and adds integration coverage for enterprise SSO provider redirects. The sign-in route now forwards the user email as a login hint when starting SSO, and the test verifies the provider authorization page accepts the generated redirect. Includes the package release-age exclusion needed for the requested emulator version.