### PR TITLE
bugfix-batch-0139: Preserve env replacement values literally

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -77,6 +77,24 @@ LLM_API_KEY=
     expect(result).toContain("GOOGLE_CLIENT_ID=google-id");
   });
 
+  it("should preserve replacement tokens and escape quoted values", () => {
+    const result = generateEnvFile({
+      env: {
+        DATABASE_URL: 'postgresql://user:$&"pa\\ss@db:5432/test',
+        AUTH_SECRET: "secret-$&-value",
+      },
+      useDockerInfra: false,
+      llmProvider: "anthropic",
+      template: "DATABASE_URL=placeholder\nAUTH_SECRET=old\n",
+    });
+
+    expect(result).toContain(
+      'DATABASE_URL="postgresql://user:$&\\"pa\\\\ss@db:5432/test"',
+    );
+    expect(result).toContain("AUTH_SECRET=secret-$&-value");
+    expect(result).not.toContain("AUTH_SECRET=secret-AUTH_SECRET=old-value");
+  });
+
   it("should set Docker-specific values when useDockerInfra is true", () => {
     const dockerEnv: EnvConfig = {
       ...baseEnv,
@@ -544,6 +562,12 @@ describe("updateEnvValue", () => {
     const content = "FOO=old";
     const result = updateEnvValue(content, "FOO", 'hello"world');
     expect(result).toContain('FOO="hello\\"world"');
+  });
+
+  it("should preserve replacement tokens when updating values", () => {
+    const content = "FOO=old";
+    const result = updateEnvValue(content, "FOO", "new-$&-value");
+    expect(result).toBe("FOO=new-$&-value");
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -20,7 +20,7 @@ export function generateEnvFile(config: {
 
   // Helper to wrap a value in quotes if defined (prevents "undefined" string bug)
   const wrapInQuotes = (value: string | undefined): string | undefined =>
-    value !== undefined ? `"${value}"` : undefined;
+    value !== undefined ? `"${escapeEnvQuotedValue(value)}"` : undefined;
 
   // Helper to set a value (handles both commented and uncommented lines)
   const setValue = (key: string, value: string | undefined) => {
@@ -32,7 +32,7 @@ export function generateEnvFile(config: {
     ];
     for (const pattern of patterns) {
       if (pattern.test(content)) {
-        content = content.replace(pattern, `${key}=${value}`);
+        content = content.replace(pattern, () => `${key}=${value}`);
         return;
       }
     }
@@ -213,19 +213,16 @@ export function updateEnvValue(
   value: string,
 ): string {
   const needsQuotes = /[\s"'#]/.test(value) || value.includes("://");
-  const escaped = needsQuotes
-    ? value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-    : value;
-  const formatted = needsQuotes ? `"${escaped}"` : value;
+  const formatted = needsQuotes ? `"${escapeEnvQuotedValue(value)}"` : value;
 
   const uncommented = new RegExp(`^${key}=.*$`, "m");
   if (uncommented.test(content)) {
-    return content.replace(uncommented, `${key}=${formatted}`);
+    return content.replace(uncommented, () => `${key}=${formatted}`);
   }
 
   const commented = new RegExp(`^# ${key}=.*$`, "m");
   if (commented.test(content)) {
-    return content.replace(commented, `${key}=${formatted}`);
+    return content.replace(commented, () => `${key}=${formatted}`);
   }
 
   return `${content.trimEnd()}\n${key}=${formatted}\n`;
@@ -262,4 +259,8 @@ export function parsePortConflict(stderr: string): string | null {
   }
 
   return null;
+}
+
+function escapeEnvQuotedValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use function replacements when writing env values so `$&` and other replacement tokens are preserved literally.
- Escape backslashes and double quotes when generating quoted env values.
- Add regression coverage for replacement-token and quoted-value handling.

## Verification
- `/workspace/apps/web/node_modules/.bin/vitest run packages/cli/src/utils.test.ts`
- `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

