### PR TITLE
test: Reuse shared test helpers

### DIFF
--- a/apps/web/__tests__/mocks/sentry-nextjs.mock.ts
+++ b/apps/web/__tests__/mocks/sentry-nextjs.mock.ts
@@ -1,0 +1,8 @@
+import { vi } from "vitest";
+
+export const setTag = vi.fn();
+export const setUser = vi.fn();
+export const captureException = vi.fn();
+export const withServerActionInstrumentation = vi.fn(
+  async (_name: string, callback: () => Promise<unknown>) => callback(),
+);

--- a/apps/web/ee/billing/stripe/ai-overage.test.ts
+++ b/apps/web/ee/billing/stripe/ai-overage.test.ts
@@ -1,6 +1,6 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const { mockEnv } = vi.hoisted(() => ({
   mockEnv: {} as { STRIPE_AI_GENERATION_OVERAGE_CONFIG?: string },
@@ -41,7 +41,7 @@ vi.mock("@/app/(app)/premium/config", () => ({
   getStripeSubscriptionTier: mockGetStripeSubscriptionTier,
 }));
 
-const logger = createScopedLogger("ai-overage-test");
+const logger = createTestLogger();
 
 describe("syncAiGenerationOverageForUpcomingInvoice", () => {
   beforeEach(() => {

--- a/apps/web/ee/billing/stripe/payments.test.ts
+++ b/apps/web/ee/billing/stripe/payments.test.ts
@@ -1,7 +1,7 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProcessorType } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const { mockFindUnique, mockUpsert } = vi.hoisted(() => ({
   mockFindUnique: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-const logger = createScopedLogger("stripe-payments-test");
+const logger = createTestLogger();
 
 describe("syncStripeInvoicePayment", () => {
   beforeEach(() => {

--- a/apps/web/ee/billing/stripe/refunds.test.ts
+++ b/apps/web/ee/billing/stripe/refunds.test.ts
@@ -1,6 +1,6 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const { mockChargeRetrieve, mockPaymentIntentRetrieve, mockInvoiceRetrieve } =
   vi.hoisted(() => ({
@@ -23,7 +23,7 @@ vi.mock("@/ee/billing/stripe", () => ({
   }),
 }));
 
-const logger = createScopedLogger("stripe-refunds-test");
+const logger = createTestLogger();
 
 describe("getStripeCustomerIdForRefund", () => {
   beforeEach(() => {

--- a/apps/web/utils/actions/email-account.test.ts
+++ b/apps/web/utils/actions/email-account.test.ts
@@ -8,14 +8,7 @@ vi.mock("@/utils/auth", () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
 }));
-vi.mock("@sentry/nextjs", () => ({
-  setTag: vi.fn(),
-  setUser: vi.fn(),
-  captureException: vi.fn(),
-  withServerActionInstrumentation: vi.fn(
-    async (_name: string, callback: () => Promise<unknown>) => callback(),
-  ),
-}));
+vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
 
 const { updateContactRoleMock } = vi.hoisted(() => ({
   updateContactRoleMock: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/actions/onboarding.test.ts
+++ b/apps/web/utils/actions/onboarding.test.ts
@@ -8,14 +8,7 @@ vi.mock("@/utils/auth", () => ({
     user: { id: "user-1", email: "user@example.com" },
   })),
 }));
-vi.mock("@sentry/nextjs", () => ({
-  setTag: vi.fn(),
-  setUser: vi.fn(),
-  captureException: vi.fn(),
-  withServerActionInstrumentation: vi.fn(
-    async (_name: string, callback: () => Promise<unknown>) => callback(),
-  ),
-}));
+vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
 
 const { updateContactRoleMock, updateContactCompanySizeMock } = vi.hoisted(
   () => ({

--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -19,14 +19,7 @@ vi.mock("@/utils/auth", () => ({
 vi.mock("next/headers", () => ({
   headers: vi.fn(async () => new Headers()),
 }));
-vi.mock("@sentry/nextjs", () => ({
-  setTag: vi.fn(),
-  setUser: vi.fn(),
-  captureException: vi.fn(),
-  withServerActionInstrumentation: vi.fn(
-    async (_name: string, callback: () => Promise<unknown>) => callback(),
-  ),
-}));
+vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
 vi.mock("@/utils/cookies.server", () => ({
   clearLastEmailAccountCookie: vi.fn(),
 }));


### PR DESCRIPTION
Reuses shared test helpers in focused unit tests to reduce repeated setup.

- Adds a reusable Sentry mock for server-action instrumentation tests
- Updates focused action tests to use the shared Sentry mock
- Updates focused billing tests to use the shared test logger helper
- Leaves dedicated Sentry behavior tests unchanged

Validation:
- pnpm --dir apps/web test --run utils/actions/email-account.test.ts utils/actions/user.test.ts utils/actions/onboarding.test.ts
- pnpm --dir apps/web test --run ee/billing/stripe/ai-overage.test.ts ee/billing/stripe/payments.test.ts ee/billing/stripe/refunds.test.ts