### PR TITLE
Fix duplicate reminder processing

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -202,6 +202,7 @@ describe("processAccountFollowUps - dedup logic", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     envMock.NEXT_PUBLIC_AUTO_DRAFT_DISABLED = false;
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([]);
   });
 
   it("skips threads with existing unresolved tracker that has followUpAppliedAt", async () => {
@@ -419,6 +420,52 @@ describe("processAccountFollowUps - dedup logic", () => {
 
     expect(applyFollowUpLabel).toHaveBeenCalledTimes(1);
     expect(generateFollowUpDraft).toHaveBeenCalledTimes(1);
+    expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify again when Outlook returns a different provider ID for the same sent message", async () => {
+    const sentAt = "2026-01-01T12:00:00.000Z";
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-outlook-repeat", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi
+        .fn()
+        .mockResolvedValueOnce(mockAwaitingMessage("msg-outlook-1", sentAt))
+        .mockResolvedValueOnce(mockAwaitingMessage("msg-outlook-2", sentAt)),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
+      { id: "channel-outlook-repeat" } as any,
+    ]);
+
+    vi.mocked(prisma.threadTracker.findMany)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          threadId: "thread-outlook-repeat",
+          messageId: "msg-outlook-1",
+          sentAt: new Date(sentAt),
+        } as any,
+      ]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
+      id: "tracker-outlook-repeat",
+    } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(applyFollowUpLabel).toHaveBeenCalledTimes(1);
+    expect(sendFollowUpNotification).toHaveBeenCalledTimes(1);
     expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -447,6 +447,7 @@ describe("processAccountFollowUps - dedup logic", () => {
         {
           threadId: "thread-outlook-repeat",
           messageId: "msg-outlook-1",
+          resolved: false,
           sentAt: new Date(sentAt),
         } as any,
       ]);
@@ -467,6 +468,48 @@ describe("processAccountFollowUps - dedup logic", () => {
     expect(applyFollowUpLabel).toHaveBeenCalledTimes(1);
     expect(sendFollowUpNotification).toHaveBeenCalledTimes(1);
     expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use sentAt to skip resolved trackers with a different message", async () => {
+    const sentAt = "2026-01-01T12:00:00.000Z";
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-resolved-repeat", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi
+        .fn()
+        .mockResolvedValue(mockAwaitingMessage("msg-resolved-new", sentAt)),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([
+      {
+        threadId: "thread-resolved-repeat",
+        messageId: "msg-resolved-old",
+        resolved: true,
+        sentAt: new Date(sentAt),
+      } as any,
+    ]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
+      id: "tracker-resolved-repeat",
+    } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(applyFollowUpLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-resolved-repeat",
+        messageId: "msg-resolved-new",
+      }),
+    );
+    expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
+    expect(generateFollowUpDraft).toHaveBeenCalledTimes(1);
   });
 
   it("does not create a second draft when duplicate outbound processing resolved the tracker", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -610,7 +610,7 @@ async function getProcessedFollowUpLedger({
         { followUpDraftId: { not: null } },
       ],
     },
-    select: { threadId: true, messageId: true, sentAt: true },
+    select: { threadId: true, messageId: true, resolved: true, sentAt: true },
   });
 
   const processedLedger: ProcessedFollowUpLedger = new Map();
@@ -621,15 +621,17 @@ async function getProcessedFollowUpLedger({
       sentAtTimes: new Set<number>(),
     };
     processed.messageIds.add(tracker.messageId);
-    if (tracker.sentAt) processed.sentAtTimes.add(tracker.sentAt.getTime());
+    if (!tracker.resolved && tracker.sentAt) {
+      processed.sentAtTimes.add(tracker.sentAt.getTime());
+    }
     processedLedger.set(tracker.threadId, processed);
   }
 
   return processedLedger;
 }
 
-// sentAt is checked alongside messageId because Outlook can return a different
-// provider message ID for the same sent message across runs.
+// sentAt is checked for unresolved trackers because Outlook can return a
+// different provider message ID for the same sent message across runs.
 function hasFollowUpBeenProcessed({
   processedLedger,
   threadId,

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -385,6 +385,7 @@ async function processFollowUpsForType({
           processedLedger,
           threadId: thread.id,
           messageId: lastMessage.id,
+          sentAt: messageDate,
         })
       ) {
         skippedAlreadyProcessedCount++;
@@ -586,13 +587,18 @@ function getThresholdWithWindow(threshold: Date, windowMinutes: number): Date {
   return addMinutes(threshold, windowMinutes);
 }
 
+type ProcessedFollowUpLedger = Map<
+  string,
+  { messageIds: Set<string>; sentAtTimes: Set<number> }
+>;
+
 async function getProcessedFollowUpLedger({
   emailAccountId,
   threadIds,
 }: {
   emailAccountId: string;
   threadIds: string[];
-}): Promise<Map<string, Set<string>>> {
+}): Promise<ProcessedFollowUpLedger> {
   if (threadIds.length === 0) return new Map();
 
   const existingTrackers = await prisma.threadTracker.findMany({
@@ -604,31 +610,44 @@ async function getProcessedFollowUpLedger({
         { followUpDraftId: { not: null } },
       ],
     },
-    select: { threadId: true, messageId: true },
+    select: { threadId: true, messageId: true, sentAt: true },
   });
 
-  const processedLedger = new Map<string, Set<string>>();
+  const processedLedger: ProcessedFollowUpLedger = new Map();
 
   for (const tracker of existingTrackers) {
-    const messageIds =
-      processedLedger.get(tracker.threadId) ?? new Set<string>();
-    messageIds.add(tracker.messageId);
-    processedLedger.set(tracker.threadId, messageIds);
+    const processed = processedLedger.get(tracker.threadId) ?? {
+      messageIds: new Set<string>(),
+      sentAtTimes: new Set<number>(),
+    };
+    processed.messageIds.add(tracker.messageId);
+    if (tracker.sentAt) processed.sentAtTimes.add(tracker.sentAt.getTime());
+    processedLedger.set(tracker.threadId, processed);
   }
 
   return processedLedger;
 }
 
+// sentAt is checked alongside messageId because Outlook can return a different
+// provider message ID for the same sent message across runs.
 function hasFollowUpBeenProcessed({
   processedLedger,
   threadId,
   messageId,
+  sentAt,
 }: {
-  processedLedger: Map<string, Set<string>>;
+  processedLedger: ProcessedFollowUpLedger;
   threadId: string;
   messageId: string;
+  sentAt: Date;
 }): boolean {
-  return processedLedger.get(threadId)?.has(messageId) ?? false;
+  const processed = processedLedger.get(threadId);
+  if (!processed) return false;
+
+  return (
+    processed.messageIds.has(messageId) ||
+    processed.sentAtTimes.has(sentAt.getTime())
+  );
 }
 
 async function processLoadedFollowUpReminderAccount({


### PR DESCRIPTION
Updates reminder dedupe so already processed messages are recognized by provider message ID or sent timestamp. This prevents repeated notifications when the same message is returned with a different provider ID.\n\n- Track sent timestamps in the processed reminder ledger\n- Add regression coverage for repeated scheduled processing