### PR TITLE
calendar: Share token save handling

### DIFF
--- a/apps/web/utils/calendar/client.test.ts
+++ b/apps/web/utils/calendar/client.test.ts
@@ -47,9 +47,11 @@ vi.mock("@googleapis/calendar", () => ({
 describe("google calendar client", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 1 } as any);
   });
 
   it("saves refreshed tokens to the requested calendar connection", async () => {
+    const expectedExpiresAt = Date.now() - 1000;
     const refreshedExpiresAt = Date.now() + 3_600_000;
     refreshAccessToken.mockResolvedValue({
       credentials: {
@@ -64,20 +66,27 @@ describe("google calendar client", () => {
     await getCalendarClientWithRefresh({
       accessToken: "stale-access-token",
       refreshToken: "target-refresh-token",
-      expiresAt: Date.now() - 1000,
+      expiresAt: expectedExpiresAt,
       emailAccountId: "email-account-id",
       connectionId: "target-google-connection-id",
       logger,
     });
 
-    expect(prisma.calendarConnection.update).toHaveBeenCalledWith({
-      where: { id: "target-google-connection-id" },
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "target-google-connection-id",
+        expiresAt: {
+          gte: new Date(expectedExpiresAt),
+          lt: new Date(expectedExpiresAt + 1),
+        },
+      },
       data: {
         accessToken: "new-access-token",
         refreshToken: undefined,
         expiresAt: new Date(refreshedExpiresAt),
       },
     });
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
     expect(prisma.calendarConnection.findFirst).not.toHaveBeenCalled();
   });
 
@@ -109,11 +118,33 @@ describe("google calendar client", () => {
       },
       select: { id: true },
     });
-    expect(prisma.calendarConnection.update).toHaveBeenCalledWith(
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "target-google-connection-id" },
+        where: expect.objectContaining({ id: "target-google-connection-id" }),
       }),
     );
+  });
+
+  it("skips stale Google calendar token saves when another refresh already won", async () => {
+    prisma.calendarConnection.updateMany.mockResolvedValue({ count: 0 } as any);
+    refreshAccessToken.mockResolvedValue({
+      credentials: {
+        access_token: "new-access-token",
+        expiry_date: Date.now() + 3_600_000,
+      },
+    });
+
+    await getCalendarClientWithRefresh({
+      accessToken: "stale-access-token",
+      refreshToken: "target-refresh-token",
+      expiresAt: Date.now() - 1000,
+      emailAccountId: "email-account-id",
+      connectionId: "target-google-connection-id",
+      logger,
+    });
+
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+    expect(prisma.calendarConnection.updateMany).toHaveBeenCalledOnce();
   });
 
   it("uses emulator-aware OAuth and Calendar API options", async () => {

--- a/apps/web/utils/calendar/client.ts
+++ b/apps/web/utils/calendar/client.ts
@@ -8,6 +8,7 @@ import {
   getGoogleApiRootUrl,
   getGoogleOauthClientOptions,
 } from "@/utils/google/oauth";
+import { saveCalendarTokens } from "@/utils/calendar/save-calendar-tokens";
 
 type AuthOptions = {
   accessToken?: string | null;
@@ -88,11 +89,12 @@ export const getCalendarClientWithRefresh = async ({
     if (calendarConnectionId) {
       await saveCalendarTokens({
         tokens: {
-          access_token: newAccessToken ?? undefined,
-          refresh_token: newRefreshToken,
-          expires_at: newExpiresAt,
+          accessToken: newAccessToken ?? undefined,
+          refreshToken: newRefreshToken,
+          expiresAt: newExpiresAt ? new Date(newExpiresAt) : null,
         },
         connectionId: calendarConnectionId,
+        expectedExpiresAt: expiresAt,
         logger,
       });
     } else {
@@ -132,42 +134,5 @@ export async function fetchGoogleCalendars(
   } catch (error) {
     logger.error("Error fetching Google calendars", { error });
     throw new SafeError("Failed to fetch calendars");
-  }
-}
-
-async function saveCalendarTokens({
-  tokens,
-  connectionId,
-  logger,
-}: {
-  tokens: {
-    access_token?: string;
-    refresh_token?: string;
-    expires_at?: number; // milliseconds
-  };
-  connectionId: string;
-  logger: Logger;
-}) {
-  if (!tokens.access_token) {
-    logger.warn("No access token to save for calendar connection", {
-      connectionId,
-    });
-    return;
-  }
-
-  try {
-    await prisma.calendarConnection.update({
-      where: { id: connectionId },
-      data: {
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
-        expiresAt: tokens.expires_at ? new Date(tokens.expires_at) : null,
-      },
-    });
-
-    logger.info("Calendar tokens saved successfully", { connectionId });
-  } catch (error) {
-    logger.error("Failed to save calendar tokens", { error, connectionId });
-    throw error;
   }
 }

--- a/apps/web/utils/calendar/save-calendar-tokens.ts
+++ b/apps/web/utils/calendar/save-calendar-tokens.ts
@@ -1,0 +1,59 @@
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+export async function saveCalendarTokens({
+  tokens,
+  connectionId,
+  expectedExpiresAt,
+  logger,
+}: {
+  tokens: {
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: Date | null;
+  };
+  connectionId: string;
+  expectedExpiresAt: number | null;
+  logger: Logger;
+}) {
+  if (!tokens.accessToken) {
+    logger.warn("No access token to save for calendar connection", {
+      connectionId,
+    });
+    return;
+  }
+
+  try {
+    const result = await prisma.calendarConnection.updateMany({
+      where: {
+        id: connectionId,
+        expiresAt: getExpectedExpiresAtWhere(expectedExpiresAt),
+      },
+      data: {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt: tokens.expiresAt ?? null,
+      },
+    });
+
+    if (result.count === 0) {
+      logger.info("Skipped stale calendar token update", { connectionId });
+      return { status: "conflict" as const };
+    }
+
+    logger.info("Calendar tokens saved successfully", { connectionId });
+    return { status: "saved" as const };
+  } catch (error) {
+    logger.error("Failed to save calendar tokens", { error, connectionId });
+    throw error;
+  }
+}
+
+function getExpectedExpiresAtWhere(expectedExpiresAt: number | null) {
+  if (!expectedExpiresAt) return null;
+
+  return {
+    gte: new Date(expectedExpiresAt),
+    lt: new Date(expectedExpiresAt + 1),
+  };
+}

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -8,6 +8,7 @@ import {
 import { CALENDAR_SCOPES } from "@/utils/outlook/scopes";
 import { SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
+import { saveCalendarTokens } from "@/utils/calendar/save-calendar-tokens";
 import {
   Client,
   type AuthenticationProvider,
@@ -101,9 +102,9 @@ export const getCalendarClientWithRefresh = async ({
     if (calendarConnection) {
       await saveCalendarTokens({
         tokens: {
-          access_token: tokens.access_token,
-          refresh_token: tokens.refresh_token,
-          expires_at: Math.floor(Date.now() / 1000 + Number(tokens.expires_in)),
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token,
+          expiresAt: new Date(Date.now() + Number(tokens.expires_in) * 1000),
         },
         connectionId: calendarConnection.id,
         expectedExpiresAt: expiresAt,
@@ -157,63 +158,4 @@ export async function fetchMicrosoftCalendars(
     logger.error("Error fetching Microsoft calendars", { error });
     throw new SafeError("Failed to fetch calendars");
   }
-}
-
-async function saveCalendarTokens({
-  tokens,
-  connectionId,
-  expectedExpiresAt,
-  logger,
-}: {
-  tokens: {
-    access_token?: string;
-    refresh_token?: string;
-    expires_at?: number; // seconds
-  };
-  connectionId: string;
-  expectedExpiresAt: number | null;
-  logger: Logger;
-}) {
-  if (!tokens.access_token) {
-    logger.warn("No access token to save for calendar connection", {
-      connectionId,
-    });
-    return;
-  }
-
-  try {
-    const result = await prisma.calendarConnection.updateMany({
-      where: {
-        id: connectionId,
-        expiresAt: getExpectedExpiresAtWhere(expectedExpiresAt),
-      },
-      data: {
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
-        expiresAt: tokens.expires_at
-          ? new Date(tokens.expires_at * 1000)
-          : null,
-      },
-    });
-
-    if (result.count === 0) {
-      logger.info("Skipped stale calendar token update", { connectionId });
-      return { status: "conflict" as const };
-    }
-
-    logger.info("Calendar tokens saved successfully", { connectionId });
-    return { status: "saved" as const };
-  } catch (error) {
-    logger.error("Failed to save calendar tokens", { error, connectionId });
-    throw error;
-  }
-}
-
-function getExpectedExpiresAtWhere(expectedExpiresAt: number | null) {
-  if (!expectedExpiresAt) return null;
-
-  return {
-    gte: new Date(expectedExpiresAt),
-    lt: new Date(expectedExpiresAt + 1),
-  };
 }


### PR DESCRIPTION
Refactors calendar token persistence so provider clients share the same stale-write protection. This keeps token refresh behavior consistent across calendar providers.

- Adds a shared calendar token save helper with optimistic concurrency checks
- Updates Google and Microsoft calendar refresh paths to use the shared helper
- Expands Google calendar tests for stale token save conflicts

Validation:
- pnpm --filter inbox-zero-ai test utils/calendar/client.test.ts utils/outlook/calendar-client-occ.test.ts --run
- pnpm --filter inbox-zero-ai exec biome check utils/calendar/client.ts utils/calendar/client.test.ts utils/calendar/save-calendar-tokens.ts utils/outlook/calendar-client.ts utils/outlook/calendar-client-occ.test.ts
- git diff --check