### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/.claude/skills/cloud-dev-environment/SKILL.md
+++ b/.claude/skills/cloud-dev-environment/SKILL.md
@@ -10,7 +10,7 @@ description: Cursor Cloud VM setup and service startup instructions for local de
 - **Redis 7 + serverless-redis-http**: Caching/rate-limiting. Redis on port 6380, HTTP proxy on port 8079.
 
 ## Starting services
-1. Start Docker daemon: `sudo dockerd` (already running in snapshot).
+1. Start Docker daemon: `sudo dockerd &>/dev/null &` then `sudo chmod 666 /var/run/docker.sock` if not already running (check `docker info`).
 2. Start databases: `docker compose -f docker-compose.dev.yml up -d` from repo root.
 3. Run Prisma migrations: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
 4. Start dev server: `pnpm dev` from repo root.
@@ -18,8 +18,18 @@ description: Cursor Cloud VM setup and service startup instructions for local de
 ## Environment file
 The app reads `apps/web/.env.local`. Required non-obvious env vars beyond `.env.example` defaults:
 - `DEFAULT_LLM_PROVIDER` (e.g. `openai`) — app crashes at startup without this.
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` — hard-required by `env.ts` validation. Use Google emulator credentials for local dev (see below).
+- `UPSTASH_REDIS_TOKEN` must be set to `dev_token` to match the `SRH_TOKEN` default in `docker-compose.dev.yml`.
 - `MICROSOFT_WEBHOOK_CLIENT_STATE` — required if `MICROSOFT_CLIENT_ID` is set.
-- `UPSTASH_REDIS_TOKEN` must match the `SRH_TOKEN` in `docker-compose.dev.yml` (default: `dev_token`).
+
+## Google emulator for local dev
+Use the Google emulator instead of real OAuth credentials:
+```
+GOOGLE_CLIENT_ID=emulate-google-client.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=emulate-google-secret
+GOOGLE_BASE_URL=http://localhost:4002
+```
+Start the emulator: `docker compose -f docker-compose.dev.yml --profile google-emulator up -d`.
 
 ## Testing
 - `pnpm test` runs Vitest unit/integration tests (no DB or external services required).
@@ -28,3 +38,13 @@ The app reads `apps/web/.env.local`. Required non-obvious env vars beyond `.env.
 
 ## Docker in this environment
 The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running, then `sudo chmod 666 /var/run/docker.sock`.
+
+The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install it:
+```bash
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo curl -SL https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+```
+
+## Onboarding flow
+After a fresh login via the Google emulator, the app forces an onboarding wizard. Some onboarding buttons require JavaScript `click()` calls rather than standard browser clicks (React event delegation quirk in headless/automation contexts).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,4 @@ See `.claude/skills/fullstack-workflow/SKILL.md` for full examples and templates
 - Data fetching: SWR on the client. Call `mutate()` after mutations.
 - Forms: React Hook Form + `useAction` hook. Use `getActionErrorMessage(error.error)` for errors.
 - Loading states: use `LoadingContent` component.
-
-## Cursor Cloud specific instructions
-
-See `.claude/skills/cloud-dev-environment/SKILL.md` for Cloud VM setup, service startup, env var gotchas, and Docker caveats.
+- Cursor Cloud VM setup: see `.claude/skills/cloud-dev-environment/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,16 @@ See `.claude/skills/fullstack-workflow/SKILL.md` for full examples and templates
 - Data fetching: SWR on the client. Call `mutate()` after mutations.
 - Forms: React Hook Form + `useAction` hook. Use `getActionErrorMessage(error.error)` for errors.
 - Loading states: use `LoadingContent` component.
+
+## Cursor Cloud specific instructions
+
+See `.claude/skills/cloud-dev-environment/SKILL.md` for full service startup steps.
+
+Key non-obvious caveats:
+- **Docker daemon**: Run `sudo dockerd &>/dev/null &` then `sudo chmod 666 /var/run/docker.sock` if Docker is not already running (check `docker info`). The VM uses `fuse-overlayfs` storage driver and `iptables-legacy`.
+- **Docker Compose plugin**: The VM ships `docker-compose` (v1) but not the `docker compose` plugin (v2). If missing, install manually: `sudo mkdir -p /usr/local/lib/docker/cli-plugins && sudo curl -SL https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose && sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose`.
+- **`env.ts` validation**: The app hard-requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` at startup. Use the Google emulator credentials (`emulate-google-client.apps.googleusercontent.com` / `emulate-google-secret`) with `GOOGLE_BASE_URL=http://localhost:4002` for local dev without real Google OAuth. Start the emulator via `docker compose -f docker-compose.dev.yml --profile google-emulator up -d`.
+- **`UPSTASH_REDIS_TOKEN`**: Must be set to `dev_token` to match the `SRH_TOKEN` default in `docker-compose.dev.yml`.
+- **`DEFAULT_LLM_PROVIDER`**: Required; set to any valid provider (e.g. `openai`) even with a placeholder API key to avoid startup crash.
+- **Prisma migrations**: Always use `pnpm prisma:migrate:local` (not bare `prisma migrate dev`) — it loads `.env.local` via `dotenv-cli`.
+- **Onboarding flow**: After a fresh login via the Google emulator, the app forces an onboarding wizard. Some onboarding buttons require JavaScript `click()` calls rather than standard browser clicks (React event delegation quirk in headless/automation contexts).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,13 +77,4 @@ See `.claude/skills/fullstack-workflow/SKILL.md` for full examples and templates
 
 ## Cursor Cloud specific instructions
 
-See `.claude/skills/cloud-dev-environment/SKILL.md` for full service startup steps.
-
-Key non-obvious caveats:
-- **Docker daemon**: Run `sudo dockerd &>/dev/null &` then `sudo chmod 666 /var/run/docker.sock` if Docker is not already running (check `docker info`). The VM uses `fuse-overlayfs` storage driver and `iptables-legacy`.
-- **Docker Compose plugin**: The VM ships `docker-compose` (v1) but not the `docker compose` plugin (v2). If missing, install manually: `sudo mkdir -p /usr/local/lib/docker/cli-plugins && sudo curl -SL https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose && sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose`.
-- **`env.ts` validation**: The app hard-requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` at startup. Use the Google emulator credentials (`emulate-google-client.apps.googleusercontent.com` / `emulate-google-secret`) with `GOOGLE_BASE_URL=http://localhost:4002` for local dev without real Google OAuth. Start the emulator via `docker compose -f docker-compose.dev.yml --profile google-emulator up -d`.
-- **`UPSTASH_REDIS_TOKEN`**: Must be set to `dev_token` to match the `SRH_TOKEN` default in `docker-compose.dev.yml`.
-- **`DEFAULT_LLM_PROVIDER`**: Required; set to any valid provider (e.g. `openai`) even with a placeholder API key to avoid startup crash.
-- **Prisma migrations**: Always use `pnpm prisma:migrate:local` (not bare `prisma migrate dev`) — it loads `.env.local` via `dotenv-cli`.
-- **Onboarding flow**: After a fresh login via the Google emulator, the app forces an onboarding wizard. Some onboarding buttons require JavaScript `click()` calls rather than standard browser clicks (React event delegation quirk in headless/automation contexts).
+See `.claude/skills/cloud-dev-environment/SKILL.md` for Cloud VM setup, service startup, env var gotchas, and Docker caveats.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cursor Cloud VM development caveats discovered during environment setup.

**Changes:**
- **`.claude/skills/cloud-dev-environment/SKILL.md`** — expanded with all non-obvious cloud VM caveats: Docker daemon/Compose plugin setup, required env vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `DEFAULT_LLM_PROVIDER`, `UPSTASH_REDIS_TOKEN`), Google emulator credentials, Prisma migration command, and onboarding automation quirk.
- **`AGENTS.md`** — one-liner reference to the skill file instead of inline cloud instructions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e9e2c6-b7db-4219-82ed-60d86cfe55cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e9e2c6-b7db-4219-82ed-60d86cfe55cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

