### PR TITLE
ci: Trigger evals for regression tests

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -25,6 +25,7 @@ on:
       - "apps/web/utils/ai/**"
       - "apps/web/utils/llms/**"
       - "apps/web/__tests__/ai-*.test.ts"
+      - "apps/web/__tests__/ai-regression/**"
       - "apps/web/__tests__/ai/**"
       - "apps/web/__tests__/eval/**"
 
@@ -35,6 +36,7 @@ on:
       - "apps/web/utils/ai/**"
       - "apps/web/utils/llms/**"
       - "apps/web/__tests__/ai-*.test.ts"
+      - "apps/web/__tests__/ai-regression/**"
       - "apps/web/__tests__/ai/**"
       - "apps/web/__tests__/eval/**"
 


### PR DESCRIPTION
Ensures the AI eval workflow runs when regression test files change. This wires existing coverage into the same PR and main-branch triggers as other AI eval files.

- Added the regression test directory to AI eval workflow path filters
- Kept the change limited to CI workflow trigger metadata