### PR TITLE
docs: Add enterprise SSO and SCIM details

### DIFF
--- a/apps/web/app/(app)/premium/PremiumModal.tsx
+++ b/apps/web/app/(app)/premium/PremiumModal.tsx
@@ -21,7 +21,8 @@ function EnterpriseFooter() {
       <div>
         <h3 className="font-semibold text-gray-900">Enterprise</h3>
         <p className="text-sm text-gray-600">
-          SSO, on-premise deployment, and dedicated support for large teams.
+          SSO, SCIM, on-premise deployment, and dedicated support for large
+          teams.
         </p>
       </div>
       <Button variant="outline" asChild>

--- a/apps/web/app/(app)/premium/config.ts
+++ b/apps/web/app/(app)/premium/config.ts
@@ -380,6 +380,9 @@ const enterpriseTier: Tier = {
       text: "SSO login",
     },
     {
+      text: "SCIM user provisioning",
+    },
+    {
       text: "On-premise deployment (optional)",
     },
     {

--- a/apps/web/app/(landing)/pricing/PricingFAQs.tsx
+++ b/apps/web/app/(landing)/pricing/PricingFAQs.tsx
@@ -71,11 +71,12 @@ const pricingFaqs: {
         <Anchor href="https://go.getinboxzero.com/sales" newTab>
           Contact our sales team
         </Anchor>{" "}
-        for custom pricing, SSO, on-premise deployment, and dedicated support.
+        for custom pricing, SSO, SCIM, on-premise deployment, and dedicated
+        support.
       </span>
     ),
     answerText:
-      "Contact our sales team for custom pricing, SSO, on-premise deployment, and dedicated support.",
+      "Contact our sales team for custom pricing, SSO, SCIM, on-premise deployment, and dedicated support.",
   },
 ];
 

--- a/apps/web/components/new-landing/sections/Pricing.tsx
+++ b/apps/web/components/new-landing/sections/Pricing.tsx
@@ -142,8 +142,8 @@ export function Pricing() {
                 <div>
                   <h3 className="font-title text-lg">Enterprise</h3>
                   <Paragraph size="sm" className="mt-1">
-                    Need SSO, on-premise deployment, or a dedicated account
-                    manager?
+                    Need SSO, SCIM, on-premise deployment, or a dedicated
+                    account manager?
                   </Paragraph>
                 </div>
               </div>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,6 +87,7 @@
               "hosting/google-oauth",
               "hosting/google-pubsub",
               "hosting/microsoft-oauth",
+              "hosting/sso",
               "hosting/llm-setup"
             ]
           },

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -120,7 +120,7 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `AUTH_ALLOWED_EMAIL_DOMAINS` | No | Comma-separated list of email domains allowed to create new auth users (for example `company.com,subsidiary.org`). | Open sign-up |
 | `AUTO_JOIN_ORGANIZATION_ENABLED` | No | Automatically add new users to the single organization on sign-up. Only enable this if your deployment explicitly wants automatic org membership. | `false` |
 | `AUTO_ENABLE_ORG_ANALYTICS` | No | Default new organization memberships to analytics enabled | `false` |
-| `SSO_LOGIN_ENABLED` | No | Show the "Sign in with SSO" button on the login screen. Default is off. | `false` |
+| `SSO_LOGIN_ENABLED` | No | Show the "Sign in with SSO" button on the login screen. Configuring an SSO provider is a separate admin setup step. | `false` |
 | **Feature Flags** ||||
 | `NEXT_PUBLIC_CONTACTS_ENABLED` | No | Enable contacts feature | `false` |
 | `NEXT_PUBLIC_EMAIL_SEND_ENABLED` | No | Enable email sending | `true` |
@@ -149,6 +149,7 @@ For detailed setup instructions, see the [Setup Guides](/hosting/setup-guides):
 
 - [Google OAuth](/hosting/google-oauth)
 - [Microsoft OAuth](/hosting/microsoft-oauth)
+- [Enterprise SSO and SCIM](/hosting/sso)
 - [Google PubSub](/hosting/google-pubsub)
 - [LLM](/hosting/llm-setup)
 

--- a/docs/hosting/setup-guides.mdx
+++ b/docs/hosting/setup-guides.mdx
@@ -7,7 +7,7 @@ description: 'Manual setup for OAuth, PubSub, and your AI provider'
   The [setup CLI](/hosting/quick-start) walks you through all of this interactively. These guides are for manual configuration or reference.
 </Tip>
 
-## OAuth
+## Authentication
 
 <CardGroup cols={2}>
   <Card title="Google OAuth" href="/hosting/google-oauth">
@@ -15,6 +15,9 @@ description: 'Manual setup for OAuth, PubSub, and your AI provider'
   </Card>
   <Card title="Microsoft OAuth" href="/hosting/microsoft-oauth">
     Configure Azure app registration, credentials, and Graph permissions.
+  </Card>
+  <Card title="Enterprise SSO and SCIM" href="/hosting/sso">
+    Configure SAML SSO and SCIM user provisioning for organization deployments.
   </Card>
 </CardGroup>
 

--- a/docs/hosting/sso.mdx
+++ b/docs/hosting/sso.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Enterprise SSO and SCIM'
+description: 'Configure SAML SSO and SCIM user provisioning for organization deployments.'
+---
+
+Inbox Zero supports SAML SSO and SCIM user provisioning for organization deployments.
+
+<Info>
+  If you use the hosted Inbox Zero cloud platform, contact sales to enable SSO or SCIM for your organization. If you self-host Inbox Zero, an app admin configures SSO and SCIM from the admin page.
+</Info>
+
+## When to Use This
+
+Use SSO and SCIM when your organization wants to manage Inbox Zero access through an identity provider such as Okta, Microsoft Entra ID, or Google Workspace.
+
+- **SSO** lets users sign in with your identity provider instead of a personal login flow.
+- **SCIM** lets your identity provider provision, update, and deprovision users.
+
+## Prerequisites
+
+- A deployed Inbox Zero instance with a stable `NEXT_PUBLIC_BASE_URL`.
+- An admin user listed in `ADMINS`.
+- SAML IdP metadata XML from your identity provider.
+- The organization domain users will sign in with.
+- `SSO_LOGIN_ENABLED=true` if you want to show the "Sign in with SSO" button on the login page.
+
+## Configure SSO
+
+1. Sign in as an app admin.
+2. Open `/admin`.
+3. Click **Register SSO Provider**.
+4. Enter the organization name, provider ID, email domain, and SAML IdP metadata XML.
+5. Save the ACS callback URL returned after registration.
+6. Add the ACS callback URL to your identity provider's SAML application.
+
+The ACS callback URL uses this format:
+
+```txt
+https://your-domain.com/api/auth/sso/saml2/callback/{providerId}
+```
+
+Users sign in through `/login/sso` using their email and the organization slug (a slugified form of the organization name you registered).
+
+## Configure SCIM
+
+SCIM requires a registered SSO provider. As an app admin, generate a SCIM bearer token for the same provider ID, then configure your identity provider with:
+
+| Setting | Value |
+| ------- | ----- |
+| SCIM base URL | `https://your-domain.com/api/auth/scim/v2` |
+| Authentication | Bearer token |
+| Supported resource | Users |
+
+Keep the SCIM token secret. Rotate it if it is exposed.
+
+## Managed Setup
+
+Hosted cloud organizations, or self-hosted deployments that want help configuring enterprise access, can contact sales from the pricing page.


### PR DESCRIPTION
Updates enterprise plan copy to mention SCIM alongside SSO.

- Adds an SSO and SCIM setup guide for organization deployments.
- Links the guide from developer setup and environment variable docs.