### PR TITLE
Configurable AI draft retention and cleanup

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/AiDraftCleanupSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/AiDraftCleanupSetting.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAction } from "next-safe-action/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/Input";
+import { Toggle } from "@/components/Toggle";
+import { LoadingContent } from "@/components/LoadingContent";
+import { MutedText } from "@/components/Typography";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Label } from "@/components/ui/label";
+import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { createSettingActionErrorHandler } from "@/utils/actions/error-handling";
+import { updateAiDraftCleanupSettingsAction } from "@/utils/actions/email-account";
+import { cleanupAIDraftsAction } from "@/utils/actions/user";
+import { toastError, toastSuccess } from "@/components/Toast";
+import { getActionErrorMessage } from "@/utils/error";
+import { BRAND_NAME } from "@/utils/branding";
+
+export function AiDraftCleanupSetting() {
+  const { data, isLoading, error, mutate } = useEmailAccountFull();
+  const { emailAccountId } = useAccount();
+  const autoEnabled = data?.aiDraftAutoCleanupEnabled ?? true;
+  const persistedDays = data?.aiDraftRetentionDays ?? 14;
+
+  const [daysInput, setDaysInput] = useState(String(persistedDays));
+
+  useEffect(() => {
+    setDaysInput(String(persistedDays));
+  }, [persistedDays]);
+
+  const { execute: executeSave, isExecuting: isSaving } = useAction(
+    updateAiDraftCleanupSettingsAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        mutate();
+      },
+      onError: createSettingActionErrorHandler({
+        mutate,
+        prefix: "Failed to update draft cleanup settings",
+      }),
+    },
+  );
+
+  const handleToggle = useCallback(
+    (nextAuto: boolean) => {
+      if (!data) return;
+      mutate(
+        {
+          ...data,
+          aiDraftAutoCleanupEnabled: nextAuto,
+        },
+        false,
+      );
+      executeSave({
+        aiDraftAutoCleanupEnabled: nextAuto,
+        aiDraftRetentionDays: persistedDays,
+      });
+    },
+    [data, executeSave, mutate, persistedDays],
+  );
+
+  const commitDays = useCallback(() => {
+    if (!data) return;
+    const parsed = Number.parseInt(daysInput, 10);
+    if (!Number.isFinite(parsed)) {
+      setDaysInput(String(persistedDays));
+      return;
+    }
+    const clamped = Math.min(365, Math.max(1, Math.floor(parsed)));
+    setDaysInput(String(clamped));
+    if (clamped === persistedDays) return;
+
+    mutate(
+      {
+        ...data,
+        aiDraftRetentionDays: clamped,
+      },
+      false,
+    );
+
+    executeSave({
+      aiDraftAutoCleanupEnabled: autoEnabled,
+      aiDraftRetentionDays: clamped,
+    });
+  }, [autoEnabled, data, daysInput, executeSave, mutate, persistedDays]);
+
+  const [manualSummary, setManualSummary] = useState<{
+    deleted: number;
+    skippedModified: number;
+  } | null>(null);
+
+  const { execute: executeCleanup, isExecuting: isCleaning } = useAction(
+    cleanupAIDraftsAction.bind(null, emailAccountId),
+    {
+      onSuccess: (res) => {
+        if (res.data) {
+          setManualSummary(res.data);
+          if (res.data.deleted === 0 && res.data.skippedModified === 0) {
+            toastSuccess({ description: "No eligible drafts found." });
+          } else if (res.data.deleted === 0) {
+            toastSuccess({
+              description:
+                "Eligible drafts were edited by you, so none were removed.",
+            });
+          } else {
+            toastSuccess({
+              description: `Removed ${res.data.deleted} draft${res.data.deleted === 1 ? "" : "s"}.`,
+            });
+          }
+        }
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error),
+        });
+      },
+    },
+  );
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <div className="space-y-2">
+          <h3 className="font-medium">AI draft cleanup</h3>
+          <MutedText>
+            This only affects drafts that {BRAND_NAME} created for you and that
+            still match the saved content—your edits always stay. Other drafts
+            in your mailbox are never deleted.
+          </MutedText>
+        </div>
+
+        <LoadingContent
+          loading={isLoading}
+          error={error}
+          loadingComponent={
+            <div className="space-y-3">
+              <Skeleton className="h-9 w-full max-w-md" />
+              <Skeleton className="h-9 w-full max-w-xs" />
+            </div>
+          }
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-sm font-medium">
+                Automatically remove old drafts
+              </p>
+              <MutedText className="text-xs">
+                Runs in the background when enabled. Uses the age below.
+              </MutedText>
+            </div>
+            <Toggle
+              name="ai-draft-auto-cleanup"
+              enabled={autoEnabled}
+              onChange={handleToggle}
+              disabled={!data || isSaving}
+            />
+          </div>
+
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="ai-draft-retention-days">Age threshold</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="ai-draft-retention-days"
+                  type="number"
+                  min={1}
+                  max={365}
+                  className="w-24"
+                  value={daysInput}
+                  disabled={!data || isSaving}
+                  onChange={(e) => setDaysInput(e.target.value)}
+                  onBlur={commitDays}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.currentTarget.blur();
+                    }
+                  }}
+                />
+                <span className="text-sm text-muted-foreground">days</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <MutedText className="text-xs">
+              Remove eligible drafts immediately (same rules—only unedited AI
+              drafts older than {persistedDays}{" "}
+              {persistedDays === 1 ? "day" : "days"}).
+            </MutedText>
+            <Button
+              size="sm"
+              variant="outline"
+              loading={isCleaning}
+              onClick={() => {
+                setManualSummary(null);
+                executeCleanup();
+              }}
+            >
+              Remove eligible drafts now
+            </Button>
+          </div>
+
+          {manualSummary &&
+            manualSummary.deleted > 0 &&
+            manualSummary.skippedModified > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {manualSummary.skippedModified} draft
+                {manualSummary.skippedModified === 1 ? " was" : "s were"} kept
+                because you edited{" "}
+                {manualSummary.skippedModified === 1 ? "it" : "them"}.
+              </p>
+            )}
+        </LoadingContent>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/SettingsTab.tsx
@@ -3,6 +3,7 @@ import { SensitiveDataPolicySetting } from "@/app/(app)/[emailAccountId]/assista
 import { DigestSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DigestSetting";
 import { DraftConfidenceSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftConfidenceSetting";
 import { DraftReplies } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftReplies";
+import { AiDraftCleanupSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/AiDraftCleanupSetting";
 import { DraftKnowledgeSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/DraftKnowledgeSetting";
 import { FollowUpRemindersSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/FollowUpRemindersSetting";
 import { HiddenAiDraftLinksSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/HiddenAiDraftLinksSetting";
@@ -23,6 +24,7 @@ export function SettingsTab() {
       {!autoDraftDisabled && (
         <div className="space-y-2">
           <DraftReplies />
+          <AiDraftCleanupSetting />
           <DraftConfidenceSetting />
         </div>
       )}

--- a/apps/web/app/(app)/[emailAccountId]/settings/CleanupDraftsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/CleanupDraftsSection.tsx
@@ -18,8 +18,10 @@ import { BRAND_NAME } from "@/utils/branding";
 
 export function CleanupDraftsSection({
   emailAccountId,
+  retentionDays = 14,
 }: {
   emailAccountId: string;
+  retentionDays?: number;
 }) {
   const [result, setResult] = useState<{
     deleted: number;
@@ -61,7 +63,7 @@ export function CleanupDraftsSection({
         <ItemContent>
           <ItemTitle>Clean Up AI Drafts</ItemTitle>
           <ItemDescription>
-            {`Delete drafts created by ${BRAND_NAME} that are older than 3 days and haven't been edited by you`}
+            {`Delete drafts ${BRAND_NAME} created for you that are older than ${retentionDays} ${retentionDays === 1 ? "day" : "days"} and still match the saved text (you edited drafts are never removed). Does not delete other drafts.`}
           </ItemDescription>
         </ItemContent>
         <ItemActions>

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -277,7 +277,10 @@ function EmailAccountSettingsCard({
             emailAccountEmail={emailAccount.email}
             allAccounts={allAccounts}
           />
-          <CleanupDraftsSection emailAccountId={emailAccount.id} />
+          <CleanupDraftsSection
+            emailAccountId={emailAccount.id}
+            retentionDays={emailAccount.aiDraftRetentionDays ?? 14}
+          />
           <ResetAnalyticsSection emailAccountId={emailAccount.id} />
         </>
       )}

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -45,6 +45,7 @@ import {
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 import { env } from "@/env";
+import { cleanupAIDraftsForAccount } from "@/utils/ai/draft-cleanup";
 
 const FOLLOW_UP_ELIGIBILITY_WINDOW_MINUTES = 15;
 const FOLLOW_UP_THREAD_SCAN_LIMIT = 50;
@@ -245,18 +246,17 @@ export async function processAccountFollowUps({
     logger,
   });
 
-  // Draft cleanup temporarily disabled to avoid deleting old drafts.
-  // Wrapped in try/catch since it's non-critical
-  // try {
-  //   await cleanupStaleDrafts({
-  //     emailAccountId,
-  //     provider,
-  //     logger,
-  //   });
-  // } catch (error) {
-  //   logger.error("Failed to cleanup stale drafts", { error });
-  //   captureException(error);
-  // }
+  try {
+    await cleanupAIDraftsForAccount({
+      emailAccountId,
+      provider: providerName,
+      logger,
+      trigger: "scheduled",
+    });
+  } catch (error) {
+    logger.error("Failed to cleanup stale AI drafts", { error });
+    captureException(error);
+  }
 
   logger.info("Finished processing follow-ups for account");
 }

--- a/apps/web/app/api/user/email-account/route.ts
+++ b/apps/web/app/api/user/email-account/route.ts
@@ -43,6 +43,8 @@ async function getEmailAccount({
       followUpNeedsReplyDays: true,
       followUpAutoDraftEnabled: true,
       digestSendEmail: true,
+      aiDraftAutoCleanupEnabled: true,
+      aiDraftRetentionDays: true,
     },
   });
 

--- a/apps/web/app/api/user/email-accounts/route.ts
+++ b/apps/web/app/api/user/email-accounts/route.ts
@@ -39,6 +39,8 @@ async function getEmailAccounts({ userId }: { userId: string }) {
           email: true,
         },
       },
+      aiDraftAutoCleanupEnabled: true,
+      aiDraftRetentionDays: true,
     },
     orderBy: {
       createdAt: "asc",

--- a/apps/web/prisma/migrations/20260506120000_ai_draft_cleanup_settings/migration.sql
+++ b/apps/web/prisma/migrations/20260506120000_ai_draft_cleanup_settings/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN     "aiDraftAutoCleanupEnabled" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "aiDraftRetentionDays" INTEGER NOT NULL DEFAULT 14;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -150,6 +150,8 @@ model EmailAccount {
   multiRuleSelectionEnabled Boolean              @default(false)
   sensitiveDataPolicy       String?
   draftReplyConfidence      DraftReplyConfidence @default(ALL_EMAILS)
+  aiDraftAutoCleanupEnabled Boolean              @default(true)
+  aiDraftRetentionDays      Int                  @default(14)
   allowHiddenAiDraftLinks   Boolean              @default(false)
   rulesRevision             Int                  @default(0)
 

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -555,6 +555,7 @@ export const adminCleanupDraftsAction = adminActionClient
         emailAccountId: emailAccount.id,
         provider: emailAccount.account.provider,
         logger,
+        trigger: "manual",
       });
 
       totalDeleted += result.deleted;

--- a/apps/web/utils/actions/email-account.ts
+++ b/apps/web/utils/actions/email-account.ts
@@ -10,6 +10,7 @@ import { SafeError } from "@/utils/error";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { updateContactRole } from "@inboxzero/loops";
 import {
+  updateAiDraftCleanupBody,
   updateHiddenAiDraftLinksBody,
   updateReferralSignatureBody,
 } from "@/utils/actions/email-account.validation";
@@ -126,6 +127,29 @@ export const updateHiddenAiDraftLinksAction = actionClient
       await prisma.emailAccount.update({
         where: { id: emailAccountId },
         data: { allowHiddenAiDraftLinks: enabled },
+      });
+    },
+  );
+
+export const updateAiDraftCleanupSettingsAction = actionClient
+  .metadata({ name: "updateAiDraftCleanupSettings" })
+  .inputSchema(updateAiDraftCleanupBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, logger },
+      parsedInput: { aiDraftAutoCleanupEnabled, aiDraftRetentionDays },
+    }) => {
+      logger.info("Updating AI draft cleanup settings", {
+        aiDraftAutoCleanupEnabled,
+        aiDraftRetentionDays,
+      });
+
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: {
+          aiDraftAutoCleanupEnabled,
+          aiDraftRetentionDays,
+        },
       });
     },
   );

--- a/apps/web/utils/actions/email-account.validation.ts
+++ b/apps/web/utils/actions/email-account.validation.ts
@@ -7,3 +7,8 @@ export const updateReferralSignatureBody = z.object({
 export const updateHiddenAiDraftLinksBody = z.object({
   enabled: z.boolean(),
 });
+
+export const updateAiDraftCleanupBody = z.object({
+  aiDraftAutoCleanupEnabled: z.boolean(),
+  aiDraftRetentionDays: z.coerce.number().int().min(1).max(365),
+});

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -78,7 +78,12 @@ export const deleteAccountAction = actionClientUser
 export const cleanupAIDraftsAction = actionClient
   .metadata({ name: "cleanupAIDrafts" })
   .action(async ({ ctx: { emailAccountId, provider, logger } }) =>
-    cleanupAIDraftsForAccount({ emailAccountId, provider, logger }),
+    cleanupAIDraftsForAccount({
+      emailAccountId,
+      provider,
+      logger,
+      trigger: "manual",
+    }),
   );
 
 export const deleteEmailAccountAction = actionClientUser

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      findUnique: vi.fn(),
+    },
+    executedAction: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+
+import prisma from "@/utils/prisma";
+import { cleanupAIDraftsForAccount } from "@/utils/ai/draft-cleanup";
+import type { Logger } from "@/utils/logger";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+} as unknown as Logger;
+
+describe("cleanupAIDraftsForAccount", () => {
+  it("skips database work for scheduled runs when auto cleanup is disabled", async () => {
+    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue({
+      aiDraftAutoCleanupEnabled: false,
+      aiDraftRetentionDays: 14,
+    } as Awaited<ReturnType<typeof prisma.emailAccount.findUnique>>);
+
+    const result = await cleanupAIDraftsForAccount({
+      emailAccountId: "acc-1",
+      provider: "GOOGLE",
+      logger,
+      trigger: "scheduled",
+    });
+
+    expect(result).toEqual({
+      total: 0,
+      deleted: 0,
+      skippedModified: 0,
+      alreadyGone: 0,
+      errors: 0,
+    });
+    expect(prisma.executedAction.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -4,19 +4,57 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import type { Logger } from "@/utils/logger";
 
-const STALE_DAYS = 3;
+export type AiDraftCleanupTrigger = "scheduled" | "manual";
+
+const MIN_RETENTION_DAYS = 1;
+const MAX_RETENTION_DAYS = 365;
 
 export async function cleanupAIDraftsForAccount({
   emailAccountId,
   provider: providerName,
   logger,
+  trigger = "manual",
 }: {
   emailAccountId: string;
   provider: string;
   logger: Logger;
+  trigger?: AiDraftCleanupTrigger;
 }) {
+  const account = await prisma.emailAccount.findUnique({
+    where: { id: emailAccountId },
+    select: {
+      aiDraftAutoCleanupEnabled: true,
+      aiDraftRetentionDays: true,
+    },
+  });
+
+  if (!account) {
+    logger.warn("Email account not found for AI draft cleanup", {
+      emailAccountId,
+    });
+    return {
+      total: 0,
+      deleted: 0,
+      skippedModified: 0,
+      alreadyGone: 0,
+      errors: 0,
+    };
+  }
+
+  if (trigger === "scheduled" && !account.aiDraftAutoCleanupEnabled) {
+    return {
+      total: 0,
+      deleted: 0,
+      skippedModified: 0,
+      alreadyGone: 0,
+      errors: 0,
+    };
+  }
+
+  const staleDays = clampRetentionDays(account.aiDraftRetentionDays);
+
   const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - STALE_DAYS);
+  cutoffDate.setDate(cutoffDate.getDate() - staleDays);
 
   const staleDrafts = await prisma.executedAction.findMany({
     where: {
@@ -114,4 +152,12 @@ export async function cleanupAIDraftsForAccount({
     alreadyGone,
     errors,
   };
+}
+
+function clampRetentionDays(days: number): number {
+  if (!Number.isFinite(days)) return 14;
+  return Math.min(
+    MAX_RETENTION_DAYS,
+    Math.max(MIN_RETENTION_DAYS, Math.floor(days)),
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Fact-check:** Automatic cleanup was **not** 30 days. Rule-based AI drafts used a hardcoded **3-day** age threshold in `cleanupAIDraftsForAccount`. There was **no** periodic job hooked up for that path (the commented block in follow-up processing was a different helper for follow-up tracker drafts at **7 days**, and it was disabled).

- **Database:** `EmailAccount.aiDraftAutoCleanupEnabled` (default `true`) and `aiDraftRetentionDays` (default **14**).

- **Backend:** `cleanupAIDraftsForAccount` reads account settings, clamps days to 1–365, skips **scheduled** runs when auto cleanup is off, and always runs **manual** cleanup (settings button / admin). **Scheduled** cleanup runs from the follow-up reminder processor after each account’s follow-up pass.

- **UI:** New **Assistant → Settings** card “AI draft cleanup” under auto draft replies: toggle for automatic removal, numeric age threshold, manual “Remove eligible drafts now”, and copy stating only **unedited AI drafts we created** are removed—not arbitrary mailbox drafts.

- **Global Settings:** Per-account “Clean Up AI Drafts” row uses the account’s retention days in the description.

## Testing

- `pnpm lint`
- `vitest utils/ai/draft-cleanup.test.ts`
- `vitest app/api/follow-up-reminders/process.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b64b5f1a-d84a-4082-ae0f-45dc845c90eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b64b5f1a-d84a-4082-ae0f-45dc845c90eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

