### PR TITLE
Add emoji prefixes to messaging notifications

### DIFF
--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -274,7 +274,7 @@ function formatDigestText({
   itemsByRule: ItemsByRule;
 }): string {
   const sections: string[] = [
-    `Your Inbox Zero digest — ${formatDigestDate(date)}`,
+    `📋 Your Inbox Zero digest — ${formatDigestDate(date)}`,
   ];
 
   for (const [ruleKey, items] of Object.entries(itemsByRule)) {

--- a/apps/web/utils/follow-up/copy.ts
+++ b/apps/web/utils/follow-up/copy.ts
@@ -9,6 +9,7 @@ export function getFollowUpCopy(trackerType: ThreadTrackerType) {
     directionLine: isAwaiting ? "they haven't replied" : "you haven't replied",
     preposition: isAwaiting ? "to" : "from",
     verb: isAwaiting ? "sent" : "received",
+    emoji: isAwaiting ? "⏳" : "✍️",
   };
 }
 

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -212,10 +212,11 @@ function formatFollowUpText({
   snippet,
   threadLink,
 }: FollowUpNotificationContent): string {
-  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
+  const { directionLine, preposition, verb, emoji } =
+    getFollowUpCopy(trackerType);
 
   const lines = [
-    `Follow-up nudge — ${directionLine}`,
+    `${emoji} Follow-up nudge — ${directionLine}`,
     subject,
     `${preposition} ${counterpartyName} <${counterpartyEmail}> · ${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
   ];
@@ -236,7 +237,8 @@ function buildTelegramFollowUpCard({
   threadLink,
   threadLinkLabel,
 }: FollowUpNotificationContent) {
-  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
+  const { directionLine, preposition, verb, emoji } =
+    getFollowUpCopy(trackerType);
   const children: CardChild[] = [
     CardText(
       [
@@ -263,7 +265,7 @@ function buildTelegramFollowUpCard({
   }
 
   return Card({
-    title: "Follow-up nudge",
+    title: `${emoji} Follow-up nudge`,
     children,
   });
 }

--- a/apps/web/utils/meeting-briefs/send-briefing.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.ts
@@ -354,7 +354,7 @@ function formatMeetingBriefingText({
   briefingContent: BriefingContent;
 }) {
   const sections = [
-    `Briefing for ${meetingTitle}`,
+    `📅 Briefing for ${meetingTitle}`,
     `Starting at ${formattedTime}`,
   ];
 

--- a/apps/web/utils/messaging/providers/slack/messages/digest.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/digest.ts
@@ -26,7 +26,7 @@ export function buildDigestBlocks({
       type: "header",
       text: {
         type: "plain_text",
-        text: `Your Inbox Zero digest — ${formatDigestDate(date)}`,
+        text: `📋 Your Inbox Zero digest — ${formatDigestDate(date)}`,
         emoji: true,
       },
     },

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -26,7 +26,8 @@ export function buildFollowUpReminderBlocks({
   threadLink,
   trackerId,
 }: FollowUpReminderBlocksParams): (KnownBlock | Block)[] {
-  const { directionLine, preposition, verb } = getFollowUpCopy(trackerType);
+  const { directionLine, preposition, verb, emoji } =
+    getFollowUpCopy(trackerType);
   const sentenceVerb = `${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`;
 
   const counterpartyMarkdown = `${preposition} *${escapeSlackText(counterpartyName)}* \`<${escapeSlackText(counterpartyEmail)}>\``;
@@ -34,7 +35,11 @@ export function buildFollowUpReminderBlocks({
   const blocks: (KnownBlock | Block)[] = [
     {
       type: "header",
-      text: { type: "plain_text", text: "Follow-up nudge", emoji: true },
+      text: {
+        type: "plain_text",
+        text: `${emoji} Follow-up nudge`,
+        emoji: true,
+      },
     },
     {
       type: "context",

--- a/apps/web/utils/messaging/providers/slack/messages/meeting-briefing.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/meeting-briefing.ts
@@ -36,7 +36,7 @@ export function buildMeetingBriefingBlocks({
       type: "header",
       text: {
         type: "plain_text",
-        text: `Briefing: ${meetingTitle}`,
+        text: `📅 Briefing: ${meetingTitle}`,
         emoji: true,
       },
     },


### PR DESCRIPTION
## Summary
- Prefix Slack/Teams/Telegram notifications with an emoji so the message type is recognizable at a glance.
- Follow-up nudges pick the emoji from tracker direction (⏳ awaiting their reply, ✍️ you need to reply); digests get 📋 and meeting briefs 📅.

## Test plan
- [ ] Trigger a follow-up reminder of each tracker type and verify the lead line emoji on Slack, Teams, and Telegram.
- [ ] Send a digest and a meeting brief and confirm the prefix appears across all three providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)