### PR TITLE
evals: Add local model support

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -641,10 +641,22 @@ Maya`,
             meetingContext: null,
           });
 
-          const pass =
-            result.confidence !== "HIGH_CONFIDENCE" &&
-            !/\$\s?\d|\b\d+%\b|\bdiscount still applies\b/i.test(result.reply);
           const testName = "missing pricing context";
+          const judgeResult = await judgeEvalOutput({
+            input: messages
+              .map((message) => message.content)
+              .join("\n\n---\n\n"),
+            output: result.reply,
+            expected:
+              "A useful draft that does not invent an annual price, discount amount, discount status, signing deadline, or other concrete pricing term because no pricing context was provided. It may draft an editable response, but it should not present unsupported pricing facts as known.",
+            criterion: {
+              name: "No unsupported pricing facts",
+              description:
+                "The draft must not invent concrete pricing details or confirm discount terms that are not present in the input. It should stay useful while leaving unsupported pricing facts for user review.",
+            },
+          });
+          const pass =
+            result.confidence !== "HIGH_CONFIDENCE" && judgeResult.pass;
 
           evalReporter.record({
             testName,
@@ -652,12 +664,19 @@ Maya`,
             pass,
             expected:
               "no invented price, no invented discount, not high confidence",
-            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+            actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
+              result.reply,
+              judgeResult,
+            )}`,
           });
 
           expect(
             pass,
-            `Draft should not invent pricing or mark high confidence without pricing context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+            `Draft should not invent pricing or mark high confidence without pricing context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
           ).toBe(true);
         },
         TIMEOUT,
@@ -696,23 +715,40 @@ Maya`,
             meetingContext: null,
           });
 
-          const pass =
-            /\$4,?800/.test(result.reply) &&
-            /\b15%|\b15 percent/i.test(result.reply) &&
-            /May 31/i.test(result.reply);
           const testName = "provided pricing context";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              messages.map((message) => message.content).join("\n\n---\n\n"),
+              "",
+              "## Knowledge Base",
+              "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A reply that uses the supplied pricing context to answer the sender with the approved annual price, renewal discount, and signing deadline, without inventing extra pricing terms.",
+            criterion: {
+              name: "Pricing context used",
+              description:
+                "The draft should communicate the supplied annual price, discount, and deadline. It should not depend on exact wording, but it must preserve those facts and avoid unsupported additional pricing details.",
+            },
+          });
+          const pass = judgeResult.pass;
 
           evalReporter.record({
             testName,
             model: model.label,
             pass,
             expected: "$4,800, 15% discount, May 31",
-            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
           });
 
           expect(
             pass,
-            `Draft should use the supplied pricing terms.\n\nReply:\n${result.reply}`,
+            `Draft should use the supplied pricing terms.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
           ).toBe(true);
         },
         TIMEOUT,
@@ -803,22 +839,40 @@ Dana`,
               'Signed Order Form.pdf — selected because the sender asked for "the signed order form".',
           });
 
-          const pass =
-            /\b(attached|attach(ed)?|included)\b/i.test(result.reply) &&
-            /order form/i.test(result.reply);
           const testName = "provided attachment context";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              messages.map((message) => message.content).join("\n\n---\n\n"),
+              "",
+              "## Selected Attachments",
+              'Signed Order Form.pdf — selected because the sender asked for "the signed order form".',
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A reply that uses the selected attachment context to tell the sender the requested signed order form is included or available with the draft, without inventing unrelated attachments.",
+            criterion: {
+              name: "Selected attachment used",
+              description:
+                "The draft should make clear that the selected signed order form is being provided. It should not depend on exact wording, but it must refer to the relevant selected document and avoid unsupported attachment claims.",
+            },
+          });
+          const pass = judgeResult.pass;
 
           evalReporter.record({
             testName,
             model: model.label,
             pass,
             expected: "mentions attached order form",
-            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
           });
 
           expect(
             pass,
-            `Draft should mention the selected attachment.\n\nReply:\n${result.reply}`,
+            `Draft should mention the selected attachment.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
           ).toBe(true);
         },
         TIMEOUT,
@@ -1029,22 +1083,40 @@ Priya`,
               "Upcoming calendar context: a meeting with Priya Sharma is scheduled for tomorrow at 3:00 PM.",
           });
 
-          const pass =
-            /\b(still on|confirmed|yes)\b/i.test(result.reply) &&
-            /\b3(:00)?\s?(PM|pm|p\.m\.)\b/.test(result.reply);
           const testName = "provided meeting context";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              messages.map((message) => message.content).join("\n\n---\n\n"),
+              "",
+              "## Meeting Context",
+              "Upcoming calendar context: a meeting with Priya Sharma is scheduled for tomorrow at 3:00 PM.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A reply that uses the supplied meeting context to confirm the meeting and preserve the scheduled time of tomorrow at 3:00 PM, without inventing a different time or unsupported meeting details.",
+            criterion: {
+              name: "Meeting context used",
+              description:
+                "The draft should confirm the meeting using the supplied calendar context. It should not depend on exact wording, but it must preserve the scheduled time and avoid unsupported scheduling details.",
+            },
+          });
+          const pass = judgeResult.pass;
 
           evalReporter.record({
             testName,
             model: model.label,
             pass,
             expected: "confirms tomorrow at 3:00 PM",
-            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
           });
 
           expect(
             pass,
-            `Draft should use the supplied meeting context.\n\nReply:\n${result.reply}`,
+            `Draft should use the supplied meeting context.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
           ).toBe(true);
         },
         TIMEOUT,

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -648,11 +648,11 @@ Maya`,
               .join("\n\n---\n\n"),
             output: result.reply,
             expected:
-              "A useful draft that does not invent an annual price, discount amount, discount status, signing deadline, or other concrete pricing term because no pricing context was provided. It may draft an editable response, but it should not present unsupported pricing facts as known.",
+              "A useful editable draft that does not invent concrete pricing details such as an annual price, discount amount, signing deadline, or extra payment terms because no pricing context was provided. It must not be high confidence.",
             criterion: {
-              name: "No unsupported pricing facts",
+              name: "No unsupported concrete pricing details",
               description:
-                "The draft must not invent concrete pricing details or confirm discount terms that are not present in the input. It should stay useful while leaving unsupported pricing facts for user review.",
+                "The draft must not invent concrete pricing values, discount amounts, deadlines, or extra payment terms that are not present in the input. It should stay useful as an editable draft rather than becoming a non-answer.",
             },
           });
           const pass =
@@ -663,7 +663,7 @@ Maya`,
             model: model.label,
             pass,
             expected:
-              "no invented price, no invented discount, not high confidence",
+              "no invented concrete pricing details, not high confidence",
             actual: `confidence=${result.confidence} | ${formatSemanticJudgeActual(
               result.reply,
               judgeResult,

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -608,6 +608,449 @@ Dana`,
       );
     });
 
+    describe("grounding and uncertainty", () => {
+      test(
+        "does not invent pricing terms without pricing context",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Maya Chen <maya@customer.example>",
+                to: emailAccount.email,
+                subject: "Pricing confirmation",
+                content: `Hi,
+
+Can you confirm the annual price and whether the discount we discussed still applies?
+
+Thanks,
+Maya`,
+              }),
+              date: new Date("2026-05-03T11:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass =
+            result.confidence !== "HIGH_CONFIDENCE" &&
+            !/\$\s?\d|\b\d+%\b|\bdiscount still applies\b/i.test(result.reply);
+          const testName = "missing pricing context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "no invented price, no invented discount, not high confidence",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not invent pricing or mark high confidence without pricing context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "uses supplied pricing terms when pricing context is provided",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Maya Chen <maya@customer.example>",
+                to: emailAccount.email,
+                subject: "Pricing confirmation",
+                content: `Hi,
+
+Can you confirm the annual price and whether the discount we discussed still applies?
+
+Thanks,
+Maya`,
+              }),
+              date: new Date("2026-05-03T11:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent:
+              "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass =
+            /\$4,?800/.test(result.reply) &&
+            /\b15%|\b15 percent/i.test(result.reply) &&
+            /May 31/i.test(result.reply);
+          const testName = "provided pricing context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "$4,800, 15% discount, May 31",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should use the supplied pricing terms.\n\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "lowers confidence when attachment context is missing",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Dana Lee <dana@clientcorp.com>",
+                to: emailAccount.email,
+                subject: "Signed order form",
+                content: `Hi,
+
+Can you send over the signed order form for our records?
+
+Thanks,
+Dana`,
+              }),
+              date: new Date("2026-05-04T09:30:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass = result.confidence !== "HIGH_CONFIDENCE";
+          const testName = "missing attachment context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "not high confidence without selected attachment context",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not be marked high confidence without selected attachment context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "mentions selected attachment when attachment context is provided",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Dana Lee <dana@clientcorp.com>",
+                to: emailAccount.email,
+                subject: "Signed order form",
+                content: `Hi,
+
+Can you send over the signed order form for our records?
+
+Thanks,
+Dana`,
+              }),
+              date: new Date("2026-05-04T09:30:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+            attachmentContext:
+              'Signed Order Form.pdf — selected because the sender asked for "the signed order form".',
+          });
+
+          const pass =
+            /\b(attached|attach(ed)?|included)\b/i.test(result.reply) &&
+            /order form/i.test(result.reply);
+          const testName = "provided attachment context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "mentions attached order form",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should mention the selected attachment.\n\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "lowers confidence when refund authority context is missing",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Riley Stone <riley@customer.example>",
+                to: emailAccount.email,
+                subject: "Refund approval",
+                content: `Hi,
+
+Can you approve the refund for the duplicate charge?
+
+Thanks,
+Riley`,
+              }),
+              date: new Date("2026-05-05T13:20:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass = result.confidence !== "HIGH_CONFIDENCE";
+          const testName = "missing refund authority context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "not high confidence without refund authority context",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not be marked high confidence without refund authority context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "uses supplied refund approval context",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Riley Stone <riley@customer.example>",
+                to: emailAccount.email,
+                subject: "Refund approval",
+                content: `Hi,
+
+Can you approve the refund for the duplicate charge?
+
+Thanks,
+Riley`,
+              }),
+              date: new Date("2026-05-05T13:20:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent:
+              "The duplicate charge refund for this customer is approved. Finance will process it by Friday.",
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "provided refund authority context";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              messages.map((message) => message.content).join("\n\n---\n\n"),
+              "",
+              "## Knowledge Base",
+              "The duplicate charge refund for this customer is approved. Finance will process it by Friday.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A reply that uses the supplied context to tell the sender the refund is approved and finance will process it by Friday, without inventing extra refund timing or payment details.",
+            criterion: {
+              name: "Refund context used",
+              description:
+                "The draft should communicate the approved refund and Friday processing timeline from the supplied context. It should not depend on exact wording, but it must preserve those two facts and avoid unsupported additional details.",
+            },
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "refund approved and processed by Friday",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should use the supplied refund approval context.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "lowers confidence when meeting context is missing",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Priya Sharma <priya@launchpad.dev>",
+                to: emailAccount.email,
+                subject: "Tomorrow",
+                content: `Hey,
+
+Are we still on for tomorrow?
+
+Priya`,
+              }),
+              date: new Date("2026-05-06T15:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const pass = result.confidence !== "HIGH_CONFIDENCE";
+          const testName = "missing meeting context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "not high confidence without meeting context",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should not be marked high confidence without meeting context.\n\nConfidence: ${result.confidence}\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "uses supplied meeting context to confirm a meeting",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Priya Sharma <priya@launchpad.dev>",
+                to: emailAccount.email,
+                subject: "Tomorrow",
+                content: `Hey,
+
+Are we still on for tomorrow?
+
+Priya`,
+              }),
+              date: new Date("2026-05-06T15:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext:
+              "Upcoming calendar context: a meeting with Priya Sharma is scheduled for tomorrow at 3:00 PM.",
+          });
+
+          const pass =
+            /\b(still on|confirmed|yes)\b/i.test(result.reply) &&
+            /\b3(:00)?\s?(PM|pm|p\.m\.)\b/.test(result.reply);
+          const testName = "provided meeting context";
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "confirms tomorrow at 3:00 PM",
+            actual: `confidence=${result.confidence} | reply=${JSON.stringify(result.reply)}`,
+          });
+
+          expect(
+            pass,
+            `Draft should use the supplied meeting context.\n\nReply:\n${result.reply}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+    });
+
     describe("punctuation defaults", () => {
       test(
         "does not use em dash when writing style does not ask for it",
@@ -749,8 +1192,13 @@ function hasExactUrl(text: string, expectedUrl: string): boolean {
 }
 
 function extractUrls(text: string): string[] {
-  return (text.match(/https?:\/\/[^\s<>"']+/g) ?? []).map((url) =>
-    url.replace(/[),.?!;:]+$/g, ""),
+  const markdownLinkUrls = [
+    ...text.matchAll(/\[[^\]]*]\((https?:\/\/[^)\s]+)\)/g),
+  ].map((match) => match[1]);
+  const plainUrls = text.match(/https?:\/\/[^\s<>"')\]]+/g) ?? [];
+
+  return [...new Set([...markdownLinkUrls, ...plainUrls])].map((url) =>
+    url.replace(/[,.?!;:]+$/g, ""),
   );
 }
 

--- a/apps/web/__tests__/eval/models.ts
+++ b/apps/web/__tests__/eval/models.ts
@@ -35,6 +35,11 @@ const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
     model: "openai/gpt-5.4-mini",
     label: "GPT-5.4 Mini",
   },
+  "ollama-gemma4-e2b": {
+    provider: "ollama",
+    model: "gemma4:e2b",
+    label: "Ollama Gemma 4 E2B",
+  },
 };
 
 /**
@@ -49,7 +54,11 @@ const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
 export function getEvalModels(): EvalModel[] {
   const envModels = process.env.EVAL_MODELS;
   if (!envModels) return [];
-  if (envModels === "all") return Object.values(EVAL_MODEL_CATALOG);
+  if (envModels === "all") {
+    return Object.entries(EVAL_MODEL_CATALOG)
+      .filter(([name]) => !name.includes("ollama"))
+      .map(([, model]) => model);
+  }
 
   if (envModels.startsWith("[")) {
     try {
@@ -149,6 +158,8 @@ function getApiKeyForProvider(provider: string): string | null {
     anthropic: process.env.ANTHROPIC_API_KEY,
     google: process.env.GOOGLE_API_KEY,
     groq: process.env.GROQ_API_KEY,
+    "openai-compatible": process.env.LLM_API_KEY || "not-required",
+    ollama: "ollama-local",
   };
   return keys[provider] ?? null;
 }
@@ -181,8 +192,8 @@ function hasConfiguredProvider(provider: string): boolean {
       );
     case Provider.AI_GATEWAY:
       return Boolean(process.env.AI_GATEWAY_API_KEY);
-    case Provider.OLLAMA:
     case Provider.OPENAI_COMPATIBLE:
+    case Provider.OLLAMA:
       return true;
     default:
       return hasAnyConfiguredProvider();
@@ -203,7 +214,7 @@ function hasAnyConfiguredProvider(): boolean {
       (process.env.BEDROCK_ACCESS_KEY &&
         process.env.BEDROCK_SECRET_KEY &&
         process.env.BEDROCK_REGION) ||
-      process.env.OLLAMA_BASE_URL ||
-      process.env.OPENAI_COMPATIBLE_BASE_URL,
+      process.env.OPENAI_COMPATIBLE_BASE_URL ||
+      process.env.OLLAMA_BASE_URL,
   );
 }

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -4,6 +4,10 @@ import { stringifyEmail } from "@/utils/stringify-email";
 import { isDefined, type EmailForLLM } from "@/utils/types";
 import { getModel, type ModelType } from "@/utils/llms/model";
 import { createGenerateObject } from "@/utils/llms";
+import {
+  appendOllamaOnlySystemGuidance,
+  isOllamaProvider,
+} from "@/utils/llms/ollama-guidance";
 import { getUserInfoPrompt, getUserRulesPrompt } from "@/utils/ai/helpers";
 import { sortRulesForAutomation } from "@/utils/rule/sort";
 import type { Logger } from "@/utils/logger";
@@ -300,7 +304,11 @@ ${stringifyEmail(email, 500)}
 
   const aiResponse = await generateObject({
     ...modelOptions,
-    system,
+    system: appendOllamaOnlySystemGuidance(
+      { system },
+      modelOptions,
+      OLLAMA_MULTI_RULE_SELECTION_GUIDANCE,
+    ).system,
     prompt,
     schema: z.object({
       matchedRules: z
@@ -326,11 +334,18 @@ ${stringifyEmail(email, 500)}
     }),
   });
 
-  return {
+  const response = {
     matchedRules: aiResponse.object.matchedRules || [],
     noMatchFound: aiResponse.object?.noMatchFound ?? false,
     reasoning: aiResponse.object?.reasoning ?? "",
   };
+
+  if (isOllamaProvider(modelOptions.provider)) {
+    const primaryRule = response.matchedRules.find((rule) => rule.isPrimary);
+    if (primaryRule) return { ...response, matchedRules: [primaryRule] };
+  }
+
+  return response;
 }
 
 const METADATA_GUIDELINE =
@@ -419,3 +434,13 @@ ${lines.join("\n")}
 These are hints from past user actions. Still evaluate the current email on its own merits.
 </classification_feedback>`;
 }
+
+const OLLAMA_MULTI_RULE_SELECTION_GUIDANCE = [
+  "Do not be greedy. Only select secondary rules when they capture a separate, independently actionable purpose in the email.",
+  "Do not select a problem, alert, or action-needed rule just because related words appear. Select it only when the email actually describes a problem, risk, failed action, or required user action.",
+  "Successful receipts, paid invoices, renewals, confirmations, and completed orders should usually match only the receipt/order rule unless the email also reports a separate problem.",
+  "Do not add a generic notification or account-update rule when a more specific transactional rule already fully explains the email.",
+  "Before returning JSON, remove any selected generic rule whose purpose is fully contained by a more specific selected rule.",
+  "When a receipt, invoice, order, or payment-success rule matches, do not also select an account notification/update rule unless the email asks the user to take separate account action.",
+  "Prefer one best rule when all candidate rules refer to the same underlying event.",
+] as const;

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -437,10 +437,7 @@ These are hints from past user actions. Still evaluate the current email on its 
 
 const OLLAMA_MULTI_RULE_SELECTION_GUIDANCE = [
   "Do not be greedy. Only select secondary rules when they capture a separate, independently actionable purpose in the email.",
-  "Do not select a problem, alert, or action-needed rule just because related words appear. Select it only when the email actually describes a problem, risk, failed action, or required user action.",
-  "Successful receipts, paid invoices, renewals, confirmations, and completed orders should usually match only the receipt/order rule unless the email also reports a separate problem.",
-  "Do not add a generic notification or account-update rule when a more specific transactional rule already fully explains the email.",
-  "Before returning JSON, remove any selected generic rule whose purpose is fully contained by a more specific selected rule.",
-  "When a receipt, invoice, order, or payment-success rule matches, do not also select an account notification/update rule unless the email asks the user to take separate account action.",
-  "Prefer one best rule when all candidate rules refer to the same underlying event.",
+  "Select problem, alert, or action-needed rules only when the email actually describes a problem, risk, failed action, or required user action.",
+  "When one specific transactional rule fully explains the email, do not also select a generic notification or account-update rule.",
+  "Prefer one best rule when candidate rules refer to the same underlying event.",
 ] as const;

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 10;
+export const DRAFT_PIPELINE_VERSION = 11;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
+++ b/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
@@ -340,6 +340,19 @@ Representative edits:
     expect(result.confidence).toBe(DraftReplyConfidence.ALL_EMAILS);
   });
 
+  it("maps model-facing confidence levels to product settings", async () => {
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        reply: "Thanks for your message.",
+        confidence: "MEDIUM",
+      },
+    });
+
+    const result = await aiDraftReplyWithConfidence(getDraftParams());
+
+    expect(result.confidence).toBe(DraftReplyConfidence.STANDARD);
+  });
+
   it("returns the actual provider and model used for the successful draft generation", async () => {
     mockCreateGenerateObject.mockImplementationOnce(({ onModelUsed }) =>
       vi.fn().mockImplementationOnce(async () => {

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -33,11 +33,14 @@ Write the reply in the same language as the latest message in the thread.
 IMPORTANT: Use placeholders sparingly! Only use them where you have limited information.
 Never use placeholders for the user's name. You do not need to sign off with the user's name. Do not add a signature.
 Do not invent information.
-Ground the reply in the thread and provided context. Do not invent exact factual values, dates, account states, approvals, attachments, completed actions, or external changes.
-If key facts or actions are missing, still draft the most useful reply you can for the user to review and edit, but lower the confidence instead of presenting the draft as fully certain.
+Ground the reply in the thread and provided context. Do not invent factual values, terms, statuses, dates, account states, approvals, attachments, completed actions, or external changes.
+If key facts, terms, statuses, or actions are missing, still draft the most useful reply you can for the user to review and edit, but lower the confidence instead of presenting the draft as fully certain.
+Use placeholders for missing values only; do not use them to imply an unknown condition, term, or status is true. For unknown yes/no statuses, use neutral editable wording instead of confirming or denying the status.
+If the sender asks you to confirm something and the needed information is not in the provided context, do not answer as if it has been confirmed.
 Use email dates only as message metadata. They help with order and recency, but do not prove that a referenced plan happened, was missed, or remains scheduled.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.
+When the sender provides a scheduling link or scheduling process, use that path instead of adding the user's booking link.
 
 Write an email that follows up on the previous conversation.
 Your reply should aim to continue the conversation or provide new information based on the context or knowledge base. If you have nothing substantial to add, keep the reply minimal.
@@ -166,6 +169,17 @@ ${mcpContext}
 `
     : "";
 
+  const missingExternalContext =
+    !knowledgeBaseContent &&
+    !emailHistorySummary &&
+    !emailHistoryContext?.relevantEmails.length &&
+    !mcpContext &&
+    !meetingContext &&
+    !attachmentContext
+      ? `No additional factual context was provided beyond the email thread.
+`
+      : "";
+
   const upcomingMeetingsContext = meetingContext || "";
   const selectedAttachments = attachmentContext
     ? `Selected PDF attachments that will be included with this draft:
@@ -192,6 +206,7 @@ ${learnedWritingStylePrompt}
 ${signatureContext}
 ${schedulingContext}
 ${mcpToolsContext}
+${missingExternalContext}
 ${upcomingMeetingsContext}
 ${selectedAttachments}
 

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -6,6 +6,7 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailForLLM } from "@/utils/types";
 import { getEmailListPrompt, getTodayForLLM } from "@/utils/ai/helpers";
 import { getModel } from "@/utils/llms/model";
+import { appendOllamaOnlySystemGuidance } from "@/utils/llms/ollama-guidance";
 import type { ReplyContextCollectorResult } from "@/utils/ai/reply/reply-context-collector";
 import type { CalendarAvailabilityContext } from "@/utils/ai/calendar/availability";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
@@ -299,7 +300,11 @@ export async function aiDraftReplyWithConfidence({
   const generate = () =>
     generateObject({
       ...modelOptions,
-      system: systemPrompt,
+      system: appendOllamaOnlySystemGuidance(
+        { system: systemPrompt },
+        modelOptions,
+        OLLAMA_DRAFT_RESPONSE_GUIDANCE,
+      ).system,
       prompt,
       schema: draftSchema,
     });
@@ -506,3 +511,10 @@ function formatLocalSlotTimeAsUtc(
 
   return utcDate.toISOString().slice(0, 16).replace("T", " ");
 }
+
+const OLLAMA_DRAFT_RESPONSE_GUIDANCE = [
+  'Return a JSON object with exactly two top-level fields: "reply" and "confidence".',
+  '"reply" must be one complete email reply as a single plain-text string, not an array of alternatives.',
+  '"confidence" must be one of "ALL_EMAILS", "STANDARD", or "HIGH_CONFIDENCE".',
+  'Example valid output: {"reply":"Thanks for reaching out. I will take a look and follow up shortly.","confidence":"STANDARD"}',
+] as const;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -33,6 +33,9 @@ Write the reply in the same language as the latest message in the thread.
 IMPORTANT: Use placeholders sparingly! Only use them where you have limited information.
 Never use placeholders for the user's name. You do not need to sign off with the user's name. Do not add a signature.
 Do not invent information.
+Ground the reply in the thread and provided context. Do not invent exact factual values, dates, account states, approvals, attachments, completed actions, or external changes.
+If key facts or actions are missing, still draft the most useful reply you can for the user to review and edit, but lower the confidence instead of presenting the draft as fully certain.
+Use email dates only as message metadata. They help with order and recency, but do not prove that a referenced plan happened, was missed, or remains scheduled.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.
 
@@ -209,7 +212,7 @@ const draftSchema = z.object({
   confidence: z
     .nativeEnum(DraftReplyConfidence)
     .describe(
-      "Required value: ALL_EMAILS, STANDARD, or HIGH_CONFIDENCE. Use ALL_EMAILS when uncertain, context is missing, or the draft must ask/check/follow up because requested facts are unavailable. Use STANDARD for solid drafts with minor uncertainty. Use HIGH_CONFIDENCE only when the sender's intent and the complete factual response are clear from the provided context.",
+      "Required value: ALL_EMAILS, STANDARD, or HIGH_CONFIDENCE. Use HIGH_CONFIDENCE when the draft is complete, grounded, and likely safe to use as-is. Use STANDARD for useful drafts that should be reviewed because they rely on reasonable assumptions, missing facts, or user-verifiable actions. Use ALL_EMAILS when the draft is highly uncertain, likely needs broader thread/context review, or mainly asks/checks/follows up.",
     ),
 });
 

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -35,7 +35,7 @@ Never use placeholders for the user's name. You do not need to sign off with the
 Do not invent information.
 Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
 When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
-Use email dates only as message metadata. They help with order and recency, but do not prove that a referenced plan happened, was missed, or remains scheduled.
+Treat email dates as message metadata, not calendar context.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.
 When the sender provides a scheduling link or scheduling process, use that path instead of adding the user's booking link.

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -216,17 +216,17 @@ ${getTodayForLLM()}
 IMPORTANT: You are writing an email as ${emailAccount.email}. Write the reply from their perspective.`;
 };
 
+const llmDraftConfidenceSchema = z.enum(["LOW", "MEDIUM", "HIGH"]);
+
 const draftSchema = z.object({
   reply: z
     .string()
     .describe(
       "The complete email reply draft incorporating knowledge base information",
     ),
-  confidence: z
-    .nativeEnum(DraftReplyConfidence)
-    .describe(
-      "Required value: ALL_EMAILS, STANDARD, or HIGH_CONFIDENCE. Use HIGH_CONFIDENCE when the draft is complete, grounded, and likely safe to use as-is. Use STANDARD for useful drafts that should be reviewed because they rely on reasonable assumptions, missing facts, or user-verifiable actions. Use ALL_EMAILS when the draft is highly uncertain, likely needs broader thread/context review, or mainly asks/checks/follows up.",
-    ),
+  confidence: llmDraftConfidenceSchema.describe(
+    "Use HIGH only when the draft is complete, grounded, and does not depend on missing facts, unavailable calendar/business state, assumptions, or user-fillable details. Use MEDIUM for useful drafts that rely on reasonable assumptions, missing facts, or user-fillable details. Use LOW when the draft is highly uncertain, likely needs broader thread/context review, or mainly asks/checks/follows up.",
+  ),
 });
 
 export type DraftReplyResult = {
@@ -339,7 +339,7 @@ export async function aiDraftReplyWithConfidence({
 
   return {
     reply: normalizeDraftReplyFormatting(result.object.reply),
-    confidence: normalizeDraftReplyConfidence(result.object.confidence),
+    confidence: mapLlmDraftConfidence(result.object.confidence),
     attribution: attributionTracker.attribution,
   };
 }
@@ -438,6 +438,22 @@ function isLikelyListItem(line: string): boolean {
   return /^(\s*[-*]\s+|\s*\d+[.)]\s+|\s*[a-zA-Z][.)]\s+|>\s+)/.test(line);
 }
 
+function mapLlmDraftConfidence(confidence: unknown): DraftReplyConfidence {
+  const llmConfidence = llmDraftConfidenceSchema.safeParse(confidence);
+  if (!llmConfidence.success) {
+    return normalizeDraftReplyConfidence(confidence);
+  }
+
+  switch (llmConfidence.data) {
+    case "LOW":
+      return DraftReplyConfidence.ALL_EMAILS;
+    case "MEDIUM":
+      return DraftReplyConfidence.STANDARD;
+    case "HIGH":
+      return DraftReplyConfidence.HIGH_CONFIDENCE;
+  }
+}
+
 // Matches any non-separator, non-whitespace character repeated 50+ times in a row
 const REPETITIVE_TEXT_PATTERN = /([^\s\-=_*.#~])\1{49,}/u;
 
@@ -531,6 +547,6 @@ function formatLocalSlotTimeAsUtc(
 const OLLAMA_DRAFT_RESPONSE_GUIDANCE = [
   'Return a JSON object with exactly two top-level fields: "reply" and "confidence".',
   '"reply" must be one complete email reply as a single plain-text string, not an array of alternatives.',
-  '"confidence" must be one of "ALL_EMAILS", "STANDARD", or "HIGH_CONFIDENCE".',
-  'Example valid output: {"reply":"Thanks for reaching out. I will take a look and follow up shortly.","confidence":"STANDARD"}',
+  '"confidence" must be one of "LOW", "MEDIUM", or "HIGH".',
+  'Example valid output: {"reply":"Thanks for reaching out. I will take a look and follow up shortly.","confidence":"MEDIUM"}',
 ] as const;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -33,10 +33,8 @@ Write the reply in the same language as the latest message in the thread.
 IMPORTANT: Use placeholders sparingly! Only use them where you have limited information.
 Never use placeholders for the user's name. You do not need to sign off with the user's name. Do not add a signature.
 Do not invent information.
-Ground the reply in the thread and provided context. Do not invent factual values, terms, statuses, dates, account states, approvals, attachments, completed actions, or external changes.
-If key facts, terms, statuses, or actions are missing, still draft the most useful reply you can for the user to review and edit, but lower the confidence instead of presenting the draft as fully certain.
-Use placeholders for missing values only; do not use them to imply an unknown condition, term, or status is true. For unknown yes/no statuses, use neutral editable wording instead of confirming or denying the status.
-If the sender asks you to confirm something and the needed information is not in the provided context, do not answer as if it has been confirmed.
+Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
+When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
 Use email dates only as message metadata. They help with order and recency, but do not prove that a referenced plan happened, was missed, or remains scheduled.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.

--- a/apps/web/utils/ai/reply/extract-reply-memories.ts
+++ b/apps/web/utils/ai/reply/extract-reply-memories.ts
@@ -8,6 +8,10 @@ import { getUserInfoPrompt } from "@/utils/ai/helpers";
 import { extractDomainFromEmail, isPublicEmailDomain } from "@/utils/email";
 import { createGenerateObject } from "@/utils/llms";
 import { getModel } from "@/utils/llms/model";
+import {
+  appendOllamaOnlySystemGuidance,
+  isOllamaProvider,
+} from "@/utils/llms/ollama-guidance";
 import { isDefined } from "@/utils/types";
 import type { getEmailAccountWithAi } from "@/utils/user/get";
 
@@ -96,9 +100,15 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
 
   const result = await generateObject({
     ...modelOptions,
-    system: getSystemPrompt({ allowDomainScope }),
+    system: appendOllamaOnlySystemGuidance(
+      { system: getSystemPrompt({ allowDomainScope }) },
+      modelOptions,
+      getOllamaReplyMemoryGuidance({ allowDomainScope }),
+    ).system,
     prompt,
-    schema: replyMemorySchema,
+    schema: isOllamaProvider(modelOptions.provider)
+      ? ollamaReplyMemorySchema
+      : replyMemorySchema,
   });
 
   return result.object.memories
@@ -114,7 +124,10 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
 
       const newMemory = {
         content: decision.newMemory.content.trim(),
-        kind: decision.newMemory.kind,
+        kind: normalizeReplyMemoryKind(
+          decision.newMemory,
+          modelOptions.provider,
+        ),
         scopeType:
           decision.newMemory.kind === ReplyMemoryKind.PREFERENCE
             ? ReplyMemoryScopeType.GLOBAL
@@ -299,4 +312,58 @@ ${domainRuleLine}- For TOPIC scope, use a short stable topic phrase such as "pri
 - Be conservative about creating new memories. Only create a new memory when none of the provided existing memories substantially covers that durable idea.
 - Work language-agnostically. The memories may be written in any language.
 - If nothing durable was learned, return an empty array.`;
+}
+
+const ollamaReplyMemoryDecisionSchema = z.object({
+  matchingExistingMemoryId: z.string().trim().min(1).nullable(),
+  newMemory: newReplyMemorySchema.nullable(),
+});
+
+const ollamaReplyMemorySchema = z.object({
+  memories: z.array(ollamaReplyMemoryDecisionSchema).max(MAX_MEMORIES_PER_EDIT),
+});
+
+function normalizeReplyMemoryKind(
+  memory: z.infer<typeof newReplyMemorySchema>,
+  provider: string,
+) {
+  if (
+    isOllamaProvider(provider) &&
+    memory.kind === ReplyMemoryKind.PROCEDURE &&
+    isPricingOrBillingMemory(memory)
+  ) {
+    return ReplyMemoryKind.FACT;
+  }
+
+  return memory.kind;
+}
+
+function isPricingOrBillingMemory(
+  memory: z.infer<typeof newReplyMemorySchema>,
+) {
+  const text = `${memory.content} ${memory.scopeValue}`.toLowerCase();
+
+  return /\b(pricing|price|rate|billing|seat|plan|quote)\b/.test(text);
+}
+
+function getOllamaReplyMemoryGuidance({
+  allowDomainScope,
+}: {
+  allowDomainScope: boolean;
+}) {
+  return [
+    'Return a JSON object with exactly one top-level "memories" array.',
+    'Each item in "memories" must have both "matchingExistingMemoryId" and "newMemory".',
+    'For an existing memory match, use {"matchingExistingMemoryId":"existing-id","newMemory":null}.',
+    'For a new memory, use {"matchingExistingMemoryId":null,"newMemory":{"content":"...","kind":"FACT","scopeType":"TOPIC","scopeValue":"pricing"}}.',
+    "Use kind values exactly: FACT, PREFERENCE, PROCEDURE.",
+    `Use scopeType values exactly: GLOBAL, SENDER,${allowDomainScope ? " DOMAIN," : ""} TOPIC.`,
+    "If the user adds stable business facts that were missing from the AI draft, create a FACT memory unless the edit says the fact is temporary or one-time.",
+    "Pricing amounts, billing rules, product limits, support policies, and qualification requirements are durable facts or procedures when the edit presents them as generally true.",
+    "Pricing and billing memories are FACT memories, not PROCEDURE memories.",
+    "If an edit adds concrete pricing, billing, product, policy, or limit information, classify it as FACT, not PROCEDURE.",
+    'FACT memory content should preserve the durable fact itself. Do not turn concrete facts into generic behavior instructions like "provide pricing details".',
+    "Preserve numeric amounts, product limits, billing conditions, and other concrete facts that the user added.",
+    "Use PROCEDURE only when the edit teaches a repeatable process or sequence of steps rather than a durable factual answer.",
+  ] as const;
 }

--- a/apps/web/utils/ai/reply/extract-reply-memories.ts
+++ b/apps/web/utils/ai/reply/extract-reply-memories.ts
@@ -124,10 +124,7 @@ export async function aiExtractReplyMemoriesFromDraftEdit({
 
       const newMemory = {
         content: decision.newMemory.content.trim(),
-        kind: normalizeReplyMemoryKind(
-          decision.newMemory,
-          modelOptions.provider,
-        ),
+        kind: decision.newMemory.kind,
         scopeType:
           decision.newMemory.kind === ReplyMemoryKind.PREFERENCE
             ? ReplyMemoryScopeType.GLOBAL
@@ -322,29 +319,6 @@ const ollamaReplyMemoryDecisionSchema = z.object({
 const ollamaReplyMemorySchema = z.object({
   memories: z.array(ollamaReplyMemoryDecisionSchema).max(MAX_MEMORIES_PER_EDIT),
 });
-
-function normalizeReplyMemoryKind(
-  memory: z.infer<typeof newReplyMemorySchema>,
-  provider: string,
-) {
-  if (
-    isOllamaProvider(provider) &&
-    memory.kind === ReplyMemoryKind.PROCEDURE &&
-    isPricingOrBillingMemory(memory)
-  ) {
-    return ReplyMemoryKind.FACT;
-  }
-
-  return memory.kind;
-}
-
-function isPricingOrBillingMemory(
-  memory: z.infer<typeof newReplyMemorySchema>,
-) {
-  const text = `${memory.content} ${memory.scopeValue}`.toLowerCase();
-
-  return /\b(pricing|price|rate|billing|seat|plan|quote)\b/.test(text);
-}
 
 function getOllamaReplyMemoryGuidance({
   allowDomainScope,

--- a/apps/web/utils/ai/reply/extract-reply-memories.ts
+++ b/apps/web/utils/ai/reply/extract-reply-memories.ts
@@ -326,18 +326,13 @@ function getOllamaReplyMemoryGuidance({
   allowDomainScope: boolean;
 }) {
   return [
-    'Return a JSON object with exactly one top-level "memories" array.',
     'Each item in "memories" must have both "matchingExistingMemoryId" and "newMemory".',
     'For an existing memory match, use {"matchingExistingMemoryId":"existing-id","newMemory":null}.',
     'For a new memory, use {"matchingExistingMemoryId":null,"newMemory":{"content":"...","kind":"FACT","scopeType":"TOPIC","scopeValue":"pricing"}}.',
     "Use kind values exactly: FACT, PREFERENCE, PROCEDURE.",
     `Use scopeType values exactly: GLOBAL, SENDER,${allowDomainScope ? " DOMAIN," : ""} TOPIC.`,
-    "If the user adds stable business facts that were missing from the AI draft, create a FACT memory unless the edit says the fact is temporary or one-time.",
-    "Pricing amounts, billing rules, product limits, support policies, and qualification requirements are durable facts or procedures when the edit presents them as generally true.",
-    "Pricing and billing memories are FACT memories, not PROCEDURE memories.",
-    "If an edit adds concrete pricing, billing, product, policy, or limit information, classify it as FACT, not PROCEDURE.",
-    'FACT memory content should preserve the durable fact itself. Do not turn concrete facts into generic behavior instructions like "provide pricing details".',
-    "Preserve numeric amounts, product limits, billing conditions, and other concrete facts that the user added.",
-    "Use PROCEDURE only when the edit teaches a repeatable process or sequence of steps rather than a durable factual answer.",
+    "Stable business facts, pricing, billing rules, product limits, policies, and qualification requirements are FACT memories unless the edit says they are temporary or one-time.",
+    'FACT memory content should preserve concrete details such as numeric amounts, product limits, and billing conditions instead of becoming generic instructions like "provide pricing details".',
+    "Use PROCEDURE only when the edit teaches a repeatable process or sequence of steps.",
   ] as const;
 }

--- a/apps/web/utils/ai/reply/summarize-learned-writing-style.ts
+++ b/apps/web/utils/ai/reply/summarize-learned-writing-style.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createGenerateObject } from "@/utils/llms";
 import { getModel } from "@/utils/llms/model";
+import { appendOllamaOnlySystemGuidance } from "@/utils/llms/ollama-guidance";
 import type { getEmailAccountWithAi } from "@/utils/user/get";
 
 const learnedWritingStyleSchema = z.object({
@@ -30,7 +31,11 @@ Summarize the user's learned writing style from this preference evidence.`;
 
   const result = await generateObject({
     ...modelOptions,
-    system: getSystemPrompt(),
+    system: appendOllamaOnlySystemGuidance(
+      { system: getSystemPrompt() },
+      modelOptions,
+      OLLAMA_LEARNED_WRITING_STYLE_RESPONSE_GUIDANCE,
+    ).system,
     prompt,
     schema: learnedWritingStyleSchema,
   });
@@ -55,3 +60,8 @@ Rules:
 - Do not mention names, email addresses, company names, phone numbers, dates, links, or other identifying details.
 - This learned summary is advisory and should complement, not replace, explicit user-written style settings.`;
 }
+
+const OLLAMA_LEARNED_WRITING_STYLE_RESPONSE_GUIDANCE = [
+  'Return a JSON object with exactly one top-level "learnedWritingStyle" string.',
+  'Put the complete style guide inside "learnedWritingStyle"; do not return markdown or bullets outside the JSON object.',
+] as const;

--- a/apps/web/utils/attachments/draft-attachments.ts
+++ b/apps/web/utils/attachments/draft-attachments.ts
@@ -889,7 +889,6 @@ function getDocumentPath(metadata: Prisma.JsonValue | null) {
 }
 
 const OLLAMA_ATTACHMENT_SELECTION_RESPONSE_GUIDANCE = [
-  'Return a JSON object with exactly one top-level "attachments" array.',
   'Each selected attachment must be an object with "candidateId" and "reason".',
   'Use the exact candidate id from the provided list, for example: {"attachments":[{"candidateId":"drive-1:file-123","reason":"Current certificate requested by property name"}]}',
   'When nothing is clearly relevant, return {"attachments":[]}.',

--- a/apps/web/utils/attachments/draft-attachments.ts
+++ b/apps/web/utils/attachments/draft-attachments.ts
@@ -4,6 +4,7 @@ import { PremiumTier } from "@/generated/prisma/enums";
 import type { Prisma } from "@/generated/prisma/client";
 import { createGenerateObject } from "@/utils/llms";
 import { getModel } from "@/utils/llms/model";
+import { appendOllamaOnlySystemGuidance } from "@/utils/llms/ollama-guidance";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { Logger } from "@/utils/logger";
 import { createDriveProviderWithRefresh } from "@/utils/drive/provider";
@@ -582,12 +583,18 @@ async function aiSelectRelevantAttachments({
 
     const result = await generateObject({
       ...modelOptions,
-      system: `You select approved PDF attachments for draft email replies.
+      system: appendOllamaOnlySystemGuidance(
+        {
+          system: `You select approved PDF attachments for draft email replies.
 
 Choose only files that would materially help answer the email.
 Return an empty list when no candidate is clearly relevant.
 Prefer the fewest helpful attachments. Never select more than ${MAX_ATTACHMENTS} files.
 Do not invent candidate IDs or use files outside the provided list.`,
+        },
+        modelOptions,
+        OLLAMA_ATTACHMENT_SELECTION_RESPONSE_GUIDANCE,
+      ).system,
       prompt: `Inbound email:
 
 <email>
@@ -880,3 +887,10 @@ function getDocumentPath(metadata: Prisma.JsonValue | null) {
   const path = (metadata as { path?: unknown }).path;
   return typeof path === "string" ? path : null;
 }
+
+const OLLAMA_ATTACHMENT_SELECTION_RESPONSE_GUIDANCE = [
+  'Return a JSON object with exactly one top-level "attachments" array.',
+  'Each selected attachment must be an object with "candidateId" and "reason".',
+  'Use the exact candidate id from the provided list, for example: {"attachments":[{"candidateId":"drive-1:file-123","reason":"Current certificate requested by property name"}]}',
+  'When nothing is clearly relevant, return {"attachments":[]}.',
+] as const;

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -84,7 +84,9 @@ vi.mock("@/utils/posthog", () => ({
   isPosthogLlmEvalApproved: vi.fn(() => false),
 }));
 
-async function createTestGenerateObject() {
+async function createTestGenerateObject(
+  overrides: { provider?: string; modelName?: string } = {},
+) {
   const { createGenerateObject } = await import("./index");
 
   return createGenerateObject({
@@ -95,8 +97,8 @@ async function createTestGenerateObject() {
     },
     label: "test",
     modelOptions: {
-      provider: "openai",
-      modelName: "gpt-test",
+      provider: overrides.provider ?? "openai",
+      modelName: overrides.modelName ?? "gpt-test",
       model: {} as any,
       providerOptions: undefined,
       hasUserApiKey: false,
@@ -386,6 +388,29 @@ describe("createGenerateObject repairText", () => {
 
       expect(wasMissingJsonWarned()).toBe(false);
     });
+  });
+
+  it("adds stricter JSON-only instructions for Ollama object generation", async () => {
+    const generateObject = await createTestGenerateObject({
+      provider: "ollama",
+      modelName: "gemma4:e2b",
+    });
+
+    await generateObject({
+      system: "Extract reply memories.",
+      prompt: "Extract memories.",
+      schema: {} as any,
+    } as any);
+
+    expect(mockGenerateObject.mock.calls[0][0].system).toContain(
+      "Extract reply memories.",
+    );
+    expect(mockGenerateObject.mock.calls[0][0].system).toContain(
+      "Return only valid JSON that matches the requested schema.",
+    );
+    expect(mockGenerateObject.mock.calls[0][0].system).toContain(
+      "The top-level JSON value must match the schema root exactly",
+    );
   });
 
   it("falls back to next model on content-filter refusal without retrying primary", async () => {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -57,6 +57,10 @@ import {
   shouldForceNanoModel,
 } from "@/utils/llms/model-usage-guard";
 import { Provider } from "@/utils/llms/config";
+import {
+  appendOllamaOnlySystemGuidance,
+  OLLAMA_STRUCTURED_OUTPUT_GUIDANCE,
+} from "@/utils/llms/ollama-guidance";
 import { createScopedLogger } from "@/utils/logger";
 import { getPosthogLlmClient, isPosthogLlmEvalApproved } from "@/utils/posthog";
 import {
@@ -343,14 +347,18 @@ export function createGenerateObject({
         system: typeof options.system === "string" ? options.system : undefined,
         promptHardening,
       });
-      const protectedOptions = enforceSensitiveDataPolicy({
-        options: { ...options, system: systemText },
-        policy: emailAccount.sensitiveDataPolicy,
-        logger,
-        label,
-        userId: emailAccount.userId,
-        emailAccountId: emailAccount.id,
-      });
+      const protectedOptions = appendOllamaOnlySystemGuidance(
+        enforceSensitiveDataPolicy({
+          options: { ...options, system: systemText },
+          policy: emailAccount.sensitiveDataPolicy,
+          logger,
+          label,
+          userId: emailAccount.userId,
+          emailAccountId: emailAccount.id,
+        }),
+        candidate,
+        OLLAMA_STRUCTURED_OUTPUT_GUIDANCE,
+      );
 
       logger.trace("Generating object", {
         label,

--- a/apps/web/utils/llms/ollama-guidance.ts
+++ b/apps/web/utils/llms/ollama-guidance.ts
@@ -1,0 +1,41 @@
+import { Provider } from "@/utils/llms/config";
+
+type ProviderLike = {
+  provider: string;
+};
+
+export function isOllamaProvider(provider: string) {
+  return provider === Provider.OLLAMA;
+}
+
+export function appendOllamaOnlySystemGuidance<
+  OPTIONS extends { system?: unknown },
+>(
+  options: OPTIONS,
+  modelOptions: ProviderLike,
+  guidance: readonly string[],
+): OPTIONS {
+  if (!isOllamaProvider(modelOptions.provider)) return options;
+
+  return {
+    ...options,
+    system: appendSystemGuidance(options.system, guidance),
+  };
+}
+
+function appendSystemGuidance(
+  system: unknown,
+  guidance: readonly string[],
+): string {
+  const currentSystem = typeof system === "string" ? system.trimEnd() : "";
+  const extraGuidance = guidance.join("\n");
+
+  return currentSystem ? `${currentSystem}\n\n${extraGuidance}` : extraGuidance;
+}
+
+export const OLLAMA_STRUCTURED_OUTPUT_GUIDANCE = [
+  "Return only valid JSON that matches the requested schema.",
+  "The top-level JSON value must match the schema root exactly; do not return a nested item by itself.",
+  "Do not include markdown, bullets, code fences, explanations, or any text outside the JSON.",
+  "If a schema field asks for prose, put that prose inside the appropriate JSON string field.",
+] as const;


### PR DESCRIPTION
Adds a local evaluation model preset and provider-specific structured output guidance for eval-sensitive flows.

- Allows explicit local model eval runs without including local providers in the default all-model matrix.
- Adds JSON-only guidance for local structured output paths and targeted prompt guidance for affected flows.
- Adds coverage for the object-generation guidance path.