### PR TITLE
follow-up: Clarify notification copy

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -323,13 +323,17 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const awaitingBlocks = JSON.stringify(awaitingCall![0].blocks);
       expect(awaitingBlocks).toContain("Follow-up nudge");
-      expect(awaitingBlocks).toContain("they haven't replied");
-      expect(awaitingBlocks).toContain("sent 4 days ago");
+      expect(awaitingBlocks).toContain(
+        "Waiting for their reply to your sent email",
+      );
+      expect(awaitingBlocks).toContain("4 days ago");
       expect(awaitingBlocks).toContain("Jane Partner");
       expect(awaitingBlocks).toContain("jane@partner.com");
-      // AWAITING: the user emailed Jane — preposition must be "to", not "from"
-      expect(awaitingBlocks).toContain("to *Jane Partner*");
-      expect(awaitingBlocks).not.toContain("from *Jane Partner*");
+      // AWAITING: the user emailed Jane, so the reminder should make that clear.
+      expect(awaitingBlocks).toContain("You sent this email to *Jane Partner*");
+      expect(awaitingBlocks).not.toContain(
+        "You received this email from *Jane Partner*",
+      );
       expect(awaitingBlocks).toContain(
         "Wanted to check whether the redlines have landed.",
       );
@@ -339,9 +343,13 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const needsReplyBlocks = JSON.stringify(needsReplyCall![0].blocks);
       expect(needsReplyBlocks).toContain("Follow-up nudge");
-      expect(needsReplyBlocks).toContain("you haven't replied");
-      expect(needsReplyBlocks).toContain("received 1 day ago");
-      expect(needsReplyBlocks).toContain("from *Alex Customer*");
+      expect(needsReplyBlocks).toContain(
+        "You haven't replied to this email yet",
+      );
+      expect(needsReplyBlocks).toContain("1 day ago");
+      expect(needsReplyBlocks).toContain(
+        "You received this email from *Alex Customer*",
+      );
       expect(needsReplyBlocks).toContain(
         "Could you walk me through the SSO setup?",
       );

--- a/apps/web/utils/follow-up/copy.ts
+++ b/apps/web/utils/follow-up/copy.ts
@@ -1,4 +1,5 @@
 import { ThreadTrackerType } from "@/generated/prisma/enums";
+import he from "he";
 
 const SNIPPET_MAX_CHARS = 280;
 
@@ -6,15 +7,23 @@ export function getFollowUpCopy(trackerType: ThreadTrackerType) {
   const isAwaiting = trackerType === ThreadTrackerType.AWAITING;
   return {
     isAwaiting,
-    directionLine: isAwaiting ? "they haven't replied" : "you haven't replied",
-    preposition: isAwaiting ? "to" : "from",
-    verb: isAwaiting ? "sent" : "received",
+    directionLine: isAwaiting
+      ? "Waiting for their reply to your sent email"
+      : "You haven't replied to this email yet",
+    counterpartyPrefix: isAwaiting
+      ? "You sent this email to"
+      : "You received this email from",
+    snippetLabel: isAwaiting ? "Your sent email" : "Email awaiting your reply",
     emoji: isAwaiting ? "⏳" : "✍️",
   };
 }
 
 export function truncateSnippet(snippet: string): string {
-  const collapsed = snippet.replace(/\s+/g, " ").trim();
+  const collapsed = normalizeFollowUpText(snippet);
   if (collapsed.length <= SNIPPET_MAX_CHARS) return collapsed;
   return `${collapsed.slice(0, SNIPPET_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+export function normalizeFollowUpText(text: string): string {
+  return he.decode(text).replace(/\s+/g, " ").trim();
 }

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -19,7 +19,11 @@ import {
 import { isMessagingChannelOperational } from "@/utils/messaging/channel-validity";
 import prisma from "@/utils/prisma";
 import { pluralize } from "@/utils/string";
-import { getFollowUpCopy, truncateSnippet } from "@/utils/follow-up/copy";
+import {
+  getFollowUpCopy,
+  normalizeFollowUpText,
+  truncateSnippet,
+} from "@/utils/follow-up/copy";
 
 export type FollowUpNotificationChannel = {
   id: string;
@@ -212,13 +216,13 @@ function formatFollowUpText({
   snippet,
   threadLink,
 }: FollowUpNotificationContent): string {
-  const { directionLine, preposition, verb, emoji } =
+  const { directionLine, counterpartyPrefix, emoji } =
     getFollowUpCopy(trackerType);
 
   const lines = [
     `${emoji} Follow-up nudge — ${directionLine}`,
-    subject,
-    `${preposition} ${counterpartyName} <${counterpartyEmail}> · ${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
+    normalizeFollowUpText(subject),
+    `${counterpartyPrefix} ${normalizeFollowUpText(counterpartyName)} <${counterpartyEmail}> · ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
   ];
 
   if (snippet) lines.push(`> ${truncateSnippet(snippet)}`);
@@ -237,20 +241,20 @@ function buildTelegramFollowUpCard({
   threadLink,
   threadLinkLabel,
 }: FollowUpNotificationContent) {
-  const { directionLine, preposition, verb, emoji } =
+  const { directionLine, counterpartyPrefix, snippetLabel, emoji } =
     getFollowUpCopy(trackerType);
   const children: CardChild[] = [
     CardText(
       [
         directionLine,
-        subject,
-        `${preposition} ${counterpartyName} <${counterpartyEmail}> · ${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
+        normalizeFollowUpText(subject),
+        `${counterpartyPrefix} ${normalizeFollowUpText(counterpartyName)} <${counterpartyEmail}> · ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
       ].join("\n\n"),
     ),
   ];
 
   if (snippet) {
-    children.push(CardText(`> ${truncateSnippet(snippet)}`));
+    children.push(CardText(`${snippetLabel}:\n> ${truncateSnippet(snippet)}`));
   }
 
   if (threadLink) {

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
@@ -27,16 +27,20 @@ function blocksJson(params: Parameters<typeof buildFollowUpReminderBlocks>[0]) {
 }
 
 describe("buildFollowUpReminderBlocks", () => {
-  it("AWAITING: surfaces direction (they haven't replied) in the message", () => {
+  it("AWAITING: makes clear the user sent the email and is waiting for a reply", () => {
     const json = blocksJson(baseAwaitingParams);
-    expect(json).toContain("they haven't replied");
-    expect(json).not.toContain("you haven't replied");
+    expect(json).toContain("Waiting for their reply to your sent email");
+    expect(json).toContain("You sent this email to");
+    expect(json).toContain("Your sent email:");
+    expect(json).not.toContain("You haven't replied to this email yet");
   });
 
-  it("NEEDS_REPLY: surfaces direction (you haven't replied) in the message", () => {
+  it("NEEDS_REPLY: makes clear the user received the email and has not replied", () => {
     const json = blocksJson(baseNeedsReplyParams);
-    expect(json).toContain("you haven't replied");
-    expect(json).not.toContain("they haven't replied");
+    expect(json).toContain("You haven't replied to this email yet");
+    expect(json).toContain("You received this email from");
+    expect(json).toContain("Email awaiting your reply:");
+    expect(json).not.toContain("Waiting for their reply to your sent email");
   });
 
   it("renders the counterparty name and email together", () => {
@@ -45,26 +49,26 @@ describe("buildFollowUpReminderBlocks", () => {
     expect(json).toContain("test@example.com");
   });
 
-  it("AWAITING: prefixes the counterparty with 'to'", () => {
+  it("AWAITING: identifies the counterparty as the recipient", () => {
     const json = blocksJson(baseAwaitingParams);
-    expect(json).toContain("to ");
-    expect(json).not.toContain("from Test Counterparty");
+    expect(json).toContain("You sent this email to *Test Counterparty*");
+    expect(json).not.toContain("You received this email from");
   });
 
-  it("NEEDS_REPLY: prefixes the counterparty with 'from'", () => {
+  it("NEEDS_REPLY: identifies the counterparty as the sender", () => {
     const json = blocksJson(baseNeedsReplyParams);
-    expect(json).toContain("from ");
-    expect(json).not.toContain("to Test Counterparty");
+    expect(json).toContain("You received this email from *Test Counterparty*");
+    expect(json).not.toContain("You sent this email to");
   });
 
-  it("renders 'sent N days ago' for AWAITING", () => {
+  it("renders elapsed time for AWAITING", () => {
     const json = blocksJson(baseAwaitingParams);
-    expect(json).toContain("sent 4 days ago");
+    expect(json).toContain("4 days ago");
   });
 
-  it("renders 'received N day ago' for NEEDS_REPLY (singular)", () => {
+  it("renders singular elapsed time for NEEDS_REPLY", () => {
     const json = blocksJson(baseNeedsReplyParams);
-    expect(json).toContain("received 1 day ago");
+    expect(json).toContain("1 day ago");
   });
 
   it("includes the message snippet so the user knows what the thread is about", () => {
@@ -124,5 +128,17 @@ describe("buildFollowUpReminderBlocks", () => {
     expect(json).toContain("Q1 &lt;plan&gt; &amp; review");
     expect(json).toContain("A&amp;B Partners");
     expect(json).toContain("&lt;script&gt; tag in body");
+  });
+
+  it("decodes email HTML entities before escaping for Slack", () => {
+    const json = blocksJson({
+      ...baseAwaitingParams,
+      subject: "Status &amp; next steps",
+      snippet: "If it&#39;s still missing, send a screenshot.",
+    });
+    expect(json).toContain("Status &amp; next steps");
+    expect(json).toContain("If it's still missing, send a screenshot.");
+    expect(json).not.toContain("it&amp;#39;s");
+    expect(json).not.toContain("it&#39;s");
   });
 });

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -1,7 +1,11 @@
 import type { ActionsBlock, Button, KnownBlock, Block } from "@slack/types";
 import type { ThreadTrackerType } from "@/generated/prisma/enums";
 import { escapeSlackText } from "@/utils/messaging/providers/slack/format";
-import { getFollowUpCopy, truncateSnippet } from "@/utils/follow-up/copy";
+import {
+  getFollowUpCopy,
+  normalizeFollowUpText,
+  truncateSnippet,
+} from "@/utils/follow-up/copy";
 import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "@/utils/follow-up/follow-up-actions";
 import { pluralize } from "@/utils/string";
 
@@ -26,11 +30,11 @@ export function buildFollowUpReminderBlocks({
   threadLink,
   trackerId,
 }: FollowUpReminderBlocksParams): (KnownBlock | Block)[] {
-  const { directionLine, preposition, verb, emoji } =
+  const { directionLine, counterpartyPrefix, snippetLabel, emoji } =
     getFollowUpCopy(trackerType);
-  const sentenceVerb = `${verb} ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`;
+  const elapsedTime = `${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`;
 
-  const counterpartyMarkdown = `${preposition} *${escapeSlackText(counterpartyName)}* \`<${escapeSlackText(counterpartyEmail)}>\``;
+  const counterpartyMarkdown = `${escapeSlackText(counterpartyPrefix)} *${escapeSlackText(normalizeFollowUpText(counterpartyName))}* \`<${escapeSlackText(counterpartyEmail)}>\``;
 
   const blocks: (KnownBlock | Block)[] = [
     {
@@ -49,7 +53,7 @@ export function buildFollowUpReminderBlocks({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${escapeSlackText(subject)}*\n${counterpartyMarkdown} · ${sentenceVerb}`,
+        text: `*${escapeSlackText(normalizeFollowUpText(subject))}*\n${counterpartyMarkdown} · ${elapsedTime}`,
       },
     },
   ];
@@ -59,7 +63,7 @@ export function buildFollowUpReminderBlocks({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `> ${escapeSlackText(truncateSnippet(snippet))}`,
+        text: `*${escapeSlackText(snippetLabel)}:*\n> ${escapeSlackText(truncateSnippet(snippet))}`,
       },
     });
   }


### PR DESCRIPTION
Improves follow-up notification copy so users can tell whether a reminder is about an email they sent or one awaiting their reply.

- Decodes HTML entities in follow-up text before rendering notifications.
- Updates Slack reminder blocks and shared channel copy labels.
- Covers the behavior with Slack unit and integration tests.

Validation: biome check, focused unit tests, and the Slack notification integration test passed.