### PR TITLE
Add trial usage controls

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useReducer, useRef, useState } from "react";
-import Link from "next/link";
 import { PauseIcon, PlayIcon, SquareIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SectionDescription } from "@/components/Typography";
@@ -33,13 +32,13 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { fetchWithAccount } from "@/utils/fetch";
 import { Toggle } from "@/components/Toggle";
 import { hasTierAccess } from "@/utils/premium";
-import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 import { BulkProcessActivityLog } from "@/app/(app)/[emailAccountId]/assistant/BulkProcessActivityLog";
 import {
   bulkRunReducer,
   getProgressMessage,
   initialBulkRunState,
 } from "@/app/(app)/[emailAccountId]/assistant/bulk-run-rules-reducer";
+import { useEndStripeTrial } from "@/app/(app)/premium/ManageSubscription";
 
 const TRIAL_BULK_PROCESS_EMAIL_LIMIT = 200;
 
@@ -57,7 +56,7 @@ export function BulkRunRules() {
     premium,
     tier,
   } = usePremium();
-  const { PremiumModal, openModal } = usePremiumModal();
+  const { loading: loadingEndTrial, endTrial } = useEndStripeTrial();
 
   const isBusinessPlusTier = hasTierAccess({
     tier: tier || null,
@@ -195,32 +194,35 @@ export function BulkRunRules() {
                 />
               </div>
 
-              <div className="flex items-center justify-between gap-4">
-                <Toggle
-                  name="include-read"
-                  label="Include read emails"
-                  enabled={includeRead}
-                  onChange={(enabled) => setIncludeRead(enabled)}
-                  disabled={isProcessing || !isBusinessPlusTier}
-                />
-                {!isBusinessPlusTier && hasAiAccess && (
-                  <Link
-                    href="/premium"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      openModal();
-                    }}
-                    className="text-sm text-primary hover:underline whitespace-nowrap"
-                  >
-                    Upgrade to Professional to enable
-                  </Link>
-                )}
-              </div>
+              <Toggle
+                name="include-read"
+                label="Include read emails"
+                enabled={includeRead}
+                onChange={(enabled) => setIncludeRead(enabled)}
+                disabled={isProcessing || !isBusinessPlusTier}
+                tooltipText={
+                  !isBusinessPlusTier && hasAiAccess
+                    ? "Including read emails is available on the Professional plan."
+                    : undefined
+                }
+              />
 
               {isTrial && (
-                <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
-                  Trials can process up to {TRIAL_BULK_PROCESS_EMAIL_LIMIT} past
-                  emails at a time.
+                <div className="flex flex-col gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200 sm:flex-row sm:items-center sm:justify-between">
+                  <span>
+                    Trials can process up to {TRIAL_BULK_PROCESS_EMAIL_LIMIT}{" "}
+                    past emails at a time.
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    loading={loadingEndTrial}
+                    onClick={endTrial}
+                    className="self-start border-blue-300 bg-white text-blue-900 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-100 dark:hover:bg-blue-900 sm:self-auto"
+                  >
+                    Start paid plan now
+                  </Button>
                 </div>
               )}
 
@@ -280,7 +282,6 @@ export function BulkRunRules() {
           </LoadingContent>
         </DialogContent>
       </Dialog>
-      <PremiumModal />
     </div>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -41,6 +41,8 @@ import {
   initialBulkRunState,
 } from "@/app/(app)/[emailAccountId]/assistant/bulk-run-rules-reducer";
 
+const TRIAL_BULK_PROCESS_EMAIL_LIMIT = 200;
+
 export function BulkRunRules() {
   const { emailAccountId } = useAccount();
 
@@ -49,13 +51,19 @@ export function BulkRunRules() {
 
   const queue = useAiQueueState();
 
-  const { hasAiAccess, isLoading: isLoadingPremium, tier } = usePremium();
+  const {
+    hasAiAccess,
+    isLoading: isLoadingPremium,
+    premium,
+    tier,
+  } = usePremium();
   const { PremiumModal, openModal } = usePremiumModal();
 
   const isBusinessPlusTier = hasTierAccess({
     tier: tier || null,
     minimumTier: "PROFESSIONAL_MONTHLY",
   });
+  const isTrial = premium?.stripeSubscriptionStatus === "trialing";
 
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
@@ -97,7 +105,12 @@ export function BulkRunRules() {
     try {
       abortRef.current = await onRun(
         emailAccountId,
-        { startDate, endDate, includeRead },
+        {
+          startDate,
+          endDate,
+          includeRead,
+          maxEmails: isTrial ? TRIAL_BULK_PROCESS_EMAIL_LIMIT : undefined,
+        },
         (threads) => {
           dispatch({ type: "THREADS_QUEUED", threads });
         },
@@ -204,6 +217,13 @@ export function BulkRunRules() {
                 )}
               </div>
 
+              {isTrial && (
+                <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
+                  Trials can process up to {TRIAL_BULK_PROCESS_EMAIL_LIMIT} past
+                  emails at a time.
+                </div>
+              )}
+
               {(state.status !== "idle" ||
                 state.processedThreadIds.size > 0) && (
                 <BulkProcessActivityLog
@@ -272,7 +292,13 @@ async function onRun(
     startDate,
     endDate,
     includeRead,
-  }: { startDate: Date; endDate?: Date; includeRead?: boolean },
+    maxEmails,
+  }: {
+    startDate: Date;
+    endDate?: Date;
+    includeRead?: boolean;
+    maxEmails?: number;
+  },
   onThreadsQueued: (threads: ThreadsResponse["threads"]) => void,
   onComplete: (
     status: "success" | "error" | "cancelled",
@@ -335,22 +361,32 @@ async function onRun(
       nextPageToken = data.nextPageToken || "";
 
       const threadsWithoutPlan = data.threads.filter((t) => !t.plan);
+      const remainingEmails =
+        maxEmails === undefined ? undefined : maxEmails - totalProcessed;
+      if (remainingEmails !== undefined && remainingEmails <= 0) break;
 
-      onThreadsQueued(threadsWithoutPlan);
-      totalProcessed += threadsWithoutPlan.length;
+      const threadsToQueue =
+        remainingEmails === undefined
+          ? threadsWithoutPlan
+          : threadsWithoutPlan.slice(0, remainingEmails);
 
-      runAiRules(emailAccountId, threadsWithoutPlan, false);
+      onThreadsQueued(threadsToQueue);
+      totalProcessed += threadsToQueue.length;
+
+      runAiRules(emailAccountId, threadsToQueue, false);
 
       if (aborted) {
         onComplete("cancelled", totalProcessed);
         return;
       }
 
+      if (maxEmails !== undefined && totalProcessed >= maxEmails) break;
+
       if (!nextPageToken) break;
 
       // avoid gmail api rate limits
       // ai takes longer anyway
-      await sleep(threadsWithoutPlan.length ? 5000 : 2000);
+      await sleep(threadsToQueue.length ? 5000 : 2000);
     }
 
     onComplete("success", totalProcessed);

--- a/apps/web/app/(app)/premium/ManageSubscription.tsx
+++ b/apps/web/app/(app)/premium/ManageSubscription.tsx
@@ -3,10 +3,15 @@
 import { useState } from "react";
 import { CreditCardIcon } from "lucide-react";
 import Link from "next/link";
+import { toast } from "sonner";
+import { useSWRConfig } from "swr";
 import { env } from "@/env";
 import { Button } from "@/components/ui/button";
 import { toastError } from "@/components/Toast";
-import { getBillingPortalUrlAction } from "@/utils/actions/premium";
+import {
+  endStripeTrialAction,
+  getBillingPortalUrlAction,
+} from "@/utils/actions/premium";
 import { hasActiveAppleSubscription } from "@/utils/premium";
 
 const APPLE_SUBSCRIPTION_HELP_URL = "https://support.apple.com/en-us/118428";
@@ -20,6 +25,7 @@ export function ManageSubscription({
         appleRevokedAt?: string | Date | null | undefined;
         appleSubscriptionStatus?: string | null | undefined;
         stripeSubscriptionId: string | null | undefined;
+        stripeSubscriptionStatus?: string | null | undefined;
         lemonSqueezyCustomerId: number | null | undefined;
       }
     | null
@@ -27,6 +33,7 @@ export function ManageSubscription({
 }) {
   const { loading: loadingBillingPortal, openBillingPortal } =
     useOpenBillingPortal();
+  const { loading: loadingEndTrial, endTrial } = useEndStripeTrial();
   const hasAppleSubscription = hasActiveAppleSubscription(
     premium?.appleExpiresAt || null,
     premium?.appleRevokedAt || null,
@@ -39,6 +46,13 @@ export function ManageSubscription({
 
   return (
     <>
+      {premium?.stripeSubscriptionStatus === "trialing" && (
+        <Button loading={loadingEndTrial} onClick={endTrial} variant="outline">
+          <CreditCardIcon className="mr-2 h-4 w-4" />
+          Start paid plan now
+        </Button>
+      )}
+
       {premium?.stripeSubscriptionId && (
         <Button loading={loadingBillingPortal} onClick={openBillingPortal}>
           <CreditCardIcon className="mr-2 h-4 w-4" />
@@ -137,4 +151,30 @@ function useOpenBillingPortal() {
   };
 
   return { loading, openBillingPortal };
+}
+
+function useEndStripeTrial() {
+  const [loading, setLoading] = useState(false);
+  const { mutate } = useSWRConfig();
+
+  const endTrial = async () => {
+    setLoading(true);
+    const result = await endStripeTrialAction().finally(() => {
+      setLoading(false);
+    });
+
+    if (result?.serverError) {
+      toastError({ description: result.serverError });
+      return;
+    }
+
+    if (result?.data?.status === "active") {
+      toast.success("Your paid plan is active.");
+    } else {
+      toast.message("Your trial has ended.");
+    }
+    await mutate("/api/user/me");
+  };
+
+  return { loading, endTrial };
 }

--- a/apps/web/app/(app)/premium/ManageSubscription.tsx
+++ b/apps/web/app/(app)/premium/ManageSubscription.tsx
@@ -153,7 +153,7 @@ function useOpenBillingPortal() {
   return { loading, openBillingPortal };
 }
 
-function useEndStripeTrial() {
+export function useEndStripeTrial() {
   const [loading, setLoading] = useState(false);
   const { mutate } = useSWRConfig();
 

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -440,6 +440,73 @@ export const getBillingPortalUrlAction = actionClientUser
     return { url };
   });
 
+export const endStripeTrialAction = actionClientUser
+  .metadata({ name: "endStripeTrial" })
+  .action(async ({ ctx: { userId, logger } }) => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        premium: {
+          select: {
+            id: true,
+            stripeSubscriptionId: true,
+            stripeSubscriptionStatus: true,
+          },
+        },
+      },
+    });
+
+    const premium = user?.premium;
+    if (!premium?.stripeSubscriptionId) {
+      throw new SafeError("Stripe subscription not found");
+    }
+
+    if (premium.stripeSubscriptionStatus !== "trialing") {
+      throw new SafeError("Your trial has already ended");
+    }
+
+    const stripe = getStripe();
+    const subscription = await stripe.subscriptions.update(
+      premium.stripeSubscriptionId,
+      {
+        trial_end: "now",
+      },
+    );
+    const subscriptionItem = subscription.items.data[0];
+
+    await prisma.premium.update({
+      where: { id: premium.id },
+      data: {
+        stripeSubscriptionStatus:
+          subscription.status === "trialing" &&
+          subscription.cancel_at_period_end
+            ? "canceled"
+            : subscription.status,
+        stripeTrialEnd: subscription.trial_end
+          ? new Date(subscription.trial_end * 1000)
+          : null,
+        stripeTrialConvertedAt:
+          subscription.status === "active" ? new Date() : undefined,
+        stripeRenewsAt: subscriptionItem?.current_period_end
+          ? new Date(subscriptionItem.current_period_end * 1000)
+          : null,
+        stripeCancelAtPeriodEnd: subscription.cancel_at_period_end,
+        stripeCanceledAt: subscription.canceled_at
+          ? new Date(subscription.canceled_at * 1000)
+          : null,
+        stripeEndedAt: subscription.ended_at
+          ? new Date(subscription.ended_at * 1000)
+          : null,
+      },
+    });
+
+    logger.info("Ended Stripe trial", {
+      subscriptionStatus: subscription.status,
+    });
+
+    return { status: subscription.status };
+  });
+
 export const generateCheckoutSessionAction = actionClientUser
   .metadata({ name: "generateCheckoutSession" })
   .inputSchema(

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -448,7 +448,6 @@ export const endStripeTrialAction = actionClientUser
       select: {
         premium: {
           select: {
-            id: true,
             stripeSubscriptionId: true,
             stripeSubscriptionStatus: true,
           },
@@ -472,33 +471,6 @@ export const endStripeTrialAction = actionClientUser
         trial_end: "now",
       },
     );
-    const subscriptionItem = subscription.items.data[0];
-
-    await prisma.premium.update({
-      where: { id: premium.id },
-      data: {
-        stripeSubscriptionStatus:
-          subscription.status === "trialing" &&
-          subscription.cancel_at_period_end
-            ? "canceled"
-            : subscription.status,
-        stripeTrialEnd: subscription.trial_end
-          ? new Date(subscription.trial_end * 1000)
-          : null,
-        stripeTrialConvertedAt:
-          subscription.status === "active" ? new Date() : undefined,
-        stripeRenewsAt: subscriptionItem?.current_period_end
-          ? new Date(subscriptionItem.current_period_end * 1000)
-          : null,
-        stripeCancelAtPeriodEnd: subscription.cancel_at_period_end,
-        stripeCanceledAt: subscription.canceled_at
-          ? new Date(subscription.canceled_at * 1000)
-          : null,
-        stripeEndedAt: subscription.ended_at
-          ? new Date(subscription.ended_at * 1000)
-          : null,
-      },
-    });
 
     logger.info("Ended Stripe trial", {
       subscriptionStatus: subscription.status,


### PR DESCRIPTION
Adds trial-specific controls for bulk email processing and subscription conversion. Trial users are capped in the past-email processing flow, and Stripe trial users can end their trial immediately from subscription management.

Validation:
- `cd apps/web && pnpm exec biome check app/'(app)'/'[emailAccountId]'/assistant/BulkRunRules.tsx app/'(app)'/premium/ManageSubscription.tsx utils/actions/premium.ts`
- `cd apps/web && pnpm test --run utils/llms/index.generate-object.test.ts utils/llms/model-usage-guard.test.ts`