### PR TITLE
Improve draft reply context retrieval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 
 ## LLM Features
 - Stay AI-first: fix general failure modes, not exact eval wording, and avoid brittle keyword or regex rules unless the product needs a hard guard.
+- Do not add keyword/phrase blacklists to prompts, evals, or tests just to catch a model's current bad wording. This product works across languages, so English-specific text checks are especially brittle. For LLM behavior, assert the semantic failure mode with a judge/eval criterion or structured contract instead. Example: test "does not ask unnecessary clarification or invent payment status," not "does not contain 'could you clarify' or 'specific payment'."
 - Never gate context injection or tool behavior on ad hoc user-text keyword matching; use structured state, metadata, or explicit events instead.
 - Tool descriptions should be self-contained: what the tool does, what its parameters mean, when to use it vs alternatives, prerequisites, and safety constraints specific to that tool.
 - Keep only cross-cutting policies (identity, write confirmation, security, formatting) in the system prompt. Per-tool guidance belongs in the tool description so it appears only when the tool is active.

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -222,7 +222,7 @@ Priya`,
           const testName = "genuine scheduling request";
           const judgeResult = await judgeEvalOutput({
             input: [
-              messages.map((message) => message.content).join("\n\n---\n\n"),
+              formatThreadForJudge(messages),
               "",
               "## Calendar Availability",
               JSON.stringify(
@@ -608,6 +608,247 @@ Dana`,
       );
     });
 
+    describe("sender-specific reply examples", () => {
+      const contactSpecificWritingStyle = [
+        "Keep replies concise and direct.",
+        "For close contacts, use a casual plainspoken tone.",
+        "Avoid asking clarification questions unless the incoming message is genuinely ambiguous.",
+      ].join("\n");
+
+      test(
+        "monthly payment status question stays concise and does not ask needless clarification",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Taylor Morgan <taylor@example.com>",
+                to: emailAccount.email,
+                subject: "Payment",
+                content: `Hi,
+
+Did you send the April/May payment?
+
+thanks,`,
+              }),
+              date: new Date("2026-05-11T07:20:00Z"),
+            },
+          ];
+
+          const sharedDraftOptions = {
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: contactSpecificWritingStyle,
+            mcpContext: null,
+            meetingContext: null,
+          };
+
+          const baselineResult =
+            await aiDraftReplyWithConfidence(sharedDraftOptions);
+          const result = await aiDraftReplyWithConfidence({
+            ...sharedDraftOptions,
+            senderReplyExamples: getStatusReplyExamples(emailAccount.email),
+          });
+
+          const input = formatThreadForJudge(messages);
+          const paymentReplyCriterion = {
+            name: "Concise contact-specific payment reply",
+            description:
+              "The draft should be one or two short sentences plus an optional compact greeting/sign-off. It should not ask an unnecessary clarification question or create a multi-paragraph process update. It may either say the user is checking, commit to handling it, or answer directly in the same concise style the user uses with this sender.",
+          };
+          const expectedPaymentReply =
+            "A short, direct reply suitable for a close/contact-specific relationship. It should avoid unnecessary clarification and processy filler. A useful action-oriented reply is acceptable because the user can complete the action before sending.";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              input,
+              "",
+              "## Same-sender reply examples",
+              "The user usually answers this sender in very short direct replies such as 'Not yet, will do it today', 'Done now', or 'Checking and will update you.'",
+            ].join("\n"),
+            output: result.reply,
+            expected: expectedPaymentReply,
+            criterion: paymentReplyCriterion,
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName: "monthly payment status with same-sender examples",
+            model: model.label,
+            pass,
+            expected:
+              "concise same-sender reply without needless clarification",
+            actual: formatSemanticJudgeActualWithExtra(
+              result.reply,
+              judgeResult,
+              [`baseline=${JSON.stringify(baselineResult.reply)}`],
+            ),
+          });
+
+          expect(
+            pass,
+            `Draft should stay concise and avoid needless clarification.\n\nBaseline:\n${baselineResult.reply}\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "current thread facts override conflicting same-sender examples",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: emailAccount.email,
+                to: "taylor@example.com",
+                subject: "Re: Payment",
+                content: "I sent the April/May payment this morning.",
+              }),
+              date: new Date("2026-05-11T06:30:00Z"),
+            },
+            {
+              ...getEmail({
+                from: "Taylor Morgan <taylor@example.com>",
+                to: emailAccount.email,
+                subject: "Re: Payment",
+                content: `Hi,
+
+Did you send the April/May payment?
+
+thanks,`,
+              }),
+              date: new Date("2026-05-11T07:20:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            senderReplyExamples: getStatusReplyExamples(emailAccount.email),
+            calendarAvailability: null,
+            writingStyle: contactSpecificWritingStyle,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Same-sender reply examples",
+              "The examples include short prior replies with different statuses. They are style examples only.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A concise reply that uses the current thread fact that the payment was sent this morning. It should not ignore that fact or copy a conflicting status from the same-sender examples.",
+            criterion: {
+              name: "Current thread facts override examples",
+              description:
+                "The draft should base factual status on the current thread. Same-sender examples may influence brevity and tone, but must not override or contradict facts stated in the current conversation.",
+            },
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName: "current thread facts override same-sender examples",
+            model: model.label,
+            pass,
+            expected: "current-thread fact used; examples style-only",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should use current-thread facts over examples.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "unresolved document status stays concise with same-sender examples",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Taylor Morgan <taylor@example.com>",
+                to: emailAccount.email,
+                subject: "Form",
+                content: `Hi,
+
+Did the signed form go out?
+
+thanks,`,
+              }),
+              date: new Date("2026-05-12T08:15:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            senderReplyExamples: getStatusReplyExamples(emailAccount.email),
+            calendarAvailability: null,
+            writingStyle: contactSpecificWritingStyle,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Same-sender reply examples",
+              "The examples include short prior replies with different statuses. They are style examples only.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A concise reply in the user's same-sender style. It may say the user is checking, will handle it, or has handled it, but should not ask an unnecessary clarification question or create a multi-paragraph process update.",
+            criterion: {
+              name: "Unresolved non-payment status remains concise",
+              description:
+                "For an unresolved status question outside the payment fixture, the draft should preserve the same-sender brevity and avoid needless clarification or processy filler. It may draft an action-oriented reply because the user can take the action before sending.",
+            },
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName: "unresolved document status with same-sender examples",
+            model: model.label,
+            pass,
+            expected: "concise reply without needless clarification",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should stay concise and useful.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+    });
+
     describe("grounding and uncertainty", () => {
       test(
         "does not invent pricing terms without pricing context",
@@ -718,7 +959,7 @@ Maya`,
           const testName = "provided pricing context";
           const judgeResult = await judgeEvalOutput({
             input: [
-              messages.map((message) => message.content).join("\n\n---\n\n"),
+              formatThreadForJudge(messages),
               "",
               "## Knowledge Base",
               "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
@@ -842,7 +1083,7 @@ Dana`,
           const testName = "provided attachment context";
           const judgeResult = await judgeEvalOutput({
             input: [
-              messages.map((message) => message.content).join("\n\n---\n\n"),
+              formatThreadForJudge(messages),
               "",
               "## Selected Attachments",
               'Signed Order Form.pdf — selected because the sender asked for "the signed order form".',
@@ -965,7 +1206,7 @@ Riley`,
           const testName = "provided refund authority context";
           const judgeResult = await judgeEvalOutput({
             input: [
-              messages.map((message) => message.content).join("\n\n---\n\n"),
+              formatThreadForJudge(messages),
               "",
               "## Knowledge Base",
               "The duplicate charge refund for this customer is approved. Finance will process it by Friday.",
@@ -1086,7 +1327,7 @@ Priya`,
           const testName = "provided meeting context";
           const judgeResult = await judgeEvalOutput({
             input: [
-              messages.map((message) => message.content).join("\n\n---\n\n"),
+              formatThreadForJudge(messages),
               "",
               "## Meeting Context",
               "Upcoming calendar context: a meeting with Priya Sharma is scheduled for tomorrow at 3:00 PM.",
@@ -1240,7 +1481,7 @@ async function maybeJudgeGroundedReply({
   reply: string;
 }) {
   return judgeMultiple({
-    input: messages.map((message) => message.content).join("\n\n---\n\n"),
+    input: formatThreadForJudge(messages),
     output: reply,
     expected: [
       "Reply briefly and helpfully.",
@@ -1261,6 +1502,41 @@ function hasExactUrl(text: string, expectedUrl: string): boolean {
   return extractUrls(text).some(
     (url) => normalizeUrlForComparison(url) === normalizedExpected,
   );
+}
+
+function formatThreadForJudge(messages: { content: string }[]): string {
+  return messages.map((message) => message.content).join("\n\n---\n\n");
+}
+
+function formatSemanticJudgeActualWithExtra(
+  reply: string,
+  judgeResult: Parameters<typeof formatSemanticJudgeActual>[1],
+  extra: string[] = [],
+): string {
+  return [formatSemanticJudgeActual(reply, judgeResult), ...extra].join(" | ");
+}
+
+function getStatusReplyExamples(userEmail: string): string {
+  return [
+    `<reply_example>
+<from>${userEmail}</from>
+<to>taylor@example.com</to>
+<subject>Re: quick check</subject>
+<body>Not yet, will do it today.</body>
+</reply_example>`,
+    `<reply_example>
+<from>${userEmail}</from>
+<to>taylor@example.com</to>
+<subject>Re: payment</subject>
+<body>Done now.</body>
+</reply_example>`,
+    `<reply_example>
+<from>${userEmail}</from>
+<to>taylor@example.com</to>
+<subject>Re: forms</subject>
+<body>Checking and will update you.</body>
+</reply_example>`,
+  ].join("\n\n");
 }
 
 function extractUrls(text: string): string[] {

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -646,12 +646,13 @@ thanks,`,
             meetingContext: null,
           };
 
-          const baselineResult =
-            await aiDraftReplyWithConfidence(sharedDraftOptions);
-          const result = await aiDraftReplyWithConfidence({
-            ...sharedDraftOptions,
-            senderReplyExamples: getStatusReplyExamples(emailAccount.email),
-          });
+          const [baselineResult, result] = await Promise.all([
+            aiDraftReplyWithConfidence(sharedDraftOptions),
+            aiDraftReplyWithConfidence({
+              ...sharedDraftOptions,
+              senderReplyExamples: getStatusReplyExamples(emailAccount.email),
+            }),
+          ]);
 
           const input = formatThreadForJudge(messages);
           const paymentReplyCriterion = {
@@ -680,11 +681,7 @@ thanks,`,
             pass,
             expected:
               "concise same-sender reply without needless clarification",
-            actual: formatSemanticJudgeActualWithExtra(
-              result.reply,
-              judgeResult,
-              [`baseline=${JSON.stringify(baselineResult.reply)}`],
-            ),
+            actual: `${formatSemanticJudgeActual(result.reply, judgeResult)} | baseline=${JSON.stringify(baselineResult.reply)}`,
           });
 
           expect(
@@ -1506,14 +1503,6 @@ function hasExactUrl(text: string, expectedUrl: string): boolean {
 
 function formatThreadForJudge(messages: { content: string }[]): string {
   return messages.map((message) => message.content).join("\n\n---\n\n");
-}
-
-function formatSemanticJudgeActualWithExtra(
-  reply: string,
-  judgeResult: Parameters<typeof formatSemanticJudgeActual>[1],
-  extra: string[] = [],
-): string {
-  return [formatSemanticJudgeActual(reply, judgeResult), ...extra].join(" | ");
 }
 
 function getStatusReplyExamples(userEmail: string): string {

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 11;
+export const DRAFT_PIPELINE_VERSION = 12;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-context-metadata.ts
+++ b/apps/web/utils/ai/reply/draft-context-metadata.ts
@@ -20,6 +20,8 @@ export const draftContextMetadataSchema = z.object({
     summarySourceMessageCount: z.number(),
     precedentThreadsInjected: z.boolean(),
     precedentThreadCount: z.number(),
+    sameSenderReplyExamplesInjected: z.boolean().optional(),
+    sameSenderReplyExampleCount: z.number().optional(),
   }),
   calendar: z.object({
     injected: z.boolean(),

--- a/apps/web/utils/ai/reply/draft-context-metadata.ts
+++ b/apps/web/utils/ai/reply/draft-context-metadata.ts
@@ -20,8 +20,8 @@ export const draftContextMetadataSchema = z.object({
     summarySourceMessageCount: z.number(),
     precedentThreadsInjected: z.boolean(),
     precedentThreadCount: z.number(),
-    sameSenderReplyExamplesInjected: z.boolean().optional(),
-    sameSenderReplyExampleCount: z.number().optional(),
+    sameSenderReplyExamplesInjected: z.boolean(),
+    sameSenderReplyExampleCount: z.number(),
   }),
   calendar: z.object({
     injected: z.boolean(),

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -57,6 +57,7 @@ const getUserPrompt = ({
   replyMemoryContent,
   emailHistorySummary,
   emailHistoryContext,
+  senderReplyExamples,
   calendarAvailability,
   writingStyle,
   learnedWritingStyle,
@@ -71,6 +72,7 @@ const getUserPrompt = ({
   replyMemoryContent: string | null;
   emailHistorySummary: string | null;
   emailHistoryContext: ReplyContextCollectorResult | null;
+  senderReplyExamples: string | null;
   calendarAvailability: CalendarAvailabilityContext | null;
   writingStyle: string | null;
   learnedWritingStyle: string | null;
@@ -131,6 +133,15 @@ ${item}
 <email_history_notes>
 ${emailHistoryContext.notes || "No notes"}
 </email_history_notes>
+`
+    : "";
+
+  const senderReplyExamplesContext = senderReplyExamples
+    ? `Past replies to this sender. Use for relationship, tone, brevity, and directness; current thread/context facts still win.
+
+<sender_reply_examples>
+${senderReplyExamples}
+</sender_reply_examples>
 `
     : "";
 
@@ -199,6 +210,7 @@ ${relevantKnowledge}
 ${learnedReplyMemories}
 ${historicalContext}
 ${precedentHistoryContext}
+${senderReplyExamplesContext}
 ${writingStylePrompt}
 ${learnedWritingStylePrompt}
 ${signatureContext}
@@ -242,6 +254,7 @@ export async function aiDraftReplyWithConfidence({
   replyMemoryContent = null,
   emailHistorySummary,
   emailHistoryContext,
+  senderReplyExamples = null,
   calendarAvailability,
   writingStyle,
   learnedWritingStyle = null,
@@ -256,6 +269,7 @@ export async function aiDraftReplyWithConfidence({
   replyMemoryContent?: string | null;
   emailHistorySummary: string | null;
   emailHistoryContext: ReplyContextCollectorResult | null;
+  senderReplyExamples?: string | null;
   calendarAvailability: CalendarAvailabilityContext | null;
   writingStyle: string | null;
   learnedWritingStyle?: string | null;
@@ -293,6 +307,7 @@ export async function aiDraftReplyWithConfidence({
     replyMemoryContent,
     emailHistorySummary,
     emailHistoryContext,
+    senderReplyExamples,
     calendarAvailability,
     writingStyle: effectiveWritingStyle,
     learnedWritingStyle: advisoryLearnedWritingStyle,
@@ -351,6 +366,7 @@ export async function aiDraftReply({
   replyMemoryContent = null,
   emailHistorySummary,
   emailHistoryContext,
+  senderReplyExamples = null,
   calendarAvailability,
   writingStyle,
   learnedWritingStyle = null,
@@ -365,6 +381,7 @@ export async function aiDraftReply({
   replyMemoryContent?: string | null;
   emailHistorySummary: string | null;
   emailHistoryContext: ReplyContextCollectorResult | null;
+  senderReplyExamples?: string | null;
   calendarAvailability: CalendarAvailabilityContext | null;
   writingStyle: string | null;
   learnedWritingStyle?: string | null;
@@ -380,6 +397,7 @@ export async function aiDraftReply({
     replyMemoryContent,
     emailHistorySummary,
     emailHistoryContext,
+    senderReplyExamples,
     calendarAvailability,
     writingStyle,
     learnedWritingStyle,

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -95,6 +95,7 @@ vi.mock("@/env", () => ({
 import { aiDraftReplyWithConfidence } from "@/utils/ai/reply/draft-reply";
 import { getReplyMemoriesForPrompt } from "@/utils/ai/reply/reply-memory";
 import { selectDraftAttachmentsForRule } from "@/utils/attachments/draft-attachments";
+import { aiExtractFromEmailHistory } from "@/utils/ai/knowledge/extract-from-email-history";
 import prisma from "@/utils/prisma";
 import { getReplyWithConfidence, saveReply } from "@/utils/redis/reply";
 
@@ -145,6 +146,10 @@ const createMockClient = (): EmailProvider =>
   ({
     getThreadMessages: vi.fn(),
     getPreviousConversationMessages: vi.fn().mockResolvedValue([]),
+    getThreadsWithParticipant: vi.fn().mockResolvedValue([]),
+    isSentMessage: vi.fn((message: ParsedMessage) =>
+      message.labelIds?.includes("SENT"),
+    ),
   }) as EmailProvider;
 
 const createMockEmailAccountSettings = (
@@ -477,6 +482,139 @@ describe("fetchMessagesAndGenerateDraft - thread ordering", () => {
       "msg-old",
       "msg-new",
     ]);
+  });
+
+  it("does not summarize the current thread as historical email context", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Draft reply",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+    });
+
+    const currentMessage = createMockMessage();
+    const olderMessage: ParsedMessage = {
+      ...createMockMessage(),
+      id: "msg-previous",
+      threadId: "thread-previous",
+      internalDate: "2023-12-31T10:00:00Z",
+      textPlain: "Earlier context from another thread",
+      textHtml: "<p>Earlier context from another thread</p>",
+    };
+
+    const client = createMockClient();
+    vi.mocked(client.getThreadMessages).mockResolvedValue([currentMessage]);
+    vi.mocked(client.getPreviousConversationMessages).mockResolvedValue([
+      currentMessage,
+      olderMessage,
+    ]);
+
+    await fetchMessagesAndGenerateDraft(
+      createMockEmailAccount(),
+      "thread-1",
+      client,
+      undefined,
+      logger,
+    );
+
+    expect(aiExtractFromEmailHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        historicalMessages: [
+          expect.objectContaining({
+            id: "msg-previous",
+            content: expect.stringContaining("Earlier context"),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("skips historical email extraction when only current-thread messages are returned", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Draft reply",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+    });
+
+    const currentMessage = createMockMessage();
+    const client = createMockClient();
+    vi.mocked(client.getThreadMessages).mockResolvedValue([currentMessage]);
+    vi.mocked(client.getPreviousConversationMessages).mockResolvedValue([
+      currentMessage,
+    ]);
+
+    await fetchMessagesAndGenerateDraft(
+      createMockEmailAccount(),
+      "thread-1",
+      client,
+      undefined,
+      logger,
+    );
+
+    expect(aiExtractFromEmailHistory).not.toHaveBeenCalled();
+  });
+
+  it("passes recent sent replies to the same sender into the draft prompt", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Draft reply",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+    });
+
+    const currentMessage = createMockMessage();
+    const sentReply: ParsedMessage = {
+      ...createMockMessage(),
+      id: "sent-reply",
+      threadId: "previous-thread",
+      internalDate: "2024-01-02T10:00:00Z",
+      labelIds: ["SENT"],
+      headers: {
+        ...createMockMessage().headers,
+        from: "user@example.com",
+        to: "sender@example.com",
+        subject: "Previous note",
+      },
+      textPlain: "Short previous reply.",
+      textHtml: "<p>Short previous reply.</p>",
+    };
+
+    const client = createMockClient();
+    vi.mocked(client.getThreadMessages).mockResolvedValue([currentMessage]);
+    vi.mocked(client.getThreadsWithParticipant).mockResolvedValue([
+      {
+        id: "previous-thread",
+        messages: [currentMessage, sentReply],
+        snippet: "",
+      },
+    ]);
+
+    const result = await fetchMessagesAndGenerateDraftWithConfidenceThreshold(
+      createMockEmailAccount(),
+      "thread-1",
+      client,
+      undefined,
+      logger,
+      DraftReplyConfidence.ALL_EMAILS,
+    );
+
+    expect(client.getThreadsWithParticipant).toHaveBeenCalledWith({
+      participantEmail: "sender@example.com",
+      maxThreads: 8,
+    });
+    expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderReplyExamples: expect.stringContaining("Short previous reply"),
+      }),
+    );
+    expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderReplyExamples: expect.not.stringContaining("Hello, how are you?"),
+      }),
+    );
+    expect(result.draftContextMetadata).toEqual(
+      expect.objectContaining({
+        senderHistory: expect.objectContaining({
+          sameSenderReplyExamplesInjected: true,
+          sameSenderReplyExampleCount: 1,
+        }),
+      }),
+    );
   });
 });
 

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -30,6 +30,7 @@ import { selectDraftAttachmentsForRule } from "@/utils/attachments/draft-attachm
 import type { SelectedAttachment } from "@/utils/attachments/source-schema";
 import { getReplyMemoriesForPrompt } from "@/utils/ai/reply/reply-memory";
 import type { DraftContextMetadata } from "@/utils/ai/reply/draft-context-metadata";
+import { collectSenderReplyExamples } from "@/utils/reply-tracker/sender-reply-examples";
 
 export type DraftGenerationResult = {
   attachments?: SelectedAttachment[];
@@ -233,13 +234,17 @@ async function generateDraftContent(
     messages[messages.length - 1],
     10_000,
   );
-  const historicalMessagesForLLM = previousConversationMessages?.map((msg) =>
-    getEmailForLLM(msg, {
-      maxLength: 1000,
-      extractReply: true,
-      removeForwarded: false,
-    }),
-  );
+  const currentMessageIds = new Set(threadMessages.map((msg) => msg.id));
+  const historicalMessagesForLLM = previousConversationMessages
+    ?.filter((msg) => !currentMessageIds.has(msg.id))
+    .map((msg) =>
+      getEmailForLLM(msg, {
+        maxLength: 1000,
+        extractReply: true,
+        removeForwarded: false,
+      }),
+    );
+  const senderEmail = extractEmailAddress(lastMessage.headers.from);
 
   if (historicalMessagesForLLM?.length) {
     logger.info("Fetching historical messages from sender");
@@ -278,6 +283,7 @@ async function generateDraftContent(
     upcomingMeetings,
     emailHistorySummary,
     attachmentSelection,
+    senderReplyExamples,
   ] = await Promise.all([
     aiExtractRelevantKnowledge({
       knowledgeBase,
@@ -287,7 +293,7 @@ async function generateDraftContent(
     }),
     getReplyMemoriesForPrompt({
       emailAccountId: emailAccount.id,
-      senderEmail: extractEmailAddress(lastMessage.headers.from),
+      senderEmail,
       emailContent: lastMessageContent,
       logger,
     }),
@@ -305,7 +311,7 @@ async function generateDraftContent(
     mcpAgent({ emailAccount, messages }),
     getMeetingContext({
       emailAccountId: emailAccount.id,
-      recipientEmail: extractEmailAddress(lastMessage.headers.from),
+      recipientEmail: senderEmail,
       // extract all other recipients (To, CC) for privacy filtering
       // only meetings where ALL recipients were attendees will be included
       additionalRecipients: [
@@ -325,6 +331,13 @@ async function generateDraftContent(
         })
       : Promise.resolve(null),
     attachmentSelectionPromise,
+    collectSenderReplyExamples({
+      emailAccount,
+      emailProvider,
+      senderEmail,
+      currentMessageIds,
+      logger,
+    }),
   ]);
   const {
     content: replyMemoryContent,
@@ -351,6 +364,8 @@ async function generateDraftContent(
       summarySourceMessageCount: historicalMessagesForLLM?.length ?? 0,
       precedentThreadsInjected: precedentThreadCount > 0,
       precedentThreadCount,
+      sameSenderReplyExamplesInjected: !!senderReplyExamples?.content,
+      sameSenderReplyExampleCount: senderReplyExamples?.count ?? 0,
     },
     calendar: {
       injected: !!calendarAvailability,
@@ -387,6 +402,7 @@ async function generateDraftContent(
     replyMemoryContent,
     emailHistorySummary,
     emailHistoryContext,
+    senderReplyExamples: senderReplyExamples?.content ?? null,
     calendarAvailability,
     writingStyle,
     learnedWritingStyle: emailAccountSettings?.learnedWritingStyle ?? null,

--- a/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
@@ -86,8 +86,7 @@ describe("collectSenderReplyExamples", () => {
     });
     expect(result?.count).toBe(3);
     expect(result?.content).toContain("Newer sent reply.");
-    expect(result?.content).toContain('truncated="true"');
-    expect(result?.content).toContain("[truncated]");
+    expect(result?.content).toContain("...");
     expect(result?.content).not.toContain("Tail should be omitted.");
     expect(result?.content).toContain("Older sent reply.");
     expect(result?.content).not.toContain("Oldest sent reply");

--- a/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { collectSenderReplyExamples } from "./sender-reply-examples";
+import type { EmailProvider } from "@/utils/email/types";
+import type { EmailAccountWithAI } from "@/utils/llms/types";
+import { createScopedLogger } from "@/utils/logger";
+import type { ParsedMessage } from "@/utils/types";
+
+vi.mock("server-only", () => ({}));
+
+const logger = createScopedLogger("sender-reply-examples-test");
+
+describe("collectSenderReplyExamples", () => {
+  it("returns recent sent replies to the sender and excludes current-thread messages", async () => {
+    const provider = createMockProvider({
+      messages: [
+        createMessage({
+          id: "current-message",
+          from: "user@example.com",
+          to: "sender@example.com",
+          textPlain: "Current thread reply should not be included.",
+          labelIds: ["SENT"],
+          internalDate: "2026-05-11T10:00:00Z",
+        }),
+        createMessage({
+          id: "older-sent-reply",
+          from: "user@example.com",
+          to: "sender@example.com",
+          textPlain: "Older sent reply.",
+          labelIds: ["SENT"],
+          internalDate: "2026-05-08T10:00:00Z",
+        }),
+        createMessage({
+          id: "newer-sent-reply",
+          from: "user@example.com",
+          to: "sender@example.com",
+          textPlain: "Newer sent reply.",
+          labelIds: ["SENT"],
+          internalDate: "2026-05-10T10:00:00Z",
+        }),
+        createMessage({
+          id: "received-message",
+          from: "sender@example.com",
+          to: "user@example.com",
+          textPlain: "Incoming message should not be included.",
+          labelIds: [],
+          internalDate: "2026-05-09T10:00:00Z",
+        }),
+        createMessage({
+          id: "other-recipient",
+          from: "user@example.com",
+          to: "someone@example.com",
+          textPlain: "Other recipient should not be included.",
+          labelIds: ["SENT"],
+          internalDate: "2026-05-07T10:00:00Z",
+        }),
+      ],
+    });
+
+    const result = await collectSenderReplyExamples({
+      emailAccount: createEmailAccount(),
+      emailProvider: provider,
+      senderEmail: "sender@example.com",
+      currentMessageIds: new Set(["current-message"]),
+      logger,
+    });
+
+    expect(provider.getThreadsWithParticipant).toHaveBeenCalledWith({
+      participantEmail: "sender@example.com",
+      maxThreads: 8,
+    });
+    expect(result?.count).toBe(2);
+    expect(result?.content).toContain("Newer sent reply.");
+    expect(result?.content).toContain("Older sent reply.");
+    expect(result?.content).not.toContain("Current thread reply");
+    expect(result?.content).not.toContain("Incoming message");
+    expect(result?.content).not.toContain("Other recipient");
+    expect(result?.content.indexOf("Newer sent reply.")).toBeLessThan(
+      result?.content.indexOf("Older sent reply.") ?? Number.POSITIVE_INFINITY,
+    );
+  });
+});
+
+function createMockProvider({
+  messages,
+}: {
+  messages: ParsedMessage[];
+}): EmailProvider {
+  return {
+    getThreadsWithParticipant: vi.fn().mockResolvedValue([
+      {
+        id: "thread-1",
+        messages,
+        snippet: "",
+      },
+    ]),
+    isSentMessage: vi.fn((message: ParsedMessage) =>
+      message.labelIds?.includes("SENT"),
+    ),
+  } as unknown as EmailProvider;
+}
+
+function createEmailAccount(): EmailAccountWithAI {
+  return {
+    id: "account-id",
+    email: "user@example.com",
+    userId: "user-id",
+    timezone: "UTC",
+    user: {
+      aiProvider: null,
+      aiModel: null,
+      aiApiKey: null,
+    },
+  } as EmailAccountWithAI;
+}
+
+function createMessage({
+  id,
+  from,
+  to,
+  textPlain,
+  labelIds,
+  internalDate,
+}: {
+  id: string;
+  from: string;
+  to: string;
+  textPlain: string;
+  labelIds: string[];
+  internalDate: string;
+}): ParsedMessage {
+  return {
+    id,
+    threadId: "thread-1",
+    internalDate,
+    date: internalDate,
+    historyId: "history-id",
+    inline: [],
+    labelIds,
+    snippet: textPlain,
+    subject: "Subject",
+    textHtml: `<p>${textPlain}</p>`,
+    textPlain,
+    headers: {
+      from,
+      to,
+      subject: "Subject",
+      date: internalDate,
+      "message-id": `<${id}@example.com>`,
+    },
+  };
+}

--- a/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
@@ -30,6 +30,14 @@ describe("collectSenderReplyExamples", () => {
           internalDate: "2026-05-08T10:00:00Z",
         }),
         createMessage({
+          id: "long-sent-reply",
+          from: "user@example.com",
+          to: "sender@example.com",
+          textPlain: `${"Long sent reply. ".repeat(60)}Tail should be omitted.`,
+          labelIds: ["SENT"],
+          internalDate: "2026-05-09T10:00:00Z",
+        }),
+        createMessage({
           id: "newer-sent-reply",
           from: "user@example.com",
           to: "sender@example.com",
@@ -44,6 +52,14 @@ describe("collectSenderReplyExamples", () => {
           textPlain: "Incoming message should not be included.",
           labelIds: [],
           internalDate: "2026-05-09T10:00:00Z",
+        }),
+        createMessage({
+          id: "oldest-sent-reply",
+          from: "user@example.com",
+          to: "sender@example.com",
+          textPlain: "Oldest sent reply should not fit.",
+          labelIds: ["SENT"],
+          internalDate: "2026-05-06T10:00:00Z",
         }),
         createMessage({
           id: "other-recipient",
@@ -68,9 +84,13 @@ describe("collectSenderReplyExamples", () => {
       participantEmail: "sender@example.com",
       maxThreads: 8,
     });
-    expect(result?.count).toBe(2);
+    expect(result?.count).toBe(3);
     expect(result?.content).toContain("Newer sent reply.");
+    expect(result?.content).toContain('truncated="true"');
+    expect(result?.content).toContain("[truncated]");
+    expect(result?.content).not.toContain("Tail should be omitted.");
     expect(result?.content).toContain("Older sent reply.");
+    expect(result?.content).not.toContain("Oldest sent reply");
     expect(result?.content).not.toContain("Current thread reply");
     expect(result?.content).not.toContain("Incoming message");
     expect(result?.content).not.toContain("Other recipient");

--- a/apps/web/utils/reply-tracker/sender-reply-examples.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.ts
@@ -1,0 +1,87 @@
+import { internalDateToDate } from "@/utils/date";
+import { extractEmailAddresses, isSameEmailAddress } from "@/utils/email";
+import type { EmailProvider } from "@/utils/email/types";
+import { getEmailForLLM } from "@/utils/get-email-from-message";
+import type { EmailAccountWithAI } from "@/utils/llms/types";
+import type { Logger } from "@/utils/logger";
+import { stringifyEmail } from "@/utils/stringify-email";
+
+const MAX_SEARCHED_SENDER_THREADS = 8;
+const MAX_SENDER_REPLY_EXAMPLES = 5;
+const REPLY_EXAMPLE_CONTENT_MAX_LENGTH = 800;
+
+export async function collectSenderReplyExamples({
+  emailAccount,
+  emailProvider,
+  senderEmail,
+  currentMessageIds,
+  logger,
+}: {
+  emailAccount: EmailAccountWithAI;
+  emailProvider: EmailProvider;
+  senderEmail: string;
+  currentMessageIds: Set<string>;
+  logger: Logger;
+}): Promise<{ content: string; count: number } | null> {
+  if (!senderEmail) return null;
+  if (isSameEmailAddress(senderEmail, emailAccount.email)) return null;
+
+  const normalizedSenderEmail = senderEmail.trim().toLowerCase();
+
+  try {
+    const threads = await emailProvider.getThreadsWithParticipant({
+      participantEmail: normalizedSenderEmail,
+      maxThreads: MAX_SEARCHED_SENDER_THREADS,
+    });
+
+    const sentReplies = threads
+      .flatMap((thread) => thread.messages)
+      .filter((message) => {
+        if (currentMessageIds.has(message.id)) return false;
+        if (!emailProvider.isSentMessage(message)) return false;
+
+        const recipients = extractEmailAddresses(
+          [
+            message.headers.to,
+            message.headers.cc ?? "",
+            message.headers.bcc ?? "",
+          ].join(","),
+        );
+
+        return recipients.some((recipient) =>
+          isSameEmailAddress(recipient, normalizedSenderEmail),
+        );
+      })
+      .sort(
+        (left, right) =>
+          internalDateToDate(right.internalDate).getTime() -
+          internalDateToDate(left.internalDate).getTime(),
+      )
+      .slice(0, MAX_SENDER_REPLY_EXAMPLES);
+
+    if (!sentReplies.length) return null;
+
+    return {
+      count: sentReplies.length,
+      content: sentReplies
+        .map((message) => {
+          const email = getEmailForLLM(message, {
+            maxLength: REPLY_EXAMPLE_CONTENT_MAX_LENGTH,
+            extractReply: true,
+            removeForwarded: true,
+          });
+
+          return `<reply_example>
+${stringifyEmail(email, REPLY_EXAMPLE_CONTENT_MAX_LENGTH)}
+</reply_example>`;
+        })
+        .join("\n\n"),
+    };
+  } catch (error) {
+    logger.warn("Failed to collect same-sender reply examples", {
+      error,
+      senderEmail: normalizedSenderEmail,
+    });
+    return null;
+  }
+}

--- a/apps/web/utils/reply-tracker/sender-reply-examples.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.ts
@@ -4,8 +4,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { Logger } from "@/utils/logger";
-import { removeExcessiveWhitespace } from "@/utils/string";
-import type { EmailForLLM } from "@/utils/types";
+import { stringifyEmail } from "@/utils/stringify-email";
 
 const MAX_SEARCHED_SENDER_THREADS = 8;
 const MAX_SENDER_REPLY_EXAMPLES = 3;
@@ -41,13 +40,13 @@ export async function collectSenderReplyExamples({
         if (currentMessageIds.has(message.id)) return false;
         if (!emailProvider.isSentMessage(message)) return false;
 
-        const recipients = extractEmailAddresses(
-          [
-            message.headers.to,
-            message.headers.cc ?? "",
-            message.headers.bcc ?? "",
-          ].join(","),
-        );
+        const recipients = [
+          message.headers.to,
+          message.headers.cc,
+          message.headers.bcc,
+        ]
+          .filter((header): header is string => Boolean(header))
+          .flatMap(extractEmailAddresses);
 
         return recipients.some((recipient) =>
           isSameEmailAddress(recipient, normalizedSenderEmail),
@@ -67,12 +66,11 @@ export async function collectSenderReplyExamples({
       content: sentReplies
         .map((message) => {
           const email = getEmailForLLM(message, {
-            maxLength: REPLY_EXAMPLE_BODY_MAX_LENGTH + 1,
             extractReply: true,
             removeForwarded: true,
           });
 
-          return formatReplyExample(email);
+          return `<reply_example>\n${stringifyEmail(email, REPLY_EXAMPLE_BODY_MAX_LENGTH)}\n</reply_example>`;
         })
         .join("\n\n"),
     };
@@ -83,31 +81,4 @@ export async function collectSenderReplyExamples({
     });
     return null;
   }
-}
-
-function formatReplyExample(email: EmailForLLM) {
-  const body = formatReplyExampleBody(email.content);
-  const bodyTag = body.truncated ? '<body truncated="true">' : "<body>";
-
-  return `<reply_example>
-<from>${email.from}</from>
-${email.to ? `<to>${email.to}</to>` : ""}
-${email.date ? `<date>${email.date.toISOString()}</date>` : ""}
-<subject>${email.subject}</subject>
-${bodyTag}${body.content}</body>
-</reply_example>`;
-}
-
-function formatReplyExampleBody(content: string) {
-  const cleanedContent = removeExcessiveWhitespace(content);
-  if (cleanedContent.length <= REPLY_EXAMPLE_BODY_MAX_LENGTH) {
-    return { content: cleanedContent, truncated: false };
-  }
-
-  return {
-    content: `${cleanedContent
-      .slice(0, REPLY_EXAMPLE_BODY_MAX_LENGTH)
-      .trimEnd()}\n[truncated]`,
-    truncated: true,
-  };
 }

--- a/apps/web/utils/reply-tracker/sender-reply-examples.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.ts
@@ -4,11 +4,12 @@ import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { Logger } from "@/utils/logger";
-import { stringifyEmail } from "@/utils/stringify-email";
+import { removeExcessiveWhitespace } from "@/utils/string";
+import type { EmailForLLM } from "@/utils/types";
 
 const MAX_SEARCHED_SENDER_THREADS = 8;
-const MAX_SENDER_REPLY_EXAMPLES = 5;
-const REPLY_EXAMPLE_CONTENT_MAX_LENGTH = 800;
+const MAX_SENDER_REPLY_EXAMPLES = 3;
+const REPLY_EXAMPLE_BODY_MAX_LENGTH = 600;
 
 export async function collectSenderReplyExamples({
   emailAccount,
@@ -66,14 +67,12 @@ export async function collectSenderReplyExamples({
       content: sentReplies
         .map((message) => {
           const email = getEmailForLLM(message, {
-            maxLength: REPLY_EXAMPLE_CONTENT_MAX_LENGTH,
+            maxLength: REPLY_EXAMPLE_BODY_MAX_LENGTH + 1,
             extractReply: true,
             removeForwarded: true,
           });
 
-          return `<reply_example>
-${stringifyEmail(email, REPLY_EXAMPLE_CONTENT_MAX_LENGTH)}
-</reply_example>`;
+          return formatReplyExample(email);
         })
         .join("\n\n"),
     };
@@ -84,4 +83,31 @@ ${stringifyEmail(email, REPLY_EXAMPLE_CONTENT_MAX_LENGTH)}
     });
     return null;
   }
+}
+
+function formatReplyExample(email: EmailForLLM) {
+  const body = formatReplyExampleBody(email.content);
+  const bodyTag = body.truncated ? '<body truncated="true">' : "<body>";
+
+  return `<reply_example>
+<from>${email.from}</from>
+${email.to ? `<to>${email.to}</to>` : ""}
+${email.date ? `<date>${email.date.toISOString()}</date>` : ""}
+<subject>${email.subject}</subject>
+${bodyTag}${body.content}</body>
+</reply_example>`;
+}
+
+function formatReplyExampleBody(content: string) {
+  const cleanedContent = removeExcessiveWhitespace(content);
+  if (cleanedContent.length <= REPLY_EXAMPLE_BODY_MAX_LENGTH) {
+    return { content: cleanedContent, truncated: false };
+  }
+
+  return {
+    content: `${cleanedContent
+      .slice(0, REPLY_EXAMPLE_BODY_MAX_LENGTH)
+      .trimEnd()}\n[truncated]`,
+    truncated: true,
+  };
 }


### PR DESCRIPTION
Improves draft reply generation by adding sender-specific reply examples as style context and avoiding current-thread messages being summarized as historical context.

- Adds a helper for collecting recent sent replies to the same sender.
- Records draft context metadata for injected sender examples.
- Adds unit and eval coverage for concise, grounded draft behavior.