### PR TITLE
test: Update CLI test config

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,10 +4,6 @@ export default defineConfig({
   test: {
     // Use threads pool for cleaner exit
     pool: "threads",
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
Updates the CLI package Vitest config to use the current Vitest 4 option for single-worker file execution. This removes the deprecation warning from package test runs without changing product code.

- Replaced deprecated pool-specific config with top-level file parallelism config
- Verified CLI and package test suites pass