### PR TITLE
bugfix-batch-0139: Keep digest settings response shape consistent

### DIFF
--- a/apps/web/app/api/user/digest-settings/route.test.ts
+++ b/apps/web/app/api/user/digest-settings/route.test.ts
@@ -1,0 +1,70 @@
+vi.mock("server-only", () => ({}));
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindUnique } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (
+      _scope: string,
+      handler: (
+        request: NextRequest & {
+          auth: { emailAccountId: string; userId: string; email: string };
+        },
+      ) => Promise<Response>,
+    ) =>
+    async (request: NextRequest) => {
+      const emailRequest = request as NextRequest & {
+        auth: { emailAccountId: string; userId: string; email: string };
+      };
+      emailRequest.auth = {
+        emailAccountId: "missing-email-account-id",
+        userId: "user-1",
+        email: "user@example.com",
+      };
+
+      return handler(emailRequest);
+    },
+}));
+
+import { GET } from "./route";
+
+describe("digest settings route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the complete default settings shape when the email account is missing", async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/user/digest-settings"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      toReply: false,
+      awaitingReply: false,
+      fyi: false,
+      actioned: false,
+      newsletter: false,
+      marketing: false,
+      calendar: false,
+      receipt: false,
+      notification: false,
+      coldEmail: false,
+    });
+  });
+});

--- a/apps/web/app/api/user/digest-settings/route.ts
+++ b/apps/web/app/api/user/digest-settings/route.ts
@@ -31,6 +31,10 @@ const DEFAULT_DIGEST_SETTINGS = {
   coldEmail: false,
 } satisfies Record<string, boolean>;
 
+type DigestSettings = {
+  [K in keyof typeof DEFAULT_DIGEST_SETTINGS]: boolean;
+};
+
 export type GetDigestSettingsResponse = Awaited<
   ReturnType<typeof getDigestSettings>
 >;
@@ -73,10 +77,10 @@ async function getDigestSettings({
   }
 
   // Build digest settings object
-  const digestSettings = { ...DEFAULT_DIGEST_SETTINGS };
+  const digestSettings: DigestSettings = { ...DEFAULT_DIGEST_SETTINGS };
 
   // Map system types to digest settings
-  const systemTypeToKey: Record<SystemType, keyof typeof digestSettings> = {
+  const systemTypeToKey: Record<SystemType, keyof DigestSettings> = {
     [SystemType.TO_REPLY]: "toReply",
     [SystemType.AWAITING_REPLY]: "awaitingReply",
     [SystemType.FYI]: "fyi",

--- a/apps/web/app/api/user/digest-settings/route.ts
+++ b/apps/web/app/api/user/digest-settings/route.ts
@@ -29,7 +29,7 @@ const DEFAULT_DIGEST_SETTINGS = {
   receipt: false,
   notification: false,
   coldEmail: false,
-};
+} satisfies Record<string, boolean>;
 
 export type GetDigestSettingsResponse = Awaited<
   ReturnType<typeof getDigestSettings>

--- a/apps/web/app/api/user/digest-settings/route.ts
+++ b/apps/web/app/api/user/digest-settings/route.ts
@@ -18,6 +18,19 @@ const SUPPORTED_SYSTEM_TYPES = [
   SystemType.COLD_EMAIL,
 ] as const;
 
+const DEFAULT_DIGEST_SETTINGS = {
+  toReply: false,
+  awaitingReply: false,
+  fyi: false,
+  actioned: false,
+  newsletter: false,
+  marketing: false,
+  calendar: false,
+  receipt: false,
+  notification: false,
+  coldEmail: false,
+};
+
 export type GetDigestSettingsResponse = Awaited<
   ReturnType<typeof getDigestSettings>
 >;
@@ -56,30 +69,11 @@ async function getDigestSettings({
   });
 
   if (!emailAccount) {
-    return {
-      toReply: false,
-      newsletter: false,
-      marketing: false,
-      calendar: false,
-      receipt: false,
-      notification: false,
-      coldEmail: false,
-    };
+    return { ...DEFAULT_DIGEST_SETTINGS };
   }
 
   // Build digest settings object
-  const digestSettings = {
-    toReply: false,
-    awaitingReply: false,
-    fyi: false,
-    actioned: false,
-    newsletter: false,
-    marketing: false,
-    calendar: false,
-    receipt: false,
-    notification: false,
-    coldEmail: false,
-  };
+  const digestSettings = { ...DEFAULT_DIGEST_SETTINGS };
 
   // Map system types to digest settings
   const systemTypeToKey: Record<SystemType, keyof typeof digestSettings> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared default digest settings response with all expected keys.
- Ensure the missing-account fallback includes awaitingReply, fyi, and actioned.
- Add regression coverage for the default response shape.
- Follow-up cleanup types the default settings object against the response shape.

## Verification
- `pnpm test app/api/user/digest-settings/route.test.ts --run`
- `pnpm lint` (passed with one unrelated existing warning)
- `git diff --check -- apps/web/app/api/user/digest-settings/route.ts apps/web/app/api/user/digest-settings/route.test.ts`
- Follow-up cleanup: `git diff --check`; focused test could not run in isolated cleanup worktree because dependencies were not installed there.

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

