### PR TITLE
Add messaging preview page

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -545,7 +545,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const postArgs = postMessageSpy.mock.calls[0]?.[0];
 
       expect(message).toBeDefined();
-      expect(message?.text).toContain("New email — reply drafted");
+      expect(message?.text).toContain("I drafted a reply for you");
       expect(message?.text).toContain("*sender@example.com*");
       expect(message?.text).toContain(`about "${subject}"`);
       expect(message?.text).toContain("They wrote:");
@@ -902,13 +902,12 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const postArgs = postMessageSpy.mock.calls[0]?.[0];
 
       expect(message).toBeDefined();
-      expect(message?.text).toContain("Email notification");
+      expect(message?.text).toContain("New email for you");
       expect(message?.text).toContain(`*Subject:* ${subject}`);
       expect(getActionLabels(postArgs?.blocks)).toEqual([
         "Archive",
         "Mark read",
-        "Delete",
-        "Spam",
+        "More",
         "Open in Gmail",
         "Dismiss",
       ]);
@@ -1175,7 +1174,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       });
 
       expect(message).toBeDefined();
-      expect(message?.text).toContain("New email — reply drafted");
+      expect(message?.text).toContain("I drafted a reply for you");
       expect(prisma.executedAction.update).toHaveBeenCalledWith({
         where: { id: executedActionId },
         data: {
@@ -1301,6 +1300,20 @@ function getActionLabels(blocks: unknown[] | undefined) {
     }
 
     return block.elements.flatMap((element) => {
+      if (
+        element &&
+        typeof element === "object" &&
+        "type" in element &&
+        element.type === "static_select" &&
+        "placeholder" in element &&
+        element.placeholder &&
+        typeof element.placeholder === "object" &&
+        "text" in element.placeholder &&
+        typeof element.placeholder.text === "string"
+      ) {
+        return [element.placeholder.text];
+      }
+
       if (
         !element ||
         typeof element !== "object" ||

--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -82,6 +82,9 @@ export default function Components() {
           <div>
             <TextLink href="/components/chat">Chat Components →</TextLink>
           </div>
+          <div>
+            <TextLink href="/components/slack">Slack Components →</TextLink>
+          </div>
         </div>
 
         <div className="space-y-6">

--- a/apps/web/app/(landing)/components/slack/page.tsx
+++ b/apps/web/app/(landing)/components/slack/page.tsx
@@ -1,0 +1,494 @@
+import { Fragment, type ReactNode } from "react";
+import { Container } from "@/components/Container";
+import {
+  PageHeading,
+  PageSubHeading,
+  SectionHeader,
+  TextLink,
+} from "@/components/Typography";
+import { cn } from "@/utils";
+import { ActionType, ThreadTrackerType } from "@/generated/prisma/enums";
+import { buildSlackRuleNotificationPreviewBlocks } from "@/utils/messaging/rule-notifications";
+import { buildAppHomeBlocks } from "@/utils/messaging/providers/slack/messages/app-home";
+import { buildDigestBlocks } from "@/utils/messaging/providers/slack/messages/digest";
+import {
+  buildDocumentAskBlocks,
+  buildDocumentFiledBlocks,
+} from "@/utils/messaging/providers/slack/messages/document-filing";
+import { buildFollowUpReminderBlocks } from "@/utils/messaging/providers/slack/messages/follow-up-reminder";
+import { buildMeetingBriefingBlocks } from "@/utils/messaging/providers/slack/messages/meeting-briefing";
+
+type SlackTextObject = {
+  type: string;
+  text: string;
+  emoji?: boolean;
+};
+
+type SlackElement = {
+  type: string;
+  text?: SlackTextObject;
+  placeholder?: SlackTextObject;
+  options?: Array<{
+    text: SlackTextObject;
+    value: string;
+  }>;
+  url?: string;
+  style?: "primary" | "danger";
+  action_id?: string;
+  value?: string;
+};
+
+type SlackBlock = {
+  type: string;
+  text?: SlackTextObject;
+  elements?: SlackElement[];
+  fields?: SlackTextObject[];
+};
+
+type SlackPreview = {
+  title: string;
+  blocks?: SlackBlock[];
+  text?: string;
+};
+
+const slackPreviews: SlackPreview[] = [
+  {
+    title: "Channel confirmation",
+    text: "✅ Inbox Zero connected! You can mention <@UAPP123> in this channel to chat about your emails. If you enable meeting briefs or attachment filing notifications, I can send those here too.",
+  },
+  {
+    title: "Connection onboarding DM",
+    text: "✅ Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite <@UAPP123> there. You can also DM me anytime to chat about your emails.",
+  },
+  {
+    title: "Automation channel message",
+    text: "Rule matched: a high priority email needs review.\n\n_Reply with <@UAPP123> to chat about your emails._",
+  },
+  {
+    title: "Draft reply notification",
+    blocks: buildSlackRuleNotificationPreviewBlocks({
+      actionId: "demo-draft-action",
+      actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
+      email: {
+        headers: {
+          from: "Avery Customer <avery.customer@example.com>",
+          subject: "Question about the launch checklist and rollout timeline",
+        },
+        snippet:
+          "Could you confirm whether the migration checklist includes SSO, billing handoff, and a rollback plan?",
+        textPlain:
+          "Could you confirm whether the migration checklist includes SSO, billing handoff, and a rollback plan? The implementation team also had a few notes from the kickoff.\n\nOn Friday, Jane wrote:\n> We should confirm this covers the rollout checklist.",
+      },
+      draftContent:
+        "Thanks for sending this over. The checklist covers SSO and billing handoff, and I added a rollback section for the implementation team to review.",
+      openLink: {
+        label: "Open in Gmail",
+        url: "https://mail.example.com/thread/demo",
+      },
+    }) as SlackBlock[],
+  },
+  {
+    title: "Email notification",
+    blocks: buildSlackRuleNotificationPreviewBlocks({
+      actionId: "demo-notify-action",
+      actionType: ActionType.NOTIFY_MESSAGING_CHANNEL,
+      email: {
+        headers: {
+          from: "Billing Team <billing@example.com>",
+          subject: "Receipt and account update",
+        },
+        snippet:
+          "Your receipt is attached. Please review the account details and forward this to the finance workspace if everything looks correct.",
+      },
+      openLink: {
+        label: "Open in Gmail",
+        url: "https://mail.example.com/thread/demo",
+      },
+    }) as SlackBlock[],
+  },
+  {
+    title: "Follow-up awaiting reply",
+    blocks: buildFollowUpReminderBlocks({
+      subject: "Contract terms and final approval next steps",
+      counterpartyName: "Jane Partner",
+      counterpartyEmail: "jane.partner@example.com",
+      trackerType: ThreadTrackerType.AWAITING,
+      daysSinceSent: 4,
+      snippet:
+        "Wanted to check whether the redlines have landed.\n> On Friday, Jane wrote: We will review this with legal and reply shortly.",
+      threadLink: "https://mail.example.com/thread/awaiting",
+      threadLinkLabel: "Open in Gmail",
+      trackerId: "tracker-awaiting",
+    }) as SlackBlock[],
+  },
+  {
+    title: "Follow-up needs reply",
+    blocks: buildFollowUpReminderBlocks({
+      subject:
+        "Implementation questions for the migration plan and launch timeline",
+      counterpartyName: "Alex Customer",
+      counterpartyEmail: "alex.customer@example.com",
+      trackerType: ThreadTrackerType.NEEDS_REPLY,
+      daysSinceSent: 1,
+      snippet:
+        "Could you walk me through the SSO setup and confirm the staging domain before Thursday?",
+      trackerId: "tracker-needs-reply",
+    }) as SlackBlock[],
+  },
+  {
+    title: "Digest with overflow",
+    blocks: buildDigestBlocks({
+      date: new Date("2026-04-21T09:00:00Z"),
+      ruleNames: {
+        newsletters: "Newsletters",
+        receipts: "Receipts",
+      },
+      itemsByRule: {
+        newsletters: [
+          { from: "Acme Weekly", subject: "This week in product updates" },
+          { from: "Design Notes", subject: "Five patterns worth saving" },
+          { from: "Morning Brief", subject: "Markets and tech headlines" },
+          { from: "Dev Digest", subject: "TypeScript changes to know" },
+          { from: "Ops Weekly", subject: "Reliability review" },
+          { from: "Product Hunt", subject: "Launches you might like" },
+          { from: "Security Feed", subject: "New dependency advisories" },
+        ],
+        receipts: [
+          { from: "Stripe", subject: "Your receipt from Example App" },
+          { from: "Cloud Vendor", subject: "Monthly invoice available" },
+        ],
+      },
+    }) as SlackBlock[],
+  },
+  {
+    title: "Meeting briefing",
+    blocks: buildMeetingBriefingBlocks({
+      meetingTitle: "Customer implementation review",
+      formattedTime: "Today at 2:00 PM",
+      videoConferenceLink: "https://meet.example.com/customer-review",
+      eventUrl: "https://calendar.example.com/event/123",
+      briefingContent: {
+        guests: [
+          {
+            name: "Jamie Lee",
+            email: "jamie@example.com",
+            bullets: [
+              "Leads platform operations for the customer team",
+              "Last thread asked for status and launch risks",
+            ],
+          },
+          {
+            name: "Morgan Patel",
+            email: "morgan@example.com",
+            bullets: [
+              "Owns security review",
+              "Previously requested SSO documentation",
+            ],
+          },
+        ],
+        internalTeamMembers: [
+          { name: "Taylor Admin", email: "taylor@example.com" },
+        ],
+      },
+    }) as SlackBlock[],
+  },
+  {
+    title: "Document filed",
+    blocks: buildDocumentFiledBlocks({
+      filename: "invoice-2026-04.pdf",
+      folderPath: "Finance/Invoices/2026",
+      driveProvider: "google",
+      senderEmail: "vendor@example.com",
+      fileId: "file_123",
+    }) as SlackBlock[],
+  },
+  {
+    title: "Document filing question",
+    blocks: buildDocumentAskBlocks({
+      filename: "contract-draft-v2.docx",
+      senderEmail: "legal@example.com",
+      reasoning:
+        "This looks like a legal contract, but it mentions two projects.",
+    }) as SlackBlock[],
+  },
+  {
+    title: "App Home",
+    blocks: buildAppHomeBlocks().blocks as SlackBlock[],
+  },
+];
+
+export default function SlackComponentsPage() {
+  return (
+    <Container size="6xl">
+      <div className="space-y-8 py-8">
+        <div className="space-y-3">
+          <TextLink href="/components">← Components</TextLink>
+          <div className="space-y-2">
+            <PageHeading>Slack Components</PageHeading>
+            <PageSubHeading>
+              Storybook-style previews for Slack messages sent by Inbox Zero.
+            </PageSubHeading>
+          </div>
+        </div>
+
+        <section className="space-y-6">
+          {slackPreviews.map((preview) => (
+            <SlackPreviewCard key={preview.title} preview={preview} />
+          ))}
+        </section>
+      </div>
+    </Container>
+  );
+}
+
+function SlackPreviewCard({ preview }: { preview: SlackPreview }) {
+  return (
+    <article className="space-y-3">
+      <SectionHeader>{preview.title}</SectionHeader>
+
+      <div className="min-w-0 rounded-lg border bg-[#f8f8f8] p-3">
+        <div className="rounded-lg border border-[#dedede] bg-white p-4 shadow-sm">
+          <div className="mb-3 flex items-start gap-3">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded bg-[#481449] text-lg font-semibold text-white">
+              IZ
+            </div>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-baseline gap-x-2">
+                <span className="font-bold text-[#1d1c1d]">Inbox Zero</span>
+                <span className="text-xs text-[#616061]">APP</span>
+                <span className="text-xs text-[#616061]">9:41 AM</span>
+              </div>
+              <div className="mt-2 space-y-2 text-[15px] leading-5 text-[#1d1c1d]">
+                {preview.blocks ? (
+                  <SlackBlocks blocks={preview.blocks} />
+                ) : (
+                  <SlackText text={preview.text ?? ""} />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function SlackBlocks({ blocks }: { blocks: SlackBlock[] }) {
+  return (
+    <>
+      {blocks.map((block, index) => (
+        <SlackBlockView key={`${block.type}-${index}`} block={block} />
+      ))}
+    </>
+  );
+}
+
+function SlackBlockView({ block }: { block: SlackBlock }) {
+  if (block.type === "header") {
+    return (
+      <h3 className="text-[17px] font-bold leading-6">
+        {renderTextObject(block.text)}
+      </h3>
+    );
+  }
+
+  if (block.type === "section") {
+    return (
+      <div className="whitespace-pre-wrap break-words">
+        {renderTextObject(block.text)}
+        {block.fields && (
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            {block.fields.map((field, index) => (
+              <div key={`${field.text}-${index}`}>
+                {renderTextObject(field)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (block.type === "context") {
+    return (
+      <div className="flex flex-wrap items-center gap-1 text-[13px] leading-5 text-[#616061]">
+        {block.elements?.map((element, index) => (
+          <span key={`${element.type}-${index}`}>
+            {renderTextObject(element.text)}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (block.type === "divider") {
+    return <hr className="my-3 border-[#dddddd]" />;
+  }
+
+  if (block.type === "actions") {
+    return (
+      <div className="flex flex-wrap gap-2 pt-1">
+        {block.elements?.map((element, index) => (
+          <SlackButton
+            element={element}
+            key={`${buttonLabel(element)}-${index}`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <pre className="overflow-auto rounded bg-[#f8f8f8] p-2 text-xs">
+      {JSON.stringify(block, null, 2)}
+    </pre>
+  );
+}
+
+function SlackButton({ element }: { element: SlackElement }) {
+  if (element.type === "static_select") {
+    return (
+      <button
+        className="h-9 rounded border border-[#c9c9c9] bg-white px-3 text-sm font-bold text-[#1d1c1d] shadow-sm"
+        type="button"
+      >
+        {element.placeholder?.text ?? "More"} ▾
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className={cn(
+        "h-9 rounded border border-[#c9c9c9] bg-white px-3 text-sm font-bold text-[#1d1c1d] shadow-sm",
+        element.style === "primary" &&
+          "border-[#148567] bg-[#148567] text-white",
+        element.style === "danger" && "border-[#e01e5a] text-[#e01e5a]",
+      )}
+      type="button"
+    >
+      {buttonLabel(element)}
+    </button>
+  );
+}
+
+function SlackText({ text }: { text: string }) {
+  return (
+    <div className="whitespace-pre-wrap break-words">{renderMrkdwn(text)}</div>
+  );
+}
+
+function renderTextObject(textObject: SlackTextObject | undefined) {
+  if (!textObject) return null;
+  if (textObject.type === "mrkdwn") return renderMrkdwn(textObject.text);
+  return textObject.text;
+}
+
+function renderMrkdwn(text: string) {
+  const lines = text.split("\n");
+
+  return lines.map((line, index) => {
+    const content = line.startsWith(">") ? line.replace(/^>\s?/, "") : line;
+    const rendered = renderInlineMrkdwn(content);
+
+    if (line.startsWith(">")) {
+      return (
+        <blockquote
+          className="my-1 border-l-4 border-[#dddddd] pl-3 text-[#616061]"
+          key={`${line}-${index}`}
+        >
+          {rendered}
+        </blockquote>
+      );
+    }
+
+    return (
+      <Fragment key={`${line}-${index}`}>
+        {rendered}
+        {index < lines.length - 1 ? <br /> : null}
+      </Fragment>
+    );
+  });
+}
+
+function renderInlineMrkdwn(text: string): ReactNode[] {
+  const parts = text.split(/(<[^>|]+(?:\|[^>]+)?>|`[^`]+`|\*[^*]+\*|_[^_]+_)/g);
+
+  return parts.map((part, index) => {
+    if (!part) return null;
+
+    if (part.startsWith("<") && part.endsWith(">")) {
+      return renderSlackLink(part, index);
+    }
+
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return (
+        <code
+          className="rounded bg-[#f3f3f3] px-1 py-0.5 text-[13px]"
+          key={`${part}-${index}`}
+        >
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+
+    if (part.startsWith("*") && part.endsWith("*")) {
+      return (
+        <strong key={`${part}-${index}`}>
+          {renderInlineMrkdwn(part.slice(1, -1))}
+        </strong>
+      );
+    }
+
+    if (part.startsWith("_") && part.endsWith("_")) {
+      return (
+        <em key={`${part}-${index}`}>
+          {renderInlineMrkdwn(part.slice(1, -1))}
+        </em>
+      );
+    }
+
+    return decodeSlackText(part);
+  });
+}
+
+function renderSlackLink(part: string, index: number) {
+  const value = part.slice(1, -1);
+
+  if (value.startsWith("@")) {
+    const displayName = value === "@UAPP123" ? "@Inbox Zero" : value;
+
+    return (
+      <span
+        className="rounded bg-[#e8f5fa] px-1 font-medium text-[#1264a3]"
+        key={`${part}-${index}`}
+      >
+        {displayName}
+      </span>
+    );
+  }
+
+  const [href = "", label] = value.split("|");
+  return (
+    <a
+      className="font-medium text-[#1264a3] hover:underline"
+      href={href.startsWith("http") ? href : "#"}
+      key={`${part}-${index}`}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {label ?? href}
+    </a>
+  );
+}
+
+function buttonLabel(element: SlackElement) {
+  return element.text?.text ?? "Button";
+}
+
+function decodeSlackText(text: string) {
+  return text
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -741,5 +741,5 @@ function resolveFollowUpCounterparty({
 function getThreadLinkLabel(provider: string) {
   if (isGoogleProvider(provider)) return "Open in Gmail";
   if (isMicrosoftProvider(provider)) return "Open in Outlook";
-  return "Open thread";
+  return "Open email";
 }

--- a/apps/web/app/api/slack/callback/route.test.ts
+++ b/apps/web/app/api/slack/callback/route.test.ts
@@ -161,6 +161,16 @@ describe("slack callback route", () => {
         teamName: "Acme Workspace",
       }),
     );
+    expect(
+      mockSendSlackOnboardingDirectMessageWithLogging,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "xoxb-access-token",
+        botUserId: "B123",
+        teamId: "T123",
+        userId: "U123",
+      }),
+    );
   });
 
   it("returns a processing redirect on the channels page while another request owns the OAuth code lock", async () => {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -6,6 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
+      disallow: "/components",
     },
     sitemap: [
       `${env.NEXT_PUBLIC_BASE_URL}/sitemap.xml`,

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -288,6 +288,7 @@ export const linkSlackWorkspaceAction = actionClient
       await sendSlackOnboardingDirectMessageWithLogging({
         accessToken: orgMateChannel.accessToken,
         userId: slackUser.id,
+        botUserId: orgMateChannel.botUserId,
         teamId,
         logger,
       });

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -261,7 +261,7 @@ function buildTelegramFollowUpCard({
     children.push(
       Actions([
         LinkButton({
-          label: threadLinkLabel ?? "Open thread",
+          label: threadLinkLabel ?? "Open email",
           url: threadLink,
         }),
       ]),

--- a/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
+++ b/apps/web/utils/messaging/providers/slack/handle-slack-callback.ts
@@ -131,6 +131,7 @@ export async function handleSlackCallback(
     await sendSlackOnboardingDirectMessageWithLogging({
       accessToken: tokens.access_token,
       userId: tokens.authed_user.id,
+      botUserId: tokens.bot_user_id,
       teamId: tokens.team.id,
       logger: callbackLogger,
     });

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
@@ -11,6 +11,7 @@ const baseAwaitingParams = {
   daysSinceSent: 4,
   snippet: "Following up on the proposal we sent last week.",
   threadLink: "https://mail.example.com/thread/awaiting",
+  threadLinkLabel: "Open in Gmail",
   trackerId: "tracker-abc123",
 };
 
@@ -89,6 +90,8 @@ describe("buildFollowUpReminderBlocks", () => {
   it("includes the thread link as an action button", () => {
     const json = blocksJson(baseAwaitingParams);
     expect(json).toContain("https://mail.example.com/thread/awaiting");
+    expect(json).toContain("Open in Gmail");
+    expect(json).not.toContain("Open thread");
   });
 
   it("renders a Mark done button carrying the tracker id", () => {

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -17,6 +17,7 @@ export type FollowUpReminderBlocksParams = {
   daysSinceSent: number;
   snippet?: string;
   threadLink?: string;
+  threadLinkLabel?: string;
   trackerId: string;
 };
 
@@ -28,6 +29,7 @@ export function buildFollowUpReminderBlocks({
   daysSinceSent,
   snippet,
   threadLink,
+  threadLinkLabel,
   trackerId,
 }: FollowUpReminderBlocksParams): (KnownBlock | Block)[] {
   const { directionLine, counterpartyPrefix, snippetLabel, emoji } =
@@ -72,7 +74,11 @@ export function buildFollowUpReminderBlocks({
   if (threadLink) {
     actionElements.push({
       type: "button",
-      text: { type: "plain_text", text: "Open thread", emoji: true },
+      text: {
+        type: "plain_text",
+        text: threadLinkLabel ?? "Open email",
+        emoji: true,
+      },
       url: threadLink,
     });
   }

--- a/apps/web/utils/messaging/providers/slack/send-onboarding-direct-message.ts
+++ b/apps/web/utils/messaging/providers/slack/send-onboarding-direct-message.ts
@@ -4,11 +4,13 @@ import type { Logger } from "@/utils/logger";
 export async function sendSlackOnboardingDirectMessageWithLogging({
   accessToken,
   userId,
+  botUserId,
   teamId,
   logger,
 }: {
   accessToken: string;
   userId: string;
+  botUserId?: string | null;
   teamId: string;
   logger: Logger;
 }): Promise<void> {
@@ -16,6 +18,7 @@ export async function sendSlackOnboardingDirectMessageWithLogging({
     await sendConnectionOnboardingDirectMessage({
       accessToken,
       userId,
+      botUserId,
     });
   } catch (error) {
     logger.warn("Failed to send Slack onboarding direct message", {

--- a/apps/web/utils/messaging/providers/slack/send.test.ts
+++ b/apps/web/utils/messaging/providers/slack/send.test.ts
@@ -42,6 +42,9 @@ describe("slack send helpers", () => {
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "C123",
+        text: expect.stringContaining(
+          "You can mention <@UAPP123> in this channel",
+        ),
         unfurl_links: false,
         unfurl_media: false,
       }),
@@ -78,11 +81,13 @@ describe("slack send helpers", () => {
     await sendConnectionOnboardingDirectMessage({
       accessToken: "xoxb-token",
       userId: "U123",
+      botUserId: "UAPP123",
     });
 
     expect(mockPostMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "U123",
+        text: expect.stringContaining("invite <@UAPP123> there"),
         unfurl_links: false,
         unfurl_media: false,
       }),

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -61,23 +61,25 @@ export async function sendChannelConfirmation({
   const client = createSlackClient(accessToken);
 
   await postMessageWithJoin(client, channelId, {
-    text: `✅ Inbox Zero connected! You can ${formatSlackAppMention(botUserId)} here to chat about your emails. If you enable meeting briefs or attachment filing notifications, I can send those in this channel too.`,
+    text: `✅ Inbox Zero connected! You can mention ${formatSlackAppMention(botUserId)} in this channel to chat about your emails. If you enable meeting briefs or attachment filing notifications, I can send those here too.`,
   });
 }
 
 export async function sendConnectionOnboardingDirectMessage({
   accessToken,
   userId,
+  botUserId,
 }: {
   accessToken: string;
   userId: string;
+  botUserId?: string | null;
 }): Promise<void> {
   const client = createSlackClient(accessToken);
 
   await client.chat.postMessage(
     disableSlackLinkUnfurls({
       channel: userId,
-      text: "✅ Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite @InboxZero there. You can also DM me anytime to chat about your emails.",
+      text: `✅ Inbox Zero connected. Next, choose a private channel in Inbox Zero Settings for meeting brief and attachment notifications, then invite ${formatSlackAppMention(botUserId)} there. You can also DM me anytime to chat about your emails.`,
     }),
   );
 }

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -169,7 +169,8 @@ describe("handleRuleNotificationAction", () => {
     const [, , card] = editMessage.mock.calls[0];
     const cardText = JSON.stringify(card);
 
-    expect(cardText).toContain("New email — reply drafted");
+    expect(cardText).toContain("I drafted a reply for you");
+    expect(cardText).not.toContain("📩 You got an email");
     expect(cardText).toContain("*sender@example.com*");
     expect(cardText).toContain('about \\"Test subject\\"');
     expect(cardText).toContain("They wrote:");
@@ -1067,24 +1068,25 @@ describe("sendMessagingRuleNotification", () => {
     expect(buttonLabels).toEqual([
       "Archive",
       "Mark read",
-      "Delete",
-      "Spam",
       "Open in Gmail",
       "Dismiss",
     ]);
     expect(elements).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: "button",
-          action_id: "rule_notify_trash",
-          value: "action-1",
-          style: "danger",
-        }),
-        expect.objectContaining({
-          type: "button",
-          action_id: "rule_notify_mark_spam",
-          value: "action-1",
-          style: "danger",
+          type: "static_select",
+          action_id: "rule_notify_more",
+          placeholder: { type: "plain_text", text: "More" },
+          options: [
+            expect.objectContaining({
+              text: { type: "plain_text", text: "Delete" },
+              value: "rule_notify_trash:action-1",
+            }),
+            expect.objectContaining({
+              text: { type: "plain_text", text: "Spam" },
+              value: "rule_notify_mark_spam:action-1",
+            }),
+          ],
         }),
         expect.objectContaining({
           type: "button",
@@ -1101,7 +1103,12 @@ describe("sendMessagingRuleNotification", () => {
     expect(elements).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: "static_select",
+          type: "button",
+          action_id: "rule_notify_trash",
+        }),
+        expect.objectContaining({
+          type: "button",
+          action_id: "rule_notify_mark_spam",
         }),
       ]),
     );
@@ -1815,8 +1822,8 @@ describe("buildMessagingRuleNotificationText", () => {
     const text = buildMessagingRuleNotificationText({
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
-        title: "New email — reply drafted",
-        summary: '📩 You got an email from *Sender* about "Test".',
+        title: "✍️ I drafted a reply for you",
+        summary: 'You got an email from *Sender* about "Test".',
         details: [
           "✍️ *I drafted a reply for you:*\nSee <https://example.com|details>.",
         ],
@@ -1824,7 +1831,7 @@ describe("buildMessagingRuleNotificationText", () => {
       provider: MessagingProvider.TELEGRAM,
     });
 
-    expect(text).toContain("New email — reply drafted");
+    expect(text).toContain("I drafted a reply for you");
     expect(text).toContain('You got an email from Sender about "Test".');
     expect(text).toContain("details: https://example.com");
     expect(text).toContain("Draft editing isn't available in Telegram yet.");
@@ -1838,9 +1845,8 @@ describe("buildMessagingRuleNotificationText", () => {
     const text = buildMessagingRuleNotificationText({
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
-        title: "New email — reply drafted",
-        summary:
-          '📩 You got an email from *Tom &amp; Jerry* about "A &lt;B&gt;".',
+        title: "✍️ I drafted a reply for you",
+        summary: 'You got an email from *Tom &amp; Jerry* about "A &lt;B&gt;".',
         details: ["💬 *They wrote:*\nHello &amp; welcome"],
       },
       provider: MessagingProvider.TEAMS,

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -5,6 +5,8 @@ import {
   Card,
   CardText,
   LinkButton,
+  Select,
+  SelectOption,
   type ActionEvent,
   type CardElement,
   type CardChild,
@@ -128,6 +130,42 @@ type NotificationEmailPreview = {
   textHtml?: string;
   attachments?: Array<{ filename: string }>;
 };
+
+export function buildSlackRuleNotificationPreviewBlocks({
+  actionId,
+  actionType,
+  email,
+  systemType = null,
+  draftContent,
+  draftAttachmentNames,
+  openLink,
+}: {
+  actionId: string;
+  actionType: ActionType;
+  email: NotificationEmailPreview;
+  systemType?: SystemType | null;
+  draftContent?: string | null;
+  draftAttachmentNames?: string[];
+  openLink?: NotificationOpenLink | null;
+}) {
+  const content = buildNotificationContent({
+    actionType,
+    email,
+    systemType,
+    draftContent,
+    draftAttachmentNames,
+    format: "slack",
+  });
+
+  return cardToBlockKit(
+    buildNotificationCard({
+      actionId,
+      actionType,
+      content,
+      openLink,
+    }),
+  );
+}
 
 type MessagingRuleNotificationResult = {
   delivered: boolean;
@@ -1527,7 +1565,7 @@ function buildNotificationContent({
 }: {
   actionType: ActionType;
   email: NotificationEmailPreview;
-  systemType: SystemType | string | null;
+  systemType: SystemType | null;
   draftContent?: string | null;
   draftAttachmentNames?: string[];
   format: NotificationContentFormat;
@@ -1553,7 +1591,7 @@ function buildNotificationContent({
     const emailPreview = buildEmailPreview(email, { format });
     const draftPreview = buildDraftPreview(draftContent, { format });
 
-    const summary = `📩 You got an email from *${senderDisplay}* about "${subject}".`;
+    const summary = `You got an email from *${senderDisplay}* about "${subject}".`;
 
     const details: string[] = [];
     if (emailPreview) {
@@ -1573,7 +1611,7 @@ function buildNotificationContent({
     }
 
     return {
-      title: "📩 New email — reply drafted",
+      title: "✍️ I drafted a reply for you",
       summary,
       details,
     };
@@ -1594,13 +1632,13 @@ function buildNotificationContent({
     ].filter(Boolean);
 
     return {
-      title: "📅 Calendar invite",
+      title: "📅 Calendar invite for you",
       summary: lines.join("\n"),
     };
   }
 
   return {
-    title: "✉️ Email notification",
+    title: getNotificationTitleForSystemType(systemType),
     summary: buildEmailSummary(email),
     details: [
       buildNotificationDetailSection({
@@ -1658,17 +1696,20 @@ function buildNotificationCard({
               label: "Mark read",
               value: actionId,
             }),
-            Button({
-              id: RULE_NOTIFY_TRASH_ACTION_ID,
-              label: "Delete",
-              style: "danger",
-              value: actionId,
-            }),
-            Button({
-              id: RULE_NOTIFY_MARK_SPAM_ACTION_ID,
-              label: "Spam",
-              style: "danger",
-              value: actionId,
+            Select({
+              id: RULE_NOTIFY_MORE_ACTION_ID,
+              label: "More",
+              placeholder: "More",
+              options: [
+                SelectOption({
+                  label: "Delete",
+                  value: `${RULE_NOTIFY_TRASH_ACTION_ID}:${actionId}`,
+                }),
+                SelectOption({
+                  label: "Spam",
+                  value: `${RULE_NOTIFY_MARK_SPAM_ACTION_ID}:${actionId}`,
+                }),
+              ],
             }),
             ...(openLink ? [LinkButton(openLink)] : []),
             Button({
@@ -1898,7 +1939,7 @@ function createProviderForContext(
   });
 }
 
-function getInfoNotificationTitle(systemType: SystemType | string | null) {
+function getInfoNotificationTitle(systemType: SystemType | null) {
   return systemType === SystemType.CALENDAR
     ? "Calendar invite"
     : "Email notification";
@@ -2364,4 +2405,25 @@ function getLinkedProviderLimitationText({
   }
 
   return `Quick actions like archive and mark read are Slack-only right now, so this ${providerName} message is view-only.`;
+}
+
+function getNotificationTitleForSystemType(
+  systemType: SystemType | null,
+): string {
+  switch (systemType) {
+    case SystemType.NEWSLETTER:
+      return "📰 New newsletter for you";
+    case SystemType.MARKETING:
+      return "📢 New marketing email for you";
+    case SystemType.RECEIPT:
+      return "🧾 New receipt for you";
+    case SystemType.COLD_EMAIL:
+      return "❄️ Cold email caught";
+    case SystemType.FYI:
+      return "👀 FYI for you";
+    case SystemType.NOTIFICATION:
+      return "🔔 New notification for you";
+    default:
+      return "📬 New email for you";
+  }
 }


### PR DESCRIPTION
Adds a preview page for messaging outputs and links it from the components page.

- Blocks component preview pages from robots indexing.
- Aligns Slack notification copy, action labels, and mention rendering.
- Adds preview support that reuses production notification block generation.