### PR TITLE
bugfix-batch-0139: Guard calendar token refresh writes

### DIFF
--- a/apps/web/utils/outlook/calendar-client-occ.test.ts
+++ b/apps/web/utils/outlook/calendar-client-occ.test.ts
@@ -1,0 +1,107 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { getCalendarClientWithRefresh } from "./calendar-client";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    initWithMiddleware: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  getMicrosoftGraphClientOptions: vi.fn(() => ({
+    baseUrl: "http://localhost:4003/",
+  })),
+  getMicrosoftOauthAuthorizeUrl: vi.fn(
+    () => "http://localhost:4003/oauth2/v2.0/authorize",
+  ),
+  requestMicrosoftToken: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    MICROSOFT_CLIENT_ID: "client-id",
+    MICROSOFT_CLIENT_SECRET: "client-secret",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+describe("getCalendarClientWithRefresh token save concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Client.initWithMiddleware).mockReturnValue({} as any);
+    vi.mocked(requestMicrosoftToken).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 3600,
+      }),
+    } as any);
+    prisma.calendarConnection.findFirst.mockResolvedValue({
+      id: "calendar-connection-id",
+    } as any);
+  });
+
+  it("saves refreshed Microsoft calendar tokens with optimistic concurrency", async () => {
+    const expectedExpiresAt = 1_700_000_000_000;
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    await getCalendarClientWithRefresh({
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: expectedExpiresAt,
+      emailAccountId: "email-account-id",
+      logger: createMockLogger(),
+    });
+
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "calendar-connection-id",
+        expiresAt: {
+          gte: new Date(expectedExpiresAt),
+          lt: new Date(expectedExpiresAt + 1),
+        },
+      },
+      data: {
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+        expiresAt: expect.any(Date),
+      },
+    });
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+  });
+
+  it("skips stale Microsoft calendar token saves when a concurrent refresh already won", async () => {
+    const logger = createMockLogger();
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 0 } as any);
+
+    await getCalendarClientWithRefresh({
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: 1_700_000_000_000,
+      emailAccountId: "email-account-id",
+      logger,
+    });
+
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "Skipped stale calendar token update",
+      { connectionId: "calendar-connection-id" },
+    );
+  });
+});
+
+function createMockLogger() {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    with: vi.fn(),
+  };
+}

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -106,6 +106,7 @@ export const getCalendarClientWithRefresh = async ({
           expires_at: Math.floor(Date.now() / 1000 + Number(tokens.expires_in)),
         },
         connectionId: calendarConnection.id,
+        expectedExpiresAt: expiresAt,
         logger,
       });
     } else {
@@ -161,6 +162,7 @@ export async function fetchMicrosoftCalendars(
 async function saveCalendarTokens({
   tokens,
   connectionId,
+  expectedExpiresAt,
   logger,
 }: {
   tokens: {
@@ -169,6 +171,7 @@ async function saveCalendarTokens({
     expires_at?: number; // seconds
   };
   connectionId: string;
+  expectedExpiresAt: number | null;
   logger: Logger;
 }) {
   if (!tokens.access_token) {
@@ -179,8 +182,11 @@ async function saveCalendarTokens({
   }
 
   try {
-    await prisma.calendarConnection.update({
-      where: { id: connectionId },
+    const result = await prisma.calendarConnection.updateMany({
+      where: {
+        id: connectionId,
+        expiresAt: getExpectedExpiresAtWhere(expectedExpiresAt),
+      },
       data: {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token,
@@ -190,9 +196,24 @@ async function saveCalendarTokens({
       },
     });
 
+    if (result.count === 0) {
+      logger.info("Skipped stale calendar token update", { connectionId });
+      return { status: "conflict" as const };
+    }
+
     logger.info("Calendar tokens saved successfully", { connectionId });
+    return { status: "saved" as const };
   } catch (error) {
     logger.error("Failed to save calendar tokens", { error, connectionId });
     throw error;
   }
+}
+
+function getExpectedExpiresAtWhere(expectedExpiresAt: number | null) {
+  if (!expectedExpiresAt) return null;
+
+  return {
+    gte: new Date(expectedExpiresAt),
+    lt: new Date(expectedExpiresAt + 1),
+  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Save refreshed Outlook calendar tokens with optimistic concurrency based on the previously observed expiry.
- Skip stale concurrent refresh writes instead of overwriting newer rotated tokens.
- Add regression coverage for successful saves and conflicts.

## Verification
- `pnpm test --run utils/outlook/calendar-client-occ.test.ts`
- `pnpm exec biome check utils/outlook/calendar-client.ts utils/outlook/calendar-client-occ.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

