### PR TITLE
bugfix-batch-0139: Validate AWS setup environment flags

### DIFF
--- a/packages/cli/src/setup-aws.test.ts
+++ b/packages/cli/src/setup-aws.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import * as p from "@clack/prompts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runAwsSetup, validateEnvironmentName } from "./setup-aws";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+describe("validateEnvironmentName", () => {
+  it("accepts Copilot environment names used by the interactive prompt", () => {
+    expect(validateEnvironmentName("production")).toBeUndefined();
+    expect(validateEnvironmentName("staging-2")).toBeUndefined();
+  });
+
+  it("rejects unsafe or invalid environment names", () => {
+    expect(validateEnvironmentName("../production")).toBe(
+      "Must start with a letter and contain only lowercase letters, numbers, and hyphens",
+    );
+    expect(validateEnvironmentName("Production")).toBe(
+      "Must start with a letter and contain only lowercase letters, numbers, and hyphens",
+    );
+    expect(validateEnvironmentName("")).toBe("Environment name is required");
+  });
+});
+
+describe("runAwsSetup", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects invalid --environment values before shelling out", async () => {
+    await expect(runAwsSetup({ environment: "../production" })).rejects.toThrow(
+      "process.exit:1",
+    );
+
+    expect(p.log.error).toHaveBeenCalledWith(
+      "Invalid environment name: Must start with a letter and contain only lowercase letters, numbers, and hyphens",
+    );
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/setup-aws.ts
+++ b/packages/cli/src/setup-aws.ts
@@ -86,6 +86,9 @@ const REDIS_INSTANCE_OPTIONS = [
 
 const APP_NAME = "inbox-zero";
 const SERVICE_NAME = "inbox-zero-ecs";
+const ENVIRONMENT_NAME_REGEX = /^[a-z][a-z0-9-]*$/;
+const ENVIRONMENT_NAME_ERROR =
+  "Must start with a letter and contain only lowercase letters, numbers, and hyphens";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Main Setup Function
@@ -93,6 +96,12 @@ const SERVICE_NAME = "inbox-zero-ecs";
 
 export async function runAwsSetup(options: AwsSetupOptions) {
   p.intro("AWS Copilot Setup for Inbox Zero");
+
+  const environmentError = validateEnvironmentName(options.environment);
+  if (environmentError) {
+    p.log.error(`Invalid environment name: ${environmentError}`);
+    process.exit(1);
+  }
 
   const nonInteractive = options.yes === true;
   if (nonInteractive) {
@@ -246,13 +255,7 @@ export async function runAwsSetup(options: AwsSetupOptions) {
         message: "Environment name (e.g., production, staging, dev):",
         placeholder: "production",
         initialValue: "production",
-        validate: (v) => {
-          if (!v) return "Environment name is required";
-          if (!/^[a-z][a-z0-9-]*$/.test(v)) {
-            return "Must start with a letter and contain only lowercase letters, numbers, and hyphens";
-          }
-          return;
-        },
+        validate: (v) => validateEnvironmentName(v),
       });
 
       if (p.isCancel(envInput)) {
@@ -1003,6 +1006,17 @@ function checkAwsPrerequisites(): AwsPrerequisites {
   }
 
   return { awsCliInstalled, copilotInstalled, profile, region };
+}
+
+export function validateEnvironmentName(
+  environment: string | undefined,
+): string | undefined {
+  if (environment === undefined) return;
+  if (!environment) return "Environment name is required";
+  if (!ENVIRONMENT_NAME_REGEX.test(environment)) {
+    return ENVIRONMENT_NAME_ERROR;
+  }
+  return;
 }
 
 function getRegionForProfile(profile: string): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Apply the interactive AWS environment-name validation to the `--environment` CLI flag path.
- Reject invalid environment names before cleanup/SSM path construction.
- Add focused CLI tests for invalid environment values.

## Verification
- See branch test output in agent report: focused setup-aws tests passed.

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

