### PR TITLE
bugfix-batch-0139: Prevent removing the final organization owner

### DIFF
--- a/apps/web/utils/actions/organization.test.ts
+++ b/apps/web/utils/actions/organization.test.ts
@@ -120,6 +120,7 @@ describe("removeMemberAction", () => {
       "You cannot remove yourself from the organization.",
     );
     expect(prisma.member.delete).not.toHaveBeenCalled();
+    expect(prisma.member.deleteMany).not.toHaveBeenCalled();
   });
 
   it("only lets owners remove other owners", async () => {
@@ -140,5 +141,43 @@ describe("removeMemberAction", () => {
 
     expect(result?.serverError).toBe("Only owners can remove other owners.");
     expect(prisma.member.delete).not.toHaveBeenCalled();
+    expect(prisma.member.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("re-checks another owner exists while deleting an owner", async () => {
+    prisma.member.findUnique.mockResolvedValue({
+      id: "member-2",
+      emailAccountId: "email-account-2",
+      organizationId: "org-1",
+      role: "owner",
+    } as any);
+    prisma.member.findFirst.mockResolvedValue({
+      role: "owner",
+      emailAccountId: "email-account-1",
+    } as any);
+    prisma.member.deleteMany.mockResolvedValue({ count: 0 });
+
+    const result = await removeMemberAction({
+      memberId: "member-2",
+    });
+
+    expect(prisma.member.count).not.toHaveBeenCalled();
+    expect(prisma.member.delete).not.toHaveBeenCalled();
+    expect(prisma.member.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "member-2",
+        organization: {
+          members: {
+            some: {
+              id: { not: "member-2" },
+              role: "owner",
+            },
+          },
+        },
+      },
+    });
+    expect(result?.serverError).toBe(
+      "Cannot remove the last remaining owner from the organization.",
+    );
   });
 });

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -306,10 +306,21 @@ export const removeMemberAction = actionClientUser
     });
 
     if (targetMember.role === "owner") {
-      const ownerCount = await prisma.member.count({
-        where: { organizationId: targetMember.organizationId, role: "owner" },
+      const deletedMember = await prisma.member.deleteMany({
+        where: {
+          id: memberId,
+          organization: {
+            members: {
+              some: {
+                id: { not: memberId },
+                role: "owner",
+              },
+            },
+          },
+        },
       });
-      if (ownerCount === 1) {
+
+      if (deletedMember.count !== 1) {
         throw new SafeError(
           "Cannot remove the last remaining owner from the organization.",
         );
@@ -329,7 +340,9 @@ export const removeMemberAction = actionClientUser
       }
     }
 
-    await prisma.member.delete({ where: { id: memberId } });
+    if (targetMember.role !== "owner") {
+      await prisma.member.delete({ where: { id: memberId } });
+    }
   });
 
 export const updateMemberRoleAction = actionClientUser


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the owner count/delete race with a conditional deleteMany guard.
- Verify the delete actually happened and preserve the last-owner invariant under contention.
- Add organization action regression coverage.

## Verification
- `pnpm install`
- `pnpm test --run utils/actions/organization.test.ts`
- `pnpm --filter inbox-zero-ai lint -- utils/actions/organization.ts utils/actions/organization.test.ts` (passed with one unrelated existing warning)
- `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

