### PR TITLE
bugfix-batch-0139: Atomically claim pending digest sends

### DIFF
--- a/apps/web/app/api/resend/digest/route.test.ts
+++ b/apps/web/app/api/resend/digest/route.test.ts
@@ -1,0 +1,192 @@
+vi.mock("server-only", () => ({}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DigestStatus } from "@/generated/prisma/enums";
+import { createScopedLogger } from "@/utils/logger";
+import prisma from "@/utils/__mocks__/prisma";
+
+const {
+  mockCreateEmailProvider,
+  mockCreateUnsubscribeToken,
+  mockSendDigest,
+  mockCaptureException,
+} = vi.hoisted(() => ({
+  mockCreateEmailProvider: vi.fn(),
+  mockCreateUnsubscribeToken: vi.fn(),
+  mockSendDigest: vi.fn(),
+  mockCaptureException: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (
+      _scope: string,
+      handler: (
+        request: Request & {
+          auth: { emailAccountId: string };
+          logger: ReturnType<typeof createScopedLogger>;
+        },
+      ) => Promise<Response>,
+    ) =>
+    (request: Request) =>
+      handler(
+        Object.assign(request, {
+          auth: { emailAccountId: "email-account-1" },
+          logger: createScopedLogger("test/resend-digest"),
+        }),
+      ),
+  withError:
+    (_scope: string, handler: (request: Request) => Promise<Response>) =>
+    (request: Request) =>
+      handler(request),
+}));
+
+vi.mock("@/utils/qstash", () => ({
+  withQstashOrInternal:
+    (
+      handler: (
+        request: Request & { logger: ReturnType<typeof createScopedLogger> },
+      ) => Promise<Response>,
+    ) =>
+    (request: Request) =>
+      handler(
+        Object.assign(request, {
+          logger: createScopedLogger("test/resend-digest"),
+        }),
+      ),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: mockCreateEmailProvider,
+}));
+
+vi.mock("@/utils/unsubscribe", () => ({
+  createUnsubscribeToken: mockCreateUnsubscribeToken,
+}));
+
+vi.mock("@/utils/digest/send-digest", () => ({
+  sendDigest: mockSendDigest,
+}));
+
+vi.mock("@/utils/error", async (importActual) => {
+  const actual = await importActual<typeof import("@/utils/error")>();
+  return {
+    ...actual,
+    captureException: mockCaptureException,
+  };
+});
+
+import { POST } from "./route";
+
+describe("resend digest route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      account: { provider: "google", refresh_token: "refresh-token" },
+    } as any);
+    prisma.schedule.findUnique.mockResolvedValue({
+      id: "schedule-1",
+      intervalDays: 1,
+      occurrences: null,
+      daysOfWeek: null,
+      timeOfDay: null,
+      lastOccurrenceAt: null,
+      nextOccurrenceAt: new Date("2026-05-05T08:00:00Z"),
+    } as any);
+    prisma.digest.findMany.mockResolvedValue([]);
+    prisma.digest.updateMany.mockResolvedValue({ count: 0 });
+    prisma.digest.updateManyAndReturn.mockResolvedValue([]);
+    prisma.schedule.update.mockResolvedValue({} as any);
+    prisma.digestItem.updateMany.mockResolvedValue({ count: 1 });
+    prisma.$transaction.mockResolvedValue([]);
+    mockCreateEmailProvider.mockResolvedValue({
+      getMessagesBatch: vi.fn().mockResolvedValue([
+        {
+          id: "message-1",
+          headers: { from: "Sender <sender@example.com>", subject: "Hello" },
+        },
+      ]),
+    });
+    mockCreateUnsubscribeToken.mockResolvedValue("unsubscribe-token");
+    mockSendDigest.mockResolvedValue(undefined);
+  });
+
+  it("does not send when another worker claimed the pending digests first", async () => {
+    prisma.digest.findMany.mockResolvedValue([
+      {
+        id: "digest-1",
+        items: [
+          {
+            messageId: "message-1",
+            content: JSON.stringify({ content: "Digest item" }),
+            action: null,
+          },
+        ],
+      },
+    ] as any);
+    prisma.digest.updateManyAndReturn.mockResolvedValue([]);
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      message: "No digests to process",
+    });
+    expect(prisma.digest.updateManyAndReturn).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-1",
+        status: DigestStatus.PENDING,
+      },
+      data: {
+        status: DigestStatus.PROCESSING,
+      },
+      select: {
+        id: true,
+        items: {
+          select: {
+            messageId: true,
+            content: true,
+            action: {
+              select: {
+                executedRule: {
+                  select: {
+                    rule: {
+                      select: {
+                        name: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(mockSendDigest).not.toHaveBeenCalled();
+    expect(prisma.digest.updateMany).not.toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ["digest-1"],
+        },
+      },
+      data: {
+        status: DigestStatus.PROCESSING,
+      },
+    });
+  });
+});
+
+function createRequest() {
+  return new Request("http://localhost/api/resend/digest", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ emailAccountId: "email-account-1" }),
+  });
+}

--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -128,12 +128,6 @@ async function sendEmail({
     return { success: false, message: "Account has no refresh token" };
   }
 
-  const emailProvider = await createEmailProvider({
-    emailAccountId,
-    provider: emailAccount.account.provider,
-    logger,
-  });
-
   const digestScheduleData = await getDigestSchedule({ emailAccountId });
   const digestScheduleProgression = digestScheduleData
     ? getDigestScheduleProgression(digestScheduleData, now)
@@ -153,10 +147,13 @@ async function sendEmail({
     }
   }
 
-  const pendingDigests = await prisma.digest.findMany({
+  const pendingDigests = await prisma.digest.updateManyAndReturn({
     where: {
       emailAccountId,
       status: DigestStatus.PENDING,
+    },
+    data: {
+      status: DigestStatus.PROCESSING,
     },
     select: {
       id: true,
@@ -182,20 +179,6 @@ async function sendEmail({
     },
   });
 
-  if (pendingDigests.length) {
-    // Mark all found digests as processing
-    await prisma.digest.updateMany({
-      where: {
-        id: {
-          in: pendingDigests.map((d) => d.id),
-        },
-      },
-      data: {
-        status: DigestStatus.PROCESSING,
-      },
-    });
-  }
-
   try {
     // Return early if no digests were found, unless force is true
     if (pendingDigests.length === 0) {
@@ -215,6 +198,12 @@ async function sendEmail({
       // When force is true, send an empty digest to indicate the system is working
       logger.info("Force sending empty digest", { emailAccountId });
     }
+
+    const emailProvider = await createEmailProvider({
+      emailAccountId,
+      provider: emailAccount.account.provider,
+      logger,
+    });
 
     // Store the digest IDs for the final update
     const processedDigestIds = pendingDigests.map((d) => d.id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Claim pending digest rows with a status-guarded update before sending.
- Process only digests that were actually transitioned to processing.
- Add regression coverage for a contended claim that should not send duplicates.

## Verification
- `pnpm test --run app/api/resend/digest/route.test.ts`
- `pnpm exec biome check app/api/resend/digest/route.ts app/api/resend/digest/route.test.ts`
- `pnpm lint` (passed with one unrelated existing warning)

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

