### PR TITLE
bugfix-batch-0139: Return 401 for invalid analyze sender API key

### DIFF
--- a/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { afterMock, headersMock, isValidInternalApiKeyMock } = vi.hoisted(
+  () => ({
+    afterMock: vi.fn(),
+    headersMock: vi.fn(),
+    isValidInternalApiKeyMock: vi.fn(),
+  }),
+);
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}));
+
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: afterMock,
+  };
+});
+
+vi.mock("@/utils/middleware", () => ({
+  withError:
+    (
+      _scope: string,
+      handler: (request: Request, ...args: unknown[]) => Promise<Response>,
+    ) =>
+    (request: Request, ...args: unknown[]) =>
+      handler(request, ...args),
+}));
+
+vi.mock("@/utils/internal-api", () => ({
+  isValidInternalApiKey: isValidInternalApiKeyMock,
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      findUnique: vi.fn(),
+    },
+    newsletter: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/ai/choose-rule/ai-detect-recurring-pattern", () => ({
+  aiDetectRecurringPattern: vi.fn(),
+}));
+
+vi.mock("@/utils/email", () => ({
+  extractEmailAddress: vi.fn((value: string) => value),
+}));
+
+vi.mock("@/utils/get-email-from-message", () => ({
+  getEmailForLLM: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/learned-patterns", () => ({
+  saveLearnedPattern: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/check-sender-rule-history", () => ({
+  checkSenderRuleHistory: vi.fn(),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+
+import { POST } from "./route";
+
+describe("analyze sender pattern route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    headersMock.mockResolvedValue(new Headers());
+    isValidInternalApiKeyMock.mockReturnValue(true);
+  });
+
+  it("returns 401 when the internal API key is invalid", async () => {
+    isValidInternalApiKeyMock.mockReturnValue(false);
+
+    const response = await POST(createRequest() as never);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid API key",
+    });
+    expect(afterMock).not.toHaveBeenCalled();
+  });
+});
+
+function createRequest() {
+  const request = new Request(
+    "https://example.com/api/ai/analyze-sender-pattern",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        emailAccountId: "email-account-1",
+        from: "sender@example.com",
+      }),
+    },
+  ) as Request & {
+    logger: {
+      error: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  request.logger = {
+    error: vi.fn(),
+  };
+
+  return request;
+}

--- a/apps/web/app/api/ai/analyze-sender-pattern/route.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.ts
@@ -35,7 +35,7 @@ export const POST = withError(
 
     if (!isValidInternalApiKey(await headers(), logger)) {
       logger.error("Invalid API key for sender pattern analysis", json);
-      return NextResponse.json({ error: "Invalid API key" });
+      return NextResponse.json({ error: "Invalid API key" }, { status: 401 });
     }
 
     const data = schema.parse(json);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Return HTTP 401 when the analyze-sender-pattern internal API key is invalid.
- Add a focused regression test for the invalid-key response status.

## Verification
- `pnpm test --run app/api/ai/analyze-sender-pattern/route.test.ts`
- `pnpm exec biome check app/api/ai/analyze-sender-pattern/route.ts app/api/ai/analyze-sender-pattern/route.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

