### PR TITLE
bugfix-batch-0139: Encode PostHog distinct_id email lookups

### DIFF
--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -7,6 +7,8 @@ vi.mock("@/env", () => ({
   env: {
     NEXT_PUBLIC_POSTHOG_KEY: "phc_test_key",
     NEXT_PUBLIC_POSTHOG_API_HOST: undefined,
+    POSTHOG_API_SECRET: "posthog-secret",
+    POSTHOG_PROJECT_ID: "project-1",
     NODE_ENV: "test",
   },
 }));
@@ -31,6 +33,7 @@ vi.mock("@/utils/prisma");
 
 import {
   FIRST_TIME_EVENTS,
+  deletePosthogUser,
   trackFirstTimeEvent,
   trackUserDeleted,
   trackUserDeletionRequested,
@@ -125,6 +128,40 @@ describe("trackFirstTimeEvent", () => {
 describe("user deletion events", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("encodes email special characters when looking up the PostHog user", async () => {
+    const email = "person+tag&team#100%@example.com";
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          results: [{ id: "person-id", distinct_ids: [email] }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({} as Response);
+
+    await deletePosthogUser({ email });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://app.posthog.com/api/projects/project-1/persons/?distinct_id=person%2Btag%26team%23100%25%40example.com",
+      {
+        headers: {
+          Authorization: "Bearer posthog-secret",
+        },
+      },
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://app.posthog.com/api/projects/project-1/persons/person-id/?delete_events=true",
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: "Bearer posthog-secret",
+        },
+      },
+    );
   });
 
   it("captures deletion requested with an anonymous distinct id", async () => {

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -37,17 +37,17 @@ export function isPosthogLlmEvalApproved(email: string) {
 }
 
 async function getPosthogUserId(options: { email: string }) {
-  const personsEndpoint = `https://app.posthog.com/api/projects/${env.POSTHOG_PROJECT_ID}/persons/`;
+  const personsEndpoint = new URL(
+    `https://app.posthog.com/api/projects/${env.POSTHOG_PROJECT_ID}/persons/`,
+  );
+  personsEndpoint.searchParams.set("distinct_id", options.email);
 
   // 1. find user id by distinct id
-  const responseGet = await fetch(
-    `${personsEndpoint}?distinct_id=${options.email}`,
-    {
-      headers: {
-        Authorization: `Bearer ${env.POSTHOG_API_SECRET}`,
-      },
+  const responseGet = await fetch(personsEndpoint.toString(), {
+    headers: {
+      Authorization: `Bearer ${env.POSTHOG_API_SECRET}`,
     },
-  );
+  });
 
   const resGet: { results: { id: string; distinct_ids: string[] }[] } =
     await responseGet.json();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Build the PostHog person lookup URL with URLSearchParams.
- Preserve emails containing URL-special characters such as +, &, #, and %.
- Add regression coverage for encoded email lookups.

## Verification
- `pnpm test utils/posthog.test.ts --run`
- `pnpm check apps/web/utils/posthog.ts apps/web/utils/posthog.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

