### PR TITLE
admin: Fix premium downgrade

### DIFF
--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -329,6 +329,7 @@ export const adminChangePremiumStatusAction = adminActionClient
         await prisma.premium.update({
           where: { id: userToUpgrade.user.premiumId },
           data: {
+            tier: null,
             adminGrantExpiresAt: null,
             adminGrantTier: null,
           },


### PR DESCRIPTION
Clears the local premium tier when an admin downgrades a user. This preserves existing billing metadata while allowing the admin panel downgrade to take effect.