### PR TITLE
webhook: Use ORM history lookup

### DIFF
--- a/apps/web/utils/webhook/validate-webhook-account.test.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.test.ts
@@ -401,22 +401,28 @@ describe("getWebhookEmailAccount", () => {
       email: "user@example.com",
       watchEmailsSubscriptionId: "new-subscription-id",
     };
+    const historicalSubscriptionId = `old-sub-id' OR 1=1 --`;
 
-    vi.mocked(prisma.emailAccount.findFirst).mockResolvedValue(null);
-    vi.mocked(prisma.$queryRaw).mockResolvedValue([
-      { id: "resolved-account-id" },
-    ]);
-    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue(
-      historicalAccount as any,
-    );
+    vi.mocked(prisma.emailAccount.findFirst)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(historicalAccount as any);
 
     const result = await getWebhookEmailAccount(
-      { watchEmailsSubscriptionId: "old-rotated-sub-id" },
+      { watchEmailsSubscriptionId: historicalSubscriptionId },
       logger,
     );
 
     expect(result).toEqual(historicalAccount);
-    expect(prisma.$queryRaw).toHaveBeenCalled();
+    expect(prisma.emailAccount.findFirst).toHaveBeenNthCalledWith(2, {
+      where: {
+        watchEmailsSubscriptionHistory: {
+          array_contains: [{ subscriptionId: historicalSubscriptionId }],
+        },
+      },
+      select: expect.any(Object),
+    });
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
     expect(logErrorWithDedupe).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -92,27 +92,23 @@ export async function getWebhookEmailAccount(
         subscriptionId: where.watchEmailsSubscriptionId,
       });
 
-      const [foundAccount] = await prisma.$queryRaw<Array<{ id: string }>>`
-        SELECT id FROM "EmailAccount"
-        WHERE "watchEmailsSubscriptionHistory" @> ${JSON.stringify([
-          { subscriptionId: where.watchEmailsSubscriptionId },
-        ])}::jsonb
-        LIMIT 1
-      `;
+      emailAccount = await prisma.emailAccount.findFirst({
+        where: {
+          watchEmailsSubscriptionHistory: {
+            array_contains: [
+              { subscriptionId: where.watchEmailsSubscriptionId },
+            ],
+          },
+        },
+        select: webhookEmailAccountSelect,
+      });
 
-      if (foundAccount) {
-        emailAccount = await prisma.emailAccount.findUnique({
-          where: { id: foundAccount.id },
-          select: webhookEmailAccountSelect,
+      if (emailAccount) {
+        logger.info("Found account by historical subscription ID", {
+          subscriptionId: where.watchEmailsSubscriptionId,
+          email: emailAccount.email,
+          currentSubscriptionId: emailAccount.watchEmailsSubscriptionId,
         });
-
-        if (emailAccount) {
-          logger.info("Found account by historical subscription ID", {
-            subscriptionId: where.watchEmailsSubscriptionId,
-            email: emailAccount.email,
-            currentSubscriptionId: emailAccount.watchEmailsSubscriptionId,
-          });
-        }
       }
     }
   }


### PR DESCRIPTION
Replace the historical account lookup fallback with the ORM JSON filter instead of raw SQL. Add regression coverage for SQL-shaped subscription input and verify the raw query path is not used. Validation: `cd apps/web && pnpm test --run utils/webhook/validate-webhook-account.test.ts`; `cd apps/web && pnpm exec biome check utils/webhook/validate-webhook-account.ts utils/webhook/validate-webhook-account.test.ts`. Performance: hot current-subscription lookup is unchanged; historical fallback remains indexed and removes one database round trip on matches.