### PR TITLE
feat: add progress indicators to deep clean feature

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/clean/ConfirmationStep.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/ConfirmationStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
@@ -10,7 +11,7 @@ import { cleanInboxAction } from "@/utils/actions/clean";
 import { toastError } from "@/components/Toast";
 import { CleanAction } from "@/generated/prisma/enums";
 import { PREVIEW_RUN_COUNT } from "@/app/(app)/[emailAccountId]/clean/consts";
-import { HistoryIcon, SettingsIcon } from "lucide-react";
+import { HistoryIcon, Loader2Icon, SettingsIcon } from "lucide-react";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
 
@@ -37,8 +38,11 @@ export function ConfirmationStep({
 }) {
   const router = useRouter();
   const { emailAccountId } = useAccount();
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleStartCleaning = async () => {
+    setIsLoading(true);
+
     const result = await cleanInboxAction(emailAccountId, {
       daysOld: timeRange ?? 7,
       instructions: instructions || "",
@@ -49,6 +53,7 @@ export function ConfirmationStep({
 
     if (result?.serverError) {
       toastError({ description: result.serverError });
+      setIsLoading(false);
       return;
     }
 
@@ -116,8 +121,15 @@ export function ConfirmationStep({
       </ul>
 
       <div className="mt-6">
-        <Button size="lg" onClick={handleStartCleaning}>
-          Start Cleaning
+        <Button size="lg" onClick={handleStartCleaning} disabled={isLoading}>
+          {isLoading ? (
+            <>
+              <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+              Preparing cleanup...
+            </>
+          ) : (
+            "Start Cleaning"
+          )}
         </Button>
       </div>
 

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { parseAsString, useQueryState } from "nuqs";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { Loader2Icon } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmailItem } from "./EmailFirehoseItem";
 import { useEmailStream } from "./useEmailStream";
@@ -32,7 +33,21 @@ export function EmailFirehose({
     Record<string, "undoing" | "undone">
   >({});
 
-  const { emails } = useEmailStream(emailAccountId, isPaused, threads, tab);
+  const { emails, lastEventAt, totalReceived } = useEmailStream(
+    emailAccountId,
+    isPaused,
+    threads,
+    tab,
+  );
+
+  // Track whether the stream appears stalled (no events for 15s)
+  const [isStalled, setIsStalled] = useState(false);
+  useEffect(() => {
+    if (!lastEventAt) return;
+    setIsStalled(false);
+    const timer = setTimeout(() => setIsStalled(true), 15_000);
+    return () => clearTimeout(timer);
+  }, [lastEventAt]);
 
   // For virtualization
   const parentRef = useRef<HTMLDivElement>(null);
@@ -82,6 +97,12 @@ export function EmailFirehose({
 
   return (
     <div className="flex flex-col space-y-4">
+      <ProcessingStatus
+        totalReceived={totalReceived}
+        isStalled={isStalled}
+        lastEventAt={lastEventAt}
+        action={action}
+      />
       <Tabs defaultValue="done" className="w-full">
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="done">
@@ -145,34 +166,52 @@ export function EmailFirehose({
         </div>
       </Tabs>
 
-      {/* <div className="flex items-center justify-between text-sm text-muted-foreground">
-        <div className="flex items-center space-x-4">
-          <button
-            type="button"
-            onClick={() => setFilter(filter === "keep" ? null : "keep")}
-            className={`flex items-center ${filter === "keep" ? "rounded-md bg-blue-100 px-2 py-1 dark:bg-blue-900/30" : "hover:underline"}`}
-          >
-            <div className="mr-1 size-3 rounded-full bg-blue-500" />
-            <span>Keep</span>
-            {filter === "keep" && (
-              <XCircle className="ml-1 size-3 text-muted-foreground" />
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={() => setFilter(filter === "archived" ? null : "archived")}
-            className={`flex items-center ${filter === "archived" ? "rounded-md bg-green-100 px-2 py-1 dark:bg-green-900/30" : "hover:underline"}`}
-          >
-            <div className="mr-1 size-3 rounded-full bg-green-500" />
+    </div>
+  );
+}
+
+function ProcessingStatus({
+  totalReceived,
+  isStalled,
+  lastEventAt,
+  action,
+}: {
+  totalReceived: number;
+  isStalled: boolean;
+  lastEventAt: number | null;
+  action: CleanAction;
+}) {
+  if (totalReceived === 0 && !lastEventAt) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2Icon className="h-4 w-4 animate-spin" />
+        <span>Fetching emails from Gmail...</span>
+      </div>
+    );
+  }
+
+  const actionLabel =
+    action === CleanAction.ARCHIVE ? "archived" : "marked read";
+
+  return (
+    <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <div className="flex items-center gap-2">
+        {isStalled ? (
+          <>
+            <Loader2Icon className="h-4 w-4 animate-spin" />
             <span>
-              {action === CleanAction.ARCHIVE ? "Archived" : "Marked read"}
+              Waiting for Gmail API... ({totalReceived} emails processed)
             </span>
-            {filter === "archived" && (
-              <XCircle className="ml-1 size-3 text-muted-foreground" />
-            )}
-          </button>
-        </div>
-      </div> */}
+          </>
+        ) : (
+          <>
+            <Loader2Icon className="h-4 w-4 animate-spin" />
+            <span>
+              Processing — {totalReceived} emails {actionLabel} so far
+            </span>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.ts
+++ b/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.ts
@@ -22,6 +22,8 @@ export function useEmailStream(
   );
 
   const [isPaused, setIsPaused] = useState(initialPaused);
+  const [lastEventAt, setLastEventAt] = useState<number | null>(null);
+  const [totalReceived, setTotalReceived] = useState(initialThreads.length);
   const eventSourceRef = useRef<EventSource | null>(null);
   const maxEmails = 1000; // Maximum emails to keep in the buffer
 
@@ -57,6 +59,9 @@ export function useEmailStream(
             ...threadData,
             date: new Date(threadData.date),
           };
+
+          setLastEventAt(Date.now());
+          setTotalReceived((prev) => prev + 1);
 
           setEmailsMap((prev) => {
             // If we're at the limit and this is a new email, remove the oldest one
@@ -152,6 +157,8 @@ export function useEmailStream(
     emails,
     isPaused,
     togglePause,
+    lastEventAt,
+    totalReceived,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Loading spinner on "Start Cleaning" button** — the button previously had zero feedback after clicking. Now shows a spinner and "Preparing cleanup..." text while the server action runs and Gmail threads are fetched.
- **Live progress counter** — shows "Processing — X emails archived so far" using the existing SSE stream events. The counter updates in real-time as each thread is processed.
- **Stall detection** — when no SSE events arrive for 15 seconds (typically due to Gmail API rate limiting), the status changes to "Waiting for Gmail API... (X emails processed)" so users know the job is still running, not stuck.

## Problem

When running deep clean on a large inbox, the feature processes a batch of emails quickly, then hits Gmail's "Queries per minute per user" rate limit. The app correctly retries with backoff, but the UI shows no indication that processing is ongoing. Users see the stream stop and assume the feature is broken.

## Implementation

All changes are client-side only — no backend or schema changes required:

- `ConfirmationStep.tsx`: Added `useState` loading flag, disabled button during submission, spinner icon
- `useEmailStream.ts`: Added `lastEventAt` timestamp and `totalReceived` counter, updated on each SSE `thread` event
- `EmailFirehose.tsx`: Added `ProcessingStatus` component that shows contextual status based on stream activity, plus a 15-second inactivity timer for stall detection

## Test plan

- [ ] Click "Start Cleaning" — button should show spinner and "Preparing cleanup..."
- [ ] On the run page, verify live counter increments as emails stream in
- [ ] Wait for Gmail rate limit pause (~60s) — status should change to "Waiting for Gmail API..."
- [ ] When processing resumes, status should switch back to "Processing..."
- [ ] Verify existing email list, tabs, and undo functionality still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)