### PR TITLE
auth: Add SCIM support

### DIFF
--- a/apps/web/__tests__/integration/scim-better-auth.test.ts
+++ b/apps/web/__tests__/integration/scim-better-auth.test.ts
@@ -1,0 +1,153 @@
+import { scim } from "@better-auth/scim";
+import { betterAuth } from "better-auth";
+import { describe, expect, test } from "vitest";
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
+const PROVIDER_ID = "okta-provider";
+const SCIM_SECRET = "scim-secret";
+const BASE_URL = "http://localhost:3000";
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "Better Auth SCIM integration",
+  { timeout: 30_000 },
+  () => {
+    test("provisions, lists, updates, patches, and deletes a SCIM user", async () => {
+      const auth = betterAuth({
+        baseURL: BASE_URL,
+        secret: "test-secret-with-enough-entropy-for-scim",
+        plugins: [
+          scim({
+            defaultSCIM: [
+              {
+                providerId: PROVIDER_ID,
+                scimToken: SCIM_SECRET,
+              },
+            ],
+          }),
+        ],
+      });
+      const token = createBearerToken();
+
+      const configResponse = await auth.handler(
+        scimRequest("/api/auth/scim/v2/ServiceProviderConfig", { token }),
+      );
+      expect(configResponse.status).toBe(200);
+
+      const createResponse = await auth.handler(
+        scimRequest("/api/auth/scim/v2/Users", {
+          method: "POST",
+          token,
+          body: {
+            userName: "user@example.com",
+            externalId: "00u_test_user",
+            name: {
+              givenName: "Test",
+              familyName: "User",
+            },
+            emails: [{ value: "user@example.com", primary: true }],
+          },
+        }),
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+      expect(created.userName).toBe("user@example.com");
+      expect(created.externalId).toBe("00u_test_user");
+
+      const listResponse = await auth.handler(
+        scimRequest(
+          '/api/auth/scim/v2/Users?filter=userName eq "user@example.com"',
+          { token },
+        ),
+      );
+      expect(listResponse.status).toBe(200);
+      const list = await listResponse.json();
+      expect(list.totalResults).toBe(1);
+      expect(list.Resources[0].id).toBe(created.id);
+
+      const updateResponse = await auth.handler(
+        scimRequest(`/api/auth/scim/v2/Users/${created.id}`, {
+          method: "PUT",
+          token,
+          body: {
+            userName: "updated@example.com",
+            externalId: "00u_test_user",
+            name: {
+              formatted: "Updated User",
+            },
+            emails: [{ value: "updated@example.com", primary: true }],
+          },
+        }),
+      );
+      expect(updateResponse.status).toBe(200);
+      const updated = await updateResponse.json();
+      expect(updated.userName).toBe("updated@example.com");
+      expect(updated.displayName).toBe("Updated User");
+
+      const patchResponse = await auth.handler(
+        scimRequest(`/api/auth/scim/v2/Users/${created.id}`, {
+          method: "PATCH",
+          token,
+          body: {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations: [
+              {
+                op: "replace",
+                path: "name.formatted",
+                value: "Patched User",
+              },
+            ],
+          },
+        }),
+      );
+      expect(patchResponse.status).toBe(204);
+
+      const getResponse = await auth.handler(
+        scimRequest(`/api/auth/scim/v2/Users/${created.id}`, { token }),
+      );
+      expect(getResponse.status).toBe(200);
+      const patched = await getResponse.json();
+      expect(patched.displayName).toBe("Patched User");
+
+      const deleteResponse = await auth.handler(
+        scimRequest(`/api/auth/scim/v2/Users/${created.id}`, {
+          method: "DELETE",
+          token,
+        }),
+      );
+      expect(deleteResponse.status).toBe(204);
+
+      const deletedGetResponse = await auth.handler(
+        scimRequest(`/api/auth/scim/v2/Users/${created.id}`, { token }),
+      );
+      expect(deletedGetResponse.status).toBe(404);
+    });
+  },
+);
+
+function createBearerToken() {
+  return Buffer.from(`${SCIM_SECRET}:${PROVIDER_ID}`, "utf8").toString(
+    "base64url",
+  );
+}
+
+function scimRequest(
+  path: string,
+  {
+    method = "GET",
+    token,
+    body,
+  }: {
+    method?: string;
+    token: string;
+    body?: unknown;
+  },
+) {
+  return new Request(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body ? { "content-type": "application/scim+json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}

--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,4 +1,5 @@
 import { betterAuthConfig } from "@/utils/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 
-export const { POST, GET } = toNextJsHandler(betterAuthConfig);
+export const { POST, GET, PUT, PATCH, DELETE } =
+  toNextJsHandler(betterAuthConfig);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "@apple/app-store-server-library": "3.0.0",
     "@asteasolutions/zod-to-openapi": "8.5.0",
     "@better-auth/expo": "1.6.5",
+    "@better-auth/scim": "1.6.5",
     "@better-auth/sso": "1.6.5",
     "@chat-adapter/slack": "4.26.0",
     "@chat-adapter/state-ioredis": "4.26.0",

--- a/apps/web/prisma/migrations/20260507150000_add_scim_provider/migration.sql
+++ b/apps/web/prisma/migrations/20260507150000_add_scim_provider/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "scimProvider" (
+    "id" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "scimToken" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "scimProvider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scimProvider_providerId_key" ON "scimProvider"("providerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "scimProvider_scimToken_key" ON "scimProvider"("scimToken");
+
+-- CreateIndex
+CREATE INDEX "scimProvider_organizationId_idx" ON "scimProvider"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "scimProvider_userId_idx" ON "scimProvider"("userId");
+
+-- AddForeignKey
+ALTER TABLE "scimProvider" ADD CONSTRAINT "scimProvider_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "scimProvider" ADD CONSTRAINT "scimProvider_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -104,6 +104,7 @@ model User {
   // Referral relationships
   referralsMade    Referral[] @relation("ReferrerUser")
   referralReceived Referral?  @relation("ReferredUser")
+  scimProviders    ScimProvider[]
 }
 
 enum ApiKeyScope {
@@ -225,6 +226,7 @@ model Organization {
   updatedAt   DateTime      @updatedAt
   members     Member[]
   SsoProvider SsoProvider[]
+  ScimProvider ScimProvider[]
   sessions    Session[]
   invitations Invitation[]
 }
@@ -286,6 +288,22 @@ model SsoProvider {
   @@index([emailAccountId])
   @@index([organizationId])
   @@map("ssoProvider")
+}
+
+model ScimProvider {
+  id             String        @id @default(cuid())
+  providerId     String        @unique
+  scimToken      String        @unique
+  organizationId String?
+  organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  userId         String?
+  user           User?         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  @@index([organizationId])
+  @@index([userId])
+  @@map("scimProvider")
 }
 
 model Digest {

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -1,4 +1,5 @@
 import { sso } from "@better-auth/sso";
+import { scim } from "@better-auth/scim";
 import { expo } from "@better-auth/expo";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 import type { GenericOAuthConfig } from "better-auth/plugins/generic-oauth";
@@ -47,6 +48,7 @@ import {
   hasAppleOauthConfig,
 } from "@/utils/oauth/provider-config";
 import { getAppleClientSecret } from "@/utils/auth/apple-client-secret";
+import { assertCanGenerateScimToken } from "@/utils/auth/scim";
 import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("auth");
@@ -215,6 +217,16 @@ export const betterAuthConfig = betterAuth({
     sso({
       disableImplicitSignUp: false,
       organizationProvisioning: { disabled: true },
+    }),
+    scim({
+      providerOwnership: { enabled: true },
+      storeSCIMToken: "hashed",
+      beforeSCIMTokenGenerated: async ({ user, scimToken }) => {
+        await assertCanGenerateScimToken({
+          userEmail: user.email,
+          scimToken,
+        });
+      },
     }),
     ...(genericOauthPlugin ? [genericOauthPlugin] : []),
     ...(mobileAuthOrigins.length > 0 ? [expo()] : []),

--- a/apps/web/utils/auth/scim.test.ts
+++ b/apps/web/utils/auth/scim.test.ts
@@ -1,0 +1,80 @@
+import { APIError } from "better-auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  assertCanGenerateScimToken,
+  getScimProviderIdFromToken,
+} from "@/utils/auth/scim";
+import { isAdmin } from "@/utils/admin";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/admin", () => ({
+  isAdmin: vi.fn(),
+}));
+
+describe("getScimProviderIdFromToken", () => {
+  it("extracts the provider id from a Better Auth SCIM bearer token", () => {
+    const token = createToken("secret", "provider-id");
+
+    expect(getScimProviderIdFromToken(token)).toBe("provider-id");
+  });
+
+  it("returns null when the token does not contain a provider id", () => {
+    const token = Buffer.from("secret-only", "utf8").toString("base64url");
+
+    expect(getScimProviderIdFromToken(token)).toBeNull();
+  });
+});
+
+describe("assertCanGenerateScimToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects non-admin users before checking providers", async () => {
+    vi.mocked(isAdmin).mockReturnValue(false);
+
+    await expect(
+      assertCanGenerateScimToken({
+        userEmail: "user@example.com",
+        scimToken: createToken("secret", "provider-id"),
+      }),
+    ).rejects.toBeInstanceOf(APIError);
+
+    expect(prisma.ssoProvider.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects tokens for providers that are not registered for SSO", async () => {
+    vi.mocked(isAdmin).mockReturnValue(true);
+    prisma.ssoProvider.findUnique.mockResolvedValue(null);
+
+    await expect(
+      assertCanGenerateScimToken({
+        userEmail: "admin@example.com",
+        scimToken: createToken("secret", "missing-provider"),
+      }),
+    ).rejects.toBeInstanceOf(APIError);
+
+    expect(prisma.ssoProvider.findUnique).toHaveBeenCalledWith({
+      where: { providerId: "missing-provider" },
+      select: { id: true },
+    });
+  });
+
+  it("allows admins to generate tokens for registered SSO providers", async () => {
+    vi.mocked(isAdmin).mockReturnValue(true);
+    prisma.ssoProvider.findUnique.mockResolvedValue({ id: "sso-provider-id" });
+
+    await expect(
+      assertCanGenerateScimToken({
+        userEmail: "admin@example.com",
+        scimToken: createToken("secret", "provider-id"),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+function createToken(secret: string, providerId: string) {
+  return Buffer.from(`${secret}:${providerId}`, "utf8").toString("base64url");
+}

--- a/apps/web/utils/auth/scim.ts
+++ b/apps/web/utils/auth/scim.ts
@@ -1,0 +1,42 @@
+import { APIError } from "better-auth";
+import { isAdmin } from "@/utils/admin";
+import prisma from "@/utils/prisma";
+
+export async function assertCanGenerateScimToken({
+  userEmail,
+  scimToken,
+}: {
+  userEmail?: string | null;
+  scimToken: string;
+}) {
+  if (!isAdmin({ email: userEmail })) {
+    throw new APIError("FORBIDDEN", {
+      message: "Only admins can generate SCIM tokens",
+    });
+  }
+
+  const providerId = getScimProviderIdFromToken(scimToken);
+  if (!providerId) {
+    throw new APIError("BAD_REQUEST", {
+      message: "Invalid SCIM token",
+    });
+  }
+
+  const ssoProvider = await prisma.ssoProvider.findUnique({
+    where: { providerId },
+    select: { id: true },
+  });
+
+  if (!ssoProvider) {
+    throw new APIError("BAD_REQUEST", {
+      message: "SCIM tokens can only be generated for registered SSO providers",
+    });
+  }
+}
+
+export function getScimProviderIdFromToken(scimToken: string) {
+  const decoded = Buffer.from(scimToken, "base64url").toString("utf8");
+  const [, providerId] = decoded.split(":");
+
+  return providerId || null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@better-auth/expo':
         specifier: 1.6.5
         version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(better-auth@1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3)))
+      '@better-auth/scim':
+        specifier: 1.6.5
+        version: 1.6.5(2eb0e39714589a30932f89b7676b887b)
       '@better-auth/sso':
         specifier: 1.6.5
         version: 1.6.5(784acc98c6f48fb6cb4a5e5dd24c49de)
@@ -1851,6 +1854,14 @@ packages:
         optional: true
       prisma:
         optional: true
+
+  '@better-auth/scim@1.6.5':
+    resolution: {integrity: sha512-UtgsDCq7pXKKCsm02l5ibLPgv7/KX/J07nCoAw4DWIKcHZsC1AI0gJbZmAvGyWP2Zv7pPbsQqQmrbG63HDN/Cg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.5
+      '@better-auth/utils': 0.4.0
+      better-auth: ^1.6.5
+      better-call: 1.3.5
 
   '@better-auth/sso@1.6.5':
     resolution: {integrity: sha512-9mmdv94+dblf9+9TsOJeF+CVDVjPMydbhhdO8bjR8riwg0Dc8eJple2w1fgo/5wBEDyVRpipU8K13QSR7wlyzQ==}
@@ -14478,6 +14489,14 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       prisma: 7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+
+  '@better-auth/scim@1.6.5(2eb0e39714589a30932f89b7676b887b)':
+    dependencies:
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.2.1))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+      better-auth: 1.6.5(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(mongodb@7.1.0(gcp-metadata@7.0.1)(socks@2.8.7))(mysql2@3.15.3)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(svelte@5.38.6(@typescript-eslint/types@8.58.0))(vitest@4.1.4)(vue@3.5.20(typescript@6.0.3))
+      better-call: 1.3.5(zod@4.2.1)
+      zod: 4.3.6
 
   '@better-auth/sso@1.6.5(784acc98c6f48fb6cb4a5e5dd24c49de)':
     dependencies:


### PR DESCRIPTION
Adds SCIM provisioning support to the auth flow with Better Auth and stores provider tokens in the database. The integration keeps token generation restricted to admins and registered SSO providers.

- Adds SCIM provider persistence and migration
- Enables SCIM HTTP methods on the auth route
- Adds unit and integration coverage for token gating and SCIM user lifecycle