### PR TITLE
bugfix-batch-0139: Serialize personal instruction appends

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -29,6 +29,7 @@ const {
   mockPosthogCaptureEvent: vi.fn(),
   mockUnsubscribeSenderAndMark: vi.fn(),
   mockPrisma: {
+    $queryRaw: vi.fn(),
     emailAccount: {
       findUnique: vi.fn(),
       update: vi.fn(),
@@ -2098,10 +2099,12 @@ describe("aiProcessAssistantChat", () => {
   it("updatePersonalInstructions in append mode preserves existing content", async () => {
     const tools = await captureToolSet();
 
-    mockPrisma.emailAccount.findUnique.mockResolvedValue({
-      about: "Existing instructions",
-    });
-    mockPrisma.emailAccount.update.mockResolvedValue({});
+    mockPrisma.$queryRaw.mockResolvedValue([
+      {
+        previous: "Existing instructions",
+        updated: "Existing instructions\nAdditional preference",
+      },
+    ]);
 
     const result = await tools.updatePersonalInstructions.execute({
       personalInstructions: "Additional preference",
@@ -2111,20 +2114,18 @@ describe("aiProcessAssistantChat", () => {
     expect(result.success).toBe(true);
     expect(result.updated).toBe("Existing instructions\nAdditional preference");
     expect(result.previous).toBe("Existing instructions");
-    expect(mockPrisma.emailAccount.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: { about: "Existing instructions\nAdditional preference" },
-      }),
-    );
+    expect(mockPrisma.emailAccount.update).not.toHaveBeenCalled();
   });
 
   it("updatePersonalInstructions defaults to append mode", async () => {
     const tools = await captureToolSet();
 
-    mockPrisma.emailAccount.findUnique.mockResolvedValue({
-      about: "Existing instructions",
-    });
-    mockPrisma.emailAccount.update.mockResolvedValue({});
+    mockPrisma.$queryRaw.mockResolvedValue([
+      {
+        previous: "Existing instructions",
+        updated: "Existing instructions\nAdditional preference",
+      },
+    ]);
 
     const result = await tools.updatePersonalInstructions.execute({
       personalInstructions: "Additional preference",
@@ -2132,20 +2133,18 @@ describe("aiProcessAssistantChat", () => {
 
     expect(result.success).toBe(true);
     expect(result.updated).toBe("Existing instructions\nAdditional preference");
-    expect(mockPrisma.emailAccount.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: { about: "Existing instructions\nAdditional preference" },
-      }),
-    );
+    expect(mockPrisma.emailAccount.update).not.toHaveBeenCalled();
   });
 
   it("updatePersonalInstructions in append mode with no existing about sets new content", async () => {
     const tools = await captureToolSet();
 
-    mockPrisma.emailAccount.findUnique.mockResolvedValue({
-      about: null,
-    });
-    mockPrisma.emailAccount.update.mockResolvedValue({});
+    mockPrisma.$queryRaw.mockResolvedValue([
+      {
+        previous: null,
+        updated: "First instructions",
+      },
+    ]);
 
     const result = await tools.updatePersonalInstructions.execute({
       personalInstructions: "First instructions",

--- a/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
@@ -1,0 +1,71 @@
+import type { Prisma } from "@/generated/prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+import { updatePersonalInstructionsTool } from "./update-personal-instructions-tool";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const logger = createScopedLogger("update-personal-instructions-tool-test");
+
+describe("updatePersonalInstructionsTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves concurrent append updates", async () => {
+    let about = "Existing instructions";
+    let activeWrites = 0;
+
+    vi.mocked(prisma.$queryRaw).mockImplementation(
+      async (query: TemplateStringsArray | Prisma.Sql) => {
+        activeWrites += 1;
+        const snapshot = about;
+        await Promise.resolve();
+        if (activeWrites > 1) expect(about).toBe(snapshot);
+
+        const values = "values" in query ? query.values : [];
+        const personalInstructions = values[1] as string;
+        const previous = about;
+        about = about
+          ? `${about}\n${personalInstructions}`
+          : personalInstructions;
+
+        activeWrites -= 1;
+        return [{ previous, updated: about }];
+      },
+    );
+
+    const toolInstance = updatePersonalInstructionsTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      logger,
+    });
+
+    const [firstResult, secondResult] = await Promise.all([
+      toolInstance.execute({
+        personalInstructions: "First append",
+        mode: "append",
+      }),
+      toolInstance.execute({
+        personalInstructions: "Second append",
+        mode: "append",
+      }),
+    ]);
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(true);
+    expect(about.split("\n")).toEqual(
+      expect.arrayContaining([
+        "Existing instructions",
+        "First append",
+        "Second append",
+      ]),
+    );
+    expect(prisma.emailAccount.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
@@ -19,26 +19,48 @@ describe("updatePersonalInstructionsTool", () => {
 
   it("preserves concurrent append updates", async () => {
     let about = "Existing instructions";
-    let activeWrites = 0;
+    let locked = false;
+    let sawOverlappingQuery = false;
+    let activeQueries = 0;
+    const lockWaiters: Array<() => void> = [];
 
     vi.mocked(prisma.$queryRaw).mockImplementation(
       async (query: TemplateStringsArray | Prisma.Sql) => {
-        activeWrites += 1;
-        const snapshot = about;
-        await Promise.resolve();
-        if (activeWrites > 1) expect(about).toBe(snapshot);
+        activeQueries += 1;
+        if (activeQueries > 1) sawOverlappingQuery = true;
 
-        const values = "values" in query ? query.values : [];
-        const personalInstructions = values[1] as string;
-        const previous = about;
-        about = about
-          ? `${about}\n${personalInstructions}`
-          : personalInstructions;
+        const usesRowLock = getSqlText(query).includes("FOR UPDATE");
+        if (usesRowLock) await acquireLock();
 
-        activeWrites -= 1;
-        return [{ previous, updated: about }];
+        try {
+          const values = "values" in query ? query.values : [];
+          const personalInstructions = values[1] as string;
+          const previous = about;
+          await Promise.resolve();
+
+          about = previous
+            ? `${previous}\n${personalInstructions}`
+            : personalInstructions;
+
+          return [{ previous, updated: about }];
+        } finally {
+          if (usesRowLock) releaseLock();
+          activeQueries -= 1;
+        }
       },
     );
+
+    async function acquireLock() {
+      while (locked) {
+        await new Promise<void>((resolve) => lockWaiters.push(resolve));
+      }
+      locked = true;
+    }
+
+    function releaseLock() {
+      locked = false;
+      lockWaiters.shift()?.();
+    }
 
     const toolInstance = updatePersonalInstructionsTool({
       email: "user@example.com",
@@ -59,6 +81,7 @@ describe("updatePersonalInstructionsTool", () => {
 
     expect(firstResult.success).toBe(true);
     expect(secondResult.success).toBe(true);
+    expect(sawOverlappingQuery).toBe(true);
     expect(about.split("\n")).toEqual(
       expect.arrayContaining([
         "Existing instructions",
@@ -69,3 +92,8 @@ describe("updatePersonalInstructionsTool", () => {
     expect(prisma.emailAccount.update).not.toHaveBeenCalled();
   });
 });
+
+function getSqlText(query: TemplateStringsArray | Prisma.Sql) {
+  if ("sql" in query) return query.sql;
+  return Array.from(query).join("?");
+}

--- a/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.ts
@@ -1,5 +1,6 @@
 import { type InferUITool, tool } from "ai";
 import { z } from "zod";
+import { Prisma } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { trackRuleToolCall } from "./shared";
@@ -41,27 +42,50 @@ Append by default; replace only when the user clearly wants an overwrite.`,
         logger,
       });
       try {
+        if (mode === "append") {
+          const [updatedAccount] = await prisma.$queryRaw<
+            Array<{ previous: string | null; updated: string | null }>
+          >(Prisma.sql`
+            WITH existing AS (
+              SELECT "id", "about" AS "previous"
+              FROM "EmailAccount"
+              WHERE "id" = ${emailAccountId}
+              FOR UPDATE
+            )
+            UPDATE "EmailAccount"
+            SET "about" = CASE
+              WHEN existing."previous" IS NULL OR existing."previous" = '' THEN ${personalInstructions}
+              ELSE existing."previous" || E'\n' || ${personalInstructions}
+            END
+            FROM existing
+            WHERE "EmailAccount"."id" = existing."id"
+            RETURNING existing."previous", "EmailAccount"."about" AS "updated"
+          `);
+
+          if (!updatedAccount) return { error: "Account not found" };
+
+          return {
+            success: true,
+            previous: updatedAccount.previous,
+            updated: updatedAccount.updated,
+          };
+        }
+
         const existing = await prisma.emailAccount.findUnique({
           where: { id: emailAccountId },
           select: { about: true },
         });
-
         if (!existing) return { error: "Account not found" };
-
-        const updatedAbout =
-          mode === "append" && existing.about
-            ? `${existing.about}\n${personalInstructions}`
-            : personalInstructions;
 
         await prisma.emailAccount.update({
           where: { id: emailAccountId },
-          data: { about: updatedAbout },
+          data: { about: personalInstructions },
         });
 
         return {
           success: true,
           previous: existing.about,
-          updated: updatedAbout,
+          updated: personalInstructions,
         };
       } catch (error) {
         logger.error("Failed to update personal instructions", { error });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use a row-locked SQL update path for append-mode personal instruction updates.
- Preserve replace-mode behavior.
- Add focused tool coverage and update assistant chat coverage.

## Verification
- `pnpm test utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts __tests__/ai-assistant-chat.test.ts`
- `pnpm exec biome check utils/ai/assistant/tools/rules/update-personal-instructions-tool.ts utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts __tests__/ai-assistant-chat.test.ts`
- `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

