### PR TITLE
bugfix-batch-0139: Revalidate drafts before deletion

### DIFF
--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -151,6 +151,97 @@ describe("handlePreviousDraftDeletion", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it("should not delete when draft changes between validation and deletion", async () => {
+    const mockPreviousDraft = {
+      id: "action-111",
+      draftId: "draft-222",
+      content: "Hello, this is a test draft",
+    };
+
+    const originalDraft: ParsedMessage = {
+      id: "msg-123",
+      threadId: "thread-456",
+      textPlain:
+        "Hello, this is a test draft\n\nOn Monday wrote:\n> Previous message",
+      textHtml: undefined,
+      subject: "subject",
+      date: new Date().toISOString(),
+      snippet: "Hello, this is a test draft",
+      historyId: "12345",
+      internalDate: "1234567890",
+      headers: {
+        from: "test@example.com",
+        to: "recipient@example.com",
+        subject: "Test Subject",
+        date: "Mon, 1 Jan 2024 12:00:00 +0000",
+      },
+      labelIds: [],
+      inline: [],
+    };
+    const userEditedDraft: ParsedMessage = {
+      ...originalDraft,
+      textPlain:
+        "Hello, this is a USER EDITED draft\n\nOn Monday wrote:\n> Previous message",
+      snippet: "Hello, this is a USER EDITED draft",
+    };
+
+    mockFindFirst.mockResolvedValue(mockPreviousDraft);
+    mockGetDraft
+      .mockResolvedValueOnce(originalDraft)
+      .mockResolvedValueOnce(userEditedDraft);
+
+    await handlePreviousDraftDeletion({
+      client: mockClient,
+      executedRule: mockExecutedRule,
+      logger,
+    });
+
+    expect(mockGetDraft).toHaveBeenCalledTimes(2);
+    expect(mockDeleteDraft).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("should not delete draft when original content is missing", async () => {
+    const mockPreviousDraft = {
+      id: "action-111",
+      draftId: "draft-222",
+      content: null,
+    };
+
+    const mockCurrentDraft: ParsedMessage = {
+      id: "msg-123",
+      threadId: "thread-456",
+      textPlain: "Potentially user modified draft",
+      textHtml: undefined,
+      subject: "subject",
+      date: new Date().toISOString(),
+      snippet: "Potentially user modified draft",
+      historyId: "12345",
+      internalDate: "1234567890",
+      headers: {
+        from: "test@example.com",
+        to: "recipient@example.com",
+        subject: "Test Subject",
+        date: "Mon, 1 Jan 2024 12:00:00 +0000",
+      },
+      labelIds: [],
+      inline: [],
+    };
+
+    mockFindFirst.mockResolvedValue(mockPreviousDraft);
+    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+
+    await handlePreviousDraftDeletion({
+      client: mockClient,
+      executedRule: mockExecutedRule,
+      logger,
+    });
+
+    expect(mockGetDraft).toHaveBeenCalledWith("draft-222");
+    expect(mockDeleteDraft).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("should handle no previous draft found", async () => {
     mockFindFirst.mockResolvedValue(null);
 

--- a/apps/web/utils/ai/choose-rule/draft-management.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.ts
@@ -63,15 +63,34 @@ export async function handlePreviousDraftDeletion({
       return;
     }
 
-    const isUnmodified =
-      !previousDraftAction.content ||
+    if (previousDraftAction.content === null) {
+      logger.info("Previous draft content missing, skipping deletion.");
+      return;
+    }
+
+    if (
       isDraftUnmodified({
         originalContent: previousDraftAction.content,
         currentDraft: currentDraftDetails,
         logger,
-      });
+      })
+    ) {
+      const latestDraftDetails = await client.getDraft(
+        previousDraftAction.draftId,
+      );
+      const isStillUnmodified =
+        !!(latestDraftDetails?.textPlain || latestDraftDetails?.textHtml) &&
+        isDraftUnmodified({
+          originalContent: previousDraftAction.content,
+          currentDraft: latestDraftDetails,
+          logger,
+        });
 
-    if (isUnmodified) {
+      if (!isStillUnmodified) {
+        logger.info("Draft changed before deletion, skipping deletion.");
+        return;
+      }
+
       logger.info("Draft content matches, deleting draft.");
 
       await Promise.all([


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Re-fetch draft contents immediately before deleting a previous generated draft.
- Revalidate content against the saved original just before deletion.
- Preserve best-effort behavior because provider delete APIs do not expose conditional etag/version deletion.

## Verification
- `pnpm test --run utils/ai/choose-rule/draft-management.test.ts`
- `pnpm exec biome check utils/ai/choose-rule/draft-management.ts utils/ai/choose-rule/draft-management.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

