### PR TITLE
Fix AI content policy enforcement

### DIFF
--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -2,6 +2,8 @@ import {
   APICallError,
   type ModelMessage,
   type Tool,
+  type ToolExecutionOptions,
+  type ToolSet,
   ToolLoopAgent,
   type JSONValue,
   type FlexibleSchema,
@@ -61,8 +63,10 @@ import {
 } from "@/utils/ai/security";
 import {
   enforceSensitiveDataPolicy,
+  enforceSensitiveToolOutputPolicy,
   redactSensitiveContentForLogging,
 } from "@/utils/llms/sensitive-content";
+import { resolveSensitiveDataPolicy } from "@/utils/dlp/policy.server";
 import {
   extractLLMErrorInfo,
   isTransientNetworkError,
@@ -166,6 +170,13 @@ export function createGenerateText({
         userId: emailAccount.userId,
         emailAccountId: emailAccount.id,
       });
+      const protectedTools = wrapToolsWithSensitiveDataPolicy({
+        tools: protectedOptions.tools,
+        policy: emailAccount.sensitiveDataPolicy,
+        label,
+        userId: emailAccount.userId,
+        emailAccountId: emailAccount.id,
+      });
 
       logger.trace("Generating text", {
         label,
@@ -199,6 +210,7 @@ export function createGenerateText({
       const result = await generateText(
         {
           ...protectedOptions,
+          ...(protectedTools ? { tools: protectedTools } : {}),
           ...commonOptions,
           providerOptions,
           model: withPosthogTracing({
@@ -569,7 +581,13 @@ export async function chatCompletionStream({
       return streamText({
         model,
         messages: protectedMessages as ModelMessage[],
-        tools,
+        tools: wrapToolsWithSensitiveDataPolicy({
+          tools,
+          policy: sensitiveDataPolicy,
+          label,
+          userId,
+          emailAccountId,
+        }),
         stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
         ...commonOptions,
         providerOptions: providerOptions,
@@ -727,7 +745,13 @@ export async function toolCallAgentStream({
       provider: candidate.provider,
       modelName: candidate.modelName,
     });
-    const candidateTools = tools;
+    const candidateTools = wrapToolsWithSensitiveDataPolicy({
+      tools,
+      policy: sensitiveDataPolicy,
+      label,
+      userId,
+      emailAccountId,
+    });
     const excludedTools: string[] = [];
     const replacedTools: string[] = [];
 
@@ -844,6 +868,93 @@ export async function toolCallAgentStream({
   }
 
   throw new Error("No models available for tool-call stream");
+}
+
+function wrapToolsWithSensitiveDataPolicy<TTools extends ToolSet | undefined>({
+  tools,
+  policy,
+  label,
+  userId,
+  emailAccountId,
+}: {
+  tools: TTools;
+  policy?: string | null;
+  label: string;
+  userId?: string;
+  emailAccountId: string;
+}): TTools {
+  if (!tools || resolveSensitiveDataPolicy(policy) === "ALLOW") return tools;
+
+  const protectedTools: ToolSet = { ...tools };
+
+  for (const [toolName, toolDefinition] of Object.entries(protectedTools)) {
+    const execute = toolDefinition.execute;
+    if (!execute) continue;
+
+    protectedTools[toolName] = {
+      ...toolDefinition,
+      execute(input: unknown, options: ToolExecutionOptions) {
+        const output = execute.call(toolDefinition, input, options);
+
+        if (isAsyncIterable(output)) {
+          return enforceSensitiveToolOutputStream({
+            output,
+            policy,
+            label,
+            toolName,
+            userId,
+            emailAccountId,
+          });
+        }
+
+        return Promise.resolve(output).then((resolvedOutput) =>
+          enforceSensitiveToolOutputPolicy({
+            output: resolvedOutput,
+            policy,
+            logger,
+            label: `${label}:${toolName}`,
+            userId,
+            emailAccountId,
+          }),
+        );
+      },
+    } as ToolSet[string];
+  }
+
+  return protectedTools as TTools;
+}
+
+async function* enforceSensitiveToolOutputStream({
+  output,
+  policy,
+  label,
+  toolName,
+  userId,
+  emailAccountId,
+}: {
+  output: AsyncIterable<unknown>;
+  policy?: string | null;
+  label: string;
+  toolName: string;
+  userId?: string;
+  emailAccountId: string;
+}) {
+  for await (const item of output) {
+    yield enforceSensitiveToolOutputPolicy({
+      output: item,
+      policy,
+      logger,
+      label: `${label}:${toolName}`,
+      userId,
+      emailAccountId,
+    });
+  }
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    typeof value === "object" && value !== null && Symbol.asyncIterator in value
+  );
 }
 
 async function handleError(

--- a/apps/web/utils/llms/sensitive-content.test.ts
+++ b/apps/web/utils/llms/sensitive-content.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
-import { enforceSensitiveDataPolicy } from "@/utils/llms/sensitive-content";
+import {
+  enforceSensitiveDataPolicy,
+  enforceSensitiveToolOutputPolicy,
+} from "@/utils/llms/sensitive-content";
 
 const logger = createScopedLogger("llms-sensitive-content-test");
 
@@ -69,6 +72,160 @@ describe("Sensitive data policy enforcement", () => {
         label: "test",
       }),
     ).toThrow("blocked by your account settings");
+
+    warnSpy.mockRestore();
+  });
+
+  it("redacts sensitive strings inside readEmail tool output", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const secret = "d".repeat(24);
+    const output = {
+      messageId: "message-1",
+      threadId: "thread-1",
+      from: "sender@example.com",
+      to: "user@example.com",
+      subject: "Credentials",
+      content: `Use api_key=${secret}`,
+      attachments: [
+        {
+          filename: "billing.txt",
+          content: "card 4242 4242 4242 4242",
+        },
+      ],
+    };
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output,
+      policy: "REDACT",
+      logger,
+      label: "assistant-chat:readEmail",
+    });
+
+    expect(result).not.toBe(output);
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain("4242 4242 4242 4242");
+    expect(JSON.stringify(result)).toContain("[REDACTED:CREDENTIAL]");
+    expect(JSON.stringify(result)).toContain("[REDACTED:PAYMENT_CARD]");
+
+    warnSpy.mockRestore();
+  });
+
+  it("blocks readEmail tool output when configured", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const privateKey = [
+      `-----BEGIN ${"PRIVATE"} KEY-----`,
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC",
+      `-----END ${"PRIVATE"} KEY-----`,
+    ].join("\n");
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output: {
+        messageId: "message-1",
+        content: privateKey,
+      },
+      policy: "BLOCK",
+      logger,
+      label: "assistant-chat:readEmail",
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      error: expect.stringContaining("tool result was blocked"),
+    });
+    expect(JSON.stringify(result)).not.toContain("BEGIN PRIVATE KEY");
+
+    warnSpy.mockRestore();
+  });
+
+  it("redacts sensitive strings inside readAttachment tool output", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const token = `Bearer ${"e".repeat(24)}`;
+    const output = {
+      filename: "export.csv",
+      mimeType: "text/csv",
+      size: 200,
+      contentAvailable: true,
+      content: `authorization: ${token}`,
+      truncated: false,
+    };
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output,
+      policy: "REDACT",
+      logger,
+      label: "assistant-chat:readAttachment",
+    });
+
+    expect(result).not.toBe(output);
+    expect(JSON.stringify(result)).not.toContain(token);
+    expect(JSON.stringify(result)).toContain("[REDACTED:CREDENTIAL]");
+
+    warnSpy.mockRestore();
+  });
+
+  it("blocks readAttachment tool output when configured", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const secret = "f".repeat(24);
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output: {
+        filename: "secret.txt",
+        contentAvailable: true,
+        content: `client_secret=${secret}`,
+      },
+      policy: "BLOCK",
+      logger,
+      label: "assistant-chat:readAttachment",
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      error: expect.stringContaining("tool result was blocked"),
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+
+    warnSpy.mockRestore();
+  });
+
+  it("redacts sensitive strings inside tool output object keys", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sensitiveKey = `api_key=${"g".repeat(24)}`;
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output: {
+        [sensitiveKey]: "metadata",
+        safe: "value",
+      },
+      policy: "REDACT",
+      logger,
+      label: "assistant-chat:testTool",
+    });
+
+    expect(JSON.stringify(result)).not.toContain(sensitiveKey);
+    expect(Object.keys(result)).toContain("api_key=[REDACTED:CREDENTIAL]");
+    expect(result.safe).toBe("value");
+
+    warnSpy.mockRestore();
+  });
+
+  it("blocks tool output when only an object key contains sensitive content", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sensitiveKey = `client_secret=${"h".repeat(24)}`;
+
+    const result = enforceSensitiveToolOutputPolicy({
+      output: {
+        [sensitiveKey]: "metadata",
+      },
+      policy: "BLOCK",
+      logger,
+      label: "assistant-chat:testTool",
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      error: expect.stringContaining("tool result was blocked"),
+    });
+    expect(JSON.stringify(result)).not.toContain(sensitiveKey);
 
     warnSpy.mockRestore();
   });

--- a/apps/web/utils/llms/sensitive-content.ts
+++ b/apps/web/utils/llms/sensitive-content.ts
@@ -21,6 +21,12 @@ type LlmRequestOptions = {
   system?: unknown;
 };
 
+const BLOCKED_TOOL_OUTPUT = {
+  error:
+    "Sensitive content was detected, so this tool result was blocked by your account settings.",
+  blocked: true,
+} as const;
+
 export function enforceSensitiveDataPolicy<T extends LlmRequestOptions>({
   options,
   emailAccountId,
@@ -29,14 +35,58 @@ export function enforceSensitiveDataPolicy<T extends LlmRequestOptions>({
   policy,
   userId,
 }: LlmSensitiveDataOptions & { options: T }): T {
-  const parsedPolicy = resolveSensitiveDataPolicy(policy);
-  if (parsedPolicy === "ALLOW") return options;
+  return enforceSensitiveDataPolicyOnValue({
+    value: options,
+    emailAccountId,
+    label,
+    logger,
+    policy,
+    userId,
+    getFindings: getLlmRequestSensitiveContentFindings,
+  });
+}
 
-  const findings = getSensitiveContentFindings(options);
-  if (findings.length === 0) return options;
+export function enforceSensitiveToolOutputPolicy<T>({
+  output,
+  emailAccountId,
+  label,
+  logger,
+  policy,
+  userId,
+}: LlmSensitiveDataOptions & { output: T }): T {
+  return enforceSensitiveDataPolicyOnValue({
+    value: output,
+    emailAccountId,
+    label,
+    logger,
+    policy,
+    userId,
+    blockReplacement: BLOCKED_TOOL_OUTPUT,
+  });
+}
+
+function enforceSensitiveDataPolicyOnValue<T>({
+  value,
+  emailAccountId,
+  label,
+  logger,
+  policy,
+  userId,
+  blockReplacement,
+  getFindings = getSensitiveContentFindings,
+}: LlmSensitiveDataOptions & {
+  blockReplacement?: unknown;
+  getFindings?: (value: T) => SensitiveContentFinding[];
+  value: T;
+}): T {
+  const parsedPolicy = resolveSensitiveDataPolicy(policy);
+  if (parsedPolicy === "ALLOW") return value;
+
+  const findings = getFindings(value);
+  if (findings.length === 0) return value;
 
   const summary = summarizeFindings(findings);
-  logger.warn("Sensitive content detected in AI request", {
+  logger.warn("Sensitive content detected in AI content", {
     emailAccountId,
     userId,
     label,
@@ -45,23 +95,30 @@ export function enforceSensitiveDataPolicy<T extends LlmRequestOptions>({
   });
 
   if (parsedPolicy === "BLOCK") {
+    if (blockReplacement !== undefined) return blockReplacement as T;
+
     throw new SafeError(
       "Sensitive content was detected, so this AI request was blocked by your account settings.",
     );
   }
 
   if (parsedPolicy === "REDACT") {
-    return redactLlmRequestOptions(options);
+    return redactUnknown(value) as T;
   }
 
-  return options;
+  return value;
 }
 
 export function redactSensitiveContentForLogging(text: string | undefined) {
   return text ? redactSensitiveContent(text) : undefined;
 }
 
-function getSensitiveContentFindings(options: LlmRequestOptions) {
+function getSensitiveContentFindings(value: unknown) {
+  const strings = collectStrings(value);
+  return strings.flatMap((text) => scanSensitiveContent(text));
+}
+
+function getLlmRequestSensitiveContentFindings(options: LlmRequestOptions) {
   const strings = [
     ...collectStrings(options.system),
     ...collectStrings(options.prompt),
@@ -69,31 +126,6 @@ function getSensitiveContentFindings(options: LlmRequestOptions) {
   ];
 
   return strings.flatMap((text) => scanSensitiveContent(text));
-}
-
-function redactLlmRequestOptions<T extends LlmRequestOptions>(options: T): T {
-  let changed = false;
-  const nextOptions: LlmRequestOptions = { ...options };
-
-  if ("system" in options) {
-    const nextSystem = redactUnknown(options.system);
-    if (nextSystem !== options.system) changed = true;
-    nextOptions.system = nextSystem;
-  }
-
-  if ("prompt" in options) {
-    const nextPrompt = redactUnknown(options.prompt);
-    if (nextPrompt !== options.prompt) changed = true;
-    nextOptions.prompt = nextPrompt;
-  }
-
-  if ("messages" in options) {
-    const nextMessages = redactUnknown(options.messages);
-    if (nextMessages !== options.messages) changed = true;
-    nextOptions.messages = nextMessages;
-  }
-
-  return changed ? (nextOptions as T) : options;
 }
 
 function redactUnknown(value: unknown): unknown {
@@ -118,9 +150,12 @@ function redactUnknown(value: unknown): unknown {
     const nextValue: Record<string, unknown> = {};
 
     for (const [key, item] of Object.entries(value)) {
+      const nextKey = redactSensitiveContent(key);
+      if (nextKey !== key) changed = true;
+
       const nextItem = redactUnknown(item);
       if (nextItem !== item) changed = true;
-      nextValue[key] = nextItem;
+      nextValue[nextKey] = nextItem;
     }
 
     return changed ? nextValue : value;
@@ -137,7 +172,10 @@ function collectStrings(value: unknown): string[] {
   }
 
   if (isRecord(value)) {
-    return Object.values(value).flatMap((item) => collectStrings(item));
+    return Object.entries(value).flatMap(([key, item]) => [
+      key,
+      ...collectStrings(item),
+    ]);
   }
 
   return [];


### PR DESCRIPTION
Adds sensitive content policy enforcement to AI tool outputs before later model steps.\n\n- Wraps executable tools in LLM generation and streaming paths so returned output is checked against the configured policy.\n- Adds regression coverage for redaction and blocking of tool output shapes.\n\nTests: pnpm test --run utils/llms/sensitive-content.test.ts; pnpm test --run utils/llms/index.generate-object.test.ts; pnpm exec biome check apps/web/utils/llms/index.ts apps/web/utils/llms/sensitive-content.ts apps/web/utils/llms/sensitive-content.test.ts