### PR TITLE
security: Validate pagination URLs

### DIFF
--- a/apps/web/app/api/messages/validation.ts
+++ b/apps/web/app/api/messages/validation.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 export const messageQuerySchema = z.object({
   q: z.string().nullish(),
-  pageToken: z.string().nullish(),
+  pageToken: microsoftGraphPageTokenSchema,
 });
 export type MessageQuery = z.infer<typeof messageQuerySchema>;
 

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -46,6 +46,7 @@ import {
   getCategorizationStatusSnapshot,
 } from "@/utils/redis/categorization-progress";
 import { extractErrorInfo, isRetryableError } from "@/utils/outlook/retry";
+import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 const SEARCH_INBOX_MAX_RESULTS = 20;
 const MAX_SENDER_CATEGORIZATION_WAIT_MS = 1500;
@@ -440,10 +441,9 @@ function searchInboxInputSchema(provider: string) {
       .max(SEARCH_INBOX_MAX_RESULTS)
       .default(SEARCH_INBOX_MAX_RESULTS)
       .describe("Maximum number of messages to return."),
-    pageToken: z
-      .string()
-      .nullish()
-      .describe("Use the page token returned from a prior search to paginate."),
+    pageToken: microsoftGraphPageTokenSchema.describe(
+      "Use the page token returned from a prior search to paginate.",
+    ),
   });
 }
 

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -55,6 +55,7 @@ import {
   createAutoArchiveFilter,
 } from "@/utils/outlook/filter";
 import { queryMessagesWithFilters } from "@/utils/outlook/message";
+import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 import type {
   EmailProvider,
   EmailThread,
@@ -302,10 +303,10 @@ export class OutlookProvider implements EmailProvider {
     const { maxResults, after, before, pageToken } = options;
 
     const buildRequest = () => {
-      // pageToken is the full @odata.nextLink URL, which already encodes
-      // top/skip/filter from the original request.
-      if (pageToken?.startsWith("http")) {
-        return this.client.getClient().api(pageToken);
+      // The nextLink already encodes top/skip/filter from the original request.
+      const nextLink = resolveMicrosoftGraphNextLink(pageToken);
+      if (nextLink) {
+        return this.client.getClient().api(nextLink);
       }
 
       const filters: string[] = [];
@@ -1523,9 +1524,9 @@ export class OutlookProvider implements EmailProvider {
     const maxResults = options.maxResults || 50;
 
     const fetchThreadPage = async (pageToken?: string) => {
-      // If pageToken is a URL, fetch directly (per MS docs, don't extract $skiptoken)
-      if (pageToken?.startsWith("http")) {
-        return await client.api(pageToken).get();
+      const nextLink = resolveMicrosoftGraphNextLink(pageToken);
+      if (nextLink) {
+        return await client.api(nextLink).get();
       }
 
       // Determine endpoint and build filters based on query type

--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -1,13 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { Message } from "@microsoft/microsoft-graph-types";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   buildOutlookSearchFallbackQuery,
   convertMessage,
+  queryBatchMessages,
+  queryMessagesWithAttachments,
+  queryMessagesWithFilters,
   sanitizeOutlookSearchQuery,
   sanitizeKqlValue,
   sanitizeKqlFieldQuery,
   sanitizeKqlTextQuery,
 } from "@/utils/outlook/message";
+import type { OutlookClient } from "@/utils/outlook/client";
 
 describe("convertMessage", () => {
   describe("category ID mapping", () => {
@@ -110,6 +115,57 @@ describe("convertMessage", () => {
       expect(result.labelIds).toContain("INBOX");
       expect(result.labelIds).toContain("uuid-urgent-123");
     });
+  });
+});
+
+describe("queryBatchMessages", () => {
+  it("rejects full URL page tokens outside Microsoft Graph", async () => {
+    const api = vi.fn().mockReturnValue({ get: vi.fn() });
+    const client = createCachedOutlookClient(api);
+
+    await expect(
+      queryBatchMessages(
+        client,
+        { pageToken: "http://169.254.169.254/latest/meta-data" },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow("Invalid Outlook page token");
+
+    expect(api).not.toHaveBeenCalled();
+  });
+});
+
+describe("queryMessagesWithFilters", () => {
+  it("rejects full URL page tokens outside Microsoft Graph", async () => {
+    const api = vi.fn().mockReturnValue({ get: vi.fn() });
+    const client = createCachedOutlookClient(api);
+
+    await expect(
+      queryMessagesWithFilters(
+        client,
+        { pageToken: "http://169.254.169.254/latest/meta-data" },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow("Invalid Outlook page token");
+
+    expect(api).not.toHaveBeenCalled();
+  });
+});
+
+describe("queryMessagesWithAttachments", () => {
+  it("rejects full URL page tokens outside Microsoft Graph", async () => {
+    const api = vi.fn().mockReturnValue({ get: vi.fn() });
+    const client = createCachedOutlookClient(api);
+
+    await expect(
+      queryMessagesWithAttachments(
+        client,
+        { pageToken: "http://169.254.169.254/latest/meta-data" },
+        createTestLogger(),
+      ),
+    ).rejects.toThrow("Invalid Outlook page token");
+
+    expect(api).not.toHaveBeenCalled();
   });
 });
 
@@ -403,3 +459,15 @@ describe("buildOutlookSearchFallbackQuery", () => {
     expect(buildOutlookSearchFallbackQuery("sender@example.com")).toBeNull();
   });
 });
+
+function createCachedOutlookClient(
+  api: ReturnType<typeof vi.fn>,
+): OutlookClient {
+  return {
+    getClient: () => ({ api }),
+    getFolderIdCache: () => ({ inbox: "inbox-folder-id" }),
+    setFolderIdCache: vi.fn(),
+    getCategoryMapCache: () => new Map(),
+    setCategoryMapCache: vi.fn(),
+  } as unknown as OutlookClient;
+}

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -10,6 +10,7 @@ import { withOutlookRetry } from "@/utils/outlook/retry";
 import { formatEmailWithName } from "@/utils/email";
 import type { Logger } from "@/utils/logger";
 import { isOutlookThrottlingError } from "@/utils/error";
+import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 
 // Standard fields to select when fetching messages from Microsoft Graph API
 // internetMessageId is the RFC 5322 Message-ID header, needed for cross-provider email threading
@@ -426,11 +427,11 @@ export async function queryBatchMessages(
     getCategoryMap(client, logger),
   ]);
 
-  // If pageToken is a URL, fetch directly (per MS docs, don't extract $skiptoken)
-  if (pageToken?.startsWith("http")) {
+  const nextLink = resolveMicrosoftGraphNextLink(pageToken);
+  if (nextLink) {
     const response: { value: Message[]; "@odata.nextLink"?: string } =
       await withOutlookRetry(
-        () => client.getClient().api(pageToken).get(),
+        () => client.getClient().api(nextLink).get(),
         logger,
       );
 
@@ -589,11 +590,11 @@ export async function queryMessagesWithFilters(
     getCategoryMap(client, logger),
   ]);
 
-  // If pageToken is a URL, fetch directly (per MS docs, don't extract $skiptoken)
-  if (pageToken?.startsWith("http")) {
+  const nextLink = resolveMicrosoftGraphNextLink(pageToken);
+  if (nextLink) {
     const response: { value: Message[]; "@odata.nextLink"?: string } =
       await withOutlookRetry(
-        () => client.getClient().api(pageToken).get(),
+        () => client.getClient().api(nextLink).get(),
         logger,
       );
 
@@ -685,11 +686,11 @@ export async function queryMessagesWithAttachments(
 
   const categoryMap = await getCategoryMap(client, logger);
 
-  // If pageToken is a URL, fetch directly (per MS docs, don't extract $skiptoken)
-  if (options.pageToken?.startsWith("http")) {
+  const nextLink = resolveMicrosoftGraphNextLink(options.pageToken);
+  if (nextLink) {
     const response: { value: Message[]; "@odata.nextLink"?: string } =
       await withOutlookRetry(
-        () => client.getClient().api(options.pageToken!).get(),
+        () => client.getClient().api(nextLink).get(),
         logger,
       );
 

--- a/apps/web/utils/outlook/page-token.test.ts
+++ b/apps/web/utils/outlook/page-token.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAllowedMicrosoftGraphPageToken,
+  resolveMicrosoftGraphNextLink,
+} from "@/utils/outlook/page-token";
+
+describe("isAllowedMicrosoftGraphPageToken", () => {
+  it("allows opaque continuation tokens", () => {
+    expect(isAllowedMicrosoftGraphPageToken("page-token-1")).toBe(true);
+  });
+
+  it("allows Microsoft Graph next links", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=abc",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows Microsoft Graph national cloud next links", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "https://microsoftgraph.chinacloudapi.cn/v1.0/me/messages?$skiptoken=abc",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects non-Graph hosts", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "https://graph.microsoft.com.example.com/v1.0/me/messages",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects non-https Graph URLs", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "http://graph.microsoft.com/v1.0/me/messages?$skiptoken=abc",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(isAllowedMicrosoftGraphPageToken("//169.254.169.254/latest")).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveMicrosoftGraphNextLink", () => {
+  it("returns the URL for allowed Microsoft Graph next links", () => {
+    const pageToken =
+      "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=abc";
+
+    expect(resolveMicrosoftGraphNextLink(pageToken)).toBe(pageToken);
+  });
+
+  it("returns null for opaque tokens", () => {
+    expect(resolveMicrosoftGraphNextLink("page-token-1")).toBeNull();
+  });
+
+  it("returns null for nullish tokens", () => {
+    expect(resolveMicrosoftGraphNextLink(null)).toBeNull();
+    expect(resolveMicrosoftGraphNextLink(undefined)).toBeNull();
+  });
+
+  it("throws for absolute URLs outside Microsoft Graph", () => {
+    expect(() =>
+      resolveMicrosoftGraphNextLink("http://169.254.169.254/latest/meta-data"),
+    ).toThrow("Invalid Outlook page token");
+  });
+});

--- a/apps/web/utils/outlook/page-token.ts
+++ b/apps/web/utils/outlook/page-token.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+const MICROSOFT_GRAPH_PAGE_TOKEN_HOSTS = new Set([
+  "graph.microsoft.com",
+  "graph.microsoft.us",
+  "dod-graph.microsoft.us",
+  "graph.microsoft.de",
+  "microsoftgraph.chinacloudapi.cn",
+]);
+
+const URL_PAGE_TOKEN_PATTERN = /^(?:[a-z][a-z\d+.-]*:)?\/\//i;
+
+export function isAbsoluteUrlPageToken(pageToken?: string | null): boolean {
+  return Boolean(pageToken && URL_PAGE_TOKEN_PATTERN.test(pageToken));
+}
+
+export function isAllowedMicrosoftGraphPageToken(
+  pageToken?: string | null,
+): boolean {
+  if (!isAbsoluteUrlPageToken(pageToken)) return true;
+
+  try {
+    const url = new URL(pageToken!);
+
+    return (
+      url.protocol === "https:" &&
+      MICROSOFT_GRAPH_PAGE_TOKEN_HOSTS.has(url.hostname.toLowerCase()) &&
+      (!url.port || url.port === "443")
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Returns the URL to pass to Microsoft Graph if `pageToken` is an @odata.nextLink,
+// `null` for opaque continuation tokens, or throws if the token is an absolute URL
+// pointing somewhere other than a Graph endpoint (SSRF guard).
+export function resolveMicrosoftGraphNextLink(
+  pageToken?: string | null,
+): string | null {
+  if (!isAbsoluteUrlPageToken(pageToken)) return null;
+  if (!isAllowedMicrosoftGraphPageToken(pageToken)) {
+    throw new Error("Invalid Outlook page token");
+  }
+  return pageToken!;
+}
+
+export const microsoftGraphPageTokenSchema = z
+  .string()
+  .nullish()
+  .refine(isAllowedMicrosoftGraphPageToken, { message: "Invalid page token" });

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -10,6 +10,7 @@ import {
   getFolderIds,
 } from "@/utils/outlook/message";
 import { withOutlookRetry } from "@/utils/outlook/retry";
+import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 
 export async function getThread(
   threadId: string,
@@ -107,9 +108,12 @@ export async function getThreadsWithNextPageToken({
   pageToken?: string;
   logger: Logger;
 }) {
+  const endpoint =
+    resolveMicrosoftGraphNextLink(pageToken) || pageToken || "/me/messages";
+
   let request = client
     .getClient()
-    .api(pageToken || "/me/messages")
+    .api(endpoint)
     .top(maxResults)
     .select("id,conversationId,subject,bodyPreview");
 

--- a/apps/web/utils/threads/validation.ts
+++ b/apps/web/utils/threads/validation.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
+import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 export const threadsQuery = z.object({
   fromEmail: z.string().nullish(),
   limit: z.coerce.number().max(100).nullish(),
   type: z.string().nullish(),
-  nextPageToken: z.string().nullish(),
+  nextPageToken: microsoftGraphPageTokenSchema,
   labelId: z.string().nullish(), // For Google
   labelIds: z.array(z.string()).nullish(), // For Google
   excludeLabelNames: z.array(z.string()).nullish(), // For Google


### PR DESCRIPTION
Adds shared validation for pagination tokens so URL-based continuation tokens must target approved Microsoft Graph HTTPS hosts while opaque tokens remain accepted.

- Applies validation to message, thread, and assistant pagination entry points.
- Adds regression coverage for disallowed URL tokens and allowed Graph continuation tokens.

Tests: pnpm test --run utils/outlook/message.test.ts utils/outlook/page-token.test.ts utils/email/microsoft.test.ts utils/outlook/thread-helpers.test.ts