### PR TITLE
bugfix-batch-0139: Guard email account deletion races

### DIFF
--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import prisma from "@/utils/__mocks__/prisma";
+import { updateAccountSeats } from "@/utils/premium/seats";
+import { aliasPosthogUser } from "@/utils/posthog";
+import { deleteEmailAccountAction } from "./user";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "primary@example.com" },
+  })),
+  betterAuthConfig: {
+    api: {
+      signOut: vi.fn(),
+    },
+  },
+}));
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+
+  return {
+    ...actual,
+    after: vi.fn((callback: () => Promise<void> | void) => callback()),
+  };
+});
+vi.mock("@sentry/nextjs", () => ({
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+  captureException: vi.fn(),
+  withServerActionInstrumentation: vi.fn(
+    async (_name: string, callback: () => Promise<unknown>) => callback(),
+  ),
+}));
+vi.mock("@/utils/cookies.server", () => ({
+  clearLastEmailAccountCookie: vi.fn(),
+}));
+vi.mock("@/utils/user/delete", () => ({
+  deleteUser: vi.fn(),
+}));
+vi.mock("@/utils/posthog", () => ({
+  aliasPosthogUser: vi.fn(),
+}));
+vi.mock("@/utils/premium/seats", () => ({
+  updateAccountSeats: vi.fn(),
+}));
+vi.mock("@/utils/ai/draft-cleanup", () => ({
+  cleanupAIDraftsForAccount: vi.fn(),
+}));
+
+describe("deleteEmailAccountAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.account.delete.mockResolvedValue({ id: "account-1" } as any);
+    prisma.user.update.mockResolvedValue({ id: "user-1" } as any);
+    prisma.$queryRaw.mockResolvedValue([{ pg_advisory_xact_lock: "" }]);
+    prisma.$transaction.mockImplementation(async (operations) =>
+      Promise.all(operations as Promise<unknown>[]),
+    );
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "primary@example.com",
+      accountId: "account-1",
+      user: { email: "primary@example.com" },
+    } as Awaited<ReturnType<typeof prisma.emailAccount.findUnique>>);
+  });
+
+  it("promotes another account before deleting the primary account", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "alternate-email-account",
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: "https://example.com/avatar.png",
+      },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.stringContaining("pg_advisory_xact_lock"),
+      ]),
+      "user-1",
+    );
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: {
+        id: "user-1",
+        email: "primary@example.com",
+        emailAccounts: { some: { id: "alternate-email-account" } },
+      },
+      data: {
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: "https://example.com/avatar.png",
+      },
+    });
+    expect(prisma.account.delete).toHaveBeenCalledWith({
+      where: { id: "account-1", userId: "user-1" },
+    });
+    expect(aliasPosthogUser).toHaveBeenCalledWith({
+      oldEmail: "primary@example.com",
+      newEmail: "alternate@example.com",
+    });
+    expect(updateAccountSeats).toHaveBeenCalledWith({ userId: "user-1" });
+  });
+
+  it("does not delete the primary account when promotion loses a concurrent update", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "alternate-email-account",
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: null,
+      },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.$transaction.mockRejectedValue(newPrismaNotFoundError());
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBe("Email account already changed");
+    expect(aliasPosthogUser).not.toHaveBeenCalled();
+    expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a promoted account with a stale non-primary request", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "alternate@example.com",
+      accountId: "account-2",
+      user: { email: "primary@example.com" },
+    } as Awaited<ReturnType<typeof prisma.emailAccount.findUnique>>);
+    prisma.account.delete.mockRejectedValue(newPrismaNotFoundError());
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "alternate-email-account",
+    });
+
+    expect(result?.serverError).toBe("Email account already changed");
+    expect(prisma.account.delete).toHaveBeenCalledWith({
+      where: {
+        id: "account-2",
+        userId: "user-1",
+        emailAccount: { user: { email: "primary@example.com" } },
+      },
+    });
+    expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+});
+
+function newPrismaNotFoundError() {
+  return new Prisma.PrismaClientKnownRequestError("Record not found", {
+    code: "P2025",
+    clientVersion: "test",
+  });
+}

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -125,8 +125,7 @@ export const deleteEmailAccountAction = actionClientUser
       const newPrimaryAccount = otherEmailAccounts[0];
       const oldEmail = emailAccount.user.email;
 
-      await runDeleteEmailAccountTransaction([
-        getDeleteEmailAccountLock(userId),
+      await runDeleteEmailAccountTransaction(userId, [
         prisma.user.update({
           where: {
             id: userId,
@@ -152,8 +151,7 @@ export const deleteEmailAccountAction = actionClientUser
         });
       });
     } else {
-      await runDeleteEmailAccountTransaction([
-        getDeleteEmailAccountLock(userId),
+      await runDeleteEmailAccountTransaction(userId, [
         prisma.account.delete({
           where: {
             id: emailAccount.accountId,
@@ -170,10 +168,16 @@ export const deleteEmailAccountAction = actionClientUser
   });
 
 async function runDeleteEmailAccountTransaction(
+  userId: string,
   operations: Prisma.PrismaPromise<unknown>[],
 ) {
   try {
-    await prisma.$transaction(operations);
+    await prisma.$transaction([
+      prisma.$queryRaw`
+        SELECT pg_advisory_xact_lock(539114481, hashtext(${userId}))
+      `,
+      ...operations,
+    ]);
   } catch (error) {
     if (isNotFoundError(error)) {
       throw new SafeError("Email account already changed");
@@ -181,10 +185,4 @@ async function runDeleteEmailAccountTransaction(
 
     throw error;
   }
-}
-
-function getDeleteEmailAccountLock(userId: string) {
-  return prisma.$queryRaw`
-    SELECT pg_advisory_xact_lock(539114481, hashtext(${userId}))
-  `;
 }

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -2,7 +2,6 @@
 
 import { z } from "zod";
 import { after } from "next/server";
-import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
 import { deleteUser } from "@/utils/user/delete";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
@@ -18,6 +17,7 @@ import {
 import { clearLastEmailAccountCookie } from "@/utils/cookies.server";
 import { aliasPosthogUser } from "@/utils/posthog";
 import { cleanupAIDraftsForAccount } from "@/utils/ai/draft-cleanup";
+import { isNotFoundError } from "@/utils/prisma-helpers";
 
 export const saveAboutAction = actionClient
   .metadata({ name: "saveAbout" })
@@ -174,21 +174,12 @@ async function runDeleteEmailAccountTransaction(
   try {
     await prisma.$transaction(operations);
   } catch (error) {
-    if (isPrismaNotFoundError(error)) {
+    if (isNotFoundError(error)) {
       throw new SafeError("Email account already changed");
     }
 
     throw error;
   }
-}
-
-function isPrismaNotFoundError(
-  error: unknown,
-): error is Prisma.PrismaClientKnownRequestError {
-  return (
-    error instanceof Prisma.PrismaClientKnownRequestError &&
-    error.code === "P2025"
-  );
 }
 
 function getDeleteEmailAccountLock(userId: string) {

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { after } from "next/server";
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
 import { deleteUser } from "@/utils/user/delete";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
@@ -169,7 +170,7 @@ export const deleteEmailAccountAction = actionClientUser
   });
 
 async function runDeleteEmailAccountTransaction(
-  operations: Parameters<typeof prisma.$transaction>[0],
+  operations: Prisma.PrismaPromise<unknown>[],
 ) {
   try {
     await prisma.$transaction(operations);

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { after } from "next/server";
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
 import { deleteUser } from "@/utils/user/delete";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
@@ -123,14 +124,24 @@ export const deleteEmailAccountAction = actionClientUser
       const newPrimaryAccount = otherEmailAccounts[0];
       const oldEmail = emailAccount.user.email;
 
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          email: newPrimaryAccount.email,
-          name: newPrimaryAccount.name,
-          image: newPrimaryAccount.image,
-        },
-      });
+      await runDeleteEmailAccountTransaction([
+        getDeleteEmailAccountLock(userId),
+        prisma.user.update({
+          where: {
+            id: userId,
+            email: oldEmail,
+            emailAccounts: { some: { id: newPrimaryAccount.id } },
+          },
+          data: {
+            email: newPrimaryAccount.email,
+            name: newPrimaryAccount.name,
+            image: newPrimaryAccount.image,
+          },
+        }),
+        prisma.account.delete({
+          where: { id: emailAccount.accountId, userId },
+        }),
+      ]);
 
       // Alias the old PostHog identity to the new one
       after(async () => {
@@ -139,13 +150,49 @@ export const deleteEmailAccountAction = actionClientUser
           newEmail: newPrimaryAccount.email,
         });
       });
+    } else {
+      await runDeleteEmailAccountTransaction([
+        getDeleteEmailAccountLock(userId),
+        prisma.account.delete({
+          where: {
+            id: emailAccount.accountId,
+            userId,
+            emailAccount: { user: { email: emailAccount.user.email } },
+          },
+        }),
+      ]);
     }
-
-    await prisma.account.delete({
-      where: { id: emailAccount.accountId, userId },
-    });
 
     after(async () => {
       await updateAccountSeats({ userId });
     });
   });
+
+async function runDeleteEmailAccountTransaction(
+  operations: Parameters<typeof prisma.$transaction>[0],
+) {
+  try {
+    await prisma.$transaction(operations);
+  } catch (error) {
+    if (isPrismaNotFoundError(error)) {
+      throw new SafeError("Email account already changed");
+    }
+
+    throw error;
+  }
+}
+
+function isPrismaNotFoundError(
+  error: unknown,
+): error is Prisma.PrismaClientKnownRequestError {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2025"
+  );
+}
+
+function getDeleteEmailAccountLock(userId: string) {
+  return prisma.$queryRaw`
+    SELECT pg_advisory_xact_lock(539114481, hashtext(${userId}))
+  `;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Serialize the email account delete/promotion/delete sequence with array-form Prisma transaction operations.
- Add conditional updates/deletes to avoid stale primary promotion and promoted-account deletion races.
- Add regression coverage for the deletion race behavior.
- Follow-up cleanup reuses the shared Prisma not-found helper.

## Verification
- `pnpm test utils/actions/user.test.ts --run`
- `pnpm exec biome check utils/actions/user.ts utils/actions/user.test.ts`
- Follow-up cleanup: `/workspace/apps/web/node_modules/.bin/vitest run utils/actions/user.test.ts`; `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

