### PR TITLE
logging: Refine error serialization

### DIFF
--- a/apps/web/utils/logger.test.ts
+++ b/apps/web/utils/logger.test.ts
@@ -73,6 +73,120 @@ describe("Logger", () => {
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 
+  it("logs one serialized production error to Axiom without errorFull", () => {
+    mockedEnv.NODE_ENV = "production";
+    mockedEnv.AXIOM_TOKEN = "server-token";
+
+    const logger = createScopedLogger("test");
+    const error = {
+      name: "ProviderError",
+      message: "Provider request failed",
+      code: "rate_limit_exceeded",
+      statusCode: 429,
+      requestId: "req_123",
+      retriesLeft: 2,
+      retryDelay: 500,
+      config: {
+        url: "https://api.example.test/v1/messages",
+        method: "POST",
+        retryConfig: {
+          currentRetryAttempt: 1,
+          statusCodesToRetry: [429, 500],
+          totalTimeout: 60_000,
+        },
+      },
+      responseHeaders: {
+        "x-request-id": "header_req_123",
+        "content-type": "application/json",
+        server: "provider",
+      },
+      cause: {
+        code: "ECONNRESET",
+        message: "socket hang up",
+        socket: {
+          bytesRead: 10,
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    };
+
+    logger.error("Provider error", { error, operation: "send" });
+
+    expect(log.error).toHaveBeenCalledWith("Provider error", {
+      scope: "test",
+      operation: "send",
+      errorMessage: "Provider request failed",
+      error: expect.objectContaining({
+        name: "ProviderError",
+        message: "Provider request failed",
+        code: "rate_limit_exceeded",
+        statusCode: 429,
+        requestId: "req_123",
+        config: expect.objectContaining({
+          url: "https://api.example.test/v1/messages",
+          method: "POST",
+          retryConfig: expect.objectContaining({
+            currentRetryAttempt: 1,
+          }),
+        }),
+        cause: expect.objectContaining({
+          code: "ECONNRESET",
+          message: "socket hang up",
+        }),
+      }),
+    });
+    expect(log.error).not.toHaveBeenCalledWith(
+      "Provider error",
+      expect.objectContaining({ errorFull: expect.anything() }),
+    );
+  });
+
+  it("uses the serialized production error format for Axiom warnings", () => {
+    mockedEnv.NODE_ENV = "production";
+    mockedEnv.AXIOM_TOKEN = "server-token";
+
+    const logger = createScopedLogger("test");
+
+    logger.warn("Retrying provider request", {
+      error: {
+        headers: {
+          "x-request-id": "header_req_456",
+          server: "provider",
+        },
+        response: {
+          data: {
+            error: {
+              message: "Rate limited",
+              status: 429,
+              code: "RESOURCE_EXHAUSTED",
+            },
+          },
+        },
+        config: {
+          retryConfig: {
+            statusCodesToRetry: [429, 500],
+          },
+        },
+      },
+    });
+
+    expect(log.warn).toHaveBeenCalledWith("Retrying provider request", {
+      scope: "test",
+      errorMessage: "Rate limited",
+      error: expect.objectContaining({
+        response: expect.objectContaining({
+          data: {
+            error: {
+              message: "Rate limited",
+              status: 429,
+              code: "RESOURCE_EXHAUSTED",
+            },
+          },
+        }),
+      }),
+    });
+  });
+
   it("does not use Axiom logging when only the public token is configured", () => {
     mockedEnv.NEXT_PUBLIC_AXIOM_TOKEN = "public-token";
 

--- a/apps/web/utils/logger.ts
+++ b/apps/web/utils/logger.ts
@@ -1,4 +1,5 @@
 /** biome-ignore-all lint/suspicious/noConsole: we use console.log for development logs */
+import get from "lodash/get";
 import { log } from "next-axiom";
 import { serializeError } from "serialize-error";
 import { env } from "@/env";
@@ -85,14 +86,20 @@ export function createScopedLogger(scope: string) {
 function createAxiomLogger(scope: string) {
   const createLogger = (fields: Record<string, unknown> = {}) => ({
     info: (message: string, args?: Record<string, unknown>) =>
-      log.info(message, hashSensitiveFields({ scope, ...fields, ...args })),
+      log.info(
+        message,
+        hashSensitiveFields({ scope, ...fields, ...formatError(args) }),
+      ),
     error: (message: string, args?: Record<string, unknown>) =>
       log.error(
         message,
         hashSensitiveFields({ scope, ...fields, ...formatError(args) }),
       ),
     warn: (message: string, args?: Record<string, unknown>) =>
-      log.warn(message, hashSensitiveFields({ scope, ...fields, ...args })),
+      log.warn(
+        message,
+        hashSensitiveFields({ scope, ...fields, ...formatError(args) }),
+      ),
     trace: (
       message: string,
       args?: Record<string, unknown> | (() => Record<string, unknown>),
@@ -101,7 +108,7 @@ function createAxiomLogger(scope: string) {
       const resolved = typeof args === "function" ? args() : args;
       log.debug(
         message,
-        hashSensitiveFields({ scope, ...fields, ...resolved }),
+        hashSensitiveFields({ scope, ...fields, ...formatError(resolved) }),
       );
     },
     with: (newFields: Record<string, unknown>) =>
@@ -127,14 +134,13 @@ function formatError(args?: Record<string, unknown>) {
   if (env.NODE_ENV !== "production") return args;
   if (!args?.error) return args;
 
-  const error = args.error;
-  const errorMessage = getSimpleErrorMessage(error) ?? "Unknown error";
-  const errorFull = serializeError(error);
+  const error = serializeError(args.error);
+  const { error: _rawError, ...argsWithoutError } = args;
 
   return {
-    ...args,
-    error: errorMessage,
-    errorFull,
+    ...argsWithoutError,
+    error,
+    errorMessage: getSimpleErrorMessage(error) ?? "Unknown error",
   };
 }
 
@@ -158,39 +164,29 @@ function processErrorsInObject(obj: unknown): unknown {
   return obj;
 }
 
+const NESTED_ERROR_MESSAGE_PATHS = [
+  ["message"],
+  ["error", "message"],
+  ["cause", "message"],
+  ["response", "data", "error", "message"],
+  ["data", "error", "message"],
+  ["lastError", "data", "error", "message"],
+  ["error", "cause", "message"],
+  ["error", "response", "data", "error", "message"],
+  ["error", "data", "error", "message"],
+  ["error", "lastError", "data", "error", "message"],
+] as const;
+
 function getSimpleErrorMessage(error: unknown): string | undefined {
-  if (typeof error === "string") {
-    return error;
-  }
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
 
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (!hasMessageField(error) && !hasNestedErrorField(error)) {
-    return;
-  }
-
-  if (hasMessageField(error) && typeof error.message === "string") {
-    return error.message;
-  }
-
-  if (hasNestedErrorField(error)) {
-    const nested = error.error;
-    if (hasMessageField(nested) && typeof nested.message === "string") {
-      return nested.message;
-    }
+  for (const path of NESTED_ERROR_MESSAGE_PATHS) {
+    const value = get(error, path);
+    if (typeof value === "string") return value;
   }
 
   return;
-}
-
-function hasMessageField(value: unknown): value is { message?: unknown } {
-  return typeof value === "object" && value !== null && "message" in value;
-}
-
-function hasNestedErrorField(value: unknown): value is { error: unknown } {
-  return typeof value === "object" && value !== null && "error" in value;
 }
 
 // Field names that contain PII and should be hashed in production


### PR DESCRIPTION
Refines production error logging so each event keeps one serialized error representation while retaining a flat message for querying.

- Serialize logged errors consistently across Axiom log levels
- Remove the duplicate full-error field from production log payloads
- Add focused coverage for error and warning log payloads

Performance impact: adds one serialization pass for Axiom log calls that include an error object, with no database calls, network calls, or user-facing hot-path changes beyond existing logging work.