### PR TITLE
bugfix-batch-0139: Surface Outlook calendar reauth errors

### DIFF
--- a/apps/web/utils/outlook/calendar-client.test.ts
+++ b/apps/web/utils/outlook/calendar-client.test.ts
@@ -1,0 +1,113 @@
+import { Client } from "@microsoft/microsoft-graph-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { SafeError } from "@/utils/error";
+import prisma from "@/utils/__mocks__/prisma";
+import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { getCalendarClientWithRefresh } from "./calendar-client";
+
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    initWithMiddleware: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/microsoft/oauth", () => ({
+  getMicrosoftGraphClientOptions: vi.fn(() => ({
+    baseUrl: "http://localhost:4003/",
+  })),
+  getMicrosoftOauthAuthorizeUrl: vi.fn(
+    () => "http://localhost:4003/oauth2/v2.0/authorize",
+  ),
+  requestMicrosoftToken: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    MICROSOFT_CLIENT_ID: "client-id",
+    MICROSOFT_CLIENT_SECRET: "client-secret",
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+const logger = createTestLogger();
+
+describe("getCalendarClientWithRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks Microsoft calendar disconnected and throws a reconnect SafeError for invalid_grant", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("invalid_grant: refresh token revoked"),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toMatchObject({
+      name: "SafeError",
+      safeMessage:
+        "Your Microsoft calendar authorization has expired. Please reconnect your calendar.",
+    });
+
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        provider: "microsoft",
+        isConnected: true,
+      },
+      data: { isConnected: false },
+    });
+    expect(Client.initWithMiddleware).not.toHaveBeenCalled();
+  });
+
+  it("marks Microsoft calendar disconnected and throws a reconnect SafeError for AADSTS reauth failures", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse(
+        "AADSTS50173: The provided grant has expired due to it being revoked.",
+      ),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toBeInstanceOf(
+      SafeError,
+    );
+
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        provider: "microsoft",
+        isConnected: true,
+      },
+      data: { isConnected: false },
+    });
+  });
+
+  it("rethrows non-reauth token refresh failures without disconnecting the calendar", async () => {
+    vi.mocked(requestMicrosoftToken).mockResolvedValue(
+      tokenErrorResponse("temporarily_unavailable"),
+    );
+
+    await expect(refreshExpiredCalendarClient()).rejects.toThrow(
+      "temporarily_unavailable",
+    );
+
+    expect(prisma.calendarConnection.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+function refreshExpiredCalendarClient() {
+  return getCalendarClientWithRefresh({
+    accessToken: "stale-access-token",
+    refreshToken: "refresh-token",
+    expiresAt: Date.now() - 1000,
+    emailAccountId: "email-account-id",
+    logger,
+  });
+}
+
+function tokenErrorResponse(errorDescription: string) {
+  return {
+    ok: false,
+    json: vi.fn().mockResolvedValue({ error_description: errorDescription }),
+  } as any;
+}

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -120,14 +120,20 @@ export const getCalendarClientWithRefresh = async ({
       ...getMicrosoftGraphClientOptions(tokens.access_token),
     });
   } catch (error) {
-    const isInvalidGrantError =
-      error instanceof Error && error.message.includes("invalid_grant");
+    if (isMicrosoftCalendarReauthError(error)) {
+      logger.warn(
+        "Microsoft calendar authorization expired - user needs to reconnect",
+        {
+          emailAccountId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
 
-    if (isInvalidGrantError) {
-      logger.warn("Error refreshing Calendar access token", {
-        emailAccountId,
-        error: error.message,
-      });
+      await markMicrosoftCalendarDisconnected(emailAccountId);
+
+      throw new SafeError(
+        "Your Microsoft calendar authorization has expired. Please reconnect your calendar.",
+      );
     }
 
     throw error;
@@ -195,4 +201,34 @@ async function saveCalendarTokens({
     logger.error("Failed to save calendar tokens", { error, connectionId });
     throw error;
   }
+}
+
+async function markMicrosoftCalendarDisconnected(emailAccountId: string) {
+  await prisma.calendarConnection.updateMany({
+    where: {
+      emailAccountId,
+      provider: "microsoft",
+      isConnected: true,
+    },
+    data: { isConnected: false },
+  });
+}
+
+function isMicrosoftCalendarReauthError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    message.includes("AADSTS70000") ||
+    message.includes("AADSTS70008") ||
+    message.includes("AADSTS70011") ||
+    message.includes("AADSTS700082") ||
+    message.includes("AADSTS50173") ||
+    message.includes("AADSTS65001") ||
+    message.includes("AADSTS500011") ||
+    message.includes("AADSTS54005") ||
+    message.includes("AADSTS50076") ||
+    message.includes("AADSTS50079") ||
+    message.includes("AADSTS50158") ||
+    message.includes("invalid_grant")
+  );
 }

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -214,21 +214,25 @@ async function markMicrosoftCalendarDisconnected(emailAccountId: string) {
   });
 }
 
+const MICROSOFT_CALENDAR_REAUTH_ERROR_MARKERS = [
+  "AADSTS70000",
+  "AADSTS70008",
+  "AADSTS70011",
+  "AADSTS700082",
+  "AADSTS50173",
+  "AADSTS65001",
+  "AADSTS500011",
+  "AADSTS54005",
+  "AADSTS50076",
+  "AADSTS50079",
+  "AADSTS50158",
+  "invalid_grant",
+];
+
 function isMicrosoftCalendarReauthError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
 
-  return (
-    message.includes("AADSTS70000") ||
-    message.includes("AADSTS70008") ||
-    message.includes("AADSTS70011") ||
-    message.includes("AADSTS700082") ||
-    message.includes("AADSTS50173") ||
-    message.includes("AADSTS65001") ||
-    message.includes("AADSTS500011") ||
-    message.includes("AADSTS54005") ||
-    message.includes("AADSTS50076") ||
-    message.includes("AADSTS50079") ||
-    message.includes("AADSTS50158") ||
-    message.includes("invalid_grant")
+  return MICROSOFT_CALENDAR_REAUTH_ERROR_MARKERS.some((marker) =>
+    message.includes(marker),
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat invalid_grant and Microsoft AADSTS reauth failures as calendar reconnect-required errors.
- Mark the Microsoft calendar connection disconnected on reauth-required refresh failures.
- Throw a user-facing SafeError instead of a raw provider error.
- Follow-up cleanup replaced the long error-code boolean chain with a named code list.

## Verification
- `cd apps/web && pnpm test utils/outlook/calendar-client.test.ts --run`
- `cd apps/web && pnpm test utils/outlook/client.test.ts utils/outlook/calendar-client.test.ts --run`
- `cd apps/web && pnpm exec biome check utils/outlook/calendar-client.ts utils/outlook/calendar-client.test.ts`
- Follow-up cleanup: `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

