### PR TITLE
logging: Improve Gmail batch fetch context

### DIFF
--- a/apps/web/app/api/google/webhook/process-history.ts
+++ b/apps/web/app/api/google/webhook/process-history.ts
@@ -60,6 +60,9 @@ export async function processHistoryForUser(
     hasAiAccess: userHasAiAccess,
   } = validation.data;
 
+  // biome-ignore lint/style/noParameterAssign: allowed for logging
+  logger = logger.with({ userId: validatedEmailAccount.userId });
+
   Sentry.setTag("emailAccountId", validatedEmailAccount.id);
   Sentry.setUser({
     id: validatedEmailAccount.userId,

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -111,6 +111,7 @@ async function sendEmail({
   const emailAccount = await prisma.emailAccount.findUnique({
     where: { id: emailAccountId },
     select: {
+      userId: true,
       email: true,
       account: {
         select: {
@@ -124,6 +125,8 @@ async function sendEmail({
     logger.error("Email account not found");
     return { success: false };
   }
+
+  logger = logger.with({ userId: emailAccount.userId });
 
   const coldEmailRule = await prisma.rule.findUnique({
     where: {
@@ -207,6 +210,7 @@ async function sendEmail({
     ? await getMessagesBatch({
         messageIds,
         accessToken: emailAccount.account.access_token,
+        logger,
       })
     : [];
 

--- a/apps/web/utils/ai/group/find-newsletters.ts
+++ b/apps/web/utils/ai/group/find-newsletters.ts
@@ -1,6 +1,7 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import uniq from "lodash/uniq";
 import { queryBatchMessagesPages } from "@/utils/gmail/message";
+import type { Logger } from "@/utils/logger";
 
 export const newsletterSenders = [
   "substack.com",
@@ -12,14 +13,17 @@ const ignoreList = ["@github.com", "@google.com", "@gmail.com", "@slack.com"];
 export async function findNewsletters(
   gmail: gmail_v1.Gmail,
   userEmail: string,
+  logger: Logger,
 ) {
   const messages = await queryBatchMessagesPages(gmail, {
     query: "newsletter",
     maxResults: 100,
+    logger,
   });
   const messages2 = await queryBatchMessagesPages(gmail, {
     query: `from:(${newsletterSenders.join(" OR ")})`,
     maxResults: 100,
+    logger,
   });
 
   return uniq(

--- a/apps/web/utils/ai/group/find-receipts.ts
+++ b/apps/web/utils/ai/group/find-receipts.ts
@@ -6,6 +6,7 @@ import { GroupItemType } from "@/generated/prisma/enums";
 import { findMatchingGroupItem } from "@/utils/group/find-matching-group";
 import { generalizeSubject } from "@/utils/string";
 import type { ParsedMessage } from "@/utils/types";
+import type { Logger } from "@/utils/logger";
 
 // Predefined lists of receipt senders and subjects
 const defaultReceiptSenders = [
@@ -38,9 +39,13 @@ const defaultReceiptSubjects = [
 ];
 
 // Find additional receipts from the user's inbox that don't match the predefined lists
-export async function findReceipts(gmail: gmail_v1.Gmail, userEmail: string) {
-  const senders = await findReceiptSenders(gmail);
-  const subjects = await findReceiptSubjects(gmail);
+export async function findReceipts(
+  gmail: gmail_v1.Gmail,
+  userEmail: string,
+  logger: Logger,
+) {
+  const senders = await findReceiptSenders(gmail, logger);
+  const subjects = await findReceiptSubjects(gmail, logger);
 
   // filter out senders that would match the default list
   const filteredSenders = senders.filter(
@@ -97,11 +102,12 @@ export async function findReceipts(gmail: gmail_v1.Gmail, userEmail: string) {
 
 const receiptSenders = ["invoice", "receipt", "payment"];
 
-async function findReceiptSenders(gmail: gmail_v1.Gmail) {
+async function findReceiptSenders(gmail: gmail_v1.Gmail, logger: Logger) {
   const query = `from:(${receiptSenders.join(" OR ")})`;
   const messages = await queryBatchMessagesPages(gmail, {
     query,
     maxResults: 100,
+    logger,
   });
 
   return uniq(messages.map((message) => message.headers.from));
@@ -117,11 +123,12 @@ const receiptSubjects = [
   '"billing statement"',
 ];
 
-async function findReceiptSubjects(gmail: gmail_v1.Gmail) {
+async function findReceiptSubjects(gmail: gmail_v1.Gmail, logger: Logger) {
   const query = `subject:(${receiptSubjects.join(" OR ")})`;
   const messages = await queryBatchMessagesPages(gmail, {
     query,
     maxResults: 100,
+    logger,
   });
 
   return uniqBy(

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -210,19 +210,24 @@ export class GmailProvider implements EmailProvider {
   async getMessageByRfc822MessageId(
     rfc822MessageId: string,
   ): Promise<ParsedMessage | null> {
-    const message = await getMessageByRfc822Id(rfc822MessageId, this.client);
+    const message = await getMessageByRfc822Id(
+      rfc822MessageId,
+      this.client,
+      this.logger,
+    );
     if (!message) return null;
     return parseMessage(message);
   }
 
   async getSentMessages(maxResults = 20): Promise<ParsedMessage[]> {
-    return getSentMessages(this.client, maxResults);
+    return getSentMessages(this.client, this.logger, maxResults);
   }
 
   async getInboxMessages(maxResults = 20): Promise<ParsedMessage[]> {
     const messages = await queryBatchMessages(this.client, {
       query: "in:inbox",
       maxResults,
+      logger: this.logger,
     });
     return messages.messages;
   }
@@ -976,6 +981,7 @@ export class GmailProvider implements EmailProvider {
     return getMessagesBatch({
       messageIds,
       accessToken: getAccessTokenFromClient(this.client),
+      logger: this.logger,
     });
   }
 
@@ -1038,6 +1044,7 @@ export class GmailProvider implements EmailProvider {
     const originalMessage = await getMessageByRfc822Id(
       originalMessageId,
       this.client,
+      this.logger,
     );
     if (!originalMessage) return null;
     return parseMessage(originalMessage);
@@ -1281,6 +1288,7 @@ export class GmailProvider implements EmailProvider {
     return getMessagesBatch({
       messageIds,
       accessToken: getAccessTokenFromClient(this.client),
+      logger: this.logger,
     });
   }
 

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -4,16 +4,10 @@ import {
   hasPreviousCommunicationsWithSenderOrDomain,
 } from "./message";
 import { getBatch } from "@/utils/gmail/batch";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/utils/gmail/batch");
-vi.mock("@/utils/logger", () => ({
-  createScopedLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }));
@@ -22,6 +16,11 @@ vi.mock("gmail-api-parse-message", () => ({
 }));
 
 describe("getMessagesBatch", () => {
+  const logger = createTestLogger();
+  const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+  vi.spyOn(logger, "info").mockImplementation(() => {});
+  vi.spyOn(logger, "warn").mockImplementation(() => {});
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -51,7 +50,7 @@ describe("getMessagesBatch", () => {
         },
       ]);
 
-    const result = await getMessagesBatch({ messageIds, accessToken });
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("id1");
@@ -73,7 +72,7 @@ describe("getMessagesBatch", () => {
       },
     ]);
 
-    const result = await getMessagesBatch({ messageIds, accessToken });
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
     expect(result).toHaveLength(0);
     expect(getBatch).toHaveBeenCalledTimes(1);
@@ -102,7 +101,7 @@ describe("getMessagesBatch", () => {
         },
       ]);
 
-    const result = await getMessagesBatch({ messageIds, accessToken });
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("id1");
@@ -142,13 +141,22 @@ describe("getMessagesBatch", () => {
         })),
       );
 
-    const result = await getMessagesBatch({ messageIds, accessToken });
+    const result = await getMessagesBatch({ messageIds, accessToken, logger });
 
     expect(result).toHaveLength(12);
     expect(getBatch).toHaveBeenCalledTimes(3);
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
       12, 10, 2,
     ]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error fetching message, adding to retry queue",
+      expect.objectContaining({
+        messageId: "id1",
+        code: 429,
+        errorMessage: "Too many concurrent requests for user",
+        reason: "rateLimitExceeded",
+      }),
+    );
   });
 });
 

--- a/apps/web/utils/gmail/message.ts
+++ b/apps/web/utils/gmail/message.ts
@@ -10,15 +10,14 @@ import {
 } from "@/utils/types";
 import { getBatch } from "@/utils/gmail/batch";
 import { getSearchTermForSender } from "@/utils/email";
-import { createScopedLogger } from "@/utils/logger";
 import { sleep } from "@/utils/sleep";
 import { getAccessTokenFromClient } from "@/utils/gmail/client";
 import { GmailLabel } from "@/utils/gmail/label";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import parse from "gmail-api-parse-message";
 import { isRetryableError, withGmailRetry } from "@/utils/gmail/retry";
+import type { Logger } from "@/utils/logger";
 
-const logger = createScopedLogger("gmail/message");
 const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
 
 export function parseMessage(
@@ -87,6 +86,7 @@ export async function getMessage(
 export async function getMessageByRfc822Id(
   rfc822MessageId: string,
   gmail: gmail_v1.Gmail,
+  logger: Logger,
 ) {
   // Search for message using RFC822 Message-ID header
   // Remove any < > brackets if present
@@ -115,10 +115,12 @@ export async function getMessagesBatch({
   messageIds,
   accessToken,
   retryCount = 0,
+  logger,
 }: {
   messageIds: string[];
   accessToken: string;
   retryCount?: number;
+  logger: Logger;
 }): Promise<ParsedMessage[]> {
   if (!accessToken) throw new Error("No access token");
 
@@ -138,7 +140,9 @@ export async function getMessagesBatch({
   let shouldRetryInSmallerBatches = false;
 
   if (batch.some((m) => isBatchError(m) && m.error.code === 401)) {
-    logger.error("Error fetching messages", { firstBatchItem: batch?.[0] });
+    logger.error("Error fetching messages", {
+      firstBatchItem: batch?.[0],
+    });
     throw new Error("Invalid access token");
   }
 
@@ -165,8 +169,9 @@ export async function getMessagesBatch({
         }
 
         logger.error("Error fetching message, adding to retry queue", {
+          messageId: messageIds[i],
           code,
-          error: errorMessage,
+          errorMessage,
           reason,
         });
         if (isRateLimit) shouldRetryInSmallerBatches = true;
@@ -192,11 +197,13 @@ export async function getMessagesBatch({
           messageIds: missingIds,
           accessToken,
           retryCount: nextRetryCount,
+          logger,
         })
       : await getMessagesBatch({
           messageIds: missingIds,
           accessToken,
           retryCount: nextRetryCount,
+          logger,
         });
     return [...messages, ...missingMessages];
   }
@@ -297,9 +304,11 @@ export async function queryBatchMessages(
     query?: string;
     maxResults?: number;
     pageToken?: string;
+    logger: Logger;
   },
 ) {
   const { query, pageToken } = options;
+  const { logger } = options;
 
   const MAX_RESULTS = 20;
 
@@ -320,7 +329,12 @@ export async function queryBatchMessages(
   if (!messages.messages) return { messages: [], nextPageToken: undefined };
   const messageIds = messages.messages.map((m) => m.id).filter(isDefined);
   return {
-    messages: (await getMessagesBatch({ messageIds, accessToken })) || [],
+    messages:
+      (await getMessagesBatch({
+        messageIds,
+        accessToken,
+        logger,
+      })) || [],
     nextPageToken: messages.nextPageToken,
   };
 }
@@ -331,9 +345,11 @@ export async function queryBatchMessagesPages(
   {
     query,
     maxResults,
+    logger,
   }: {
     query: string;
     maxResults: number;
+    logger: Logger;
   },
 ) {
   const messages: ParsedMessage[] = [];
@@ -343,6 +359,7 @@ export async function queryBatchMessagesPages(
       await queryBatchMessages(gmail, {
         query,
         pageToken: nextPageToken,
+        logger,
       });
     messages.push(...pageMessages);
     nextPageToken = nextToken || undefined;
@@ -351,10 +368,15 @@ export async function queryBatchMessagesPages(
   return messages;
 }
 
-export async function getSentMessages(gmail: gmail_v1.Gmail, maxResults = 20) {
+export async function getSentMessages(
+  gmail: gmail_v1.Gmail,
+  logger: Logger,
+  maxResults = 20,
+) {
   const messages = await queryBatchMessages(gmail, {
     query: "label:sent",
     maxResults,
+    logger,
   });
   return messages.messages;
 }
@@ -363,10 +385,12 @@ async function getMessagesBatchInRetryChunks({
   messageIds,
   accessToken,
   retryCount,
+  logger,
 }: {
   messageIds: string[];
   accessToken: string;
   retryCount: number;
+  logger: Logger;
 }) {
   const chunkedMessages = chunk(messageIds, RATE_LIMIT_RETRY_BATCH_SIZE);
   const messages: ParsedMessage[] = [];
@@ -376,6 +400,7 @@ async function getMessagesBatchInRetryChunks({
       messageIds: messageIdsChunk,
       accessToken,
       retryCount,
+      logger,
     });
     messages.push(...chunkMessages);
   }


### PR DESCRIPTION
Improves Gmail batch fetch logging by requiring request/provider loggers to be passed through helper calls. Adds message-level retry context without using the reserved error field, and includes user context where it is already available in batch fetch flows. Updates the focused Gmail batch test coverage for rate-limit retry logging.