### PR TITLE
Gate digest settings by plan

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -78,6 +78,8 @@ import {
 import { handleRuleAttachmentSourceSave } from "@/utils/attachments/rule";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import type { GetMessagingChannelsResponse } from "@/app/api/user/messaging-channels/route";
+import { usePremium } from "@/hooks/usePremium";
+import { hasTierAccess } from "@/utils/premium";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
 import { sortActionsByPriority } from "@/utils/action-sort";
 import {
@@ -128,6 +130,11 @@ export function RuleForm({
   onCancel?: () => void;
 }) {
   const { emailAccountId, provider } = useAccount();
+  const { tier, isLoading: isLoadingPremium } = usePremium();
+  const hasDigestAccess = hasTierAccess({
+    tier,
+    minimumTier: "PLUS_MONTHLY",
+  });
   const ruleEditorActions = getRuleEditorActions(rule.actions);
 
   const form = useForm<CreateRuleBody>({
@@ -232,7 +239,7 @@ export function RuleForm({
 
       // Add DIGEST action if digest is enabled
       const actionsToSubmit = [...normalizedActions];
-      if (data.digest) {
+      if (data.digest && hasDigestAccess) {
         const existingDigestAction = rule.actions.find(
           (action) => action.type === ActionType.DIGEST,
         );
@@ -367,6 +374,7 @@ export function RuleForm({
       onSuccess,
       mutate,
       rule,
+      hasDigestAccess,
     ],
   );
 
@@ -583,15 +591,30 @@ export function RuleForm({
                 {env.NEXT_PUBLIC_DIGEST_ENABLED && (
                   <AdvancedRow
                     title="Include in digest"
-                    description="Show matched emails in your digest summary."
+                    description={
+                      hasDigestAccess
+                        ? "Show matched emails in your digest summary."
+                        : "Available on the Plus plan."
+                    }
                   >
-                    <Toggle
-                      name="digest"
-                      enabled={watch("digest") || false}
-                      onChange={(enabled) => {
-                        setValue("digest", enabled);
-                      }}
-                    />
+                    <Tooltip
+                      content="Digest summaries require the Plus plan."
+                      hide={hasDigestAccess}
+                    >
+                      <span>
+                        <Toggle
+                          name="digest"
+                          enabled={
+                            hasDigestAccess && (watch("digest") || false)
+                          }
+                          disabled={!hasDigestAccess || isLoadingPremium}
+                          onChange={(enabled) => {
+                            if (!hasDigestAccess) return;
+                            setValue("digest", enabled);
+                          }}
+                        />
+                      </span>
+                    </Tooltip>
                   </AdvancedRow>
                 )}
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -238,13 +238,17 @@ export function RuleForm({
         isDraftReplyActionType(action.type),
       );
 
-      // Add DIGEST action if digest is enabled
+      // Add DIGEST action if digest is enabled. When the user lacks access,
+      // the toggle is hidden, so preserve any existing DIGEST action rather
+      // than silently dropping it.
       const actionsToSubmit = [...normalizedActions];
-      if (data.digest && hasDigestAccess) {
-        const existingDigestAction = rule.actions.find(
-          (action) => action.type === ActionType.DIGEST,
-        );
-
+      const existingDigestAction = rule.actions.find(
+        (action) => action.type === ActionType.DIGEST,
+      );
+      const includeDigestAction = hasDigestAccess
+        ? data.digest
+        : !!existingDigestAction;
+      if (includeDigestAction) {
         actionsToSubmit.push({
           id: existingDigestAction?.id,
           type: ActionType.DIGEST,

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -238,9 +238,8 @@ export function RuleForm({
         isDraftReplyActionType(action.type),
       );
 
-      // Add DIGEST action if digest is enabled. When the user lacks access,
-      // the toggle is hidden, so preserve any existing DIGEST action rather
-      // than silently dropping it.
+      // When the user lacks digest access the toggle is hidden, so preserve
+      // any existing DIGEST action rather than silently dropping it.
       const actionsToSubmit = [...normalizedActions];
       const existingDigestAction = rule.actions.find(
         (action) => action.type === ActionType.DIGEST,

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.tsx
@@ -80,6 +80,7 @@ import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import type { GetMessagingChannelsResponse } from "@/app/api/user/messaging-channels/route";
 import { usePremium } from "@/hooks/usePremium";
 import { hasTierAccess } from "@/utils/premium";
+import { UpgradeToPlusButton } from "@/components/UpgradeToPlusButton";
 import { getConnectedRuleNotificationChannels } from "@/utils/messaging/routes";
 import { sortActionsByPriority } from "@/utils/action-sort";
 import {
@@ -591,30 +592,19 @@ export function RuleForm({
                 {env.NEXT_PUBLIC_DIGEST_ENABLED && (
                   <AdvancedRow
                     title="Include in digest"
-                    description={
-                      hasDigestAccess
-                        ? "Show matched emails in your digest summary."
-                        : "Available on the Plus plan."
-                    }
+                    description="Show matched emails in your digest summary."
                   >
-                    <Tooltip
-                      content="Digest summaries require the Plus plan."
-                      hide={hasDigestAccess}
-                    >
-                      <span>
-                        <Toggle
-                          name="digest"
-                          enabled={
-                            hasDigestAccess && (watch("digest") || false)
-                          }
-                          disabled={!hasDigestAccess || isLoadingPremium}
-                          onChange={(enabled) => {
-                            if (!hasDigestAccess) return;
-                            setValue("digest", enabled);
-                          }}
-                        />
-                      </span>
-                    </Tooltip>
+                    {isLoadingPremium ? null : hasDigestAccess ? (
+                      <Toggle
+                        name="digest"
+                        enabled={watch("digest") || false}
+                        onChange={(enabled) => {
+                          setValue("digest", enabled);
+                        }}
+                      />
+                    ) : (
+                      <UpgradeToPlusButton tooltip="Upgrade to the Plus plan to include emails in your digest." />
+                    )}
                   </AdvancedRow>
                 )}
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Toggle } from "@/components/Toggle";
+import { Tooltip } from "@/components/Tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DigestSettingsForm } from "@/app/(app)/[emailAccountId]/settings/DigestSettingsForm";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
@@ -69,39 +70,40 @@ export function DigestSetting() {
     <>
       <SettingCard
         title="Digest"
-        description={
-          hasDigestAccess
-            ? "Get a daily summary of your newsletter emails."
-            : "Daily digest emails are available on the Plus plan."
-        }
+        description="Get a daily summary of your newsletter emails."
         right={
           isLoading || isLoadingPremium ? (
             <Skeleton className="h-5 w-9" />
-          ) : hasDigestAccess ? (
+          ) : (
             <div className="flex items-center gap-2">
-              {enabled && (
-                <Dialog open={open} onOpenChange={setOpen}>
-                  <DialogTrigger asChild>
-                    <Button variant="outline" size="sm">
-                      Configure
-                    </Button>
-                  </DialogTrigger>
-                  <DigestSettingsDialogContent
-                    onSuccess={() => setOpen(false)}
-                  />
-                </Dialog>
+              {hasDigestAccess ? (
+                enabled && (
+                  <Dialog open={open} onOpenChange={setOpen}>
+                    <DialogTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        Configure
+                      </Button>
+                    </DialogTrigger>
+                    <DigestSettingsDialogContent
+                      onSuccess={() => setOpen(false)}
+                    />
+                  </Dialog>
+                )
+              ) : (
+                <Tooltip content="Upgrade to the Plus plan to enable daily digest emails.">
+                  <Button variant="outline" size="sm" onClick={openModal}>
+                    <CrownIcon className="mr-2 h-4 w-4" />
+                    Upgrade
+                  </Button>
+                </Tooltip>
               )}
               <Toggle
                 name="digest-enabled"
-                enabled={enabled}
+                enabled={hasDigestAccess && enabled}
+                disabled={!hasDigestAccess}
                 onChange={handleToggle}
               />
             </div>
-          ) : (
-            <Button variant="outline" size="sm" onClick={openModal}>
-              <CrownIcon className="mr-2 h-4 w-4" />
-              Upgrade
-            </Button>
           )
         }
       />

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { CrownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SettingCard } from "@/components/SettingCard";
 import {
@@ -13,8 +12,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Toggle } from "@/components/Toggle";
-import { Tooltip } from "@/components/Tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
+import { UpgradeToPlusButton } from "@/components/UpgradeToPlusButton";
 import { DigestSettingsForm } from "@/app/(app)/[emailAccountId]/settings/DigestSettingsForm";
 import { useEmailAccountFull } from "@/hooks/useEmailAccountFull";
 import { useAction } from "next-safe-action/hooks";
@@ -23,13 +22,11 @@ import { toastError } from "@/components/Toast";
 import { createCanonicalTimeOfDay } from "@/utils/schedule";
 import { usePremium } from "@/hooks/usePremium";
 import { hasTierAccess } from "@/utils/premium";
-import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 
 export function DigestSetting() {
   const [open, setOpen] = useState(false);
   const { data, isLoading, mutate } = useEmailAccountFull();
   const { tier, isLoading: isLoadingPremium } = usePremium();
-  const { PremiumModal, openModal } = usePremiumModal();
 
   const enabled = data?.digestSchedule != null;
   const hasDigestAccess = hasTierAccess({
@@ -66,49 +63,52 @@ export function DigestSetting() {
     [data, mutate, executeToggle],
   );
 
-  return (
-    <>
+  if (isLoading || isLoadingPremium) {
+    return (
+      <SettingCard
+        title="Digest"
+        description="Get a daily summary of your newsletter emails."
+        right={<Skeleton className="h-5 w-9" />}
+      />
+    );
+  }
+
+  if (!hasDigestAccess) {
+    return (
       <SettingCard
         title="Digest"
         description="Get a daily summary of your newsletter emails."
         right={
-          isLoading || isLoadingPremium ? (
-            <Skeleton className="h-5 w-9" />
-          ) : (
-            <div className="flex items-center gap-2">
-              {hasDigestAccess ? (
-                enabled && (
-                  <Dialog open={open} onOpenChange={setOpen}>
-                    <DialogTrigger asChild>
-                      <Button variant="outline" size="sm">
-                        Configure
-                      </Button>
-                    </DialogTrigger>
-                    <DigestSettingsDialogContent
-                      onSuccess={() => setOpen(false)}
-                    />
-                  </Dialog>
-                )
-              ) : (
-                <Tooltip content="Upgrade to the Plus plan to enable daily digest emails.">
-                  <Button variant="outline" size="sm" onClick={openModal}>
-                    <CrownIcon className="mr-2 h-4 w-4" />
-                    Upgrade
-                  </Button>
-                </Tooltip>
-              )}
-              <Toggle
-                name="digest-enabled"
-                enabled={hasDigestAccess && enabled}
-                disabled={!hasDigestAccess}
-                onChange={handleToggle}
-              />
-            </div>
-          )
+          <UpgradeToPlusButton tooltip="Upgrade to the Plus plan to enable daily digest emails." />
         }
       />
-      <PremiumModal />
-    </>
+    );
+  }
+
+  return (
+    <SettingCard
+      title="Digest"
+      description="Get a daily summary of your newsletter emails."
+      right={
+        <div className="flex items-center gap-2">
+          {enabled && (
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  Configure
+                </Button>
+              </DialogTrigger>
+              <DigestSettingsDialogContent onSuccess={() => setOpen(false)} />
+            </Dialog>
+          )}
+          <Toggle
+            name="digest-enabled"
+            enabled={enabled}
+            onChange={handleToggle}
+          />
+        </div>
+      }
+    />
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -63,51 +63,43 @@ export function DigestSetting() {
     [data, mutate, executeToggle],
   );
 
-  if (isLoading || isLoadingPremium) {
-    return (
-      <SettingCard
-        title="Digest"
-        description="Get a daily summary of your newsletter emails."
-        right={<Skeleton className="h-5 w-9" />}
-      />
-    );
-  }
+  const renderRight = () => {
+    if (isLoading || isLoadingPremium) {
+      return <Skeleton className="h-5 w-9" />;
+    }
 
-  if (!hasDigestAccess) {
+    if (!hasDigestAccess) {
+      return (
+        <UpgradeToPlusButton tooltip="Upgrade to the Plus plan to enable daily digest emails." />
+      );
+    }
+
     return (
-      <SettingCard
-        title="Digest"
-        description="Get a daily summary of your newsletter emails."
-        right={
-          <UpgradeToPlusButton tooltip="Upgrade to the Plus plan to enable daily digest emails." />
-        }
-      />
+      <div className="flex items-center gap-2">
+        {enabled && (
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="sm">
+                Configure
+              </Button>
+            </DialogTrigger>
+            <DigestSettingsDialogContent onSuccess={() => setOpen(false)} />
+          </Dialog>
+        )}
+        <Toggle
+          name="digest-enabled"
+          enabled={enabled}
+          onChange={handleToggle}
+        />
+      </div>
     );
-  }
+  };
 
   return (
     <SettingCard
       title="Digest"
       description="Get a daily summary of your newsletter emails."
-      right={
-        <div className="flex items-center gap-2">
-          {enabled && (
-            <Dialog open={open} onOpenChange={setOpen}>
-              <DialogTrigger asChild>
-                <Button variant="outline" size="sm">
-                  Configure
-                </Button>
-              </DialogTrigger>
-              <DigestSettingsDialogContent onSuccess={() => setOpen(false)} />
-            </Dialog>
-          )}
-          <Toggle
-            name="digest-enabled"
-            enabled={enabled}
-            onChange={handleToggle}
-          />
-        </div>
-      }
+      right={renderRight()}
     />
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/DigestSetting.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { CrownIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SettingCard } from "@/components/SettingCard";
 import {
@@ -19,12 +20,21 @@ import { useAction } from "next-safe-action/hooks";
 import { toggleDigestAction } from "@/utils/actions/settings";
 import { toastError } from "@/components/Toast";
 import { createCanonicalTimeOfDay } from "@/utils/schedule";
+import { usePremium } from "@/hooks/usePremium";
+import { hasTierAccess } from "@/utils/premium";
+import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 
 export function DigestSetting() {
   const [open, setOpen] = useState(false);
   const { data, isLoading, mutate } = useEmailAccountFull();
+  const { tier, isLoading: isLoadingPremium } = usePremium();
+  const { PremiumModal, openModal } = usePremiumModal();
 
   const enabled = data?.digestSchedule != null;
+  const hasDigestAccess = hasTierAccess({
+    tier,
+    minimumTier: "PLUS_MONTHLY",
+  });
 
   const { execute: executeToggle } = useAction(
     toggleDigestAction.bind(null, data?.id ?? ""),
@@ -56,33 +66,47 @@ export function DigestSetting() {
   );
 
   return (
-    <SettingCard
-      title="Digest"
-      description="Get a daily summary of your newsletter emails."
-      right={
-        isLoading ? (
-          <Skeleton className="h-5 w-9" />
-        ) : (
-          <div className="flex items-center gap-2">
-            {enabled && (
-              <Dialog open={open} onOpenChange={setOpen}>
-                <DialogTrigger asChild>
-                  <Button variant="outline" size="sm">
-                    Configure
-                  </Button>
-                </DialogTrigger>
-                <DigestSettingsDialogContent onSuccess={() => setOpen(false)} />
-              </Dialog>
-            )}
-            <Toggle
-              name="digest-enabled"
-              enabled={enabled}
-              onChange={handleToggle}
-            />
-          </div>
-        )
-      }
-    />
+    <>
+      <SettingCard
+        title="Digest"
+        description={
+          hasDigestAccess
+            ? "Get a daily summary of your newsletter emails."
+            : "Daily digest emails are available on the Plus plan."
+        }
+        right={
+          isLoading || isLoadingPremium ? (
+            <Skeleton className="h-5 w-9" />
+          ) : hasDigestAccess ? (
+            <div className="flex items-center gap-2">
+              {enabled && (
+                <Dialog open={open} onOpenChange={setOpen}>
+                  <DialogTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      Configure
+                    </Button>
+                  </DialogTrigger>
+                  <DigestSettingsDialogContent
+                    onSuccess={() => setOpen(false)}
+                  />
+                </Dialog>
+              )}
+              <Toggle
+                name="digest-enabled"
+                enabled={enabled}
+                onChange={handleToggle}
+              />
+            </div>
+          ) : (
+            <Button variant="outline" size="sm" onClick={openModal}>
+              <CrownIcon className="mr-2 h-4 w-4" />
+              Upgrade
+            </Button>
+          )
+        }
+      />
+      <PremiumModal />
+    </>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -81,6 +81,7 @@ import { prefixPath } from "@/utils/path";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import { usePremium } from "@/hooks/usePremium";
 import { hasTierAccess } from "@/utils/premium";
+import { UpgradeToPlusButton } from "@/components/UpgradeToPlusButton";
 
 type LinkableProvider = "TEAMS" | "TELEGRAM";
 
@@ -459,11 +460,10 @@ function ConnectedChannelSection({
           const digestLocked =
             feature.purpose === MessagingRoutePurpose.DIGESTS &&
             !hasDigestAccess;
-          const disabled =
-            !canEnableMessagingFeatureRoute(
-              channel.destinations,
-              feature.purpose,
-            ) || digestLocked;
+          const disabled = !canEnableMessagingFeatureRoute(
+            channel.destinations,
+            feature.purpose,
+          );
 
           return (
             <div key={feature.purpose}>
@@ -480,11 +480,7 @@ function ConnectedChannelSection({
               )}
               <FeatureRouteToggle
                 name={feature.name}
-                description={
-                  digestLocked
-                    ? "Digest delivery to chat is available on the Plus plan."
-                    : feature.description
-                }
+                description={feature.description}
                 purpose={feature.purpose}
                 messagingChannelId={channel.id}
                 destination={destination}
@@ -493,8 +489,10 @@ function ConnectedChannelSection({
                 emailAccountId={emailAccountId}
                 onUpdate={onUpdate}
                 disabled={disabled}
-                disabledReason={
-                  digestLocked ? "Digests require the Plus plan." : undefined
+                upgradeTooltip={
+                  digestLocked
+                    ? "Upgrade to the Plus plan to deliver digests to chat."
+                    : undefined
                 }
               />
             </div>
@@ -779,7 +777,7 @@ function FeatureRouteToggle({
   emailAccountId,
   onUpdate,
   disabled,
-  disabledReason,
+  upgradeTooltip,
 }: {
   name: string;
   description: string;
@@ -791,7 +789,7 @@ function FeatureRouteToggle({
   emailAccountId: string;
   onUpdate: () => void;
   disabled?: boolean;
-  disabledReason?: string;
+  upgradeTooltip?: string;
 }) {
   const analytics = useProductAnalytics("channels");
   const { execute, status } = useAction(
@@ -817,29 +815,29 @@ function FeatureRouteToggle({
       </ItemContent>
       <ItemActions>
         <div className="flex items-center gap-2">
-          <FeatureRouteAction
-            purpose={purpose}
-            emailAccountId={emailAccountId}
-            disabled={!!disabledReason}
-            disabledReason={disabledReason}
-          />
-          {showTargetSelect && !disabledReason && (
-            <SlackNotificationTargetSelect
-              emailAccountId={emailAccountId}
-              messagingChannelId={messagingChannelId}
-              purpose={purpose}
-              targetId={destination.targetId}
-              targetLabel={destination.targetLabel}
-              isDm={destination.isDm}
-              canSendAsDm={canSendAsDm}
-              onUpdate={onUpdate}
-            />
-          )}
-          <Tooltip content={disabledReason} hide={!disabledReason}>
-            <span>
+          {upgradeTooltip ? (
+            <UpgradeToPlusButton tooltip={upgradeTooltip} />
+          ) : (
+            <>
+              <FeatureRouteAction
+                purpose={purpose}
+                emailAccountId={emailAccountId}
+              />
+              {showTargetSelect && (
+                <SlackNotificationTargetSelect
+                  emailAccountId={emailAccountId}
+                  messagingChannelId={messagingChannelId}
+                  purpose={purpose}
+                  targetId={destination.targetId}
+                  targetLabel={destination.targetLabel}
+                  isDm={destination.isDm}
+                  canSendAsDm={canSendAsDm}
+                  onUpdate={onUpdate}
+                />
+              )}
               <Toggle
                 name={`feature-${purpose}-${messagingChannelId}`}
-                enabled={destination.enabled && !disabledReason}
+                enabled={destination.enabled}
                 disabled={disabled || status === "executing"}
                 onChange={(enabled) => {
                   if (disabled) return;
@@ -850,8 +848,8 @@ function FeatureRouteToggle({
                   execute({ channelId: messagingChannelId, purpose, enabled });
                 }}
               />
-            </span>
-          </Tooltip>
+            </>
+          )}
         </div>
       </ItemActions>
     </Item>
@@ -861,13 +859,9 @@ function FeatureRouteToggle({
 function FeatureRouteAction({
   purpose,
   emailAccountId,
-  disabled,
-  disabledReason,
 }: {
   purpose: MessagingFeatureRoutePurpose;
   emailAccountId: string;
-  disabled: boolean;
-  disabledReason?: string;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -893,18 +887,15 @@ function FeatureRouteAction({
 
   return (
     <>
-      <Tooltip content={disabledReason ?? "Configure"}>
-        <span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            disabled={disabled}
-            onClick={() => setOpen(true)}
-          >
-            <Settings2Icon className="h-4 w-4" />
-          </Button>
-        </span>
+      <Tooltip content="Configure">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => setOpen(true)}
+        >
+          <Settings2Icon className="h-4 w-4" />
+        </Button>
       </Tooltip>
       <Dialog open={open} onOpenChange={setOpen}>
         {purpose === MessagingRoutePurpose.DIGESTS ? (

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -79,6 +79,8 @@ import type { RulesResponse } from "@/app/api/user/rules/route";
 import type { MessagingActionType } from "@/utils/actions/messaging-channels.validation";
 import { prefixPath } from "@/utils/path";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { usePremium } from "@/hooks/usePremium";
+import { hasTierAccess } from "@/utils/premium";
 
 type LinkableProvider = "TEAMS" | "TELEGRAM";
 
@@ -126,6 +128,11 @@ type Rule = RulesResponse[number];
 
 export function Channels() {
   const { emailAccountId } = useAccount();
+  const { tier, isLoading: isLoadingPremium } = usePremium();
+  const hasDigestAccess = hasTierAccess({
+    tier,
+    minimumTier: "PLUS_MONTHLY",
+  });
   const {
     data: channelsData,
     isLoading: isLoadingChannels,
@@ -183,7 +190,7 @@ export function Channels() {
       />
 
       <LoadingContent
-        loading={isLoadingChannels || isLoadingRules}
+        loading={isLoadingChannels || isLoadingRules || isLoadingPremium}
         error={channelsError || rulesError}
       >
         <div className="space-y-10">
@@ -203,6 +210,7 @@ export function Channels() {
                   channel={channel}
                   rules={visibleRules}
                   emailAccountId={emailAccountId}
+                  hasDigestAccess={hasDigestAccess}
                   onUpdate={onUpdate}
                 />
               ));
@@ -310,11 +318,13 @@ function ConnectedChannelSection({
   channel,
   rules,
   emailAccountId,
+  hasDigestAccess,
   onUpdate,
 }: {
   channel: ChannelFromResponse;
   rules: Rule[];
   emailAccountId: string;
+  hasDigestAccess: boolean;
   onUpdate: () => void;
 }) {
   const analytics = useProductAnalytics("channels");
@@ -446,6 +456,14 @@ function ConnectedChannelSection({
             channel.destinations,
             feature.purpose,
           );
+          const isDigestFeature =
+            feature.purpose === MessagingRoutePurpose.DIGESTS;
+          const disabled =
+            !canEnableMessagingFeatureRoute(
+              channel.destinations,
+              feature.purpose,
+            ) ||
+            (isDigestFeature && !hasDigestAccess);
 
           return (
             <div key={feature.purpose}>
@@ -462,7 +480,11 @@ function ConnectedChannelSection({
               )}
               <FeatureRouteToggle
                 name={feature.name}
-                description={feature.description}
+                description={
+                  isDigestFeature && !hasDigestAccess
+                    ? "Digest delivery to chat is available on the Plus plan."
+                    : feature.description
+                }
                 purpose={feature.purpose}
                 messagingChannelId={channel.id}
                 destination={destination}
@@ -470,11 +492,11 @@ function ConnectedChannelSection({
                 canSendAsDm={channel.canSendAsDm}
                 emailAccountId={emailAccountId}
                 onUpdate={onUpdate}
-                disabled={
-                  !canEnableMessagingFeatureRoute(
-                    channel.destinations,
-                    feature.purpose,
-                  )
+                disabled={disabled}
+                disabledReason={
+                  isDigestFeature && !hasDigestAccess
+                    ? "Digests require the Plus plan."
+                    : undefined
                 }
               />
             </div>
@@ -759,6 +781,7 @@ function FeatureRouteToggle({
   emailAccountId,
   onUpdate,
   disabled,
+  disabledReason,
 }: {
   name: string;
   description: string;
@@ -770,6 +793,7 @@ function FeatureRouteToggle({
   emailAccountId: string;
   onUpdate: () => void;
   disabled?: boolean;
+  disabledReason?: string;
 }) {
   const analytics = useProductAnalytics("channels");
   const { execute, status } = useAction(
@@ -798,8 +822,10 @@ function FeatureRouteToggle({
           <FeatureRouteAction
             purpose={purpose}
             emailAccountId={emailAccountId}
+            disabled={!!disabledReason}
+            disabledReason={disabledReason}
           />
-          {showTargetSelect && (
+          {showTargetSelect && !disabledReason && (
             <SlackNotificationTargetSelect
               emailAccountId={emailAccountId}
               messagingChannelId={messagingChannelId}
@@ -811,19 +837,23 @@ function FeatureRouteToggle({
               onUpdate={onUpdate}
             />
           )}
-          <Toggle
-            name={`feature-${purpose}-${messagingChannelId}`}
-            enabled={destination.enabled}
-            disabled={disabled || status === "executing"}
-            onChange={(enabled) => {
-              if (disabled) return;
-              analytics.captureAction("feature_route_toggled", {
-                purpose,
-                enabled,
-              });
-              execute({ channelId: messagingChannelId, purpose, enabled });
-            }}
-          />
+          <Tooltip content={disabledReason} hide={!disabledReason}>
+            <span>
+              <Toggle
+                name={`feature-${purpose}-${messagingChannelId}`}
+                enabled={destination.enabled && !disabledReason}
+                disabled={disabled || status === "executing"}
+                onChange={(enabled) => {
+                  if (disabled) return;
+                  analytics.captureAction("feature_route_toggled", {
+                    purpose,
+                    enabled,
+                  });
+                  execute({ channelId: messagingChannelId, purpose, enabled });
+                }}
+              />
+            </span>
+          </Tooltip>
         </div>
       </ItemActions>
     </Item>
@@ -833,9 +863,13 @@ function FeatureRouteToggle({
 function FeatureRouteAction({
   purpose,
   emailAccountId,
+  disabled,
+  disabledReason,
 }: {
   purpose: MessagingFeatureRoutePurpose;
   emailAccountId: string;
+  disabled: boolean;
+  disabledReason?: string;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -861,15 +895,18 @@ function FeatureRouteAction({
 
   return (
     <>
-      <Tooltip content="Configure">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => setOpen(true)}
-        >
-          <Settings2Icon className="h-4 w-4" />
-        </Button>
+      <Tooltip content={disabledReason ?? "Configure"}>
+        <span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            disabled={disabled}
+            onClick={() => setOpen(true)}
+          >
+            <Settings2Icon className="h-4 w-4" />
+          </Button>
+        </span>
       </Tooltip>
       <Dialog open={open} onOpenChange={setOpen}>
         {purpose === MessagingRoutePurpose.DIGESTS ? (

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -456,14 +456,14 @@ function ConnectedChannelSection({
             channel.destinations,
             feature.purpose,
           );
-          const isDigestFeature =
-            feature.purpose === MessagingRoutePurpose.DIGESTS;
+          const digestLocked =
+            feature.purpose === MessagingRoutePurpose.DIGESTS &&
+            !hasDigestAccess;
           const disabled =
             !canEnableMessagingFeatureRoute(
               channel.destinations,
               feature.purpose,
-            ) ||
-            (isDigestFeature && !hasDigestAccess);
+            ) || digestLocked;
 
           return (
             <div key={feature.purpose}>
@@ -481,7 +481,7 @@ function ConnectedChannelSection({
               <FeatureRouteToggle
                 name={feature.name}
                 description={
-                  isDigestFeature && !hasDigestAccess
+                  digestLocked
                     ? "Digest delivery to chat is available on the Plus plan."
                     : feature.description
                 }
@@ -494,9 +494,7 @@ function ConnectedChannelSection({
                 onUpdate={onUpdate}
                 disabled={disabled}
                 disabledReason={
-                  isDigestFeature && !hasDigestAccess
-                    ? "Digests require the Plus plan."
-                    : undefined
+                  digestLocked ? "Digests require the Plus plan." : undefined
                 }
               />
             </div>

--- a/apps/web/app/(app)/premium/PremiumModal.tsx
+++ b/apps/web/app/(app)/premium/PremiumModal.tsx
@@ -40,7 +40,7 @@ export function usePremiumModal() {
     return (
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         {/* premium upgrade doesn't support dark mode yet as it appears on homepage */}
-        <DialogContent className="max-w-5xl bg-white">
+        <DialogContent className="max-w-6xl bg-white">
           <Pricing
             header={<PricingDialogHeader />}
             displayTiers={modalTiers}

--- a/apps/web/app/(app)/premium/PremiumModal.tsx
+++ b/apps/web/app/(app)/premium/PremiumModal.tsx
@@ -40,7 +40,7 @@ export function usePremiumModal() {
     return (
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         {/* premium upgrade doesn't support dark mode yet as it appears on homepage */}
-        <DialogContent className="max-w-4xl bg-white">
+        <DialogContent className="max-w-5xl bg-white">
           <Pricing
             header={<PricingDialogHeader />}
             displayTiers={modalTiers}

--- a/apps/web/app/api/v1/rules/[id]/route.ts
+++ b/apps/web/app/api/v1/rules/[id]/route.ts
@@ -8,6 +8,8 @@ import {
   rulePathParamsSchema,
   ruleRequestBodySchema,
 } from "@/app/api/v1/rules/validation";
+import { ActionType } from "@/generated/prisma/enums";
+import { assertCanUseDigests } from "@/utils/premium/server";
 
 export const GET = withAccountApiKey(
   "v1/rules/detail",
@@ -33,10 +35,14 @@ export const PUT = withAccountApiKey(
   "v1/rules/update",
   ["RULES_WRITE"],
   async (request, { params }) => {
-    const { emailAccountId, provider } = request.apiAuth;
+    const { emailAccountId, provider, userId } = request.apiAuth;
     const routeParams = rulePathParamsSchema.parse(await params);
     const body = ruleRequestBodySchema.parse(await request.json());
     const ruleInput = toRuleWriteInput(body);
+
+    if (ruleInput.actions.some((action) => action.type === ActionType.DIGEST)) {
+      await assertCanUseDigests(userId);
+    }
 
     const existingRule = await prisma.rule.findFirst({
       where: { id: routeParams.id, emailAccountId },

--- a/apps/web/app/api/v1/rules/[id]/route.ts
+++ b/apps/web/app/api/v1/rules/[id]/route.ts
@@ -8,8 +8,7 @@ import {
   rulePathParamsSchema,
   ruleRequestBodySchema,
 } from "@/app/api/v1/rules/validation";
-import { ActionType } from "@/generated/prisma/enums";
-import { assertCanUseDigests } from "@/utils/premium/server";
+import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
 
 export const GET = withAccountApiKey(
   "v1/rules/detail",
@@ -40,9 +39,7 @@ export const PUT = withAccountApiKey(
     const body = ruleRequestBodySchema.parse(await request.json());
     const ruleInput = toRuleWriteInput(body);
 
-    if (ruleInput.actions.some((action) => action.type === ActionType.DIGEST)) {
-      await assertCanUseDigests(userId);
-    }
+    await assertCanUseDigestsIfNeeded(userId, ruleInput.actions);
 
     const existingRule = await prisma.rule.findFirst({
       where: { id: routeParams.id, emailAccountId },

--- a/apps/web/app/api/v1/rules/route.ts
+++ b/apps/web/app/api/v1/rules/route.ts
@@ -5,8 +5,7 @@ import { createRule } from "@/utils/rule/rule";
 import { toRuleWriteInput } from "@/app/api/v1/rules/request";
 import { apiRuleSelect, serializeRule } from "@/app/api/v1/rules/serializers";
 import { ruleRequestBodySchema } from "@/app/api/v1/rules/validation";
-import { ActionType } from "@/generated/prisma/enums";
-import { assertCanUseDigests } from "@/utils/premium/server";
+import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
 
 export const GET = withAccountApiKey(
   "v1/rules",
@@ -34,9 +33,7 @@ export const POST = withAccountApiKey(
     const body = ruleRequestBodySchema.parse(await request.json());
     const ruleInput = toRuleWriteInput(body);
 
-    if (ruleInput.actions.some((action) => action.type === ActionType.DIGEST)) {
-      await assertCanUseDigests(userId);
-    }
+    await assertCanUseDigestsIfNeeded(userId, ruleInput.actions);
 
     const createdRule = await createRule({
       result: {

--- a/apps/web/app/api/v1/rules/route.ts
+++ b/apps/web/app/api/v1/rules/route.ts
@@ -5,6 +5,8 @@ import { createRule } from "@/utils/rule/rule";
 import { toRuleWriteInput } from "@/app/api/v1/rules/request";
 import { apiRuleSelect, serializeRule } from "@/app/api/v1/rules/serializers";
 import { ruleRequestBodySchema } from "@/app/api/v1/rules/validation";
+import { ActionType } from "@/generated/prisma/enums";
+import { assertCanUseDigests } from "@/utils/premium/server";
 
 export const GET = withAccountApiKey(
   "v1/rules",
@@ -28,9 +30,13 @@ export const POST = withAccountApiKey(
   "v1/rules",
   ["RULES_WRITE"],
   async (request) => {
-    const { emailAccountId, provider } = request.apiAuth;
+    const { emailAccountId, provider, userId } = request.apiAuth;
     const body = ruleRequestBodySchema.parse(await request.json());
     const ruleInput = toRuleWriteInput(body);
+
+    if (ruleInput.actions.some((action) => action.type === ActionType.DIGEST)) {
+      await assertCanUseDigests(userId);
+    }
 
     const createdRule = await createRule({
       result: {

--- a/apps/web/components/UpgradeToPlusButton.tsx
+++ b/apps/web/components/UpgradeToPlusButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { CrownIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/Tooltip";
+import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
+
+export function UpgradeToPlusButton({ tooltip }: { tooltip: string }) {
+  const { PremiumModal, openModal } = usePremiumModal();
+
+  return (
+    <>
+      <Tooltip content={tooltip}>
+        <Button variant="outline" size="sm" onClick={openModal}>
+          <CrownIcon className="mr-2 h-4 w-4" />
+          Upgrade
+        </Button>
+      </Tooltip>
+      <PremiumModal />
+    </>
+  );
+}

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -38,7 +38,7 @@ import { upsertSlackRoute } from "@/utils/messaging/slack-routes";
 import { sendSlackOnboardingDirectMessageWithLogging } from "@/utils/messaging/providers/slack/send-onboarding-direct-message";
 import { lookupSlackUserByEmail } from "@/utils/messaging/providers/slack/users";
 import { callTelegramBotApi } from "@/utils/messaging/providers/telegram/api";
-import { checkHasAccess } from "@/utils/premium/server";
+import { assertCanUseDigests } from "@/utils/premium/server";
 
 export const updateSlackRouteAction = actionClient
   .metadata({ name: "updateSlackRoute" })
@@ -504,15 +504,4 @@ async function syncMessagingFeatureRoute({
       targetId: rulesRoute.targetId,
     },
   });
-}
-
-async function assertCanUseDigests(userId: string) {
-  const hasDigestAccess = await checkHasAccess({
-    userId,
-    minimumTier: "PLUS_MONTHLY",
-  });
-
-  if (!hasDigestAccess) {
-    throw new SafeError("Digest delivery is available on the Plus plan.");
-  }
 }

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -38,6 +38,7 @@ import { upsertSlackRoute } from "@/utils/messaging/slack-routes";
 import { sendSlackOnboardingDirectMessageWithLogging } from "@/utils/messaging/providers/slack/send-onboarding-direct-message";
 import { lookupSlackUserByEmail } from "@/utils/messaging/providers/slack/users";
 import { callTelegramBotApi } from "@/utils/messaging/providers/telegram/api";
+import { checkHasAccess } from "@/utils/premium/server";
 
 export const updateSlackRouteAction = actionClient
   .metadata({ name: "updateSlackRoute" })
@@ -94,9 +95,13 @@ export const updateMessagingFeatureRouteAction = actionClient
   .inputSchema(updateMessagingFeatureRouteBody)
   .action(
     async ({
-      ctx: { emailAccountId },
+      ctx: { emailAccountId, userId },
       parsedInput: { channelId, purpose, enabled },
     }) => {
+      if (enabled && purpose === MessagingRoutePurpose.DIGESTS) {
+        await assertCanUseDigests(userId);
+      }
+
       const where = {
         id_emailAccountId: { id: channelId, emailAccountId },
       };
@@ -151,12 +156,18 @@ export const updateMeetingBriefsEmailDeliveryAction = actionClient
 export const updateDigestEmailDeliveryAction = actionClient
   .metadata({ name: "updateDigestEmailDelivery" })
   .inputSchema(updateDigestEmailDeliveryBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput: { sendEmail } }) => {
-    await prisma.emailAccount.update({
-      where: { id: emailAccountId },
-      data: { digestSendEmail: sendEmail },
-    });
-  });
+  .action(
+    async ({ ctx: { emailAccountId, userId }, parsedInput: { sendEmail } }) => {
+      if (sendEmail) {
+        await assertCanUseDigests(userId);
+      }
+
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        data: { digestSendEmail: sendEmail },
+      });
+    },
+  );
 
 export const disconnectChannelAction = actionClient
   .metadata({ name: "disconnectChannel" })
@@ -493,4 +504,15 @@ async function syncMessagingFeatureRoute({
       targetId: rulesRoute.targetId,
     },
   });
+}
+
+async function assertCanUseDigests(userId: string) {
+  const hasDigestAccess = await checkHasAccess({
+    userId,
+    minimumTier: "PLUS_MONTHLY",
+  });
+
+  if (!hasDigestAccess) {
+    throw new SafeError("Digest delivery is available on the Plus plan.");
+  }
 }

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -55,7 +55,7 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { bulkProcessInboxEmails } from "@/utils/ai/choose-rule/bulk-process-emails";
 import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
-import { assertCanUseDigests } from "@/utils/premium/server";
+import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
@@ -71,9 +71,7 @@ export const createRuleAction = actionClient
         conditionalOperator,
       },
     }) => {
-      if (actions?.some((action) => action.type === ActionType.DIGEST)) {
-        await assertCanUseDigests(userId);
-      }
+      await assertCanUseDigestsIfNeeded(userId, actions ?? []);
 
       const conditions = flattenConditions(conditionsInput, logger);
 
@@ -127,9 +125,7 @@ export const updateRuleAction = actionClient
         conditionalOperator,
       },
     }) => {
-      if (actions.some((action) => action.type === ActionType.DIGEST)) {
-        await assertCanUseDigests(userId);
-      }
+      await assertCanUseDigestsIfNeeded(userId, actions);
 
       const conditions = flattenConditions(conditionsInput, logger);
 
@@ -583,12 +579,10 @@ export const copyRulesFromAccountAction = actionClientUser
         return { copiedCount: 0, replacedCount: 0 };
       }
 
-      const copiesDigestAction = sourceRules.some((rule) =>
-        rule.actions.some((action) => action.type === ActionType.DIGEST),
+      await assertCanUseDigestsIfNeeded(
+        userId,
+        sourceRules.flatMap((rule) => rule.actions),
       );
-      if (copiesDigestAction) {
-        await assertCanUseDigests(userId);
-      }
 
       // Fetch existing rules in target account to check for duplicates
       const targetRules = await prisma.rule.findMany({
@@ -1050,12 +1044,10 @@ export const importRulesAction = actionClient
     }) => {
       logger.info("Importing rules", { count: rules.length });
 
-      const importsDigestAction = rules.some((rule) =>
-        rule.actions.some((action) => action.type === ActionType.DIGEST),
+      await assertCanUseDigestsIfNeeded(
+        userId,
+        rules.flatMap((rule) => rule.actions),
       );
-      if (importsDigestAction) {
-        await assertCanUseDigests(userId);
-      }
 
       // Fetch existing rules to check for duplicates by name or systemType
       const existingRules = await prisma.rule.findMany({

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -583,6 +583,13 @@ export const copyRulesFromAccountAction = actionClientUser
         return { copiedCount: 0, replacedCount: 0 };
       }
 
+      const copiesDigestAction = sourceRules.some((rule) =>
+        rule.actions.some((action) => action.type === ActionType.DIGEST),
+      );
+      if (copiesDigestAction) {
+        await assertCanUseDigests(userId);
+      }
+
       // Fetch existing rules in target account to check for duplicates
       const targetRules = await prisma.rule.findMany({
         where: { emailAccountId: targetEmailAccountId },
@@ -1037,8 +1044,18 @@ export const importRulesAction = actionClient
   .metadata({ name: "importRules" })
   .inputSchema(importRulesBody)
   .action(
-    async ({ ctx: { emailAccountId, logger }, parsedInput: { rules } }) => {
+    async ({
+      ctx: { emailAccountId, userId, logger },
+      parsedInput: { rules },
+    }) => {
       logger.info("Importing rules", { count: rules.length });
+
+      const importsDigestAction = rules.some((rule) =>
+        rule.actions.some((action) => action.type === ActionType.DIGEST),
+      );
+      if (importsDigestAction) {
+        await assertCanUseDigests(userId);
+      }
 
       // Fetch existing rules to check for duplicates by name or systemType
       const existingRules = await prisma.rule.findMany({

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -55,7 +55,7 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { bulkProcessInboxEmails } from "@/utils/ai/choose-rule/bulk-process-emails";
 import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
-import { checkHasAccess } from "@/utils/premium/server";
+import { assertCanUseDigests } from "@/utils/premium/server";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
@@ -855,17 +855,6 @@ function handleRuleError(error: unknown, logger: Logger) {
   }
   logger.error("Error creating/updating rule", { error });
   throw new SafeError("Error creating/updating rule");
-}
-
-async function assertCanUseDigests(userId: string) {
-  const hasDigestAccess = await checkHasAccess({
-    userId,
-    minimumTier: "PLUS_MONTHLY",
-  });
-
-  if (!hasDigestAccess) {
-    throw new SafeError("Digest actions are available on the Plus plan.");
-  }
 }
 
 async function resolveActionLabels<

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -55,13 +55,14 @@ import { isGoogleProvider } from "@/utils/email/provider-types";
 import { bulkProcessInboxEmails } from "@/utils/ai/choose-rule/bulk-process-emails";
 import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
+import { checkHasAccess } from "@/utils/premium/server";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
   .inputSchema(createRuleBody)
   .action(
     async ({
-      ctx: { emailAccountId, logger, provider },
+      ctx: { emailAccountId, userId, logger, provider },
       parsedInput: {
         name,
         runOnThreads,
@@ -70,6 +71,10 @@ export const createRuleAction = actionClient
         conditionalOperator,
       },
     }) => {
+      if (actions?.some((action) => action.type === ActionType.DIGEST)) {
+        await assertCanUseDigests(userId);
+      }
+
       const conditions = flattenConditions(conditionsInput, logger);
 
       const resolvedActions = await resolveActionLabels(
@@ -112,7 +117,7 @@ export const updateRuleAction = actionClient
   .inputSchema(updateRuleBody)
   .action(
     async ({
-      ctx: { emailAccountId, logger, provider },
+      ctx: { emailAccountId, userId, logger, provider },
       parsedInput: {
         id,
         name,
@@ -122,6 +127,10 @@ export const updateRuleAction = actionClient
         conditionalOperator,
       },
     }) => {
+      if (actions.some((action) => action.type === ActionType.DIGEST)) {
+        await assertCanUseDigests(userId);
+      }
+
       const conditions = flattenConditions(conditionsInput, logger);
 
       const resolvedActions = await resolveActionLabels(
@@ -846,6 +855,17 @@ function handleRuleError(error: unknown, logger: Logger) {
   }
   logger.error("Error creating/updating rule", { error });
   throw new SafeError("Error creating/updating rule");
+}
+
+async function assertCanUseDigests(userId: string) {
+  const hasDigestAccess = await checkHasAccess({
+    userId,
+    minimumTier: "PLUS_MONTHLY",
+  });
+
+  if (!hasDigestAccess) {
+    throw new SafeError("Digest actions are available on the Plus plan.");
+  }
 }
 
 async function resolveActionLabels<

--- a/apps/web/utils/actions/settings.ts
+++ b/apps/web/utils/actions/settings.ts
@@ -23,7 +23,7 @@ import { SafeError } from "@/utils/error";
 import { env } from "@/env";
 import { addActionOwnershipToInput } from "@/utils/rule/rule";
 import { isSensitiveDataPolicyLocked } from "@/utils/dlp/policy.server";
-import { checkHasAccess } from "@/utils/premium/server";
+import { assertCanUseDigests } from "@/utils/premium/server";
 
 export const updateEmailSettingsAction = actionClient
   .metadata({ name: "updateEmailSettings" })
@@ -282,14 +282,3 @@ export const toggleDigestAction = actionClient
       return { success: true };
     },
   );
-
-async function assertCanUseDigests(userId: string) {
-  const hasDigestAccess = await checkHasAccess({
-    userId,
-    minimumTier: "PLUS_MONTHLY",
-  });
-
-  if (!hasDigestAccess) {
-    throw new SafeError("Digest emails are available on the Plus plan.");
-  }
-}

--- a/apps/web/utils/actions/settings.ts
+++ b/apps/web/utils/actions/settings.ts
@@ -23,6 +23,7 @@ import { SafeError } from "@/utils/error";
 import { env } from "@/env";
 import { addActionOwnershipToInput } from "@/utils/rule/rule";
 import { isSensitiveDataPolicyLocked } from "@/utils/dlp/policy.server";
+import { checkHasAccess } from "@/utils/premium/server";
 
 export const updateEmailSettingsAction = actionClient
   .metadata({ name: "updateEmailSettings" })
@@ -132,7 +133,9 @@ export const updateSensitiveDataPolicyAction = actionClient
 export const updateDigestScheduleAction = actionClient
   .metadata({ name: "updateDigestSchedule" })
   .inputSchema(saveDigestScheduleBody)
-  .action(async ({ ctx: { emailAccountId }, parsedInput }) => {
+  .action(async ({ ctx: { emailAccountId, userId }, parsedInput }) => {
+    await assertCanUseDigests(userId);
+
     const { intervalDays, daysOfWeek, timeOfDay, occurrences } = parsedInput;
 
     const create: Prisma.ScheduleUpsertArgs["create"] = {
@@ -164,9 +167,13 @@ export const updateDigestItemsAction = actionClient
   .inputSchema(updateDigestItemsBody)
   .action(
     async ({
-      ctx: { emailAccountId, logger },
+      ctx: { emailAccountId, userId, logger },
       parsedInput: { ruleDigestPreferences },
     }) => {
+      if (Object.values(ruleDigestPreferences).some(Boolean)) {
+        await assertCanUseDigests(userId);
+      }
+
       const promises = Object.entries(ruleDigestPreferences).map(
         async ([ruleId, enabled]) => {
           // Verify the rule belongs to this email account
@@ -220,10 +227,12 @@ export const toggleDigestAction = actionClient
   .inputSchema(toggleDigestBody)
   .action(
     async ({
-      ctx: { emailAccountId },
+      ctx: { emailAccountId, userId },
       parsedInput: { enabled, timeOfDay },
     }) => {
       if (enabled) {
+        await assertCanUseDigests(userId);
+
         const defaultSchedule = {
           intervalDays: 1,
           occurrences: 1,
@@ -273,3 +282,14 @@ export const toggleDigestAction = actionClient
       return { success: true };
     },
   );
+
+async function assertCanUseDigests(userId: string) {
+  const hasDigestAccess = await checkHasAccess({
+    userId,
+    minimumTier: "PLUS_MONTHLY",
+  });
+
+  if (!hasDigestAccess) {
+    throw new SafeError("Digest emails are available on the Plus plan.");
+  }
+}

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -164,6 +164,17 @@ export async function cancelPremiumLemon({
   });
 }
 
+export async function assertCanUseDigests(userId: string) {
+  const hasDigestAccess = await checkHasAccess({
+    userId,
+    minimumTier: "PLUS_MONTHLY",
+  });
+
+  if (!hasDigestAccess) {
+    throw new SafeError("Digests are available on the Plus plan.");
+  }
+}
+
 export async function checkHasAccess({
   userId,
   minimumTier,

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -171,7 +171,7 @@ export async function assertCanUseDigests(userId: string) {
   });
 
   if (!hasDigestAccess) {
-    throw new SafeError("Digests are available on the Plus plan.");
+    throw new SafeError("Digests are available on the Plus plan.", 403);
   }
 }
 

--- a/apps/web/utils/premium/server.ts
+++ b/apps/web/utils/premium/server.ts
@@ -1,6 +1,6 @@
 import { after } from "next/server";
 import prisma from "@/utils/prisma";
-import type { PremiumTier } from "@/generated/prisma/enums";
+import { ActionType, type PremiumTier } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
 import {
@@ -172,6 +172,15 @@ export async function assertCanUseDigests(userId: string) {
 
   if (!hasDigestAccess) {
     throw new SafeError("Digests are available on the Plus plan.", 403);
+  }
+}
+
+export async function assertCanUseDigestsIfNeeded(
+  userId: string,
+  actions: { type: ActionType }[],
+) {
+  if (actions.some((action) => action.type === ActionType.DIGEST)) {
+    await assertCanUseDigests(userId);
   }
 }
 


### PR DESCRIPTION
Digest settings now reflect the required plan before users can enable delivery.

- Disable digest controls below the required plan in assistant settings, rule editing, and channel settings.
- Add server-side entitlement checks for digest schedules, routes, delivery preferences, and rule actions.

Validation: pnpm --filter inbox-zero-ai lint; pnpm --filter inbox-zero-ai check-server-actions