### PR TITLE
test: Use real logger in unit tests

### DIFF
--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -4,21 +4,6 @@ import { GmailLabel } from "@/utils/gmail/label";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/utils/logger", () => ({
-  createScopedLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    trace: vi.fn(),
-    with: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      trace: vi.fn(),
-    }),
-  }),
-}));
-
 vi.mock("@/utils/gmail/retry", () => ({
   withGmailRetry: (fn: () => unknown) => fn(),
 }));

--- a/apps/web/utils/premium/seats.test.ts
+++ b/apps/web/utils/premium/seats.test.ts
@@ -28,14 +28,6 @@ vi.mock("@/utils/prisma", () => ({
   default: {},
 }));
 
-vi.mock("@/utils/logger", () => ({
-  createScopedLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
-
 vi.mock("@/ee/billing/lemon/index", () => ({
   updateSubscriptionItemQuantity: vi.fn(),
 }));


### PR DESCRIPTION
Removes unnecessary logger module mocks from deterministic unit tests so they use the production logger import path.

- Dropped direct logger mocks from two unit test files
- Leaves log behavior on the real implementation instead of replacing the logger module

Validation:
- pnpm test utils/gmail/draft.test.ts utils/premium/seats.test.ts