### PR TITLE
automation: Skip archive for protected sender

### DIFF
--- a/apps/web/utils/ai/automated-archive-exception.test.ts
+++ b/apps/web/utils/ai/automated-archive-exception.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionType } from "@/generated/prisma/enums";
+import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
+
+vi.mock("server-only", () => ({}));
+
+const { envMock } = vi.hoisted(() => ({
+  envMock: {
+    WHITELIST_FROM: undefined as string | undefined,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+describe("shouldSkipAutomatedArchiveForSender", () => {
+  beforeEach(() => {
+    envMock.WHITELIST_FROM = undefined;
+  });
+
+  it("skips archive actions for the whitelisted sender", () => {
+    envMock.WHITELIST_FROM = "onboarding@getinboxzero.com";
+
+    expect(
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.ARCHIVE,
+        from: "Inbox Zero <onboarding@getinboxzero.com>",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not skip archive actions for ordinary senders", () => {
+    envMock.WHITELIST_FROM = "onboarding@getinboxzero.com";
+
+    expect(
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.ARCHIVE,
+        from: "Sender <sender@example.com>",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip non-archive actions for company senders", () => {
+    envMock.WHITELIST_FROM = "onboarding@getinboxzero.com";
+
+    expect(
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.LABEL,
+        from: "Inbox Zero <onboarding@getinboxzero.com>",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/utils/ai/automated-archive-exception.ts
+++ b/apps/web/utils/ai/automated-archive-exception.ts
@@ -1,0 +1,18 @@
+import { ActionType } from "@/generated/prisma/enums";
+import { env } from "@/env";
+import { extractEmailAddress } from "@/utils/email";
+
+export function shouldSkipAutomatedArchiveForSender({
+  actionType,
+  from,
+}: {
+  actionType: ActionType;
+  from: string;
+}) {
+  if (actionType !== ActionType.ARCHIVE || !env.WHITELIST_FROM) return false;
+
+  return (
+    extractEmailAddress(from).toLowerCase() ===
+    extractEmailAddress(env.WHITELIST_FROM).toLowerCase()
+  );
+}

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -9,6 +9,16 @@ import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("server-only", () => ({}));
 
+const { envMock } = vi.hoisted(() => ({
+  envMock: {
+    WHITELIST_FROM: undefined as string | undefined,
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
 vi.mock("@/utils/ai/actions", () => ({
   runActionFunction: vi.fn(),
 }));
@@ -65,7 +75,50 @@ describe("executeAct", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    envMock.WHITELIST_FROM = undefined;
     mockExecutedRuleUpdate.mockResolvedValue({});
+  });
+
+  it("keeps labels but skips archive for protected company senders", async () => {
+    envMock.WHITELIST_FROM = "onboarding@getinboxzero.com";
+    mockRunActionFunction.mockResolvedValueOnce({ success: true });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [
+        { id: "action-1", type: ActionType.LABEL, label: "Marketing" },
+        { id: "action-2", type: ActionType.ARCHIVE },
+      ],
+    } as any;
+
+    const result = await executeAct({
+      client: mockClient,
+      executedRule,
+      message: {
+        ...message,
+        headers: {
+          ...message.headers,
+          from: "Inbox Zero <onboarding@getinboxzero.com>",
+        },
+      },
+      emailAccount,
+      logger,
+    });
+
+    expect(result).toBe(ExecutedRuleStatus.APPLIED);
+    expect(mockRunActionFunction).toHaveBeenCalledTimes(1);
+    expect(mockRunActionFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          id: "action-1",
+          type: ActionType.LABEL,
+        }),
+      }),
+    );
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: { status: ExecutedRuleStatus.APPLIED },
+    });
   });
 
   it("marks executed rule as ERROR when notify sender reports a failure", async () => {

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -8,6 +8,7 @@ import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-ma
 import type { EmailProvider } from "@/utils/email/types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
+import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 
 const MODULE = "ai-execute-act";
 
@@ -45,6 +46,18 @@ export async function executeAct({
 
   for (const action of executedRule.actionItems) {
     try {
+      if (
+        shouldSkipAutomatedArchiveForSender({
+          actionType: action.type,
+          from: message.headers.from,
+        })
+      ) {
+        log.info("Skipping automated archive for protected company sender", {
+          actionId: action.id,
+        });
+        continue;
+      }
+
       const actionResult = await runActionFunction({
         client,
         email: message,


### PR DESCRIPTION
Adds a small automation guard that skips immediate archive actions for a configured protected sender while still allowing other actions to run.\n\nIncludes focused unit coverage for the sender guard and rule execution behavior.