### PR TITLE
Update footer contact link

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -63,6 +63,7 @@ export const footerNavigation = {
   support: [
     { name: "Pricing", href: "/pricing" },
     { name: "Support", href: "/support" },
+    { name: "Contact us", href: `mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}` },
     {
       name: "Documentation",
       href: "https://docs.getinboxzero.com",
@@ -146,6 +147,7 @@ const selfHostedFooter = {
       href: "https://docs.getinboxzero.com",
       target: "_blank",
     },
+    { name: "Contact us", href: `mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}` },
     { name: "GitHub", href: "/github", target: "_blank" },
     { name: "Discord", href: "/discord", target: "_blank" },
   ],

--- a/apps/web/components/new-landing/sections/Footer.tsx
+++ b/apps/web/components/new-landing/sections/Footer.tsx
@@ -21,6 +21,7 @@ const selfHostedFooter = {
       href: "https://docs.getinboxzero.com",
       target: "_blank",
     },
+    { name: "Contact us", href: `mailto:${env.NEXT_PUBLIC_SUPPORT_EMAIL}` },
     { name: "GitHub", href: "/github", target: "_blank" },
     { name: "Discord", href: "/discord", target: "_blank" },
   ],

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -322,7 +322,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_SUPPORT_EMAIL: z
       .string()
       .optional()
-      .default("elie@getinboxzero.com"),
+      .default("support@getinboxzero.com"),
     NEXT_PUBLIC_GTM_ID: z.string().optional(),
     NEXT_PUBLIC_CRISP_WEBSITE_ID: z.string().optional(),
     NEXT_PUBLIC_WELCOME_UPGRADE_ENABLED: booleanString


### PR DESCRIPTION
Updates footer contact links to use the configured public support email.

- Adds a Contact us link to footer navigation variants.
- Updates the default support email configuration.

Performance impact: no added runtime work beyond rendering an additional static footer link; no database or network calls; no hot-path risk.