### PR TITLE
marketing: Add case studies to top nav

### DIFF
--- a/apps/web/components/new-landing/HeaderLinks.tsx
+++ b/apps/web/components/new-landing/HeaderLinks.tsx
@@ -22,6 +22,7 @@ import {
 
 const navigation = [
   { name: "Enterprise", href: "/enterprise" },
+  { name: "Case Studies", href: "/case-studies" },
   { name: "Pricing", href: "/pricing" },
 ];
 


### PR DESCRIPTION
Adds Case Studies to the desktop top navigation.\n\n- links the existing /case-studies page from the HeaderLinks navigation array\n\nValidation: pnpm exec biome check apps/web/components/new-landing/HeaderLinks.tsx