### PR TITLE
messaging: tidy Slack notification action row and subject layout

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -907,9 +907,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(getActionLabels(postArgs?.blocks)).toEqual([
         "Archive",
         "Mark read",
-        "More",
         "Open in Gmail",
         "Dismiss",
+        "More",
       ]);
     });
 

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -547,7 +547,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(message).toBeDefined();
       expect(message?.text).toContain("I drafted a reply for you");
       expect(message?.text).toContain("*sender@example.com*");
-      expect(message?.text).toContain(`about "${subject}"`);
+      expect(message?.text).toContain(`*Subject:* ${subject}`);
       expect(message?.text).toContain("They wrote:");
       expect(message?.text).toContain("Can you help with this request?");
       expect(message?.text).toContain("I drafted a reply for you:");

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -172,7 +172,7 @@ describe("handleRuleNotificationAction", () => {
     expect(cardText).toContain("I drafted a reply for you");
     expect(cardText).not.toContain("📩 You got an email");
     expect(cardText).toContain("*sender@example.com*");
-    expect(cardText).toContain('about \\"Test subject\\"');
+    expect(cardText).toContain("*Subject:* Test subject");
     expect(cardText).toContain("They wrote:");
     expect(cardText).toContain("Original message body");
     expect(cardText).toContain("I drafted a reply for you:");
@@ -1823,7 +1823,7 @@ describe("buildMessagingRuleNotificationText", () => {
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
         title: "✍️ I drafted a reply for you",
-        summary: 'You got an email from *Sender* about "Test".',
+        summary: "You got an email from *Sender*.\n*Subject:* Test",
         details: [
           "✍️ *I drafted a reply for you:*\nSee <https://example.com|details>.",
         ],
@@ -1832,7 +1832,8 @@ describe("buildMessagingRuleNotificationText", () => {
     });
 
     expect(text).toContain("I drafted a reply for you");
-    expect(text).toContain('You got an email from Sender about "Test".');
+    expect(text).toContain("You got an email from Sender.");
+    expect(text).toContain("Subject: Test");
     expect(text).toContain("details: https://example.com");
     expect(text).toContain("Draft editing isn't available in Telegram yet.");
   });
@@ -1846,7 +1847,8 @@ describe("buildMessagingRuleNotificationText", () => {
       actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
       content: {
         title: "✍️ I drafted a reply for you",
-        summary: 'You got an email from *Tom &amp; Jerry* about "A &lt;B&gt;".',
+        summary:
+          "You got an email from *Tom &amp; Jerry*.\n*Subject:* A &lt;B&gt;",
         details: ["💬 *They wrote:*\nHello &amp; welcome"],
       },
       provider: MessagingProvider.TEAMS,

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1591,7 +1591,7 @@ function buildNotificationContent({
     const emailPreview = buildEmailPreview(email, { format });
     const draftPreview = buildDraftPreview(draftContent, { format });
 
-    const summary = `You got an email from *${senderDisplay}* about "${subject}".`;
+    const summary = `You got an email from *${senderDisplay}*.\n*Subject:* ${subject}`;
 
     const details: string[] = [];
     if (emailPreview) {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1696,6 +1696,12 @@ function buildNotificationCard({
               label: "Mark read",
               value: actionId,
             }),
+            ...(openLink ? [LinkButton(openLink)] : []),
+            Button({
+              id: RULE_DRAFT_DISMISS_ACTION_ID,
+              label: "Dismiss",
+              value: actionId,
+            }),
             Select({
               id: RULE_NOTIFY_MORE_ACTION_ID,
               label: "More",
@@ -1710,12 +1716,6 @@ function buildNotificationCard({
                   value: `${RULE_NOTIFY_MARK_SPAM_ACTION_ID}:${actionId}`,
                 }),
               ],
-            }),
-            ...(openLink ? [LinkButton(openLink)] : []),
-            Button({
-              id: RULE_DRAFT_DISMISS_ACTION_ID,
-              label: "Dismiss",
-              value: actionId,
             }),
           ],
     ),


### PR DESCRIPTION
## Summary

Two small UX tweaks to Slack rule notifications:

- Move the More overflow menu to the absolute end of the action row (Archive, Mark read, Open in Gmail, Dismiss, More). Slack convention puts overflow last so primary actions stay visible.
- Put the email subject on its own line in the draft-reply summary, prefixed with *Subject:*. Long subjects buried inside "from X about Y" were hard to scan.

## Test plan

- [ ] Existing unit tests pass (41/41 locally)
- [ ] Verify in Slack: action row reads Archive, Mark read, Open in Gmail, Dismiss, More
- [ ] Verify in Slack: draft-reply card shows the subject on its own line under the sender

🤖 Generated with [Claude Code](https://claude.com/claude-code)