### PR TITLE
assistant: Hide internal rule retry errors

### DIFF
--- a/apps/web/utils/ai/assistant/tools/rules/get-learned-patterns-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/get-learned-patterns-tool.ts
@@ -2,7 +2,7 @@ import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
-import { trackRuleToolCall } from "./shared";
+import { buildHiddenRuleNotFoundError, trackRuleToolCall } from "./shared";
 
 export const getLearnedPatternsTool = ({
   email,
@@ -41,10 +41,7 @@ export const getLearnedPatternsTool = ({
         });
 
         if (!rule) {
-          return {
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         return {

--- a/apps/web/utils/ai/assistant/tools/rules/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/shared.ts
@@ -6,11 +6,14 @@ import type {
 } from "@/utils/ai/rule/create-rule-schema";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
+import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
 
 export const emptyInputSchema = z.object({});
 
 const RULE_READ_FRESHNESS_WINDOW_MS = 2 * 60 * 1000;
+const RULE_NOT_FOUND_ERROR =
+  "Rule not found. Try listing the rules again. The user may have made changes since you last checked.";
 
 export function buildCreateRuleSchemaFromChatToolInput(
   input: z.infer<ReturnType<typeof createRuleSchema>>,
@@ -99,4 +102,11 @@ export function validateRuleWasReadRecently({
   }
 
   return null;
+}
+
+export function buildHiddenRuleNotFoundError() {
+  return hideToolErrorFromUser({
+    success: false,
+    error: RULE_NOT_FOUND_ERROR,
+  });
 }

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
@@ -48,6 +48,41 @@ describe("updateLearnedPatternsTool", () => {
     expect(prisma.rule.findUnique).not.toHaveBeenCalled();
   });
 
+  it("marks missing-rule retry guidance as hidden from user display", async () => {
+    prisma.rule.findUnique.mockResolvedValueOnce(null);
+
+    const toolInstance = updateLearnedPatternsTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["VIP senders", "2026-04-12T10:00:00.000Z"],
+        ]),
+      }),
+    });
+
+    const result = await toolInstance.execute({
+      ruleName: "VIP senders",
+      learnedPatterns: [
+        {
+          exclude: {
+            from: "sender@example.com",
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
+      toolErrorVisibility: "hidden",
+    });
+  });
+
   it("returns a failure when saving learned patterns fails", async () => {
     prisma.rule.findUnique
       .mockResolvedValueOnce({

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.ts
@@ -6,7 +6,11 @@ import { GroupItemType } from "@/generated/prisma/enums";
 import { saveLearnedPatterns } from "@/utils/rule/learned-patterns";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
-import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+import {
+  buildHiddenRuleNotFoundError,
+  trackRuleToolCall,
+  validateRuleWasReadRecently,
+} from "./shared";
 
 export const updateLearnedPatternsTool = ({
   email,
@@ -90,11 +94,7 @@ export const updateLearnedPatternsTool = ({
         });
 
         if (!rule) {
-          return {
-            success: false,
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         const staleReadError = validateRuleWasReadRecently({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-actions-tool.ts
@@ -8,7 +8,11 @@ import { updateRuleActions } from "@/utils/rule/rule";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
-import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+import {
+  buildHiddenRuleNotFoundError,
+  trackRuleToolCall,
+  validateRuleWasReadRecently,
+} from "./shared";
 
 export const updateRuleActionsTool = ({
   email,
@@ -77,11 +81,7 @@ export const updateRuleActionsTool = ({
         });
 
         if (!rule) {
-          return {
-            success: false,
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         const staleReadError = validateRuleWasReadRecently({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-conditions-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-conditions-tool.ts
@@ -6,7 +6,11 @@ import { updateRuleConditionSchema } from "@/utils/actions/rule.validation";
 import { partialUpdateRule } from "@/utils/rule/rule";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
-import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+import {
+  buildHiddenRuleNotFoundError,
+  trackRuleToolCall,
+  validateRuleWasReadRecently,
+} from "./shared";
 
 export const updateRuleConditionsTool = ({
   email,
@@ -58,11 +62,7 @@ export const updateRuleConditionsTool = ({
         });
 
         if (!rule) {
-          return {
-            success: false,
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         const staleReadError = validateRuleWasReadRecently({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-state-tool.ts
@@ -6,7 +6,11 @@ import prisma from "@/utils/prisma";
 import { setRuleEnabled } from "@/utils/rule/rule";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
-import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+import {
+  buildHiddenRuleNotFoundError,
+  trackRuleToolCall,
+  validateRuleWasReadRecently,
+} from "./shared";
 
 export const ruleStateOperationSchema = z.enum(["enable", "disable", "delete"]);
 
@@ -62,11 +66,7 @@ export const updateRuleStateTool = ({
         });
 
         if (!rule) {
-          return {
-            success: false,
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         const staleReadError = validateRuleWasReadRecently({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -23,7 +23,11 @@ import {
 } from "@/utils/ai/rule/rule-condition-descriptions";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
 import type { RuleReadState } from "../../chat-rule-state";
-import { trackRuleToolCall, validateRuleWasReadRecently } from "./shared";
+import {
+  buildHiddenRuleNotFoundError,
+  trackRuleToolCall,
+  validateRuleWasReadRecently,
+} from "./shared";
 
 export const updateRuleTool = ({
   email,
@@ -122,11 +126,7 @@ export const updateRuleTool = ({
         });
 
         if (!rule) {
-          return {
-            success: false,
-            error:
-              "Rule not found. Try listing the rules again. The user may have made changes since you last checked.",
-          };
+          return buildHiddenRuleNotFoundError();
         }
 
         const staleReadError = validateRuleWasReadRecently({


### PR DESCRIPTION
Hides internal rule retry errors from user-facing assistant chat output while preserving retry guidance for the model.

- Centralizes the hidden missing-rule error output for rule tools.
- Applies the hidden output across rule read and update tools.
- Adds unit coverage for the hidden missing-rule path.