### PR TITLE
calendar: Fix token refresh row selection

### DIFF
--- a/apps/web/__tests__/e2e/calendar/google-calendar.test.ts
+++ b/apps/web/__tests__/e2e/calendar/google-calendar.test.ts
@@ -121,6 +121,7 @@ describe.skipIf(!RUN_E2E_TESTS)("Google Calendar Integration Tests", () => {
       refreshToken: connection.refreshToken,
       expiresAt: connection.expiresAt?.getTime() || null,
       emailAccountId: connection.emailAccountId,
+      connectionId: connection.id,
       logger,
     });
 
@@ -196,6 +197,7 @@ describe.skipIf(!RUN_E2E_TESTS)("Google Calendar Integration Tests", () => {
         refreshToken: calendarConnection.refreshToken,
         expiresAt: calendarConnection.expiresAt?.getTime() || null,
         emailAccountId: calendarConnection.emailAccountId,
+        connectionId: calendarConnection.id,
         calendarIds: enabledCalendars.map((c) => c.calendarId),
         timeMin,
         timeMax,

--- a/apps/web/utils/calendar/availability-types.ts
+++ b/apps/web/utils/calendar/availability-types.ts
@@ -9,6 +9,7 @@ export interface CalendarAvailabilityProvider {
    */
   fetchBusyPeriods(params: {
     accessToken?: string | null;
+    connectionId?: string | null;
     refreshToken: string | null;
     expiresAt: number | null;
     emailAccountId: string;

--- a/apps/web/utils/calendar/client.test.ts
+++ b/apps/web/utils/calendar/client.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { auth, calendar } from "@googleapis/calendar";
+import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { getCalendarClientWithRefresh } from "@/utils/calendar/client";
+import {
+  getGoogleApiRootUrl,
+  getGoogleOauthClientOptions,
+} from "../google/oauth";
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  },
+}));
+
+vi.mock("@/utils/google/oauth", () => ({
+  getGoogleApiRootUrl: vi.fn(() => "http://localhost:4444"),
+  getGoogleOauthClientOptions: vi.fn((redirectUri?: string) => ({
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    redirectUri,
+    endpoints: {
+      oauth2TokenUrl: "http://localhost:4444/oauth2/token",
+    },
+  })),
+}));
+
+const setCredentials = vi.fn();
+const refreshAccessToken = vi.fn();
+const logger = createTestLogger();
+
+vi.mock("@googleapis/calendar", () => ({
+  auth: {
+    OAuth2: vi.fn(function OAuth2() {
+      return {
+        setCredentials,
+        refreshAccessToken,
+      };
+    }),
+  },
+  calendar: vi.fn(),
+}));
+
+describe("google calendar client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("saves refreshed tokens to the requested calendar connection", async () => {
+    const refreshedExpiresAt = Date.now() + 3_600_000;
+    refreshAccessToken.mockResolvedValue({
+      credentials: {
+        access_token: "new-access-token",
+        expiry_date: refreshedExpiresAt,
+      },
+    });
+    vi.mocked(prisma.calendarConnection.findFirst).mockResolvedValue({
+      id: "first-google-connection-id",
+    } as any);
+
+    await getCalendarClientWithRefresh({
+      accessToken: "stale-access-token",
+      refreshToken: "target-refresh-token",
+      expiresAt: Date.now() - 1000,
+      emailAccountId: "email-account-id",
+      connectionId: "target-google-connection-id",
+      logger,
+    });
+
+    expect(prisma.calendarConnection.update).toHaveBeenCalledWith({
+      where: { id: "target-google-connection-id" },
+      data: {
+        accessToken: "new-access-token",
+        refreshToken: undefined,
+        expiresAt: new Date(refreshedExpiresAt),
+      },
+    });
+    expect(prisma.calendarConnection.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("matches the calendar connection by refresh token when no connection id is provided", async () => {
+    const refreshedExpiresAt = Date.now() + 3_600_000;
+    refreshAccessToken.mockResolvedValue({
+      credentials: {
+        access_token: "new-access-token",
+        expiry_date: refreshedExpiresAt,
+      },
+    });
+    vi.mocked(prisma.calendarConnection.findFirst).mockResolvedValue({
+      id: "target-google-connection-id",
+    } as any);
+
+    await getCalendarClientWithRefresh({
+      accessToken: "stale-access-token",
+      refreshToken: "target-refresh-token",
+      expiresAt: Date.now() - 1000,
+      emailAccountId: "email-account-id",
+      logger,
+    });
+
+    expect(prisma.calendarConnection.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-id",
+        provider: "google",
+        refreshToken: "target-refresh-token",
+      },
+      select: { id: true },
+    });
+    expect(prisma.calendarConnection.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "target-google-connection-id" },
+      }),
+    );
+  });
+
+  it("uses emulator-aware OAuth and Calendar API options", async () => {
+    await getCalendarClientWithRefresh({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      emailAccountId: "email-account-id",
+      logger,
+    });
+
+    expect(getGoogleOauthClientOptions).toHaveBeenCalledWith();
+    expect(auth.OAuth2).toHaveBeenCalledWith({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      redirectUri: undefined,
+      endpoints: {
+        oauth2TokenUrl: "http://localhost:4444/oauth2/token",
+      },
+    });
+    expect(getGoogleApiRootUrl).toHaveBeenCalledWith();
+    expect(calendar).toHaveBeenCalledWith({
+      version: "v3",
+      auth: expect.any(Object),
+      rootUrl: "http://localhost:4444",
+    });
+  });
+});

--- a/apps/web/utils/calendar/client.ts
+++ b/apps/web/utils/calendar/client.ts
@@ -40,12 +40,14 @@ export const getCalendarClientWithRefresh = async ({
   refreshToken,
   expiresAt,
   emailAccountId,
+  connectionId,
   logger,
 }: {
   accessToken?: string | null;
   refreshToken: string | null;
   expiresAt: number | null;
   emailAccountId: string;
+  connectionId?: string | null;
   logger: Logger;
 }): Promise<calendar_v3.Calendar> => {
   if (!refreshToken) {
@@ -70,23 +72,27 @@ export const getCalendarClientWithRefresh = async ({
     const newExpiresAt = tokens.credentials.expiry_date ?? undefined;
     const newRefreshToken = tokens.credentials.refresh_token ?? undefined;
 
-    // Find the calendar connection to update
-    const calendarConnection = await prisma.calendarConnection.findFirst({
-      where: {
-        emailAccountId,
-        provider: "google",
-      },
-      select: { id: true },
-    });
+    const calendarConnectionId =
+      connectionId ??
+      (
+        await prisma.calendarConnection.findFirst({
+          where: {
+            emailAccountId,
+            provider: "google",
+            refreshToken,
+          },
+          select: { id: true },
+        })
+      )?.id;
 
-    if (calendarConnection) {
+    if (calendarConnectionId) {
       await saveCalendarTokens({
         tokens: {
           access_token: newAccessToken ?? undefined,
           refresh_token: newRefreshToken,
           expires_at: newExpiresAt,
         },
-        connectionId: calendarConnection.id,
+        connectionId: calendarConnectionId,
         logger,
       });
     } else {

--- a/apps/web/utils/calendar/client.ts
+++ b/apps/web/utils/calendar/client.ts
@@ -72,18 +72,18 @@ export const getCalendarClientWithRefresh = async ({
     const newExpiresAt = tokens.credentials.expiry_date ?? undefined;
     const newRefreshToken = tokens.credentials.refresh_token ?? undefined;
 
-    const calendarConnectionId =
-      connectionId ??
-      (
-        await prisma.calendarConnection.findFirst({
-          where: {
-            emailAccountId,
-            provider: "google",
-            refreshToken,
-          },
-          select: { id: true },
-        })
-      )?.id;
+    let calendarConnectionId = connectionId ?? null;
+    if (!calendarConnectionId) {
+      const calendarConnection = await prisma.calendarConnection.findFirst({
+        where: {
+          emailAccountId,
+          provider: "google",
+          refreshToken,
+        },
+        select: { id: true },
+      });
+      calendarConnectionId = calendarConnection?.id ?? null;
+    }
 
     if (calendarConnectionId) {
       await saveCalendarTokens({

--- a/apps/web/utils/calendar/event-provider.ts
+++ b/apps/web/utils/calendar/event-provider.ts
@@ -43,6 +43,7 @@ export async function createCalendarEventProviders(
           new GoogleCalendarEventProvider(
             {
               accessToken: connection.accessToken,
+              connectionId: connection.id,
               refreshToken: connection.refreshToken,
               expiresAt: connection.expiresAt?.getTime() ?? null,
               emailAccountId,

--- a/apps/web/utils/calendar/providers/google-availability.ts
+++ b/apps/web/utils/calendar/providers/google-availability.ts
@@ -68,6 +68,7 @@ export function createGoogleAvailabilityProvider(
 
     async fetchBusyPeriods({
       accessToken,
+      connectionId,
       refreshToken,
       expiresAt,
       emailAccountId,
@@ -80,6 +81,7 @@ export function createGoogleAvailabilityProvider(
         refreshToken,
         expiresAt,
         emailAccountId,
+        connectionId,
         logger,
       });
 

--- a/apps/web/utils/calendar/providers/google-events.ts
+++ b/apps/web/utils/calendar/providers/google-events.ts
@@ -8,6 +8,7 @@ import type { Logger } from "@/utils/logger";
 
 export interface GoogleCalendarConnectionParams {
   accessToken: string | null;
+  connectionId: string;
   emailAccountId: string;
   expiresAt: number | null;
   refreshToken: string | null;
@@ -28,6 +29,7 @@ export class GoogleCalendarEventProvider implements CalendarEventProvider {
       refreshToken: this.connection.refreshToken,
       expiresAt: this.connection.expiresAt,
       emailAccountId: this.connection.emailAccountId,
+      connectionId: this.connection.connectionId,
       logger: this.logger,
     });
   }

--- a/apps/web/utils/calendar/providers/google.ts
+++ b/apps/web/utils/calendar/providers/google.ts
@@ -59,6 +59,7 @@ export function createGoogleCalendarProvider(
           refreshToken,
           expiresAt: expiresAt?.getTime() ?? null,
           emailAccountId,
+          connectionId,
           logger,
         });
 

--- a/apps/web/utils/calendar/unified-availability.ts
+++ b/apps/web/utils/calendar/unified-availability.ts
@@ -82,6 +82,7 @@ export async function getUnifiedCalendarAvailability({
       googleAvailabilityProvider
         .fetchBusyPeriods({
           accessToken: connection.accessToken,
+          connectionId: connection.id,
           refreshToken: connection.refreshToken,
           expiresAt: connection.expiresAt?.getTime() || null,
           emailAccountId,


### PR DESCRIPTION
Updates Google calendar token refresh to persist refreshed tokens to the specific calendar connection being used, with a refresh-token lookup fallback for compatibility.

- Threads connection IDs through Google calendar availability, event, and sync paths
- Adds unit coverage for connection-specific refresh persistence and emulator-aware client setup

Tests: `cd apps/web && pnpm test --run utils/calendar/client.test.ts utils/calendar/unified-availability.test.ts utils/calendar/providers/google.test.ts`