### PR TITLE
Fix follow-up notification body formatting

### DIFF
--- a/apps/web/utils/follow-up/copy.test.ts
+++ b/apps/web/utils/follow-up/copy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFollowUpText, truncateSnippet } from "./copy";
+
+describe("follow-up notification copy", () => {
+  it("keeps metadata normalized to a single line", () => {
+    expect(normalizeFollowUpText("  Status&nbsp;update\n\nfrom\tAlex  ")).toBe(
+      "Status update from Alex",
+    );
+  });
+
+  it("preserves readable snippet paragraphs beyond the short metadata preview length", () => {
+    const body =
+      "I hope you're doing well. I'm reaching out because I'd like to find some time for us to reunite and discuss the new ebook. ";
+    const snippet = [
+      "Hi Barbara,",
+      "",
+      body.repeat(3).trim(),
+      "Please let me know when you might be available to chat.",
+      "",
+      "Best regards,",
+    ].join("\n");
+
+    expect(snippet.length).toBeGreaterThan(280);
+    expect(truncateSnippet(snippet)).toBe(snippet);
+  });
+});

--- a/apps/web/utils/follow-up/copy.ts
+++ b/apps/web/utils/follow-up/copy.ts
@@ -1,7 +1,7 @@
 import { ThreadTrackerType } from "@/generated/prisma/enums";
 import he from "he";
 
-const SNIPPET_MAX_CHARS = 280;
+const SNIPPET_MAX_CHARS = 1800;
 
 export function getFollowUpCopy(trackerType: ThreadTrackerType) {
   const isAwaiting = trackerType === ThreadTrackerType.AWAITING;
@@ -18,12 +18,26 @@ export function getFollowUpCopy(trackerType: ThreadTrackerType) {
   };
 }
 
-export function truncateSnippet(snippet: string): string {
-  const collapsed = normalizeFollowUpText(snippet);
-  if (collapsed.length <= SNIPPET_MAX_CHARS) return collapsed;
-  return `${collapsed.slice(0, SNIPPET_MAX_CHARS - 1).trimEnd()}…`;
+export function truncateSnippet(
+  snippet: string,
+  maxChars = SNIPPET_MAX_CHARS,
+): string {
+  const normalized = normalizeFollowUpSnippet(snippet);
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 1).trimEnd()}…`;
 }
 
 export function normalizeFollowUpText(text: string): string {
   return he.decode(text).replace(/\s+/g, " ").trim();
+}
+
+function normalizeFollowUpSnippet(text: string): string {
+  return he
+    .decode(text)
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -147,6 +147,36 @@ describe("sendFollowUpNotification", () => {
     expect(serializedCard).not.toContain(`Open: ${threadLink}`);
   });
 
+  it("preserves multi-line Telegram snippets past the old short preview cap", async () => {
+    const body =
+      "I hope you're doing well. I'm reaching out because I'd like to find some time for us to reunite and discuss the new ebook. ";
+    const snippet = [
+      "Hi Barbara,",
+      "",
+      body.repeat(3).trim(),
+      "Please let me know when you might be available to chat.",
+      "",
+      "Best regards,",
+    ].join("\n");
+
+    expect(snippet.length).toBeGreaterThan(280);
+
+    await sendFollowUpNotification({
+      channels: [telegramChannel],
+      ...baseArgs,
+      snippet,
+    });
+
+    const [, card] = mockTelegramPostMessage.mock.calls[0];
+    const snippetChild = (card as any).children.find(
+      (child: any) =>
+        child.type === "text" && child.content.includes("Your sent email:"),
+    );
+
+    expect(snippetChild.content).toContain("> Hi Barbara,\n>\n> I hope");
+    expect(snippetChild.content).toContain("Best regards,");
+  });
+
   it("fans out across multiple channels in parallel", async () => {
     await sendFollowUpNotification({
       channels: [slackChannel, teamsChannel],

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -25,6 +25,8 @@ import {
   truncateSnippet,
 } from "@/utils/follow-up/copy";
 
+const TELEGRAM_SNIPPET_MAX_CHARS = 3000;
+
 export type FollowUpNotificationChannel = {
   id: string;
   provider: MessagingProvider;
@@ -225,7 +227,8 @@ function formatFollowUpText({
     `${counterpartyPrefix} ${normalizeFollowUpText(counterpartyName)} <${counterpartyEmail}> · ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
   ];
 
-  if (snippet) lines.push(`> ${truncateSnippet(snippet)}`);
+  const formattedSnippet = snippet ? formatQuotedSnippet(snippet) : "";
+  if (formattedSnippet) lines.push(formattedSnippet);
   if (threadLink) lines.push(`Open: ${threadLink}`);
 
   return lines.join("\n");
@@ -253,8 +256,12 @@ function buildTelegramFollowUpCard({
     ),
   ];
 
-  if (snippet) {
-    children.push(CardText(`${snippetLabel}:\n> ${truncateSnippet(snippet)}`));
+  const formattedSnippet = snippet
+    ? formatQuotedSnippet(snippet, TELEGRAM_SNIPPET_MAX_CHARS)
+    : "";
+
+  if (formattedSnippet) {
+    children.push(CardText(`${snippetLabel}:\n${formattedSnippet}`));
   }
 
   if (threadLink) {
@@ -272,4 +279,11 @@ function buildTelegramFollowUpCard({
     title: `${emoji} Follow-up nudge`,
     children,
   });
+}
+
+function formatQuotedSnippet(snippet: string, maxChars?: number): string {
+  return truncateSnippet(snippet, maxChars)
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n");
 }

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts
@@ -77,6 +77,62 @@ describe("buildFollowUpReminderBlocks", () => {
     expect(json).toContain("Following up on the proposal we sent last week.");
   });
 
+  it("preserves snippet paragraph breaks in quoted Slack text", () => {
+    const blocks = buildFollowUpReminderBlocks({
+      ...baseAwaitingParams,
+      snippet: [
+        "Hi Barbara,",
+        "",
+        "I hope you're doing well.",
+        "I'm reaching out because I'd like to find some time for us to reconnect.",
+        "",
+        "Best regards,",
+      ].join("\n"),
+    });
+
+    const snippetBlock = blocks.find(
+      (block) =>
+        block.type === "section" &&
+        "text" in block &&
+        block.text?.type === "mrkdwn" &&
+        block.text.text.includes("Your sent email:"),
+    );
+
+    expect(snippetBlock).toBeDefined();
+    expect((snippetBlock as any).text.text).toBe(
+      [
+        "*Your sent email:*",
+        "> Hi Barbara,",
+        ">",
+        "> I hope you're doing well.",
+        "> I'm reaching out because I'd like to find some time for us to reconnect.",
+        ">",
+        "> Best regards,",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps escaped snippet text within Slack section limits", () => {
+    const blocks = buildFollowUpReminderBlocks({
+      ...baseAwaitingParams,
+      snippet: `Intro\n${"&<> ".repeat(1200)}`,
+    });
+
+    const snippetBlock = blocks.find(
+      (block) =>
+        block.type === "section" &&
+        "text" in block &&
+        block.text?.type === "mrkdwn" &&
+        block.text.text.includes("Your sent email:"),
+    );
+
+    expect(snippetBlock).toBeDefined();
+    const text = (snippetBlock as any).text.text;
+    expect(text.length).toBeLessThanOrEqual(3000);
+    expect(text).toContain("&amp;&lt;&gt;");
+    expect(text).toContain("…");
+  });
+
   it("omits the snippet block when no snippet is provided", () => {
     const json = blocksJson({ ...baseAwaitingParams, snippet: undefined });
     expect(json).not.toContain("Following up on");

--- a/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
+++ b/apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts
@@ -9,6 +9,9 @@ import {
 import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "@/utils/follow-up/follow-up-actions";
 import { pluralize } from "@/utils/string";
 
+const SLACK_SNIPPET_MAX_CHARS = 2200;
+const SLACK_SECTION_TEXT_MAX_CHARS = 3000;
+
 export type FollowUpReminderBlocksParams = {
   subject: string;
   counterpartyName: string;
@@ -65,7 +68,7 @@ export function buildFollowUpReminderBlocks({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${escapeSlackText(snippetLabel)}:*\n> ${escapeSlackText(truncateSnippet(snippet))}`,
+        text: formatSlackSnippetSectionText(snippetLabel, snippet),
       },
     });
   }
@@ -100,4 +103,40 @@ export function buildFollowUpReminderBlocks({
   });
 
   return blocks;
+}
+
+function formatSlackSnippetSectionText(label: string, snippet: string): string {
+  const prefix = `*${escapeSlackText(label)}:*`;
+  const format = (maxChars: number) =>
+    `${prefix}\n${formatSlackQuotedText(truncateSnippet(snippet, maxChars))}`;
+
+  const fullText = format(SLACK_SNIPPET_MAX_CHARS);
+  if (fullText.length <= SLACK_SECTION_TEXT_MAX_CHARS) return fullText;
+
+  let best = format(1);
+  let low = 1;
+  let high = SLACK_SNIPPET_MAX_CHARS;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = format(mid);
+    if (candidate.length <= SLACK_SECTION_TEXT_MAX_CHARS) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return best;
+}
+
+function formatSlackQuotedText(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      const escaped = escapeSlackText(line);
+      return escaped ? `> ${escaped}` : ">";
+    })
+    .join("\n");
 }


### PR DESCRIPTION
## Summary
- Preserve paragraph breaks in follow-up email snippets instead of collapsing them into one line.
- Increase body preview limits for Slack/Telegram while keeping provider caps bounded.
- Add regressions for multi-line Slack/Telegram rendering and Slack section text limits after escaping.

## Tests
- pnpm --filter inbox-zero-ai test --run utils/follow-up/copy.test.ts utils/messaging/providers/slack/messages/follow-up-reminder.test.ts utils/follow-up/send-follow-up-notification.test.ts
- pnpm exec biome check apps/web/utils/follow-up/copy.ts apps/web/utils/follow-up/copy.test.ts apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.ts apps/web/utils/messaging/providers/slack/messages/follow-up-reminder.test.ts apps/web/utils/follow-up/send-follow-up-notification.ts apps/web/utils/follow-up/send-follow-up-notification.test.ts

## Review
Automated review initially found a Slack 3000-character section limit edge case after escaping; this PR includes a follow-up fix and regression test for that.