### PR TITLE
debug: show drafting reply memories on debug page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/debug/memories/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/memories/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import type { ReplyMemoryKind, ReplyMemoryScopeType } from "@prisma/client";
+import type {
+  ReplyMemoryKind,
+  ReplyMemoryScopeType,
+} from "@/generated/prisma/enums";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import useSWR from "swr";

--- a/apps/web/app/(app)/[emailAccountId]/debug/memories/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/memories/page.tsx
@@ -1,13 +1,29 @@
 "use client";
 
+import type { ReplyMemoryKind, ReplyMemoryScopeType } from "@prisma/client";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import useSWR from "swr";
+import { Badge } from "@/components/ui/badge";
 import { LoadingContent } from "@/components/LoadingContent";
 import { PageWrapper } from "@/components/PageWrapper";
 import { PageHeading } from "@/components/Typography";
 import type { DebugMemoriesResponse } from "@/app/api/user/debug/memories/route";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { prefixPath } from "@/utils/path";
+
+const REPLY_MEMORY_KIND_LABELS: Record<ReplyMemoryKind, string> = {
+  FACT: "Fact",
+  PREFERENCE: "Preference",
+  PROCEDURE: "Procedure",
+};
+
+const REPLY_MEMORY_SCOPE_LABELS: Record<ReplyMemoryScopeType, string> = {
+  GLOBAL: "Global",
+  SENDER: "Sender",
+  DOMAIN: "Domain",
+  TOPIC: "Topic",
+};
 
 export default function DebugMemoriesPage() {
   const { emailAccountId } = useAccount();
@@ -21,39 +37,124 @@ export default function DebugMemoriesPage() {
 
       <LoadingContent loading={isLoading} error={error}>
         <div className="mt-6 space-y-6">
-          <div className="rounded-lg border p-3 sm:w-fit">
-            <p className="text-xs text-muted-foreground">Total Memories</p>
-            <p className="mt-1 text-lg font-medium">{data?.totalCount ?? 0}</p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <MemoryCountCard label="Total memories" count={data?.totalCount} />
+            <MemoryCountCard
+              label="Chat memories"
+              count={data?.chatMemoryCount}
+            />
+            <MemoryCountCard
+              label="Drafting reply memories"
+              count={data?.replyMemoryCount}
+            />
           </div>
 
-          <div className="space-y-2">
-            {data?.memories?.map((memory) => (
+          <MemorySection
+            title="Chat memories"
+            emptyMessage="No chat memories stored yet."
+            items={data?.chatMemories}
+            renderItem={(memory) => (
               <div key={memory.id} className="rounded-lg border p-3">
-                <p className="text-sm">{memory.content}</p>
-                <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>{new Date(memory.createdAt).toLocaleString()}</span>
-                  {memory.chatId && (
-                    <Link
-                      href={prefixPath(
-                        emailAccountId,
-                        `/assistant?chatId=${memory.chatId}`,
-                      )}
-                      className="underline hover:text-foreground"
-                    >
-                      View chat
-                    </Link>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">Chat</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(memory.createdAt).toLocaleString()}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm">{memory.content}</p>
+                {memory.chatId && (
+                  <Link
+                    href={prefixPath(
+                      emailAccountId,
+                      `/assistant?chatId=${memory.chatId}`,
+                    )}
+                    className="mt-2 inline-block text-xs underline hover:text-foreground"
+                  >
+                    View chat
+                  </Link>
+                )}
+              </div>
+            )}
+          />
+
+          <MemorySection
+            title="Drafting reply memories"
+            emptyMessage="No drafting reply memories stored yet."
+            items={data?.replyMemories}
+            renderItem={(memory) => (
+              <div key={memory.id} className="rounded-lg border p-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge>{REPLY_MEMORY_KIND_LABELS[memory.kind]}</Badge>
+                  <Badge variant="secondary">
+                    {formatScope(memory.scopeType, memory.scopeValue)}
+                  </Badge>
+                  {memory.isLearnedStyleEvidence && (
+                    <Badge variant="outline">Learned style</Badge>
                   )}
+                  <span className="text-xs text-muted-foreground">
+                    {memory._count.sources}{" "}
+                    {memory._count.sources === 1 ? "source" : "sources"}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm">{memory.content}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  <span>
+                    Created {new Date(memory.createdAt).toLocaleString()}
+                  </span>
+                  <span>
+                    Updated {new Date(memory.updatedAt).toLocaleString()}
+                  </span>
                 </div>
               </div>
-            ))}
-            {data?.memories?.length === 0 && (
-              <p className="text-sm text-muted-foreground">
-                No memories stored yet.
-              </p>
             )}
-          </div>
+          />
         </div>
       </LoadingContent>
     </PageWrapper>
   );
+}
+
+function MemoryCountCard({
+  label,
+  count,
+}: {
+  label: string;
+  count: number | undefined;
+}) {
+  return (
+    <div className="rounded-lg border p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 text-lg font-medium">{count ?? 0}</p>
+    </div>
+  );
+}
+
+function MemorySection<T>({
+  title,
+  emptyMessage,
+  items,
+  renderItem,
+}: {
+  title: string;
+  emptyMessage: string;
+  items: T[] | undefined;
+  renderItem: (item: T) => ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-base font-semibold">{title}</h2>
+      {items && items.length > 0 ? (
+        <div className="space-y-2">{items.map(renderItem)}</div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      )}
+    </section>
+  );
+}
+
+function formatScope(scopeType: ReplyMemoryScopeType, scopeValue: string) {
+  const label = REPLY_MEMORY_SCOPE_LABELS[scopeType];
+  if (!scopeValue) return label;
+
+  return `${label}: ${scopeValue}`;
 }

--- a/apps/web/app/api/user/debug/memories/route.test.ts
+++ b/apps/web/app/api/user/debug/memories/route.test.ts
@@ -1,0 +1,100 @@
+vi.mock("server-only", () => ({}));
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (
+      _scope: string,
+      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
+    ) =>
+    (request: NextRequest, ...args: unknown[]) =>
+      handler(
+        request as NextRequest & {
+          auth: { emailAccountId: string };
+        },
+        ...args,
+      ),
+}));
+
+import { GET } from "./route";
+
+describe("user/debug/memories route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns chat memories and drafting reply memories separately", async () => {
+    const chatMemoryCreatedAt = new Date("2026-05-01T10:00:00.000Z");
+    const replyMemoryCreatedAt = new Date("2026-05-02T10:00:00.000Z");
+    const replyMemoryUpdatedAt = new Date("2026-05-03T10:00:00.000Z");
+
+    prisma.chatMemory.findMany.mockResolvedValue([
+      {
+        id: "chat-memory-1",
+        content: "Use concise responses.",
+        createdAt: chatMemoryCreatedAt,
+        updatedAt: chatMemoryCreatedAt,
+        chatId: "chat-1",
+      },
+    ]);
+    prisma.chatMemory.count.mockResolvedValue(1);
+    prisma.replyMemory.findMany.mockResolvedValue([
+      {
+        id: "reply-memory-1",
+        content: "Mention the next step first.",
+        createdAt: replyMemoryCreatedAt,
+        updatedAt: replyMemoryUpdatedAt,
+        kind: "PREFERENCE",
+        scopeType: "GLOBAL",
+        scopeValue: "",
+        isLearnedStyleEvidence: true,
+        _count: { sources: 2 },
+      },
+    ]);
+    prisma.replyMemory.count.mockResolvedValue(1);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/user/debug/memories",
+    );
+    (
+      request as NextRequest & {
+        auth: { emailAccountId: string };
+      }
+    ).auth = { emailAccountId: "email-account-1" };
+
+    const response = await GET(request, {} as never);
+    const body = await response.json();
+
+    expect(body).toEqual({
+      chatMemories: [
+        {
+          id: "chat-memory-1",
+          content: "Use concise responses.",
+          createdAt: chatMemoryCreatedAt.toISOString(),
+          updatedAt: chatMemoryCreatedAt.toISOString(),
+          chatId: "chat-1",
+        },
+      ],
+      replyMemories: [
+        {
+          id: "reply-memory-1",
+          content: "Mention the next step first.",
+          createdAt: replyMemoryCreatedAt.toISOString(),
+          updatedAt: replyMemoryUpdatedAt.toISOString(),
+          kind: "PREFERENCE",
+          scopeType: "GLOBAL",
+          scopeValue: "",
+          isLearnedStyleEvidence: true,
+          _count: { sources: 2 },
+        },
+      ],
+      chatMemoryCount: 1,
+      replyMemoryCount: 1,
+      totalCount: 2,
+    });
+  });
+});

--- a/apps/web/app/api/user/debug/memories/route.ts
+++ b/apps/web/app/api/user/debug/memories/route.ts
@@ -17,21 +17,45 @@ async function getMemoriesDebugData({
 }: {
   emailAccountId: string;
 }) {
-  const [memories, totalCount] = await Promise.all([
-    prisma.chatMemory.findMany({
-      where: { emailAccountId },
-      orderBy: { createdAt: "desc" },
-      take: 200,
-      select: {
-        id: true,
-        content: true,
-        createdAt: true,
-        updatedAt: true,
-        chatId: true,
-      },
-    }),
-    prisma.chatMemory.count({ where: { emailAccountId } }),
-  ]);
+  const [chatMemories, chatMemoryCount, replyMemories, replyMemoryCount] =
+    await Promise.all([
+      prisma.chatMemory.findMany({
+        where: { emailAccountId },
+        orderBy: { createdAt: "desc" },
+        take: 200,
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          updatedAt: true,
+          chatId: true,
+        },
+      }),
+      prisma.chatMemory.count({ where: { emailAccountId } }),
+      prisma.replyMemory.findMany({
+        where: { emailAccountId },
+        orderBy: { updatedAt: "desc" },
+        take: 200,
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          updatedAt: true,
+          kind: true,
+          scopeType: true,
+          scopeValue: true,
+          isLearnedStyleEvidence: true,
+          _count: { select: { sources: true } },
+        },
+      }),
+      prisma.replyMemory.count({ where: { emailAccountId } }),
+    ]);
 
-  return { memories, totalCount };
+  return {
+    chatMemories,
+    replyMemories,
+    chatMemoryCount,
+    replyMemoryCount,
+    totalCount: chatMemoryCount + replyMemoryCount,
+  };
 }


### PR DESCRIPTION
## TLDR
Splits the debug memories page into chat-memory and drafting-reply-memory sections with per-kind counts and type-safe enum labels.

- Adds drafting reply memories alongside chat memories on the admin debug page
- Returns separated arrays plus chat/reply/total counts from the debug API route
- Type-safe Record<enum, label> mappings catch new Prisma enum values at compile time
- Adds a route test asserting the response shape

## Test plan
- [ ] Open the debug memories page and verify both sections render with badges
- [ ] Confirm empty states show when an account has no memories of a given kind
- [ ] Confirm counts match the underlying tables