### PR TITLE
deployment: Add Kubernetes Helm chart

### DIFF
--- a/charts/inbox-zero/Chart.yaml
+++ b/charts/inbox-zero/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: inbox-zero
+description: A Helm chart for running Inbox Zero on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - inbox-zero
+  - email
+  - ai
+  - nextjs
+home: https://www.getinboxzero.com
+sources:
+  - https://github.com/elie222/inbox-zero
+maintainers:
+  - name: Inbox Zero

--- a/charts/inbox-zero/README.md
+++ b/charts/inbox-zero/README.md
@@ -2,88 +2,34 @@
 
 This chart maps the Docker Compose self-hosting stack onto Kubernetes:
 
-- `web` Deployment: runs the Next.js standalone server from the published Inbox Zero image.
-- `migrate` Job: runs Prisma migrations before Helm installs or upgrades the app when managed Postgres is enabled.
-- `worker` Deployment: optional BullMQ worker using the same image and `/app/docker/scripts/start-worker.sh`.
-- `cron` CronJobs: call the app's scheduled endpoints with `CRON_SECRET`.
-- `postgresql` StatefulSet: optional in-cluster Postgres for simple installs.
-- `redis` StatefulSet and `redis-http` Deployment: optional Redis plus an Upstash-compatible HTTP bridge.
-- `ingress` and `service`: expose the web app inside or outside the cluster.
+- `web` Deployment for the Next.js app
+- `worker` Deployment for the optional BullMQ worker
+- CronJobs for scheduled endpoints
+- optional bundled Postgres, Redis, and Redis HTTP bridge for demos
+- managed Postgres and Redis configuration for production
+- optional Ingress and ServiceAccount resources
 
 For production, use managed Postgres and managed Redis. The bundled StatefulSets are intended for demos and small self-hosted installs, not production workloads that need backups, failover, monitoring, and tested restores.
 
+## Documentation
+
+Use the Kubernetes hosting guide for installation and operations:
+
+- [Kubernetes Deployment](../../docs/hosting/kubernetes.mdx)
+- [Environment Variables](../../docs/hosting/environment-variables.mdx)
+
 ## Install
 
-Create a values file with real secrets:
-
-```yaml
-ingress:
-  enabled: true
-  className: nginx
-  hosts:
-    - host: app.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: inbox-zero-tls
-      hosts:
-        - app.example.com
-
-env:
-  NEXT_PUBLIC_BASE_URL: https://app.example.com
-  GOOGLE_PUBSUB_TOPIC_NAME: projects/example/topics/inbox-zero
-  DEFAULT_LLM_PROVIDER: openai
-  DEFAULT_LLM_MODEL: gpt-5.4-mini
-
-secretEnv:
-  AUTH_SECRET: change-me
-  GOOGLE_CLIENT_ID: change-me
-  GOOGLE_CLIENT_SECRET: change-me
-  EMAIL_ENCRYPT_SECRET: change-me
-  EMAIL_ENCRYPT_SALT: change-me
-  INTERNAL_API_KEY: change-me
-  API_KEY_SALT: change-me
-  CRON_SECRET: change-me
-  OPENAI_API_KEY: change-me
-  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
-
-postgresql:
-  auth:
-    password: replace-with-random-value
-
-redis:
-  auth:
-    password: replace-with-random-value
-
-redisHttp:
-  token: replace-with-random-value
-```
-
-Then install:
-
 ```bash
-helm upgrade --install inbox-zero ./charts/inbox-zero -n inbox-zero --create-namespace -f values.prod.yaml
+helm upgrade --install inbox-zero ./charts/inbox-zero \
+  -n inbox-zero \
+  --create-namespace \
+  -f values.prod.yaml
 ```
 
-## Recommended Production Values
+## Production Shape
 
-Use managed Postgres and Redis by enabling the external service blocks:
-
-```yaml
-externalDatabase:
-  enabled: true
-  databaseUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
-  directUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
-
-externalRedis:
-  enabled: true
-  redisUrl: rediss://:password@redis.example.com:6379
-  upstashRedisUrl: https://example.upstash.io
-  upstashRedisToken: change-me
-```
-
-For production secrets, prefer pre-created Kubernetes Secrets:
+Use managed data services through existing Kubernetes Secrets:
 
 ```yaml
 externalDatabase:
@@ -95,72 +41,25 @@ externalRedis:
   enabled: true
   existingSecret:
     name: inbox-zero-redis
-```
 
-Those Secrets should contain:
-
-```env
-DATABASE_URL=postgresql://...
-DIRECT_URL=postgresql://...
-REDIS_URL=rediss://...
-UPSTASH_REDIS_URL=https://...
-UPSTASH_REDIS_TOKEN=...
-```
-
-You can also keep all app secrets outside Helm:
-
-```yaml
 existingSecret: inbox-zero-secrets
-existingConfigMap: inbox-zero-config
 ```
 
-The existing Secret should contain the same environment-variable keys the app expects, such as `DATABASE_URL`, `DIRECT_URL`, `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, and provider API keys.
+The app environment keys belong in `inbox-zero-secrets`; see the environment variable reference for the full list.
 
-If you use `existingSecret` with bundled Postgres or Redis, it must also contain `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, `UPSTASH_REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
+## Demo Data Services
 
-If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
-
-## Background Jobs
-
-The default chart enables the BullMQ worker:
+Bundled Postgres, Redis, and Redis HTTP require explicit secret values:
 
 ```yaml
-env:
-  QUEUE_BACKEND: bullmq
-worker:
-  enabled: true
+postgresql:
+  auth:
+    password: replace-with-random-value
+
+redis:
+  auth:
+    password: replace-with-random-value
+
+redisHttp:
+  token: replace-with-random-value
 ```
-
-To use QStash instead:
-
-```yaml
-env:
-  QUEUE_BACKEND: qstash
-worker:
-  enabled: false
-secretEnv:
-  QSTASH_TOKEN: change-me
-  QSTASH_CURRENT_SIGNING_KEY: change-me
-  QSTASH_NEXT_SIGNING_KEY: change-me
-```
-
-## Smoke Test
-
-```bash
-kubectl get pods -n inbox-zero
-kubectl rollout status deploy/inbox-zero-web -n inbox-zero
-kubectl port-forward svc/inbox-zero-web 3000:80 -n inbox-zero
-curl http://localhost:3000/api/health
-```
-
-## Scaling Notes
-
-With `externalDatabase.enabled=true`, Helm runs migrations in a pre-install/pre-upgrade Job and sets `SKIP_DB_MIGRATIONS=true` on the web pods. This keeps multi-replica web rollouts cleaner.
-
-Bundled Postgres installs keep the web container's startup migration behavior because the database is created as part of the same Helm release.
-
-Bundled Postgres, Redis, and Redis HTTP require explicit secret values. Generate them before installing, for example with `openssl rand -hex 32`.
-
-CronJobs call the internal web Service, so they do not need public network access. If `CRON_SECRET` is empty, scheduled requests will fail once the app requires authorization for those endpoints.
-
-Cron schedules are configured under `cron.jobs`. The defaults follow the Docker self-hosting setup, so some schedules differ from hosted deployment schedules.

--- a/charts/inbox-zero/README.md
+++ b/charts/inbox-zero/README.md
@@ -116,7 +116,7 @@ existingConfigMap: inbox-zero-config
 
 The existing Secret should contain the same environment-variable keys the app expects, such as `DATABASE_URL`, `DIRECT_URL`, `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, and provider API keys.
 
-If you use `existingSecret` with bundled Postgres or Redis, it must also contain `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
+If you use `existingSecret` with bundled Postgres or Redis, it must also contain `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, `UPSTASH_REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
 
 If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
 

--- a/charts/inbox-zero/README.md
+++ b/charts/inbox-zero/README.md
@@ -10,7 +10,7 @@ This chart maps the Docker Compose self-hosting stack onto Kubernetes:
 - `redis` StatefulSet and `redis-http` Deployment: optional Redis plus an Upstash-compatible HTTP bridge.
 - `ingress` and `service`: expose the web app inside or outside the cluster.
 
-For production, use managed Postgres and managed Redis. The bundled StatefulSets are intended for demos and small self-hosted installs.
+For production, use managed Postgres and managed Redis. The bundled StatefulSets are intended for demos and small self-hosted installs, not production workloads that need backups, failover, monitoring, and tested restores.
 
 ## Install
 

--- a/charts/inbox-zero/README.md
+++ b/charts/inbox-zero/README.md
@@ -47,6 +47,17 @@ secretEnv:
   CRON_SECRET: change-me
   OPENAI_API_KEY: change-me
   GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
+
+postgresql:
+  auth:
+    password: replace-with-random-value
+
+redis:
+  auth:
+    password: replace-with-random-value
+
+redisHttp:
+  token: replace-with-random-value
 ```
 
 Then install:
@@ -105,6 +116,8 @@ existingConfigMap: inbox-zero-config
 
 The existing Secret should contain the same environment-variable keys the app expects, such as `DATABASE_URL`, `DIRECT_URL`, `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, and provider API keys.
 
+If you use `existingSecret` with bundled Postgres or Redis, it must also contain `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
+
 If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
 
 ## Background Jobs
@@ -146,4 +159,8 @@ With `externalDatabase.enabled=true`, Helm runs migrations in a pre-install/pre-
 
 Bundled Postgres installs keep the web container's startup migration behavior because the database is created as part of the same Helm release.
 
+Bundled Postgres, Redis, and Redis HTTP require explicit secret values. Generate them before installing, for example with `openssl rand -hex 32`.
+
 CronJobs call the internal web Service, so they do not need public network access. If `CRON_SECRET` is empty, scheduled requests will fail once the app requires authorization for those endpoints.
+
+Cron schedules are configured under `cron.jobs`. The defaults follow the Docker self-hosting setup, so some schedules differ from hosted deployment schedules.

--- a/charts/inbox-zero/README.md
+++ b/charts/inbox-zero/README.md
@@ -1,0 +1,149 @@
+# Inbox Zero Helm Chart
+
+This chart maps the Docker Compose self-hosting stack onto Kubernetes:
+
+- `web` Deployment: runs the Next.js standalone server from the published Inbox Zero image.
+- `migrate` Job: runs Prisma migrations before Helm installs or upgrades the app when managed Postgres is enabled.
+- `worker` Deployment: optional BullMQ worker using the same image and `/app/docker/scripts/start-worker.sh`.
+- `cron` CronJobs: call the app's scheduled endpoints with `CRON_SECRET`.
+- `postgresql` StatefulSet: optional in-cluster Postgres for simple installs.
+- `redis` StatefulSet and `redis-http` Deployment: optional Redis plus an Upstash-compatible HTTP bridge.
+- `ingress` and `service`: expose the web app inside or outside the cluster.
+
+For production, use managed Postgres and managed Redis. The bundled StatefulSets are intended for demos and small self-hosted installs.
+
+## Install
+
+Create a values file with real secrets:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: inbox-zero-tls
+      hosts:
+        - app.example.com
+
+env:
+  NEXT_PUBLIC_BASE_URL: https://app.example.com
+  GOOGLE_PUBSUB_TOPIC_NAME: projects/example/topics/inbox-zero
+  DEFAULT_LLM_PROVIDER: openai
+  DEFAULT_LLM_MODEL: gpt-5.4-mini
+
+secretEnv:
+  AUTH_SECRET: change-me
+  GOOGLE_CLIENT_ID: change-me
+  GOOGLE_CLIENT_SECRET: change-me
+  EMAIL_ENCRYPT_SECRET: change-me
+  EMAIL_ENCRYPT_SALT: change-me
+  INTERNAL_API_KEY: change-me
+  API_KEY_SALT: change-me
+  CRON_SECRET: change-me
+  OPENAI_API_KEY: change-me
+  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
+```
+
+Then install:
+
+```bash
+helm upgrade --install inbox-zero ./charts/inbox-zero -n inbox-zero --create-namespace -f values.prod.yaml
+```
+
+## Recommended Production Values
+
+Use managed Postgres and Redis by enabling the external service blocks:
+
+```yaml
+externalDatabase:
+  enabled: true
+  databaseUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
+  directUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
+
+externalRedis:
+  enabled: true
+  redisUrl: rediss://:password@redis.example.com:6379
+  upstashRedisUrl: https://example.upstash.io
+  upstashRedisToken: change-me
+```
+
+For production secrets, prefer pre-created Kubernetes Secrets:
+
+```yaml
+externalDatabase:
+  enabled: true
+  existingSecret:
+    name: inbox-zero-database
+
+externalRedis:
+  enabled: true
+  existingSecret:
+    name: inbox-zero-redis
+```
+
+Those Secrets should contain:
+
+```env
+DATABASE_URL=postgresql://...
+DIRECT_URL=postgresql://...
+REDIS_URL=rediss://...
+UPSTASH_REDIS_URL=https://...
+UPSTASH_REDIS_TOKEN=...
+```
+
+You can also keep all app secrets outside Helm:
+
+```yaml
+existingSecret: inbox-zero-secrets
+existingConfigMap: inbox-zero-config
+```
+
+The existing Secret should contain the same environment-variable keys the app expects, such as `DATABASE_URL`, `DIRECT_URL`, `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, and provider API keys.
+
+If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
+
+## Background Jobs
+
+The default chart enables the BullMQ worker:
+
+```yaml
+env:
+  QUEUE_BACKEND: bullmq
+worker:
+  enabled: true
+```
+
+To use QStash instead:
+
+```yaml
+env:
+  QUEUE_BACKEND: qstash
+worker:
+  enabled: false
+secretEnv:
+  QSTASH_TOKEN: change-me
+  QSTASH_CURRENT_SIGNING_KEY: change-me
+  QSTASH_NEXT_SIGNING_KEY: change-me
+```
+
+## Smoke Test
+
+```bash
+kubectl get pods -n inbox-zero
+kubectl rollout status deploy/inbox-zero-web -n inbox-zero
+kubectl port-forward svc/inbox-zero-web 3000:80 -n inbox-zero
+curl http://localhost:3000/api/health
+```
+
+## Scaling Notes
+
+With `externalDatabase.enabled=true`, Helm runs migrations in a pre-install/pre-upgrade Job and sets `SKIP_DB_MIGRATIONS=true` on the web pods. This keeps multi-replica web rollouts cleaner.
+
+Bundled Postgres installs keep the web container's startup migration behavior because the database is created as part of the same Helm release.
+
+CronJobs call the internal web Service, so they do not need public network access. If `CRON_SECRET` is empty, scheduled requests will fail once the app requires authorization for those endpoints.

--- a/charts/inbox-zero/templates/_helpers.tpl
+++ b/charts/inbox-zero/templates/_helpers.tpl
@@ -1,0 +1,154 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inbox-zero.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "inbox-zero.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "inbox-zero.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "inbox-zero.labels" -}}
+helm.sh/chart: {{ include "inbox-zero.chart" . }}
+app.kubernetes.io/name: {{ include "inbox-zero.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "inbox-zero.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inbox-zero.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "inbox-zero.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "inbox-zero.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "inbox-zero.configMapName" -}}
+{{- default (printf "%s-config" (include "inbox-zero.fullname" .)) .Values.existingConfigMap -}}
+{{- end -}}
+
+{{- define "inbox-zero.secretName" -}}
+{{- default (printf "%s-secret" (include "inbox-zero.fullname" .)) .Values.existingSecret -}}
+{{- end -}}
+
+{{- define "inbox-zero.webServiceName" -}}
+{{- printf "%s-web" (include "inbox-zero.fullname" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.postgresqlServiceName" -}}
+{{- printf "%s-postgresql" (include "inbox-zero.fullname" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.redisServiceName" -}}
+{{- printf "%s-redis" (include "inbox-zero.fullname" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.redisHttpServiceName" -}}
+{{- printf "%s-redis-http" (include "inbox-zero.fullname" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.databaseUrl" -}}
+{{- printf "postgresql://%s:%s@%s:5432/%s?schema=public" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "inbox-zero.postgresqlServiceName" .) .Values.postgresql.auth.database -}}
+{{- end -}}
+
+{{- define "inbox-zero.redisUrl" -}}
+{{- printf "redis://%s:6379" (include "inbox-zero.redisServiceName" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.redisHttpUrl" -}}
+{{- printf "http://%s:80" (include "inbox-zero.redisHttpServiceName" .) -}}
+{{- end -}}
+
+{{- define "inbox-zero.internalApiUrl" -}}
+{{- printf "http://%s:%v" (include "inbox-zero.webServiceName" .) .Values.service.port -}}
+{{- end -}}
+
+{{- define "inbox-zero.externalDatabaseEnvRefs" -}}
+{{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.name }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.name }}
+      key: {{ .Values.externalDatabase.existingSecret.databaseUrlKey }}
+- name: DIRECT_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.existingSecret.name }}
+      key: {{ .Values.externalDatabase.existingSecret.directUrlKey }}
+{{- end }}
+{{- end -}}
+
+{{- define "inbox-zero.externalRedisEnvRefs" -}}
+{{- if and .Values.externalRedis.enabled .Values.externalRedis.existingSecret.name }}
+- name: REDIS_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalRedis.existingSecret.name }}
+      key: {{ .Values.externalRedis.existingSecret.redisUrlKey }}
+- name: UPSTASH_REDIS_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalRedis.existingSecret.name }}
+      key: {{ .Values.externalRedis.existingSecret.upstashRedisUrlKey }}
+- name: UPSTASH_REDIS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalRedis.existingSecret.name }}
+      key: {{ .Values.externalRedis.existingSecret.upstashRedisTokenKey }}
+{{- end }}
+{{- end -}}
+
+{{- define "inbox-zero.migrationDatabaseEnv" -}}
+{{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.name }}
+{{- include "inbox-zero.externalDatabaseEnvRefs" . }}
+{{- else if .Values.externalDatabase.enabled }}
+- name: DATABASE_URL
+  value: {{ required "externalDatabase.databaseUrl is required when externalDatabase.enabled=true and no externalDatabase.existingSecret.name is set" .Values.externalDatabase.databaseUrl | quote }}
+- name: DIRECT_URL
+  value: {{ default .Values.externalDatabase.databaseUrl .Values.externalDatabase.directUrl | quote }}
+{{- else if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
+- name: DATABASE_URL
+  value: {{ include "inbox-zero.databaseUrl" . | quote }}
+- name: DIRECT_URL
+  value: {{ include "inbox-zero.databaseUrl" . | quote }}
+{{- else if .Values.existingSecret }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "inbox-zero.secretName" . }}
+      key: DATABASE_URL
+- name: DIRECT_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "inbox-zero.secretName" . }}
+      key: DIRECT_URL
+{{- else if index .Values.secretEnv "DATABASE_URL" }}
+- name: DATABASE_URL
+  value: {{ index .Values.secretEnv "DATABASE_URL" | quote }}
+- name: DIRECT_URL
+  value: {{ default (index .Values.secretEnv "DATABASE_URL") (index .Values.secretEnv "DIRECT_URL") | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/inbox-zero/templates/_helpers.tpl
+++ b/charts/inbox-zero/templates/_helpers.tpl
@@ -71,11 +71,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "inbox-zero.databaseUrl" -}}
-{{- printf "postgresql://%s:%s@%s:5432/%s?schema=public" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "inbox-zero.postgresqlServiceName" .) .Values.postgresql.auth.database -}}
+{{- $password := required "postgresql.auth.password is required when using bundled Postgres" .Values.postgresql.auth.password -}}
+{{- printf "postgresql://%s:%s@%s:5432/%s?schema=public" (.Values.postgresql.auth.username | urlquery) ($password | urlquery) (include "inbox-zero.postgresqlServiceName" .) (.Values.postgresql.auth.database | urlquery) -}}
 {{- end -}}
 
 {{- define "inbox-zero.redisUrl" -}}
-{{- printf "redis://%s:6379" (include "inbox-zero.redisServiceName" .) -}}
+{{- $password := required "redis.auth.password is required when using bundled Redis" .Values.redis.auth.password -}}
+{{- printf "redis://:%s@%s:6379" ($password | urlquery) (include "inbox-zero.redisServiceName" .) -}}
 {{- end -}}
 
 {{- define "inbox-zero.redisHttpUrl" -}}
@@ -124,6 +126,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "inbox-zero.migrationDatabaseEnv" -}}
 {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret.name }}
 {{- include "inbox-zero.externalDatabaseEnvRefs" . }}
+{{- else if and .Values.externalDatabase.enabled .Values.existingSecret }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "inbox-zero.secretName" . }}
+      key: DATABASE_URL
+- name: DIRECT_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "inbox-zero.secretName" . }}
+      key: DIRECT_URL
 {{- else if .Values.externalDatabase.enabled }}
 - name: DATABASE_URL
   value: {{ required "externalDatabase.databaseUrl is required when externalDatabase.enabled=true and no externalDatabase.existingSecret.name is set" .Values.externalDatabase.databaseUrl | quote }}

--- a/charts/inbox-zero/templates/configmap.yaml
+++ b/charts/inbox-zero/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inbox-zero.configMapName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/cronjobs.yaml
+++ b/charts/inbox-zero/templates/cronjobs.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.cron.enabled -}}
+{{- range $name, $job := .Values.cron.jobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "inbox-zero.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "inbox-zero.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: cron
+spec:
+  schedule: {{ $job.schedule | quote }}
+  concurrencyPolicy: {{ $.Values.cron.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ $.Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $.Values.cron.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "inbox-zero.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: cron
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: curl
+              image: "{{ $.Values.cron.image.repository }}:{{ $.Values.cron.image.tag }}"
+              imagePullPolicy: {{ $.Values.cron.image.pullPolicy }}
+              env:
+                - name: CRON_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "inbox-zero.secretName" $ }}
+                      key: CRON_SECRET
+                - name: URL
+                  value: {{ printf "%s%s" (include "inbox-zero.internalApiUrl" $) $job.path | quote }}
+              command:
+                - sh
+                - -ec
+                - curl --fail --silent --show-error --location "$URL" -H "Authorization: Bearer $CRON_SECRET"
+              resources:
+                {{- toYaml $.Values.cron.resources | nindent 16 }}
+{{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/ingress.yaml
+++ b/charts/inbox-zero/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "inbox-zero.fullname" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "inbox-zero.webServiceName" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/migration-job.yaml
+++ b/charts/inbox-zero/templates/migration-job.yaml
@@ -6,12 +6,10 @@ metadata:
   labels:
     {{- include "inbox-zero.labels" . | nindent 4 }}
     app.kubernetes.io/component: migration
-  {{- if .Values.migrations.useHelmHooks }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": {{ .Values.migrations.hookDeletePolicy | quote }}
-  {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds }}

--- a/charts/inbox-zero/templates/migration-job.yaml
+++ b/charts/inbox-zero/templates/migration-job.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.migrations.enabled .Values.externalDatabase.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "inbox-zero.fullname" . }}-migrate
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  {{- if .Values.migrations.useHelmHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": {{ .Values.migrations.hookDeletePolicy | quote }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "inbox-zero.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/docker/scripts/migrate.sh
+          env:
+            {{- include "inbox-zero.migrationDatabaseEnv" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+{{- end }}

--- a/charts/inbox-zero/templates/postgresql.yaml
+++ b/charts/inbox-zero/templates/postgresql.yaml
@@ -93,6 +93,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.postgresql.persistence.size }}
-  {{- else }}
   {{- end }}
 {{- end }}

--- a/charts/inbox-zero/templates/postgresql.yaml
+++ b/charts/inbox-zero/templates/postgresql.yaml
@@ -1,0 +1,98 @@
+{{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inbox-zero.postgresqlServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+  selector:
+    {{- include "inbox-zero.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "inbox-zero.postgresqlServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "inbox-zero.postgresqlServiceName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "inbox-zero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      {{- if not .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+  {{- else }}
+  {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/redis-http.yaml
+++ b/charts/inbox-zero/templates/redis-http.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.redis.enabled .Values.redisHttp.enabled (not .Values.externalRedis.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inbox-zero.redisHttpServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    {{- include "inbox-zero.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inbox-zero.redisHttpServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "inbox-zero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis-http
+  template:
+    metadata:
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis-http
+    spec:
+      containers:
+        - name: redis-http
+          image: "{{ .Values.redisHttp.image.repository }}:{{ .Values.redisHttp.image.tag }}"
+          imagePullPolicy: {{ .Values.redisHttp.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: SRH_MODE
+              value: env
+            - name: SRH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: UPSTASH_REDIS_TOKEN
+            - name: SRH_CONNECTION_STRING
+              value: {{ include "inbox-zero.redisUrl" . | quote }}
+          resources:
+            {{- toYaml .Values.redisHttp.resources | nindent 12 }}
+{{- end }}

--- a/charts/inbox-zero/templates/redis-http.yaml
+++ b/charts/inbox-zero/templates/redis-http.yaml
@@ -30,6 +30,8 @@ spec:
       app.kubernetes.io/component: redis-http
   template:
     metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis-http
@@ -50,7 +52,14 @@ spec:
                   name: {{ include "inbox-zero.secretName" . }}
                   key: UPSTASH_REDIS_TOKEN
             - name: SRH_CONNECTION_STRING
+              {{- if .Values.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: REDIS_URL
+              {{- else }}
               value: {{ include "inbox-zero.redisUrl" . | quote }}
+              {{- end }}
           resources:
             {{- toYaml .Values.redisHttp.resources | nindent 12 }}
 {{- end }}

--- a/charts/inbox-zero/templates/redis-http.yaml
+++ b/charts/inbox-zero/templates/redis-http.yaml
@@ -36,6 +36,9 @@ spec:
         {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis-http
     spec:
+      serviceAccountName: {{ include "inbox-zero.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
@@ -80,4 +83,6 @@ spec:
               {{- end }}
           resources:
             {{- toYaml .Values.redisHttp.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
 {{- end }}

--- a/charts/inbox-zero/templates/redis-http.yaml
+++ b/charts/inbox-zero/templates/redis-http.yaml
@@ -36,6 +36,24 @@ spec:
         {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis-http
     spec:
+      initContainers:
+        - name: wait-for-redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - until redis-cli -h "$REDIS_HOST" ping | grep -q PONG; do sleep 2; done
+          env:
+            - name: REDIS_HOST
+              value: {{ include "inbox-zero.redisServiceName" . | quote }}
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: REDIS_PASSWORD
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       containers:
         - name: redis-http
           image: "{{ .Values.redisHttp.image.repository }}:{{ .Values.redisHttp.image.tag }}"

--- a/charts/inbox-zero/templates/redis.yaml
+++ b/charts/inbox-zero/templates/redis.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.redis.enabled (not .Values.externalRedis.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inbox-zero.redisServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+  selector:
+    {{- include "inbox-zero.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "inbox-zero.redisServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "inbox-zero.redisServiceName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "inbox-zero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      {{- if not .Values.redis.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+  {{- if .Values.redis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.redis.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+  {{- else }}
+  {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/redis.yaml
+++ b/charts/inbox-zero/templates/redis.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "inbox-zero.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis
 spec:
+  clusterIP: None
   ports:
     - name: redis
       port: 6379
@@ -44,21 +45,33 @@ spec:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          args:
+            - redis-server
+            - --requirepass
+            - $(REDIS_PASSWORD)
           ports:
             - name: redis
               containerPort: 6379
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: REDIS_PASSWORD
           readinessProbe:
             exec:
               command:
-                - redis-cli
-                - ping
+                - sh
+                - -ec
+                - redis-cli -a "$REDIS_PASSWORD" ping
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             exec:
               command:
-                - redis-cli
-                - ping
+                - sh
+                - -ec
+                - redis-cli -a "$REDIS_PASSWORD" ping
             initialDelaySeconds: 30
             periodSeconds: 30
           volumeMounts:
@@ -79,6 +92,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.redis.persistence.size }}
-  {{- else }}
   {{- end }}
 {{- end }}

--- a/charts/inbox-zero/templates/secret.yaml
+++ b/charts/inbox-zero/templates/secret.yaml
@@ -13,22 +13,19 @@ stringData:
   {{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
   DATABASE_URL: {{ include "inbox-zero.databaseUrl" . | quote }}
   DIRECT_URL: {{ include "inbox-zero.databaseUrl" . | quote }}
-  POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
+  POSTGRES_PASSWORD: {{ required "postgresql.auth.password is required when using bundled Postgres" .Values.postgresql.auth.password | quote }}
   {{- end }}
   {{- if and .Values.externalDatabase.enabled (not .Values.externalDatabase.existingSecret.name) }}
-  {{- if .Values.externalDatabase.databaseUrl }}
-  DATABASE_URL: {{ .Values.externalDatabase.databaseUrl | quote }}
-  {{- end }}
-  {{- if or .Values.externalDatabase.directUrl .Values.externalDatabase.databaseUrl }}
+  DATABASE_URL: {{ required "externalDatabase.databaseUrl is required when externalDatabase.enabled=true and no externalDatabase.existingSecret.name is set" .Values.externalDatabase.databaseUrl | quote }}
   DIRECT_URL: {{ default .Values.externalDatabase.databaseUrl .Values.externalDatabase.directUrl | quote }}
-  {{- end }}
   {{- end }}
   {{- if and .Values.redis.enabled (not .Values.externalRedis.enabled) }}
   REDIS_URL: {{ include "inbox-zero.redisUrl" . | quote }}
+  REDIS_PASSWORD: {{ required "redis.auth.password is required when using bundled Redis" .Values.redis.auth.password | quote }}
   {{- end }}
   {{- if and .Values.redis.enabled .Values.redisHttp.enabled (not .Values.externalRedis.enabled) }}
   UPSTASH_REDIS_URL: {{ include "inbox-zero.redisHttpUrl" . | quote }}
-  UPSTASH_REDIS_TOKEN: {{ .Values.redisHttp.token | quote }}
+  UPSTASH_REDIS_TOKEN: {{ required "redisHttp.token is required when redisHttp.enabled=true" .Values.redisHttp.token | quote }}
   {{- end }}
   {{- if and .Values.externalRedis.enabled (not .Values.externalRedis.existingSecret.name) }}
   {{- if .Values.externalRedis.redisUrl }}

--- a/charts/inbox-zero/templates/secret.yaml
+++ b/charts/inbox-zero/templates/secret.yaml
@@ -1,0 +1,44 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "inbox-zero.secretName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
+  DATABASE_URL: {{ include "inbox-zero.databaseUrl" . | quote }}
+  DIRECT_URL: {{ include "inbox-zero.databaseUrl" . | quote }}
+  POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
+  {{- end }}
+  {{- if and .Values.externalDatabase.enabled (not .Values.externalDatabase.existingSecret.name) }}
+  {{- if .Values.externalDatabase.databaseUrl }}
+  DATABASE_URL: {{ .Values.externalDatabase.databaseUrl | quote }}
+  {{- end }}
+  {{- if or .Values.externalDatabase.directUrl .Values.externalDatabase.databaseUrl }}
+  DIRECT_URL: {{ default .Values.externalDatabase.databaseUrl .Values.externalDatabase.directUrl | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if and .Values.redis.enabled (not .Values.externalRedis.enabled) }}
+  REDIS_URL: {{ include "inbox-zero.redisUrl" . | quote }}
+  {{- end }}
+  {{- if and .Values.redis.enabled .Values.redisHttp.enabled (not .Values.externalRedis.enabled) }}
+  UPSTASH_REDIS_URL: {{ include "inbox-zero.redisHttpUrl" . | quote }}
+  UPSTASH_REDIS_TOKEN: {{ .Values.redisHttp.token | quote }}
+  {{- end }}
+  {{- if and .Values.externalRedis.enabled (not .Values.externalRedis.existingSecret.name) }}
+  {{- if .Values.externalRedis.redisUrl }}
+  REDIS_URL: {{ .Values.externalRedis.redisUrl | quote }}
+  {{- end }}
+  {{- if .Values.externalRedis.upstashRedisUrl }}
+  UPSTASH_REDIS_URL: {{ .Values.externalRedis.upstashRedisUrl | quote }}
+  {{- end }}
+  {{- if .Values.externalRedis.upstashRedisToken }}
+  UPSTASH_REDIS_TOKEN: {{ .Values.externalRedis.upstashRedisToken | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/serviceaccount.yaml
+++ b/charts/inbox-zero/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "inbox-zero.serviceAccountName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/web-deployment.yaml
+++ b/charts/inbox-zero/templates/web-deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inbox-zero.webServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inbox-zero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "inbox-zero.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "inbox-zero.configMapName" . }}
+            - secretRef:
+                name: {{ include "inbox-zero.secretName" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: PORT
+              value: {{ .Values.web.port | quote }}
+            - name: INTERNAL_API_URL
+              value: {{ include "inbox-zero.internalApiUrl" . | quote }}
+            {{- if and .Values.migrations.enabled .Values.externalDatabase.enabled }}
+            - name: SKIP_DB_MIGRATIONS
+              value: "true"
+            {{- end }}
+            {{- include "inbox-zero.externalDatabaseEnvRefs" . | nindent 12 }}
+            {{- include "inbox-zero.externalRedisEnvRefs" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            failureThreshold: {{ .Values.web.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.web.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/inbox-zero/templates/web-deployment.yaml
+++ b/charts/inbox-zero/templates/web-deployment.yaml
@@ -33,6 +33,25 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - until pg_isready -h "$POSTGRES_HOST" -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do sleep 2; done
+          env:
+            - name: POSTGRES_HOST
+              value: {{ include "inbox-zero.postgresqlServiceName" . | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- end }}
       containers:
         - name: web
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -52,6 +71,8 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.web.port | quote }}
+            - name: HOSTNAME
+              value: "0.0.0.0"
             - name: INTERNAL_API_URL
               value: {{ include "inbox-zero.internalApiUrl" . | quote }}
             {{- if and .Values.migrations.enabled .Values.externalDatabase.enabled }}

--- a/charts/inbox-zero/templates/web-service.yaml
+++ b/charts/inbox-zero/templates/web-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "inbox-zero.webServiceName" . }}
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "inbox-zero.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/inbox-zero/templates/worker-deployment.yaml
+++ b/charts/inbox-zero/templates/worker-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.worker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "inbox-zero.fullname" . }}-worker
+  labels:
+    {{- include "inbox-zero.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "inbox-zero.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "inbox-zero.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "inbox-zero.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/docker/scripts/start-worker.sh
+          envFrom:
+            - configMapRef:
+                name: {{ include "inbox-zero.configMapName" . }}
+            - secretRef:
+                name: {{ include "inbox-zero.secretName" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: INTERNAL_API_URL
+              value: {{ include "inbox-zero.internalApiUrl" . | quote }}
+            {{- if .Values.worker.queues }}
+            - name: WORKER_QUEUES
+              value: {{ .Values.worker.queues | quote }}
+            {{- end }}
+            {{- if and .Values.externalRedis.enabled .Values.externalRedis.existingSecret.name }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalRedis.existingSecret.name }}
+                  key: {{ .Values.externalRedis.existingSecret.redisUrlKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/inbox-zero/templates/worker-deployment.yaml
+++ b/charts/inbox-zero/templates/worker-deployment.yaml
@@ -34,6 +34,26 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.redis.enabled (not .Values.externalRedis.enabled) }}
+      initContainers:
+        - name: wait-for-redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - until redis-cli -h "$REDIS_HOST" ping | grep -q PONG; do sleep 2; done
+          env:
+            - name: REDIS_HOST
+              value: {{ include "inbox-zero.redisServiceName" . | quote }}
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inbox-zero.secretName" . }}
+                  key: REDIS_PASSWORD
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -198,9 +198,7 @@ redisHttp:
   resources:
     requests:
       cpu: 50m
-      memory: 64Mi
-    limits:
-      memory: 256Mi
+      memory: 128Mi
 
 worker:
   enabled: true

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -56,7 +56,6 @@ migrations:
   # web pods skip startup migrations. Bundled Postgres installs keep startup
   # migrations because the database is created as part of the same release.
   enabled: true
-  useHelmHooks: true
   hookDeletePolicy: before-hook-creation,hook-succeeded
   backoffLimit: 2
   activeDeadlineSeconds: 420
@@ -139,7 +138,8 @@ postgresql:
     pullPolicy: IfNotPresent
   auth:
     username: postgres
-    password: password
+    # Required when using bundled Postgres. Do not use a guessable value.
+    password: ""
     database: inboxzero
   persistence:
     enabled: true
@@ -169,6 +169,9 @@ externalRedis:
 redis:
   # Ignored when externalRedis.enabled=true.
   enabled: true
+  auth:
+    # Required when using bundled Redis. Do not use a guessable value.
+    password: ""
   image:
     repository: redis
     tag: "7"
@@ -190,7 +193,8 @@ redisHttp:
     repository: hiett/serverless-redis-http
     tag: latest
     pullPolicy: IfNotPresent
-  token: change-me
+  # Required when redisHttp.enabled=true. Do not use a guessable value.
+  token: ""
   resources:
     requests:
       cpu: 50m
@@ -231,6 +235,9 @@ cron:
     reasoning-retention:
       schedule: "0 3 * * *"
       path: /api/cron/reasoning-retention
+    draft-cleanup:
+      schedule: "0 4 * * *"
+      path: /api/cron/draft-cleanup
     follow-up-reminders:
       schedule: "0 * * * *"
       path: /api/follow-up-reminders

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -1,0 +1,251 @@
+# Default values for the Inbox Zero Helm chart.
+#
+# This chart can run a self-contained stack for evaluation, or connect the app
+# to managed Postgres and Redis services for production.
+
+image:
+  repository: ghcr.io/elie222/inbox-zero
+  tag: latest
+  pullPolicy: Always
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+web:
+  replicaCount: 1
+  port: 3000
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
+migrations:
+  # For managed Postgres, Helm runs migrations before web pods roll out and
+  # web pods skip startup migrations. Bundled Postgres installs keep startup
+  # migrations because the database is created as part of the same release.
+  enabled: true
+  useHelmHooks: true
+  hookDeletePolicy: before-hook-creation,hook-succeeded
+  backoffLimit: 2
+  activeDeadlineSeconds: 420
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 768Mi
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: inbox-zero.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Non-secret application environment variables.
+# Set NEXT_PUBLIC_BASE_URL to the public URL users and OAuth providers will use.
+env:
+  NODE_ENV: production
+  NEXT_PUBLIC_BASE_URL: https://inbox-zero.example.com
+  NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: "true"
+  NEXT_PUBLIC_EMAIL_SEND_ENABLED: "true"
+  NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: "true"
+  DEFAULT_LLM_PROVIDER: openai
+  DEFAULT_LLM_MODEL: gpt-5.4-mini
+  GOOGLE_PUBSUB_TOPIC_NAME: projects/example/topics/inbox-zero
+  QUEUE_BACKEND: bullmq
+
+# Secret application environment variables.
+# For production, prefer existingSecret and manage these values outside Helm.
+secretEnv:
+  AUTH_SECRET: ""
+  GOOGLE_CLIENT_ID: ""
+  GOOGLE_CLIENT_SECRET: ""
+  EMAIL_ENCRYPT_SECRET: ""
+  EMAIL_ENCRYPT_SALT: ""
+  INTERNAL_API_KEY: ""
+  API_KEY_SALT: ""
+  CRON_SECRET: ""
+  OPENAI_API_KEY: ""
+  GOOGLE_PUBSUB_VERIFICATION_TOKEN: ""
+  MICROSOFT_CLIENT_ID: ""
+  MICROSOFT_CLIENT_SECRET: ""
+  MICROSOFT_WEBHOOK_CLIENT_STATE: ""
+
+existingSecret: ""
+existingConfigMap: ""
+extraEnv: []
+extraEnvFrom: []
+
+externalDatabase:
+  # Set enabled=true to use managed Postgres instead of the bundled StatefulSet.
+  # databaseUrl/directUrl are stored in the chart-created Secret. For production,
+  # prefer existingSecret so database credentials are managed outside Helm.
+  enabled: false
+  databaseUrl: ""
+  directUrl: ""
+  existingSecret:
+    name: ""
+    databaseUrlKey: DATABASE_URL
+    directUrlKey: DIRECT_URL
+
+postgresql:
+  # Ignored when externalDatabase.enabled=true.
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  auth:
+    username: postgres
+    password: password
+    database: inboxzero
+  persistence:
+    enabled: true
+    size: 20Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+externalRedis:
+  # Set enabled=true to use managed Redis instead of the bundled StatefulSet.
+  # Values here are stored in the chart-created Secret. For production, prefer
+  # existingSecret so Redis credentials are managed outside Helm.
+  enabled: false
+  redisUrl: ""
+  upstashRedisUrl: ""
+  upstashRedisToken: ""
+  existingSecret:
+    name: ""
+    redisUrlKey: REDIS_URL
+    upstashRedisUrlKey: UPSTASH_REDIS_URL
+    upstashRedisTokenKey: UPSTASH_REDIS_TOKEN
+
+redis:
+  # Ignored when externalRedis.enabled=true.
+  enabled: true
+  image:
+    repository: redis
+    tag: "7"
+    pullPolicy: IfNotPresent
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+redisHttp:
+  enabled: true
+  image:
+    repository: hiett/serverless-redis-http
+    tag: latest
+    pullPolicy: IfNotPresent
+  token: change-me
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+worker:
+  enabled: true
+  replicaCount: 1
+  queues: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 768Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+cron:
+  enabled: true
+  image:
+    repository: curlimages/curl
+    tag: "8.17.0"
+    pullPolicy: IfNotPresent
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobs:
+    scheduled-actions:
+      schedule: "* * * * *"
+      path: /api/cron/scheduled-actions
+    automation-jobs:
+      schedule: "*/15 * * * *"
+      path: /api/cron/automation-jobs
+    reasoning-retention:
+      schedule: "0 3 * * *"
+      path: /api/cron/reasoning-retention
+    follow-up-reminders:
+      schedule: "0 * * * *"
+      path: /api/follow-up-reminders
+    digest:
+      schedule: "*/30 * * * *"
+      path: /api/resend/digest/all
+    meeting-briefs:
+      schedule: "*/15 * * * *"
+      path: /api/meeting-briefs
+    watch-renewal:
+      schedule: "0 */6 * * *"
+      path: /api/watch/all
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      memory: 128Mi

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -52,9 +52,9 @@ web:
     periodSeconds: 10
 
 migrations:
-  # For managed Postgres, Helm runs migrations before web pods roll out and
-  # web pods skip startup migrations. Bundled Postgres installs keep startup
-  # migrations because the database is created as part of the same release.
+  # Controls the Helm migration Job for managed Postgres. Bundled Postgres
+  # installs still run startup migrations from the web pod because the database
+  # is created as part of the same release.
   enabled: true
   hookDeletePolicy: before-hook-creation,hook-succeeded
   backoffLimit: 2

--- a/docker/scripts/configure-rds-ca.sh
+++ b/docker/scripts/configure-rds-ca.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Source this script before commands that connect to AWS RDS. Managed RDS
+# databases use Amazon's CA, which is not present in the Alpine trust store.
+RDS_CA_BUNDLE="/app/rds-combined-ca-bundle.pem"
+
+if echo "$DATABASE_URL $DIRECT_URL $PREVIEW_DATABASE_URL_UNPOOLED" | grep -q "amazonaws.com"; then
+    if [ ! -f "$RDS_CA_BUNDLE" ]; then
+        echo "🔒 Downloading AWS RDS CA bundle..."
+        if wget -q -O "$RDS_CA_BUNDLE" \
+            "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" 2>/dev/null; then
+            echo "✅ RDS CA certificates installed"
+        else
+            echo "⚠️  Could not download RDS CA bundle, continuing..."
+            rm -f "$RDS_CA_BUNDLE"
+        fi
+    fi
+    if [ -f "$RDS_CA_BUNDLE" ]; then
+        export NODE_EXTRA_CA_CERTS="$RDS_CA_BUNDLE"
+    fi
+fi

--- a/docker/scripts/migrate.sh
+++ b/docker/scripts/migrate.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+. /app/docker/scripts/configure-rds-ca.sh
+
+if [ -z "$DATABASE_URL" ] && [ -z "$PREVIEW_DATABASE_URL_UNPOOLED" ] && [ -z "$DIRECT_URL" ]; then
+    echo "No database URL configured. Skipping database migrations."
+    exit 0
+fi
+
+MIGRATION_TIMEOUT_SECONDS="${MIGRATION_TIMEOUT_SECONDS:-320}"
+
+echo "🔄 Running database migrations..."
+
+# Prisma 7 requires a config file for migrations because the schema no longer
+# carries the datasource URL.
+if timeout "$MIGRATION_TIMEOUT_SECONDS" prisma migrate deploy --config=/app/docker/scripts/prisma.config.ts --schema=./apps/web/prisma/schema.prisma; then
+    echo "✅ Database migrations completed successfully"
+else
+    EXIT_CODE=$?
+    if [ "$EXIT_CODE" -eq 124 ]; then
+        echo "⚠️  Migration timeout (${MIGRATION_TIMEOUT_SECONDS}s) exceeded"
+    else
+        echo "⚠️  Migration failed with exit code $EXIT_CODE"
+    fi
+    exit "$EXIT_CODE"
+fi

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -6,27 +6,7 @@ set -e
 
 echo "🚀 Starting Inbox Zero..."
 
-# Install AWS RDS CA certificates for SSL database connections.
-# Only runs when any database URL points to an RDS instance. Managed databases
-# use Amazon's own CA which isn't in the default Alpine trust store, causing
-# Prisma to reject the certificate. Checks all DB URLs since migrations may use
-# DIRECT_URL or PREVIEW_DATABASE_URL_UNPOOLED instead of DATABASE_URL.
-RDS_CA_BUNDLE="/app/rds-combined-ca-bundle.pem"
-if echo "$DATABASE_URL $DIRECT_URL $PREVIEW_DATABASE_URL_UNPOOLED" | grep -q "amazonaws.com"; then
-    if [ ! -f "$RDS_CA_BUNDLE" ]; then
-        echo "🔒 Downloading AWS RDS CA bundle..."
-        if wget -q -O "$RDS_CA_BUNDLE" \
-            "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" 2>/dev/null; then
-            echo "✅ RDS CA certificates installed"
-        else
-            echo "⚠️  Could not download RDS CA bundle, continuing..."
-            rm -f "$RDS_CA_BUNDLE"
-        fi
-    fi
-    if [ -f "$RDS_CA_BUNDLE" ]; then
-        export NODE_EXTRA_CA_CERTS="$RDS_CA_BUNDLE"
-    fi
-fi
+. /app/docker/scripts/configure-rds-ca.sh
 
 # Define the variables to replace
 # Add more NEXT_PUBLIC_ variables here as needed
@@ -66,18 +46,10 @@ if [ -n "$NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED" ]; then
     /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED"
 fi
 
-if [ -n "$DATABASE_URL" ] || [ -n "$PREVIEW_DATABASE_URL_UNPOOLED" ] || [ -n "$DIRECT_URL" ]; then
-    echo "🔄 Running database migrations..."
-    # Prisma 7 requires config file for migrations (schema no longer supports url)
-    if timeout 320 prisma migrate deploy --config=/app/docker/scripts/prisma.config.ts --schema=./apps/web/prisma/schema.prisma; then
-        echo "✅ Database migrations completed successfully"
-    else
-        EXIT_CODE=$?
-        if [ $EXIT_CODE -eq 124 ]; then
-            echo "⚠️  Migration timeout (320s) exceeded"
-        else
-            echo "⚠️  Migration failed with exit code $EXIT_CODE"
-        fi
+if [ "${SKIP_DB_MIGRATIONS:-false}" = "true" ]; then
+    echo "Skipping database migrations during web startup."
+else
+    if ! /app/docker/scripts/migrate.sh; then
         echo "⚠️  Continuing startup (database might be unavailable or migrations already applied)"
     fi
 fi

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
             "group": "Self-Hosting",
             "pages": [
               "hosting/self-hosting",
+              "hosting/kubernetes",
               "hosting/vercel",
               "hosting/environment-variables",
               "hosting/troubleshooting",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,9 +94,9 @@
             "group": "Self-Hosting",
             "pages": [
               "hosting/self-hosting",
-              "hosting/kubernetes",
-              "hosting/vercel",
               "hosting/environment-variables",
+              "hosting/vercel",
+              "hosting/kubernetes",
               "hosting/troubleshooting",
               "hosting/image-proxy"
             ]

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -29,9 +29,11 @@ helm upgrade --install inbox-zero ./charts/inbox-zero \
   -f values.prod.yaml
 ```
 
-## Minimal Values
+## Values File
 
-Create `values.prod.yaml` with your public URL, OAuth settings, generated secrets, and LLM provider credentials:
+The Helm chart does not replace the normal app configuration. Use the [Environment Variables reference](/hosting/environment-variables), [Google OAuth guide](/hosting/google-oauth), [Microsoft OAuth guide](/hosting/microsoft-oauth), and [LLM setup guide](/hosting/llm-setup) for the full app configuration.
+
+Create `values.prod.yaml` with your public URL, ingress settings, and either `secretEnv` values or an `existingSecret`:
 
 ```yaml
 ingress:
@@ -56,14 +58,14 @@ env:
 
 secretEnv:
   AUTH_SECRET: change-me
-  GOOGLE_CLIENT_ID: change-me
-  GOOGLE_CLIENT_SECRET: change-me
-  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
   EMAIL_ENCRYPT_SECRET: change-me
   EMAIL_ENCRYPT_SALT: change-me
   INTERNAL_API_KEY: change-me
   API_KEY_SALT: change-me
   CRON_SECRET: change-me
+  GOOGLE_CLIENT_ID: change-me
+  GOOGLE_CLIENT_SECRET: change-me
+  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
   OPENAI_API_KEY: change-me
 
 postgresql:

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -33,7 +33,7 @@ helm upgrade --install inbox-zero ./charts/inbox-zero \
 
 The Helm chart does not replace the normal app configuration. Use the [Environment Variables reference](/hosting/environment-variables), [Google OAuth guide](/hosting/google-oauth), [Microsoft OAuth guide](/hosting/microsoft-oauth), and [LLM setup guide](/hosting/llm-setup) for the full app configuration.
 
-Create `values.prod.yaml` with your public URL, ingress settings, and either `secretEnv` values or an `existingSecret`:
+Create `values.prod.yaml` with your public URL, ingress settings, and app configuration. Put app secrets in `secretEnv` or point the chart at an existing Kubernetes Secret.
 
 ```yaml
 ingress:
@@ -52,21 +52,17 @@ ingress:
 env:
   NEXT_PUBLIC_BASE_URL: https://app.example.com
   GOOGLE_PUBSUB_TOPIC_NAME: projects/example/topics/inbox-zero
-  DEFAULT_LLM_PROVIDER: openai
-  DEFAULT_LLM_MODEL: gpt-5.4-mini
   QUEUE_BACKEND: bullmq
 
-secretEnv:
-  AUTH_SECRET: change-me
-  EMAIL_ENCRYPT_SECRET: change-me
-  EMAIL_ENCRYPT_SALT: change-me
-  INTERNAL_API_KEY: change-me
-  API_KEY_SALT: change-me
-  CRON_SECRET: change-me
-  GOOGLE_CLIENT_ID: change-me
-  GOOGLE_CLIENT_SECRET: change-me
-  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
-  OPENAI_API_KEY: change-me
+existingSecret: inbox-zero-secrets
+```
+
+`inbox-zero-secrets` should contain the required app environment variables from the [Environment Variables reference](/hosting/environment-variables). You can use `secretEnv` instead for simple installs.
+
+For a first install with bundled Postgres and Redis, also provide generated values for the bundled services:
+
+```yaml
+existingSecret: ""
 
 postgresql:
   auth:
@@ -84,22 +80,7 @@ The default chart includes Postgres, Redis, the Redis HTTP bridge, web, worker, 
 
 ## Recommended Production Setup
 
-Use managed Postgres and Redis:
-
-```yaml
-externalDatabase:
-  enabled: true
-  databaseUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
-  directUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
-
-externalRedis:
-  enabled: true
-  redisUrl: rediss://:password@redis.example.com:6379
-  upstashRedisUrl: https://example.upstash.io
-  upstashRedisToken: change-me
-```
-
-For production, it is better to keep these values in existing Kubernetes Secrets:
+Use managed Postgres and Redis through existing Kubernetes Secrets:
 
 ```yaml
 externalDatabase:
@@ -119,17 +100,7 @@ externalRedis:
 
 You can use plain Kubernetes Secrets, External Secrets, Sealed Secrets, SOPS, or a cloud secret controller.
 
-App secrets can use the same pattern:
-
-```yaml
-existingSecret: inbox-zero-secrets
-```
-
-That Secret should contain values like `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, `API_KEY_SALT`, `CRON_SECRET`, and your LLM provider API key.
-
-If you use that same Secret with bundled Postgres or Redis, include `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, `UPSTASH_REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
-
-If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
+Use `existingSecret` for app secrets too. See the [Environment Variables reference](/hosting/environment-variables) for the full list, including OAuth, LLM, Redis, and QStash variables.
 
 ## Background Jobs
 
@@ -151,11 +122,9 @@ env:
   QUEUE_BACKEND: qstash
 worker:
   enabled: false
-secretEnv:
-  QSTASH_TOKEN: change-me
-  QSTASH_CURRENT_SIGNING_KEY: change-me
-  QSTASH_NEXT_SIGNING_KEY: change-me
 ```
+
+Provide the QStash secrets using `secretEnv` or `existingSecret`; see the [Environment Variables reference](/hosting/environment-variables).
 
 ## Smoke Test
 

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -78,7 +78,7 @@ redisHttp:
   token: replace-with-random-value
 ```
 
-The default chart includes Postgres, Redis, the Redis HTTP bridge, web, worker, and CronJobs. That is useful for a first Kubernetes install. For production, use managed Postgres and Redis.
+The default chart includes Postgres, Redis, the Redis HTTP bridge, web, worker, and CronJobs. That is useful for a first Kubernetes install. For production, use managed Postgres and Redis with backups, failover, monitoring, and tested restores.
 
 ## Recommended Production Setup
 

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -1,0 +1,175 @@
+---
+title: 'Kubernetes Deployment'
+description: 'Run Inbox Zero on Kubernetes with the Helm chart'
+---
+
+Inbox Zero can run on Kubernetes as the same pieces used by Docker Compose:
+
+- A `web` Deployment for the Next.js app.
+- A migration Job that runs Prisma migrations before Helm installs or upgrades the app when managed Postgres is enabled.
+- An optional BullMQ `worker` Deployment for durable background jobs.
+- CronJobs for scheduled endpoints like watch renewal, meeting briefs, follow-up reminders, and retention.
+- Postgres and Redis, either managed externally or installed in-cluster for a simple self-hosted stack.
+- An Ingress in front of the web Service.
+
+## Chart Location
+
+The chart lives in the repository at:
+
+```bash
+charts/inbox-zero
+```
+
+Install it with:
+
+```bash
+helm upgrade --install inbox-zero ./charts/inbox-zero \
+  -n inbox-zero \
+  --create-namespace \
+  -f values.prod.yaml
+```
+
+## Minimal Values
+
+Create `values.prod.yaml` with your public URL, OAuth settings, generated secrets, and LLM provider credentials:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: inbox-zero-tls
+      hosts:
+        - app.example.com
+
+env:
+  NEXT_PUBLIC_BASE_URL: https://app.example.com
+  GOOGLE_PUBSUB_TOPIC_NAME: projects/example/topics/inbox-zero
+  DEFAULT_LLM_PROVIDER: openai
+  DEFAULT_LLM_MODEL: gpt-5.4-mini
+  QUEUE_BACKEND: bullmq
+
+secretEnv:
+  AUTH_SECRET: change-me
+  GOOGLE_CLIENT_ID: change-me
+  GOOGLE_CLIENT_SECRET: change-me
+  GOOGLE_PUBSUB_VERIFICATION_TOKEN: change-me
+  EMAIL_ENCRYPT_SECRET: change-me
+  EMAIL_ENCRYPT_SALT: change-me
+  INTERNAL_API_KEY: change-me
+  API_KEY_SALT: change-me
+  CRON_SECRET: change-me
+  OPENAI_API_KEY: change-me
+```
+
+The default chart includes Postgres, Redis, the Redis HTTP bridge, web, worker, and CronJobs. That is useful for a first Kubernetes install. For production, use managed Postgres and Redis.
+
+## Recommended Production Setup
+
+Use managed Postgres and Redis:
+
+```yaml
+externalDatabase:
+  enabled: true
+  databaseUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
+  directUrl: postgresql://user:password@postgres.example.com:5432/inboxzero?schema=public
+
+externalRedis:
+  enabled: true
+  redisUrl: rediss://:password@redis.example.com:6379
+  upstashRedisUrl: https://example.upstash.io
+  upstashRedisToken: change-me
+```
+
+For production, it is better to keep these values in existing Kubernetes Secrets:
+
+```yaml
+externalDatabase:
+  enabled: true
+  existingSecret:
+    name: inbox-zero-database
+
+externalRedis:
+  enabled: true
+  existingSecret:
+    name: inbox-zero-redis
+```
+
+`inbox-zero-database` should contain `DATABASE_URL` and `DIRECT_URL`.
+
+`inbox-zero-redis` should contain `REDIS_URL`, `UPSTASH_REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
+
+You can use plain Kubernetes Secrets, External Secrets, Sealed Secrets, SOPS, or a cloud secret controller.
+
+App secrets can use the same pattern:
+
+```yaml
+existingSecret: inbox-zero-secrets
+```
+
+That Secret should contain values like `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, `API_KEY_SALT`, `CRON_SECRET`, and your LLM provider API key.
+
+If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
+
+## Background Jobs
+
+BullMQ is the default Kubernetes queue mode:
+
+```yaml
+env:
+  QUEUE_BACKEND: bullmq
+worker:
+  enabled: true
+```
+
+The worker reads from Redis and forwards jobs to the internal web Service using `INTERNAL_API_KEY`.
+
+To use QStash instead, disable the worker:
+
+```yaml
+env:
+  QUEUE_BACKEND: qstash
+worker:
+  enabled: false
+secretEnv:
+  QSTASH_TOKEN: change-me
+  QSTASH_CURRENT_SIGNING_KEY: change-me
+  QSTASH_NEXT_SIGNING_KEY: change-me
+```
+
+## Smoke Test
+
+After installing, check the rollout:
+
+```bash
+kubectl get pods -n inbox-zero
+kubectl rollout status deploy/inbox-zero-web -n inbox-zero
+```
+
+Test the health endpoint:
+
+```bash
+kubectl port-forward svc/inbox-zero-web 3000:80 -n inbox-zero
+curl http://localhost:3000/api/health
+```
+
+Test one scheduled job:
+
+```bash
+kubectl create job --from=cronjob/inbox-zero-watch-renewal test-watch-renewal -n inbox-zero
+kubectl logs job/test-watch-renewal -n inbox-zero
+```
+
+## Operational Notes
+
+- Set `NEXT_PUBLIC_BASE_URL` to the external HTTPS URL used by users and OAuth providers.
+- With managed Postgres, Helm runs Prisma migrations in a pre-install/pre-upgrade Job.
+- Web pods set `SKIP_DB_MIGRATIONS=true` when the migration Job is enabled.
+- With bundled Postgres, the web container runs migrations during startup.
+- CronJobs call the internal Service, not the public Ingress.
+- The `/api/health` endpoint supports lightweight Kubernetes probes without an API key.

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -65,6 +65,17 @@ secretEnv:
   API_KEY_SALT: change-me
   CRON_SECRET: change-me
   OPENAI_API_KEY: change-me
+
+postgresql:
+  auth:
+    password: replace-with-random-value
+
+redis:
+  auth:
+    password: replace-with-random-value
+
+redisHttp:
+  token: replace-with-random-value
 ```
 
 The default chart includes Postgres, Redis, the Redis HTTP bridge, web, worker, and CronJobs. That is useful for a first Kubernetes install. For production, use managed Postgres and Redis.
@@ -113,6 +124,8 @@ existingSecret: inbox-zero-secrets
 ```
 
 That Secret should contain values like `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, `API_KEY_SALT`, `CRON_SECRET`, and your LLM provider API key.
+
+If you use that same Secret with bundled Postgres or Redis, include `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
 
 If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
 
@@ -171,5 +184,7 @@ kubectl logs job/test-watch-renewal -n inbox-zero
 - With managed Postgres, Helm runs Prisma migrations in a pre-install/pre-upgrade Job.
 - Web pods set `SKIP_DB_MIGRATIONS=true` when the migration Job is enabled.
 - With bundled Postgres, the web container runs migrations during startup.
+- Bundled Postgres, Redis, and Redis HTTP require explicit secret values. Generate them before installing, for example with `openssl rand -hex 32`.
 - CronJobs call the internal Service, not the public Ingress.
+- Cron schedules are configured under `cron.jobs`. The defaults follow the Docker self-hosting setup, so some schedules differ from hosted deployment schedules.
 - The `/api/health` endpoint supports lightweight Kubernetes probes without an API key.

--- a/docs/hosting/kubernetes.mdx
+++ b/docs/hosting/kubernetes.mdx
@@ -125,7 +125,7 @@ existingSecret: inbox-zero-secrets
 
 That Secret should contain values like `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `EMAIL_ENCRYPT_SECRET`, `EMAIL_ENCRYPT_SALT`, `INTERNAL_API_KEY`, `API_KEY_SALT`, `CRON_SECRET`, and your LLM provider API key.
 
-If you use that same Secret with bundled Postgres or Redis, include `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
+If you use that same Secret with bundled Postgres or Redis, include `POSTGRES_PASSWORD`, `DATABASE_URL`, `DIRECT_URL`, `REDIS_PASSWORD`, `REDIS_URL`, `UPSTASH_REDIS_URL`, and `UPSTASH_REDIS_TOKEN`.
 
 If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to non-empty placeholder values such as `skipped`.
 


### PR DESCRIPTION
Adds a Helm chart for running the app on Kubernetes with web, worker, scheduled jobs, optional bundled data services, and managed service configuration.

- Adds migration script support for Kubernetes rollouts
- Documents managed Postgres and Redis setup
- Adds Kubernetes smoke test commands