### PR TITLE
bugfix-batch-0139: Escape Terraform tfvars interpolation markers

### DIFF
--- a/packages/cli/src/setup-terraform.test.ts
+++ b/packages/cli/src/setup-terraform.test.ts
@@ -15,14 +15,16 @@ describe("renderTerraformTfvars", () => {
       rdsInstanceClass: "db.t3.micro",
       enableRedis: false,
       redisInstanceClass: "cache.t4g.micro",
-      googleClientId: "google-id",
+      googleClientId: "google-$id",
       googleClientSecret: "google-secret",
       googlePubsubTopicName: "projects/demo/topics/inbox-zero",
       defaultLlmProvider: "openai",
-      defaultLlmModel: "",
+      defaultLlmModel: "model-100%",
     });
 
     expect(tfvars).toContain('app_name = "app-$${file(\\"/tmp/name\\")}"');
     expect(tfvars).toContain('environment = "%%{if true}prod%%{endif}"');
+    expect(tfvars).toContain('google_client_id = "google-$id"');
+    expect(tfvars).toContain('default_llm_model = "model-100%"');
   });
 });

--- a/packages/cli/src/setup-terraform.test.ts
+++ b/packages/cli/src/setup-terraform.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderTerraformTfvars } from "./setup-terraform";
+
+describe("renderTerraformTfvars", () => {
+  it("renders Terraform interpolation syntax as literal text", () => {
+    const expressionMarker = "$";
+    const tfvars = renderTerraformTfvars({
+      appName: `app-${expressionMarker}{file("/tmp/name")}`,
+      environment: "%{if true}prod%{endif}",
+      region: "us-east-1",
+      baseUrl: "",
+      domainName: "",
+      route53ZoneId: "",
+      acmCertificateArn: "",
+      rdsInstanceClass: "db.t3.micro",
+      enableRedis: false,
+      redisInstanceClass: "cache.t4g.micro",
+      googleClientId: "google-id",
+      googleClientSecret: "google-secret",
+      googlePubsubTopicName: "projects/demo/topics/inbox-zero",
+      defaultLlmProvider: "openai",
+      defaultLlmModel: "",
+    });
+
+    expect(tfvars).toContain('app_name = "app-$${file(\\"/tmp/name\\")}"');
+    expect(tfvars).toContain('environment = "%%{if true}prod%%{endif}"');
+  });
+});

--- a/packages/cli/src/setup-terraform.ts
+++ b/packages/cli/src/setup-terraform.ts
@@ -874,8 +874,8 @@ function escapeTfValue(value: string) {
   return value
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
-    .replace(/\$/g, "$$$$")
-    .replace(/%/g, "%%");
+    .replace(/\$\{/g, () => "$${")
+    .replace(/%\{/g, "%%{");
 }
 
 function addOptionalTfVar(lines: string[], key: string, value?: string) {

--- a/packages/cli/src/setup-terraform.ts
+++ b/packages/cli/src/setup-terraform.ts
@@ -791,7 +791,7 @@ function buildTerraformFiles(config: TerraformVarsConfig) {
   };
 }
 
-function renderTerraformTfvars(config: TerraformVarsConfig) {
+export function renderTerraformTfvars(config: TerraformVarsConfig) {
   const lines = [
     `app_name = "${escapeTfValue(config.appName)}"`,
     `environment = "${escapeTfValue(config.environment)}"`,
@@ -871,7 +871,11 @@ function renderTerraformTfvars(config: TerraformVarsConfig) {
 }
 
 function escapeTfValue(value: string) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "$$$$")
+    .replace(/%/g, "%%");
 }
 
 function addOptionalTfVar(lines: string[], key: string, value?: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Escape HCL template markers in generated Terraform tfvars values.
- Add tests covering literal `${...}` and `%{...}` user-provided values.

## Verification
- See branch test output in agent report: focused setup-terraform tests passed.

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

