### PR TITLE
bugfix-batch-0139: Make timezone autopopulate conditional

### DIFF
--- a/apps/web/utils/calendar/timezone-helpers.test.ts
+++ b/apps/web/utils/calendar/timezone-helpers.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import type { Logger } from "@/utils/logger";
+import { autoPopulateTimezone } from "./timezone-helpers";
+
+vi.mock("@/utils/prisma");
+
+const logger = {
+  info: vi.fn(),
+} as unknown as Logger;
+
+describe("autoPopulateTimezone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets the primary calendar timezone only when the email account timezone is still null", async () => {
+    prisma.emailAccount.updateMany.mockResolvedValue({ count: 1 });
+
+    await autoPopulateTimezone(
+      "email-account-1",
+      [
+        { timeZone: "America/Chicago" },
+        { timeZone: "America/New_York", primary: true },
+      ],
+      logger,
+    );
+
+    expect(prisma.emailAccount.updateMany).toHaveBeenCalledWith({
+      where: { id: "email-account-1", timezone: null },
+      data: { timezone: "America/New_York" },
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "Auto-populated EmailAccount timezone",
+      {
+        emailAccountId: "email-account-1",
+        timezone: "America/New_York",
+      },
+    );
+  });
+
+  it("does not log when another writer already populated the timezone", async () => {
+    prisma.emailAccount.updateMany.mockResolvedValue({ count: 0 });
+
+    await autoPopulateTimezone(
+      "email-account-1",
+      [{ timeZone: "America/New_York", primary: true }],
+      logger,
+    );
+
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("does not update when calendars have no timezone", async () => {
+    await autoPopulateTimezone("email-account-1", [{}], logger);
+
+    expect(prisma.emailAccount.updateMany).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/calendar/timezone-helpers.ts
+++ b/apps/web/utils/calendar/timezone-helpers.ts
@@ -13,27 +13,23 @@ export async function autoPopulateTimezone(
   }>,
   logger: Logger,
 ): Promise<void> {
-  const emailAccount = await prisma.emailAccount.findUnique({
-    where: { id: emailAccountId },
-    select: { timezone: true },
+  // Try primary calendar first (Google uses 'primary', Microsoft uses 'isDefaultCalendar')
+  const primaryCalendar = calendars.find(
+    (cal) => cal.primary || cal.isDefaultCalendar,
+  );
+  const timezoneToSet = primaryCalendar?.timeZone || calendars[0]?.timeZone;
+
+  if (!timezoneToSet) return;
+
+  const result = await prisma.emailAccount.updateMany({
+    where: { id: emailAccountId, timezone: null },
+    data: { timezone: timezoneToSet },
   });
 
-  if (!emailAccount?.timezone) {
-    // Try primary calendar first (Google uses 'primary', Microsoft uses 'isDefaultCalendar')
-    const primaryCalendar = calendars.find(
-      (cal) => cal.primary || cal.isDefaultCalendar,
-    );
-    const timezoneToSet = primaryCalendar?.timeZone || calendars[0]?.timeZone;
+  if (result.count === 0) return;
 
-    if (timezoneToSet) {
-      await prisma.emailAccount.update({
-        where: { id: emailAccountId },
-        data: { timezone: timezoneToSet },
-      });
-      logger.info("Auto-populated EmailAccount timezone", {
-        emailAccountId,
-        timezone: timezoneToSet,
-      });
-    }
-  }
+  logger.info("Auto-populated EmailAccount timezone", {
+    emailAccountId,
+    timezone: timezoneToSet,
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace timezone read-then-write with a single conditional updateMany guarded on null timezone.
- Log only when the conditional update writes a row.
- Add regression coverage for preserving an existing timezone.

## Verification
- `cd apps/web && pnpm test --run utils/calendar/timezone-helpers.test.ts`
- `cd apps/web && pnpm exec biome check utils/calendar/timezone-helpers.ts utils/calendar/timezone-helpers.test.ts`
- `cd apps/web && pnpm lint` (failed on unrelated pre-existing files)

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

