### PR TITLE
premium: Require tier for entitlements

### DIFF
--- a/apps/web/utils/premium/index.test.ts
+++ b/apps/web/utils/premium/index.test.ts
@@ -14,6 +14,7 @@ import {
   getPremiumUserFilter,
   getUserTier,
   hasActiveAppleSubscription,
+  isActivePremium,
   isPremium,
   isPremiumRecord,
 } from "./index";
@@ -50,6 +51,7 @@ describe("Apple premium helpers", () => {
         appleSubscriptionStatus: "ACTIVE",
         lemonSqueezyRenewsAt: null,
         stripeSubscriptionStatus: null,
+        tier: "STARTER_MONTHLY",
       }),
     ).toBe(true);
   });
@@ -115,6 +117,47 @@ describe("Apple premium helpers", () => {
 
     expect(isPremiumRecord(null)).toBe(true);
   });
+
+  it("does not treat active processor state as premium without a tier", () => {
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+    const activeProcessorRecords = [
+      { stripeSubscriptionStatus: "active", tier: null },
+      { lemonSqueezyRenewsAt: futureDate, tier: null },
+      {
+        appleExpiresAt: futureDate,
+        appleRevokedAt: null,
+        appleSubscriptionStatus: "ACTIVE",
+        tier: null,
+      },
+    ];
+
+    for (const premium of activeProcessorRecords) {
+      expect(isPremiumRecord(premium)).toBe(false);
+    }
+  });
+
+  it("does not treat active grant state as premium without an admin grant tier", () => {
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+
+    expect(
+      isPremiumRecord({
+        adminGrantExpiresAt: futureDate,
+        adminGrantTier: null,
+        lemonSqueezyRenewsAt: null,
+        stripeSubscriptionStatus: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat active processor state as active premium without a tier", () => {
+    expect(
+      isActivePremium({
+        stripeSubscriptionStatus: "active",
+        lemonSqueezyRenewsAt: null,
+        tier: null,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("digest access", () => {
@@ -158,6 +201,21 @@ describe("digest access", () => {
               },
             },
           ]),
+        }),
+      ]),
+    );
+  });
+
+  it("requires a non-null tier when filtering premium users without a minimum tier", () => {
+    const filter = getPremiumUserFilter();
+
+    expect(filter.user.premium.OR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          AND: expect.arrayContaining([{ tier: { not: null } }]),
+        }),
+        expect.objectContaining({
+          AND: expect.arrayContaining([{ adminGrantTier: { not: null } }]),
         }),
       ]),
     );

--- a/apps/web/utils/premium/index.ts
+++ b/apps/web/utils/premium/index.ts
@@ -25,6 +25,10 @@ function isPremiumStripe(stripeSubscriptionStatus: string | null): boolean {
   return activeStatuses.includes(stripeSubscriptionStatus);
 }
 
+function isActiveStripe(stripeSubscriptionStatus: string | null): boolean {
+  return stripeSubscriptionStatus === "active";
+}
+
 function isPremiumLemonSqueezy(
   lemonSqueezyRenewsAt: Date | string | null,
 ): boolean {
@@ -97,13 +101,9 @@ export const isPremiumRecord = (
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return true;
   if (!premium) return false;
 
-  return isPremium(
-    premium.lemonSqueezyRenewsAt ?? null,
-    premium.stripeSubscriptionStatus ?? null,
-    premium.appleExpiresAt ?? null,
-    premium.appleRevokedAt ?? null,
-    premium.appleSubscriptionStatus ?? null,
-    premium.adminGrantExpiresAt ?? null,
+  return (
+    hasProcessorPremiumEntitlement(premium) ||
+    hasAdminGrantPremiumEntitlement(premium)
   );
 };
 
@@ -115,14 +115,8 @@ export const isActivePremium = (
   if (!premium) return false;
 
   return (
-    premium.stripeSubscriptionStatus === "active" ||
-    isPremiumLemonSqueezy(premium.lemonSqueezyRenewsAt ?? null) ||
-    isPremiumAdminGrant(premium.adminGrantExpiresAt ?? null) ||
-    hasActiveAppleSubscription(
-      premium.appleExpiresAt ?? null,
-      premium.appleRevokedAt ?? null,
-      premium.appleSubscriptionStatus,
-    )
+    hasActiveProcessorPremiumEntitlement(premium) ||
+    hasAdminGrantPremiumEntitlement(premium)
   );
 };
 
@@ -267,10 +261,12 @@ export function getPremiumUserFilter({
   if (env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS) return {};
 
   const minimumTiers = minimumTier ? getTiersAtOrAbove(minimumTier) : undefined;
-  const tierFilter = minimumTiers ? [{ tier: { in: minimumTiers } }] : [];
+  const tierFilter = minimumTiers
+    ? [{ tier: { in: minimumTiers } }]
+    : [{ tier: { not: null } }];
   const adminGrantTierFilter = minimumTiers
     ? [{ adminGrantTier: { in: minimumTiers } }]
-    : [];
+    : [{ adminGrantTier: { not: null } }];
   const now = new Date();
 
   return {
@@ -303,4 +299,38 @@ export function getPremiumUserFilter({
       },
     },
   };
+}
+
+function hasProcessorPremiumEntitlement(premium: PremiumStatusRecord) {
+  if (!premium.tier) return false;
+
+  return (
+    isPremiumStripe(premium.stripeSubscriptionStatus ?? null) ||
+    isPremiumLemonSqueezy(premium.lemonSqueezyRenewsAt ?? null) ||
+    hasActiveAppleSubscription(
+      premium.appleExpiresAt ?? null,
+      premium.appleRevokedAt ?? null,
+      premium.appleSubscriptionStatus,
+    )
+  );
+}
+
+function hasActiveProcessorPremiumEntitlement(premium: PremiumStatusRecord) {
+  if (!premium.tier) return false;
+
+  return (
+    isActiveStripe(premium.stripeSubscriptionStatus ?? null) ||
+    isPremiumLemonSqueezy(premium.lemonSqueezyRenewsAt ?? null) ||
+    hasActiveAppleSubscription(
+      premium.appleExpiresAt ?? null,
+      premium.appleRevokedAt ?? null,
+      premium.appleSubscriptionStatus,
+    )
+  );
+}
+
+function hasAdminGrantPremiumEntitlement(premium: PremiumStatusRecord) {
+  if (!premium.adminGrantTier) return false;
+
+  return isPremiumAdminGrant(premium.adminGrantExpiresAt ?? null);
 }


### PR DESCRIPTION
Requires premium entitlement checks to have an effective tier before active processor state grants access. Keeps admin grants tied to their grant tier and updates premium helper tests for tierless entitlement records.