### PR TITLE
drafts: Normalize collapsed draft formatting

### DIFF
--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 11;
+export const DRAFT_PIPELINE_VERSION = 12;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
+++ b/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
@@ -3,6 +3,7 @@ import { getEmail, getEmailAccount } from "@/__tests__/helpers";
 import {
   aiDraftReply,
   aiDraftReplyWithConfidence,
+  normalizeDraftReplyFormatting,
 } from "@/utils/ai/reply/draft-reply";
 import { DRAFT_PIPELINE_VERSION } from "@/utils/ai/reply/draft-attribution";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
@@ -35,13 +36,9 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("preserves existing blank-line paragraph spacing", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
+    );
 
     expect(result).toBe(
       "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
@@ -49,13 +46,9 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("converts single-line paragraph separators into blank-line separators", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "First paragraph.\nSecond paragraph.\nThird paragraph.",
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\nSecond paragraph.\nThird paragraph.",
+    );
 
     expect(result).toBe(
       "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
@@ -63,26 +56,27 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("converts two single-line paragraphs into blank-line paragraphs", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "First paragraph.\nSecond paragraph.",
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\nSecond paragraph.",
+    );
 
     expect(result).toBe("First paragraph.\n\nSecond paragraph.");
   });
 
-  it("decodes escaped newline sequences from model output", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply:
-          "First paragraph.\\nSecond paragraph.\\nThird paragraph.\\r\\nFourth paragraph.",
-      },
-    });
+  it("normalizes carriage returns and unicode line separators", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\r\nSecond paragraph.\rThird paragraph.\u2028Fourth paragraph.\u2029Fifth paragraph.",
+    );
 
-    const result = await aiDraftReply(getDraftParams());
+    expect(result).toBe(
+      "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n\nFourth paragraph.\n\nFifth paragraph.",
+    );
+  });
+
+  it("decodes escaped newline sequences from model output", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\\nSecond paragraph.\\nThird paragraph.\\r\\nFourth paragraph.",
+    );
 
     expect(result).toBe(
       "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n\nFourth paragraph.",
@@ -90,28 +84,61 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("decodes escaped newline sequences in mixed newline output", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "First paragraph.\nSecond paragraph.\\nThird paragraph.",
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\nSecond paragraph.\\nThird paragraph.",
+    );
 
     expect(result).toBe(
       "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
     );
   });
 
-  it("normalizes mixed single and double newline paragraph separators", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply:
-          "First paragraph.\nSecond paragraph.\n\nThird paragraph.\nFourth paragraph.",
-      },
-    });
+  it("decodes escaped carriage return sequences", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\\rSecond paragraph.",
+    );
 
-    const result = await aiDraftReply(getDraftParams());
+    expect(result).toBe("First paragraph.\n\nSecond paragraph.");
+  });
+
+  it("trims trailing whitespace and collapses excessive blank lines", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "  First paragraph.   \n\n\n\nSecond paragraph. \t ",
+    );
+
+    expect(result).toBe("First paragraph.\n\nSecond paragraph.");
+  });
+
+  it("repairs paragraph breaks collapsed without spaces", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "First sentence in the opening paragraph.Second sentence starts the next paragraph.Third sentence starts another paragraph.",
+    );
+
+    expect(result).toBe(
+      "First sentence in the opening paragraph.\n\nSecond sentence starts the next paragraph.\n\nThird sentence starts another paragraph.",
+    );
+  });
+
+  it("does not split a single ordinary glued abbreviation-like boundary", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "The draft uses v1.Release wording for the note.",
+    );
+
+    expect(result).toBe("The draft uses v1.Release wording for the note.");
+  });
+
+  it("leaves ordinary single-line text unchanged", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "One short sentence with no paragraph breaks.",
+    );
+
+    expect(result).toBe("One short sentence with no paragraph breaks.");
+  });
+
+  it("normalizes mixed single and double newline paragraph separators", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "First paragraph.\nSecond paragraph.\n\nThird paragraph.\nFourth paragraph.",
+    );
 
     expect(result).toBe(
       "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n\nFourth paragraph.",
@@ -119,15 +146,9 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("normalizes long replies with more than 8 single-line paragraphs", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: Array.from({ length: 9 }, (_, i) => `Paragraph ${i + 1}.`).join(
-          "\n",
-        ),
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      Array.from({ length: 9 }, (_, i) => `Paragraph ${i + 1}.`).join("\n"),
+    );
 
     expect(result).toBe(
       Array.from({ length: 9 }, (_, i) => `Paragraph ${i + 1}.`).join("\n\n"),
@@ -135,15 +156,19 @@ describe("aiDraftReply formatting", () => {
   });
 
   it("does not convert list output into double-spaced paragraphs", async () => {
-    mockGenerateObject.mockResolvedValueOnce({
-      object: {
-        reply: "- First item\n- Second item\n- Third item",
-      },
-    });
-
-    const result = await aiDraftReply(getDraftParams());
+    const result = normalizeDraftReplyFormatting(
+      "- First item\n- Second item\n- Third item",
+    );
 
     expect(result).toBe("- First item\n- Second item\n- Third item");
+  });
+
+  it("does not convert low-punctuation line breaks into paragraphs", async () => {
+    const result = normalizeDraftReplyFormatting(
+      "Heading\nShort detail\nAnother detail.",
+    );
+
+    expect(result).toBe("Heading\nShort detail\nAnother detail.");
   });
 
   it("retries once then rejects persistent repetitive output", async () => {

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -392,7 +392,7 @@ export async function aiDraftReply({
   return result.reply;
 }
 
-function normalizeDraftReplyFormatting(reply: string): string {
+export function normalizeDraftReplyFormatting(reply: string): string {
   const withNormalizedLineEndings = reply.replace(/\r\n?|\u2028|\u2029/g, "\n");
 
   const withDecodedEscapedNewlines = /\\r\\n|\\n|\\r/.test(
@@ -411,7 +411,10 @@ function normalizeDraftReplyFormatting(reply: string): string {
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 
-  const nonEmptyLines = cleaned
+  const withRepairedCollapsedParagraphs =
+    repairCollapsedParagraphBoundaries(cleaned);
+
+  const nonEmptyLines = withRepairedCollapsedParagraphs
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
@@ -420,7 +423,18 @@ function normalizeDraftReplyFormatting(reply: string): string {
     return nonEmptyLines.join("\n\n");
   }
 
-  return cleaned;
+  return withRepairedCollapsedParagraphs;
+}
+
+function repairCollapsedParagraphBoundaries(reply: string): string {
+  if (reply.includes("\n")) return reply;
+
+  const gluedSentenceBoundaryPattern = /([a-z0-9][.!?])(?=[A-Z])/g;
+  const boundaryMatches = reply.match(gluedSentenceBoundaryPattern);
+
+  if (!boundaryMatches || boundaryMatches.length < 2) return reply;
+
+  return reply.replace(gluedSentenceBoundaryPattern, "$1\n\n");
 }
 
 function shouldConvertSingleLineBreaksToParagraphs(lines: string[]): boolean {


### PR DESCRIPTION
Normalize malformed draft reply paragraph spacing before provider rendering.

- Add a formatter guard for collapsed sentence boundaries in generated draft text
- Cover formatter branches with direct unit tests and bump draft pipeline attribution

Validation:
- pnpm --filter inbox-zero-ai test --run utils/ai/reply/draft-reply.formatting.test.ts
- pnpm --filter inbox-zero-ai exec biome check utils/ai/reply/draft-reply.ts utils/ai/reply/draft-reply.formatting.test.ts utils/ai/reply/draft-attribution.ts

Performance impact: Adds small in-memory string normalization only during draft generation. No new database calls, network calls, or hot-path UI work.