### PR TITLE
bugfix-batch-0139: Validate CLI config names before env paths

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1815,22 +1815,6 @@ function checkContainersRunning(composeArgs: string[]): boolean {
   return (result.stdout?.toString().trim() ?? "") !== "";
 }
 
-const CONFIG_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
-
-export function validateConfigName(name: string): string {
-  if (!CONFIG_NAME_PATTERN.test(name)) {
-    throw new Error(
-      "Configuration name may only contain letters, numbers, underscores, and hyphens.",
-    );
-  }
-
-  return name;
-}
-
-export function getEnvFileName(name?: string): string {
-  return name ? `.env.${validateConfigName(name)}` : ".env";
-}
-
 // Only run main() when executed directly, not when imported for testing
 const isMainModule =
   process.argv[1] &&

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -14,6 +14,7 @@ import {
   parsePortConflict,
   updateEnvValue,
   redactValue,
+  getEnvFileName,
   type EnvConfig,
 } from "./utils";
 import { LLM_PROVIDER_OPTIONS, promptLlmCredentials } from "./llm";
@@ -118,7 +119,7 @@ function fixComposeEnvPaths(composeContent: string): string {
 }
 
 function findEnvFile(name?: string): string | null {
-  const envFileName = name ? `.env.${name}` : ".env";
+  const envFileName = getEnvFileName(name);
 
   if (REPO_ROOT) {
     const repoEnv = resolve(REPO_ROOT, "apps/web", envFileName);
@@ -552,7 +553,7 @@ async function runSetupQuick(options: { name?: string }) {
 
   // Determine file paths first so we can read existing config
   const configDir = REPO_ROOT ?? STANDALONE_CONFIG_DIR;
-  const envFileName = configName ? `.env.${configName}` : ".env";
+  const envFileName = getEnvFileName(configName);
   const envFile = REPO_ROOT
     ? resolve(REPO_ROOT, "apps/web", envFileName)
     : resolve(STANDALONE_CONFIG_DIR, envFileName);
@@ -874,7 +875,7 @@ async function runSetupAdvanced(options: { name?: string }) {
 
   // Determine paths - if in repo, write to apps/web/.env, otherwise use standalone
   const configDir = REPO_ROOT ?? STANDALONE_CONFIG_DIR;
-  const envFileName = configName ? `.env.${configName}` : ".env";
+  const envFileName = getEnvFileName(configName);
   const envFile = REPO_ROOT
     ? resolve(REPO_ROOT, "apps/web", envFileName)
     : resolve(STANDALONE_CONFIG_DIR, envFileName);
@@ -1812,6 +1813,22 @@ function checkContainersRunning(composeArgs: string[]): boolean {
   });
   if (result.status !== 0) return false;
   return (result.stdout?.toString().trim() ?? "") !== "";
+}
+
+const CONFIG_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function validateConfigName(name: string): string {
+  if (!CONFIG_NAME_PATTERN.test(name)) {
+    throw new Error(
+      "Configuration name may only contain letters, numbers, underscores, and hyphens.",
+    );
+  }
+
+  return name;
+}
+
+export function getEnvFileName(name?: string): string {
+  return name ? `.env.${validateConfigName(name)}` : ".env";
 }
 
 // Only run main() when executed directly, not when imported for testing

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   generateSecret,
   generateEnvFile,
+  getEnvFileName,
   isSensitiveKey,
   parseEnvFile,
   parsePortConflict,
@@ -31,6 +32,22 @@ describe("generateSecret", () => {
       secrets.add(generateSecret(16));
     }
     expect(secrets.size).toBe(100);
+  });
+});
+
+describe("getEnvFileName", () => {
+  it("should reject names with path traversal characters", () => {
+    expect(() => getEnvFileName("../../secrets")).toThrow(
+      "Configuration name may only contain letters, numbers, underscores, and hyphens.",
+    );
+    expect(() => getEnvFileName("nested/config")).toThrow(
+      "Configuration name may only contain letters, numbers, underscores, and hyphens.",
+    );
+  });
+
+  it("should build env file names for safe config names", () => {
+    expect(getEnvFileName()).toBe(".env");
+    expect(getEnvFileName("staging_1-prod")).toBe(".env.staging_1-prod");
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -3,9 +3,24 @@ import { randomBytes } from "node:crypto";
 // Environment variable builder
 export type EnvConfig = Record<string, string | undefined>;
 
+const CONFIG_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CONFIG_NAME_ERROR =
+  "Configuration name may only contain letters, numbers, underscores, and hyphens.";
+
 // Secret generation
 export function generateSecret(bytes: number): string {
   return randomBytes(bytes).toString("hex");
+}
+
+export function validateConfigName(name: string): string {
+  if (!CONFIG_NAME_PATTERN.test(name)) {
+    throw new Error(CONFIG_NAME_ERROR);
+  }
+  return name;
+}
+
+export function getEnvFileName(name?: string): string {
+  return name ? `.env.${validateConfigName(name)}` : ".env";
 }
 
 export function generateEnvFile(config: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Validate `--name`/config names against an allowlist before constructing `.env.<name>` paths.
- Reuse a single env filename helper across setup/config lookup paths.
- Add regression coverage for rejecting path traversal and separator characters.
- Follow-up cleanup removed duplicate helper definitions from `main.ts`.

## Verification
- `/workspace/apps/web/node_modules/.bin/vitest run packages/cli/src/utils.test.ts`
- `git diff --check`

Batch marker: `bugfix-batch-0139`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7279534f-5d15-48ee-aceb-02900cc60139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

