### PR TITLE
feat(chat): rename / soft-delete chats from hover menu

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -76,6 +76,13 @@ export const POST = withEmailAccount("chat", async (request) => {
     );
   }
 
+  if (chat.deletedAt) {
+    return NextResponse.json(
+      { error: "This chat has been deleted." },
+      { status: 410 },
+    );
+  }
+
   const chatHasHistory =
     chat.messages.length > 0 || chat.compactions.length > 0;
   const { message, context, inlineActions } = data;

--- a/apps/web/app/api/chats/[chatId]/route.ts
+++ b/apps/web/app/api/chats/[chatId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import prisma from "@/utils/prisma";
 import { withEmailAccount } from "@/utils/middleware";
+import { softDeleteChat } from "@/utils/chat/soft-delete";
 
 export type GetChatResponse = Awaited<ReturnType<typeof getChat>>;
 const updateChatSchema = z.object({
@@ -105,10 +106,11 @@ async function getChat({
   chatId: string;
   emailAccountId: string;
 }) {
-  const chat = await prisma.chat.findUnique({
+  const chat = await prisma.chat.findFirst({
     where: {
       id: chatId,
       emailAccountId,
+      deletedAt: null,
     },
     include: {
       messages: {
@@ -135,6 +137,7 @@ async function updateChat({
     where: {
       id: chatId,
       emailAccountId,
+      deletedAt: null,
     },
     data: {
       ...(name !== undefined ? { name } : {}),
@@ -143,10 +146,11 @@ async function updateChat({
 
   if (result.count === 0) return null;
 
-  return prisma.chat.findUnique({
+  return prisma.chat.findFirst({
     where: {
       id: chatId,
       emailAccountId,
+      deletedAt: null,
     },
     include: {
       messages: {
@@ -165,12 +169,5 @@ async function deleteChat({
   chatId: string;
   emailAccountId: string;
 }) {
-  const result = await prisma.chat.deleteMany({
-    where: {
-      id: chatId,
-      emailAccountId,
-    },
-  });
-
-  return result.count > 0;
+  return softDeleteChat({ chatId, emailAccountId });
 }

--- a/apps/web/app/api/chats/route.ts
+++ b/apps/web/app/api/chats/route.ts
@@ -14,6 +14,7 @@ async function getChats({ emailAccountId }: { emailAccountId: string }) {
   const chats = await prisma.chat.findMany({
     where: {
       emailAccountId,
+      deletedAt: null,
     },
     orderBy: { updatedAt: "desc" },
   });

--- a/apps/web/components/assistant-chat/ChatHistoryItem.tsx
+++ b/apps/web/components/assistant-chat/ChatHistoryItem.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { MoreHorizontalIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { ChatHistoryEntry } from "@/components/assistant-chat/chat-history-types";
+import { getChatHistoryLabel } from "@/components/assistant-chat/chat-history-types";
+
+export function ChatHistoryItem({
+  chat,
+  onSelect,
+  onRename,
+  onDelete,
+}: {
+  chat: ChatHistoryEntry;
+  onSelect: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <div className="group/chat-row relative flex items-center">
+      <DropdownMenuItem
+        className="flex-1 truncate pr-9"
+        onSelect={() => onSelect()}
+      >
+        <span className="truncate">{getChatHistoryLabel(chat)}</span>
+      </DropdownMenuItem>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Chat options"
+            className={
+              "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
+              (menuOpen
+                ? "opacity-100"
+                : "opacity-0 group-hover/chat-row:opacity-100")
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              setMenuOpen(true);
+            }}
+          >
+            <MoreHorizontalIcon className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          side="right"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setMenuOpen(false);
+              onRename();
+            }}
+          >
+            <PencilIcon className="mr-2 size-4" />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setMenuOpen(false);
+              onDelete();
+            }}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2Icon className="mr-2 size-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/components/assistant-chat/ChatHistoryItem.tsx
+++ b/apps/web/components/assistant-chat/ChatHistoryItem.tsx
@@ -41,7 +41,7 @@ export function ChatHistoryItem({
               "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
               (menuOpen
                 ? "opacity-100"
-                : "opacity-0 group-hover/chat-row:opacity-100")
+                : "opacity-0 group-hover/chat-row:opacity-100 group-focus-within/chat-row:opacity-100")
             }
             onClick={(e) => {
               e.stopPropagation();

--- a/apps/web/components/assistant-chat/DeleteChatDialog.tsx
+++ b/apps/web/components/assistant-chat/DeleteChatDialog.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { deleteChatAction } from "@/utils/actions/chat";
+import { getActionErrorMessage } from "@/utils/error";
+
+export function DeleteChatDialog({
+  open,
+  onOpenChange,
+  chatId,
+  label,
+  onDeleted,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatId: string;
+  label: string;
+  onDeleted: () => void;
+}) {
+  const { emailAccountId } = useAccount();
+  const { execute, isExecuting } = useAction(
+    deleteChatAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Chat deleted." });
+        onDeleted();
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error, {
+            prefix: "Failed to delete chat",
+          }),
+        });
+      },
+    },
+  );
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+          <AlertDialogDescription>
+            &ldquo;{label}&rdquo; will be removed from your chat history and its
+            messages will be redacted. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isExecuting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              execute({ chatId });
+            }}
+            disabled={isExecuting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isExecuting ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/components/assistant-chat/RenameChatDialog.tsx
+++ b/apps/web/components/assistant-chat/RenameChatDialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { useAction } from "next-safe-action/hooks";
+import { useSWRConfig } from "swr";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/Input";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { renameChatAction } from "@/utils/actions/chat";
+import {
+  renameChatFormBody,
+  type RenameChatFormBody,
+} from "@/utils/actions/chat.validation";
+import { getActionErrorMessage } from "@/utils/error";
+
+export function RenameChatDialog({
+  open,
+  onOpenChange,
+  chatId,
+  currentName,
+  defaultLabel,
+  onRenamed,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatId: string;
+  currentName: string;
+  defaultLabel: string;
+  onRenamed: () => void;
+}) {
+  const { emailAccountId } = useAccount();
+  const { mutate: globalMutate } = useSWRConfig();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty, isValid },
+  } = useForm<RenameChatFormBody>({
+    resolver: zodResolver(renameChatFormBody),
+    defaultValues: { name: currentName },
+    mode: "onChange",
+  });
+
+  useEffect(() => {
+    if (open) reset({ name: currentName });
+  }, [open, currentName, reset]);
+
+  const { execute, isExecuting } = useAction(
+    renameChatAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Chat renamed." });
+        onRenamed();
+        globalMutate(`/api/chats/${chatId}`);
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error, {
+            prefix: "Failed to rename chat",
+          }),
+        });
+      },
+    },
+  );
+
+  const onSubmit: SubmitHandler<RenameChatFormBody> = ({ name }) => {
+    execute({ chatId, name });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename chat</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Input
+            type="text"
+            name="name"
+            placeholder={defaultLabel}
+            registerProps={register("name")}
+            error={errors.name}
+          />
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isExecuting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              loading={isExecuting}
+              disabled={!isDirty || !isValid}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/assistant-chat/chat-history-types.ts
+++ b/apps/web/components/assistant-chat/chat-history-types.ts
@@ -1,0 +1,9 @@
+import type { GetChatsResponse } from "@/app/api/chats/route";
+
+export type ChatHistoryEntry = GetChatsResponse["chats"][number];
+
+export function getChatHistoryLabel(
+  chat: Pick<ChatHistoryEntry, "name" | "createdAt">,
+): string {
+  return chat.name ?? `Chat from ${new Date(chat.createdAt).toLocaleString()}`;
+}

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -5,10 +5,15 @@ import {
   ArrowUpIcon,
   HistoryIcon,
   Loader2,
+  MoreHorizontalIcon,
   PaperclipIcon,
+  PencilIcon,
   PlusIcon,
   SquareIcon,
+  Trash2Icon,
 } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useSWRConfig } from "swr";
 import { Messages } from "./messages";
 import { PreviewAttachment } from "./preview-attachment";
 import { Button } from "@/components/ui/button";
@@ -18,11 +23,30 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { useChats } from "@/hooks/useChats";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Tooltip } from "@/components/Tooltip";
 import { useChat } from "@/providers/ChatProvider";
 import type { Attachment } from "@/providers/ChatProvider";
+import { useAccount } from "@/providers/EmailAccountProvider";
 import {
   PromptInput,
   PromptInputTextarea,
@@ -34,6 +58,9 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
 import type { MessageContext } from "@/app/api/chat/validation";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { getActionErrorMessage } from "@/utils/error";
+import { deleteChatAction, renameChatAction } from "@/utils/actions/chat";
 
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB
 const MAX_FILES = 5;
@@ -454,12 +481,12 @@ function NewChatButton() {
 }
 
 function ChatHistoryDropdown() {
-  const { setChatId } = useChat();
   const [shouldLoadChats, setShouldLoadChats] = useState(false);
+  const [open, setOpen] = useState(false);
   const { data, error, isLoading, mutate } = useChats(shouldLoadChats);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <Tooltip content="View previous conversations">
         <DropdownMenuTrigger asChild>
           <Button
@@ -473,7 +500,7 @@ function ChatHistoryDropdown() {
           </Button>
         </DropdownMenuTrigger>
       </Tooltip>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-72">
         <LoadingContent
           loading={isLoading}
           error={error}
@@ -492,14 +519,12 @@ function ChatHistoryDropdown() {
         >
           {data && data.chats.length > 0 ? (
             data.chats.map((chatItem) => (
-              <DropdownMenuItem
+              <ChatHistoryItem
                 key={chatItem.id}
-                onSelect={() => {
-                  setChatId(chatItem.id);
-                }}
-              >
-                {`Chat from ${new Date(chatItem.createdAt).toLocaleString()}`}
-              </DropdownMenuItem>
+                chat={chatItem}
+                onMutate={mutate}
+                closeParent={() => setOpen(false)}
+              />
             ))
           ) : (
             <DropdownMenuItem disabled>
@@ -509,6 +534,258 @@ function ChatHistoryDropdown() {
         </LoadingContent>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+type ChatHistoryItemData = {
+  id: string;
+  name: string | null;
+  createdAt: string | Date;
+};
+
+function ChatHistoryItem({
+  chat,
+  onMutate,
+  closeParent,
+}: {
+  chat: ChatHistoryItemData;
+  onMutate: () => void;
+  closeParent: () => void;
+}) {
+  const { chatId, setChatId } = useChat();
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const label =
+    chat.name ?? `Chat from ${new Date(chat.createdAt).toLocaleString()}`;
+
+  return (
+    <>
+      <div className="group/chat-row relative flex items-center">
+        <DropdownMenuItem
+          className="flex-1 truncate pr-9"
+          onSelect={() => setChatId(chat.id)}
+        >
+          <span className="truncate">{label}</span>
+        </DropdownMenuItem>
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Chat options"
+              className={
+                "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
+                (menuOpen
+                  ? "opacity-100"
+                  : "opacity-0 group-hover/chat-row:opacity-100")
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                setMenuOpen(true);
+              }}
+            >
+              <MoreHorizontalIcon className="size-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side="right"
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                setMenuOpen(false);
+                closeParent();
+                setRenameOpen(true);
+              }}
+            >
+              <PencilIcon className="mr-2 size-4" />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                setMenuOpen(false);
+                closeParent();
+                setDeleteOpen(true);
+              }}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2Icon className="mr-2 size-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <RenameChatDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        chatId={chat.id}
+        currentName={chat.name ?? ""}
+        defaultLabel={label}
+        onRenamed={onMutate}
+      />
+      <DeleteChatDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        chatId={chat.id}
+        label={label}
+        onDeleted={() => {
+          if (chatId === chat.id) setChatId(null);
+          onMutate();
+        }}
+      />
+    </>
+  );
+}
+
+function RenameChatDialog({
+  open,
+  onOpenChange,
+  chatId,
+  currentName,
+  defaultLabel,
+  onRenamed,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatId: string;
+  currentName: string;
+  defaultLabel: string;
+  onRenamed: () => void;
+}) {
+  const { emailAccountId } = useAccount();
+  const { mutate: globalMutate } = useSWRConfig();
+  const [name, setName] = useState(currentName);
+
+  useEffect(() => {
+    if (open) setName(currentName);
+  }, [open, currentName]);
+
+  const { execute, isExecuting } = useAction(
+    renameChatAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Chat renamed." });
+        onRenamed();
+        globalMutate(`/api/chats/${chatId}`);
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error, {
+            prefix: "Failed to rename chat",
+          }),
+        });
+      },
+    },
+  );
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && trimmed !== currentName.trim();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename chat</DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!canSubmit) return;
+            execute({ chatId, name: trimmed });
+          }}
+        >
+          <Input
+            type="text"
+            name="name"
+            placeholder={defaultLabel}
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={200}
+          />
+          <DialogFooter className="mt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isExecuting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" loading={isExecuting} disabled={!canSubmit}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteChatDialog({
+  open,
+  onOpenChange,
+  chatId,
+  label,
+  onDeleted,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatId: string;
+  label: string;
+  onDeleted: () => void;
+}) {
+  const { emailAccountId } = useAccount();
+  const { execute, isExecuting } = useAction(
+    deleteChatAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Chat deleted." });
+        onDeleted();
+        onOpenChange(false);
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error, {
+            prefix: "Failed to delete chat",
+          }),
+        });
+      },
+    },
+  );
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete &ldquo;{label}&rdquo; and all of its
+            messages. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isExecuting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              execute({ chatId });
+            }}
+            disabled={isExecuting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isExecuting ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -480,166 +480,193 @@ function NewChatButton() {
   );
 }
 
-function ChatHistoryDropdown() {
-  const [shouldLoadChats, setShouldLoadChats] = useState(false);
-  const [open, setOpen] = useState(false);
-  const { data, error, isLoading, mutate } = useChats(shouldLoadChats);
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <Tooltip content="View previous conversations">
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onMouseEnter={() => setShouldLoadChats(true)}
-            onClick={() => mutate()}
-          >
-            <HistoryIcon className="size-5" />
-            <span className="sr-only">Chat History</span>
-          </Button>
-        </DropdownMenuTrigger>
-      </Tooltip>
-      <DropdownMenuContent align="end" className="w-72">
-        <LoadingContent
-          loading={isLoading}
-          error={error}
-          loadingComponent={
-            <DropdownMenuItem
-              disabled
-              className="flex items-center justify-center"
-            >
-              <Loader2 className="mr-2 size-4 animate-spin" />
-              Loading chats...
-            </DropdownMenuItem>
-          }
-          errorComponent={
-            <DropdownMenuItem disabled>Error loading chats</DropdownMenuItem>
-          }
-        >
-          {data && data.chats.length > 0 ? (
-            data.chats.map((chatItem) => (
-              <ChatHistoryItem
-                key={chatItem.id}
-                chat={chatItem}
-                onMutate={mutate}
-                closeParent={() => setOpen(false)}
-              />
-            ))
-          ) : (
-            <DropdownMenuItem disabled>
-              No previous chats found
-            </DropdownMenuItem>
-          )}
-        </LoadingContent>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 type ChatHistoryItemData = {
   id: string;
   name: string | null;
   createdAt: string | Date;
 };
 
+function ChatHistoryDropdown() {
+  const [shouldLoadChats, setShouldLoadChats] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<ChatHistoryItemData | null>(
+    null,
+  );
+  const [deleteTarget, setDeleteTarget] = useState<ChatHistoryItemData | null>(
+    null,
+  );
+  const { chatId, setChatId } = useChat();
+  const { data, error, isLoading, mutate } = useChats(shouldLoadChats);
+
+  const renameLabel = renameTarget
+    ? (renameTarget.name ??
+      `Chat from ${new Date(renameTarget.createdAt).toLocaleString()}`)
+    : "";
+  const deleteLabel = deleteTarget
+    ? (deleteTarget.name ??
+      `Chat from ${new Date(deleteTarget.createdAt).toLocaleString()}`)
+    : "";
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <Tooltip content="View previous conversations">
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onMouseEnter={() => setShouldLoadChats(true)}
+              onClick={() => mutate()}
+            >
+              <HistoryIcon className="size-5" />
+              <span className="sr-only">Chat History</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </Tooltip>
+        <DropdownMenuContent align="end" className="w-72">
+          <LoadingContent
+            loading={isLoading}
+            error={error}
+            loadingComponent={
+              <DropdownMenuItem
+                disabled
+                className="flex items-center justify-center"
+              >
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Loading chats...
+              </DropdownMenuItem>
+            }
+            errorComponent={
+              <DropdownMenuItem disabled>Error loading chats</DropdownMenuItem>
+            }
+          >
+            {data && data.chats.length > 0 ? (
+              data.chats.map((chatItem) => (
+                <ChatHistoryItem
+                  key={chatItem.id}
+                  chat={chatItem}
+                  onSelect={() => {
+                    setOpen(false);
+                    setChatId(chatItem.id);
+                  }}
+                  onRename={() => {
+                    setOpen(false);
+                    setRenameTarget(chatItem);
+                  }}
+                  onDelete={() => {
+                    setOpen(false);
+                    setDeleteTarget(chatItem);
+                  }}
+                />
+              ))
+            ) : (
+              <DropdownMenuItem disabled>
+                No previous chats found
+              </DropdownMenuItem>
+            )}
+          </LoadingContent>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <RenameChatDialog
+        open={renameTarget !== null}
+        onOpenChange={(value) => {
+          if (!value) setRenameTarget(null);
+        }}
+        chatId={renameTarget?.id ?? ""}
+        currentName={renameTarget?.name ?? ""}
+        defaultLabel={renameLabel}
+        onRenamed={mutate}
+      />
+      <DeleteChatDialog
+        open={deleteTarget !== null}
+        onOpenChange={(value) => {
+          if (!value) setDeleteTarget(null);
+        }}
+        chatId={deleteTarget?.id ?? ""}
+        label={deleteLabel}
+        onDeleted={() => {
+          if (deleteTarget && chatId === deleteTarget.id) setChatId(null);
+          mutate();
+        }}
+      />
+    </>
+  );
+}
+
 function ChatHistoryItem({
   chat,
-  onMutate,
-  closeParent,
+  onSelect,
+  onRename,
+  onDelete,
 }: {
   chat: ChatHistoryItemData;
-  onMutate: () => void;
-  closeParent: () => void;
+  onSelect: () => void;
+  onRename: () => void;
+  onDelete: () => void;
 }) {
-  const { chatId, setChatId } = useChat();
-  const [renameOpen, setRenameOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const label =
     chat.name ?? `Chat from ${new Date(chat.createdAt).toLocaleString()}`;
 
   return (
-    <>
-      <div className="group/chat-row relative flex items-center">
-        <DropdownMenuItem
-          className="flex-1 truncate pr-9"
-          onSelect={() => setChatId(chat.id)}
-        >
-          <span className="truncate">{label}</span>
-        </DropdownMenuItem>
-        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="Chat options"
-              className={
-                "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
-                (menuOpen
-                  ? "opacity-100"
-                  : "opacity-0 group-hover/chat-row:opacity-100")
-              }
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setMenuOpen(true);
-              }}
-            >
-              <MoreHorizontalIcon className="size-4" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            side="right"
-            onCloseAutoFocus={(e) => e.preventDefault()}
+    <div className="group/chat-row relative flex items-center">
+      <DropdownMenuItem
+        className="flex-1 truncate pr-9"
+        onSelect={() => onSelect()}
+      >
+        <span className="truncate">{label}</span>
+      </DropdownMenuItem>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Chat options"
+            className={
+              "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
+              (menuOpen
+                ? "opacity-100"
+                : "opacity-0 group-hover/chat-row:opacity-100")
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              setMenuOpen(true);
+            }}
           >
-            <DropdownMenuItem
-              onSelect={(e) => {
-                e.preventDefault();
-                setMenuOpen(false);
-                closeParent();
-                setRenameOpen(true);
-              }}
-            >
-              <PencilIcon className="mr-2 size-4" />
-              Rename
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={(e) => {
-                e.preventDefault();
-                setMenuOpen(false);
-                closeParent();
-                setDeleteOpen(true);
-              }}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2Icon className="mr-2 size-4" />
-              Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      <RenameChatDialog
-        open={renameOpen}
-        onOpenChange={setRenameOpen}
-        chatId={chat.id}
-        currentName={chat.name ?? ""}
-        defaultLabel={label}
-        onRenamed={onMutate}
-      />
-      <DeleteChatDialog
-        open={deleteOpen}
-        onOpenChange={setDeleteOpen}
-        chatId={chat.id}
-        label={label}
-        onDeleted={() => {
-          if (chatId === chat.id) setChatId(null);
-          onMutate();
-        }}
-      />
-    </>
+            <MoreHorizontalIcon className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          side="right"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setMenuOpen(false);
+              onRename();
+            }}
+          >
+            <PencilIcon className="mr-2 size-4" />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setMenuOpen(false);
+              onDelete();
+            }}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2Icon className="mr-2 size-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -767,8 +794,8 @@ function DeleteChatDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Delete chat?</AlertDialogTitle>
           <AlertDialogDescription>
-            This will permanently delete &ldquo;{label}&rdquo; and all of its
-            messages. This action cannot be undone.
+            &ldquo;{label}&rdquo; will be removed from your chat history and its
+            messages will be redacted. This action cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -5,15 +5,10 @@ import {
   ArrowUpIcon,
   HistoryIcon,
   Loader2,
-  MoreHorizontalIcon,
   PaperclipIcon,
-  PencilIcon,
   PlusIcon,
   SquareIcon,
-  Trash2Icon,
 } from "lucide-react";
-import { useAction } from "next-safe-action/hooks";
-import { useSWRConfig } from "swr";
 import { Messages } from "./messages";
 import { PreviewAttachment } from "./preview-attachment";
 import { Button } from "@/components/ui/button";
@@ -23,30 +18,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { useChats } from "@/hooks/useChats";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Tooltip } from "@/components/Tooltip";
 import { useChat } from "@/providers/ChatProvider";
 import type { Attachment } from "@/providers/ChatProvider";
-import { useAccount } from "@/providers/EmailAccountProvider";
 import {
   PromptInput,
   PromptInputTextarea,
@@ -58,9 +34,13 @@ import type { UseChatHelpers } from "@ai-sdk/react";
 import type { ChatMessage } from "@/components/assistant-chat/types";
 import type { MessageContext } from "@/app/api/chat/validation";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
-import { toastError, toastSuccess } from "@/components/Toast";
-import { getActionErrorMessage } from "@/utils/error";
-import { deleteChatAction, renameChatAction } from "@/utils/actions/chat";
+import { ChatHistoryItem } from "@/components/assistant-chat/ChatHistoryItem";
+import {
+  type ChatHistoryEntry,
+  getChatHistoryLabel,
+} from "@/components/assistant-chat/chat-history-types";
+import { RenameChatDialog } from "@/components/assistant-chat/RenameChatDialog";
+import { DeleteChatDialog } from "@/components/assistant-chat/DeleteChatDialog";
 
 const MAX_FILE_SIZE = 4 * 1024 * 1024; // 4MB
 const MAX_FILES = 5;
@@ -480,32 +460,17 @@ function NewChatButton() {
   );
 }
 
-type ChatHistoryItemData = {
-  id: string;
-  name: string | null;
-  createdAt: string | Date;
-};
-
 function ChatHistoryDropdown() {
   const [shouldLoadChats, setShouldLoadChats] = useState(false);
   const [open, setOpen] = useState(false);
-  const [renameTarget, setRenameTarget] = useState<ChatHistoryItemData | null>(
+  const [renameTarget, setRenameTarget] = useState<ChatHistoryEntry | null>(
     null,
   );
-  const [deleteTarget, setDeleteTarget] = useState<ChatHistoryItemData | null>(
+  const [deleteTarget, setDeleteTarget] = useState<ChatHistoryEntry | null>(
     null,
   );
   const { chatId, setChatId } = useChat();
   const { data, error, isLoading, mutate } = useChats(shouldLoadChats);
-
-  const renameLabel = renameTarget
-    ? (renameTarget.name ??
-      `Chat from ${new Date(renameTarget.createdAt).toLocaleString()}`)
-    : "";
-  const deleteLabel = deleteTarget
-    ? (deleteTarget.name ??
-      `Chat from ${new Date(deleteTarget.createdAt).toLocaleString()}`)
-    : "";
 
   return (
     <>
@@ -575,7 +540,7 @@ function ChatHistoryDropdown() {
         }}
         chatId={renameTarget?.id ?? ""}
         currentName={renameTarget?.name ?? ""}
-        defaultLabel={renameLabel}
+        defaultLabel={renameTarget ? getChatHistoryLabel(renameTarget) : ""}
         onRenamed={mutate}
       />
       <DeleteChatDialog
@@ -584,235 +549,13 @@ function ChatHistoryDropdown() {
           if (!value) setDeleteTarget(null);
         }}
         chatId={deleteTarget?.id ?? ""}
-        label={deleteLabel}
+        label={deleteTarget ? getChatHistoryLabel(deleteTarget) : ""}
         onDeleted={() => {
           if (deleteTarget && chatId === deleteTarget.id) setChatId(null);
           mutate();
         }}
       />
     </>
-  );
-}
-
-function ChatHistoryItem({
-  chat,
-  onSelect,
-  onRename,
-  onDelete,
-}: {
-  chat: ChatHistoryItemData;
-  onSelect: () => void;
-  onRename: () => void;
-  onDelete: () => void;
-}) {
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  const label =
-    chat.name ?? `Chat from ${new Date(chat.createdAt).toLocaleString()}`;
-
-  return (
-    <div className="group/chat-row relative flex items-center">
-      <DropdownMenuItem
-        className="flex-1 truncate pr-9"
-        onSelect={() => onSelect()}
-      >
-        <span className="truncate">{label}</span>
-      </DropdownMenuItem>
-      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label="Chat options"
-            className={
-              "absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-accent hover:text-foreground focus:opacity-100 focus:outline-none " +
-              (menuOpen
-                ? "opacity-100"
-                : "opacity-0 group-hover/chat-row:opacity-100")
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              setMenuOpen(true);
-            }}
-          >
-            <MoreHorizontalIcon className="size-4" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="start"
-          side="right"
-          onCloseAutoFocus={(e) => e.preventDefault()}
-        >
-          <DropdownMenuItem
-            onSelect={(e) => {
-              e.preventDefault();
-              setMenuOpen(false);
-              onRename();
-            }}
-          >
-            <PencilIcon className="mr-2 size-4" />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={(e) => {
-              e.preventDefault();
-              setMenuOpen(false);
-              onDelete();
-            }}
-            className="text-destructive focus:text-destructive"
-          >
-            <Trash2Icon className="mr-2 size-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-}
-
-function RenameChatDialog({
-  open,
-  onOpenChange,
-  chatId,
-  currentName,
-  defaultLabel,
-  onRenamed,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  chatId: string;
-  currentName: string;
-  defaultLabel: string;
-  onRenamed: () => void;
-}) {
-  const { emailAccountId } = useAccount();
-  const { mutate: globalMutate } = useSWRConfig();
-  const [name, setName] = useState(currentName);
-
-  useEffect(() => {
-    if (open) setName(currentName);
-  }, [open, currentName]);
-
-  const { execute, isExecuting } = useAction(
-    renameChatAction.bind(null, emailAccountId),
-    {
-      onSuccess: () => {
-        toastSuccess({ description: "Chat renamed." });
-        onRenamed();
-        globalMutate(`/api/chats/${chatId}`);
-        onOpenChange(false);
-      },
-      onError: (error) => {
-        toastError({
-          description: getActionErrorMessage(error.error, {
-            prefix: "Failed to rename chat",
-          }),
-        });
-      },
-    },
-  );
-
-  const trimmed = name.trim();
-  const canSubmit = trimmed.length > 0 && trimmed !== currentName.trim();
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Rename chat</DialogTitle>
-        </DialogHeader>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!canSubmit) return;
-            execute({ chatId, name: trimmed });
-          }}
-        >
-          <Input
-            type="text"
-            name="name"
-            placeholder={defaultLabel}
-            autoFocus
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            maxLength={200}
-          />
-          <DialogFooter className="mt-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isExecuting}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" loading={isExecuting} disabled={!canSubmit}>
-              Save
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function DeleteChatDialog({
-  open,
-  onOpenChange,
-  chatId,
-  label,
-  onDeleted,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  chatId: string;
-  label: string;
-  onDeleted: () => void;
-}) {
-  const { emailAccountId } = useAccount();
-  const { execute, isExecuting } = useAction(
-    deleteChatAction.bind(null, emailAccountId),
-    {
-      onSuccess: () => {
-        toastSuccess({ description: "Chat deleted." });
-        onDeleted();
-        onOpenChange(false);
-      },
-      onError: (error) => {
-        toastError({
-          description: getActionErrorMessage(error.error, {
-            prefix: "Failed to delete chat",
-          }),
-        });
-      },
-    },
-  );
-
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete chat?</AlertDialogTitle>
-          <AlertDialogDescription>
-            &ldquo;{label}&rdquo; will be removed from your chat history and its
-            messages will be redacted. This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isExecuting}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={(e) => {
-              e.preventDefault();
-              execute({ chatId });
-            }}
-            disabled={isExecuting}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            {isExecuting ? "Deleting..." : "Delete"}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
   );
 }
 

--- a/apps/web/prisma/migrations/20260505130000_add_chat_deleted_at/migration.sql
+++ b/apps/web/prisma/migrations/20260505130000_add_chat_deleted_at/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "Chat"
+ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+CREATE INDEX "Chat_deletedAt_idx" ON "Chat"("deletedAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1041,9 +1041,10 @@ model DraftSendLog {
 }
 
 model Chat {
-  id        String   @id @default(cuid())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id        String    @id @default(cuid())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
 
   name      String?
 
@@ -1057,6 +1058,7 @@ model Chat {
   emailAccount   EmailAccount     @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
 
   @@index([emailAccountId])
+  @@index([deletedAt])
 }
 
 model ChatMessage {

--- a/apps/web/utils/actions/chat.ts
+++ b/apps/web/utils/actions/chat.ts
@@ -7,16 +7,14 @@ import {
 } from "@/utils/actions/chat.validation";
 import prisma from "@/utils/prisma";
 import { SafeError } from "@/utils/error";
+import { softDeleteChat } from "@/utils/chat/soft-delete";
 
 export const deleteChatAction = actionClient
   .metadata({ name: "deleteChat" })
   .inputSchema(deleteChatBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { chatId } }) => {
-    const result = await prisma.chat.deleteMany({
-      where: { id: chatId, emailAccountId },
-    });
-
-    if (result.count === 0) throw new SafeError("Chat not found.");
+    const deleted = await softDeleteChat({ chatId, emailAccountId });
+    if (!deleted) throw new SafeError("Chat not found.");
   });
 
 export const renameChatAction = actionClient
@@ -25,7 +23,7 @@ export const renameChatAction = actionClient
   .action(
     async ({ ctx: { emailAccountId }, parsedInput: { chatId, name } }) => {
       const result = await prisma.chat.updateMany({
-        where: { id: chatId, emailAccountId },
+        where: { id: chatId, emailAccountId, deletedAt: null },
         data: { name },
       });
 

--- a/apps/web/utils/actions/chat.ts
+++ b/apps/web/utils/actions/chat.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { actionClient } from "@/utils/actions/safe-action";
+import {
+  deleteChatBody,
+  renameChatBody,
+} from "@/utils/actions/chat.validation";
+import prisma from "@/utils/prisma";
+import { SafeError } from "@/utils/error";
+
+export const deleteChatAction = actionClient
+  .metadata({ name: "deleteChat" })
+  .inputSchema(deleteChatBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput: { chatId } }) => {
+    const result = await prisma.chat.deleteMany({
+      where: { id: chatId, emailAccountId },
+    });
+
+    if (result.count === 0) throw new SafeError("Chat not found.");
+  });
+
+export const renameChatAction = actionClient
+  .metadata({ name: "renameChat" })
+  .inputSchema(renameChatBody)
+  .action(
+    async ({ ctx: { emailAccountId }, parsedInput: { chatId, name } }) => {
+      const result = await prisma.chat.updateMany({
+        where: { id: chatId, emailAccountId },
+        data: { name },
+      });
+
+      if (result.count === 0) throw new SafeError("Chat not found.");
+    },
+  );

--- a/apps/web/utils/actions/chat.validation.ts
+++ b/apps/web/utils/actions/chat.validation.ts
@@ -5,8 +5,12 @@ export const deleteChatBody = z.object({
 });
 export type DeleteChatBody = z.infer<typeof deleteChatBody>;
 
-export const renameChatBody = z.object({
+export const renameChatFormBody = z.object({
+  name: z.string().trim().min(1, "Name is required").max(200),
+});
+export type RenameChatFormBody = z.infer<typeof renameChatFormBody>;
+
+export const renameChatBody = renameChatFormBody.extend({
   chatId: z.string().trim().min(1),
-  name: z.string().trim().min(1).max(200),
 });
 export type RenameChatBody = z.infer<typeof renameChatBody>;

--- a/apps/web/utils/actions/chat.validation.ts
+++ b/apps/web/utils/actions/chat.validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const deleteChatBody = z.object({
+  chatId: z.string().trim().min(1),
+});
+export type DeleteChatBody = z.infer<typeof deleteChatBody>;
+
+export const renameChatBody = z.object({
+  chatId: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(200),
+});
+export type RenameChatBody = z.infer<typeof renameChatBody>;

--- a/apps/web/utils/chat/soft-delete.test.ts
+++ b/apps/web/utils/chat/soft-delete.test.ts
@@ -19,10 +19,7 @@ describe("softDeleteChat", () => {
     });
 
     expect(result).toBe(false);
-    expect(prisma.chat.update).not.toHaveBeenCalled();
-    expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
-    expect(prisma.chatCompaction.updateMany).not.toHaveBeenCalled();
-    expect(prisma.chatMemory.updateMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("is idempotent for an already soft-deleted chat", async () => {
@@ -37,19 +34,15 @@ describe("softDeleteChat", () => {
     });
 
     expect(result).toBe(true);
-    expect(prisma.chat.update).not.toHaveBeenCalled();
-    expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it("redacts messages, compactions, memories, and clears the name", async () => {
+  it("redacts messages, compactions, memories, and clears the name in one transaction", async () => {
     prisma.chat.findFirst.mockResolvedValue({
       id: "chat-1",
       deletedAt: null,
     } as never);
-    prisma.chat.update.mockResolvedValue({} as never);
-    prisma.chatMessage.updateMany.mockResolvedValue({ count: 3 } as never);
-    prisma.chatCompaction.updateMany.mockResolvedValue({ count: 1 } as never);
-    prisma.chatMemory.updateMany.mockResolvedValue({ count: 2 } as never);
+    prisma.$transaction.mockResolvedValue([] as never);
 
     const result = await softDeleteChat({
       chatId: "chat-1",
@@ -57,6 +50,7 @@ describe("softDeleteChat", () => {
     });
 
     expect(result).toBe(true);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
 
     expect(prisma.chat.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/utils/chat/soft-delete.test.ts
+++ b/apps/web/utils/chat/soft-delete.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { REDACTED_TEXT, softDeleteChat } from "./soft-delete";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+
+describe("softDeleteChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when no chat is owned by the email account", async () => {
+    prisma.chat.findFirst.mockResolvedValue(null);
+
+    const result = await softDeleteChat({
+      chatId: "chat-1",
+      emailAccountId: "ea_1",
+    });
+
+    expect(result).toBe(false);
+    expect(prisma.chat.update).not.toHaveBeenCalled();
+    expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
+    expect(prisma.chatCompaction.updateMany).not.toHaveBeenCalled();
+    expect(prisma.chatMemory.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent for an already soft-deleted chat", async () => {
+    prisma.chat.findFirst.mockResolvedValue({
+      id: "chat-1",
+      deletedAt: new Date("2026-01-01"),
+    } as never);
+
+    const result = await softDeleteChat({
+      chatId: "chat-1",
+      emailAccountId: "ea_1",
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.chat.update).not.toHaveBeenCalled();
+    expect(prisma.chatMessage.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("redacts messages, compactions, memories, and clears the name", async () => {
+    prisma.chat.findFirst.mockResolvedValue({
+      id: "chat-1",
+      deletedAt: null,
+    } as never);
+    prisma.chat.update.mockResolvedValue({} as never);
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 3 } as never);
+    prisma.chatCompaction.updateMany.mockResolvedValue({ count: 1 } as never);
+    prisma.chatMemory.updateMany.mockResolvedValue({ count: 2 } as never);
+
+    const result = await softDeleteChat({
+      chatId: "chat-1",
+      emailAccountId: "ea_1",
+    });
+
+    expect(result).toBe(true);
+
+    expect(prisma.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "chat-1" },
+        data: expect.objectContaining({
+          name: null,
+          deletedAt: expect.any(Date),
+        }),
+      }),
+    );
+
+    expect(prisma.chatMessage.updateMany).toHaveBeenCalledWith({
+      where: { chatId: "chat-1" },
+      data: { parts: [{ type: "text", text: REDACTED_TEXT }] },
+    });
+    expect(prisma.chatCompaction.updateMany).toHaveBeenCalledWith({
+      where: { chatId: "chat-1" },
+      data: { summary: REDACTED_TEXT },
+    });
+    expect(prisma.chatMemory.updateMany).toHaveBeenCalledWith({
+      where: { chatId: "chat-1" },
+      data: { content: REDACTED_TEXT },
+    });
+  });
+});

--- a/apps/web/utils/chat/soft-delete.ts
+++ b/apps/web/utils/chat/soft-delete.ts
@@ -35,14 +35,14 @@ export async function softDeleteChat({
   if (!chat) return false;
   if (chat.deletedAt) return true;
 
-  const now = new Date();
-
-  await prisma.chat.update({
-    where: { id: chat.id },
-    data: { deletedAt: now, name: null },
-  });
-
-  await Promise.all([
+  // Run as a single transaction so a failed redaction can't leave a chat
+  // marked as deleted while messages, compactions, or memories are still
+  // readable.
+  await prisma.$transaction([
+    prisma.chat.update({
+      where: { id: chat.id },
+      data: { deletedAt: new Date(), name: null },
+    }),
     prisma.chatMessage.updateMany({
       where: { chatId: chat.id },
       data: { parts: REDACTED_PARTS },

--- a/apps/web/utils/chat/soft-delete.ts
+++ b/apps/web/utils/chat/soft-delete.ts
@@ -1,0 +1,61 @@
+import prisma from "@/utils/prisma";
+
+export const REDACTED_TEXT = "[REDACTED]";
+
+const REDACTED_PARTS = [{ type: "text", text: REDACTED_TEXT }];
+
+/**
+ * Soft-deletes a chat owned by `emailAccountId`.
+ *
+ * The Chat row itself is preserved (with `deletedAt` set) so platform-level
+ * analytics and audit trails still work, but every piece of user-supplied or
+ * model-generated content tied to the chat is replaced with a redacted
+ * placeholder. This includes:
+ *  - `Chat.name`
+ *  - `ChatMessage.parts` for every message in the chat
+ *  - `ChatCompaction.summary` for every compaction in the chat
+ *  - `ChatMemory.content` for memories linked to this chat
+ *
+ * Returns `true` if the chat existed and is now soft-deleted (or was already
+ * soft-deleted), `false` if no chat with the given id was owned by this
+ * account.
+ */
+export async function softDeleteChat({
+  chatId,
+  emailAccountId,
+}: {
+  chatId: string;
+  emailAccountId: string;
+}): Promise<boolean> {
+  const chat = await prisma.chat.findFirst({
+    where: { id: chatId, emailAccountId },
+    select: { id: true, deletedAt: true },
+  });
+
+  if (!chat) return false;
+  if (chat.deletedAt) return true;
+
+  const now = new Date();
+
+  await prisma.chat.update({
+    where: { id: chat.id },
+    data: { deletedAt: now, name: null },
+  });
+
+  await Promise.all([
+    prisma.chatMessage.updateMany({
+      where: { chatId: chat.id },
+      data: { parts: REDACTED_PARTS },
+    }),
+    prisma.chatCompaction.updateMany({
+      where: { chatId: chat.id },
+      data: { summary: REDACTED_TEXT },
+    }),
+    prisma.chatMemory.updateMany({
+      where: { chatId: chat.id },
+      data: { content: REDACTED_TEXT },
+    }),
+  ]);
+
+  return true;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a hover-revealed three-dots menu on each row of the chat-history dropdown for **Rename** and **Delete**. Delete is implemented as a soft-delete that redacts user content while leaving the rows in place, so the user no longer sees anything sensitive but the platform can still see that a chat existed (counts, timestamps, audit, etc.).

## UI walkthrough (tested locally against the dev server)

### 1. Hover-revealed three-dots
Default chat history dropdown, then hovering the first row reveals the dots:

[Chat history dropdown](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-chat-history-dropdown.png)
[Three-dots appears on hover](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F02-three-dots-on-hover.png)

### 2. Rename / Delete options
Clicking the dots opens a small menu next to the row:

[Rename / Delete menu](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F03-rename-delete-menu.png)

### 3. Rename
Rename opens a Dialog prefilled with the current name (Save is disabled until it changes):

[Rename dialog prefilled](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F04-rename-dialog.png)
[Rename with new name typed](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F05-rename-with-new-name.png)

After saving, the new name shows up at the top of the list:

[Chat list after rename](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F06-list-after-rename.png)

### 4. Soft-delete
Delete opens an AlertDialog with copy that reflects the soft-delete behaviour:

[Delete confirmation dialog](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F07-delete-confirm.png)

After confirming, the success toast appears and the chat is gone from the list:

[Chat deleted toast](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F08-delete-toast.png)
[List with deleted chat hidden](https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F09-list-after-delete.png)

Verifying in Postgres: the `Chat` row is preserved with `deletedAt` set, and every `ChatMessage.parts` for that chat has been replaced with `[REDACTED]`:

```
     id      |          name           | soft_deleted
-------------+-------------------------+--------------
 chat-demo-1 |                         | t
 chat-demo-3 | Daily inbox triage plan | f
 ...

  id   |   chatId    |                  parts
-------+-------------+------------------------------------------
 msg-1 | chat-demo-1 | [{"text": "[REDACTED]", "type": "text"}]
 msg-2 | chat-demo-1 | [{"text": "[REDACTED]", "type": "text"}]
```

## Implementation

**Frontend**

- Each chat row in `ChatHistoryDropdown` now shows a `MoreHorizontal` button on hover/focus (Tailwind `group-hover` so the list looks clean at rest).
- Clicking the dots opens a small `DropdownMenu` with **Rename** and **Delete**.
- Rename / Delete dialog state is hoisted into the parent dropdown so dialogs outlive the dropdown closing.
- Rename uses a `Dialog` with an `Input`; delete uses an `AlertDialog` for confirmation.
- The list now displays `Chat.name` when set, falling back to `Chat from <date>`. Deleting the active chat clears `chatId` and refreshes the list.
- All shadcn/ui primitives reused: `DropdownMenu`, `Dialog`, `AlertDialog`, `Input`, `Button`, plus `lucide-react` icons.

**Soft-delete model**

- New nullable column `Chat.deletedAt` (+ index), migration `20260505130000_add_chat_deleted_at`.
- New helper `utils/chat/soft-delete.ts` that, on first delete:
  - Sets `Chat.deletedAt = now()` and clears `Chat.name`
  - Replaces `ChatMessage.parts` with `[{ type: "text", text: "[REDACTED]" }]` for every message
  - Replaces `ChatCompaction.summary` with `"[REDACTED]"`
  - Replaces `ChatMemory.content` with `"[REDACTED]"` for memories linked to this chat
- Idempotent on already-deleted chats; returns `false` if no chat with that id is owned by the email account.

**Routes / actions wired up**

- `deleteChatAction` (server action) and `DELETE /api/chats/[chatId]` both call `softDeleteChat`.
- `GET /api/chats`, `GET /api/chats/[chatId]`, and `PATCH /api/chats/[chatId]` filter `deletedAt: null` so deleted chats disappear from the UI and cannot be appended to or renamed.
- `POST /api/chat` returns 410 Gone if the chat has been soft-deleted, preventing the assistant from continuing a deleted conversation.

## Tests / checks

- New `utils/chat/soft-delete.test.ts` covers: not-found, idempotency on already-deleted, and the redaction across messages / compactions / memories + name clear.
- All existing unit tests still pass (`pnpm test`).
- `pnpm exec biome check` passes for the changed files; `tsc --noEmit` reports no new errors for the changed files.
- End-to-end UI flow (open dropdown → hover → menu → rename → delete) verified locally against the dev server with the Google emulator.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e05a3dc-806b-4ea2-819a-2bf74e5fe087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

