### PR TITLE
docs: minimal Cursor Cloud Docker notes in cloud-dev skill

### DIFF
--- a/.claude/skills/cloud-dev-environment/SKILL.md
+++ b/.claude/skills/cloud-dev-environment/SKILL.md
@@ -12,10 +12,14 @@ Instructions for **Cursor Cloud agents** bringing up Postgres/Redis and the app 
 - **Redis 7 + serverless-redis-http**: Caching/rate-limiting. Redis on port 6380, HTTP proxy on port 8079.
 
 ## Starting services
-1. Start Docker daemon: `sudo dockerd &>/dev/null &` if not already running (check `sudo docker info` or `docker info`). If `docker info` fails with permission denied on the socket, grant **only your user** access (do not use `chmod 666`, which lets any local process use Docker): `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` (install the `acl` package if `setfacl` is missing). If you cannot use ACLs, run Compose with `sudo docker compose ...` instead of relaxing socket permissions globally.
-2. Start databases: `docker compose -f docker-compose.dev.yml up -d` from repo root (prefix with `sudo docker` if the socket is still root-only).
-3. Run Prisma migrations: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
-4. Start dev server: `pnpm dev` from repo root.
+Run these in order; each step must succeed before the next (commands are from repo root unless noted).
+
+1. **Docker daemon is up**: `sudo docker info` must print a **Server** section (not only `Client:` followed by “Cannot connect to the Docker daemon”). If it cannot connect, run `sudo dockerd &>/dev/null &`, wait a few seconds, run `sudo docker info` again until it succeeds.
+2. **Your user can talk to Docker**: `docker ps` must exit **0** (same user you use for `pnpm`). If you get “permission denied” on `/var/run/docker.sock`, do **not** use `chmod 666`. Prefer: `sudo apt-get update && sudo apt-get install -y acl` then `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock`, then `docker ps` again. If ACLs are not an option, use `sudo docker compose ...` for Compose commands below instead of widening the socket to everyone.
+3. **Compose v2 is available**: `docker compose version` must print a version. If the command is missing, install the plugin (see **Docker in this environment** below), then re-run `docker compose version`.
+4. **Databases**: `docker compose -f docker-compose.dev.yml up -d` must exit **0**.
+5. **Prisma**: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
+6. **App**: `pnpm dev` from repo root.
 
 ## Environment file
 The app reads `apps/web/.env.local`. Required non-obvious env vars beyond `.env.example` defaults:
@@ -41,7 +45,7 @@ Start the emulator: `docker compose -f docker-compose.dev.yml --profile google-e
 ## Docker in this environment
 The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running. If your user cannot access `/var/run/docker.sock`, use `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` as above—not a world-writable socket.
 
-The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install a **pinned** release (bump the version when you intentionally upgrade):
+The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` does not work, install a **pinned** release (bump the version when you intentionally upgrade):
 ```bash
 COMPOSE_VERSION=v2.29.2
 TMP="$(mktemp)"

--- a/.claude/skills/cloud-dev-environment/SKILL.md
+++ b/.claude/skills/cloud-dev-environment/SKILL.md
@@ -10,8 +10,8 @@ description: Cursor Cloud VM setup and service startup instructions for local de
 - **Redis 7 + serverless-redis-http**: Caching/rate-limiting. Redis on port 6380, HTTP proxy on port 8079.
 
 ## Starting services
-1. Start Docker daemon: `sudo dockerd &>/dev/null &` then `sudo chmod 666 /var/run/docker.sock` if not already running (check `docker info`).
-2. Start databases: `docker compose -f docker-compose.dev.yml up -d` from repo root.
+1. Start Docker daemon: `sudo dockerd &>/dev/null &` if not already running (check `sudo docker info` or `docker info`). If `docker info` fails with permission denied on the socket, grant **only your user** access (do not use `chmod 666`, which lets any local process use Docker): `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` (install the `acl` package if `setfacl` is missing). If you cannot use ACLs, run Compose with `sudo docker compose ...` instead of relaxing socket permissions globally.
+2. Start databases: `docker compose -f docker-compose.dev.yml up -d` from repo root (prefix with `sudo docker` if the socket is still root-only).
 3. Run Prisma migrations: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
 4. Start dev server: `pnpm dev` from repo root.
 
@@ -37,14 +37,20 @@ Start the emulator: `docker compose -f docker-compose.dev.yml --profile google-e
 - AI tests (`pnpm test-ai`) require a real LLM API key and are skipped by default.
 
 ## Docker in this environment
-The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running, then `sudo chmod 666 /var/run/docker.sock`.
+The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running. If your user cannot access `/var/run/docker.sock`, use `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` as above—not a world-writable socket.
 
-The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install it:
+The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install a **pinned** binary and verify SHA256 before placing it in the plugin path (updates the version/sha256 together when bumping):
 ```bash
+COMPOSE_VERSION=v2.29.2
+COMPOSE_SHA256=d037bd4937bf18fba67cff4366e084ee125a3e15c25657ee1aeceff8db3672b4
+TMP="$(mktemp)"
+curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o "$TMP"
+echo "${COMPOSE_SHA256}  ${TMP}" | sha256sum -c -
 sudo mkdir -p /usr/local/lib/docker/cli-plugins
-sudo curl -SL https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+sudo install -m 0755 "$TMP" /usr/local/lib/docker/cli-plugins/docker-compose
+rm -f "$TMP"
 ```
+Official checksums for each release are listed next to the binary on the [Compose releases](https://github.com/docker/compose/releases) page.
 
 ## Onboarding flow
 After a fresh login via the Google emulator, the app forces an onboarding wizard. Some onboarding buttons require JavaScript `click()` calls rather than standard browser clicks (React event delegation quirk in headless/automation contexts).

--- a/.claude/skills/cloud-dev-environment/SKILL.md
+++ b/.claude/skills/cloud-dev-environment/SKILL.md
@@ -4,6 +4,8 @@ description: Cursor Cloud VM setup and service startup instructions for local de
 ---
 # Cloud Development Environment
 
+Instructions for **Cursor Cloud agents** bringing up Postgres/Redis and the app in a disposable dev VM. They are not production hardening: a pinned Compose binary from GitHub is enough (same trust boundary as other `curl`/package installs in setup).
+
 ## Services overview
 - **Main app** (`apps/web`): Next.js 16 app (Turbopack). Runs on port 3000.
 - **PostgreSQL 16**: Primary database. Runs on port 5432 via `docker-compose.dev.yml`.
@@ -39,18 +41,15 @@ Start the emulator: `docker compose -f docker-compose.dev.yml --profile google-e
 ## Docker in this environment
 The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running. If your user cannot access `/var/run/docker.sock`, use `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` as above—not a world-writable socket.
 
-The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install a **pinned** binary and verify SHA256 before placing it in the plugin path (updates the version/sha256 together when bumping):
+The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install a **pinned** release (bump the version when you intentionally upgrade):
 ```bash
 COMPOSE_VERSION=v2.29.2
-COMPOSE_SHA256=d037bd4937bf18fba67cff4366e084ee125a3e15c25657ee1aeceff8db3672b4
 TMP="$(mktemp)"
 curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o "$TMP"
-echo "${COMPOSE_SHA256}  ${TMP}" | sha256sum -c -
 sudo mkdir -p /usr/local/lib/docker/cli-plugins
 sudo install -m 0755 "$TMP" /usr/local/lib/docker/cli-plugins/docker-compose
 rm -f "$TMP"
 ```
-Official checksums for each release are listed next to the binary on the [Compose releases](https://github.com/docker/compose/releases) page.
 
 ## Onboarding flow
 After a fresh login via the Google emulator, the app forces an onboarding wizard. Some onboarding buttons require JavaScript `click()` calls rather than standard browser clicks (React event delegation quirk in headless/automation contexts).

--- a/.claude/skills/cloud-dev-environment/SKILL.md
+++ b/.claude/skills/cloud-dev-environment/SKILL.md
@@ -4,22 +4,16 @@ description: Cursor Cloud VM setup and service startup instructions for local de
 ---
 # Cloud Development Environment
 
-Instructions for **Cursor Cloud agents** bringing up Postgres/Redis and the app in a disposable dev VM. They are not production hardening: a pinned Compose binary from GitHub is enough (same trust boundary as other `curl`/package installs in setup).
-
 ## Services overview
 - **Main app** (`apps/web`): Next.js 16 app (Turbopack). Runs on port 3000.
 - **PostgreSQL 16**: Primary database. Runs on port 5432 via `docker-compose.dev.yml`.
 - **Redis 7 + serverless-redis-http**: Caching/rate-limiting. Redis on port 6380, HTTP proxy on port 8079.
 
 ## Starting services
-Run these in order; each step must succeed before the next (commands are from repo root unless noted).
-
-1. **Docker daemon is up**: `sudo docker info` must print a **Server** section (not only `Client:` followed by “Cannot connect to the Docker daemon”). If it cannot connect, run `sudo dockerd &>/dev/null &`, wait a few seconds, run `sudo docker info` again until it succeeds.
-2. **Your user can talk to Docker**: `docker ps` must exit **0** (same user you use for `pnpm`). If you get “permission denied” on `/var/run/docker.sock`, do **not** use `chmod 666`. Prefer: `sudo apt-get update && sudo apt-get install -y acl` then `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock`, then `docker ps` again. If ACLs are not an option, use `sudo docker compose ...` for Compose commands below instead of widening the socket to everyone.
-3. **Compose v2 is available**: `docker compose version` must print a version. If the command is missing, install the plugin (see **Docker in this environment** below), then re-run `docker compose version`.
-4. **Databases**: `docker compose -f docker-compose.dev.yml up -d` must exit **0**.
-5. **Prisma**: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
-6. **App**: `pnpm dev` from repo root.
+1. Start Docker daemon if needed: `sudo dockerd &>/dev/null &`, then confirm with `docker info` (or `sudo docker info` if the client cannot reach the daemon yet).
+2. Start databases from repo root: `docker compose -f docker-compose.dev.yml up -d`. If you get permission denied on `/var/run/docker.sock`, run the same command with `sudo docker compose` instead of making the socket world-writable.
+3. Run Prisma migrations: `cd apps/web && pnpm prisma:migrate:local` (uses `dotenv -e .env.local`; do NOT use bare `prisma migrate dev` — it won't load `.env.local`).
+4. Start dev server: `pnpm dev` from repo root.
 
 ## Environment file
 The app reads `apps/web/.env.local`. Required non-obvious env vars beyond `.env.example` defaults:
@@ -43,16 +37,13 @@ Start the emulator: `docker compose -f docker-compose.dev.yml --profile google-e
 - AI tests (`pnpm test-ai`) require a real LLM API key and are skipped by default.
 
 ## Docker in this environment
-The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running. If your user cannot access `/var/run/docker.sock`, use `sudo setfacl -m "u:$(whoami):rw" /var/run/docker.sock` as above—not a world-writable socket.
+The cloud VM is a Docker-in-Docker setup. Docker requires `fuse-overlayfs` storage driver and `iptables-legacy`. These are configured during initial setup. After snapshot restore, run `sudo dockerd &>/dev/null &` if Docker daemon is not running.
 
-The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` does not work, install a **pinned** release (bump the version when you intentionally upgrade):
+The VM may not have the Docker Compose v2 plugin pre-installed. If `docker compose version` fails, install it:
 ```bash
-COMPOSE_VERSION=v2.29.2
-TMP="$(mktemp)"
-curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o "$TMP"
 sudo mkdir -p /usr/local/lib/docker/cli-plugins
-sudo install -m 0755 "$TMP" /usr/local/lib/docker/cli-plugins/docker-compose
-rm -f "$TMP"
+sudo curl -fsSL https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 ```
 
 ## Onboarding flow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Minimal update to `.claude/skills/cloud-dev-environment/SKILL.md` for Cursor Cloud dev:

- **Removed `chmod 666`** on `/var/run/docker.sock` (still avoid world-writable socket).
- **One-line fix** if permission denied: use `sudo docker compose ...` instead of relaxing the socket for everyone.
- **Compose install**: simple pinned `v2.29.2` `curl` + `chmod +x` (no temp file, ACL, or checksum steps).

Everything else matches the original short skill shape.

## Verification

Doc-only change; no code paths affected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84e90533-e31b-45cd-b1d6-b666b941cd42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84e90533-e31b-45cd-b1d6-b666b941cd42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

