### PR TITLE
test: Remove duplicate next server mocks

### DIFF
--- a/apps/web/__tests__/e2e/flows/setup.ts
+++ b/apps/web/__tests__/e2e/flows/setup.ts
@@ -29,20 +29,6 @@ vi.mock("@/utils/redis/message-processing", () => ({
   markOutboundMessageProcessed: vi.fn().mockResolvedValue(true),
 }));
 
-// Mock Next.js after() to run immediately in tests
-// This ensures webhook processing completes before assertions
-vi.mock("next/server", async () => {
-  const actual =
-    await vi.importActual<typeof import("next/server")>("next/server");
-  return {
-    ...actual,
-    after: async (fn: () => void | Promise<void>) => {
-      // Run the async function and wait for it
-      await fn();
-    },
-  };
-});
-
 /**
  * Initialize test environment
  *

--- a/apps/web/__tests__/e2e/gmail-operations.test.ts
+++ b/apps/web/__tests__/e2e/gmail-operations.test.ts
@@ -39,14 +39,13 @@ vi.mock("@/utils/redis/message-processing", () => ({
   markOutboundMessageProcessed: vi.fn().mockResolvedValue(true),
 }));
 
-// Mock Next.js after() to run immediately in tests
+// Keep this e2e mock non-blocking to match the existing webhook test behavior.
 vi.mock("next/server", async () => {
   const actual =
     await vi.importActual<typeof import("next/server")>("next/server");
   return {
     ...actual,
     after: (fn: () => void | Promise<void>) => {
-      // Run the function immediately instead of deferring it
       Promise.resolve()
         .then(fn)
         .catch(() => {});

--- a/apps/web/__tests__/e2e/outlook-operations.test.ts
+++ b/apps/web/__tests__/e2e/outlook-operations.test.ts
@@ -45,18 +45,6 @@ vi.mock("@/utils/redis/message-processing", () => ({
   markOutboundMessageProcessed: vi.fn().mockResolvedValue(true),
 }));
 
-// Mock Next.js after() to run synchronously and await in tests
-vi.mock("next/server", async () => {
-  const actual =
-    await vi.importActual<typeof import("next/server")>("next/server");
-  return {
-    ...actual,
-    after: async (fn: () => void | Promise<void>) => {
-      await fn();
-    },
-  };
-});
-
 describe.skipIf(!RUN_E2E_TESTS)("Outlook Operations Integration Tests", () => {
   let provider: EmailProvider;
 

--- a/apps/web/__tests__/integration/rule-execution.test.ts
+++ b/apps/web/__tests__/integration/rule-execution.test.ts
@@ -30,11 +30,6 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-// Mock next/server — label action uses after() for lazy updates
-vi.mock("next/server", () => ({
-  after: vi.fn((fn: () => void) => fn()),
-}));
-
 // Mock Tinybird — archiveThread publishes analytics
 vi.mock("@inboxzero/tinybird", () => ({
   publishArchive: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/__tests__/integration/webhook-action.test.ts
+++ b/apps/web/__tests__/integration/webhook-action.test.ts
@@ -33,10 +33,6 @@ vi.mock("@/utils/prisma", () => ({
 
 const TEST_WEBHOOK_SECRET = "test-secret-abc123";
 
-vi.mock("next/server", () => ({
-  after: vi.fn((fn: () => void) => fn()),
-}));
-
 vi.mock("@inboxzero/tinybird", () => ({
   publishArchive: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/__tests__/integration/webhook-flow.test.ts
+++ b/apps/web/__tests__/integration/webhook-flow.test.ts
@@ -27,10 +27,6 @@ import {
 } from "@/generated/prisma/enums";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 
-vi.mock("next/server", () => ({
-  after: vi.fn((fn: () => void) => fn()),
-}));
-
 const mockExecutedRuleFindFirst = vi.fn().mockResolvedValue(null);
 const mockExecutedRuleUpdate = vi.fn().mockResolvedValue({});
 

--- a/apps/web/app/api/apple/webhook/route.test.ts
+++ b/apps/web/app/api/apple/webhook/route.test.ts
@@ -21,14 +21,6 @@ vi.mock("@/utils/middleware", () => ({
       handler(request, ...args),
 }));
 
-vi.mock("next/server", async (importOriginal) => {
-  const original = await importOriginal<typeof import("next/server")>();
-  return {
-    ...original,
-    after: (fn: () => void | Promise<void>) => Promise.resolve(fn()),
-  };
-});
-
 vi.mock("@/utils/error", () => ({
   captureException: vi.fn(),
 }));

--- a/apps/web/app/api/google/webhook/process-history-item.test.ts
+++ b/apps/web/app/api/google/webhook/process-history-item.test.ts
@@ -13,9 +13,6 @@ import { createEmailProvider } from "@/utils/email/provider";
 
 const logger = createTestLogger();
 
-vi.mock("next/server", () => ({
-  after: vi.fn((callback) => callback()),
-}));
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/redis/message-processing", () => ({
   acquireOutboundMessageLock: vi.fn().mockResolvedValue("lock-token-1"),

--- a/apps/web/app/api/outlook/webhook/process-history.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.test.ts
@@ -16,14 +16,6 @@ import { createTestLogger } from "@/__tests__/helpers";
 const logger = createTestLogger();
 vi.spyOn(logger, "with").mockReturnValue(logger);
 
-vi.mock("next/server", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("next/server")>();
-  return {
-    ...actual,
-    after: vi.fn((callback: () => Promise<void> | void) => callback()),
-  };
-});
-
 vi.mock("@/utils/webhook/validate-webhook-account", () => ({
   getWebhookEmailAccount: vi.fn(),
   validateWebhookAccount: vi.fn(),

--- a/apps/web/app/api/slack/events/route.test.ts
+++ b/apps/web/app/api/slack/events/route.test.ts
@@ -39,14 +39,6 @@ vi.mock("@/env", () => ({
   },
 }));
 
-vi.mock("next/server", async (importOriginal) => {
-  const original = await importOriginal<typeof import("next/server")>();
-  return {
-    ...original,
-    after: (fn: () => void) => fn(),
-  };
-});
-
 vi.mock("@/utils/messaging/providers/slack/verify-signature", () => ({
   validateSlackWebhookRequest: (...args: unknown[]) =>
     validateSlackWebhookRequestMock(...args),

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -35,13 +35,6 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
-vi.mock("next/server", () => ({
-  after: vi.fn(),
-  NextResponse: {
-    json: vi.fn(),
-  },
-}));
-
 vi.mock("@/ee/billing/stripe", () => ({
   getStripe: vi.fn(),
 }));

--- a/apps/web/utils/actions/email-account.test.ts
+++ b/apps/web/utils/actions/email-account.test.ts
@@ -8,14 +8,6 @@ vi.mock("@/utils/auth", () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
 }));
-vi.mock("next/server", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("next/server")>();
-
-  return {
-    ...actual,
-    after: vi.fn((callback: () => Promise<void> | void) => callback()),
-  };
-});
 vi.mock("@sentry/nextjs", () => ({
   setTag: vi.fn(),
   setUser: vi.fn(),

--- a/apps/web/utils/actions/onboarding.test.ts
+++ b/apps/web/utils/actions/onboarding.test.ts
@@ -8,14 +8,6 @@ vi.mock("@/utils/auth", () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
 }));
-vi.mock("next/server", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("next/server")>();
-
-  return {
-    ...actual,
-    after: vi.fn((callback: () => Promise<void> | void) => callback()),
-  };
-});
 vi.mock("@sentry/nextjs", () => ({
   setTag: vi.fn(),
   setUser: vi.fn(),

--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -19,14 +19,6 @@ vi.mock("@/utils/auth", () => ({
 vi.mock("next/headers", () => ({
   headers: vi.fn(async () => new Headers()),
 }));
-vi.mock("next/server", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("next/server")>();
-
-  return {
-    ...actual,
-    after: vi.fn((callback: () => Promise<void> | void) => callback()),
-  };
-});
 vi.mock("@sentry/nextjs", () => ({
   setTag: vi.fn(),
   setUser: vi.fn(),

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -28,7 +28,6 @@ import { executeAct } from "@/utils/ai/choose-rule/execute";
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
-vi.mock("next/server", () => ({ after: vi.fn((fn) => fn()) }));
 vi.mock("@/utils/ai/choose-rule/match-rules", () => ({
   findMatchingRules: vi.fn(),
 }));

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -13,9 +13,6 @@ const { createRuleHistoryMock, mockEnv } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/utils/prisma");
-vi.mock("next/server", () => ({
-  after: vi.fn((callback: () => Promise<void> | void) => callback()),
-}));
 vi.mock("@/utils/risk", () => ({
   getActionRiskLevel: vi.fn(),
 }));

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -11,9 +11,6 @@ import { processAttachment } from "@/utils/drive/filing-engine";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 
-vi.mock("next/server", () => ({
-  after: vi.fn((callback) => callback()),
-}));
 vi.mock("@/utils/prisma", () => ({
   default: {
     executedRule: {


### PR DESCRIPTION
Removes local next/server mocks that duplicate the global Vitest setup behavior.

- Drops redundant after() mocks from focused test files
- Keeps local mocks where tests intentionally spy on, suppress, or customize after() behavior
- Leaves product runtime code unchanged

Validation:
- pnpm --dir apps/web test --run app/api/apple/webhook/route.test.ts app/api/slack/events/route.test.ts utils/actions/onboarding.test.ts
- pnpm --dir apps/web exec vitest --run __tests__/e2e/gmail-operations.test.ts __tests__/e2e/flows/draft-cleanup.test.ts