### PR TITLE
bugfix-batch-0139: Sanitize analyze sender auth failure logs

### DIFF
--- a/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { afterMock, headersMock, isValidInternalApiKeyMock } = vi.hoisted(
+  () => ({
+    afterMock: vi.fn(),
+    headersMock: vi.fn(),
+    isValidInternalApiKeyMock: vi.fn(),
+  }),
+);
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}));
+
+vi.mock("next/server", async (importOriginal) => {
+  const original = await importOriginal<typeof import("next/server")>();
+  return {
+    ...original,
+    after: afterMock,
+  };
+});
+
+vi.mock("@/utils/middleware", () => ({
+  withError:
+    (
+      _scope: string,
+      handler: (request: Request, ...args: unknown[]) => Promise<Response>,
+    ) =>
+    (request: Request, ...args: unknown[]) =>
+      handler(request, ...args),
+}));
+
+vi.mock("@/utils/internal-api", () => ({
+  isValidInternalApiKey: isValidInternalApiKeyMock,
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      findUnique: vi.fn(),
+    },
+    newsletter: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/ai/choose-rule/ai-detect-recurring-pattern", () => ({
+  aiDetectRecurringPattern: vi.fn(),
+}));
+
+vi.mock("@/utils/email", () => ({
+  extractEmailAddress: vi.fn((value: string) => value),
+}));
+
+vi.mock("@/utils/get-email-from-message", () => ({
+  getEmailForLLM: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/learned-patterns", () => ({
+  saveLearnedPattern: vi.fn(),
+}));
+
+vi.mock("@/utils/rule/check-sender-rule-history", () => ({
+  checkSenderRuleHistory: vi.fn(),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+
+import { POST } from "./route";
+
+describe("analyze sender pattern route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    headersMock.mockResolvedValue(new Headers());
+    isValidInternalApiKeyMock.mockReturnValue(true);
+  });
+
+  it("does not log the raw body when the internal API key is invalid", async () => {
+    isValidInternalApiKeyMock.mockReturnValue(false);
+    const logger = {
+      error: vi.fn(),
+    };
+
+    await POST(
+      createRequest({
+        logger,
+        body: {
+          emailAccountId: "email-account-1",
+          from: "sender@example.com",
+          attackerControlled: "do-not-log-this-secret",
+        },
+      }) as never,
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Invalid API key for sender pattern analysis",
+      {
+        bodyKeys: ["emailAccountId", "from", "attackerControlled"],
+      },
+    );
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain(
+      "do-not-log-this-secret",
+    );
+    expect(afterMock).not.toHaveBeenCalled();
+  });
+});
+
+function createRequest({
+  logger,
+  body,
+}: {
+  logger: {
+    error: ReturnType<typeof vi.fn>;
+  };
+  body: Record<string, unknown>;
+}) {
+  const request = new Request(
+    "https://example.com/api/ai/analyze-sender-pattern",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  ) as Request & {
+    logger: typeof logger;
+  };
+
+  request.logger = logger;
+
+  return request;
+}

--- a/apps/web/app/api/ai/analyze-sender-pattern/route.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.ts
@@ -26,6 +26,9 @@ const schema = z.object({
 });
 export type AnalyzeSenderPatternBody = z.infer<typeof schema>;
 
+const MAX_LOGGED_BODY_KEYS = 20;
+const MAX_LOGGED_BODY_KEY_LENGTH = 100;
+
 export const POST = withError(
   "api/ai/analyze-sender-pattern",
   async (request) => {
@@ -34,7 +37,9 @@ export const POST = withError(
     let logger = request.logger;
 
     if (!isValidInternalApiKey(await headers(), logger)) {
-      logger.error("Invalid API key for sender pattern analysis", json);
+      logger.error("Invalid API key for sender pattern analysis", {
+        bodyKeys: getSafeBodyKeys(json),
+      });
       return NextResponse.json({ error: "Invalid API key" });
     }
 
@@ -363,4 +368,12 @@ async function getEmailAccountWithRules({
       },
     },
   });
+}
+
+function getSafeBodyKeys(json: unknown) {
+  if (!json || typeof json !== "object" || Array.isArray(json)) return [];
+
+  return Object.keys(json)
+    .slice(0, MAX_LOGGED_BODY_KEYS)
+    .map((key) => key.slice(0, MAX_LOGGED_BODY_KEY_LENGTH));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Avoid logging the full unvalidated analyze-sender-pattern request body on invalid API key failures.
- Log bounded body key metadata instead.
- Add regression coverage ensuring body values are not emitted in auth failure logs.

## Verification
- `pnpm test --run app/api/ai/analyze-sender-pattern/route.test.ts`
- `pnpm exec biome check app/api/ai/analyze-sender-pattern/route.ts app/api/ai/analyze-sender-pattern/route.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

