### PR TITLE
Harden client redirect handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Check server action exports
         run: pnpm -F inbox-zero-ai check-server-actions
 
+      - name: Check client redirects
+        run: pnpm -F inbox-zero-ai check-client-redirects
+
       - name: Run tests
         run: pnpm -F inbox-zero-ai test
         env:

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConnectCalendar.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConnectCalendar.tsx
@@ -11,6 +11,7 @@ import { fetchWithAccount } from "@/utils/fetch";
 import { CALENDAR_ONBOARDING_RETURN_COOKIE } from "@/utils/calendar/constants";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
 import type { AppPage } from "@/utils/analytics/product";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export function ConnectCalendar({
   analyticsPage,
@@ -49,7 +50,7 @@ export function ConnectCalendar({
 
       const data: GetCalendarAuthUrlResponse = await response.json();
       setOnboardingReturnCookie();
-      window.location.href = data.url;
+      redirectToSafeUrl(data.url, { allowExternal: true });
     } catch (error) {
       analytics.captureAction("calendar_connect_start_failed", {
         provider: "google",
@@ -84,7 +85,7 @@ export function ConnectCalendar({
 
       const data: GetCalendarAuthUrlResponse = await response.json();
       setOnboardingReturnCookie();
-      window.location.href = data.url;
+      redirectToSafeUrl(data.url, { allowExternal: true });
     } catch (error) {
       analytics.captureAction("calendar_connect_start_failed", {
         provider: "microsoft",

--- a/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export function ConnectDrive() {
   const { emailAccountId } = useAccount();
@@ -39,7 +40,7 @@ export function ConnectDrive() {
 
       if (!data?.url) throw new Error("Invalid auth URL");
 
-      window.location.href = data.url;
+      redirectToSafeUrl(data.url, { allowExternal: true });
     } catch (error) {
       captureException(error, {
         extra: { context: "Google Drive OAuth initiation" },
@@ -69,7 +70,7 @@ export function ConnectDrive() {
 
       if (!data?.url) throw new Error("Invalid auth URL");
 
-      window.location.href = data.url;
+      redirectToSafeUrl(data.url, { allowExternal: true });
     } catch (error) {
       captureException(error, {
         extra: { context: "OneDrive OAuth initiation" },

--- a/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/integrations/IntegrationRow.tsx
@@ -28,6 +28,7 @@ import { RequestAccessDialog } from "./RequestAccessDialog";
 import { truncate } from "@/utils/string";
 import { Notice } from "@/components/Notice";
 import { useProductAnalytics } from "@/hooks/useProductAnalytics";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 interface IntegrationRowProps {
   integration: GetIntegrationsResponse["integrations"][number];
@@ -81,7 +82,7 @@ export function IntegrationRow({
       }
 
       const data: GetMcpAuthUrlResponse = await response.json();
-      window.location.href = data.url;
+      redirectToSafeUrl(data.url, { allowExternal: true });
     } catch (error) {
       analytics.captureAction("integration_connect_failed", {
         integration: integration.name,

--- a/apps/web/app/(app)/[emailAccountId]/onboarding-brief/StepReady.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding-brief/StepReady.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/app/(app)/premium/PricingFrequencyToggle";
 import { generateCheckoutSessionAction } from "@/utils/actions/premium";
 import { toastError } from "@/components/Toast";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 const PRICING_FEATURES = [
   "Briefs for every external meeting",
@@ -51,7 +52,7 @@ export function StepReady() {
         return;
       }
 
-      window.location.href = result.data.url;
+      redirectToSafeUrl(result.data.url, { allowExternal: true });
     } catch {
       toastError({ description: "Error creating checkout session" });
     } finally {

--- a/apps/web/app/(app)/[emailAccountId]/permissions/consent/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/permissions/consent/page.tsx
@@ -9,6 +9,7 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { toastError } from "@/components/Toast";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { BRAND_NAME } from "@/utils/branding";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export default function PermissionsConsentPage() {
   const { provider, isLoading: accountLoading } = useAccount();
@@ -21,7 +22,7 @@ export default function PermissionsConsentPage() {
     try {
       const accountProvider = provider === "microsoft" ? "microsoft" : "google";
       const url = await getAccountLinkingUrl(accountProvider);
-      window.location.href = url;
+      redirectToSafeUrl(url, { allowExternal: true });
     } catch {
       toastError({
         title: "Error initiating reconnection",

--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -44,6 +44,7 @@ import {
 import { fetchWithAccount } from "@/utils/fetch";
 import { captureException } from "@/utils/error";
 import { getActionErrorMessage } from "@/utils/error";
+import { redirectToSafeUrl } from "@/utils/redirect";
 import type { GetSlackAuthUrlResponse } from "@/app/api/slack/auth-url/route";
 import {
   type MessagingProvider,
@@ -117,7 +118,7 @@ export function ConnectedAppsSection({
             title: "Email not found in Slack",
             description: "Redirecting to Slack authorization...",
           });
-          window.location.href = authUrl;
+          redirectToSafeUrl(authUrl, { allowExternal: true });
         } else {
           toastError({ description: msg ?? "Failed to link Slack" });
         }
@@ -174,7 +175,7 @@ export function ConnectedAppsSection({
       }
 
       if (data.url) {
-        window.location.href = data.url;
+        redirectToSafeUrl(data.url, { allowExternal: true });
       } else {
         throw new Error("No auth URL returned");
       }
@@ -224,7 +225,9 @@ export function ConnectedAppsSection({
                     type="button"
                     className="text-xs text-muted-foreground underline underline-offset-4"
                     onClick={() => {
-                      if (authUrl) window.location.href = authUrl;
+                      if (authUrl) {
+                        redirectToSafeUrl(authUrl, { allowExternal: true });
+                      }
                     }}
                   >
                     Install manually

--- a/apps/web/app/(app)/accounts/AddAccount.tsx
+++ b/apps/web/app/(app)/accounts/AddAccount.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { MutedText } from "@/components/Typography";
 import { getAccountLinkingUrl } from "@/utils/account-linking";
 import { isGoogleProvider } from "@/utils/email/provider-types";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export function AddAccount({
   helperText = "You will be billed for each account.",
@@ -25,7 +26,7 @@ export function AddAccount({
 
     try {
       const url = await getAccountLinkingUrl(provider);
-      window.location.href = url;
+      redirectToSafeUrl(url, { allowExternal: true });
     } catch (error) {
       console.error(`Error initiating ${provider} link:`, error);
       toastError({

--- a/apps/web/app/(app)/premium/ManageSubscription.tsx
+++ b/apps/web/app/(app)/premium/ManageSubscription.tsx
@@ -13,6 +13,7 @@ import {
   getBillingPortalUrlAction,
 } from "@/utils/actions/premium";
 import { hasActiveAppleSubscription } from "@/utils/premium";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 const APPLE_SUBSCRIPTION_HELP_URL = "https://support.apple.com/en-us/118428";
 
@@ -146,7 +147,7 @@ function useOpenBillingPortal() {
           "Error loading billing portal. Please contact support.",
       });
     } else {
-      window.location.href = url;
+      redirectToSafeUrl(url, { allowExternal: true });
     }
   };
 

--- a/apps/web/app/(app)/premium/Pricing.tsx
+++ b/apps/web/app/(app)/premium/Pricing.tsx
@@ -35,6 +35,7 @@ import { LoadingMiniSpinner } from "@/components/Loading";
 import { cn } from "@/utils";
 import { ManageSubscription } from "@/app/(app)/premium/ManageSubscription";
 import { captureException } from "@/utils/error";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export type PricingProps = {
   header?: React.ReactNode;
@@ -321,7 +322,7 @@ function PriceTier({
 
           // Handle enterprise tier differently - redirect to sales page
           if (tier.ctaLink) {
-            window.location.href = tier.ctaLink;
+            redirectToSafeUrl(tier.ctaLink, { allowExternal: true });
             return;
           }
 
@@ -381,7 +382,7 @@ function PriceTier({
               return;
             }
 
-            window.location.href = result.data.url;
+            redirectToSafeUrl(result.data.url, { allowExternal: true });
           }
 
           try {

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -18,7 +18,7 @@ import { signIn, signInWithOauth2 } from "@/utils/auth-client";
 import { WELCOME_PATH } from "@/utils/config";
 import { toastError } from "@/components/Toast";
 import { normalizeInternalPath } from "@/utils/path";
-import { buildRedirectUrl } from "@/utils/redirect";
+import { buildRedirectUrl, redirectToSafeUrl } from "@/utils/redirect";
 import { getPossessiveBrandName } from "@/utils/branding";
 import { AlertBasic } from "@/components/Alert";
 import { createClientLogger } from "@/utils/logger-client";
@@ -60,7 +60,7 @@ export function LoginForm({
         if (!result.url) {
           throw new Error("Missing Google sign-in redirect URL");
         }
-        window.location.href = result.url;
+        redirectToSafeUrl(result.url, { allowExternal: true });
       } else {
         await signIn.social({
           provider: "google",

--- a/apps/web/components/AccountSwitcher.tsx
+++ b/apps/web/components/AccountSwitcher.tsx
@@ -23,6 +23,7 @@ import type { GetEmailAccountsResponse } from "@/app/api/user/email-accounts/rou
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { setLastEmailAccountAction } from "@/utils/actions/email-account-cookie";
 import { ProfileImage } from "@/components/ProfileImage";
+import { redirectToSafeUrl } from "@/utils/redirect";
 export function AccountSwitcher() {
   const { data: accountsData } = useAccounts();
 
@@ -79,7 +80,7 @@ export function AccountSwitcherInternal({
 
       // Force a hard page reload to refresh all data.
       // I tried to fix with resetting the SWR cache but it didn't seem to work. This is much more reliable anyway.
-      window.location.href = getHref(emailAccountId);
+      redirectToSafeUrl(getHref(emailAccountId));
     },
     [getHref],
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "lint": "biome check .",
     "check-enums": "node scripts/check-enum-imports.js",
     "check-server-actions": "node scripts/check-server-action-exports.js",
+    "check-client-redirects": "node scripts/check-client-redirects.js",
     "generate-llm-pricing": "tsx scripts/generate-llm-pricing.ts",
     "test": "cross-env RUN_AI_TESTS=false vitest",
     "test-ai": "cross-env RUN_AI_TESTS=true vitest --run",

--- a/apps/web/providers/SWRProvider.tsx
+++ b/apps/web/providers/SWRProvider.tsx
@@ -17,6 +17,7 @@ import {
   NO_REFRESH_TOKEN_ERROR_CODE,
 } from "@/utils/config";
 import { prefixPath } from "@/utils/path";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 // https://swr.vercel.app/docs/error-handling#status-code-and-error-object
 const fetcher = async (
@@ -72,7 +73,7 @@ const fetcher = async (
 
         console.log(`${errorMessage}, redirecting to consent page...`);
         const redirectUrl = prefixPath(emailAccountId, "/permissions/consent");
-        window.location.href = redirectUrl;
+        redirectToSafeUrl(redirectUrl);
         return;
       }
     }

--- a/apps/web/scripts/check-client-redirects.js
+++ b/apps/web/scripts/check-client-redirects.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = process.cwd();
+const allowedRedirectHelper = path.join(root, "utils", "redirect.ts");
+const ignoredDirectories = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "generated",
+  "node_modules",
+  "out",
+]);
+const restrictedRedirectPatterns = [
+  {
+    pattern: /\bwindow\s*\.\s*location\s*\.\s*href\s*=/g,
+    message: "Use redirectToSafeUrl instead of assigning window.location.href.",
+  },
+  {
+    pattern: /\bwindow\s*\.\s*location\s*\.\s*(assign|replace)\s*\(/g,
+    message:
+      "Use redirectToSafeUrl instead of calling window.location redirects directly.",
+  },
+  {
+    pattern: /(?<![\w$.])location\s*\.\s*href\s*=/g,
+    message: "Use redirectToSafeUrl instead of assigning location.href.",
+  },
+  {
+    pattern: /(?<![\w$.])location\s*\.\s*(assign|replace)\s*\(/g,
+    message:
+      "Use redirectToSafeUrl instead of calling location redirects directly.",
+  },
+];
+
+const violations = [];
+
+for (const file of collectSourceFiles(root)) {
+  if (file === allowedRedirectHelper) continue;
+
+  const content = fs.readFileSync(file, "utf8");
+  for (const { pattern, message } of restrictedRedirectPatterns) {
+    pattern.lastIndex = 0;
+
+    for (const match of content.matchAll(pattern)) {
+      violations.push({
+        file,
+        line: getLineNumber(content, match.index),
+        match: match[0],
+        message,
+      });
+    }
+  }
+}
+
+if (violations.length === 0) {
+  console.log("Client redirects use the safe redirect helper.");
+  process.exit(0);
+}
+
+console.error(
+  `Found ${violations.length} direct client redirect ${
+    violations.length === 1 ? "sink" : "sinks"
+  }:\n`,
+);
+
+for (const violation of violations) {
+  console.error(`${path.relative(root, violation.file)}:${violation.line}`);
+  console.error(`  ${violation.match}`);
+  console.error(`  ${violation.message}\n`);
+}
+
+process.exit(1);
+
+function* collectSourceFiles(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (ignoredDirectories.has(entry.name)) continue;
+
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* collectSourceFiles(fullPath);
+      continue;
+    }
+
+    if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      yield fullPath;
+    }
+  }
+}
+
+function getLineNumber(content, index) {
+  return content.slice(0, index).split("\n").length;
+}

--- a/apps/web/scripts/check-client-redirects.js
+++ b/apps/web/scripts/check-client-redirects.js
@@ -3,20 +3,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const ts = require("typescript");
+const { collectSourceFiles } = require("./lib/source-files");
 
 const root = process.cwd();
 const allowedRedirectHelper = path.join(root, "utils", "redirect.ts");
-const ignoredDirectories = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  "build",
-  "coverage",
-  "dist",
-  "generated",
-  "node_modules",
-  "out",
-]);
 const globalLocationOwners = new Set([
   "document",
   "globalThis",
@@ -66,22 +56,6 @@ for (const violation of violations) {
 }
 
 process.exit(1);
-
-function* collectSourceFiles(directory) {
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    if (ignoredDirectories.has(entry.name)) continue;
-
-    const fullPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      yield* collectSourceFiles(fullPath);
-      continue;
-    }
-
-    if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
-      yield fullPath;
-    }
-  }
-}
 
 function findRestrictedRedirects(sourceFile, file) {
   const sourceViolations = [];

--- a/apps/web/scripts/check-client-redirects.js
+++ b/apps/web/scripts/check-client-redirects.js
@@ -2,6 +2,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const ts = require("typescript");
 
 const root = process.cwd();
 const allowedRedirectHelper = path.join(root, "utils", "redirect.ts");
@@ -16,26 +17,19 @@ const ignoredDirectories = new Set([
   "node_modules",
   "out",
 ]);
-const restrictedRedirectPatterns = [
-  {
-    pattern: /\bwindow\s*\.\s*location\s*\.\s*href\s*=/g,
-    message: "Use redirectToSafeUrl instead of assigning window.location.href.",
-  },
-  {
-    pattern: /\bwindow\s*\.\s*location\s*\.\s*(assign|replace)\s*\(/g,
-    message:
-      "Use redirectToSafeUrl instead of calling window.location redirects directly.",
-  },
-  {
-    pattern: /(?<![\w$.])location\s*\.\s*href\s*=/g,
-    message: "Use redirectToSafeUrl instead of assigning location.href.",
-  },
-  {
-    pattern: /(?<![\w$.])location\s*\.\s*(assign|replace)\s*\(/g,
-    message:
-      "Use redirectToSafeUrl instead of calling location redirects directly.",
-  },
-];
+const globalLocationOwners = new Set([
+  "document",
+  "globalThis",
+  "parent",
+  "self",
+  "top",
+  "window",
+]);
+const redirectCallNames = new Set(["assign", "replace"]);
+const redirectAssignmentMessage =
+  "Use redirectToSafeUrl instead of assigning location.href.";
+const redirectCallMessage =
+  "Use redirectToSafeUrl instead of calling location redirects directly.";
 
 const violations = [];
 
@@ -43,18 +37,15 @@ for (const file of collectSourceFiles(root)) {
   if (file === allowedRedirectHelper) continue;
 
   const content = fs.readFileSync(file, "utf8");
-  for (const { pattern, message } of restrictedRedirectPatterns) {
-    pattern.lastIndex = 0;
+  const sourceFile = ts.createSourceFile(
+    file,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
 
-    for (const match of content.matchAll(pattern)) {
-      violations.push({
-        file,
-        line: getLineNumber(content, match.index),
-        match: match[0],
-        message,
-      });
-    }
-  }
+  violations.push(...findRestrictedRedirects(sourceFile, file));
 }
 
 if (violations.length === 0) {
@@ -92,6 +83,116 @@ function* collectSourceFiles(directory) {
   }
 }
 
-function getLineNumber(content, index) {
-  return content.slice(0, index).split("\n").length;
+function findRestrictedRedirects(sourceFile, file) {
+  const sourceViolations = [];
+
+  visit(sourceFile);
+  return sourceViolations;
+
+  function visit(node) {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isLocationHrefAccess(node.left)
+    ) {
+      sourceViolations.push(
+        createViolation(sourceFile, node.left, file, {
+          message: redirectAssignmentMessage,
+        }),
+      );
+    }
+
+    if (ts.isCallExpression(node) && isLocationRedirectCall(node.expression)) {
+      sourceViolations.push(
+        createViolation(sourceFile, node.expression, file, {
+          message: redirectCallMessage,
+        }),
+      );
+    }
+
+    ts.forEachChild(node, visit);
+  }
+}
+
+function createViolation(sourceFile, node, file, { message }) {
+  const { line } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile),
+  );
+
+  return {
+    file,
+    line: line + 1,
+    match: node.getText(sourceFile),
+    message,
+  };
+}
+
+function isLocationHrefAccess(expression) {
+  const propertyAccess = getStaticPropertyAccess(expression);
+  return (
+    propertyAccess?.name === "href" &&
+    isLocationExpression(propertyAccess.target)
+  );
+}
+
+function isLocationRedirectCall(expression) {
+  const propertyAccess = getStaticPropertyAccess(expression);
+  return (
+    !!propertyAccess &&
+    redirectCallNames.has(propertyAccess.name) &&
+    isLocationExpression(propertyAccess.target)
+  );
+}
+
+function isLocationExpression(expression) {
+  const locationExpression = stripExpression(expression);
+  if (ts.isIdentifier(locationExpression)) {
+    return locationExpression.text === "location";
+  }
+
+  const propertyAccess = getStaticPropertyAccess(locationExpression);
+  return (
+    propertyAccess?.name === "location" &&
+    isKnownGlobalLocationOwner(propertyAccess.target)
+  );
+}
+
+function isKnownGlobalLocationOwner(expression) {
+  const owner = stripExpression(expression);
+  return ts.isIdentifier(owner) && globalLocationOwners.has(owner.text);
+}
+
+function getStaticPropertyAccess(expression) {
+  const target = stripExpression(expression);
+
+  if (ts.isPropertyAccessExpression(target)) {
+    return { target: target.expression, name: target.name.text };
+  }
+
+  if (
+    ts.isElementAccessExpression(target) &&
+    (ts.isStringLiteral(target.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(target.argumentExpression))
+  ) {
+    return {
+      target: target.expression,
+      name: target.argumentExpression.text,
+    };
+  }
+
+  return null;
+}
+
+function stripExpression(expression) {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+
+  return current;
 }

--- a/apps/web/scripts/check-client-redirects.test.ts
+++ b/apps/web/scripts/check-client-redirects.test.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = path.join(
+  process.cwd(),
+  "scripts/check-client-redirects.js",
+);
+
+let testRoot: string;
+
+beforeEach(async () => {
+  testRoot = await mkdtemp(path.join(tmpdir(), "client-redirect-check-"));
+  await writeSource("utils/redirect.ts", "window.location.assign('/allowed');");
+});
+
+afterEach(async () => {
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe("check-client-redirects", () => {
+  it("rejects globalThis location redirects", async () => {
+    await writeSource(
+      "components/Redirect.tsx",
+      "export function redirect(url: string) { globalThis.location.href = url; }",
+    );
+
+    await expect(runCheck()).rejects.toMatchObject({
+      stdout: "",
+      stderr: expect.stringContaining("components/Redirect.tsx:1"),
+    });
+  });
+
+  it("ignores redirect sink text in comments and strings", async () => {
+    await writeSource(
+      "components/Copy.tsx",
+      `
+        const example = "window.location.href = '/billing'";
+        // globalThis.location.assign('/billing')
+        export const text = example;
+      `,
+    );
+
+    await expect(runCheck()).resolves.toMatchObject({
+      stdout: expect.stringContaining(
+        "Client redirects use the safe redirect helper.",
+      ),
+    });
+  });
+});
+
+async function runCheck() {
+  return execFileAsync("node", [scriptPath], { cwd: testRoot });
+}
+
+async function writeSource(relativePath: string, content: string) {
+  const filePath = path.join(testRoot, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content);
+}

--- a/apps/web/scripts/check-server-action-exports.js
+++ b/apps/web/scripts/check-server-action-exports.js
@@ -10,19 +10,9 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { collectSourceFiles } = require("./lib/source-files");
 
 const root = process.cwd();
-const ignoredDirectories = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  "build",
-  "coverage",
-  "dist",
-  "generated",
-  "node_modules",
-  "out",
-]);
 
 const violations = [];
 
@@ -77,22 +67,6 @@ console.error(
   'Move helpers to a separate server-only module without top-level "use server". For direct exported Server Actions, add a server-action-export: allow comment.',
 );
 process.exit(1);
-
-function* collectSourceFiles(directory) {
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    if (ignoredDirectories.has(entry.name)) continue;
-
-    const fullPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      yield* collectSourceFiles(fullPath);
-      continue;
-    }
-
-    if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
-      yield fullPath;
-    }
-  }
-}
 
 function hasTopLevelUseServer(content) {
   const source = stripLeadingTrivia(content);

--- a/apps/web/scripts/lib/source-files.js
+++ b/apps/web/scripts/lib/source-files.js
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ignoredDirectories = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "generated",
+  "node_modules",
+  "out",
+]);
+
+function* collectSourceFiles(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (ignoredDirectories.has(entry.name)) continue;
+
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* collectSourceFiles(fullPath);
+      continue;
+    }
+
+    if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      yield fullPath;
+    }
+  }
+}
+
+module.exports = { collectSourceFiles };

--- a/apps/web/utils/redirect.test.ts
+++ b/apps/web/utils/redirect.test.ts
@@ -90,6 +90,18 @@ describe("getSafeRedirectUrl", () => {
     ).toBe("/settings?tab=profile");
   });
 
+  it("falls back for same-origin URLs that normalize to protocol-relative paths", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://app.example.com" },
+    });
+
+    expect(
+      getSafeRedirectUrl("https://app.example.com//example.com/path", {
+        fallbackUrl: "/login",
+      }),
+    ).toBe("/login");
+  });
+
   it("falls back for external redirects unless explicitly allowed", () => {
     expect(getSafeRedirectUrl("https://example.com/oauth")).toBe("/");
     expect(

--- a/apps/web/utils/redirect.test.ts
+++ b/apps/web/utils/redirect.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { buildLoginRedirectUrl, buildRedirectUrl } from "@/utils/redirect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildLoginRedirectUrl,
+  buildRedirectUrl,
+  getSafeRedirectUrl,
+} from "@/utils/redirect";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("buildRedirectUrl", () => {
   it("returns base path when no searchParams", () => {
@@ -62,5 +70,47 @@ describe("buildLoginRedirectUrl", () => {
     expect(buildLoginRedirectUrl("https://example.com/automation")).toBe(
       "/login",
     );
+  });
+});
+
+describe("getSafeRedirectUrl", () => {
+  it("preserves internal redirects", () => {
+    expect(getSafeRedirectUrl("/settings?tab=profile#accounts")).toBe(
+      "/settings?tab=profile#accounts",
+    );
+  });
+
+  it("normalizes same-origin redirects to internal paths", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://app.example.com" },
+    });
+
+    expect(
+      getSafeRedirectUrl("https://app.example.com/settings?tab=profile"),
+    ).toBe("/settings?tab=profile");
+  });
+
+  it("falls back for external redirects unless explicitly allowed", () => {
+    expect(getSafeRedirectUrl("https://example.com/oauth")).toBe("/");
+    expect(
+      getSafeRedirectUrl("https://example.com/oauth", {
+        allowExternal: true,
+      }),
+    ).toBe("https://example.com/oauth");
+  });
+
+  it("rejects script and non-HTTPS external redirects", () => {
+    expect(
+      getSafeRedirectUrl("javascript:alert(1)", {
+        allowExternal: true,
+        fallbackUrl: "/login",
+      }),
+    ).toBe("/login");
+    expect(
+      getSafeRedirectUrl("http://example.com/oauth", {
+        allowExternal: true,
+        fallbackUrl: "/login",
+      }),
+    ).toBe("/login");
   });
 });

--- a/apps/web/utils/redirect.ts
+++ b/apps/web/utils/redirect.ts
@@ -44,7 +44,11 @@ export function getSafeRedirectUrl(
   try {
     const parsedUrl = new URL(redirectUrl);
     if (currentOrigin && parsedUrl.origin === currentOrigin) {
-      return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+      return (
+        normalizeInternalPath(
+          `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
+        ) ?? fallbackUrl
+      );
     }
 
     if (!options.allowExternal) return fallbackUrl;

--- a/apps/web/utils/redirect.ts
+++ b/apps/web/utils/redirect.ts
@@ -1,5 +1,10 @@
 import { normalizeInternalPath } from "@/utils/path";
 
+type SafeRedirectUrlOptions = {
+  allowExternal?: boolean;
+  fallbackUrl?: `/${string}`;
+};
+
 export function buildRedirectUrl(
   basePath: string,
   searchParams?: Record<string, string | string[] | undefined>,
@@ -24,4 +29,56 @@ export function buildLoginRedirectUrl(nextPath: string | null | undefined) {
   if (!normalizedNextPath) return "/login";
 
   return buildRedirectUrl("/login", { next: normalizedNextPath });
+}
+
+export function getSafeRedirectUrl(
+  redirectUrl: string | null | undefined,
+  options: SafeRedirectUrlOptions = {},
+) {
+  const fallbackUrl = options.fallbackUrl ?? "/";
+  const internalPath = normalizeInternalPath(redirectUrl);
+  if (internalPath) return internalPath;
+  if (!redirectUrl) return fallbackUrl;
+
+  const currentOrigin = getCurrentOrigin();
+  try {
+    const parsedUrl = new URL(redirectUrl);
+    if (currentOrigin && parsedUrl.origin === currentOrigin) {
+      return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+    }
+
+    if (!options.allowExternal) return fallbackUrl;
+    if (
+      parsedUrl.protocol === "https:" ||
+      isDevelopmentLocalHttpUrl(parsedUrl)
+    ) {
+      return parsedUrl.toString();
+    }
+  } catch {
+    return fallbackUrl;
+  }
+
+  return fallbackUrl;
+}
+
+export function redirectToSafeUrl(
+  redirectUrl: string | null | undefined,
+  options: SafeRedirectUrlOptions = {},
+) {
+  window.location.assign(getSafeRedirectUrl(redirectUrl, options));
+}
+
+function getCurrentOrigin() {
+  if (typeof window === "undefined") return null;
+  return window.location.origin;
+}
+
+function isDevelopmentLocalHttpUrl(url: URL) {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    url.protocol === "http:" &&
+    (url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "[::1]")
+  );
 }

--- a/apps/web/utils/user.ts
+++ b/apps/web/utils/user.ts
@@ -2,6 +2,7 @@
 
 import { signOut } from "@/utils/auth-client";
 import { clearLastEmailAccountAction } from "@/utils/actions/email-account-cookie";
+import { redirectToSafeUrl } from "@/utils/redirect";
 
 export async function logOut(callbackUrl?: string) {
   clearLastEmailAccountAction();
@@ -9,10 +10,10 @@ export async function logOut(callbackUrl?: string) {
   await signOut({
     fetchOptions: {
       onSuccess: () => {
-        window.location.href = callbackUrl || "/";
+        redirectToSafeUrl(callbackUrl);
       },
       onError: () => {
-        window.location.href = callbackUrl || "/";
+        redirectToSafeUrl(callbackUrl);
       },
     },
   });


### PR DESCRIPTION
Adds a shared safe redirect helper for client-side navigation and routes existing browser redirects through it.

- Normalizes internal and same-origin redirects, while requiring explicit opt-in for HTTPS external redirects.
- Adds focused tests plus a CI-only custom check to prevent direct client redirect sinks.

Validation: pnpm --filter inbox-zero-ai lint; pnpm --filter inbox-zero-ai check-client-redirects; pnpm --filter inbox-zero-ai test utils/redirect.test.ts