### PR TITLE
bugfix-batch-0139: Refresh Outlook calendar tokens before expiry

### DIFF
--- a/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
+++ b/apps/web/utils/outlook/calendar-client-refresh-buffer.test.ts
@@ -1,0 +1,89 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { getCalendarClientWithRefresh } from "./calendar-client";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    initWithMiddleware: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  getMicrosoftGraphClientOptions: vi.fn(() => ({
+    baseUrl: "http://localhost:4003/",
+  })),
+  getMicrosoftOauthAuthorizeUrl: vi.fn(
+    () => "http://localhost:4003/oauth2/v2.0/authorize",
+  ),
+  requestMicrosoftToken: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    MICROSOFT_CLIENT_ID: "client-id",
+    MICROSOFT_CLIENT_SECRET: "client-secret",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+describe("getCalendarClientWithRefresh token buffer", () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    vi.mocked(Client.initWithMiddleware).mockReturnValue({} as any);
+    vi.mocked(requestMicrosoftToken).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 3600,
+      }),
+    } as any);
+    prisma.calendarConnection.findFirst.mockResolvedValue({
+      id: "calendar-connection-id",
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("refreshes a cached token that expires within ten minutes", async () => {
+    await getCalendarClientWithRefresh({
+      accessToken: "cached-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: now.getTime() + 9 * 60 * 1000,
+      emailAccountId: "email-account-id",
+      logger: createMockLogger(),
+    });
+
+    expect(requestMicrosoftToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+        grant_type: "refresh_token",
+      }),
+    );
+    expect(Client.initWithMiddleware).toHaveBeenCalledWith({
+      authProvider: expect.any(Object),
+      baseUrl: "http://localhost:4003/",
+    });
+  });
+});
+
+function createMockLogger() {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    with: vi.fn(),
+  };
+}

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -13,6 +13,8 @@ import {
   type AuthenticationProvider,
 } from "@microsoft/microsoft-graph-client";
 
+const TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000;
+
 class CalendarAuthProvider implements AuthenticationProvider {
   private readonly accessToken: string;
 
@@ -57,7 +59,11 @@ export const getCalendarClientWithRefresh = async ({
   if (!refreshToken) throw new SafeError("No refresh token");
 
   // Check if token is still valid
-  if (expiresAt && expiresAt > Date.now() && accessToken) {
+  if (
+    expiresAt &&
+    expiresAt > Date.now() + TOKEN_REFRESH_BUFFER_MS &&
+    accessToken
+  ) {
     const authProvider = new CalendarAuthProvider(accessToken);
     return Client.initWithMiddleware({
       authProvider,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a ten-minute refresh buffer to Outlook calendar token reuse checks.
- Refresh near-expiry calendar tokens before Graph calls can run past expiry.
- Add focused regression coverage for near-expiry token handling.

## Verification
- `pnpm test --run utils/outlook/calendar-client-refresh-buffer.test.ts`
- `pnpm exec biome check utils/outlook/calendar-client.ts utils/outlook/calendar-client-refresh-buffer.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

