### PR TITLE
ci: Run package tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
           INTERNAL_API_KEY: "secret"
           NEXT_PUBLIC_BASE_URL: "http://localhost:3000"
 
+      - name: Run package tests
+        run: pnpm test:packages
+
       - name: Run integration tests
         run: pnpm -F inbox-zero-ai test-integration
         env:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "turbo dev --filter=./apps/web",
     "worker": "pnpm --filter @inboxzero/worker start",
     "test": "turbo run test --filter=./apps/web",
+    "test:packages": "pnpm -r --filter @inbox-zero/api --filter @inbox-zero/cli --filter @inboxzero/image-proxy --filter @inboxzero/image-proxy-aws test",
     "lint": "turbo lint",
     "postinstall": "sh clone-marketing.sh",
     "prepare": "husky install",


### PR DESCRIPTION
Adds deterministic package tests to the main CI test workflow so existing workspace coverage is enforced. This avoids AI eval spend while catching regressions in package code.

- Added a root package-test script for existing Vitest suites
- Runs package tests after web unit tests and before integration tests