### PR TITLE
outlook: improve reconciliation logging

### DIFF
--- a/apps/web/utils/outlook/backfill-recent-messages.test.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.test.ts
@@ -28,6 +28,8 @@ describe("backfillRecentOutlookMessages", () => {
   });
 
   it("processes unseen recent messages oldest first", async () => {
+    const infoSpy = vi.spyOn(logger, "info");
+
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessagesWithPagination: vi
         .fn()
@@ -70,6 +72,27 @@ describe("backfillRecentOutlookMessages", () => {
     });
 
     expect(result).toEqual({ processedCount: 2, candidateCount: 3 });
+    expect(infoSpy).toHaveBeenCalledWith(
+      "Reconciling recent Outlook messages",
+      expect.objectContaining({
+        maxMessages: 5,
+        pageCount: 2,
+        candidateCount: 3,
+        unseenCount: 2,
+        subscriptionId: "subscription-id",
+      }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      "Finished reconciling recent Outlook messages",
+      expect.objectContaining({
+        maxMessages: 5,
+        pageCount: 2,
+        candidateCount: 3,
+        unseenCount: 2,
+        processedCount: 2,
+        subscriptionId: "subscription-id",
+      }),
+    );
     expect(processHistoryForUser).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -95,6 +118,8 @@ describe("backfillRecentOutlookMessages", () => {
   });
 
   it("returns without processing when there are no recent messages", async () => {
+    const infoSpy = vi.spyOn(logger, "info");
+
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessagesWithPagination: vi.fn().mockResolvedValue({
         messages: [],
@@ -110,6 +135,13 @@ describe("backfillRecentOutlookMessages", () => {
     });
 
     expect(result).toEqual({ processedCount: 0, candidateCount: 0 });
+    expect(infoSpy).toHaveBeenCalledWith(
+      "No recent Outlook messages found for reconciliation",
+      expect.objectContaining({
+        maxMessages: 5,
+        pageCount: 1,
+      }),
+    );
     expect(prisma.emailMessage.findMany).not.toHaveBeenCalled();
     expect(processHistoryForUser).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/outlook/backfill-recent-messages.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.ts
@@ -28,7 +28,7 @@ export async function backfillRecentOutlookMessages({
     logger,
   });
 
-  const candidateMessages = await listRecentMessages({
+  const { messages: candidateMessages, pageCount } = await listRecentMessages({
     provider,
     after,
     maxMessages,
@@ -38,6 +38,7 @@ export async function backfillRecentOutlookMessages({
     logger.info("No recent Outlook messages found for reconciliation", {
       after,
       maxMessages,
+      pageCount,
     });
     return { processedCount: 0, candidateCount: 0 };
   }
@@ -62,6 +63,8 @@ export async function backfillRecentOutlookMessages({
 
   logger.info("Reconciling recent Outlook messages", {
     after,
+    maxMessages,
+    pageCount,
     candidateCount: candidateMessages.length,
     unseenCount: unseenMessages.length,
     subscriptionId,
@@ -88,6 +91,16 @@ export async function backfillRecentOutlookMessages({
     }
   }
 
+  logger.info("Finished reconciling recent Outlook messages", {
+    after,
+    maxMessages,
+    pageCount,
+    candidateCount: candidateMessages.length,
+    unseenCount: unseenMessages.length,
+    processedCount,
+    subscriptionId,
+  });
+
   return {
     processedCount,
     candidateCount: candidateMessages.length,
@@ -106,6 +119,7 @@ async function listRecentMessages({
   const messages: ParsedMessage[] = [];
   const seenMessageIds = new Set<string>();
   let pageToken: string | undefined;
+  let pageCount = 0;
 
   while (messages.length < maxMessages) {
     const response = await provider.getMessagesWithPagination({
@@ -116,6 +130,7 @@ async function listRecentMessages({
       ),
       pageToken,
     });
+    pageCount++;
 
     for (const message of response.messages) {
       if (seenMessageIds.has(message.id)) continue;
@@ -127,5 +142,5 @@ async function listRecentMessages({
     pageToken = response.nextPageToken;
   }
 
-  return messages;
+  return { messages, pageCount };
 }


### PR DESCRIPTION
Improves observability for recent message reconciliation.

- Logs pagination and reconciliation totals for Outlook backfill
- Covers the new logging behavior in focused tests

Validation: pnpm test --run utils/outlook/backfill-recent-messages.test.ts