### PR TITLE
Fix stale trial limit alert

### DIFF
--- a/apps/web/app/(app)/AiAutomationStatusBanner.tsx
+++ b/apps/web/app/(app)/AiAutomationStatusBanner.tsx
@@ -13,7 +13,7 @@ export function AiAutomationStatusBanner() {
   if (status?.status !== "trial_ai_limit_reached") return null;
 
   return (
-    <div className="mx-auto max-w-screen-xl w-full px-4 mt-6 mb-2 space-y-2">
+    <div className="mx-auto max-w-screen-xl w-full px-4 mt-6 mb-2">
       <AlertError
         title="Action Required"
         description={

--- a/apps/web/app/(app)/AiAutomationStatusBanner.tsx
+++ b/apps/web/app/(app)/AiAutomationStatusBanner.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { AlertError } from "@/components/Alert";
+import { Button } from "@/components/ui/button";
+import { useAiAutomationStatus } from "@/hooks/useAiAutomationStatus";
+
+export function AiAutomationStatusBanner() {
+  const { data: status } = useAiAutomationStatus();
+
+  if (status?.status !== "trial_ai_limit_reached") return null;
+
+  return (
+    <div className="mx-auto max-w-screen-xl w-full px-4 mt-6 mb-2 space-y-2">
+      <AlertError
+        title="Action Required"
+        description={
+          <div className="flex flex-col gap-3 mt-2">
+            <p>{status.message}</p>
+
+            <Button asChild variant="red" size="sm" className="w-fit">
+              <Link href="/premium">Upgrade</Link>
+            </Button>
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(app)/AiAutomationStatusBanner.tsx
+++ b/apps/web/app/(app)/AiAutomationStatusBanner.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import Link from "next/link";
+import { CreditCardIcon } from "lucide-react";
 import { AlertError } from "@/components/Alert";
 import { Button } from "@/components/ui/button";
 import { useAiAutomationStatus } from "@/hooks/useAiAutomationStatus";
+import { useEndStripeTrial } from "@/hooks/useEndStripeTrial";
 
 export function AiAutomationStatusBanner() {
   const { data: status } = useAiAutomationStatus();
+  const { loading, endTrial } = useEndStripeTrial();
 
   if (status?.status !== "trial_ai_limit_reached") return null;
 
@@ -18,8 +20,15 @@ export function AiAutomationStatusBanner() {
           <div className="flex flex-col gap-3 mt-2">
             <p>{status.message}</p>
 
-            <Button asChild variant="red" size="sm" className="w-fit">
-              <Link href="/premium">Upgrade</Link>
+            <Button
+              loading={loading}
+              onClick={endTrial}
+              variant="red"
+              size="sm"
+              className="w-fit"
+            >
+              <CreditCardIcon className="mr-2 h-4 w-4" />
+              Start paid plan now
             </Button>
           </div>
         }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -38,7 +38,7 @@ import {
   getProgressMessage,
   initialBulkRunState,
 } from "@/app/(app)/[emailAccountId]/assistant/bulk-run-rules-reducer";
-import { useEndStripeTrial } from "@/app/(app)/premium/ManageSubscription";
+import { useEndStripeTrial } from "@/hooks/useEndStripeTrial";
 
 const TRIAL_BULK_PROCESS_EMAIL_LIMIT = 200;
 

--- a/apps/web/app/(app)/[emailAccountId]/usage/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/usage/page.tsx
@@ -51,8 +51,9 @@ export default async function UsagePage(props: {
   if (!emailAccount) notFound();
 
   const usage = await getUsage({
+    emailAccountId,
+    legacyEmail: emailAccount.email,
     userId: emailAccount.user.id,
-    email: emailAccount.email,
   });
   const isOwnAccount = emailAccount.user.id === userId;
 

--- a/apps/web/app/(app)/[emailAccountId]/usage/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/usage/page.tsx
@@ -50,7 +50,10 @@ export default async function UsagePage(props: {
 
   if (!emailAccount) notFound();
 
-  const usage = await getUsage({ email: emailAccount.email });
+  const usage = await getUsage({
+    userId: emailAccount.user.id,
+    email: emailAccount.email,
+  });
   const isOwnAccount = emailAccount.user.id === userId;
 
   return (

--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -56,7 +56,12 @@ export function AdminTopSpenders() {
               </TableHeader>
               <TableBody>
                 {topSpenders.map((spender, index) => (
-                  <TableRow key={spender.userId ?? spender.email ?? index}>
+                  <TableRow
+                    key={
+                      ("userId" in spender ? spender.userId : spender.email) ??
+                      index
+                    }
+                  >
                     <TableCell>{index + 1}</TableCell>
                     <TableCell className="font-mono text-xs">
                       {spender.emailAccountId ?? "-"}

--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -56,13 +56,13 @@ export function AdminTopSpenders() {
               </TableHeader>
               <TableBody>
                 {topSpenders.map((spender, index) => (
-                  <TableRow key={spender.email}>
+                  <TableRow key={spender.userId ?? spender.email ?? index}>
                     <TableCell>{index + 1}</TableCell>
                     <TableCell className="font-mono text-xs">
                       {spender.emailAccountId ?? "-"}
                     </TableCell>
                     <TableCell className="font-mono text-xs sm:text-sm">
-                      {spender.email}
+                      {spender.email ?? "-"}
                     </TableCell>
                     <TableCell>
                       {spender.userEmailAccountCount ?? "-"}

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -11,6 +11,7 @@ import { CommandK } from "@/components/CommandK";
 import { AppProviders } from "@/providers/AppProviders";
 import { AssessUser } from "@/app/(app)/[emailAccountId]/assess";
 import { SentryIdentify } from "@/app/(app)/sentry-identify";
+import { AiAutomationStatusBanner } from "@/app/(app)/AiAutomationStatusBanner";
 import { ErrorMessages } from "@/app/(app)/ErrorMessages";
 import { ProviderRateLimitBanner } from "@/app/(app)/ProviderRateLimitBanner";
 import { QueueInitializer } from "@/store/QueueInitializer";
@@ -73,6 +74,7 @@ export default async function AppLayout({
       <div className="font-inter">
         <AppProviders>
           <SideNavWithTopNav defaultOpen={!isClosed}>
+            <AiAutomationStatusBanner />
             <ErrorMessages />
             <ProviderRateLimitBanner />
             {children}

--- a/apps/web/app/(app)/premium/ManageSubscription.tsx
+++ b/apps/web/app/(app)/premium/ManageSubscription.tsx
@@ -3,15 +3,11 @@
 import { useState } from "react";
 import { CreditCardIcon } from "lucide-react";
 import Link from "next/link";
-import { toast } from "sonner";
-import { useSWRConfig } from "swr";
 import { env } from "@/env";
 import { Button } from "@/components/ui/button";
 import { toastError } from "@/components/Toast";
-import {
-  endStripeTrialAction,
-  getBillingPortalUrlAction,
-} from "@/utils/actions/premium";
+import { useEndStripeTrial } from "@/hooks/useEndStripeTrial";
+import { getBillingPortalUrlAction } from "@/utils/actions/premium";
 import { hasActiveAppleSubscription } from "@/utils/premium";
 import { redirectToSafeUrl } from "@/utils/redirect";
 
@@ -152,30 +148,4 @@ function useOpenBillingPortal() {
   };
 
   return { loading, openBillingPortal };
-}
-
-export function useEndStripeTrial() {
-  const [loading, setLoading] = useState(false);
-  const { mutate } = useSWRConfig();
-
-  const endTrial = async () => {
-    setLoading(true);
-    const result = await endStripeTrialAction().finally(() => {
-      setLoading(false);
-    });
-
-    if (result?.serverError) {
-      toastError({ description: result.serverError });
-      return;
-    }
-
-    if (result?.data?.status === "active") {
-      toast.success("Your paid plan is active.");
-    } else {
-      toast.message("Your trial has ended.");
-    }
-    await mutate("/api/user/me");
-  };
-
-  return { loading, endTrial };
 }

--- a/apps/web/app/api/admin/top-spenders/route.test.ts
+++ b/apps/web/app/api/admin/top-spenders/route.test.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/middleware", () => ({
+  withAdmin: (_name: string, handler: unknown) => handler,
+}));
+vi.mock("@/utils/redis/usage", () => ({
+  getTopWeeklyUsageCosts: vi.fn(),
+}));
+vi.mock("@/env", () => ({
+  env: {
+    AI_NANO_WEEKLY_SPEND_LIMIT_USD: 2,
+    NANO_LLM_PROVIDER: "openai",
+    NANO_LLM_MODEL: "gpt-5-nano",
+  },
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/admin/top-spenders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps legacy email-keyed weekly spend to the owning user", async () => {
+    vi.mocked(getTopWeeklyUsageCosts).mockResolvedValue([
+      { email: "account@example.com", cost: 3 },
+    ]);
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "email-account-1",
+        email: "account@example.com",
+        userId: "user-1",
+      },
+    ] as any);
+    prisma.user.findMany.mockResolvedValue([
+      {
+        id: "user-1",
+        email: "user@example.com",
+        aiApiKey: null,
+        emailAccounts: [
+          { id: "email-account-1", email: "account@example.com" },
+        ],
+      },
+    ] as any);
+
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/admin/top-spenders"),
+    );
+    const data = await response.json();
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith({
+      where: { email: { in: ["account@example.com"] } },
+      select: { id: true, email: true, userId: true },
+    });
+    expect(data.topSpenders).toEqual([
+      {
+        email: "account@example.com",
+        cost: 3,
+        emailAccountId: "email-account-1",
+        userEmailAccountCount: 1,
+        nanoLimitedBySpendGuard: true,
+      },
+    ]);
+  });
+});

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -15,42 +15,41 @@ async function getData() {
   const topSpenders = await getTopWeeklyUsageCosts({ limit: 25 });
   if (!topSpenders.length) return { topSpenders: [] };
 
-  const emails = topSpenders.map((spender) => spender.email);
+  const emails = topSpenders.flatMap((spender) =>
+    spender.email ? [spender.email] : [],
+  );
   const emailAccounts = await prisma.emailAccount.findMany({
     where: { email: { in: emails } },
     select: { id: true, email: true, userId: true },
   });
 
-  const userIds = [...new Set(emailAccounts.map((account) => account.userId))];
-  const allUserEmailAccounts = userIds.length
-    ? await prisma.emailAccount.findMany({
-        where: { userId: { in: userIds } },
-        select: { id: true, email: true, userId: true },
-      })
-    : [];
-  const usersWithApiKey = userIds.length
+  const userIds = [
+    ...new Set([
+      ...topSpenders.flatMap((spender) =>
+        spender.userId ? [spender.userId] : [],
+      ),
+      ...emailAccounts.map((account) => account.userId),
+    ]),
+  ];
+  const users = userIds.length
     ? await prisma.user.findMany({
-        where: {
-          id: { in: userIds },
-          AND: [{ aiApiKey: { not: null } }, { aiApiKey: { not: "" } }],
+        where: { id: { in: userIds } },
+        select: {
+          id: true,
+          email: true,
+          aiApiKey: true,
+          emailAccounts: {
+            select: { id: true, email: true },
+            orderBy: { createdAt: "asc" },
+          },
         },
-        select: { id: true },
       })
     : [];
 
   const emailAccountByEmail = new Map(
     emailAccounts.map((account) => [account.email, account]),
   );
-  const emailAccountsByUserId = new Map<
-    string,
-    Array<{ id: string; email: string }>
-  >();
-  for (const account of allUserEmailAccounts) {
-    const existingAccounts = emailAccountsByUserId.get(account.userId) ?? [];
-    existingAccounts.push({ id: account.id, email: account.email });
-    emailAccountsByUserId.set(account.userId, existingAccounts);
-  }
-  const userIdsWithApiKey = new Set(usersWithApiKey.map((user) => user.id));
+  const usersById = new Map(users.map((user) => [user.id, user]));
 
   const nanoWeeklySpendLimitUsd = env.AI_NANO_WEEKLY_SPEND_LIMIT_USD ?? null;
   const nanoModelConfigured = !!env.NANO_LLM_PROVIDER && !!env.NANO_LLM_MODEL;
@@ -59,17 +58,19 @@ async function getData() {
 
   return {
     topSpenders: topSpenders.map((spender) => {
-      const emailAccount = emailAccountByEmail.get(spender.email);
-      const hasUserApiKey = emailAccount
-        ? userIdsWithApiKey.has(emailAccount.userId)
-        : false;
+      const emailAccount = spender.email
+        ? emailAccountByEmail.get(spender.email)
+        : undefined;
+      const userId = spender.userId ?? emailAccount?.userId ?? null;
+      const user = userId ? usersById.get(userId) : null;
+      const hasUserApiKey = !!user?.aiApiKey;
+      const primaryEmailAccount = emailAccount ?? user?.emailAccounts[0];
 
       return {
         ...spender,
-        emailAccountId: emailAccount?.id ?? null,
-        userEmailAccountCount: emailAccount
-          ? (emailAccountsByUserId.get(emailAccount.userId)?.length ?? 0)
-          : 0,
+        email: spender.email ?? user?.email ?? null,
+        emailAccountId: primaryEmailAccount?.id ?? null,
+        userEmailAccountCount: user?.emailAccounts.length ?? 0,
         nanoLimitedBySpendGuard:
           nanoLimiterEnabled &&
           nanoWeeklySpendLimitUsd !== null &&

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -16,17 +16,19 @@ async function getData() {
   if (!topSpenders.length) return { topSpenders: [] };
 
   const emails = topSpenders.flatMap((spender) =>
-    spender.email ? [spender.email] : [],
+    "email" in spender ? [spender.email] : [],
   );
-  const emailAccounts = await prisma.emailAccount.findMany({
-    where: { email: { in: emails } },
-    select: { id: true, email: true, userId: true },
-  });
+  const emailAccounts = emails.length
+    ? await prisma.emailAccount.findMany({
+        where: { email: { in: emails } },
+        select: { id: true, email: true, userId: true },
+      })
+    : [];
 
   const userIds = [
     ...new Set([
       ...topSpenders.flatMap((spender) =>
-        spender.userId ? [spender.userId] : [],
+        "userId" in spender ? [spender.userId] : [],
       ),
       ...emailAccounts.map((account) => account.userId),
     ]),
@@ -58,17 +60,17 @@ async function getData() {
 
   return {
     topSpenders: topSpenders.map((spender) => {
-      const emailAccount = spender.email
-        ? emailAccountByEmail.get(spender.email)
-        : undefined;
-      const userId = spender.userId ?? emailAccount?.userId ?? null;
+      const emailAccount =
+        "email" in spender ? emailAccountByEmail.get(spender.email) : null;
+      const userId =
+        "userId" in spender ? spender.userId : emailAccount?.userId;
       const user = userId ? usersById.get(userId) : null;
       const hasUserApiKey = !!user?.aiApiKey;
       const primaryEmailAccount = emailAccount ?? user?.emailAccounts[0];
 
       return {
         ...spender,
-        email: spender.email ?? user?.email ?? null,
+        email: "email" in spender ? spender.email : (user?.email ?? null),
         emailAccountId: primaryEmailAccount?.id ?? null,
         userEmailAccountCount: user?.emailAccounts.length ?? 0,
         nanoLimitedBySpendGuard:

--- a/apps/web/app/api/user/ai-automation-status/route.ts
+++ b/apps/web/app/api/user/ai-automation-status/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getUserTrialAiUsageLimitStatus } from "@/utils/llms/model-usage-guard";
+import { withAuth } from "@/utils/middleware";
+
+export type GetAiAutomationStatusResponse = Awaited<
+  ReturnType<typeof getUserTrialAiUsageLimitStatus>
+>;
+
+export const GET = withAuth("user/ai-automation-status", async (request) =>
+  NextResponse.json(
+    await getUserTrialAiUsageLimitStatus({ userId: request.auth.userId }),
+  ),
+);

--- a/apps/web/hooks/useAiAutomationStatus.ts
+++ b/apps/web/hooks/useAiAutomationStatus.ts
@@ -1,9 +1,13 @@
 import useSWR from "swr";
 import type { GetAiAutomationStatusResponse } from "@/app/api/user/ai-automation-status/route";
+import { usePremium } from "@/hooks/usePremium";
 
 export function useAiAutomationStatus() {
+  const { premium } = usePremium();
+  const isTrial = premium?.stripeSubscriptionStatus === "trialing";
+
   return useSWR<GetAiAutomationStatusResponse>(
-    "/api/user/ai-automation-status",
+    isTrial ? "/api/user/ai-automation-status" : null,
     {
       revalidateOnFocus: false,
     },

--- a/apps/web/hooks/useAiAutomationStatus.ts
+++ b/apps/web/hooks/useAiAutomationStatus.ts
@@ -1,0 +1,11 @@
+import useSWR from "swr";
+import type { GetAiAutomationStatusResponse } from "@/app/api/user/ai-automation-status/route";
+
+export function useAiAutomationStatus() {
+  return useSWR<GetAiAutomationStatusResponse>(
+    "/api/user/ai-automation-status",
+    {
+      revalidateOnFocus: false,
+    },
+  );
+}

--- a/apps/web/hooks/useEndStripeTrial.ts
+++ b/apps/web/hooks/useEndStripeTrial.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useSWRConfig } from "swr";
+import { toastError } from "@/components/Toast";
+import { endStripeTrialAction } from "@/utils/actions/premium";
+
+export function useEndStripeTrial() {
+  const [loading, setLoading] = useState(false);
+  const { mutate } = useSWRConfig();
+
+  const endTrial = async () => {
+    setLoading(true);
+    const result = await endStripeTrialAction().finally(() => {
+      setLoading(false);
+    });
+
+    if (result?.serverError) {
+      toastError({ description: result.serverError });
+      return;
+    }
+
+    if (result?.data?.status === "active") {
+      toast.success("Your paid plan is active.");
+    } else {
+      toast.message("Your trial has ended.");
+    }
+
+    await Promise.all([
+      mutate("/api/user/me"),
+      mutate("/api/user/ai-automation-status"),
+    ]);
+  };
+
+  return { loading, endTrial };
+}

--- a/apps/web/utils/error-messages/index.test.ts
+++ b/apps/web/utils/error-messages/index.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { ErrorType, getUserErrorMessages } from "@/utils/error-messages";
+
+vi.mock("@/utils/prisma");
+vi.mock("@inboxzero/resend", () => ({
+  sendActionRequiredEmail: vi.fn(),
+}));
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: false,
+    NEXT_PUBLIC_BASE_URL: "https://example.com",
+    RESEND_FROM_EMAIL: "support@example.com",
+  },
+}));
+vi.mock("@/utils/unsubscribe", () => ({
+  createUnsubscribeToken: vi.fn(),
+}));
+
+describe("getUserErrorMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes legacy trial AI limit errors from generic user errors", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.TRIAL_AI_LIMIT_REACHED]: {
+          message: "Trial limit reached",
+          timestamp: "2026-05-08T18:01:24.429Z",
+        },
+      },
+    } as any);
+
+    const result = await getUserErrorMessages("user-1");
+
+    expect(result).toBeNull();
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { errorMessages: {} },
+    });
+  });
+
+  it("keeps unrelated errors when removing a legacy trial AI limit error", async () => {
+    const apiKeyError = {
+      message: "Invalid API key",
+      timestamp: "2026-05-08T18:01:24.429Z",
+    };
+
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.TRIAL_AI_LIMIT_REACHED]: {
+          message: "Trial limit reached",
+          timestamp: "2026-05-08T18:01:24.429Z",
+        },
+        [ErrorType.INVALID_AI_MODEL]: apiKeyError,
+      },
+    } as any);
+
+    const result = await getUserErrorMessages("user-1");
+
+    expect(result).toEqual({ [ErrorType.INVALID_AI_MODEL]: apiKeyError });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { errorMessages: { [ErrorType.INVALID_AI_MODEL]: apiKeyError } },
+    });
+  });
+
+  it("returns durable user errors unchanged", async () => {
+    const errorMessages = {
+      [ErrorType.INVALID_AI_MODEL]: {
+        message: "Invalid API key",
+        timestamp: "2026-05-08T18:01:24.429Z",
+      },
+    };
+
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages,
+    } as any);
+
+    const result = await getUserErrorMessages("user-1");
+
+    expect(result).toEqual(errorMessages);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/error-messages/index.ts
+++ b/apps/web/utils/error-messages/index.ts
@@ -7,6 +7,20 @@ import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
 // Used to store error messages for a user which we display in the UI
 
+export const ErrorType = {
+  INCORRECT_API_KEY: "Incorrect API key",
+  INVALID_AI_MODEL: "Invalid AI model",
+  API_KEY_DEACTIVATED: "API key deactivated",
+  AI_QUOTA_ERROR: "AI quota error",
+  INSUFFICIENT_CREDITS: "Insufficient AI credits",
+  TRIAL_AI_LIMIT_REACHED: "Trial AI limit reached",
+  ACCOUNT_DISCONNECTED: "Account disconnected",
+  // Legacy keys kept for clearing old stored errors
+  INCORRECT_OPENAI_API_KEY: "Incorrect OpenAI API key",
+  OPENAI_API_KEY_DEACTIVATED: "OpenAI API key deactivated",
+  ANTHROPIC_INSUFFICIENT_BALANCE: "Anthropic insufficient balance",
+} as const;
+
 type ErrorMessageEntry = {
   message: string;
   timestamp: string;
@@ -14,6 +28,11 @@ type ErrorMessageEntry = {
 };
 
 type ErrorMessages = Record<string, ErrorMessageEntry>;
+type ErrorTypeValue = (typeof ErrorType)[keyof typeof ErrorType];
+export type PersistedErrorType = Exclude<
+  ErrorTypeValue,
+  typeof ErrorType.TRIAL_AI_LIMIT_REACHED
+>;
 
 export async function getUserErrorMessages(
   userId: string,
@@ -22,12 +41,28 @@ export async function getUserErrorMessages(
     where: { id: userId },
     select: { errorMessages: true },
   });
-  return (user?.errorMessages as ErrorMessages) || null;
+  const errorMessages = (user?.errorMessages as ErrorMessages) || null;
+
+  if (errorMessages?.[ErrorType.TRIAL_AI_LIMIT_REACHED]) {
+    const updatedErrorMessages = { ...errorMessages };
+    delete updatedErrorMessages[ErrorType.TRIAL_AI_LIMIT_REACHED];
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { errorMessages: updatedErrorMessages },
+    });
+
+    return Object.keys(updatedErrorMessages).length
+      ? updatedErrorMessages
+      : null;
+  }
+
+  return errorMessages;
 }
 
 export async function addUserErrorMessage(
   userId: string,
-  errorType: (typeof ErrorType)[keyof typeof ErrorType],
+  errorType: PersistedErrorType,
   errorMessage: string,
   logger: Logger,
 ): Promise<void> {
@@ -77,7 +112,7 @@ export async function clearSpecificErrorMessages({
   logger,
 }: {
   userId: string;
-  errorTypes: (typeof ErrorType)[keyof typeof ErrorType][];
+  errorTypes: ErrorTypeValue[];
   logger: Logger;
 }): Promise<void> {
   try {
@@ -109,22 +144,8 @@ export async function clearSpecificErrorMessages({
   }
 }
 
-export const ErrorType = {
-  INCORRECT_API_KEY: "Incorrect API key",
-  INVALID_AI_MODEL: "Invalid AI model",
-  API_KEY_DEACTIVATED: "API key deactivated",
-  AI_QUOTA_ERROR: "AI quota error",
-  INSUFFICIENT_CREDITS: "Insufficient AI credits",
-  TRIAL_AI_LIMIT_REACHED: "Trial AI limit reached",
-  ACCOUNT_DISCONNECTED: "Account disconnected",
-  // Legacy keys kept for clearing old stored errors
-  INCORRECT_OPENAI_API_KEY: "Incorrect OpenAI API key",
-  OPENAI_API_KEY_DEACTIVATED: "OpenAI API key deactivated",
-  ANTHROPIC_INSUFFICIENT_BALANCE: "Anthropic insufficient balance",
-};
-
 const errorTypeConfig: Record<
-  (typeof ErrorType)[keyof typeof ErrorType],
+  PersistedErrorType,
   { label: string; actionUrl: string; actionLabel: string }
 > = {
   [ErrorType.INCORRECT_API_KEY]: {
@@ -151,11 +172,6 @@ const errorTypeConfig: Record<
     label: "Insufficient Credits",
     actionUrl: "/settings",
     actionLabel: "Update Settings",
-  },
-  [ErrorType.TRIAL_AI_LIMIT_REACHED]: {
-    label: "Trial AI Limit Reached",
-    actionUrl: "/premium",
-    actionLabel: "Upgrade",
   },
   [ErrorType.ACCOUNT_DISCONNECTED]: {
     label: "Account Disconnected",
@@ -191,7 +207,7 @@ export async function addUserErrorMessageWithNotification({
   userId: string;
   userEmail: string;
   emailAccountId: string;
-  errorType: (typeof ErrorType)[keyof typeof ErrorType];
+  errorType: PersistedErrorType;
   errorMessage: string;
   logger: Logger;
 }): Promise<void> {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -30,6 +30,7 @@ import type { EmailAccountWithAI, UserAIFields } from "@/utils/llms/types";
 import {
   addUserErrorMessageWithNotification,
   ErrorType,
+  type PersistedErrorType,
 } from "@/utils/error-messages";
 import {
   attachLlmRepairMetadata,
@@ -238,6 +239,7 @@ export function createGenerateText({
         await saveUsageWithMetadata({
           result,
           usage: result.usage,
+          userId: emailAccount.userId,
           email: emailAccount.email,
           emailAccountId: emailAccount.id,
           provider: candidate.provider,
@@ -429,6 +431,7 @@ export function createGenerateObject({
         await saveUsageWithMetadata({
           result,
           usage: result.usage,
+          userId: emailAccount.userId,
           email: emailAccount.email,
           emailAccountId: emailAccount.id,
           provider: candidate.provider,
@@ -600,6 +603,7 @@ export async function chatCompletionStream({
           const usagePromise = saveUsageWithMetadata({
             result,
             usage: result.usage,
+            userId,
             email: userEmail,
             emailAccountId,
             provider: candidate.provider,
@@ -797,6 +801,7 @@ export async function toolCallAgentStream({
         const usagePromise = saveUsageWithMetadata({
           result,
           usage: result.totalUsage,
+          userId,
           email: userEmail,
           emailAccountId,
           provider: candidate.provider,
@@ -1006,7 +1011,7 @@ async function handleError(
 
   if (APICallError.isInstance(error)) {
     const notifyUser = async (
-      errorType: (typeof ErrorType)[keyof typeof ErrorType],
+      errorType: PersistedErrorType,
       errorMessage: string,
     ) => {
       if (hasUserApiKey) markAsHandledUserKeyError(error);
@@ -1592,6 +1597,7 @@ function getUsageMetadata(result: unknown): UsageMetadata {
 async function saveUsageWithMetadata({
   result,
   usage,
+  userId,
   email,
   emailAccountId,
   provider,
@@ -1601,6 +1607,7 @@ async function saveUsageWithMetadata({
 }: {
   result: unknown;
   usage: Parameters<typeof saveAiUsage>[0]["usage"];
+  userId?: string;
   email: string;
   emailAccountId: string;
   provider: string;
@@ -1611,6 +1618,7 @@ async function saveUsageWithMetadata({
   const usageMetadata = getUsageMetadata(result);
 
   await saveAiUsage({
+    userId,
     email,
     emailAccountId,
     usage,

--- a/apps/web/utils/llms/model-usage-guard.test.ts
+++ b/apps/web/utils/llms/model-usage-guard.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assertTrialAiUsageAllowed,
+  getUserTrialAiUsageLimitStatus,
   shouldForceNanoModel,
   TRIAL_AI_LIMIT_REACHED_MESSAGE,
 } from "@/utils/llms/model-usage-guard";
 import { getWeeklyUsageCost } from "@/utils/redis/usage";
 import { env } from "@/env";
 import prisma from "@/utils/__mocks__/prisma";
-import {
-  addUserErrorMessageWithNotification,
-  ErrorType,
-} from "@/utils/error-messages";
 import { SafeError } from "@/utils/error";
+import { redis } from "@/utils/redis";
+import { sendActionRequiredEmail } from "@inboxzero/resend";
+import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
 vi.mock("server-only", () => ({}));
 
@@ -19,19 +19,29 @@ vi.mock("@/utils/redis/usage", () => ({
   getWeeklyUsageCost: vi.fn(),
 }));
 
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
 vi.mock("@/utils/prisma");
 
-vi.mock("@/utils/error-messages", () => ({
-  ErrorType: {
-    TRIAL_AI_LIMIT_REACHED: "Trial AI limit reached",
-  },
-  addUserErrorMessageWithNotification: vi.fn(),
+vi.mock("@inboxzero/resend", () => ({
+  sendActionRequiredEmail: vi.fn(),
+}));
+
+vi.mock("@/utils/unsubscribe", () => ({
+  createUnsubscribeToken: vi.fn(),
 }));
 
 vi.mock("@/env", () => ({
   env: {
     AI_NANO_WEEKLY_SPEND_LIMIT_USD: undefined,
     AI_TRIAL_WEEKLY_SPEND_LIMIT_USD: undefined,
+    NEXT_PUBLIC_BASE_URL: "https://example.com",
+    RESEND_FROM_EMAIL: "support@example.com",
     NANO_LLM_PROVIDER: undefined,
     NANO_LLM_MODEL: undefined,
   },
@@ -162,7 +172,6 @@ describe("assertTrialAiUsageAllowed", () => {
         stripeSubscriptionStatus: "active",
         lemonSubscriptionStatus: null,
       },
-      errorMessages: null,
     } as any);
 
     await assertTrialAiUsageAllowed({
@@ -173,18 +182,24 @@ describe("assertTrialAiUsageAllowed", () => {
       emailAccountId: "account-1",
     });
 
-    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
+    expect(getWeeklyUsageCost).toHaveBeenCalledWith({
+      userId: "user-1",
+      fallbackEmails: ["user@example.com"],
+    });
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(sendActionRequiredEmail).not.toHaveBeenCalled();
   });
 
-  it("blocks trial users over the spend limit and stores an upgrade alert", async () => {
+  it("blocks trial users over the spend limit and sends an upgrade email once", async () => {
     vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = 2;
     vi.mocked(getWeeklyUsageCost).mockResolvedValue(3);
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(createUnsubscribeToken).mockResolvedValue("unsubscribe-token");
     prisma.user.findUnique.mockResolvedValue({
       premium: {
         stripeSubscriptionStatus: "trialing",
         lemonSubscriptionStatus: null,
       },
-      errorMessages: null,
     } as any);
 
     await expect(
@@ -197,29 +212,35 @@ describe("assertTrialAiUsageAllowed", () => {
       }),
     ).rejects.toThrow(SafeError);
 
-    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: "user-1",
-        userEmail: "user@example.com",
-        emailAccountId: "account-1",
-        errorType: ErrorType.TRIAL_AI_LIMIT_REACHED,
-        errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
-      }),
+    expect(redis.set).toHaveBeenCalledWith(
+      "trial-ai-limit-notification:user-1",
+      expect.any(String),
+      { ex: 5_184_000, nx: true },
     );
+    expect(sendActionRequiredEmail).toHaveBeenCalledWith({
+      from: "support@example.com",
+      to: "user@example.com",
+      emailProps: {
+        baseUrl: "https://example.com",
+        email: "user@example.com",
+        unsubscribeToken: "unsubscribe-token",
+        errorType: "Trial AI Limit Reached",
+        errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
+        actionUrl: "/premium",
+        actionLabel: "Upgrade",
+      },
+    });
+    expect(prisma.user.update).not.toHaveBeenCalled();
   });
 
-  it("does not rewrite an existing trial limit alert on every blocked call", async () => {
+  it("does not resend a trial limit email when the notification marker exists", async () => {
     vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = 2;
     vi.mocked(getWeeklyUsageCost).mockResolvedValue(3);
+    vi.mocked(redis.set).mockResolvedValue(null);
     prisma.user.findUnique.mockResolvedValue({
       premium: {
         stripeSubscriptionStatus: "trialing",
         lemonSubscriptionStatus: null,
-      },
-      errorMessages: {
-        [ErrorType.TRIAL_AI_LIMIT_REACHED]: {
-          message: TRIAL_AI_LIMIT_REACHED_MESSAGE,
-        },
       },
     } as any);
 
@@ -233,6 +254,72 @@ describe("assertTrialAiUsageAllowed", () => {
       }),
     ).rejects.toThrow(SafeError);
 
-    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
+    expect(sendActionRequiredEmail).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("getUserTrialAiUsageLimitStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = undefined;
+  });
+
+  it("returns allowed when trial spend limit is not configured", async () => {
+    const status = await getUserTrialAiUsageLimitStatus({
+      userId: "user-1",
+    });
+
+    expect(status).toEqual({ status: "allowed" });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns allowed for paid users without checking usage", async () => {
+    vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = 2;
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      aiApiKey: null,
+      emailAccounts: [{ email: "account@example.com" }],
+      premium: {
+        stripeSubscriptionStatus: "active",
+        lemonSubscriptionStatus: null,
+      },
+    } as any);
+
+    const status = await getUserTrialAiUsageLimitStatus({
+      userId: "user-1",
+    });
+
+    expect(status).toEqual({ status: "allowed" });
+    expect(getWeeklyUsageCost).not.toHaveBeenCalled();
+  });
+
+  it("returns a dynamic trial limit status for trial users over the limit", async () => {
+    vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = 2;
+    vi.mocked(getWeeklyUsageCost).mockResolvedValue(3);
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      aiApiKey: null,
+      emailAccounts: [{ email: "account@example.com" }],
+      premium: {
+        stripeSubscriptionStatus: "trialing",
+        lemonSubscriptionStatus: null,
+      },
+    } as any);
+
+    const status = await getUserTrialAiUsageLimitStatus({
+      userId: "user-1",
+    });
+
+    expect(getWeeklyUsageCost).toHaveBeenCalledWith({
+      userId: "user-1",
+      fallbackEmails: ["user@example.com", "account@example.com"],
+    });
+    expect(status).toEqual({
+      status: "trial_ai_limit_reached",
+      message: TRIAL_AI_LIMIT_REACHED_MESSAGE,
+      weeklySpendUsd: 3,
+      weeklyLimitUsd: 2,
+    });
   });
 });

--- a/apps/web/utils/llms/model-usage-guard.test.ts
+++ b/apps/web/utils/llms/model-usage-guard.test.ts
@@ -61,6 +61,7 @@ describe("shouldForceNanoModel", () => {
       userEmail: "user@example.com",
       hasUserApiKey: false,
       label: "assistant-chat",
+      userId: "user-1",
     });
 
     expect(result.shouldForce).toBe(false);
@@ -89,6 +90,7 @@ describe("shouldForceNanoModel", () => {
       userEmail: "user@example.com",
       hasUserApiKey: false,
       label: "assistant-chat",
+      userId: "user-1",
     });
 
     expect(result.shouldForce).toBe(false);
@@ -105,6 +107,7 @@ describe("shouldForceNanoModel", () => {
       userEmail: "user@example.com",
       hasUserApiKey: false,
       label: "assistant-chat",
+      userId: "user-1",
     });
 
     expect(result.shouldForce).toBe(true);
@@ -122,6 +125,7 @@ describe("shouldForceNanoModel", () => {
       userEmail: "user@example.com",
       hasUserApiKey: false,
       label: "assistant-chat",
+      userId: "user-1",
     });
 
     expect(result.shouldForce).toBe(false);
@@ -168,6 +172,8 @@ describe("assertTrialAiUsageAllowed", () => {
     vi.mocked(env).AI_TRIAL_WEEKLY_SPEND_LIMIT_USD = 2;
     vi.mocked(getWeeklyUsageCost).mockResolvedValue(3);
     prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      emailAccounts: [{ email: "account@example.com" }],
       premium: {
         stripeSubscriptionStatus: "active",
         lemonSubscriptionStatus: null,
@@ -182,10 +188,7 @@ describe("assertTrialAiUsageAllowed", () => {
       emailAccountId: "account-1",
     });
 
-    expect(getWeeklyUsageCost).toHaveBeenCalledWith({
-      userId: "user-1",
-      fallbackEmails: ["user@example.com"],
-    });
+    expect(getWeeklyUsageCost).not.toHaveBeenCalled();
     expect(redis.set).not.toHaveBeenCalled();
     expect(sendActionRequiredEmail).not.toHaveBeenCalled();
   });
@@ -196,6 +199,8 @@ describe("assertTrialAiUsageAllowed", () => {
     vi.mocked(redis.set).mockResolvedValue("OK");
     vi.mocked(createUnsubscribeToken).mockResolvedValue("unsubscribe-token");
     prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      emailAccounts: [{ email: "account@example.com" }],
       premium: {
         stripeSubscriptionStatus: "trialing",
         lemonSubscriptionStatus: null,
@@ -212,6 +217,10 @@ describe("assertTrialAiUsageAllowed", () => {
       }),
     ).rejects.toThrow(SafeError);
 
+    expect(getWeeklyUsageCost).toHaveBeenCalledWith({
+      userId: "user-1",
+      legacyEmails: ["user@example.com", "account@example.com"],
+    });
     expect(redis.set).toHaveBeenCalledWith(
       "trial-ai-limit-notification:user-1",
       expect.any(String),
@@ -227,7 +236,7 @@ describe("assertTrialAiUsageAllowed", () => {
         errorType: "Trial AI Limit Reached",
         errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
         actionUrl: "/premium",
-        actionLabel: "Upgrade",
+        actionLabel: "Start paid plan now",
       },
     });
     expect(prisma.user.update).not.toHaveBeenCalled();
@@ -238,6 +247,8 @@ describe("assertTrialAiUsageAllowed", () => {
     vi.mocked(getWeeklyUsageCost).mockResolvedValue(3);
     vi.mocked(redis.set).mockResolvedValue(null);
     prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      emailAccounts: [{ email: "account@example.com" }],
       premium: {
         stripeSubscriptionStatus: "trialing",
         lemonSubscriptionStatus: null,
@@ -313,7 +324,7 @@ describe("getUserTrialAiUsageLimitStatus", () => {
 
     expect(getWeeklyUsageCost).toHaveBeenCalledWith({
       userId: "user-1",
-      fallbackEmails: ["user@example.com", "account@example.com"],
+      legacyEmails: ["user@example.com", "account@example.com"],
     });
     expect(status).toEqual({
       status: "trial_ai_limit_reached",

--- a/apps/web/utils/llms/model-usage-guard.ts
+++ b/apps/web/utils/llms/model-usage-guard.ts
@@ -71,54 +71,20 @@ export async function assertTrialAiUsageAllowed(options: {
   userId?: string;
   emailAccountId?: string;
 }): Promise<void> {
-  const weeklyLimitUsd = env.AI_TRIAL_WEEKLY_SPEND_LIMIT_USD;
-  if (!weeklyLimitUsd) return;
   if (options.hasUserApiKey) return;
   if (!options.userId || !options.emailAccountId) return;
 
-  const user = await prisma.user.findUnique({
-    where: { id: options.userId },
-    select: {
-      email: true,
-      emailAccounts: { select: { email: true } },
-      premium: {
-        select: {
-          stripeSubscriptionStatus: true,
-          lemonSubscriptionStatus: true,
-        },
-      },
-    },
+  const status = await getUserTrialAiUsageLimitStatus({
+    userId: options.userId,
   });
-
-  if (!user || !isTrialPremium(user.premium)) return;
-
-  let weeklySpendUsd = 0;
-  try {
-    weeklySpendUsd = await getWeeklyUsageCost({
-      userId: options.userId,
-      legacyEmails: getLegacyUsageEmails({
-        email: user.email ?? options.userEmail,
-        emailAccounts: user.emailAccounts,
-      }),
-    });
-  } catch (error) {
-    logger.error("Failed to evaluate trial AI spend guard", {
-      label: options.label,
-      userId: options.userId,
-      emailAccountId: options.emailAccountId,
-      error,
-    });
-    return;
-  }
-
-  if (weeklySpendUsd < weeklyLimitUsd) return;
+  if (status.status === "allowed") return;
 
   logger.warn("Blocking trial AI call due to weekly spend", {
     label: options.label,
     userId: options.userId,
     emailAccountId: options.emailAccountId,
-    weeklySpendUsd,
-    weeklyLimitUsd,
+    weeklySpendUsd: status.weeklySpendUsd,
+    weeklyLimitUsd: status.weeklyLimitUsd,
   });
 
   await sendTrialAiLimitReachedEmailOnce({

--- a/apps/web/utils/llms/model-usage-guard.ts
+++ b/apps/web/utils/llms/model-usage-guard.ts
@@ -11,7 +11,7 @@ const logger = createScopedLogger("llms/model-usage-guard");
 const TRIAL_AI_LIMIT_NOTIFICATION_TTL_SECONDS = 60 * 24 * 60 * 60;
 
 export const TRIAL_AI_LIMIT_REACHED_MESSAGE =
-  "Your trial has reached the AI usage limit. Upgrade to continue using AI automation.";
+  "Your trial has reached the AI usage limit. Start your paid plan now to continue using AI automation.";
 
 type TrialAiUsageLimitStatus =
   | { status: "allowed" }
@@ -51,7 +51,7 @@ export async function getUserTrialAiUsageLimitStatus(options: {
   try {
     weeklySpendUsd = await getWeeklyUsageCost({
       userId: options.userId,
-      fallbackEmails: getLegacyUsageEmails(user),
+      legacyEmails: getLegacyUsageEmails(user),
     });
   } catch (error) {
     logger.error("Failed to evaluate trial AI spend status", {
@@ -76,11 +76,30 @@ export async function assertTrialAiUsageAllowed(options: {
   if (options.hasUserApiKey) return;
   if (!options.userId || !options.emailAccountId) return;
 
+  const user = await prisma.user.findUnique({
+    where: { id: options.userId },
+    select: {
+      email: true,
+      emailAccounts: { select: { email: true } },
+      premium: {
+        select: {
+          stripeSubscriptionStatus: true,
+          lemonSubscriptionStatus: true,
+        },
+      },
+    },
+  });
+
+  if (!user || !isTrialPremium(user.premium)) return;
+
   let weeklySpendUsd = 0;
   try {
     weeklySpendUsd = await getWeeklyUsageCost({
       userId: options.userId,
-      fallbackEmails: [options.userEmail],
+      legacyEmails: getLegacyUsageEmails({
+        email: user.email ?? options.userEmail,
+        emailAccounts: user.emailAccounts,
+      }),
     });
   } catch (error) {
     logger.error("Failed to evaluate trial AI spend guard", {
@@ -93,20 +112,6 @@ export async function assertTrialAiUsageAllowed(options: {
   }
 
   if (weeklySpendUsd < weeklyLimitUsd) return;
-
-  const user = await prisma.user.findUnique({
-    where: { id: options.userId },
-    select: {
-      premium: {
-        select: {
-          stripeSubscriptionStatus: true,
-          lemonSubscriptionStatus: true,
-        },
-      },
-    },
-  });
-
-  if (!isTrialPremium(user?.premium)) return;
 
   logger.warn("Blocking trial AI call due to weekly spend", {
     label: options.label,
@@ -143,7 +148,7 @@ async function sendTrialAiLimitReachedEmailOnce({
     nx: true,
   });
 
-  if (claimedNotification !== "OK") return;
+  if (!claimedNotification) return;
 
   try {
     const unsubscribeToken = await createUnsubscribeToken({ emailAccountId });
@@ -158,7 +163,7 @@ async function sendTrialAiLimitReachedEmailOnce({
         errorType: "Trial AI Limit Reached",
         errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
         actionUrl: "/premium",
-        actionLabel: "Upgrade",
+        actionLabel: "Start paid plan now",
       },
     });
 
@@ -212,12 +217,14 @@ export async function shouldForceNanoModel(options: {
     });
     return { shouldForce: false, weeklySpendUsd: null, weeklyLimitUsd };
   }
+  if (!options.userId) {
+    return { shouldForce: false, weeklySpendUsd: null, weeklyLimitUsd };
+  }
 
   try {
     const weeklySpendUsd = await getWeeklyUsageCost({
       userId: options.userId,
-      email: options.userId ? undefined : options.userEmail,
-      fallbackEmails: options.userId ? [options.userEmail] : [],
+      legacyEmails: [options.userEmail],
     });
     return {
       shouldForce: weeklySpendUsd >= weeklyLimitUsd,
@@ -250,6 +257,15 @@ function isTrialPremium(
   );
 }
 
+function getLegacyUsageEmails(user: {
+  email: string | null;
+  emailAccounts: Array<{ email: string }>;
+}) {
+  return Array.from(
+    new Set([user.email, ...user.emailAccounts.map(({ email }) => email)]),
+  ).flatMap((email) => (email ? [email] : []));
+}
+
 function getTrialAiUsageLimitStatus({
   weeklySpendUsd,
   weeklyLimitUsd,
@@ -269,13 +285,4 @@ function getTrialAiUsageLimitStatus({
 
 function getTrialAiLimitNotificationKey(userId: string) {
   return `trial-ai-limit-notification:${userId}`;
-}
-
-function getLegacyUsageEmails(user: {
-  email: string;
-  emailAccounts: Array<{ email: string }>;
-}) {
-  return [
-    ...new Set([user.email, ...user.emailAccounts.map(({ email }) => email)]),
-  ];
 }

--- a/apps/web/utils/llms/model-usage-guard.ts
+++ b/apps/web/utils/llms/model-usage-guard.ts
@@ -1,17 +1,68 @@
 import { env } from "@/env";
 import { getWeeklyUsageCost } from "@/utils/redis/usage";
-import { createScopedLogger } from "@/utils/logger";
+import { createScopedLogger, type Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { SafeError } from "@/utils/error";
-import {
-  addUserErrorMessageWithNotification,
-  ErrorType,
-} from "@/utils/error-messages";
+import { redis } from "@/utils/redis";
+import { sendActionRequiredEmail } from "@inboxzero/resend";
+import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
 const logger = createScopedLogger("llms/model-usage-guard");
+const TRIAL_AI_LIMIT_NOTIFICATION_TTL_SECONDS = 60 * 24 * 60 * 60;
 
 export const TRIAL_AI_LIMIT_REACHED_MESSAGE =
   "Your trial has reached the AI usage limit. Upgrade to continue using AI automation.";
+
+type TrialAiUsageLimitStatus =
+  | { status: "allowed" }
+  | {
+      status: "trial_ai_limit_reached";
+      message: string;
+      weeklySpendUsd: number;
+      weeklyLimitUsd: number;
+    };
+
+export async function getUserTrialAiUsageLimitStatus(options: {
+  userId: string;
+}): Promise<TrialAiUsageLimitStatus> {
+  const weeklyLimitUsd = env.AI_TRIAL_WEEKLY_SPEND_LIMIT_USD;
+  if (!weeklyLimitUsd) return { status: "allowed" };
+
+  const user = await prisma.user.findUnique({
+    where: { id: options.userId },
+    select: {
+      email: true,
+      aiApiKey: true,
+      emailAccounts: { select: { email: true } },
+      premium: {
+        select: {
+          stripeSubscriptionStatus: true,
+          lemonSubscriptionStatus: true,
+        },
+      },
+    },
+  });
+
+  if (!user || user.aiApiKey || !isTrialPremium(user.premium)) {
+    return { status: "allowed" };
+  }
+
+  let weeklySpendUsd = 0;
+  try {
+    weeklySpendUsd = await getWeeklyUsageCost({
+      userId: options.userId,
+      fallbackEmails: getLegacyUsageEmails(user),
+    });
+  } catch (error) {
+    logger.error("Failed to evaluate trial AI spend status", {
+      userId: options.userId,
+      error,
+    });
+    return { status: "allowed" };
+  }
+
+  return getTrialAiUsageLimitStatus({ weeklySpendUsd, weeklyLimitUsd });
+}
 
 export async function assertTrialAiUsageAllowed(options: {
   userEmail: string;
@@ -27,7 +78,10 @@ export async function assertTrialAiUsageAllowed(options: {
 
   let weeklySpendUsd = 0;
   try {
-    weeklySpendUsd = await getWeeklyUsageCost({ email: options.userEmail });
+    weeklySpendUsd = await getWeeklyUsageCost({
+      userId: options.userId,
+      fallbackEmails: [options.userEmail],
+    });
   } catch (error) {
     logger.error("Failed to evaluate trial AI spend guard", {
       label: options.label,
@@ -43,7 +97,6 @@ export async function assertTrialAiUsageAllowed(options: {
   const user = await prisma.user.findUnique({
     where: { id: options.userId },
     select: {
-      errorMessages: true,
       premium: {
         select: {
           stripeSubscriptionStatus: true,
@@ -55,13 +108,6 @@ export async function assertTrialAiUsageAllowed(options: {
 
   if (!isTrialPremium(user?.premium)) return;
 
-  const errorMessages = user?.errorMessages as
-    | Record<string, { message?: string }>
-    | null
-    | undefined;
-  const hasExistingTrialLimitError =
-    !!errorMessages?.[ErrorType.TRIAL_AI_LIMIT_REACHED];
-
   logger.warn("Blocking trial AI call due to weekly spend", {
     label: options.label,
     userId: options.userId,
@@ -70,18 +116,69 @@ export async function assertTrialAiUsageAllowed(options: {
     weeklyLimitUsd,
   });
 
-  if (!hasExistingTrialLimitError) {
-    await addUserErrorMessageWithNotification({
-      userId: options.userId,
-      userEmail: options.userEmail,
-      emailAccountId: options.emailAccountId,
-      errorType: ErrorType.TRIAL_AI_LIMIT_REACHED,
-      errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
-      logger,
-    });
-  }
+  await sendTrialAiLimitReachedEmailOnce({
+    userId: options.userId,
+    userEmail: options.userEmail,
+    emailAccountId: options.emailAccountId,
+    logger,
+  });
 
   throw new SafeError(TRIAL_AI_LIMIT_REACHED_MESSAGE);
+}
+
+async function sendTrialAiLimitReachedEmailOnce({
+  userId,
+  userEmail,
+  emailAccountId,
+  logger,
+}: {
+  userId: string;
+  userEmail: string;
+  emailAccountId: string;
+  logger: Logger;
+}) {
+  const key = getTrialAiLimitNotificationKey(userId);
+  const claimedNotification = await redis.set(key, new Date().toISOString(), {
+    ex: TRIAL_AI_LIMIT_NOTIFICATION_TTL_SECONDS,
+    nx: true,
+  });
+
+  if (claimedNotification !== "OK") return;
+
+  try {
+    const unsubscribeToken = await createUnsubscribeToken({ emailAccountId });
+
+    await sendActionRequiredEmail({
+      from: env.RESEND_FROM_EMAIL,
+      to: userEmail,
+      emailProps: {
+        baseUrl: env.NEXT_PUBLIC_BASE_URL,
+        email: userEmail,
+        unsubscribeToken,
+        errorType: "Trial AI Limit Reached",
+        errorMessage: TRIAL_AI_LIMIT_REACHED_MESSAGE,
+        actionUrl: "/premium",
+        actionLabel: "Upgrade",
+      },
+    });
+
+    logger.info("Sent action required email", {
+      errorType: "trialAiLimitReached",
+    });
+  } catch (emailError) {
+    logger.error("Failed to send trial AI limit email", {
+      error: emailError,
+    });
+
+    try {
+      await redis.del(key);
+    } catch (redisError) {
+      logger.error("Failed to clear trial AI limit notification marker", {
+        userId,
+        error: redisError,
+      });
+    }
+  }
 }
 
 export async function shouldForceNanoModel(options: {
@@ -118,7 +215,9 @@ export async function shouldForceNanoModel(options: {
 
   try {
     const weeklySpendUsd = await getWeeklyUsageCost({
-      email: options.userEmail,
+      userId: options.userId,
+      email: options.userId ? undefined : options.userEmail,
+      fallbackEmails: options.userId ? [options.userEmail] : [],
     });
     return {
       shouldForce: weeklySpendUsd >= weeklyLimitUsd,
@@ -149,4 +248,34 @@ function isTrialPremium(
     premium?.stripeSubscriptionStatus === "trialing" ||
     premium?.lemonSubscriptionStatus === "on_trial"
   );
+}
+
+function getTrialAiUsageLimitStatus({
+  weeklySpendUsd,
+  weeklyLimitUsd,
+}: {
+  weeklySpendUsd: number;
+  weeklyLimitUsd: number;
+}): TrialAiUsageLimitStatus {
+  if (weeklySpendUsd < weeklyLimitUsd) return { status: "allowed" };
+
+  return {
+    status: "trial_ai_limit_reached",
+    message: TRIAL_AI_LIMIT_REACHED_MESSAGE,
+    weeklySpendUsd,
+    weeklyLimitUsd,
+  };
+}
+
+function getTrialAiLimitNotificationKey(userId: string) {
+  return `trial-ai-limit-notification:${userId}`;
+}
+
+function getLegacyUsageEmails(user: {
+  email: string;
+  emailAccounts: Array<{ email: string }>;
+}) {
+  return [
+    ...new Set([user.email, ...user.emailAccounts.map(({ email }) => email)]),
+  ];
 }

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -235,7 +235,11 @@ describe("redis usage tracking", () => {
   it("includes post-migration legacy weekly writes during rolling deploys", async () => {
     vi.mocked(redis.get).mockImplementation(async (key: string) => {
       if (key === "usage-migration:weekly-usage-cost-user:user-1:done") {
-        return "done";
+        return JSON.stringify({
+          weeklyCosts: {
+            "usage-weekly-cost:user@example.com:2026-02-24": 1,
+          },
+        });
       }
       return null;
     });
@@ -256,6 +260,101 @@ describe("redis usage tracking", () => {
       now,
     });
 
+    expect(weeklyCost).toBeCloseTo(1.5);
+  });
+
+  it("does not persist post-migration legacy weekly writes without the migration lock", async () => {
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const legacyWeeklyCostKey = "usage-weekly-cost:user@example.com:2026-02-24";
+
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:weekly-usage-cost-user:user-1:done") {
+        return JSON.stringify({
+          weeklyCosts: {
+            [legacyWeeklyCostKey]: 1,
+          },
+        });
+      }
+      return null;
+    });
+    vi.mocked(redis.set).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:weekly-usage-cost-user:user-1:lock") {
+        return null;
+      }
+      return "OK";
+    });
+
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
+      [legacyWeeklyCostKey]: { cost: "1.5" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["user@example.com"],
+      now,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:weekly-usage-cost-user:user-1:lock",
+      expect.any(String),
+      { nx: true, ex: 300 },
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      "cost",
+      0.5,
+    );
+    expect(weeklyCost).toBeCloseTo(1.5);
+  });
+
+  it("uses the latest weekly migration marker after claiming the migration lock", async () => {
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const legacyWeeklyCostKey = "usage-weekly-cost:user@example.com:2026-02-24";
+    let doneReads = 0;
+
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key !== "usage-migration:weekly-usage-cost-user:user-1:done") {
+        return null;
+      }
+
+      doneReads += 1;
+      return JSON.stringify({
+        weeklyCosts: {
+          [legacyWeeklyCostKey]: doneReads === 1 ? 1 : 1.5,
+        },
+      });
+    });
+
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
+      [legacyWeeklyCostKey]: { cost: "1.5" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["user@example.com"],
+      now,
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:weekly-usage-cost-user:user-1:lock",
+      expect.any(String),
+      { nx: true, ex: 300 },
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      "cost",
+      0.5,
+    );
     expect(weeklyCost).toBeCloseTo(1.5);
   });
 
@@ -376,7 +475,12 @@ describe("redis usage tracking", () => {
   it("includes post-migration legacy usage writes during rolling deploys", async () => {
     vi.mocked(redis.get).mockImplementation(async (key: string) => {
       if (key === "usage-migration:usage-email-account:email-account-1:done") {
-        return "done";
+        return JSON.stringify({
+          usage: {
+            openaiCalls: 2,
+            cost: 1,
+          },
+        });
       }
       return null;
     });
@@ -400,6 +504,136 @@ describe("redis usage tracking", () => {
       userId: "user-1",
     });
 
+    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+  });
+
+  it("does not persist post-migration legacy usage writes without the migration lock", async () => {
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:usage-email-account:email-account-1:done") {
+        return JSON.stringify({
+          usage: {
+            openaiCalls: 2,
+            cost: 1,
+          },
+        });
+      }
+      return null;
+    });
+    vi.mocked(redis.set).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:usage-email-account:email-account-1:lock") {
+        return null;
+      }
+      return "OK";
+    });
+
+    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
+      {
+        "usage:email-account:email-account-1": {
+          openaiCalls: 2,
+          cost: "1.0",
+        },
+        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+      };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => usageByKey[key] ?? {},
+    );
+
+    const usage = await getUsage({
+      emailAccountId: "email-account-1",
+      legacyEmail: "user@example.com",
+      userId: "user-1",
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:usage-email-account:email-account-1:lock",
+      expect.any(String),
+      { nx: true, ex: 300 },
+    );
+    expect(redis.hincrby).not.toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "openaiCalls",
+      1,
+    );
+    expect(redis.hincrby).not.toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "openaiCalls",
+      1,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "cost",
+      0.5,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "cost",
+      0.5,
+    );
+    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+  });
+
+  it("uses the latest usage migration marker after claiming the migration lock", async () => {
+    let doneReads = 0;
+
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key !== "usage-migration:usage-email-account:email-account-1:done") {
+        return null;
+      }
+
+      doneReads += 1;
+      return JSON.stringify({
+        usage: {
+          openaiCalls: doneReads === 1 ? 2 : 3,
+          cost: doneReads === 1 ? 1 : 1.5,
+        },
+      });
+    });
+
+    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
+      {
+        "usage:email-account:email-account-1": {
+          openaiCalls: 3,
+          cost: "1.5",
+        },
+        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+      };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => usageByKey[key] ?? {},
+    );
+
+    const usage = await getUsage({
+      emailAccountId: "email-account-1",
+      legacyEmail: "user@example.com",
+      userId: "user-1",
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:usage-email-account:email-account-1:lock",
+      expect.any(String),
+      { nx: true, ex: 300 },
+    );
+    expect(redis.hincrby).not.toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "openaiCalls",
+      1,
+    );
+    expect(redis.hincrby).not.toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "openaiCalls",
+      1,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "cost",
+      0.5,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "cost",
+      0.5,
+    );
     expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
   });
 

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { redis } from "@/utils/redis";
 import {
   getTopWeeklyUsageCosts,
+  getUsage,
   getWeeklyUsageCost,
   saveUsage,
 } from "@/utils/redis/usage";
@@ -11,6 +12,9 @@ vi.mock("server-only", () => ({}));
 vi.mock("@/utils/redis", () => ({
   redis: {
     scan: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
     hgetall: vi.fn(),
     hincrby: vi.fn(),
     hincrbyfloat: vi.fn(),
@@ -18,39 +22,125 @@ vi.mock("@/utils/redis", () => ({
   },
 }));
 
-describe("redis usage weekly cost tracking", () => {
+describe("redis usage tracking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(redis.scan).mockResolvedValue(["0", []]);
+    vi.mocked(redis.get).mockResolvedValue(null);
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(redis.del).mockResolvedValue(1);
     vi.mocked(redis.hincrby).mockResolvedValue(1);
     vi.mocked(redis.hincrbyfloat).mockResolvedValue(1);
     vi.mocked(redis.expire).mockResolvedValue(1);
   });
 
-  it("sums usage cost across the last 7 days", async () => {
+  it("reads usage by email account ID", async () => {
+    vi.mocked(redis.hgetall).mockResolvedValue({ openaiCalls: 3 });
+
+    const usage = await getUsage({ emailAccountId: "email-account-1" });
+
+    expect(usage).toEqual({ openaiCalls: 3 });
+    expect(redis.hgetall).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+    );
+  });
+
+  it("migrates legacy email usage into account and user usage before reading", async () => {
+    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
+      {
+        "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
+        "usage:email-account:email-account-1": { openaiCalls: 3 },
+      };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => usageByKey[key] ?? {},
+    );
+
+    const usage = await getUsage({
+      emailAccountId: "email-account-1",
+      legacyEmail: "user@example.com",
+      userId: "user-1",
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:usage-email-account:email-account-1:lock",
+      expect.any(String),
+      { nx: true, ex: 300 },
+    );
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "openaiCalls",
+      3,
+    );
+    expect(redis.hincrby).toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "openaiCalls",
+      3,
+    );
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "cost",
+      1.25,
+    );
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:usage-email-account:email-account-1:done",
+      expect.any(String),
+    );
+    expect(usage).toEqual({ openaiCalls: 3 });
+  });
+
+  it("includes legacy email usage while another request owns the migration lock", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
+      {
+        "usage:email-account:email-account-1": {
+          openaiCalls: 2,
+          cost: "0.75",
+        },
+        "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
+      };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => usageByKey[key] ?? {},
+    );
+
+    const usage = await getUsage({
+      emailAccountId: "email-account-1",
+      legacyEmail: "user@example.com",
+      userId: "user-1",
+    });
+
+    expect(usage).toEqual({ openaiCalls: 5, cost: 2 });
+  });
+
+  it("sums user usage cost across the last 7 days", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
-    const email = "user@example.com";
     const costsByKey: Record<string, { cost?: string }> = {
-      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
-      "usage-weekly-cost:user@example.com:2026-02-23": { cost: "0.5" },
-      "usage-weekly-cost:user@example.com:2026-02-22": { cost: "0.25" },
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
+      "usage-weekly-cost:user:user-1:2026-02-23": { cost: "0.5" },
+      "usage-weekly-cost:user:user-1:2026-02-22": { cost: "0.25" },
     };
 
     vi.mocked(redis.hgetall).mockImplementation(
       async (key: string) => costsByKey[key] ?? {},
     );
 
-    const weeklyCost = await getWeeklyUsageCost({ email, now });
+    const weeklyCost = await getWeeklyUsageCost({ userId: "user-1", now });
 
     expect(weeklyCost).toBeCloseTo(2.25);
     expect(redis.hgetall).toHaveBeenCalledTimes(7);
+    expect(redis.hgetall).not.toHaveBeenCalledWith(
+      "usage-weekly-cost:user@example.com:2026-02-24",
+    );
   });
 
-  it("sums stable user usage and legacy email usage during migration", async () => {
+  it("migrates legacy weekly email spend into user weekly spend", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
     const costsByKey: Record<string, { cost?: string }> = {
-      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
-      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "0.5" },
+      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
+      "usage-weekly-cost:user@example.com:2026-02-23": { cost: "0.5" },
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "2.0" },
+      "usage-weekly-cost:user:user-1:2026-02-23": { cost: "0.5" },
     };
 
     vi.mocked(redis.hgetall).mockImplementation(
@@ -59,40 +149,143 @@ describe("redis usage weekly cost tracking", () => {
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
-      fallbackEmails: ["user@example.com"],
+      legacyEmails: ["user@example.com"],
       now,
     });
 
-    expect(weeklyCost).toBeCloseTo(2);
-    expect(redis.hgetall).toHaveBeenCalledTimes(14);
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      "cost",
+      1.5,
+    );
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-23",
+      "cost",
+      0.5,
+    );
+    expect(redis.set).toHaveBeenCalledWith(
+      "usage-migration:weekly-usage-cost-user:user-1:done",
+      expect.any(String),
+    );
+    expect(weeklyCost).toBeCloseTo(2.5);
   });
 
-  it("returns top weekly spenders ordered by cost", async () => {
+  it("includes legacy weekly spend while another request owns the migration lock", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "2.0" },
+      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["user@example.com"],
+      now,
+    });
+
+    expect(weeklyCost).toBeCloseTo(3.5);
+  });
+
+  it("does not let a partial weekly migration marker hide another legacy email", async () => {
+    let weeklyMigrationMarkedDone = false;
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:weekly-usage-cost-user:user-1:done") {
+        return weeklyMigrationMarkedDone ? "done" : null;
+      }
+      return null;
+    });
+    vi.mocked(redis.set).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:weekly-usage-cost-user:user-1:done") {
+        weeklyMigrationMarkedDone = true;
+      }
+      return "OK";
+    });
+
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:primary@example.com:2026-02-24": { cost: "1.0" },
+      "usage-weekly-cost:secondary@example.com:2026-02-24": { cost: "2.0" },
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["primary@example.com"],
+      now,
+    });
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["primary@example.com", "secondary@example.com"],
+      now,
+    });
+
+    expect(weeklyCost).toBeCloseTo(3);
+  });
+
+  it("includes post-migration legacy weekly writes during rolling deploys", async () => {
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:weekly-usage-cost-user:user-1:done") {
+        return "done";
+      }
+      return null;
+    });
+
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
+      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      legacyEmails: ["user@example.com"],
+      now,
+    });
+
+    expect(weeklyCost).toBeCloseTo(1.5);
+  });
+
+  it("returns top weekly spenders from user-keyed costs only", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
 
     vi.mocked(redis.scan)
       .mockResolvedValueOnce([
         "1",
         [
-          "usage-weekly-cost:alice@example.com:2026-02-24",
-          "usage-weekly-cost:bob@example.com:2026-02-24",
-          "usage-weekly-cost:alice@example.com:2026-02-23",
+          "usage-weekly-cost:user:user-1:2026-02-24",
+          "usage-weekly-cost:user:user-2:2026-02-24",
+          "usage-weekly-cost:user:user-1:2026-02-23",
+          "usage-weekly-cost:legacy@example.com:2026-02-24",
         ],
       ])
       .mockResolvedValueOnce([
         "0",
         [
-          "usage-weekly-cost:bob@example.com:2026-02-22",
-          "usage-weekly-cost:carol@example.com:2026-02-10",
+          "usage-weekly-cost:user:user-2:2026-02-22",
+          "usage-weekly-cost:user:user-3:2026-02-10",
         ],
       ]);
 
     const costsByKey: Record<string, { cost?: string }> = {
-      "usage-weekly-cost:alice@example.com:2026-02-24": { cost: "1.5" },
-      "usage-weekly-cost:alice@example.com:2026-02-23": { cost: "2.0" },
-      "usage-weekly-cost:bob@example.com:2026-02-24": { cost: "1.2" },
-      "usage-weekly-cost:bob@example.com:2026-02-22": { cost: "0.4" },
-      "usage-weekly-cost:carol@example.com:2026-02-10": { cost: "8.0" },
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
+      "usage-weekly-cost:user:user-1:2026-02-23": { cost: "2.0" },
+      "usage-weekly-cost:user:user-2:2026-02-24": { cost: "1.2" },
+      "usage-weekly-cost:user:user-2:2026-02-22": { cost: "0.4" },
+      "usage-weekly-cost:user:user-3:2026-02-10": { cost: "8.0" },
     };
 
     vi.mocked(redis.hgetall).mockImplementation(
@@ -102,52 +295,49 @@ describe("redis usage weekly cost tracking", () => {
     const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now });
 
     expect(topSpenders).toEqual([
-      { email: "alice@example.com", cost: 3.5 },
-      { email: "bob@example.com", cost: 1.6 },
+      { userId: "user-1", cost: 3.5 },
+      { userId: "user-2", cost: 1.6 },
     ]);
-    expect(redis.hgetall).toHaveBeenCalledTimes(4);
+    expect(redis.hgetall).toHaveBeenCalledTimes(5);
     expect(redis.hgetall).not.toHaveBeenCalledWith(
-      "usage-weekly-cost:carol@example.com:2026-02-10",
+      "usage-weekly-cost:user:user-3:2026-02-10",
     );
   });
 
-  it("stores daily usage cost when platform cost is greater than zero", async () => {
+  it("returns legacy weekly spenders before they have been migrated", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
-    const email = "user@example.com";
 
-    await saveUsage({
-      email,
-      usage: {
-        totalTokens: 300,
-        inputTokens: 200,
-        outputTokens: 100,
-      },
-      cost: 1.25,
-      now,
-    });
+    vi.mocked(redis.scan).mockResolvedValueOnce([
+      "0",
+      [
+        "usage-weekly-cost:user:user-1:2026-02-24",
+        "usage-weekly-cost:legacy@example.com:2026-02-24",
+      ],
+    ]);
 
-    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
-      "usage:user@example.com",
-      "cost",
-      1.25,
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
+      "usage-weekly-cost:legacy@example.com:2026-02-24": { cost: "2.0" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
     );
-    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
-      "usage-weekly-cost:user@example.com:2026-02-24",
-      "cost",
-      1.25,
-    );
-    expect(redis.expire).toHaveBeenCalledWith(
-      "usage-weekly-cost:user@example.com:2026-02-24",
-      691_200,
-    );
+
+    const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now });
+
+    expect(topSpenders).toEqual([
+      { email: "legacy@example.com", cost: 2.0 },
+      { userId: "user-1", cost: 1.5 },
+    ]);
   });
 
-  it("stores daily usage cost with a stable user key when user ID is available", async () => {
+  it("stores usage under both email account and user keys", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
 
     await saveUsage({
       userId: "user-1",
-      email: "user@example.com",
+      emailAccountId: "email-account-1",
       usage: {
         totalTokens: 300,
         inputTokens: 200,
@@ -157,6 +347,11 @@ describe("redis usage weekly cost tracking", () => {
       now,
     });
 
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "cost",
+      1.25,
+    );
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
       "usage:user:user-1",
       "cost",
@@ -167,6 +362,10 @@ describe("redis usage weekly cost tracking", () => {
       "cost",
       1.25,
     );
+    expect(redis.expire).toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      691_200,
+    );
     expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
       "usage:user@example.com",
       "cost",
@@ -174,11 +373,69 @@ describe("redis usage weekly cost tracking", () => {
     );
   });
 
-  it("skips daily cost updates when platform cost is zero", async () => {
+  it("includes post-migration legacy usage writes during rolling deploys", async () => {
+    vi.mocked(redis.get).mockImplementation(async (key: string) => {
+      if (key === "usage-migration:usage-email-account:email-account-1:done") {
+        return "done";
+      }
+      return null;
+    });
+
+    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
+      {
+        "usage:email-account:email-account-1": {
+          openaiCalls: 2,
+          cost: "1.0",
+        },
+        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+      };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => usageByKey[key] ?? {},
+    );
+
+    const usage = await getUsage({
+      emailAccountId: "email-account-1",
+      legacyEmail: "user@example.com",
+      userId: "user-1",
+    });
+
+    expect(usage).toEqual({ openaiCalls: 3, cost: 1.5 });
+  });
+
+  it("stores account usage without weekly spend when user ID is missing", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
 
     await saveUsage({
-      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      usage: {
+        totalTokens: 300,
+        inputTokens: 200,
+        outputTokens: 100,
+      },
+      cost: 1.25,
+      now,
+    });
+
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage:email-account:email-account-1",
+      "cost",
+      1.25,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      "cost",
+      1.25,
+    );
+    expect(redis.expire).not.toHaveBeenCalled();
+  });
+
+  it("skips cost updates when platform cost is zero", async () => {
+    const now = new Date("2026-02-24T15:00:00.000Z");
+
+    await saveUsage({
+      userId: "user-1",
+      emailAccountId: "email-account-1",
       usage: {
         totalTokens: 100,
       },

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -46,6 +46,27 @@ describe("redis usage weekly cost tracking", () => {
     expect(redis.hgetall).toHaveBeenCalledTimes(7);
   });
 
+  it("sums stable user usage and legacy email usage during migration", async () => {
+    const now = new Date("2026-02-24T15:00:00.000Z");
+    const costsByKey: Record<string, { cost?: string }> = {
+      "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
+      "usage-weekly-cost:user@example.com:2026-02-24": { cost: "0.5" },
+    };
+
+    vi.mocked(redis.hgetall).mockImplementation(
+      async (key: string) => costsByKey[key] ?? {},
+    );
+
+    const weeklyCost = await getWeeklyUsageCost({
+      userId: "user-1",
+      fallbackEmails: ["user@example.com"],
+      now,
+    });
+
+    expect(weeklyCost).toBeCloseTo(2);
+    expect(redis.hgetall).toHaveBeenCalledTimes(14);
+  });
+
   it("returns top weekly spenders ordered by cost", async () => {
     const now = new Date("2026-02-24T15:00:00.000Z");
 
@@ -118,6 +139,38 @@ describe("redis usage weekly cost tracking", () => {
     expect(redis.expire).toHaveBeenCalledWith(
       "usage-weekly-cost:user@example.com:2026-02-24",
       691_200,
+    );
+  });
+
+  it("stores daily usage cost with a stable user key when user ID is available", async () => {
+    const now = new Date("2026-02-24T15:00:00.000Z");
+
+    await saveUsage({
+      userId: "user-1",
+      email: "user@example.com",
+      usage: {
+        totalTokens: 300,
+        inputTokens: 200,
+        outputTokens: 100,
+      },
+      cost: 1.25,
+      now,
+    });
+
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage:user:user-1",
+      "cost",
+      1.25,
+    );
+    expect(redis.hincrbyfloat).toHaveBeenCalledWith(
+      "usage-weekly-cost:user:user-1:2026-02-24",
+      "cost",
+      1.25,
+    );
+    expect(redis.hincrbyfloat).not.toHaveBeenCalledWith(
+      "usage:user@example.com",
+      "cost",
+      1.25,
     );
   });
 

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -180,7 +180,7 @@ export async function getWeeklyUsageCost({
   const weeklyCosts = await Promise.all(
     usageKeys.map(async (key) => {
       const data = await redis.hgetall<{ cost?: string | number }>(key);
-      return parseUsageCost(data?.cost);
+      return parseRedisNumber(data?.cost);
     }),
   );
 
@@ -252,7 +252,7 @@ export async function getWeeklyUsageCost({
   const updatedWeeklyCosts = await Promise.all(
     usageKeys.map(async (key) => {
       const data = await redis.hgetall<{ cost?: string | number }>(key);
-      return parseUsageCost(data?.cost);
+      return parseRedisNumber(data?.cost);
     }),
   );
 
@@ -288,7 +288,7 @@ export async function getTopWeeklyUsageCosts({
         if (!parsed || !daysInWindow.has(parsed.day)) return null;
 
         const data = await redis.hgetall<{ cost?: string | number }>(key);
-        const cost = parseUsageCost(data?.cost);
+        const cost = parseRedisNumber(data?.cost);
         if (cost <= 0) return null;
 
         return { ...parsed, cost };
@@ -349,7 +349,7 @@ function getUsageDataIncrementOperations(
   if (!usage) return [];
 
   return usageFields.flatMap((field) => {
-    const value = parseUsageCost(usage[field]);
+    const value = parseRedisNumber(usage[field]);
     if (value <= 0) return [];
     if (field === "cost") return [redis.hincrbyfloat(key, field, value)];
     return [redis.hincrby(key, field, value)];
@@ -363,8 +363,8 @@ function getUsageDelta(
   const delta: RedisUsage = {};
 
   for (const field of usageFields) {
-    const legacyValue = parseUsageCost(legacyUsage?.[field]);
-    const migratedValue = parseUsageCost(migratedLegacyUsage[field]);
+    const legacyValue = parseRedisNumber(legacyUsage?.[field]);
+    const migratedValue = parseRedisNumber(migratedLegacyUsage[field]);
     const value = legacyValue - migratedValue;
     if (value > 0) delta[field] = value;
   }
@@ -373,7 +373,7 @@ function getUsageDelta(
 }
 
 function hasUsageData(usage: RedisUsage | null | undefined) {
-  return usageFields.some((field) => parseUsageCost(usage?.[field]) > 0);
+  return usageFields.some((field) => parseRedisNumber(usage?.[field]) > 0);
 }
 
 function getWeeklyUsageCostKeys(userId: string, now: Date) {
@@ -418,7 +418,7 @@ async function getLegacyWeeklyUsageCostsByKey({
       getWeeklyUsageCostDays(now).map(async (day) => {
         const key = getLegacyWeeklyUsageCostKey(email, day);
         const data = await redis.hgetall<{ cost?: string | number }>(key);
-        const cost = parseUsageCost(data?.cost);
+        const cost = parseRedisNumber(data?.cost);
         if (cost > 0) costsByKey.set(key, cost);
       }),
     ),
@@ -453,9 +453,9 @@ function parseWeeklyUsageCostKey(key: string) {
   return { subject: `email:${email}`, email, day };
 }
 
-function parseUsageCost(rawCost: string | number | undefined): number {
-  if (typeof rawCost === "number") return rawCost;
-  if (typeof rawCost === "string") return Number.parseFloat(rawCost) || 0;
+function parseRedisNumber(raw: string | number | undefined): number {
+  if (typeof raw === "number") return raw;
+  if (typeof raw === "string") return Number.parseFloat(raw) || 0;
   return 0;
 }
 
@@ -471,7 +471,7 @@ function mergeUsage(
   for (const entry of entries) {
     if (!entry) continue;
     for (const field of usageFields) {
-      const value = parseUsageCost(entry[field]);
+      const value = parseRedisNumber(entry[field]);
       if (value <= 0) continue;
       merged[field] = (merged[field] ?? 0) + value;
     }
@@ -488,8 +488,8 @@ function maxUsage(
 
   for (const field of usageFields) {
     const value = Math.max(
-      parseUsageCost(currentUsage?.[field]),
-      parseUsageCost(legacyUsage?.[field]),
+      parseRedisNumber(currentUsage?.[field]),
+      parseRedisNumber(legacyUsage?.[field]),
     );
     if (value > 0) usage[field] = value;
   }
@@ -563,7 +563,7 @@ function parseWeeklyUsageMigrationState(
 
     return new Map(
       Object.entries(parsed.weeklyCosts).flatMap(([key, value]) => {
-        const cost = parseUsageCost(value);
+        const cost = parseRedisNumber(value);
         return cost > 0 ? [[key, cost]] : [];
       }),
     );

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -73,13 +73,65 @@ export async function getUsage(options: {
     const legacyDelta = getUsageDelta(legacyUsage, migratedLegacyUsage);
 
     if (hasUsageData(legacyDelta)) {
-      await Promise.all([
-        ...getUsageDataIncrementOperations(emailAccountUsageKey, legacyDelta),
-        ...(userUsageKey
-          ? getUsageDataIncrementOperations(userUsageKey, legacyDelta)
-          : []),
-        redis.set(doneKey, JSON.stringify({ usage: legacyUsage ?? {} })),
-      ]);
+      const claimedLock = await redis.set(lockKey, new Date().toISOString(), {
+        nx: true,
+        ex: USAGE_MIGRATION_LOCK_TTL_SECONDS,
+      });
+
+      if (!claimedLock) return mergeUsage(currentUsage, legacyDelta);
+
+      try {
+        const [latestCurrentUsage, latestLegacyUsage, latestRawMigrationState] =
+          await Promise.all([
+            redis.hgetall<RedisUsage>(emailAccountUsageKey),
+            redis.hgetall<RedisUsage>(legacyUsageKey),
+            redis.get(doneKey),
+          ]);
+        const latestMigratedLegacyUsage = parseLegacyUsageMigrationState(
+          latestRawMigrationState,
+        );
+
+        if (!latestMigratedLegacyUsage) {
+          return maxUsage(latestCurrentUsage, latestLegacyUsage);
+        }
+
+        const latestLegacyDelta = getUsageDelta(
+          latestLegacyUsage,
+          latestMigratedLegacyUsage,
+        );
+
+        if (hasUsageData(latestLegacyDelta)) {
+          await Promise.all([
+            ...getUsageDataIncrementOperations(
+              emailAccountUsageKey,
+              latestLegacyDelta,
+            ),
+            ...(userUsageKey
+              ? getUsageDataIncrementOperations(userUsageKey, latestLegacyDelta)
+              : []),
+            redis.set(
+              doneKey,
+              JSON.stringify({ usage: latestLegacyUsage ?? {} }),
+            ),
+          ]);
+        }
+
+        return mergeUsage(latestCurrentUsage, latestLegacyDelta);
+      } catch (error) {
+        logger.error("Failed to migrate legacy usage delta", {
+          migrationName,
+          error,
+        });
+      } finally {
+        try {
+          await redis.del(lockKey);
+        } catch (error) {
+          logger.error("Failed to clear usage migration lock", {
+            migrationName,
+            error,
+          });
+        }
+      }
     }
 
     return mergeUsage(currentUsage, legacyDelta);
@@ -177,14 +229,7 @@ export async function getWeeklyUsageCost({
     ? await getLegacyWeeklyUsageCostsByKey({ emails: uniqueLegacyEmails, now })
     : new Map<string, number>();
 
-  const weeklyCosts = await Promise.all(
-    usageKeys.map(async (key) => {
-      const data = await redis.hgetall<{ cost?: string | number }>(key);
-      return parseRedisNumber(data?.cost);
-    }),
-  );
-
-  const migratedCost = weeklyCosts.reduce((sum, value) => sum + value, 0);
+  const migratedCost = await getWeeklyUsageCostTotal(usageKeys);
   if (!uniqueLegacyEmails.length) return migratedCost;
 
   const migrationName = `weekly-usage-cost-user:${userId}`;
@@ -201,13 +246,71 @@ export async function getWeeklyUsageCost({
     const legacyDelta = sumMapValues(legacyDeltaByKey);
 
     if (legacyDelta > 0) {
-      await Promise.all([
-        ...getWeeklyCostIncrementOperations(userId, legacyDeltaByKey),
-        redis.set(
-          doneKey,
-          JSON.stringify({ weeklyCosts: Object.fromEntries(legacyCostsByKey) }),
-        ),
-      ]);
+      const claimedLock = await redis.set(lockKey, new Date().toISOString(), {
+        nx: true,
+        ex: USAGE_MIGRATION_LOCK_TTL_SECONDS,
+      });
+
+      if (!claimedLock) return migratedCost + legacyDelta;
+
+      try {
+        const [
+          latestLegacyCostsByKey,
+          latestMigratedCost,
+          latestRawMigrationState,
+        ] = await Promise.all([
+          getLegacyWeeklyUsageCostsByKey({
+            emails: uniqueLegacyEmails,
+            now,
+          }),
+          getWeeklyUsageCostTotal(usageKeys),
+          redis.get(doneKey),
+        ]);
+        const latestMigratedLegacyCosts = parseWeeklyUsageMigrationState(
+          latestRawMigrationState,
+        );
+
+        if (!latestMigratedLegacyCosts) {
+          return Math.max(
+            latestMigratedCost,
+            sumMapValues(latestLegacyCostsByKey),
+          );
+        }
+
+        const latestLegacyDeltaByKey = getLegacyWeeklyCostDelta(
+          latestLegacyCostsByKey,
+          latestMigratedLegacyCosts,
+        );
+        const latestLegacyDelta = sumMapValues(latestLegacyDeltaByKey);
+
+        if (latestLegacyDelta > 0) {
+          await Promise.all([
+            ...getWeeklyCostIncrementOperations(userId, latestLegacyDeltaByKey),
+            redis.set(
+              doneKey,
+              JSON.stringify({
+                weeklyCosts: Object.fromEntries(latestLegacyCostsByKey),
+              }),
+            ),
+          ]);
+        }
+
+        return latestMigratedCost + latestLegacyDelta;
+      } catch (error) {
+        logger.error("Failed to migrate legacy weekly usage delta", {
+          migrationName,
+          error,
+        });
+      } finally {
+        try {
+          await redis.del(lockKey);
+        } catch (error) {
+          logger.error("Failed to clear weekly usage migration lock", {
+            migrationName,
+            error,
+          });
+        }
+      }
     }
 
     return migratedCost + legacyDelta;
@@ -249,17 +352,9 @@ export async function getWeeklyUsageCost({
     }
   }
 
-  const updatedWeeklyCosts = await Promise.all(
-    usageKeys.map(async (key) => {
-      const data = await redis.hgetall<{ cost?: string | number }>(key);
-      return parseRedisNumber(data?.cost);
-    }),
-  );
+  const updatedWeeklyCost = await getWeeklyUsageCostTotal(usageKeys);
 
-  return Math.max(
-    updatedWeeklyCosts.reduce((sum, value) => sum + value, 0),
-    sumMapValues(legacyCostsByKey),
-  );
+  return Math.max(updatedWeeklyCost, sumMapValues(legacyCostsByKey));
 }
 
 export async function getTopWeeklyUsageCosts({
@@ -374,6 +469,17 @@ function getUsageDelta(
 
 function hasUsageData(usage: RedisUsage | null | undefined) {
   return usageFields.some((field) => parseRedisNumber(usage?.[field]) > 0);
+}
+
+async function getWeeklyUsageCostTotal(keys: string[]) {
+  const weeklyCosts = await Promise.all(
+    keys.map(async (key) => {
+      const data = await redis.hgetall<{ cost?: string | number }>(key);
+      return parseRedisNumber(data?.cost);
+    }),
+  );
+
+  return weeklyCosts.reduce((sum, value) => sum + value, 0);
 }
 
 function getWeeklyUsageCostKeys(userId: string, now: Date) {

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -7,6 +7,7 @@ const logger = createScopedLogger("redis/usage");
 const WEEKLY_USAGE_COST_DAYS = 7;
 const WEEKLY_USAGE_COST_TTL_SECONDS = 8 * 24 * 60 * 60;
 const WEEKLY_USAGE_COST_KEY_PREFIX = "usage-weekly-cost";
+const USAGE_MIGRATION_LOCK_TTL_SECONDS = 5 * 60;
 
 export type RedisUsage = {
   openaiCalls?: number;
@@ -18,65 +19,144 @@ export type RedisUsage = {
   cost?: number;
 };
 
-export type WeeklyUsageCostBySubject = {
-  email?: string;
-  userId?: string;
+const usageFields = [
+  "openaiCalls",
+  "openaiTokensUsed",
+  "openaiCompletionTokensUsed",
+  "openaiPromptTokensUsed",
+  "cachedInputTokensUsed",
+  "reasoningTokensUsed",
+  "cost",
+] as const satisfies Array<keyof RedisUsage>;
+
+export type WeeklyUsageCostBySubject =
+  | { userId: string; cost: number }
+  | { email: string; cost: number };
+
+type UsageKeyIdentity =
+  | { type: "email-account"; id: string }
+  | { type: "user"; id: string };
+
+function getUsageKey(identity: UsageKeyIdentity) {
+  return `usage:${identity.type}:${identity.id}`;
+}
+
+export async function getUsage(options: {
+  emailAccountId: string;
+  legacyEmail?: string | null;
+  userId?: string | null;
+}) {
+  const emailAccountUsageKey = getUsageKey({
+    type: "email-account",
+    id: options.emailAccountId,
+  });
+  const userUsageKey = options.userId
+    ? getUsageKey({ type: "user", id: options.userId })
+    : null;
+
+  if (!options.legacyEmail) {
+    return redis.hgetall<RedisUsage>(emailAccountUsageKey);
+  }
+
+  const legacyUsageKey = getLegacyUsageKey(options.legacyEmail);
+  const migrationName = `usage-email-account:${options.emailAccountId}`;
+  const doneKey = getUsageMigrationDoneKey(migrationName);
+  const lockKey = getUsageMigrationLockKey(migrationName);
+  const rawMigrationState = await redis.get(doneKey);
+  const migratedLegacyUsage = parseLegacyUsageMigrationState(rawMigrationState);
+
+  if (migratedLegacyUsage) {
+    const [currentUsage, legacyUsage] = await Promise.all([
+      redis.hgetall<RedisUsage>(emailAccountUsageKey),
+      redis.hgetall<RedisUsage>(legacyUsageKey),
+    ]);
+    const legacyDelta = getUsageDelta(legacyUsage, migratedLegacyUsage);
+
+    if (hasUsageData(legacyDelta)) {
+      await Promise.all([
+        ...getUsageDataIncrementOperations(emailAccountUsageKey, legacyDelta),
+        ...(userUsageKey
+          ? getUsageDataIncrementOperations(userUsageKey, legacyDelta)
+          : []),
+        redis.set(doneKey, JSON.stringify({ usage: legacyUsage ?? {} })),
+      ]);
+    }
+
+    return mergeUsage(currentUsage, legacyDelta);
+  }
+
+  if (rawMigrationState) {
+    const [currentUsage, legacyUsage] = await Promise.all([
+      redis.hgetall<RedisUsage>(emailAccountUsageKey),
+      redis.hgetall<RedisUsage>(legacyUsageKey),
+    ]);
+    return maxUsage(currentUsage, legacyUsage);
+  }
+
+  const claimedLock = await redis.set(lockKey, new Date().toISOString(), {
+    nx: true,
+    ex: USAGE_MIGRATION_LOCK_TTL_SECONDS,
+  });
+  const [currentUsage, legacyUsage] = await Promise.all([
+    redis.hgetall<RedisUsage>(emailAccountUsageKey),
+    redis.hgetall<RedisUsage>(legacyUsageKey),
+  ]);
+
+  if (!claimedLock) return mergeUsage(currentUsage, legacyUsage);
+
+  try {
+    await Promise.all([
+      ...getUsageDataIncrementOperations(emailAccountUsageKey, legacyUsage),
+      ...(userUsageKey
+        ? getUsageDataIncrementOperations(userUsageKey, legacyUsage)
+        : []),
+      redis.set(doneKey, JSON.stringify({ usage: legacyUsage ?? {} })),
+    ]);
+
+    return redis.hgetall<RedisUsage>(emailAccountUsageKey);
+  } catch (error) {
+    logger.error("Failed to migrate legacy usage", {
+      migrationName,
+      error,
+    });
+    return mergeUsage(currentUsage, legacyUsage);
+  } finally {
+    try {
+      await redis.del(lockKey);
+    } catch (error) {
+      logger.error("Failed to clear usage migration lock", {
+        migrationName,
+        error,
+      });
+    }
+  }
+}
+
+export async function saveUsage(options: {
+  userId?: string | null;
+  emailAccountId: string;
+  usage: LanguageModelUsage;
   cost: number;
-};
+  now?: Date;
+}) {
+  const { userId, emailAccountId, usage, cost, now = new Date() } = options;
 
-type UsageIdentity =
-  | { userId: string; email?: string | null }
-  | { userId?: string | null; email: string };
-
-function getUsageKey(identity: UsageIdentity) {
-  return identity.userId
-    ? `usage:user:${identity.userId}`
-    : `usage:${identity.email}`;
-}
-
-export async function getUsage(options: UsageIdentity) {
-  const data = await redis.hgetall<RedisUsage>(getUsageKey(options));
-  if (!options.userId || !options.email) return data;
-
-  const legacyData = await redis.hgetall<RedisUsage>(
-    getUsageKey({ email: options.email }),
-  );
-  return mergeUsage(data, legacyData);
-}
-
-export async function saveUsage(
-  options: UsageIdentity & {
-    usage: LanguageModelUsage;
-    cost: number;
-    now?: Date;
-  },
-) {
-  const { usage, cost, now = new Date() } = options;
-
-  const key = getUsageKey(options);
-  const weeklyCostKey = getWeeklyUsageCostKey(options, now);
+  const usageKeys = [
+    getUsageKey({ type: "email-account", id: emailAccountId }),
+    ...(userId ? [getUsageKey({ type: "user", id: userId })] : []),
+  ];
+  const weeklyCostKey = userId ? getWeeklyUsageCostKey(userId, now) : null;
 
   await Promise.all([
-    // TODO: this isn't openai specific, it can be any llm
-    redis.hincrby(key, "openaiCalls", 1),
-    usage.totalTokens
-      ? redis.hincrby(key, "openaiTokensUsed", usage.totalTokens)
+    ...usageKeys.flatMap((key) =>
+      getUsageIncrementOperations(key, usage, cost),
+    ),
+    cost && weeklyCostKey
+      ? redis.hincrbyfloat(weeklyCostKey, "cost", cost)
       : null,
-    usage.outputTokens
-      ? redis.hincrby(key, "openaiCompletionTokensUsed", usage.outputTokens)
+    cost && weeklyCostKey
+      ? redis.expire(weeklyCostKey, WEEKLY_USAGE_COST_TTL_SECONDS)
       : null,
-    usage.inputTokens
-      ? redis.hincrby(key, "openaiPromptTokensUsed", usage.inputTokens)
-      : null,
-    usage.cachedInputTokens
-      ? redis.hincrby(key, "cachedInputTokensUsed", usage.cachedInputTokens)
-      : null,
-    usage.reasoningTokens
-      ? redis.hincrby(key, "reasoningTokensUsed", usage.reasoningTokens)
-      : null,
-    cost ? redis.hincrbyfloat(key, "cost", cost) : null,
-    cost ? redis.hincrbyfloat(weeklyCostKey, "cost", cost) : null,
-    cost ? redis.expire(weeklyCostKey, WEEKLY_USAGE_COST_TTL_SECONDS) : null,
   ]).catch((error) => {
     logger.error("Error saving usage", { error: error.message, cost, usage });
   });
@@ -84,23 +164,18 @@ export async function saveUsage(
 
 export async function getWeeklyUsageCost({
   userId,
-  email,
-  fallbackEmails = [],
+  legacyEmails = [],
   now = new Date(),
 }: {
-  userId?: string;
-  email?: string;
-  fallbackEmails?: string[];
+  userId: string;
+  legacyEmails?: string[];
   now?: Date;
 }) {
-  const usageKeys = [
-    ...(userId ? getWeeklyUsageCostKeys({ userId }, now) : []),
-    ...dedupe([email, ...fallbackEmails].filter(Boolean) as string[]).flatMap(
-      (legacyEmail) => getWeeklyUsageCostKeys({ email: legacyEmail }, now),
-    ),
-  ];
-
-  if (!usageKeys.length) return 0;
+  const usageKeys = getWeeklyUsageCostKeys(userId, now);
+  const uniqueLegacyEmails = Array.from(new Set(legacyEmails));
+  const legacyCostsByKey = uniqueLegacyEmails.length
+    ? await getLegacyWeeklyUsageCostsByKey({ emails: uniqueLegacyEmails, now })
+    : new Map<string, number>();
 
   const weeklyCosts = await Promise.all(
     usageKeys.map(async (key) => {
@@ -109,7 +184,82 @@ export async function getWeeklyUsageCost({
     }),
   );
 
-  return weeklyCosts.reduce((sum, value) => sum + value, 0);
+  const migratedCost = weeklyCosts.reduce((sum, value) => sum + value, 0);
+  if (!uniqueLegacyEmails.length) return migratedCost;
+
+  const migrationName = `weekly-usage-cost-user:${userId}`;
+  const doneKey = getUsageMigrationDoneKey(migrationName);
+  const lockKey = getUsageMigrationLockKey(migrationName);
+  const rawMigrationState = await redis.get(doneKey);
+  const migratedLegacyCosts = parseWeeklyUsageMigrationState(rawMigrationState);
+
+  if (migratedLegacyCosts) {
+    const legacyDeltaByKey = getLegacyWeeklyCostDelta(
+      legacyCostsByKey,
+      migratedLegacyCosts,
+    );
+    const legacyDelta = sumMapValues(legacyDeltaByKey);
+
+    if (legacyDelta > 0) {
+      await Promise.all([
+        ...getWeeklyCostIncrementOperations(userId, legacyDeltaByKey),
+        redis.set(
+          doneKey,
+          JSON.stringify({ weeklyCosts: Object.fromEntries(legacyCostsByKey) }),
+        ),
+      ]);
+    }
+
+    return migratedCost + legacyDelta;
+  }
+
+  if (rawMigrationState) {
+    return Math.max(migratedCost, sumMapValues(legacyCostsByKey));
+  }
+
+  const claimedLock = await redis.set(lockKey, new Date().toISOString(), {
+    nx: true,
+    ex: USAGE_MIGRATION_LOCK_TTL_SECONDS,
+  });
+
+  if (!claimedLock) return migratedCost + sumMapValues(legacyCostsByKey);
+
+  try {
+    await Promise.all([
+      ...getWeeklyCostIncrementOperations(userId, legacyCostsByKey),
+      redis.set(
+        doneKey,
+        JSON.stringify({ weeklyCosts: Object.fromEntries(legacyCostsByKey) }),
+      ),
+    ]);
+  } catch (error) {
+    logger.error("Failed to migrate legacy weekly usage", {
+      migrationName,
+      error,
+    });
+    return migratedCost + sumMapValues(legacyCostsByKey);
+  } finally {
+    try {
+      await redis.del(lockKey);
+    } catch (error) {
+      logger.error("Failed to clear weekly usage migration lock", {
+        migrationName,
+        error,
+      });
+    }
+  }
+
+  const updatedWeeklyCosts = await Promise.all(
+    usageKeys.map(async (key) => {
+      const data = await redis.hgetall<{ cost?: string | number }>(key);
+      return parseUsageCost(data?.cost);
+    }),
+  );
+
+  return Math.max(
+    updatedWeeklyCosts.reduce((sum, value) => sum + value, 0),
+    sumMapValues(legacyCostsByKey),
+  );
 }
 
 export async function getTopWeeklyUsageCosts({
@@ -165,9 +315,70 @@ export async function getTopWeeklyUsageCosts({
     .slice(0, limit);
 }
 
-function getWeeklyUsageCostKeys(identity: UsageIdentity, now: Date) {
+function getUsageIncrementOperations(
+  key: string,
+  usage: LanguageModelUsage,
+  cost: number,
+) {
+  return [
+    // TODO: this isn't openai specific, it can be any llm
+    redis.hincrby(key, "openaiCalls", 1),
+    usage.totalTokens
+      ? redis.hincrby(key, "openaiTokensUsed", usage.totalTokens)
+      : null,
+    usage.outputTokens
+      ? redis.hincrby(key, "openaiCompletionTokensUsed", usage.outputTokens)
+      : null,
+    usage.inputTokens
+      ? redis.hincrby(key, "openaiPromptTokensUsed", usage.inputTokens)
+      : null,
+    usage.cachedInputTokens
+      ? redis.hincrby(key, "cachedInputTokensUsed", usage.cachedInputTokens)
+      : null,
+    usage.reasoningTokens
+      ? redis.hincrby(key, "reasoningTokensUsed", usage.reasoningTokens)
+      : null,
+    cost ? redis.hincrbyfloat(key, "cost", cost) : null,
+  ];
+}
+
+function getUsageDataIncrementOperations(
+  key: string,
+  usage: RedisUsage | null,
+) {
+  if (!usage) return [];
+
+  return usageFields.flatMap((field) => {
+    const value = parseUsageCost(usage[field]);
+    if (value <= 0) return [];
+    if (field === "cost") return [redis.hincrbyfloat(key, field, value)];
+    return [redis.hincrby(key, field, value)];
+  });
+}
+
+function getUsageDelta(
+  legacyUsage: RedisUsage | null,
+  migratedLegacyUsage: RedisUsage,
+) {
+  const delta: RedisUsage = {};
+
+  for (const field of usageFields) {
+    const legacyValue = parseUsageCost(legacyUsage?.[field]);
+    const migratedValue = parseUsageCost(migratedLegacyUsage[field]);
+    const value = legacyValue - migratedValue;
+    if (value > 0) delta[field] = value;
+  }
+
+  return delta;
+}
+
+function hasUsageData(usage: RedisUsage | null | undefined) {
+  return usageFields.some((field) => parseUsageCost(usage?.[field]) > 0);
+}
+
+function getWeeklyUsageCostKeys(userId: string, now: Date) {
   const days = getWeeklyUsageCostDays(now);
-  return days.map((day) => getWeeklyUsageCostKey(identity, day));
+  return days.map((day) => getWeeklyUsageCostKey(userId, day));
 }
 
 function getWeeklyUsageCostDays(now: Date) {
@@ -178,20 +389,50 @@ function getWeeklyUsageCostDays(now: Date) {
   });
 }
 
-function getWeeklyUsageCostKey(identity: UsageIdentity, date: Date | string) {
+function getWeeklyUsageCostKey(userId: string, date: Date | string) {
   const day = typeof date === "string" ? date : getUtcDay(date);
-  if (identity.userId) {
-    return `${WEEKLY_USAGE_COST_KEY_PREFIX}:user:${identity.userId}:${day}`;
-  }
-  return `${WEEKLY_USAGE_COST_KEY_PREFIX}:${identity.email}:${day}`;
+  return `${WEEKLY_USAGE_COST_KEY_PREFIX}:user:${userId}:${day}`;
+}
+
+function getLegacyUsageKey(email: string) {
+  return `usage:${email}`;
+}
+
+function getLegacyWeeklyUsageCostKey(email: string, date: Date | string) {
+  const day = typeof date === "string" ? date : getUtcDay(date);
+  return `${WEEKLY_USAGE_COST_KEY_PREFIX}:${email}:${day}`;
+}
+
+async function getLegacyWeeklyUsageCostsByKey({
+  emails,
+  now,
+}: {
+  emails: string[];
+  now: Date;
+}) {
+  const costsByKey = new Map<string, number>();
+  if (!emails.length) return costsByKey;
+
+  await Promise.all(
+    emails.flatMap((email) =>
+      getWeeklyUsageCostDays(now).map(async (day) => {
+        const key = getLegacyWeeklyUsageCostKey(email, day);
+        const data = await redis.hgetall<{ cost?: string | number }>(key);
+        const cost = parseUsageCost(data?.cost);
+        if (cost > 0) costsByKey.set(key, cost);
+      }),
+    ),
+  );
+
+  return costsByKey;
 }
 
 function parseWeeklyUsageCostKey(key: string) {
   const prefix = `${WEEKLY_USAGE_COST_KEY_PREFIX}:`;
   if (!key.startsWith(prefix)) return null;
 
-  if (key.startsWith(`${prefix}user:`)) {
-    const userPrefix = `${prefix}user:`;
+  const userPrefix = `${prefix}user:`;
+  if (key.startsWith(userPrefix)) {
     const lastSeparatorIndex = key.lastIndexOf(":");
     if (lastSeparatorIndex <= userPrefix.length) return null;
 
@@ -229,16 +470,104 @@ function mergeUsage(
 
   for (const entry of entries) {
     if (!entry) continue;
-    for (const [key, value] of Object.entries(entry)) {
-      if (typeof value !== "number") continue;
-      const usageKey = key as keyof RedisUsage;
-      merged[usageKey] = (merged[usageKey] ?? 0) + value;
+    for (const field of usageFields) {
+      const value = parseUsageCost(entry[field]);
+      if (value <= 0) continue;
+      merged[field] = (merged[field] ?? 0) + value;
     }
   }
 
   return merged;
 }
 
-function dedupe(values: string[]) {
-  return [...new Set(values)];
+function maxUsage(
+  currentUsage: RedisUsage | null | undefined,
+  legacyUsage: RedisUsage | null | undefined,
+) {
+  const usage: RedisUsage = {};
+
+  for (const field of usageFields) {
+    const value = Math.max(
+      parseUsageCost(currentUsage?.[field]),
+      parseUsageCost(legacyUsage?.[field]),
+    );
+    if (value > 0) usage[field] = value;
+  }
+
+  return usage;
+}
+
+function getWeeklyCostIncrementOperations(
+  userId: string,
+  legacyCostsByKey: Map<string, number>,
+) {
+  return Array.from(legacyCostsByKey.entries()).flatMap(([key, cost]) => {
+    const parsed = parseWeeklyUsageCostKey(key);
+    if (!parsed) return [];
+
+    const weeklyCostKey = getWeeklyUsageCostKey(userId, parsed.day);
+    return [
+      redis.hincrbyfloat(weeklyCostKey, "cost", cost),
+      redis.expire(weeklyCostKey, WEEKLY_USAGE_COST_TTL_SECONDS),
+    ];
+  });
+}
+
+function getLegacyWeeklyCostDelta(
+  legacyCostsByKey: Map<string, number>,
+  migratedLegacyCostsByKey: Map<string, number>,
+) {
+  const delta = new Map<string, number>();
+
+  for (const [key, cost] of legacyCostsByKey.entries()) {
+    const value = cost - (migratedLegacyCostsByKey.get(key) ?? 0);
+    if (value > 0) delta.set(key, value);
+  }
+
+  return delta;
+}
+
+function sumMapValues(map: Map<string, number>) {
+  return Array.from(map.values()).reduce((sum, value) => sum + value, 0);
+}
+
+function getUsageMigrationDoneKey(migrationName: string) {
+  return `usage-migration:${migrationName}:done`;
+}
+
+function getUsageMigrationLockKey(migrationName: string) {
+  return `usage-migration:${migrationName}:lock`;
+}
+
+function parseLegacyUsageMigrationState(rawState: unknown): RedisUsage | null {
+  if (typeof rawState !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(rawState) as { usage?: RedisUsage };
+    return parsed.usage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseWeeklyUsageMigrationState(
+  rawState: unknown,
+): Map<string, number> | null {
+  if (typeof rawState !== "string") return null;
+
+  try {
+    const parsed = JSON.parse(rawState) as {
+      weeklyCosts?: Record<string, string | number>;
+    };
+    if (!parsed.weeklyCosts) return null;
+
+    return new Map(
+      Object.entries(parsed.weeklyCosts).flatMap(([key, value]) => {
+        const cost = parseUsageCost(value);
+        return cost > 0 ? [[key, cost]] : [];
+      }),
+    );
+  } catch {
+    return null;
+  }
 }

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -18,31 +18,43 @@ export type RedisUsage = {
   cost?: number;
 };
 
-export type WeeklyUsageCostByEmail = {
-  email: string;
+export type WeeklyUsageCostBySubject = {
+  email?: string;
+  userId?: string;
   cost: number;
 };
 
-function getUsageKey(email: string) {
-  return `usage:${email}`;
+type UsageIdentity =
+  | { userId: string; email?: string | null }
+  | { userId?: string | null; email: string };
+
+function getUsageKey(identity: UsageIdentity) {
+  return identity.userId
+    ? `usage:user:${identity.userId}`
+    : `usage:${identity.email}`;
 }
 
-export async function getUsage(options: { email: string }) {
-  const key = getUsageKey(options.email);
-  const data = await redis.hgetall<RedisUsage>(key);
-  return data;
+export async function getUsage(options: UsageIdentity) {
+  const data = await redis.hgetall<RedisUsage>(getUsageKey(options));
+  if (!options.userId || !options.email) return data;
+
+  const legacyData = await redis.hgetall<RedisUsage>(
+    getUsageKey({ email: options.email }),
+  );
+  return mergeUsage(data, legacyData);
 }
 
-export async function saveUsage(options: {
-  email: string;
-  usage: LanguageModelUsage;
-  cost: number;
-  now?: Date;
-}) {
-  const { email, usage, cost, now = new Date() } = options;
+export async function saveUsage(
+  options: UsageIdentity & {
+    usage: LanguageModelUsage;
+    cost: number;
+    now?: Date;
+  },
+) {
+  const { usage, cost, now = new Date() } = options;
 
-  const key = getUsageKey(email);
-  const weeklyCostKey = getWeeklyUsageCostKey(email, now);
+  const key = getUsageKey(options);
+  const weeklyCostKey = getWeeklyUsageCostKey(options, now);
 
   await Promise.all([
     // TODO: this isn't openai specific, it can be any llm
@@ -71,13 +83,24 @@ export async function saveUsage(options: {
 }
 
 export async function getWeeklyUsageCost({
+  userId,
   email,
+  fallbackEmails = [],
   now = new Date(),
 }: {
-  email: string;
+  userId?: string;
+  email?: string;
+  fallbackEmails?: string[];
   now?: Date;
 }) {
-  const usageKeys = getWeeklyUsageCostKeys(email, now);
+  const usageKeys = [
+    ...(userId ? getWeeklyUsageCostKeys({ userId }, now) : []),
+    ...dedupe([email, ...fallbackEmails].filter(Boolean) as string[]).flatMap(
+      (legacyEmail) => getWeeklyUsageCostKeys({ email: legacyEmail }, now),
+    ),
+  ];
+
+  if (!usageKeys.length) return 0;
 
   const weeklyCosts = await Promise.all(
     usageKeys.map(async (key) => {
@@ -95,11 +118,11 @@ export async function getTopWeeklyUsageCosts({
 }: {
   limit?: number;
   now?: Date;
-} = {}): Promise<WeeklyUsageCostByEmail[]> {
+} = {}): Promise<WeeklyUsageCostBySubject[]> {
   if (limit <= 0) return [];
 
   const daysInWindow = new Set(getWeeklyUsageCostDays(now));
-  const costsByEmail = new Map<string, number>();
+  const costsBySubject = new Map<string, number>();
   let cursor = "0";
 
   do {
@@ -118,28 +141,33 @@ export async function getTopWeeklyUsageCosts({
         const cost = parseUsageCost(data?.cost);
         if (cost <= 0) return null;
 
-        return { email: parsed.email, cost };
+        return { ...parsed, cost };
       }),
     );
 
     for (const entry of costEntries) {
       if (!entry) continue;
-      costsByEmail.set(
-        entry.email,
-        (costsByEmail.get(entry.email) ?? 0) + entry.cost,
+      costsBySubject.set(
+        entry.subject,
+        (costsBySubject.get(entry.subject) ?? 0) + entry.cost,
       );
     }
   } while (cursor !== "0");
 
-  return Array.from(costsByEmail.entries())
-    .map(([email, cost]) => ({ email, cost }))
+  return Array.from(costsBySubject.entries())
+    .map(([subject, cost]) => {
+      if (subject.startsWith("user:")) {
+        return { userId: subject.slice("user:".length), cost };
+      }
+      return { email: subject.slice("email:".length), cost };
+    })
     .sort((a, b) => b.cost - a.cost)
     .slice(0, limit);
 }
 
-function getWeeklyUsageCostKeys(email: string, now: Date) {
+function getWeeklyUsageCostKeys(identity: UsageIdentity, now: Date) {
   const days = getWeeklyUsageCostDays(now);
-  return days.map((day) => getWeeklyUsageCostKey(email, day));
+  return days.map((day) => getWeeklyUsageCostKey(identity, day));
 }
 
 function getWeeklyUsageCostDays(now: Date) {
@@ -150,14 +178,29 @@ function getWeeklyUsageCostDays(now: Date) {
   });
 }
 
-function getWeeklyUsageCostKey(email: string, date: Date | string) {
+function getWeeklyUsageCostKey(identity: UsageIdentity, date: Date | string) {
   const day = typeof date === "string" ? date : getUtcDay(date);
-  return `${WEEKLY_USAGE_COST_KEY_PREFIX}:${email}:${day}`;
+  if (identity.userId) {
+    return `${WEEKLY_USAGE_COST_KEY_PREFIX}:user:${identity.userId}:${day}`;
+  }
+  return `${WEEKLY_USAGE_COST_KEY_PREFIX}:${identity.email}:${day}`;
 }
 
 function parseWeeklyUsageCostKey(key: string) {
   const prefix = `${WEEKLY_USAGE_COST_KEY_PREFIX}:`;
   if (!key.startsWith(prefix)) return null;
+
+  if (key.startsWith(`${prefix}user:`)) {
+    const userPrefix = `${prefix}user:`;
+    const lastSeparatorIndex = key.lastIndexOf(":");
+    if (lastSeparatorIndex <= userPrefix.length) return null;
+
+    const userId = key.slice(userPrefix.length, lastSeparatorIndex);
+    const day = key.slice(lastSeparatorIndex + 1);
+    if (!userId || !day) return null;
+
+    return { subject: `user:${userId}`, userId, day };
+  }
 
   const lastSeparatorIndex = key.lastIndexOf(":");
   if (lastSeparatorIndex <= prefix.length) return null;
@@ -166,7 +209,7 @@ function parseWeeklyUsageCostKey(key: string) {
   const day = key.slice(lastSeparatorIndex + 1);
   if (!email || !day) return null;
 
-  return { email, day };
+  return { subject: `email:${email}`, email, day };
 }
 
 function parseUsageCost(rawCost: string | number | undefined): number {
@@ -177,4 +220,25 @@ function parseUsageCost(rawCost: string | number | undefined): number {
 
 function getUtcDay(date: Date) {
   return date.toISOString().slice(0, 10);
+}
+
+function mergeUsage(
+  ...entries: Array<RedisUsage | null | undefined>
+): RedisUsage {
+  const merged: RedisUsage = {};
+
+  for (const entry of entries) {
+    if (!entry) continue;
+    for (const [key, value] of Object.entries(entry)) {
+      if (typeof value !== "number") continue;
+      const usageKey = key as keyof RedisUsage;
+      merged[usageKey] = (merged[usageKey] ?? 0) + value;
+    }
+  }
+
+  return merged;
+}
+
+function dedupe(values: string[]) {
+  return [...new Set(values)];
 }

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -190,6 +190,7 @@ describe("saveAiUsage", () => {
     };
 
     await saveAiUsage({
+      userId: "user-1",
       email: "user@example.com",
       emailAccountId: "email-account-1",
       provider: "openai",
@@ -201,7 +202,7 @@ describe("saveAiUsage", () => {
     expect(publishAiCall).toHaveBeenCalledTimes(1);
     expect(publishAiCall).toHaveBeenCalledWith(
       expect.objectContaining({
-        userId: "user@example.com",
+        userId: "user-1",
         emailAccountId: "email-account-1",
         cachedInputTokens: 300,
         reasoningTokens: 25,
@@ -217,6 +218,7 @@ describe("saveAiUsage", () => {
     expect(saveUsage).toHaveBeenCalledTimes(1);
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
+        userId: "user-1",
         email: "user@example.com",
         usage,
         cost: calculateUsageCost({
@@ -242,6 +244,7 @@ describe("saveAiUsage", () => {
     });
 
     await saveAiUsage({
+      userId: "user-1",
       email: "user@example.com",
       emailAccountId: "email-account-1",
       provider: "openrouter",
@@ -253,7 +256,7 @@ describe("saveAiUsage", () => {
 
     expect(publishAiCall).toHaveBeenCalledWith(
       expect.objectContaining({
-        userId: "user@example.com",
+        userId: "user-1",
         emailAccountId: "email-account-1",
         cost: 0,
         estimatedCost,
@@ -263,6 +266,7 @@ describe("saveAiUsage", () => {
 
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
+        userId: "user-1",
         email: "user@example.com",
         usage,
         cost: 0,
@@ -285,6 +289,7 @@ describe("saveAiUsage", () => {
     });
 
     await saveAiUsage({
+      userId: "user-1",
       email: "user@example.com",
       emailAccountId: "email-account-1",
       provider: "openrouter",
@@ -312,6 +317,7 @@ describe("saveAiUsage", () => {
 
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
+        userId: "user-1",
         email: "user@example.com",
         usage,
         cost: estimatedCost,

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -219,7 +219,7 @@ describe("saveAiUsage", () => {
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user-1",
-        email: "user@example.com",
+        emailAccountId: "email-account-1",
         usage,
         cost: calculateUsageCost({
           provider: "openai",
@@ -267,7 +267,7 @@ describe("saveAiUsage", () => {
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user-1",
-        email: "user@example.com",
+        emailAccountId: "email-account-1",
         usage,
         cost: 0,
       }),
@@ -318,7 +318,7 @@ describe("saveAiUsage", () => {
     expect(saveUsage).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user-1",
-        email: "user@example.com",
+        emailAccountId: "email-account-1",
         usage,
         cost: estimatedCost,
       }),

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -71,7 +71,7 @@ export async function saveAiUsage({
         stepCount,
         toolCallCount,
       }),
-      saveUsage({ userId, email, cost: platformCost, usage }),
+      saveUsage({ userId, emailAccountId, cost: platformCost, usage }),
     ]);
   } catch (error) {
     logger.error("Failed to save usage", { error });

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -16,6 +16,7 @@ import { createScopedLogger } from "@/utils/logger";
 const logger = createScopedLogger("usage");
 
 export async function saveAiUsage({
+  userId,
   email,
   emailAccountId,
   provider,
@@ -29,6 +30,7 @@ export async function saveAiUsage({
   stepCount,
   toolCallCount,
 }: {
+  userId?: string;
   email: string;
   emailAccountId: string;
   provider: string;
@@ -49,7 +51,7 @@ export async function saveAiUsage({
   try {
     return Promise.all([
       publishAiCall({
-        userId: email,
+        userId: userId ?? email,
         emailAccountId,
         provider,
         model,
@@ -69,7 +71,7 @@ export async function saveAiUsage({
         stepCount,
         toolCallCount,
       }),
-      saveUsage({ email, cost: platformCost, usage }),
+      saveUsage({ userId, email, cost: platformCost, usage }),
     ]);
   } catch (error) {
     logger.error("Failed to save usage", { error });


### PR DESCRIPTION
Separates trial AI usage-limit state from generic persisted user error messages.

- Adds an authenticated AI automation status endpoint consumed by a client-side SWR banner.
- Keeps server-side LLM enforcement while using Redis notification markers for one-time trial-limit emails.
- Moves Redis usage accounting toward stable user IDs with legacy email-key fallback during the transition.
- Cleans up legacy stored trial-limit errors while preserving durable user errors.
- Adds focused unit coverage for status, notification, legacy cleanup, and usage-key behavior.