### PR TITLE
security: Harden page token handling

### DIFF
--- a/apps/web/utils/outlook/page-token.test.ts
+++ b/apps/web/utils/outlook/page-token.test.ts
@@ -25,6 +25,14 @@ describe("isAllowedMicrosoftGraphPageToken", () => {
     ).toBe(true);
   });
 
+  it("allows Microsoft Graph canary next links", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "https://canary.graph.microsoft.com/v1.0/me/messages?$skiptoken=abc",
+      ),
+    ).toBe(true);
+  });
+
   it("rejects non-Graph hosts", () => {
     expect(
       isAllowedMicrosoftGraphPageToken(
@@ -45,6 +53,14 @@ describe("isAllowedMicrosoftGraphPageToken", () => {
     expect(isAllowedMicrosoftGraphPageToken("//169.254.169.254/latest")).toBe(
       false,
     );
+  });
+
+  it("rejects tokens with embedded URLs", () => {
+    expect(
+      isAllowedMicrosoftGraphPageToken(
+        "token-prefix-https://169.254.169.254/latest",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/utils/outlook/page-token.ts
+++ b/apps/web/utils/outlook/page-token.ts
@@ -6,12 +6,18 @@ const MICROSOFT_GRAPH_PAGE_TOKEN_HOSTS = new Set([
   "dod-graph.microsoft.us",
   "graph.microsoft.de",
   "microsoftgraph.chinacloudapi.cn",
+  "canary.graph.microsoft.com",
 ]);
 
 const URL_PAGE_TOKEN_PATTERN = /^(?:[a-z][a-z\d+.-]*:)?\/\//i;
+const SDK_EMBEDDED_URL_PATTERN = /https:\/\//i;
 
 export function isAbsoluteUrlPageToken(pageToken?: string | null): boolean {
-  return Boolean(pageToken && URL_PAGE_TOKEN_PATTERN.test(pageToken));
+  return Boolean(
+    pageToken &&
+      (URL_PAGE_TOKEN_PATTERN.test(pageToken) ||
+        SDK_EMBEDDED_URL_PATTERN.test(pageToken)),
+  );
 }
 
 export function isAllowedMicrosoftGraphPageToken(

--- a/apps/web/utils/outlook/thread.test.ts
+++ b/apps/web/utils/outlook/thread.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { getThreadsWithNextPageToken } from "@/utils/outlook/thread";
+import type { OutlookClient } from "@/utils/outlook/client";
+import type { Logger } from "@/utils/logger";
+
+describe("getThreadsWithNextPageToken", () => {
+  it("does not use opaque page tokens as Graph paths", async () => {
+    const api = vi.fn().mockReturnValue(createMessagesRequest());
+
+    await getThreadsWithNextPageToken({
+      client: createOutlookClient(api),
+      pageToken: "opaque-token",
+      logger: createLogger(),
+    });
+
+    expect(api).toHaveBeenCalledWith("/me/messages");
+  });
+
+  it("rejects page tokens with embedded URLs before calling Graph", async () => {
+    const api = vi.fn().mockReturnValue(createMessagesRequest());
+
+    await expect(
+      getThreadsWithNextPageToken({
+        client: createOutlookClient(api),
+        pageToken: "prefix-https://169.254.169.254/latest",
+        logger: createLogger(),
+      }),
+    ).rejects.toThrow("Invalid Outlook page token");
+
+    expect(api).not.toHaveBeenCalled();
+  });
+});
+
+function createOutlookClient(api: ReturnType<typeof vi.fn>) {
+  return {
+    getClient: () => ({ api }),
+  } as unknown as OutlookClient;
+}
+
+function createMessagesRequest() {
+  const request = {
+    top: vi.fn(() => request),
+    select: vi.fn(() => request),
+    filter: vi.fn(() => request),
+    get: vi.fn().mockResolvedValue({ value: [] }),
+  };
+  return request;
+}
+
+function createLogger() {
+  return {
+    warn: vi.fn(),
+  } as unknown as Logger;
+}

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -108,8 +108,7 @@ export async function getThreadsWithNextPageToken({
   pageToken?: string;
   logger: Logger;
 }) {
-  const endpoint =
-    resolveMicrosoftGraphNextLink(pageToken) || pageToken || "/me/messages";
+  const endpoint = resolveMicrosoftGraphNextLink(pageToken) || "/me/messages";
 
   let request = client
     .getClient()


### PR DESCRIPTION
Tightens pagination token handling around Microsoft Graph continuation URLs.

- Aligns the allowed Graph hosts with the SDK host list.
- Rejects embedded URL markers before the SDK can reinterpret them.
- Prevents opaque Outlook thread tokens from being used as Graph paths.

Tests: pnpm test --run utils/outlook/page-token.test.ts utils/outlook/thread.test.ts utils/outlook/message.test.ts utils/email/microsoft.test.ts utils/outlook/thread-helpers.test.ts