### PR TITLE
auth: Restrict implicit account linking

### DIFF
--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -256,7 +256,9 @@ export const betterAuthConfig = betterAuth({
     storeStateStrategy: "cookie", // Required for oAuthProxy to encrypt state
     accountLinking: {
       enabled: true,
-      trustedProviders: ["google", "microsoft", "apple"],
+      // Microsoft Entra email claims can be mutable/unverified, so Microsoft
+      // must not implicitly link users by email during social sign-in.
+      trustedProviders: ["google", "apple"],
     },
   },
   verification: {


### PR DESCRIPTION
Prevents Microsoft OAuth sign-in from being treated as a trusted source for implicit email-based account linking.

- Keeps existing provider-account sign-in behavior intact
- Leaves a short code comment documenting why this provider is excluded

Tests: cd apps/web && pnpm test auth.test.ts --run