### PR TITLE
bugfix-batch-0139: Bound PostHog first-event cache

### DIFF
--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -106,6 +106,34 @@ describe("trackFirstTimeEvent", () => {
     expect(captureMock).toHaveBeenCalledTimes(1);
   });
 
+  it("evicts older in-process dedupe keys so the cache stays bounded", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+
+    await trackFirstTimeEvent({
+      emailAccountId: "bounded-cache-first-account",
+      event: FIRST_TIME_EVENTS.FIRST_CHAT_MESSAGE,
+    });
+
+    for (let i = 0; i < 1000; i++) {
+      await trackFirstTimeEvent({
+        emailAccountId: `bounded-cache-account-${i}`,
+        event: FIRST_TIME_EVENTS.FIRST_CHAT_MESSAGE,
+      });
+    }
+
+    await trackFirstTimeEvent({
+      emailAccountId: "bounded-cache-first-account",
+      event: FIRST_TIME_EVENTS.FIRST_CHAT_MESSAGE,
+    });
+
+    expect(redis.set).toHaveBeenCalledTimes(1002);
+    expect(redis.set).toHaveBeenLastCalledWith(
+      `first-event:bounded-cache-first-account:${FIRST_TIME_EVENTS.FIRST_CHAT_MESSAGE}`,
+      "1",
+      { nx: true },
+    );
+  });
+
   it("does not capture when the email account has no user email", async () => {
     vi.mocked(redis.set).mockResolvedValue("OK");
 

--- a/apps/web/utils/posthog.ts
+++ b/apps/web/utils/posthog.ts
@@ -375,7 +375,8 @@ export const FIRST_TIME_EVENTS = {
 type FirstTimeEvent =
   (typeof FIRST_TIME_EVENTS)[keyof typeof FIRST_TIME_EVENTS];
 
-const firedFirstTimeEvents = new Set<string>();
+const MAX_FIRST_TIME_EVENT_CACHE_SIZE = 1000;
+const firedFirstTimeEvents = new Map<string, true>();
 
 /**
  * Uses User.email as distinctId (not EmailAccount.email) so the event attaches
@@ -391,11 +392,11 @@ export async function trackFirstTimeEvent({
   properties?: Record<string, unknown>;
 }) {
   const key = `first-event:${emailAccountId}:${event}`;
-  if (firedFirstTimeEvents.has(key)) return;
+  if (markFirstTimeEventCacheHit(key)) return;
 
   try {
     const firstTime = await redis.set(key, "1", { nx: true });
-    firedFirstTimeEvents.add(key);
+    addFirstTimeEventCacheKey(key);
     if (!firstTime) return;
 
     const emailAccount = await prisma.emailAccount.findUnique({
@@ -437,4 +438,22 @@ function getPosthogLlmEvalApprovedEmails() {
       .map((email) => email.trim().toLowerCase())
       .filter(Boolean) ?? []
   );
+}
+
+function markFirstTimeEventCacheHit(key: string) {
+  if (!firedFirstTimeEvents.has(key)) return false;
+
+  firedFirstTimeEvents.delete(key);
+  firedFirstTimeEvents.set(key, true);
+  return true;
+}
+
+function addFirstTimeEventCacheKey(key: string) {
+  firedFirstTimeEvents.delete(key);
+  firedFirstTimeEvents.set(key, true);
+
+  if (firedFirstTimeEvents.size <= MAX_FIRST_TIME_EVENT_CACHE_SIZE) return;
+
+  const oldestKey = firedFirstTimeEvents.keys().next().value;
+  if (oldestKey) firedFirstTimeEvents.delete(oldestKey);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the unbounded module-level first-event Set with a bounded LRU-style cache.
- Keep Redis NX as the authoritative first-event guard.
- Add regression coverage for eviction and Redis re-checks.

## Verification
- `pnpm test --run utils/posthog.test.ts`
- `pnpm check apps/web/utils/posthog.ts apps/web/utils/posthog.test.ts`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

