### PR TITLE
Add emoji prefixes to Slack push text and notification titles

### DIFF
--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -17,6 +17,7 @@ import {
   buildFollowUpReminderBlocks,
   type FollowUpReminderBlocksParams,
 } from "./messages/follow-up-reminder";
+import { getFollowUpCopy } from "@/utils/follow-up/copy";
 
 export type SlackBriefingParams = MeetingBriefingBlocksParams & {
   accessToken: string;
@@ -44,7 +45,7 @@ export async function sendMeetingBriefingToSlack({
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: `Briefing for ${meetingTitle}, starting at ${formattedTime}`,
+    text: `📅 Briefing for ${meetingTitle}, starting at ${formattedTime}`,
   });
 }
 
@@ -60,7 +61,7 @@ export async function sendChannelConfirmation({
   const client = createSlackClient(accessToken);
 
   await postMessageWithJoin(client, channelId, {
-    text: `Inbox Zero connected! You can ${formatSlackAppMention(botUserId)} here to chat about your emails. If you enable meeting briefs or attachment filing notifications, I can send those in this channel too.`,
+    text: `✅ Inbox Zero connected! You can ${formatSlackAppMention(botUserId)} here to chat about your emails. If you enable meeting briefs or attachment filing notifications, I can send those in this channel too.`,
   });
 }
 
@@ -76,7 +77,7 @@ export async function sendConnectionOnboardingDirectMessage({
   await client.chat.postMessage(
     disableSlackLinkUnfurls({
       channel: userId,
-      text: "Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite @InboxZero there. You can also DM me anytime to chat about your emails.",
+      text: "✅ Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite @InboxZero there. You can also DM me anytime to chat about your emails.",
     }),
   );
 }
@@ -106,7 +107,7 @@ export async function sendDocumentFiledToSlack({
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: `Filed ${filename} to ${folderPath}`,
+    text: `📨 Filed ${filename} to ${folderPath}`,
   });
 }
 
@@ -127,7 +128,7 @@ export async function sendDocumentAskToSlack({
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: `Where should I file ${filename}?`,
+    text: `📄 Where should I file ${filename}?`,
   });
 }
 
@@ -152,7 +153,7 @@ export async function sendDigestToSlack({
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: "Your Inbox Zero digest",
+    text: "📋 Your Inbox Zero digest",
   });
 }
 
@@ -168,10 +169,11 @@ export async function sendFollowUpReminderToSlack({
 }: SlackFollowUpReminderParams): Promise<void> {
   const client = createSlackClient(accessToken);
   const blocks = buildFollowUpReminderBlocks(blockParams);
+  const { emoji } = getFollowUpCopy(blockParams.trackerType);
 
   await postMessageWithJoin(client, channelId, {
     blocks,
-    text: `Follow-up: ${blockParams.subject}`,
+    text: `${emoji} Follow-up: ${blockParams.subject}`,
   });
 }
 

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1573,7 +1573,7 @@ function buildNotificationContent({
     }
 
     return {
-      title: "New email — reply drafted",
+      title: "📩 New email — reply drafted",
       summary,
       details,
     };
@@ -1594,13 +1594,13 @@ function buildNotificationContent({
     ].filter(Boolean);
 
     return {
-      title: "Calendar invite",
+      title: "📅 Calendar invite",
       summary: lines.join("\n"),
     };
   }
 
   return {
-    title: "Email notification",
+    title: "✉️ Email notification",
     summary: buildEmailSummary(email),
     details: [
       buildNotificationDetailSection({


### PR DESCRIPTION
## Summary
- Prefix the Slack \`text\` fallback (used for mobile push and OS notification previews) so each notification type is recognizable before the rich blocks render.
- Add matching emoji prefixes to rule-notification titles (📩 draft reply, 📅 calendar invite, ✉️ generic email) so the lead line on Telegram and Teams matches the in-message visuals.
- Follow-up push text uses the same direction-aware emoji as the header (⏳ awaiting their reply, ✍️ needs your reply).

## Test plan
- [ ] Trigger each notification type (draft reply, calendar invite, digest, meeting brief, follow-up of each direction, document filed/ask, Slack onboarding) and verify the OS push preview and in-app lead line both show the expected emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)