### PR TITLE
fix: avoid scheduler fallback URL requirement

### DIFF
--- a/apps/web/__tests__/eval/reply-memory.test.ts
+++ b/apps/web/__tests__/eval/reply-memory.test.ts
@@ -1306,13 +1306,6 @@ function getCreatedMemoriesFromDecisions(
   return decisions.map((decision) => decision.newMemory).filter(isDefined);
 }
 
-function matchesOnlyExistingMemory(
-  decisions: Awaited<ReturnType<typeof aiExtractReplyMemoriesFromDraftEdit>>,
-  expectedMemoryId: string,
-) {
-  return matchesOnlyExistingMemoryIds(decisions, [expectedMemoryId]);
-}
-
 function matchesOnlyExistingMemoryIds(
   decisions: Awaited<ReturnType<typeof aiExtractReplyMemoriesFromDraftEdit>>,
   expectedMemoryIds: string[],

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -59,7 +59,9 @@ describe("health route", () => {
   });
 
   it("returns a lightweight ok response when no health API key is provided", async () => {
-    const response = await GET(new NextRequest("http://localhost:3000/api/health"));
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/health"),
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ status: "ok" });

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -214,9 +214,7 @@ describe("buildMessagingUserMessages", () => {
     expect(modelUserMessage.parts).toEqual([
       expect.objectContaining({
         type: "text",
-        text: expect.stringContaining(
-          "unsupported non-image file attachments",
-        ),
+        text: expect.stringContaining("unsupported non-image file attachments"),
       }),
       { type: "text", text: "Please draft a reply about this file." },
     ]);

--- a/apps/web/utils/premium/limits.test.ts
+++ b/apps/web/utils/premium/limits.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { SafeError } from "@/utils/error";
+import type { SafeError } from "@/utils/error";
 
 const { envMock } = vi.hoisted(() => ({
   envMock: {
@@ -25,13 +25,13 @@ describe("assertHasAiAccess", () => {
   it("throws a 404 SafeError when the user does not exist", async () => {
     prisma.user.findUnique.mockResolvedValue(null);
 
-    await expect(assertHasAiAccess({ userId: "missing-user" })).rejects.toMatchObject(
-      {
-        name: "SafeError",
-        safeMessage: "User not found",
-        statusCode: 404,
-      } satisfies Partial<SafeError>,
-    );
+    await expect(
+      assertHasAiAccess({ userId: "missing-user" }),
+    ).rejects.toMatchObject({
+      name: "SafeError",
+      safeMessage: "User not found",
+      statusCode: 404,
+    } satisfies Partial<SafeError>);
   });
 
   it("throws a 403 SafeError when the user has no premium entitlement", async () => {
@@ -39,13 +39,13 @@ describe("assertHasAiAccess", () => {
       premium: null,
     } as never);
 
-    await expect(assertHasAiAccess({ userId: "free-user" })).rejects.toMatchObject(
-      {
-        name: "SafeError",
-        safeMessage: "Please upgrade for AI access",
-        statusCode: 403,
-      } satisfies Partial<SafeError>,
-    );
+    await expect(
+      assertHasAiAccess({ userId: "free-user" }),
+    ).rejects.toMatchObject({
+      name: "SafeError",
+      safeMessage: "Please upgrade for AI access",
+      statusCode: 403,
+    } satisfies Partial<SafeError>);
   });
 
   it("throws a 403 SafeError when a premium user still lacks AI access", async () => {

--- a/apps/web/utils/scheduled-actions/scheduler.ts
+++ b/apps/web/utils/scheduled-actions/scheduler.ts
@@ -266,12 +266,12 @@ async function scheduleMessage({
   deduplicationId: string;
 }) {
   const client = getQstashClient();
-  const url = `${getInternalApiUrl()}/api/scheduled-actions/execute`;
-
   const notBefore = getUnixTime(addMinutes(new Date(), delayInMinutes));
 
   try {
     if (client) {
+      const url = `${getInternalApiUrl()}/api/scheduled-actions/execute`;
+
       const response = await client.publishJSON({
         url,
         body: payload,


### PR DESCRIPTION
Fix delayed action scheduling when QStash is not configured by only building the internal callback URL for actual QStash publishes.

Tests: pnpm test