### PR TITLE
messaging: Trim quoted reply previews

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1226,6 +1226,46 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedBlocks).not.toContain("Short snippet");
   });
 
+  it("strips quoted reply content from Slack draft notification previews", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Short snippet",
+        textPlain:
+          "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSlackPostMessage).toHaveBeenCalledTimes(1);
+
+    const [args] = mockSlackPostMessage.mock.calls[0];
+    const serializedBlocks = JSON.stringify(args.blocks);
+
+    expect(serializedBlocks).toContain("Fresh request line.");
+    expect(serializedBlocks).not.toContain("Older quoted line");
+    expect(serializedBlocks).not.toContain("On Tue, Apr 28");
+    expect(serializedBlocks).not.toContain("Short snippet");
+  });
+
   it("delivers Teams notifications through the linked messaging fallback", async () => {
     prisma.executedAction.findUnique.mockResolvedValue(
       getNotificationContext({
@@ -1342,6 +1382,52 @@ describe("sendMessagingRuleNotification", () => {
     expect(text).toContain(
       "One-click draft editing and sending aren't available in Teams yet.",
     );
+  });
+
+  it("strips quoted reply content from Teams draft notification previews", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TEAMS,
+          isConnected: true,
+          teamId: "tenant-1",
+          providerUserId: "29:teams-user",
+          accessToken: null,
+          channelId: null,
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Short snippet",
+        textPlain:
+          "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+
+    const [{ text }] = mockSendAutomationMessage.mock.calls[0];
+    expect(text).toContain("Fresh request line.");
+    expect(text).not.toContain("Older quoted line");
+    expect(text).not.toContain("On Tue, Apr 28");
+    expect(text).not.toContain("Short snippet");
   });
 
   it("sends Telegram draft notifications with a Send reply action", async () => {
@@ -1522,6 +1608,61 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedCard).not.toContain("&gt;");
     expect(serializedCard).not.toContain("&lt;");
     expect(serializedCard).not.toContain("&amp;");
+  });
+
+  it("strips quoted reply content from Telegram draft notification cards", async () => {
+    prisma.executedAction.findUnique.mockResolvedValue(
+      getNotificationContext({
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: "Draft body",
+        messagingChannel: {
+          id: "channel-1",
+          provider: MessagingProvider.TELEGRAM,
+          isConnected: true,
+          teamId: "telegram-chat-1",
+          providerUserId: "telegram-user-1",
+          accessToken: null,
+          channelId: null,
+          routes: [
+            {
+              purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+              targetId: "telegram-chat-1",
+              targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+            },
+          ],
+        },
+      }) as never,
+    );
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Short snippet",
+        textPlain:
+          "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
+      },
+      logger: createScopedLogger("test"),
+    });
+
+    expect(delivered).toBe(true);
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const serializedCard = JSON.stringify(card);
+
+    expect(serializedCard).toContain("Fresh request line.");
+    expect(serializedCard).not.toContain("Older quoted line");
+    expect(serializedCard).not.toContain("On Tue, Apr 28");
+    expect(serializedCard).not.toContain("Short snippet");
   });
 
   it("sends Telegram draft notification cards without raw markdown-sensitive text", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1854,7 +1854,10 @@ function buildEmailPreview(
   },
   { format }: { format: NotificationContentFormat },
 ) {
-  const rawPreview = emailToContent(email, { maxLength: 0 });
+  const rawPreview = emailToContent(email, {
+    maxLength: 0,
+    extractReply: true,
+  });
   const preview = formatNotificationText(
     removeExcessiveWhitespace(he.decode(rawPreview)).trim(),
     format,


### PR DESCRIPTION
Uses visible reply extraction for messaging notification previews so quoted prior thread content is not shown.\n\n- Applies the shared preview behavior across Slack, Teams, and Telegram notification paths.\n- Adds regression coverage for quoted reply previews in each messaging channel.\n\nTests: pnpm test --run utils/messaging/rule-notifications.test.ts