### PR TITLE
test: Cover operational routes

### DIFF
--- a/apps/web/app/api/automation-jobs/execute/queue/route.test.ts
+++ b/apps/web/app/api/automation-jobs/execute/queue/route.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+type QueueMetadata = {
+  deliveryCount: number;
+  messageId: string;
+};
+
+type QueueCallback = (
+  message: unknown,
+  metadata: QueueMetadata,
+) => Promise<void>;
+
+const {
+  captureExceptionMock,
+  executeAutomationJobRunMock,
+  handleCallbackMock,
+} = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+  executeAutomationJobRunMock: vi.fn(),
+  handleCallbackMock: vi.fn((callback: QueueCallback) => callback),
+}));
+
+vi.mock("@vercel/queue", () => ({
+  handleCallback: handleCallbackMock,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/utils/automation-jobs/execute", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/utils/automation-jobs/execute")>();
+
+  return {
+    ...actual,
+    executeAutomationJobRun: (...args: unknown[]) =>
+      executeAutomationJobRunMock(...args),
+  };
+});
+
+import { POST } from "./route";
+
+describe("automation job queue route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ignores invalid queue payloads without executing a job run", async () => {
+    const queueCallback = POST as unknown as QueueCallback;
+
+    await expect(
+      queueCallback(
+        { automationJobRunId: "" },
+        { deliveryCount: 1, messageId: "queue-message-1" },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(executeAutomationJobRunMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/cron/draft-cleanup/route.test.ts
+++ b/apps/web/app/api/cron/draft-cleanup/route.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+
+vi.mock("server-only", () => ({}));
+
+const testLogger = createTestLogger();
+
+const { envMock, captureExceptionMock, cleanupDraftsMock } = vi.hoisted(() => ({
+  envMock: {
+    CRON_SECRET: "cron-secret",
+  },
+  captureExceptionMock: vi.fn(),
+  cleanupDraftsMock: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/utils/ai/draft-cleanup", () => ({
+  cleanupConfiguredAIDrafts: (...args: unknown[]) => cleanupDraftsMock(...args),
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withError:
+    (
+      _scope: string,
+      handler: (
+        request: Request & {
+          logger: typeof testLogger;
+        },
+      ) => Promise<Response>,
+    ) =>
+    async (request: Request) => {
+      const requestWithLogger = request as Request & {
+        logger: typeof testLogger;
+      };
+      requestWithLogger.logger = testLogger;
+      return handler(requestWithLogger);
+    },
+}));
+
+import { GET, POST } from "./route";
+
+describe("draft cleanup cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.CRON_SECRET = "cron-secret";
+    cleanupDraftsMock.mockResolvedValue({
+      deletedDrafts: 2,
+      skippedDrafts: 1,
+    });
+  });
+
+  it("rejects GET requests without the cron bearer token", async () => {
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/draft-cleanup"),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(cleanupDraftsMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs draft cleanup for GET requests with the cron bearer token", async () => {
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/draft-cleanup", {
+        headers: { authorization: "Bearer cron-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      deletedDrafts: 2,
+      skippedDrafts: 1,
+    });
+    expect(cleanupDraftsMock).toHaveBeenCalledWith({
+      logger: testLogger,
+    });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects POST requests without the cron secret in the body", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/cron/draft-cleanup", {
+        method: "POST",
+        body: JSON.stringify({ CRON_SECRET: "wrong-secret" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(cleanupDraftsMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs draft cleanup for POST requests with the cron secret in the body", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/cron/draft-cleanup", {
+        method: "POST",
+        body: JSON.stringify({ CRON_SECRET: "cron-secret" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      deletedDrafts: 2,
+      skippedDrafts: 1,
+    });
+    expect(cleanupDraftsMock).toHaveBeenCalledWith({
+      logger: testLogger,
+    });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds deterministic route-level coverage for operational cleanup and queue handling paths. The tests verify cron authorization around draft cleanup and ensure malformed queue messages do not execute automation job runs.

- Covers draft cleanup cron GET and POST authorization paths
- Covers invalid automation job queue payload handling
- Keeps external cleanup and job execution mocked for deterministic tests