### PR TITLE
team: support inviting up to 10 members at once (INB-261)

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
 import { toastSuccess, toastError } from "@/components/Toast";
 import {
-  inviteMemberAction,
+  inviteMembersAction,
   createOrganizationAndInviteAction,
 } from "@/utils/actions/organization";
 import { isValidEmail } from "@/utils/email";
@@ -63,15 +63,20 @@ export function StepInviteTeam({
     let errorCount = 0;
 
     if (organizationId) {
-      const results = await Promise.all(
-        emails.map((email) =>
-          inviteMemberAction({ email, role: "member", organizationId }),
-        ),
-      );
-      for (const result of results) {
-        if (result?.serverError || result?.validationErrors) errorCount++;
-        else successCount++;
+      const result = await inviteMembersAction({
+        organizationId,
+        invitations: emails.map((email) => ({ email, role: "member" })),
+      });
+
+      if (result?.serverError || result?.validationErrors) {
+        toastError({ description: "Failed to send invitations" });
+        return;
       }
+
+      if (!result?.data) return;
+
+      successCount = result.data.results.filter((r) => r.success).length;
+      errorCount = result.data.results.filter((r) => !r.success).length;
     } else {
       const result = await createOrganizationAndInviteAction(emailAccountId, {
         emails,

--- a/apps/web/components/InviteMemberModal.tsx
+++ b/apps/web/components/InviteMemberModal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useForm, type SubmitHandler } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { PlusIcon, XIcon } from "lucide-react";
 import {
   Dialog,
   DialogClose,
@@ -22,21 +22,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { TooltipExplanation } from "@/components/TooltipExplanation";
 import { toastSuccess, toastError } from "@/components/Toast";
 import { TagInput } from "@/components/TagInput";
-import { Label } from "@/components/ui/label";
 import {
-  inviteMemberAction,
+  inviteMembersAction,
   createOrganizationAndInviteAction,
 } from "@/utils/actions/organization";
-import {
-  inviteMemberBody,
-  type InviteMemberBody,
-} from "@/utils/actions/organization.validation";
+import { MAX_BULK_INVITES } from "@/utils/actions/organization.validation";
 import { useDialogState } from "@/hooks/useDialogState";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { isValidEmail } from "@/utils/email";
+
+type InviteRole = "admin" | "member";
+
+type InviteFormValues = {
+  invitations: { email: string; role: InviteRole }[];
+};
 
 export function InviteMemberModal({
   organizationId,
@@ -67,18 +68,16 @@ export function InviteMemberModal({
       {trigger !== null &&
         (trigger ?? (
           <DialogTrigger asChild>
-            <Button size="sm">Invite Member</Button>
+            <Button size="sm">Invite Members</Button>
           </DialogTrigger>
         ))}
 
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>
-            {organizationId ? "Invite Member" : "Invite Members"}
-          </DialogTitle>
+          <DialogTitle>Invite teammates</DialogTitle>
           <DialogDescription>
             {organizationId
-              ? "Send an invitation to join your organization."
+              ? "We'll send each teammate an email with a link to join your organization. The link expires in two weeks."
               : "Enter email addresses to invite team members."}
           </DialogDescription>
         </DialogHeader>
@@ -108,83 +107,147 @@ function InviteForm({
 }) {
   const {
     register,
+    control,
     handleSubmit,
-    formState: { errors, isSubmitting },
-    reset,
     setValue,
     watch,
-  } = useForm<InviteMemberBody>({
-    resolver: zodResolver(inviteMemberBody),
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<InviteFormValues>({
     defaultValues: {
-      organizationId,
-      role: "member",
+      invitations: [
+        { email: "", role: "member" },
+        { email: "", role: "member" },
+      ],
     },
   });
 
-  const selectedRole = watch("role");
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "invitations",
+  });
 
-  const onSubmit: SubmitHandler<InviteMemberBody> = useCallback(
-    async (data) => {
-      const result = await inviteMemberAction(data);
+  const invitations = watch("invitations");
+  const canAddMore = fields.length < MAX_BULK_INVITES;
 
-      if (result?.serverError) {
-        toastError({
-          title: "Error sending invitation",
-          description: result.serverError,
-        });
-      } else {
-        toastSuccess({
-          description: "Invitation sent successfully!",
-        });
-        reset();
-        onClose();
-        onSuccess?.();
-      }
-    },
-    [reset, onClose, onSuccess],
-  );
+  const onSubmit = handleSubmit(async (data) => {
+    const filled = data.invitations
+      .map((i) => ({ email: i.email.trim().toLowerCase(), role: i.role }))
+      .filter((i) => i.email.length > 0);
+
+    if (filled.length === 0) {
+      toastError({ description: "Please enter at least one email address" });
+      return;
+    }
+
+    const result = await inviteMembersAction({
+      organizationId,
+      invitations: filled,
+    });
+
+    if (result?.serverError) {
+      toastError({
+        title: "Error sending invitations",
+        description: result.serverError,
+      });
+      return;
+    }
+
+    if (!result?.data) return;
+
+    const successCount = result.data.results.filter((r) => r.success).length;
+    const failures = result.data.results.filter((r) => !r.success);
+
+    if (successCount > 0) {
+      toastSuccess({
+        description: `${successCount} invitation${successCount > 1 ? "s" : ""} sent successfully!`,
+      });
+      onSuccess?.();
+    }
+
+    if (failures.length > 0) {
+      toastError({
+        title: `Failed to send ${failures.length} invitation${failures.length > 1 ? "s" : ""}`,
+        description: failures
+          .map((f) => `${f.email}: ${f.error ?? "Failed"}`)
+          .join("\n"),
+      });
+    }
+
+    if (successCount > 0) {
+      reset();
+      onClose();
+    }
+  });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <Input
-        type="email"
-        name="email"
-        label="Email Address"
-        placeholder="john.doe@example.com"
-        registerProps={register("email")}
-        error={errors.email}
-      />
-
+    <form onSubmit={onSubmit} className="space-y-4">
       <div className="space-y-2">
-        <div className="flex items-center space-x-2">
-          <Label htmlFor="role">Role</Label>
-          <TooltipExplanation
-            side="right"
-            text="Members can view and collaborate.\nAdmins can manage the organization and invite others."
-          />
-        </div>
-        <Select
-          value={selectedRole}
-          onValueChange={(value) =>
-            setValue("role", value as "admin" | "member")
-          }
-        >
-          <SelectTrigger id="role">
-            <SelectValue placeholder="Select a role" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="member">Member</SelectItem>
-            <SelectItem value="admin">Admin</SelectItem>
-          </SelectContent>
-        </Select>
+        {fields.map((field, index) => (
+          <div key={field.id} className="flex items-start gap-2">
+            <div className="flex-1 min-w-0">
+              <Input
+                type="email"
+                name={`invitations.${index}.email`}
+                placeholder="email@example.com"
+                registerProps={register(`invitations.${index}.email`, {
+                  validate: (v) =>
+                    !v.trim() ||
+                    isValidEmail(v.trim()) ||
+                    "Please enter a valid email address",
+                })}
+                error={errors.invitations?.[index]?.email}
+              />
+            </div>
+            <div className="w-[130px] flex-shrink-0">
+              <Select
+                value={invitations[index]?.role}
+                onValueChange={(value) =>
+                  setValue(`invitations.${index}.role`, value as InviteRole, {
+                    shouldDirty: true,
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => remove(index)}
+              disabled={fields.length === 1}
+              aria-label="Remove invitation"
+            >
+              <XIcon className="size-4" />
+            </Button>
+          </div>
+        ))}
       </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => append({ email: "", role: "member" })}
+        disabled={!canAddMore}
+        className="px-2 -ml-2"
+      >
+        <PlusIcon className="size-4 mr-2" />
+        Add another email
+      </Button>
 
       <DialogFooter>
         <DialogClose asChild>
           <Button variant="outline">Cancel</Button>
         </DialogClose>
         <Button type="submit" loading={isSubmitting}>
-          Send Invitation
+          Send invites
         </Button>
       </DialogFooter>
     </form>

--- a/apps/web/components/InviteMemberModal.tsx
+++ b/apps/web/components/InviteMemberModal.tsx
@@ -163,6 +163,8 @@ function InviteForm({
         description: `${successCount} invitation${successCount > 1 ? "s" : ""} sent successfully!`,
       });
       onSuccess?.();
+      reset();
+      onClose();
     }
 
     if (failures.length > 0) {
@@ -172,11 +174,6 @@ function InviteForm({
           .map((f) => `${f.email}: ${f.error ?? "Failed"}`)
           .join("\n"),
       });
-    }
-
-    if (successCount > 0) {
-      reset();
-      onClose();
     }
   });
 

--- a/apps/web/utils/actions/__tests__/invitation-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/invitation-actions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   handleInvitationAction,
-  inviteMemberAction,
+  inviteMembersAction,
 } from "@/utils/actions/organization";
 
 const { mockEnv } = vi.hoisted(() => ({
@@ -40,7 +40,7 @@ describe("createInvitationAction", () => {
     });
   });
 
-  it("invites member using emailAccountId as inviterId and sends email", async () => {
+  it("invites members using emailAccountId as inviterId and returns per-row results", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       id: "ea_inviter",
       email: "inviter@test.com",
@@ -49,26 +49,112 @@ describe("createInvitationAction", () => {
     } as any);
     prisma.member.findFirst.mockResolvedValueOnce({
       organizationId: "org_1",
+      emailAccountId: "ea_inviter",
       role: "owner",
     } as any); // caller membership
     prisma.invitation.findFirst.mockResolvedValue(null as any); // no existing
-    prisma.invitation.create.mockResolvedValue({ id: "inv_1" } as any);
+    prisma.invitation.create
+      .mockResolvedValueOnce({ id: "inv_1" } as any)
+      .mockResolvedValueOnce({ id: "inv_2" } as any);
     prisma.organization.findUnique.mockResolvedValue({ name: "Acme" } as any);
 
-    const res = await inviteMemberAction({
-      email: "user@test.com",
-      role: "member",
+    const res = await inviteMembersAction({
       organizationId: "org_1",
+      invitations: [
+        { email: "user@test.com", role: "member" },
+        { email: "second@test.com", role: "admin" },
+      ],
     });
 
-    expect(prisma.invitation.create).toHaveBeenCalledWith({
+    expect(prisma.invitation.create).toHaveBeenCalledTimes(2);
+    expect(prisma.invitation.create).toHaveBeenNthCalledWith(1, {
       data: expect.objectContaining({
+        email: "user@test.com",
         role: "member",
+        organizationId: "org_1",
+        inviterId: "ea_inviter",
+      }),
+      select: { id: true },
+    });
+    expect(prisma.invitation.create).toHaveBeenNthCalledWith(2, {
+      data: expect.objectContaining({
+        email: "second@test.com",
+        role: "admin",
         organizationId: "org_1",
       }),
       select: { id: true },
     });
-    expect(res?.data).toBeUndefined();
+    expect(res?.data).toEqual({
+      results: [
+        { email: "user@test.com", success: true },
+        { email: "second@test.com", success: true },
+      ],
+    });
+  });
+
+  it("flags already-invited emails without creating duplicates", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "ea_inviter",
+      email: "inviter@test.com",
+      name: "Inviter",
+      account: { userId: "u1", provider: "google" },
+    } as any);
+    prisma.member.findFirst.mockResolvedValueOnce({
+      organizationId: "org_1",
+      emailAccountId: "ea_inviter",
+      role: "admin",
+    } as any);
+    prisma.invitation.findFirst
+      .mockResolvedValueOnce({ id: "existing_inv" } as any)
+      .mockResolvedValueOnce(null as any);
+    prisma.invitation.create.mockResolvedValueOnce({ id: "inv_2" } as any);
+    prisma.organization.findUnique.mockResolvedValue({ name: "Acme" } as any);
+
+    const res = await inviteMembersAction({
+      organizationId: "org_1",
+      invitations: [
+        { email: "existing@test.com", role: "member" },
+        { email: "fresh@test.com", role: "member" },
+      ],
+    });
+
+    expect(prisma.invitation.create).toHaveBeenCalledTimes(1);
+    expect(res?.data).toEqual({
+      results: [
+        {
+          email: "existing@test.com",
+          success: false,
+          error: "Already invited",
+        },
+        { email: "fresh@test.com", success: true },
+      ],
+    });
+  });
+
+  it("blocks non-owners from assigning the owner role", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "ea_inviter",
+      email: "inviter@test.com",
+      name: "Inviter",
+      account: { userId: "u1", provider: "google" },
+    } as any);
+    prisma.member.findFirst.mockResolvedValueOnce({
+      organizationId: "org_1",
+      emailAccountId: "ea_inviter",
+      role: "admin",
+    } as any);
+    prisma.organization.findUnique.mockResolvedValue({ name: "Acme" } as any);
+
+    const res = await inviteMembersAction({
+      organizationId: "org_1",
+      invitations: [{ email: "boss@test.com", role: "owner" }],
+    });
+
+    expect(prisma.invitation.create).not.toHaveBeenCalled();
+    expect(res?.data?.results[0]).toMatchObject({
+      email: "boss@test.com",
+      success: false,
+    });
   });
 
   it("accepts invitation and creates member for recipient emailAccountId", async () => {

--- a/apps/web/utils/actions/__tests__/invitation-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/invitation-actions.test.ts
@@ -52,7 +52,7 @@ describe("createInvitationAction", () => {
       emailAccountId: "ea_inviter",
       role: "owner",
     } as any); // caller membership
-    prisma.invitation.findFirst.mockResolvedValue(null as any); // no existing
+    prisma.invitation.findMany.mockResolvedValue([] as any); // no existing
     prisma.invitation.create
       .mockResolvedValueOnce({ id: "inv_1" } as any)
       .mockResolvedValueOnce({ id: "inv_2" } as any);
@@ -104,9 +104,9 @@ describe("createInvitationAction", () => {
       emailAccountId: "ea_inviter",
       role: "admin",
     } as any);
-    prisma.invitation.findFirst
-      .mockResolvedValueOnce({ id: "existing_inv" } as any)
-      .mockResolvedValueOnce(null as any);
+    prisma.invitation.findMany.mockResolvedValue([
+      { email: "existing@test.com" },
+    ] as any);
     prisma.invitation.create.mockResolvedValueOnce({ id: "inv_2" } as any);
     prisma.organization.findUnique.mockResolvedValue({ name: "Acme" } as any);
 
@@ -143,6 +143,7 @@ describe("createInvitationAction", () => {
       emailAccountId: "ea_inviter",
       role: "admin",
     } as any);
+    prisma.invitation.findMany.mockResolvedValue([] as any);
     prisma.organization.findUnique.mockResolvedValue({ name: "Acme" } as any);
 
     const res = await inviteMembersAction({

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -4,7 +4,7 @@ import { after } from "next/server";
 import { actionClient, actionClientUser } from "@/utils/actions/safe-action";
 import {
   createOrganizationBody,
-  inviteMemberBody,
+  inviteMembersBody,
   removeMemberBody,
   updateMemberRoleBody,
   cancelInvitationBody,
@@ -68,13 +68,13 @@ export const createOrganizationAction = actionClient
     return organization;
   });
 
-export const inviteMemberAction = actionClientUser
-  .metadata({ name: "inviteMember" })
-  .inputSchema(inviteMemberBody)
+export const inviteMembersAction = actionClientUser
+  .metadata({ name: "inviteMembers" })
+  .inputSchema(inviteMembersBody)
   .action(
     async ({
       ctx: { userId },
-      parsedInput: { email, role, organizationId },
+      parsedInput: { invitations, organizationId },
     }) => {
       const inviterMember = await getAuthorizedOrganizationAdminMembership({
         organizationId,
@@ -83,61 +83,87 @@ export const inviteMemberAction = actionClientUser
           "Only organization owners or admins can invite members.",
       });
 
-      const inviterEmailAccount = await prisma.emailAccount.findUnique({
-        where: { id: inviterMember.emailAccountId },
-        select: { name: true, email: true },
-      });
+      const [inviterEmailAccount, org] = await Promise.all([
+        prisma.emailAccount.findUnique({
+          where: { id: inviterMember.emailAccountId },
+          select: { name: true, email: true },
+        }),
+        prisma.organization.findUnique({
+          where: { id: inviterMember.organizationId },
+          select: { name: true },
+        }),
+      ]);
 
       if (!inviterEmailAccount) {
         throw new SafeError("Email account not found.");
       }
 
-      if (role === "owner" && inviterMember.role !== "owner") {
-        throw new SafeError(
-          "Only existing owners can assign the owner role to new members.",
-        );
-      }
+      const inviterName = inviterEmailAccount.name || inviterEmailAccount.email;
+      const organizationName = org?.name || "Your organization";
 
-      const existing = await prisma.invitation.findFirst({
-        where: {
-          organizationId: inviterMember.organizationId,
-          email,
-          status: "pending",
-        },
-        select: { id: true },
-      });
-      if (existing) {
-        return;
-      }
+      const results: { email: string; success: boolean; error?: string }[] = [];
+      const seen = new Set<string>();
 
-      const invitation = await prisma.invitation.create({
-        data: {
-          organizationId: inviterMember.organizationId,
-          email,
-          role,
-          status: "pending",
-          expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14), // 14 days
-          inviterId: inviterMember.emailAccountId,
-        },
-        select: { id: true },
-      });
+      for (const { email, role } of invitations) {
+        if (seen.has(email)) {
+          results.push({ email, success: false, error: "Duplicate email" });
+          continue;
+        }
+        seen.add(email);
 
-      const org = await prisma.organization.findUnique({
-        where: { id: inviterMember.organizationId },
-        select: { name: true },
-      });
+        if (role === "owner" && inviterMember.role !== "owner") {
+          results.push({
+            email,
+            success: false,
+            error: "Only owners can assign the owner role.",
+          });
+          continue;
+        }
 
-      try {
-        await sendOrganizationInvitation({
-          email,
-          organizationName: org?.name || "Your organization",
-          inviterName: inviterEmailAccount.name || inviterEmailAccount.email,
-          invitationId: invitation.id,
+        const existing = await prisma.invitation.findFirst({
+          where: {
+            organizationId: inviterMember.organizationId,
+            email,
+            status: "pending",
+          },
+          select: { id: true },
         });
-      } catch {
-        await prisma.invitation.delete({ where: { id: invitation.id } });
-        throw new SafeError("Failed to send invitation email");
+        if (existing) {
+          results.push({ email, success: false, error: "Already invited" });
+          continue;
+        }
+
+        const invitation = await prisma.invitation.create({
+          data: {
+            organizationId: inviterMember.organizationId,
+            email,
+            role,
+            status: "pending",
+            expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14), // 14 days
+            inviterId: inviterMember.emailAccountId,
+          },
+          select: { id: true },
+        });
+
+        try {
+          await sendOrganizationInvitation({
+            email,
+            organizationName,
+            inviterName,
+            invitationId: invitation.id,
+          });
+          results.push({ email, success: true });
+        } catch {
+          await prisma.invitation.delete({ where: { id: invitation.id } });
+          results.push({
+            email,
+            success: false,
+            error: "Failed to send email",
+          });
+        }
       }
+
+      return { results };
     },
   );
 

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -101,6 +101,16 @@ export const inviteMembersAction = actionClientUser
       const inviterName = inviterEmailAccount.name || inviterEmailAccount.email;
       const organizationName = org?.name || "Your organization";
 
+      const existingInvitations = await prisma.invitation.findMany({
+        where: {
+          organizationId: inviterMember.organizationId,
+          email: { in: invitations.map((i) => i.email) },
+          status: "pending",
+        },
+        select: { email: true },
+      });
+      const alreadyInvited = new Set(existingInvitations.map((i) => i.email));
+
       const results: { email: string; success: boolean; error?: string }[] = [];
       const seen = new Set<string>();
 
@@ -120,15 +130,7 @@ export const inviteMembersAction = actionClientUser
           continue;
         }
 
-        const existing = await prisma.invitation.findFirst({
-          where: {
-            organizationId: inviterMember.organizationId,
-            email,
-            status: "pending",
-          },
-          select: { id: true },
-        });
-        if (existing) {
+        if (alreadyInvited.has(email)) {
           results.push({ email, success: false, error: "Already invited" });
           continue;
         }

--- a/apps/web/utils/actions/organization.validation.ts
+++ b/apps/web/utils/actions/organization.validation.ts
@@ -18,16 +18,28 @@ export const createOrganizationBody = z.object({
 });
 export type CreateOrganizationBody = z.infer<typeof createOrganizationBody>;
 
-export const inviteMemberBody = z.object({
-  email: z
-    .string()
-    .trim()
-    .email("Please enter a valid email address")
-    .transform((val) => val.trim().toLowerCase()),
-  role: z.enum(["owner", "admin", "member"]),
+export const MAX_BULK_INVITES = 10;
+
+export const inviteMembersBody = z.object({
+  invitations: z
+    .array(
+      z.object({
+        email: z
+          .string()
+          .trim()
+          .email("Please enter a valid email address")
+          .transform((val) => val.trim().toLowerCase()),
+        role: z.enum(["owner", "admin", "member"]),
+      }),
+    )
+    .min(1, "At least one invitation is required")
+    .max(
+      MAX_BULK_INVITES,
+      `You can invite up to ${MAX_BULK_INVITES} people at a time`,
+    ),
   organizationId: z.string().min(1, "Organization ID is required"),
 });
-export type InviteMemberBody = z.infer<typeof inviteMemberBody>;
+export type InviteMembersBody = z.infer<typeof inviteMembersBody>;
 
 export const handleInvitationBody = z.object({
   invitationId: z.string().trim().min(1, "Invitation ID is required"),


### PR DESCRIPTION
## Summary
- Replace single-invite modal and action with a bulk flow that supports up to 10 invitations per submission, each with its own role.
- Server-side `inviteMembersAction` returns per-row results so partial failures (already-invited, owner-role gating, send failures) surface to the UI.
- Onboarding step now sends one bulk request instead of fanning out single-invite calls.

## Test plan
- [ ] Unit tests pass (`pnpm test utils/actions/__tests__/invitation-actions.test.ts`)
- [ ] Open the Members page, invite 1, 2, and 10 teammates with mixed roles
- [ ] Re-invite an already-pending email and confirm the per-row error toast
- [ ] Run through the onboarding invite step

🤖 Generated with [Claude Code](https://claude.com/claude-code)