### PR TITLE
test: Centralize server-only mock

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -4,8 +4,6 @@ import { getEmailAccount, getMockMessage } from "@/__tests__/helpers";
 import { ActionType, GroupItemType } from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 const {
   envState,
   mockToolCallAgentStream,

--- a/apps/web/__tests__/ai-regression/ai-assistant-chat-send-disabled-regression.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-assistant-chat-send-disabled-regression.test.ts
@@ -6,8 +6,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 // Run with: pnpm test-ai ai-regression/ai-assistant-chat-send-disabled-regression
 
-vi.mock("server-only", () => ({}));
-
 const TIMEOUT = 15_000;
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 

--- a/apps/web/__tests__/ai-regression/ai-calendar-availability.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-calendar-availability.test.ts
@@ -10,8 +10,6 @@ const logger = createTestLogger();
 
 // Run with: pnpm test-ai ai-regression/ai-calendar-availability
 
-vi.mock("server-only", () => ({}));
-
 const TIMEOUT = 45_000;
 
 // Skip tests unless explicitly running AI tests

--- a/apps/web/__tests__/ai-regression/ai-categorize-senders.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-categorize-senders.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { aiCategorizeSenders } from "@/utils/ai/categorize-sender/ai-categorize-senders";
 import { defaultCategory } from "@/utils/categories";
 import { aiCategorizeSender } from "@/utils/ai/categorize-sender/ai-categorize-single-sender";
@@ -9,8 +9,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
 const TIMEOUT = 15_000;
-
-vi.mock("server-only", () => ({}));
 
 const emailAccount = getEmailAccount();
 

--- a/apps/web/__tests__/ai-regression/ai-choose-args.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-choose-args.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import { getActionItemsWithAiArgs } from "@/utils/ai/choose-rule/choose-args";
 import {
@@ -16,8 +16,6 @@ const logger = createTestLogger();
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
 const TIMEOUT = 15_000;
-
-vi.mock("server-only", () => ({}));
 
 function getDraftingEmailAccount() {
   return {

--- a/apps/web/__tests__/ai-regression/ai-choose-rule.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-choose-rule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { aiChooseRule } from "@/utils/ai/choose-rule/ai-choose-rule";
 import { ActionType } from "@/generated/prisma/enums";
 import { getEmail, getEmailAccount, getRule } from "@/__tests__/helpers";
@@ -8,8 +8,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 const logger = createScopedLogger("test");
-
-vi.mock("server-only", () => ({}));
 
 describe.runIf(isAiTest)("aiChooseRule", () => {
   test("Should return no rule when no rules passed", async () => {

--- a/apps/web/__tests__/ai-regression/ai-detect-recurring-pattern.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-detect-recurring-pattern.test.ts
@@ -12,7 +12,6 @@ import { formatUtcDate } from "@/utils/date";
 const TIMEOUT = 15_000;
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/braintrust", () => ({
   Braintrust: class {
     insertToDataset() {}

--- a/apps/web/__tests__/ai-regression/ai-extract-from-email-history.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-extract-from-email-history.test.ts
@@ -9,8 +9,6 @@ import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 const TIMEOUT = 15_000;
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
-
 // Skip tests unless explicitly running AI tests
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 

--- a/apps/web/__tests__/ai-regression/ai-extract-knowledge.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-extract-knowledge.test.ts
@@ -8,8 +8,6 @@ const logger = createTestLogger();
 
 // Run with: pnpm test-ai ai-regression/ai-extract-knowledge
 
-vi.mock("server-only", () => ({}));
-
 // Skip tests unless explicitly running AI tests
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 

--- a/apps/web/__tests__/ai-regression/ai-find-snippets.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-find-snippets.test.ts
@@ -1,11 +1,9 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { aiFindSnippets } from "@/utils/ai/snippets/find-snippets";
 import { getEmail, getEmailAccount } from "@/__tests__/helpers";
 // Run with: pnpm test-ai ai-regression/ai-find-snippets
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
-
-vi.mock("server-only", () => ({}));
 
 describe.runIf(isAiTest)("aiFindSnippets", () => {
   test("should find snippets in similar emails", async () => {

--- a/apps/web/__tests__/ai-regression/ai-mcp-agent.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-mcp-agent.test.ts
@@ -7,8 +7,6 @@ import { getEmailAccount, getEmail } from "@/__tests__/helpers";
 
 // Run with: pnpm test-ai ai-regression/ai-mcp-agent
 
-vi.mock("server-only", () => ({}));
-
 // Mock the MCP tools creation to return actual tools for testing
 vi.mock("@/utils/ai/mcp/mcp-tools", () => ({
   createMcpToolsForAgent: vi.fn(),

--- a/apps/web/__tests__/ai-regression/ai-meeting-briefing.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-meeting-briefing.test.ts
@@ -14,8 +14,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
-vi.mock("server-only", () => ({}));
-
 const logger = createScopedLogger("ai-meeting-briefing-test");
 
 const TIMEOUT = 60_000; // Longer timeout for agentic flow with research

--- a/apps/web/__tests__/ai-regression/ai-persona.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-persona.test.ts
@@ -7,8 +7,6 @@ const TIMEOUT = 30_000;
 
 // Run with: pnpm test-ai ai-regression/ai-persona
 
-vi.mock("server-only", () => ({}));
-
 // Skip tests unless explicitly running AI tests
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 

--- a/apps/web/__tests__/ai-regression/ai-prompt-to-rules.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-prompt-to-rules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { aiPromptToRules } from "@/utils/ai/rule/prompt-to-rules";
 import { createRuleSchema } from "@/utils/ai/rule/create-rule-schema";
 import { ActionType } from "@/generated/prisma/enums";
@@ -9,8 +9,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
 const TIMEOUT = 15_000;
-
-vi.mock("server-only", () => ({}));
 
 describe.runIf(isAiTest)("aiPromptToRules", () => {
   it(

--- a/apps/web/__tests__/ai-regression/ai-summarize-email-for-digest.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-summarize-email-for-digest.test.ts
@@ -9,8 +9,6 @@ type EmailAccountForDigest = EmailAccountWithAI & { name: string | null };
 
 // Run with: pnpm test-ai ai-regression/ai-summarize-email-for-digest
 
-vi.mock("server-only", () => ({}));
-
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 
 function getEmailAccount(overrides = {}): EmailAccountForDigest {

--- a/apps/web/__tests__/ai-regression/ai-writing-style.test.ts
+++ b/apps/web/__tests__/ai-regression/ai-writing-style.test.ts
@@ -6,8 +6,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 
 const TIMEOUT = 15_000;
 
-vi.mock("server-only", () => ({}));
-
 // Skip tests unless explicitly running AI tests
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 

--- a/apps/web/__tests__/ai-regression/determine-thread-status.test.ts
+++ b/apps/web/__tests__/ai-regression/determine-thread-status.test.ts
@@ -9,8 +9,6 @@ import { SystemType } from "@/generated/prisma/enums";
 
 // Run with: pnpm test-ai ai-regression/determine-thread-status
 
-vi.mock("server-only", () => ({}));
-
 const TIMEOUT = 15_000;
 
 // Skip tests unless explicitly running AI tests

--- a/apps/web/__tests__/ai-regression/reply/draft-follow-up.test.ts
+++ b/apps/web/__tests__/ai-regression/reply/draft-follow-up.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { aiDraftFollowUp } from "@/utils/ai/reply/draft-follow-up";
 import type { EmailForLLM } from "@/utils/types";
 import { getEmailAccount } from "@/__tests__/helpers";
@@ -6,8 +6,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 const TIMEOUT = 60_000;
 
 // Run with: pnpm test-ai ai-regression/reply/draft-follow-up
-
-vi.mock("server-only", () => ({}));
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 const TEST_TIMEOUT = 15_000;

--- a/apps/web/__tests__/ai-regression/reply/draft-reply.test.ts
+++ b/apps/web/__tests__/ai-regression/reply/draft-reply.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { aiDraftReply } from "@/utils/ai/reply/draft-reply";
 import type { EmailForLLM } from "@/utils/types";
 import { getEmailAccount } from "@/__tests__/helpers";
@@ -6,8 +6,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 const TIMEOUT = 60_000;
 
 // Run with: pnpm test-ai ai-regression/reply/draft-reply
-
-vi.mock("server-only", () => ({}));
 
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 const TEST_TIMEOUT = 15_000;

--- a/apps/web/__tests__/ai-regression/reply/reply-context-collector.test.ts
+++ b/apps/web/__tests__/ai-regression/reply/reply-context-collector.test.ts
@@ -6,8 +6,6 @@ import { getEmailAccount } from "@/__tests__/helpers";
 
 // Run with: pnpm test-ai ai-regression/reply/reply-context-collector
 
-vi.mock("server-only", () => ({}));
-
 const isAiTest = process.env.RUN_AI_TESTS === "true";
 const TEST_TIMEOUT = 60_000;
 

--- a/apps/web/__tests__/e2e/calendar/google-calendar.test.ts
+++ b/apps/web/__tests__/e2e/calendar/google-calendar.test.ts
@@ -8,7 +8,7 @@
  * 1. Set TEST_GMAIL_EMAIL env var to your Gmail address
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createGoogleAvailabilityProvider } from "@/utils/calendar/providers/google-availability";
 import { getCalendarClientWithRefresh } from "@/utils/calendar/client";
@@ -21,8 +21,6 @@ import { createScopedLogger } from "@/utils/logger";
 // ============================================
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_GMAIL_EMAIL = process.env.TEST_GMAIL_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Google Calendar Integration Tests", () => {
   let calendarConnection: {

--- a/apps/web/__tests__/e2e/calendar/microsoft-calendar.test.ts
+++ b/apps/web/__tests__/e2e/calendar/microsoft-calendar.test.ts
@@ -8,7 +8,7 @@
  * 1. Set TEST_OUTLOOK_EMAIL env var to your Outlook email
  */
 
-import { describe, test, expect, beforeAll, vi } from "vitest";
+import { describe, test, expect, beforeAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createMicrosoftAvailabilityProvider } from "@/utils/calendar/providers/microsoft-availability";
 import { createScopedLogger } from "@/utils/logger";
@@ -18,8 +18,6 @@ import { createScopedLogger } from "@/utils/logger";
 // ============================================
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Outlook Calendar Integration Tests", () => {
   let calendarConnection: {

--- a/apps/web/__tests__/e2e/cold-email/google-cold-email.test.ts
+++ b/apps/web/__tests__/e2e/cold-email/google-cold-email.test.ts
@@ -12,7 +12,7 @@
  * - TEST_GMAIL_EMAIL=<your gmail email>
  */
 
-import { describe, test, expect, beforeAll, vi } from "vitest";
+import { describe, test, expect, beforeAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import { extractEmailAddress, extractDomainFromEmail } from "@/utils/email";
@@ -23,8 +23,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_GMAIL_EMAIL = process.env.TEST_GMAIL_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS || !TEST_GMAIL_EMAIL)(
   "Cold Email Detection - Google",

--- a/apps/web/__tests__/e2e/cold-email/microsoft-cold-email.test.ts
+++ b/apps/web/__tests__/e2e/cold-email/microsoft-cold-email.test.ts
@@ -12,7 +12,7 @@
  * - TEST_OUTLOOK_EMAIL=<your outlook email>
  */
 
-import { describe, test, expect, beforeAll, vi } from "vitest";
+import { describe, test, expect, beforeAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import { extractEmailAddress, extractDomainFromEmail } from "@/utils/email";
@@ -23,8 +23,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 const PUBLIC_DOMAINS = [
   "gmail.com",

--- a/apps/web/__tests__/e2e/drafting/microsoft-drafting.test.ts
+++ b/apps/web/__tests__/e2e/drafting/microsoft-drafting.test.ts
@@ -11,7 +11,7 @@
  * 3. Set TEST_CONVERSATION_ID with a real conversationId from your logs (optional)
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { EmailProvider } from "@/utils/email/types";
@@ -31,8 +31,6 @@ const TEST_CONVERSATION_ID =
   process.env.TEST_CONVERSATION_ID ||
   "AQQkADAwATNiZmYAZS05YWEAYy1iNWY0LTAwAi0wMAoAEABuo-fmt9KvQ4u55KlWB32H";
 const TEST_OUTLOOK_MESSAGE_ID = process.env.TEST_OUTLOOK_MESSAGE_ID;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Microsoft Outlook Drafting E2E Tests", () => {
   let provider: EmailProvider;

--- a/apps/web/__tests__/e2e/flows/setup.ts
+++ b/apps/web/__tests__/e2e/flows/setup.ts
@@ -21,9 +21,6 @@ import {
 import { ensureWebhookSubscription } from "./helpers/webhook";
 import { logStep } from "./helpers/logging";
 
-// Mock server-only module (Next.js specific)
-vi.mock("server-only", () => ({}));
-
 // Mock message processing lock to always succeed
 vi.mock("@/utils/redis/message-processing", () => ({
   acquireOutboundMessageLock: vi.fn().mockResolvedValue("lock-token-1"),

--- a/apps/web/__tests__/e2e/gmail-operations.test.ts
+++ b/apps/web/__tests__/e2e/gmail-operations.test.ts
@@ -32,8 +32,6 @@ const TEST_GMAIL_EMAIL = process.env.TEST_GMAIL_EMAIL;
 let TEST_GMAIL_MESSAGE_ID =
   process.env.TEST_GMAIL_MESSAGE_ID || "199c055aa113c499";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/redis/message-processing", () => ({
   acquireOutboundMessageLock: vi.fn().mockResolvedValue("lock-token-1"),
   clearOutboundMessageLock: vi.fn().mockResolvedValue(true),

--- a/apps/web/__tests__/e2e/labeling/gmail-thread-label-removal.test.ts
+++ b/apps/web/__tests__/e2e/labeling/gmail-thread-label-removal.test.ts
@@ -9,7 +9,7 @@
  * pnpm test-e2e gmail-thread-label-removal
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { EmailProvider } from "@/utils/email/types";
@@ -22,8 +22,6 @@ import { findThreadWithMultipleMessages } from "./helpers";
 
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_GMAIL_EMAIL = process.env.TEST_GMAIL_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Gmail Thread Label Removal E2E Tests", () => {
   let provider: EmailProvider;

--- a/apps/web/__tests__/e2e/labeling/google-labeling.test.ts
+++ b/apps/web/__tests__/e2e/labeling/google-labeling.test.ts
@@ -17,7 +17,7 @@
  * - Clean up all test labels at the end
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { GmailProvider } from "@/utils/email/google";
@@ -33,8 +33,6 @@ const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_GMAIL_EMAIL = process.env.TEST_GMAIL_EMAIL;
 let _TEST_GMAIL_THREAD_ID = process.env.TEST_GMAIL_THREAD_ID;
 let _TEST_GMAIL_MESSAGE_ID = process.env.TEST_GMAIL_MESSAGE_ID;
-
-vi.mock("server-only", () => ({}));
 
 // Helper to ensure test IDs are available
 function getTestMessageId(): string {

--- a/apps/web/__tests__/e2e/labeling/microsoft-labeling.test.ts
+++ b/apps/web/__tests__/e2e/labeling/microsoft-labeling.test.ts
@@ -17,7 +17,7 @@
  * - Clean up all test labels at the end
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import { findOldMessage } from "@/__tests__/e2e/helpers";
@@ -37,8 +37,6 @@ const TEST_CONVERSATION_ID =
 const DEFAULT_TEST_OUTLOOK_MESSAGE_ID =
   "AQMkADAwATNiZmYAZS05YWEAYy1iNWY0LTAwAi0wMAoARgAAA-ybH4V64nRKkgXhv9H-GEkHAP38WoVoPXRMilGF27prOB8AAAIBDAAAAP38WoVoPXRMilGF27prOB8AAABGAqbwAAAA";
 let TEST_OUTLOOK_MESSAGE_ID = process.env.TEST_OUTLOOK_MESSAGE_ID || "";
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Microsoft Outlook Labeling E2E Tests", () => {
   let provider: EmailProvider;

--- a/apps/web/__tests__/e2e/labeling/microsoft-thread-category-removal.test.ts
+++ b/apps/web/__tests__/e2e/labeling/microsoft-thread-category-removal.test.ts
@@ -9,7 +9,7 @@
  * pnpm test-e2e microsoft-thread-category-removal
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { EmailProvider } from "@/utils/email/types";
@@ -22,8 +22,6 @@ import { findThreadWithMultipleMessages } from "./helpers";
 
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)(
   "Microsoft Outlook Thread Category Removal E2E Tests",

--- a/apps/web/__tests__/e2e/outlook-draft-read-status.test.ts
+++ b/apps/web/__tests__/e2e/outlook-draft-read-status.test.ts
@@ -9,7 +9,7 @@
  * Make sure TEST_OUTLOOK_EMAIL=you@email.com is set in .env.test
  */
 
-import { beforeAll, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import { findOldMessage } from "@/__tests__/e2e/helpers";
@@ -19,8 +19,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)(
   "Outlook Draft Read Status Preservation",

--- a/apps/web/__tests__/e2e/outlook-operations.test.ts
+++ b/apps/web/__tests__/e2e/outlook-operations.test.ts
@@ -38,8 +38,6 @@ const TEST_CONVERSATION_ID =
   "AQQkADAwATNiZmYAZS05YWEAYy1iNWY0LTAwAi0wMAoAEABuo-fmt9KvQ4u55KlWB32H"; // Real conversation ID from demoinboxzero@outlook.com
 const TEST_CATEGORY_NAME = process.env.TEST_CATEGORY_NAME || "To Reply";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/redis/message-processing", () => ({
   acquireOutboundMessageLock: vi.fn().mockResolvedValue("lock-token-1"),
   clearOutboundMessageLock: vi.fn().mockResolvedValue(true),

--- a/apps/web/__tests__/e2e/outlook-query-parsing.test.ts
+++ b/apps/web/__tests__/e2e/outlook-query-parsing.test.ts
@@ -12,7 +12,7 @@
  * - TEST_OUTLOOK_EMAIL=<your outlook email>
  */
 
-import { describe, test, expect, beforeAll, vi } from "vitest";
+import { describe, test, expect, beforeAll } from "vitest";
 import { subMonths } from "date-fns/subMonths";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -22,8 +22,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)(
   "Outlook Query Parsing E2E",

--- a/apps/web/__tests__/e2e/outlook-search.test.ts
+++ b/apps/web/__tests__/e2e/outlook-search.test.ts
@@ -9,7 +9,7 @@
  * - TEST_OUTLOOK_EMAIL=<your outlook email>
  */
 
-import { beforeAll, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { EmailProvider } from "@/utils/email/types";
@@ -18,8 +18,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 const RUN_E2E_TESTS = process.env.RUN_E2E_TESTS;
 const TEST_OUTLOOK_EMAIL = process.env.TEST_OUTLOOK_EMAIL;
-
-vi.mock("server-only", () => ({}));
 
 describe.skipIf(!RUN_E2E_TESTS)("Outlook Search Edge Cases", () => {
   let provider: EmailProvider | undefined;

--- a/apps/web/__tests__/eval/analyze-document.test.ts
+++ b/apps/web/__tests__/eval/analyze-document.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import {
   describeEvalMatrix,
   shouldRunEvalTests,
@@ -8,8 +8,6 @@ import { analyzeDocument } from "@/utils/ai/document-filing/analyze-document";
 
 // pnpm test-ai eval/analyze-document
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/analyze-document
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 30_000;

--- a/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
@@ -24,8 +24,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-attachments
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-attachments
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-calendar.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-calendar.test.ts
@@ -18,8 +18,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-calendar
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-calendar
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-core-tools.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-core-tools.test.ts
@@ -20,8 +20,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-core-tools
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-core-tools
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const MULTI_STEP_TIMEOUT = 120_000;

--- a/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
@@ -24,8 +24,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-email-actions
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-email-actions
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
@@ -14,8 +14,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 export const shouldRunEval = shouldRunEvalTests();
 export const TIMEOUT = 120_000;
 const logger = createScopedLogger("eval-assistant-chat-inbox-workflows");

--- a/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
@@ -18,8 +18,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-label-management
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-label-management
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
@@ -30,8 +30,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-memory-safety
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-memory-safety
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 240_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
@@ -22,8 +22,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-phishing-hardening.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-phishing-hardening.test.ts
@@ -22,8 +22,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-phishing-hardening
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-phishing-hardening
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-progressive-disclosure.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-progressive-disclosure.test.ts
@@ -19,8 +19,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-progressive-disclosure
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-progressive-disclosure
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-action-preservation.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-action-preservation.test.ts
@@ -25,8 +25,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing-action-preservation
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing-action-preservation
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 240_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-action-updates.test.ts
@@ -26,8 +26,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 240_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-condition-updates.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-condition-updates.test.ts
@@ -30,8 +30,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
@@ -27,8 +27,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const evalReporter = createEvalReporter();
 const logger = createScopedLogger(

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-learned-patterns.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-learned-patterns.test.ts
@@ -23,8 +23,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-overlap-exceptions.test.ts
@@ -33,8 +33,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing-overlap-exceptions
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing-overlap-exceptions
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
@@ -26,8 +26,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-rule-editing-patch-semantics
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-rule-editing-patch-semantics
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 240_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-suggestions.test.ts
@@ -38,8 +38,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-rule-suggestions.test.ts
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const evalReporter = createEvalReporter();
 const logger = createScopedLogger("eval-assistant-chat-rule-suggestions");

--- a/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
@@ -18,8 +18,6 @@ import {
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts
 
-vi.mock("server-only", () => ({}));
-
 const evalReporter = createEvalReporter();
 
 const hoisted = vi.hoisted(() => ({

--- a/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
@@ -32,8 +32,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-settings-memory
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-settings-memory
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-static-sender-rules-learned-patterns.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-static-sender-rules-learned-patterns.test.ts
@@ -22,8 +22,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-static-sender-rules
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-static-sender-rules
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 150_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-static-sender-rules-semantic.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-static-sender-rules-semantic.test.ts
@@ -27,8 +27,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-static-sender-rules
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-static-sender-rules
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 150_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-static-sender-rules-static-from.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-static-sender-rules-static-from.test.ts
@@ -23,8 +23,6 @@ import { createScopedLogger } from "@/utils/logger";
 // pnpm test-ai eval/assistant-chat-static-sender-rules
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-static-sender-rules
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 150_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
@@ -23,8 +23,6 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 // pnpm test-ai eval/assistant-chat-trash-delete
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-trash-delete
 
-vi.mock("server-only", () => ({}));
-
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
 const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/categorize-senders.test.ts
+++ b/apps/web/__tests__/eval/categorize-senders.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, afterAll } from "vitest";
+import { describe, test, expect, afterAll } from "vitest";
 import {
   describeEvalMatrix,
   shouldRunEvalTests,
@@ -9,8 +9,6 @@ import { defaultCategory } from "@/utils/categories";
 
 // pnpm test-ai eval/categorize-senders
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/categorize-senders
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, afterAll } from "vitest";
+import { describe, test, expect, afterAll } from "vitest";
 import { SystemType } from "@/generated/prisma/enums";
 import {
   describeEvalMatrix,
@@ -13,8 +13,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 // pnpm test-ai eval/choose-rule
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/choose-rule
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/classification-feedback-hint.test.ts
+++ b/apps/web/__tests__/eval/classification-feedback-hint.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, afterAll } from "vitest";
+import { describe, test, expect, afterAll } from "vitest";
 import { SystemType } from "@/generated/prisma/enums";
 import {
   describeEvalMatrix,
@@ -13,8 +13,6 @@ import { getEmail, getRule } from "@/__tests__/helpers";
 
 // pnpm test-ai eval/classification-feedback-hint
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/classification-feedback-hint
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/cold-email.test.ts
+++ b/apps/web/__tests__/eval/cold-email.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { getEmail } from "@/__tests__/helpers";
 import {
   describeEvalMatrix,
@@ -9,8 +9,6 @@ import { isColdEmail } from "@/utils/cold-email/is-cold-email";
 
 // pnpm test-ai eval/cold-email
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/cold-email
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/determine-thread-status.test.ts
+++ b/apps/web/__tests__/eval/determine-thread-status.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { getEmail } from "@/__tests__/helpers";
 import {
   describeEvalMatrix,
@@ -9,8 +9,6 @@ import { SystemType } from "@/generated/prisma/enums";
 import { aiDetermineThreadStatus } from "@/utils/ai/reply/determine-thread-status";
 
 // pnpm test-ai eval/determine-thread-status
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/draft-attachments.test.ts
+++ b/apps/web/__tests__/eval/draft-attachments.test.ts
@@ -13,7 +13,6 @@ import { selectDraftAttachmentsForRule } from "@/utils/attachments/draft-attachm
 // pnpm test-ai eval/draft-attachments
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/draft-attachments
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 vi.mock("@/utils/user/get", () => ({

--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { aiDraftReplyWithConfidence } from "@/utils/ai/reply/draft-reply";
 import { getEmail } from "@/__tests__/helpers";
 import { judgeMultiple } from "@/__tests__/eval/judge";
@@ -17,8 +17,6 @@ import {
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 90_000;
-
-vi.mock("server-only", () => ({}));
 
 describe.runIf(shouldRunEval)("draft-reply eval", () => {
   const evalReporter = createEvalReporter();

--- a/apps/web/__tests__/eval/prompt-security-core-paths.test.ts
+++ b/apps/web/__tests__/eval/prompt-security-core-paths.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { createTestLogger, getEmail, getRule } from "@/__tests__/helpers";
 import {
   describeEvalMatrix,
@@ -12,8 +12,6 @@ import { isColdEmail } from "@/utils/cold-email/is-cold-email";
 
 // pnpm test-ai eval/prompt-security-core-paths
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/prompt-security-core-paths
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;

--- a/apps/web/__tests__/eval/reply-memory.test.ts
+++ b/apps/web/__tests__/eval/reply-memory.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import { getEmail } from "@/__tests__/helpers";
 import {
   describeEvalMatrix,
@@ -18,8 +18,6 @@ import { isDefined } from "@/utils/types";
 
 // EVAL_MODELS=gpt-5.4-mini pnpm test-ai eval/reply-memory
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/reply-memory
-
-vi.mock("server-only", () => ({}));
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 180_000;

--- a/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
+++ b/apps/web/__tests__/integration/demo-inbox-fixture.test.ts
@@ -1,12 +1,10 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { saasFounderMixedInbox } from "@/__tests__/fixtures/inboxes/demo-inboxes";
 import { toGmailSeedMessages } from "@/__tests__/fixtures/inboxes/adapters";
 import {
   createGmailTestHarness,
   type GmailTestHarness,
 } from "@/__tests__/integration/helpers";
-
-vi.mock("server-only", () => ({}));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
 

--- a/apps/web/__tests__/integration/draft-creation.test.ts
+++ b/apps/web/__tests__/integration/draft-creation.test.ts
@@ -14,8 +14,6 @@ import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { draftEmail } from "@/utils/gmail/mail";
 import { sendDraft } from "@/utils/gmail/draft";
 
-vi.mock("server-only", () => ({}));
-
 // draftEmail needs ensureEmailSendingEnabled which checks env vars
 vi.mock("@/utils/mail", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/utils/mail")>();

--- a/apps/web/__tests__/integration/labeling-archiving.test.ts
+++ b/apps/web/__tests__/integration/labeling-archiving.test.ts
@@ -22,8 +22,6 @@ import {
   GmailLabel,
 } from "@/utils/gmail/label";
 
-vi.mock("server-only", () => ({}));
-
 // Mock Tinybird — archiveThread publishes analytics
 vi.mock("@inboxzero/tinybird", () => ({
   publishArchive: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/integration/provider-operations.test.ts
+++ b/apps/web/__tests__/integration/provider-operations.test.ts
@@ -17,7 +17,6 @@ import {
   type ProviderTestHarness,
 } from "./helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@inboxzero/tinybird", () => ({
   publishArchive: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/__tests__/integration/rule-execution.test.ts
+++ b/apps/web/__tests__/integration/rule-execution.test.ts
@@ -16,8 +16,6 @@ import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 // Mock Prisma — executeAct updates executedRule status
 const mockExecutedRuleUpdate = vi.fn().mockResolvedValue({});
 const mockActionUpdateMany = vi.fn().mockResolvedValue({ count: 0 });

--- a/apps/web/__tests__/integration/run-rules-learned-exclusions.test.ts
+++ b/apps/web/__tests__/integration/run-rules-learned-exclusions.test.ts
@@ -23,7 +23,6 @@ import { aiChooseRule } from "@/utils/ai/choose-rule/ai-choose-rule";
 import type { RuleWithActions } from "@/utils/types";
 import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({
   after: vi.fn(),
 }));

--- a/apps/web/__tests__/integration/security-pipeline.test.ts
+++ b/apps/web/__tests__/integration/security-pipeline.test.ts
@@ -9,7 +9,7 @@
  *   pnpm test __tests__/integration/security-pipeline.test.ts
  */
 
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect } from "vitest";
 import { ActionType } from "@/generated/prisma/enums";
 import { getAction } from "@/__tests__/helpers";
 import {
@@ -18,8 +18,6 @@ import {
   getParameterFieldsForAction,
 } from "@/utils/ai/choose-rule/choose-args";
 import type { ActionArgResponse } from "@/utils/ai/choose-rule/ai-choose-args";
-
-vi.mock("server-only", () => ({}));
 
 describe("Template variable containment through the pipeline", () => {
   test("reply action with template content merges AI content but ignores injected cc/bcc", () => {

--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -18,7 +18,6 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const aiProcessAssistantChatMock = vi.fn();

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -31,7 +31,6 @@ import {
 } from "@/generated/prisma/enums";
 import { createGmailTestHarness } from "./helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/rule/rule-history", () => ({
   createRuleHistory: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/integration/sso-okta.test.ts
+++ b/apps/web/__tests__/integration/sso-okta.test.ts
@@ -13,7 +13,6 @@ import { discoverOIDCConfig, type OIDCConfig } from "@better-auth/sso";
 import prisma from "@/utils/__mocks__/prisma";
 import { GET } from "@/app/api/sso/signin/route";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@inboxzero/loops", () => ({
   createContact: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/integration/stats-reuse-messages.test.ts
+++ b/apps/web/__tests__/integration/stats-reuse-messages.test.ts
@@ -16,8 +16,6 @@ import type { GmailProvider } from "@/utils/email/google";
 import { saveBatch } from "@/utils/actions/stats-loading";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 // Mock Prisma — saveBatch writes to emailMessage table
 const mockCreateMany = vi.fn().mockResolvedValue({ count: 0 });
 vi.mock("@/utils/prisma", () => ({

--- a/apps/web/__tests__/integration/thread-fetching.test.ts
+++ b/apps/web/__tests__/integration/thread-fetching.test.ts
@@ -8,11 +8,9 @@
  *   pnpm test-integration thread-fetching
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import { createGmailTestHarness, type GmailTestHarness } from "./helpers";
 import { getThread, getThreadsWithNextPageToken } from "@/utils/gmail/thread";
-
-vi.mock("server-only", () => ({}));
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
 const TEST_EMAIL = "thread-test@example.com";

--- a/apps/web/__tests__/integration/webhook-action.test.ts
+++ b/apps/web/__tests__/integration/webhook-action.test.ts
@@ -16,8 +16,6 @@ import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 // Mock Prisma — executeAct updates status, callWebhook reads user secret
 const mockExecutedRuleUpdate = vi.fn().mockResolvedValue({});
 vi.mock("@/utils/prisma", () => ({

--- a/apps/web/__tests__/integration/webhook-flow.test.ts
+++ b/apps/web/__tests__/integration/webhook-flow.test.ts
@@ -27,7 +27,6 @@ import {
 } from "@/generated/prisma/enums";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({
   after: vi.fn((fn: () => void) => fn()),
 }));

--- a/apps/web/__tests__/integration/worker-queue.test.ts
+++ b/apps/web/__tests__/integration/worker-queue.test.ts
@@ -17,8 +17,6 @@ import { once } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 const bullmqState = vi.hoisted(() => {
   let nextJobId = 1;
   const processors = new Map<string, Set<(job: any) => Promise<void>>>();

--- a/apps/web/__tests__/setup.ts
+++ b/apps/web/__tests__/setup.ts
@@ -2,6 +2,8 @@ import { vi } from "vitest";
 
 setRequiredTestEnv();
 
+vi.mock("server-only", () => ({}));
+
 // Mock next/server's after() to just run synchronously in tests
 vi.mock("next/server", async () => {
   const actual = await vi.importActual("next/server");

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -37,8 +37,6 @@ class MockResizeObserver {
 (globalThis as { ResizeObserver?: typeof MockResizeObserver }).ResizeObserver =
   MockResizeObserver;
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("next/navigation", () => ({
   useRouter: () => mockUseRouter(),
 }));

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.test.ts
@@ -3,8 +3,6 @@ import { env } from "@/env";
 import { ActionType, SystemType } from "@/generated/prisma/enums";
 import { getRuleActionTypeOptions } from "./RuleForm";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/env", () => ({
   env: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.test.tsx
@@ -31,8 +31,6 @@ vi.mock("next/link", () => ({
   }) => <a href={href}>{children}</a>,
 }));
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/hooks/useRules", () => ({
   useRules: () => mockUseRules(),
 }));

--- a/apps/web/app/(app)/[emailAccountId]/calendars/TimezoneDetector.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/TimezoneDetector.test.ts
@@ -6,8 +6,6 @@ import {
   type DismissedPrompt,
 } from "./TimezoneDetector.utils";
 
-vi.mock("server-only", () => ({}));
-
 describe("shouldShowTimezonePrompt", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const { afterMock, headersMock, isValidInternalApiKeyMock } = vi.hoisted(
   () => ({
     afterMock: vi.fn(),

--- a/apps/web/app/api/apple/webhook/route.test.ts
+++ b/apps/web/app/api/apple/webhook/route.test.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const { syncAppleSubscriptionToDbMock, verifyAppleNotificationPayloadMock } =
   vi.hoisted(() => ({
     syncAppleSubscriptionToDbMock: vi.fn(),

--- a/apps/web/app/api/automation-jobs/execute/queue/route.test.ts
+++ b/apps/web/app/api/automation-jobs/execute/queue/route.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 type QueueMetadata = {
   deliveryCount: number;
   messageId: string;

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount } from "@/__tests__/helpers";

--- a/apps/web/app/api/clean/history/route.test.ts
+++ b/apps/web/app/api/clean/history/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest, NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SafeError } from "@/utils/error";

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -6,8 +6,6 @@ import { CleanAction } from "@/generated/prisma/enums";
 import { getMockMessage } from "@/__tests__/helpers";
 import { SafeError } from "@/utils/error";
 
-vi.mock("server-only", () => ({}));
-
 const { cleanerEnv } = vi.hoisted(() => ({
   cleanerEnv: {
     NEXT_PUBLIC_CLEANER_ENABLED: true,

--- a/apps/web/app/api/cron/draft-cleanup/route.test.ts
+++ b/apps/web/app/api/cron/draft-cleanup/route.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 const testLogger = createTestLogger();
 
 const { envMock, captureExceptionMock, cleanupDraftsMock } = vi.hoisted(() => ({

--- a/apps/web/app/api/cron/reasoning-retention/route.test.ts
+++ b/apps/web/app/api/cron/reasoning-retention/route.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 const testLogger = createTestLogger();
 
 const { envMock, captureExceptionMock, enforceRetentionMock } = vi.hoisted(

--- a/apps/web/app/api/email-stream/route.test.ts
+++ b/apps/web/app/api/email-stream/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest, NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SafeError } from "@/utils/error";

--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -8,8 +8,6 @@ import { createScopedLogger } from "@/utils/logger";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/google/webhook/process-history-item.test.ts
+++ b/apps/web/app/api/google/webhook/process-history-item.test.ts
@@ -13,7 +13,6 @@ import { createEmailProvider } from "@/utils/email/provider";
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({
   after: vi.fn((callback) => callback()),
 }));

--- a/apps/web/app/api/google/webhook/process-history.test.ts
+++ b/apps/web/app/api/google/webhook/process-history.test.ts
@@ -13,8 +13,6 @@ const logger = createTestLogger();
 // Mock logger.with to return the same logger instance so spies work
 vi.spyOn(logger, "with").mockReturnValue(logger);
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/gmail/client", () => ({
   getGmailClientWithRefresh: vi.fn().mockResolvedValue({}),
 }));

--- a/apps/web/app/api/google/webhook/process-label-added-event.test.ts
+++ b/apps/web/app/api/google/webhook/process-label-added-event.test.ts
@@ -10,8 +10,6 @@ import { fetchSenderFromMessage } from "@/app/api/google/webhook/fetch-sender-fr
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/prisma", () => ({
   default: {
     rule: {

--- a/apps/web/app/api/google/webhook/process-label-removed-event.test.ts
+++ b/apps/web/app/api/google/webhook/process-label-removed-event.test.ts
@@ -14,8 +14,6 @@ import { findRuleByLabelId } from "@/utils/rule/classification-feedback";
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
-
 // Mock dependencies
 vi.mock("@/utils/prisma", () => ({
   default: {

--- a/apps/web/app/api/google/webhook/route.test.ts
+++ b/apps/web/app/api/google/webhook/route.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const {
   envMock,
   processHistoryForUserMock,

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/image-proxy/route.test.ts
+++ b/apps/web/app/api/image-proxy/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/app/api/mcp/[integration]/callback/route.test.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/mobile-review/sign-in/route.test.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/app/api/mobile-review/status/route.test.ts
+++ b/apps/web/app/api/mobile-review/status/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/outlook/webhook/learn-label-removal.test.ts
+++ b/apps/web/app/api/outlook/webhook/learn-label-removal.test.ts
@@ -6,8 +6,6 @@ import { getMockParsedMessage } from "@/__tests__/mocks/email-provider.mock";
 import { learnFromOutlookLabelRemoval } from "./learn-label-removal";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/prisma", () => ({
   default: {
     executedRule: {

--- a/apps/web/app/api/outlook/webhook/process-history.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.test.ts
@@ -16,7 +16,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 vi.spyOn(logger, "with").mockReturnValue(logger);
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("next/server")>();
   return {

--- a/apps/web/app/api/outlook/webhook/process-lifecycle.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-lifecycle.test.ts
@@ -14,7 +14,6 @@ import { createManagedOutlookSubscription } from "@/utils/outlook/subscription-m
 import { backfillRecentOutlookMessages } from "@/utils/outlook/backfill-recent-messages";
 import { processOutlookLifecycleNotification } from "@/app/api/outlook/webhook/process-lifecycle";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({
   default: {
     emailMessage: {

--- a/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
+++ b/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
@@ -7,7 +7,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
-vi.mock("server-only", () => ({}));
 
 describe("disableUnusedAutoDrafts", () => {
   beforeEach(() => {

--- a/apps/web/app/api/slack/events/route.test.ts
+++ b/apps/web/app/api/slack/events/route.test.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const {
   ensureSlackTeamInstallationMock,
   extractSlackTeamIdFromWebhookMock,

--- a/apps/web/app/api/sso/signin/route.test.ts
+++ b/apps/web/app/api/sso/signin/route.test.ts
@@ -1,5 +1,3 @@
-// Mock server-only as per testing guidelines
-vi.mock("server-only", () => ({}));
 vi.mock("@inboxzero/loops", () => ({
   createContact: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/app/api/telegram/events/route.test.ts
+++ b/apps/web/app/api/telegram/events/route.test.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock, handleMessagingWebhookRouteMock } = vi.hoisted(() => ({
   envMock: {
     TELEGRAM_BOT_TOKEN: "test-telegram-token" as string | undefined,

--- a/apps/web/app/api/unsubscribe/route.test.ts
+++ b/apps/web/app/api/unsubscribe/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 

--- a/apps/web/app/api/user/complete-registration/route.test.ts
+++ b/apps/web/app/api/user/complete-registration/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/app/api/user/debug/memories/route.test.ts
+++ b/apps/web/app/api/user/debug/memories/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/user/digest-settings/route.test.ts
+++ b/apps/web/app/api/user/digest-settings/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/web/app/api/user/drive/filings/route.test.ts
+++ b/apps/web/app/api/user/drive/filings/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/user/group/route.test.ts
+++ b/apps/web/app/api/user/group/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -1,5 +1,3 @@
-vi.mock("server-only", () => ({}));
-
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";

--- a/apps/web/app/api/user/stats/by-period/controller.test.ts
+++ b/apps/web/app/api/user/stats/by-period/controller.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 import { getStatsByPeriod } from "./controller";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("getStatsByPeriod", () => {

--- a/apps/web/app/api/user/stats/response-time/calculate.test.ts
+++ b/apps/web/app/api/user/stats/response-time/calculate.test.ts
@@ -8,7 +8,6 @@ import { getMockMessage as getMockMessageHelper } from "../../../../../__tests__
 import { createTestLogger } from "@/__tests__/helpers";
 import { sleep } from "@/utils/sleep";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/app/api/user/stats/response-time/controller.test.ts
+++ b/apps/web/app/api/user/stats/response-time/controller.test.ts
@@ -4,7 +4,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 import { getResponseTimeStats } from "./controller";
 import { sleep } from "@/utils/sleep";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/components/assistant-chat/tools.search-inbox-result.test.tsx
+++ b/apps/web/components/assistant-chat/tools.search-inbox-result.test.tsx
@@ -3,7 +3,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/actions/assistant-chat", () => ({
   confirmAssistantCreateRule: vi.fn(),
   confirmAssistantEmailAction: vi.fn(),

--- a/apps/web/ee/billing/stripe/sync-stripe.test.ts
+++ b/apps/web/ee/billing/stripe/sync-stripe.test.ts
@@ -1,6 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("server-only", () => ({}));
+import { describe, expect, it } from "vitest";
 
 import { getEffectiveStripeSubscriptionStatus } from "./sync-stripe";
 

--- a/apps/web/utils/actions/__tests__/copy-rules-action.test.ts
+++ b/apps/web/utils/actions/__tests__/copy-rules-action.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@/__tests__/helpers";
 import { ActionType } from "@/generated/prisma/enums";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({ user: { id: "user1", email: "test@test.com" } })),

--- a/apps/web/utils/actions/__tests__/invitation-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/invitation-actions.test.ts
@@ -12,7 +12,6 @@ const { mockEnv, mockSendOrganizationInvitation } = vi.hoisted(() => ({
   mockSendOrganizationInvitation: vi.fn(),
 }));
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({ user: { id: "u1", email: "test@test.com" } })),

--- a/apps/web/utils/actions/__tests__/organization-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/organization-actions.test.ts
@@ -8,7 +8,6 @@ const { mockEnv } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({ user: { id: "u1", email: "test@test.com" } })),

--- a/apps/web/utils/actions/ai-rule.test.ts
+++ b/apps/web/utils/actions/ai-rule.test.ts
@@ -13,7 +13,6 @@ const {
   runRulesMock: vi.fn(),
 }));
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/assistant-chat-create-rule.test.ts
+++ b/apps/web/utils/actions/assistant-chat-create-rule.test.ts
@@ -11,7 +11,6 @@ vi.mock("@/utils/rule/rule", async (importOriginal) => {
   };
 });
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({ user: { id: "u1", email: "owner@example.com" } })),

--- a/apps/web/utils/actions/assistant-chat.server-action-boundary.test.ts
+++ b/apps/web/utils/actions/assistant-chat.server-action-boundary.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/email/provider");
 vi.mock("@/utils/auth", () => ({

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -11,7 +11,6 @@ import {
 } from "@/utils/actions/assistant-chat-confirmation";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/email/provider");
 vi.mock("@/utils/auth", () => ({

--- a/apps/web/utils/actions/automation-jobs.test.ts
+++ b/apps/web/utils/actions/automation-jobs.test.ts
@@ -13,7 +13,6 @@ import {
   toggleAutomationJobAction,
 } from "@/utils/actions/automation-jobs";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/categorize.test.ts
+++ b/apps/web/utils/actions/categorize.test.ts
@@ -3,7 +3,6 @@ import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { bulkCategorizeSendersAction } from "@/utils/actions/categorize";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/email-account.test.ts
+++ b/apps/web/utils/actions/email-account.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { updateEmailAccountRoleAction } from "./email-account";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/follow-up-reminders.test.ts
+++ b/apps/web/utils/actions/follow-up-reminders.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { updateFollowUpSettingsAction } from "@/utils/actions/follow-up-reminders";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/generate-reply.test.ts
+++ b/apps/web/utils/actions/generate-reply.test.ts
@@ -7,7 +7,6 @@ import { aiGenerateNudge } from "@/utils/ai/reply/generate-nudge";
 import { getReply, saveReply } from "@/utils/redis/reply";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/mail-bulk-action.test.ts
+++ b/apps/web/utils/actions/mail-bulk-action.test.ts
@@ -3,7 +3,6 @@ import { getMockEmailAccountWithAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { bulkArchiveAction } from "@/utils/actions/mail-bulk-action";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -18,7 +18,6 @@ import {
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 import { sendChannelConfirmation } from "@/utils/messaging/providers/slack/send";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/onboarding.test.ts
+++ b/apps/web/utils/actions/onboarding.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { saveOnboardingAnswersAction } from "./onboarding";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/organization.test.ts
+++ b/apps/web/utils/actions/organization.test.ts
@@ -5,7 +5,6 @@ import {
   updateMemberRoleAction,
 } from "@/utils/actions/organization";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/rule.test.ts
+++ b/apps/web/utils/actions/rule.test.ts
@@ -17,7 +17,6 @@ vi.mock("@/utils/rule/rule", async (importOriginal) => {
   };
 });
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/email/provider", () => ({

--- a/apps/web/utils/actions/settings.test.ts
+++ b/apps/web/utils/actions/settings.test.ts
@@ -6,7 +6,6 @@ import {
 } from "./settings";
 import { Provider } from "@/utils/llms/config";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -5,7 +5,6 @@ import { updateAccountSeats } from "@/utils/premium/seats";
 import { aliasPosthogUser } from "@/utils/posthog";
 import { deleteEmailAccountAction } from "./user";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/actions/webhook.test.ts
+++ b/apps/web/utils/actions/webhook.test.ts
@@ -9,7 +9,6 @@ const { mockEnv } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(async () => ({

--- a/apps/web/utils/ai/action-attachments.test.ts
+++ b/apps/web/utils/ai/action-attachments.test.ts
@@ -4,7 +4,6 @@ import { resolveActionAttachments } from "@/utils/ai/action-attachments";
 import { resolveDraftAttachments } from "@/utils/attachments/draft-attachments";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   resolveDraftAttachments: vi.fn(),
 }));

--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -13,7 +13,6 @@ import {
 import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
-vi.mock("server-only", () => ({}));
 
 vi.mock("@/utils/attachments/draft-attachments", () => ({
   resolveDraftAttachments: vi.fn().mockResolvedValue([]),

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -15,7 +15,6 @@ import {
   startSenderCategorizationTool,
 } from "./chat-inbox-tools";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/email/provider");
 vi.mock("@/utils/posthog", () => ({

--- a/apps/web/utils/ai/assistant/chat-label-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.test.ts
@@ -4,7 +4,6 @@ import { createScopedLogger } from "@/utils/logger";
 import { createEmailProvider } from "@/utils/email/provider";
 import { createOrGetLabelTool, listLabelsTool } from "./chat-label-tools";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/email/provider");
 vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -9,8 +9,6 @@ import { createRuleTool } from "./tools/rules/create-rule-tool";
 import { updateRuleTool } from "./tools/rules/update-rule-tool";
 import { updateRuleStateTool } from "./tools/rules/update-rule-state-tool";
 
-vi.mock("server-only", () => ({}));
-
 const {
   mockCreateRule,
   mockOutboundActionsNeedChatRiskConfirmation,

--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -10,7 +10,6 @@ import { getUserPremium } from "@/utils/user/get";
 import { getAssistantCapabilitiesTool } from "./tools/settings/get-assistant-capabilities-tool";
 import { updateAssistantSettingsTool } from "./tools/settings/update-assistant-settings-tool";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
@@ -4,7 +4,6 @@ import { createScopedLogger } from "@/utils/logger";
 import { saveLearnedPatterns } from "@/utils/rule/learned-patterns";
 import { updateLearnedPatternsTool } from "./update-learned-patterns-tool";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
@@ -4,7 +4,6 @@ import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import { updatePersonalInstructionsTool } from "./update-personal-instructions-tool";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/ai/automated-archive-exception.test.ts
+++ b/apps/web/utils/ai/automated-archive-exception.test.ts
@@ -2,8 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionType } from "@/generated/prisma/enums";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock } = vi.hoisted(() => ({
   envMock: {
     WHITELIST_FROM: undefined as string | undefined,

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -8,8 +8,6 @@ const { mockGenerateText, mockCreateGenerateText } = vi.hoisted(() => {
   return { mockGenerateText, mockCreateGenerateText };
 });
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/llms", () => ({
   createGenerateText: mockCreateGenerateText,
 }));

--- a/apps/web/utils/ai/choose-rule/choose-args.security.test.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.security.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { ActionType } from "@/generated/prisma/enums";
 import { getAction } from "@/__tests__/helpers";
 import {
@@ -7,8 +7,6 @@ import {
   mergeTemplateWithVars,
   parseTemplate,
 } from "./choose-args";
-
-vi.mock("server-only", () => ({}));
 
 describe("Template Variable Containment", () => {
   it("ignores AI-injected cc/bcc when only content has a template variable", () => {

--- a/apps/web/utils/ai/choose-rule/choose-args.test.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import {
   combineActionsWithAiArgs,
@@ -11,8 +11,6 @@ import type { Action } from "@/generated/prisma/client";
 import type { DraftAttribution } from "@/utils/ai/reply/draft-attribution";
 
 // Run with: pnpm test apps/web/utils/ai/choose-rule/choose-args.test.ts
-
-vi.mock("server-only", () => ({}));
 
 describe("getParameterFieldsForAction", () => {
   it("creates schema for simple field", () => {

--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -12,8 +12,6 @@ import type { ParsedMessage } from "@/utils/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/prisma", () => ({
   default: {
     executedAction: {

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -7,8 +7,6 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock } = vi.hoisted(() => ({
   envMock: {
     WHITELIST_FROM: undefined as string | undefined,

--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -37,7 +37,6 @@ const provider = {
   isReplyInThread: vi.fn().mockReturnValue(false),
 } as unknown as EmailProvider;
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/ai/choose-rule/ai-choose-rule", () => ({
   aiChooseRule: vi.fn(),

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -28,7 +28,6 @@ import { executeAct } from "@/utils/ai/choose-rule/execute";
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({ after: vi.fn((fn) => fn()) }));
 vi.mock("@/utils/ai/choose-rule/match-rules", () => ({
   findMatchingRules: vi.fn(),

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -6,8 +6,6 @@ import {
 import { ActionType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 const mocks = vi.hoisted(() => ({
   prisma: {
     emailAccount: {

--- a/apps/web/utils/ai/group/find-newsletters.test.ts
+++ b/apps/web/utils/ai/group/find-newsletters.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { isNewsletterSender } from "./find-newsletters";
-
-vi.mock("server-only", () => ({}));
 
 describe("isNewsletterSender", () => {
   it("should match known newsletter providers", () => {

--- a/apps/web/utils/ai/group/find-receipts.test.ts
+++ b/apps/web/utils/ai/group/find-receipts.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { isReceiptSubject, isReceiptSender } from "./find-receipts";
-
-vi.mock("server-only", () => ({}));
 
 describe("isReceiptSubject", () => {
   it("should match exact receipt subjects", () => {

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { MeetingBriefingData } from "@/utils/meeting-briefs/gather-context";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/env", () => ({
   env: {
     PERPLEXITY_API_KEY: "test-key",

--- a/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
+++ b/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
@@ -14,8 +14,6 @@ const { mockCreateGenerateObject, mockGenerateObject } = vi.hoisted(() => {
   return { mockCreateGenerateObject, mockGenerateObject };
 });
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/llms/model", () => ({
   getModel: vi.fn(() => ({
     provider: "openai",

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -20,7 +20,6 @@ const { mockCreateGenerateObject, mockGenerateObject } = vi.hoisted(() => {
   return { mockCreateGenerateObject, mockGenerateObject };
 });
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/llms", () => ({
   createGenerateObject: mockCreateGenerateObject,

--- a/apps/web/utils/api-auth.test.ts
+++ b/apps/web/utils/api-auth.test.ts
@@ -14,7 +14,6 @@ import { createEmailProvider } from "@/utils/email/provider";
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/api-key");
 vi.mock("@/utils/email/provider");
-vi.mock("server-only", () => ({}));
 
 function getRequest(apiKey: string | null) {
   return {

--- a/apps/web/utils/api-middleware.test.ts
+++ b/apps/web/utils/api-middleware.test.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { SafeError } from "@/utils/error";
 import { withAccountApiKey, withStatsApiKey } from "./api-middleware";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/env", () => ({
   env: { NEXT_PUBLIC_EXTERNAL_API_ENABLED: true },
 }));

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -11,7 +11,6 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import { clearSpecificErrorMessages } from "@/utils/error-messages";
 
-vi.mock("server-only", () => ({}));
 vi.mock("better-auth", () => ({
   betterAuth: vi.fn((options: unknown) => ({
     api: {

--- a/apps/web/utils/auth/scim.test.ts
+++ b/apps/web/utils/auth/scim.test.ts
@@ -7,7 +7,6 @@ import {
 } from "@/utils/auth/scim";
 import { isAdmin } from "@/utils/admin";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/admin", () => ({
   isAdmin: vi.fn(),

--- a/apps/web/utils/automation-jobs/destination.test.ts
+++ b/apps/web/utils/automation-jobs/destination.test.ts
@@ -7,7 +7,6 @@ import {
 } from "@/generated/prisma/enums";
 import { ensureScheduledCheckInsRoute } from "./destination";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("ensureScheduledCheckInsRoute", () => {

--- a/apps/web/utils/automation-jobs/execute.test.ts
+++ b/apps/web/utils/automation-jobs/execute.test.ts
@@ -14,7 +14,6 @@ import { getAutomationJobMessage } from "@/utils/automation-jobs/message";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 import { executeAutomationJobRun } from "@/utils/automation-jobs/execute";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/premium", () => ({
   isActivePremium: vi.fn(),

--- a/apps/web/utils/automation-jobs/message.test.ts
+++ b/apps/web/utils/automation-jobs/message.test.ts
@@ -8,7 +8,6 @@ const { mockAiGenerateAutomationCheckInMessage } = vi.hoisted(() => {
   return { mockAiGenerateAutomationCheckInMessage };
 });
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/ai/automation-jobs/generate-check-in-message", () => ({
   aiGenerateAutomationCheckInMessage: mockAiGenerateAutomationCheckInMessage,
 }));

--- a/apps/web/utils/calendar/providers/microsoft-availability.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-availability.test.ts
@@ -3,7 +3,6 @@ import { createMicrosoftAvailabilityProvider } from "./microsoft-availability";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/outlook/calendar-client", () => ({
   getCalendarClientWithRefresh: vi.fn(),
 }));

--- a/apps/web/utils/calendar/unified-availability.test.ts
+++ b/apps/web/utils/calendar/unified-availability.test.ts
@@ -6,7 +6,6 @@ import { createMicrosoftAvailabilityProvider } from "./providers/microsoft-avail
 import type { BusyPeriod } from "./availability-types";
 import { getCalendarConnection, createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("./providers/google-availability");
 vi.mock("./providers/microsoft-availability");

--- a/apps/web/utils/categorize/senders/categorize.test.ts
+++ b/apps/web/utils/categorize/senders/categorize.test.ts
@@ -5,8 +5,6 @@ import { categorizeSender } from "@/utils/categorize/senders/categorize";
 import { aiCategorizeSender } from "@/utils/ai/categorize-sender/ai-categorize-single-sender";
 import { upsertSenderRecord } from "@/utils/senders/record";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/ai/categorize-sender/ai-categorize-single-sender", () => ({
   aiCategorizeSender: vi.fn(),
 }));

--- a/apps/web/utils/categorize/senders/start-bulk-categorization.test.ts
+++ b/apps/web/utils/categorize/senders/start-bulk-categorization.test.ts
@@ -3,7 +3,6 @@ import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import { startBulkCategorization } from "./start-bulk-categorization";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const {

--- a/apps/web/utils/chat/soft-delete.test.ts
+++ b/apps/web/utils/chat/soft-delete.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { REDACTED_TEXT, softDeleteChat } from "./soft-delete";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("softDeleteChat", () => {

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -6,7 +6,6 @@ import { GroupItemType } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import { extractEmailAddress } from "@/utils/email";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 vi.mock("./cold-email-rule", () => ({

--- a/apps/web/utils/cron.test.ts
+++ b/apps/web/utils/cron.test.ts
@@ -5,8 +5,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/env", () => ({ env: { CRON_SECRET: "test-secret-123" } }));
 
 function createMockRequestWithLogger(

--- a/apps/web/utils/digest/send-digest.test.ts
+++ b/apps/web/utils/digest/send-digest.test.ts
@@ -14,7 +14,6 @@ import {
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 import { sendDigestEmail } from "@inboxzero/resend";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/messaging/providers/slack/send", () => ({
   resolveSlackRouteDestination: vi.fn(),

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -9,7 +9,6 @@ import { Prisma } from "@/generated/prisma/client";
 import { createScopedLogger } from "@/utils/logger";
 import { getFilableAttachments, processAttachment } from "./filing-engine";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/drive/provider", () => ({
   createDriveProviderWithRefresh: vi.fn(),

--- a/apps/web/utils/drive/filing-messaging-notifications.test.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.test.ts
@@ -14,7 +14,6 @@ import {
 } from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/messaging/providers/slack/send", () => ({
   resolveSlackRouteDestination: vi.fn(),

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -7,7 +7,6 @@ import {
   sendFiledNotification,
 } from "./filing-notifications";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const logger = createScopedLogger("filing-notifications-test");

--- a/apps/web/utils/drive/folder-utils.test.ts
+++ b/apps/web/utils/drive/folder-utils.test.ts
@@ -3,8 +3,6 @@ import { createFolderPath } from "./folder-utils";
 import type { DriveProvider, DriveFolder } from "./types";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 function createMockFolder(id: string, name: string): DriveFolder {
   return {
     id,

--- a/apps/web/utils/drive/handle-filing-reply.test.ts
+++ b/apps/web/utils/drive/handle-filing-reply.test.ts
@@ -8,7 +8,6 @@ import {
 import { createScopedLogger } from "@/utils/logger";
 import { processFilingReply } from "./handle-filing-reply";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/ai/document-filing/parse-filing-reply", () => ({
   aiParseFilingReply: vi.fn(),

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -5,8 +5,6 @@ import { GmailLabel } from "@/utils/gmail/label";
 import * as gmailLabelModule from "@/utils/gmail/label";
 import { GmailProvider } from "./google";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock, gmailMailMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,

--- a/apps/web/utils/email/image-proxy.server.test.ts
+++ b/apps/web/utils/email/image-proxy.server.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 describe("rewriteHtmlForImageProxy", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -4,8 +4,6 @@ import * as outlookMessageModule from "@/utils/outlook/message";
 import * as outlookLabelModule from "@/utils/outlook/label";
 import { OutlookProvider } from "./microsoft";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock, outlookMailMock, getFolderIdsMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,

--- a/apps/web/utils/email/rate-limit.test.ts
+++ b/apps/web/utils/email/rate-limit.test.ts
@@ -11,8 +11,6 @@ import {
   withRateLimitRecording,
 } from "./rate-limit";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/redis", () => ({
   redis: {
     get: vi.fn(),

--- a/apps/web/utils/encryption.test.ts
+++ b/apps/web/utils/encryption.test.ts
@@ -2,8 +2,6 @@ import { createCipheriv, randomBytes, scryptSync } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { decryptToken, encryptToken } from "./encryption";
 
-vi.mock("server-only", () => ({}));
-
 const { TEST_SECRET, TEST_SALT } = vi.hoisted(() => ({
   TEST_SECRET: "test-secret-key-for-encryption-testing",
   TEST_SALT: "test-salt-for-encryption",

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -7,7 +7,6 @@ import {
   handleFollowUpReminderAction,
 } from "./follow-up-actions";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const logger = createScopedLogger("follow-up-actions-test");

--- a/apps/web/utils/follow-up/generate-draft.test.ts
+++ b/apps/web/utils/follow-up/generate-draft.test.ts
@@ -5,8 +5,6 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { aiDraftFollowUp } from "@/utils/ai/reply/draft-follow-up";
 
-vi.mock("server-only", () => ({}));
-
 const { envMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -19,7 +19,6 @@ import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 const mockTelegramOpenDm = vi.fn();
 const mockTelegramPostMessage = vi.fn();
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({ default: {} }));
 vi.mock("@/utils/messaging/providers/slack/send", () => ({
   resolveSlackRouteDestination: vi.fn(),

--- a/apps/web/utils/get-email-from-message.test.ts
+++ b/apps/web/utils/get-email-from-message.test.ts
@@ -1,8 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import { getEmailForLLM } from "./get-email-from-message";
-
-vi.mock("server-only", () => ({}));
 
 function makeParsedMessage(
   overrides: Partial<ParsedMessage> = {},

--- a/apps/web/utils/gmail/draft.test.ts
+++ b/apps/web/utils/gmail/draft.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it, vi, type Mock } from "vitest";
 import { deleteDraft, getDraft } from "@/utils/gmail/draft";
 import { GmailLabel } from "@/utils/gmail/label";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/gmail/retry", () => ({
   withGmailRetry: (fn: () => unknown) => fn(),
 }));

--- a/apps/web/utils/gmail/mail.test.ts
+++ b/apps/web/utils/gmail/mail.test.ts
@@ -1,8 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import { formatEmailDate } from "@/utils/gmail/reply";
-
-vi.mock("server-only", () => ({}));
 
 import {
   buildReplyMessageText,

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -6,7 +6,6 @@ import {
 import { getBatch } from "@/utils/gmail/batch";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/gmail/batch");
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/gmail/permissions.test.ts
+++ b/apps/web/utils/gmail/permissions.test.ts
@@ -3,7 +3,6 @@ import prisma from "@/utils/__mocks__/prisma";
 import { SCOPES } from "@/utils/gmail/scopes";
 import { handleGmailPermissionsCheck } from "./permissions";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/gmail/client", () => ({
   getAccessTokenFromClient: vi.fn(),

--- a/apps/web/utils/label/resolve-label.test.ts
+++ b/apps/web/utils/label/resolve-label.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import { resolveLabelNameAndId } from "./resolve-label";
 import type { EmailProvider } from "@/utils/email/types";
 
-vi.mock("server-only", () => ({}));
-
 describe("resolveLabelNameAndId", () => {
   it("should skip resolution for AI templates", async () => {
     const mockEmailProvider = {

--- a/apps/web/utils/llms/cli-provider.test.ts
+++ b/apps/web/utils/llms/cli-provider.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Provider } from "./config";
 
-vi.mock("server-only", () => ({}));
-
 describe("createCliLanguageModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -24,8 +24,6 @@ const {
   mockIsPosthogLlmEvalApproved: vi.fn(),
 }));
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
   return {

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const {
   mockAssertTrialAiUsageAllowed,
   mockAttachLlmRepairMetadata,

--- a/apps/web/utils/llms/index.test.ts
+++ b/apps/web/utils/llms/index.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { isTransientNetworkError, withNetworkRetry } from "./retry";
 
-vi.mock("server-only", () => ({}));
-
 // Mock sleep to avoid waiting in tests
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/llms/model-usage-guard.test.ts
+++ b/apps/web/utils/llms/model-usage-guard.test.ts
@@ -13,8 +13,6 @@ import { redis } from "@/utils/redis";
 import { sendActionRequiredEmail } from "@inboxzero/resend";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/redis/usage", () => ({
   getWeeklyUsageCost: vi.fn(),
 }));

--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -101,8 +101,6 @@ vi.mock("@/env", () => ({
   },
 }));
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("./config", async () => {
   const actual = await vi.importActual("./config");
   return {

--- a/apps/web/utils/llms/retry.test.ts
+++ b/apps/web/utils/llms/retry.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { extractLLMErrorInfo, withLLMRetry } from "./retry";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/sleep", () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   getEmailClient,
   emailToContent,
   convertEmailHtmlToText,
   parseReply,
 } from "./mail";
-
-vi.mock("server-only", () => ({}));
 
 describe("emailToContent", () => {
   describe("content source fallback", () => {

--- a/apps/web/utils/meeting-briefs/send-briefing.test.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.test.ts
@@ -14,7 +14,6 @@ import {
 } from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/messaging/providers/slack/send", () => ({
   resolveSlackRouteDestination: vi.fn(),

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -17,7 +17,6 @@ import {
   stripLeadingSlackMention,
 } from "@/utils/messaging/chat-sdk/bot";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("ensureSlackTeamInstallation", () => {

--- a/apps/web/utils/messaging/pending-email-preview.test.ts
+++ b/apps/web/utils/messaging/pending-email-preview.test.ts
@@ -1,7 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { buildPendingEmailPreview } from "./pending-email-preview";
-
-vi.mock("server-only", () => ({}));
 
 describe("buildPendingEmailPreview", () => {
   it("converts send-email HTML into plain text preview", () => {

--- a/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
@@ -19,7 +19,6 @@ const {
   mockReadUIMessageStream: vi.fn(),
 }));
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/env", () => ({
   env: {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -11,7 +11,6 @@ import {
 import { createScopedLogger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const mockCreateEmailProvider = vi.fn();

--- a/apps/web/utils/middleware.test.ts
+++ b/apps/web/utils/middleware.test.ts
@@ -15,9 +15,6 @@ import prisma from "@/utils/__mocks__/prisma";
 
 // --- Mocks ---
 
-// Mock server-only as per rule
-vi.mock("server-only", () => ({}));
-
 // Mock external dependencies
 vi.mock("better-auth", () => {
   // Define the mock function INSIDE the factory

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 const {
   createSessionMock,
   emailAccountFindManyMock,

--- a/apps/web/utils/oauth/verify.test.ts
+++ b/apps/web/utils/oauth/verify.test.ts
@@ -3,7 +3,6 @@ import { verifyEmailAccountAccess } from "./verify";
 import { RedirectError } from "./redirect";
 import prisma from "@/utils/__mocks__/prisma";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(),

--- a/apps/web/utils/outlook/backfill-recent-messages.test.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.test.ts
@@ -5,7 +5,6 @@ import prisma from "@/utils/prisma";
 import { createEmailProvider } from "@/utils/email/provider";
 import { processHistoryForUser } from "@/app/api/outlook/webhook/process-history";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({
   default: {
     emailMessage: {

--- a/apps/web/utils/outlook/folders.test.ts
+++ b/apps/web/utils/outlook/folders.test.ts
@@ -9,8 +9,6 @@ import { createScopedLogger } from "@/utils/logger";
 
 const logger = createScopedLogger("outlook/folders");
 
-vi.mock("server-only", () => ({}));
-
 // Mock the retry wrapper to just execute the function directly
 vi.mock("@/utils/outlook/retry", () => ({
   withOutlookRetry: <T>(fn: () => Promise<T>) => fn(),

--- a/apps/web/utils/outlook/subscription-manager.test.ts
+++ b/apps/web/utils/outlook/subscription-manager.test.ts
@@ -8,7 +8,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 
 // Mock dependencies
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({
   default: {
     emailAccount: {

--- a/apps/web/utils/parse/calender-event.test.ts
+++ b/apps/web/utils/parse/calender-event.test.ts
@@ -6,8 +6,6 @@ import {
 } from "./calender-event";
 import type { ParsedMessage } from "@/utils/types";
 
-vi.mock("server-only", () => ({}));
-
 describe("Calendar Event Detection", () => {
   beforeEach(() => {
     // Set fixed date to March 15, 2024

--- a/apps/web/utils/posthog.test.ts
+++ b/apps/web/utils/posthog.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/env", () => ({
   env: {
     NEXT_PUBLIC_POSTHOG_KEY: "phc_test_key",

--- a/apps/web/utils/prisma-extensions.test.ts
+++ b/apps/web/utils/prisma-extensions.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/env", () => ({
   env: {
     NODE_ENV: "test",

--- a/apps/web/utils/queue/forward-to-internal-api.test.ts
+++ b/apps/web/utils/queue/forward-to-internal-api.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
-
 describe("forwardQueueMessageToInternalApi", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -7,8 +7,6 @@ import {
   saveUsage,
 } from "@/utils/redis/usage";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/redis", () => ({
   redis: {
     scan: vi.fn(),

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -5,7 +5,6 @@ import { createScopedLogger } from "@/utils/logger";
 import { ActionType } from "@/generated/prisma/enums";
 import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/prisma-retry", () => ({
   withPrismaRetry: vi.fn().mockImplementation((fn) => fn()),

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -10,8 +10,6 @@ import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import { DRAFT_PIPELINE_VERSION } from "@/utils/ai/reply/draft-attribution";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/ai/reply/draft-reply", () => ({
   aiDraftReplyWithConfidence: vi.fn(),
 }));

--- a/apps/web/utils/reply-tracker/label-helpers.test.ts
+++ b/apps/web/utils/reply-tracker/label-helpers.test.ts
@@ -6,7 +6,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("applyThreadStatusLabel", () => {

--- a/apps/web/utils/reply-tracker/outbound.test.ts
+++ b/apps/web/utils/reply-tracker/outbound.test.ts
@@ -25,7 +25,6 @@ vi.mock("@/utils/redis/outbound-thread-status", () => ({
   clearOutboundThreadStatusLock: vi.fn(),
   markOutboundThreadStatusProcessed: vi.fn(),
 }));
-vi.mock("server-only", () => ({}));
 
 describe("handleOutboundReply", () => {
   const logger = createTestLogger();

--- a/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
@@ -5,8 +5,6 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { createScopedLogger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
 
-vi.mock("server-only", () => ({}));
-
 const logger = createScopedLogger("sender-reply-examples-test");
 
 describe("collectSenderReplyExamples", () => {

--- a/apps/web/utils/risk.test.ts
+++ b/apps/web/utils/risk.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   getRiskLevel,
   getActionRiskLevel,
@@ -10,8 +10,6 @@ import type { RulesResponse } from "@/app/api/user/rules/route";
 
 // Run with:
 // pnpm test risk.test.ts
-
-vi.mock("server-only", () => ({}));
 
 describe("getActionRiskLevel", () => {
   const testCases = [

--- a/apps/web/utils/rule/chat-rule-risk.test.ts
+++ b/apps/web/utils/rule/chat-rule-risk.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-vi.mock("server-only", () => ({}));
 import { ActionType } from "@/generated/prisma/enums";
 import { outboundActionsNeedChatRiskConfirmation } from "@/utils/rule/rule";
 

--- a/apps/web/utils/rule/classification-feedback.test.ts
+++ b/apps/web/utils/rule/classification-feedback.test.ts
@@ -8,8 +8,6 @@ import { ClassificationFeedbackEventType } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
-
 vi.mock("@/utils/prisma", () => ({
   default: {
     classificationFeedback: {

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -4,7 +4,6 @@ import prisma from "@/utils/__mocks__/prisma";
 import { GroupItemType, GroupItemSource } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 vi.mock("@/utils/prisma-helpers", () => ({

--- a/apps/web/utils/rule/record-label-removal-learning.test.ts
+++ b/apps/web/utils/rule/record-label-removal-learning.test.ts
@@ -4,7 +4,6 @@ import { saveLearnedPattern } from "@/utils/rule/learned-patterns";
 import { recordLabelRemovalLearning } from "./record-label-removal-learning";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/rule/learned-patterns", () => ({
   saveLearnedPattern: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -8,7 +8,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/user/get", () => ({
   getEmailAccountWithAiAndTokens: vi.fn(),

--- a/apps/web/utils/scheduled-actions/scheduler.test.ts
+++ b/apps/web/utils/scheduled-actions/scheduler.test.ts
@@ -4,7 +4,6 @@ import { cancelScheduledActions, createScheduledAction } from "./scheduler";
 import { canActionBeDelayed } from "@/utils/delayed-actions";
 import prisma from "@/utils/__mocks__/prisma";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 vi.mock("@/env", () => ({
   env: {

--- a/apps/web/utils/senders/record.test.ts
+++ b/apps/web/utils/senders/record.test.ts
@@ -3,7 +3,6 @@ import { NewsletterStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import { extractEmailOrThrow, upsertSenderRecord } from "./record";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 describe("sender-record", () => {

--- a/apps/web/utils/senders/unsubscribe.test.ts
+++ b/apps/web/utils/senders/unsubscribe.test.ts
@@ -3,7 +3,6 @@ import { NewsletterStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const { dnsLookupMock, httpsRequestMock } = vi.hoisted(() => ({

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import { calculateSimilarity } from "./similarity-score";
 
-vi.mock("server-only", () => ({}));
-
 describe("calculateSimilarity - basic tests", () => {
   it("should return 0.0 if either text is null or undefined", () => {
     expect(calculateSimilarity(null, "text2")).toBe(0.0);

--- a/apps/web/utils/stringify-email.test.ts
+++ b/apps/web/utils/stringify-email.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   stringifyEmail,
   stringifyEmailSimple,
   stringifyEmailFromBody,
 } from "./stringify-email";
 import type { EmailForLLM } from "@/utils/types";
-
-vi.mock("server-only", () => ({}));
 
 describe("stringifyEmail", () => {
   const mockEmail: EmailForLLM = {

--- a/apps/web/utils/user/merge-premium.test.ts
+++ b/apps/web/utils/user/merge-premium.test.ts
@@ -7,7 +7,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
-vi.mock("server-only", () => ({}));
 
 describe("transferPremiumDuringMerge", () => {
   beforeEach(() => {

--- a/apps/web/utils/webhook.test.ts
+++ b/apps/web/utils/webhook.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { callWebhook } from "./webhook";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma");
 
 const {

--- a/apps/web/utils/webhook/error-handler.test.ts
+++ b/apps/web/utils/webhook/error-handler.test.ts
@@ -4,7 +4,6 @@ import { trackError } from "@/utils/posthog";
 import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
 import { createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/posthog", () => ({
   trackError: vi.fn(),
 }));

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -11,7 +11,6 @@ import { processAttachment } from "@/utils/drive/filing-engine";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 
-vi.mock("server-only", () => ({}));
 vi.mock("next/server", () => ({
   after: vi.fn((callback) => callback()),
 }));

--- a/apps/web/utils/webhook/process-history.test.ts
+++ b/apps/web/utils/webhook/process-history.test.ts
@@ -6,7 +6,6 @@ import { processHistoryForUser as processGoogleHistoryForUser } from "@/app/api/
 import { processHistoryForUser as processOutlookHistoryForUser } from "@/app/api/outlook/webhook/process-history";
 import { backfillRecentOutlookMessages } from "@/utils/outlook/backfill-recent-messages";
 
-vi.mock("server-only", () => ({}));
 vi.mock("@/utils/prisma", () => ({
   default: {
     emailAccount: {

--- a/apps/web/utils/webhook/validate-webhook-account.test.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.test.ts
@@ -23,7 +23,6 @@ vi.mock("@/utils/email-account-client", () => ({
 vi.mock("@/utils/log-error-with-dedupe", () => ({
   logErrorWithDedupe: vi.fn(),
 }));
-vi.mock("server-only", () => ({}));
 
 import { hasAiAccess, isPremiumRecord } from "@/utils/premium";
 import { unwatchEmails } from "@/utils/email/watch-manager";


### PR DESCRIPTION
Moves the shared test mock for the server-only module into global Vitest setup and removes repeated local declarations.

- Adds the shared mock in test setup
- Removes duplicate local declarations from test files and helpers
- Leaves product runtime code unchanged

Validation:
- pnpm --dir apps/web test --run app/api/health/route.test.ts