### PR TITLE
reply: Fix draft learning from non-replies

### DIFF
--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -375,9 +375,7 @@ describe("reply-memory", () => {
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -448,7 +446,7 @@ describe("reply-memory", () => {
     });
   });
 
-  it("skips queued draft learning when the sent message is a forward", async () => {
+  it("skips queued draft learning when the sent message did not reply to the source sender", async () => {
     vi.mocked(prisma.draftSendLog.updateMany).mockResolvedValue({
       count: 0,
     });
@@ -465,9 +463,12 @@ Can you send pricing?`,
     ] as any);
     vi.mocked(prisma.draftSendLog.update).mockResolvedValue({} as any);
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider({
+      sentMessage: createSentMessage({
+        to: "teammate@example.com",
+        subject: "Fwd: Pricing question",
+      }),
+    });
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -475,7 +476,8 @@ Can you send pricing?`,
       logger,
     });
 
-    expect(provider.getMessage).not.toHaveBeenCalled();
+    expect(provider.getMessage).toHaveBeenCalledWith("source-1");
+    expect(provider.getMessage).toHaveBeenCalledWith("sent-1");
     expect(mockGenerateObject).not.toHaveBeenCalled();
     expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
     expect(prisma.draftSendLog.update).toHaveBeenCalledWith({
@@ -526,9 +528,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -589,9 +589,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
     const testLogger = createScopedLogger("reply-memory-test-unknown-id");
     const warnSpy = vi.spyOn(testLogger, "warn").mockImplementation(() => {});
 
@@ -652,9 +650,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -697,9 +693,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -827,9 +821,7 @@ Can you send pricing?`,
         },
       });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -984,9 +976,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1079,6 +1069,7 @@ Can you send pricing?`,
 
     const provider = {
       getMessage: vi.fn().mockImplementation(async (messageId: string) => {
+        if (messageId.startsWith("sent")) return createSentMessage();
         if (messageId === "source-fail") return null;
         return createSourceMessage();
       }),
@@ -1165,9 +1156,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1196,9 +1185,9 @@ Can you send pricing?`,
     ] as any);
     vi.mocked(prisma.draftSendLog.update).mockResolvedValue({} as any);
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage({ from: "" })),
-    };
+    const provider = createReplyMemoryProvider({
+      sourceMessage: createSourceMessage({ from: "" }),
+    });
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1244,9 +1233,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1297,9 +1284,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1337,13 +1322,12 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi
-        .fn()
-        .mockResolvedValue(
-          createSourceMessage({ from: "Customer <customer@gmail.com>" }),
-        ),
-    };
+    const provider = createReplyMemoryProvider({
+      sourceMessage: createSourceMessage({
+        from: "Customer <customer@gmail.com>",
+      }),
+      sentMessage: createSentMessage({ to: "customer@gmail.com" }),
+    });
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1399,9 +1383,7 @@ Can you send pricing?`,
       },
     });
 
-    const provider = {
-      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
-    };
+    const provider = createReplyMemoryProvider();
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
@@ -1833,9 +1815,45 @@ function createSourceMessage(
   } as ParsedMessage;
 }
 
+function createSentMessage(
+  overrides: Partial<ParsedMessage["headers"]> = {},
+): ParsedMessage {
+  return {
+    id: "sent-1",
+    threadId: "thread-1",
+    internalDate: "1710000000000",
+    headers: {
+      from: "user@example.com",
+      to: "sales@example.com",
+      subject: "Re: Pricing question",
+      date: "2026-03-17T10:10:00.000Z",
+      "message-id": "<sent-1@example.com>",
+      ...overrides,
+    },
+    textPlain: "Pricing depends on seat count.",
+    textHtml: "<p>Pricing depends on seat count.</p>",
+  } as ParsedMessage;
+}
+
+function createReplyMemoryProvider({
+  sourceMessage = createSourceMessage(),
+  sentMessage = createSentMessage(),
+}: {
+  sourceMessage?: ParsedMessage | null;
+  sentMessage?: ParsedMessage | null;
+} = {}) {
+  return {
+    getMessage: vi.fn().mockImplementation(async (messageId: string) => {
+      if (messageId.startsWith("sent")) return sentMessage;
+      return sourceMessage;
+    }),
+  };
+}
+
 function createDraftSendLog(
   overrides: Partial<{
     id: string;
+    sentMessageId: string;
     replyMemorySentText: string;
     replyMemoryAttemptCount: number;
     draftText: string;
@@ -1848,6 +1866,7 @@ function createDraftSendLog(
   return {
     id: overrides.id ?? "draft-send-log-1",
     createdAt: overrides.createdAt ?? new Date("2026-03-17T10:00:00.000Z"),
+    sentMessageId: overrides.sentMessageId ?? "sent-1",
     replyMemoryAttemptCount: overrides.replyMemoryAttemptCount ?? 0,
     replyMemoryProcessedAt: overrides.replyMemoryProcessedAt ?? null,
     replyMemorySentText:

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -448,6 +448,45 @@ describe("reply-memory", () => {
     });
   });
 
+  it("skips queued draft learning when the sent message is a forward", async () => {
+    vi.mocked(prisma.draftSendLog.updateMany).mockResolvedValue({
+      count: 0,
+    });
+    vi.mocked(prisma.draftSendLog.findMany).mockResolvedValue([
+      createDraftSendLog({
+        replyMemorySentText: `Can someone check this?
+
+---------- Forwarded message ----------
+From: sender@example.com
+Subject: Pricing question
+
+Can you send pricing?`,
+      }),
+    ] as any);
+    vi.mocked(prisma.draftSendLog.update).mockResolvedValue({} as any);
+
+    const provider = {
+      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
+    };
+
+    await syncReplyMemoriesFromDraftSendLogs({
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+    });
+
+    expect(provider.getMessage).not.toHaveBeenCalled();
+    expect(mockGenerateObject).not.toHaveBeenCalled();
+    expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
+    expect(prisma.draftSendLog.update).toHaveBeenCalledWith({
+      where: { id: "draft-send-log-1" },
+      data: {
+        replyMemoryProcessedAt: expect.any(Date),
+        replyMemorySentText: null,
+      },
+    });
+  });
+
   it("attaches evidence to an existing memory when extraction returns an existing memory id", async () => {
     vi.mocked(prisma.draftSendLog.updateMany).mockResolvedValue({
       count: 0,

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -7,11 +7,12 @@ import {
   extractDomainFromEmail,
   extractEmailAddress,
   isPublicEmailDomain,
+  messageRepliesToSourceSender,
 } from "@/utils/email";
 import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { Logger } from "@/utils/logger";
-import { hasForwardedContent } from "@/utils/mail";
+import { stripForwardedContent } from "@/utils/mail";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { aiExtractReplyMemoriesFromDraftEdit } from "./extract-reply-memories";
@@ -298,32 +299,26 @@ async function processReplyMemoryDraftSendLog({
   const emailAccountId =
     draftSendLog.executedAction.executedRule.emailAccountId;
   const draftText = draftSendLog.executedAction.content ?? "";
-  const sentText = draftSendLog.replyMemorySentText ?? "";
+  const sentText = stripForwardedContent(
+    draftSendLog.replyMemorySentText ?? "",
+  );
 
-  if (hasForwardedContent(sentText)) {
-    logger.info(
-      "Skipping reply memory extraction from forwarded sent message",
-      {
-        draftSendLogId: draftSendLog.id,
-      },
-    );
-    await markDraftSendLogReplyMemoryProcessed(draftSendLog.id);
-    return;
-  }
-
-  const incomingMessage = await provider
-    .getMessage(sourceMessageId)
-    .catch((error) => {
+  const [incomingMessage, sentMessage] = await Promise.all([
+    provider.getMessage(sourceMessageId).catch((error) => {
       logger.warn("Failed to load source message for reply memory learning", {
         error,
         sourceMessageId,
       });
       return null;
-    });
-
-  const senderEmail = extractEmailAddress(incomingMessage?.headers.from || "");
-  const senderDomain = extractDomainFromEmail(senderEmail).toLowerCase();
-  const normalizedSenderEmail = senderEmail.toLowerCase();
+    }),
+    provider.getMessage(draftSendLog.sentMessageId).catch((error) => {
+      logger.warn("Failed to load sent message for reply memory learning", {
+        error,
+        sentMessageId: draftSendLog.sentMessageId,
+      });
+      return null;
+    }),
+  ]);
 
   if (!incomingMessage) {
     logger.warn(
@@ -336,6 +331,38 @@ async function processReplyMemoryDraftSendLog({
     await recordDraftSendLogReplyMemoryFailure(draftSendLog);
     return;
   }
+
+  if (!sentMessage) {
+    logger.warn(
+      "Retrying reply memory extraction after sent email lookup failed",
+      {
+        draftSendLogId: draftSendLog.id,
+        sentMessageId: draftSendLog.sentMessageId,
+      },
+    );
+    await recordDraftSendLogReplyMemoryFailure(draftSendLog);
+    return;
+  }
+
+  if (
+    messageRepliesToSourceSender({
+      sentMessage,
+      sourceMessage: incomingMessage,
+    }) === false
+  ) {
+    logger.info(
+      "Skipping reply memory extraction because sent message did not reply to source sender",
+      {
+        draftSendLogId: draftSendLog.id,
+      },
+    );
+    await markDraftSendLogReplyMemoryProcessed(draftSendLog.id);
+    return;
+  }
+
+  const senderEmail = extractEmailAddress(incomingMessage.headers.from || "");
+  const senderDomain = extractDomainFromEmail(senderEmail).toLowerCase();
+  const normalizedSenderEmail = senderEmail.toLowerCase();
 
   if (!senderEmail) {
     logger.warn(

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -11,6 +11,7 @@ import {
 import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import type { Logger } from "@/utils/logger";
+import { hasForwardedContent } from "@/utils/mail";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
 import { aiExtractReplyMemoriesFromDraftEdit } from "./extract-reply-memories";
@@ -297,6 +298,18 @@ async function processReplyMemoryDraftSendLog({
   const emailAccountId =
     draftSendLog.executedAction.executedRule.emailAccountId;
   const draftText = draftSendLog.executedAction.content ?? "";
+  const sentText = draftSendLog.replyMemorySentText ?? "";
+
+  if (hasForwardedContent(sentText)) {
+    logger.info(
+      "Skipping reply memory extraction from forwarded sent message",
+      {
+        draftSendLogId: draftSendLog.id,
+      },
+    );
+    await markDraftSendLogReplyMemoryProcessed(draftSendLog.id);
+    return;
+  }
 
   const incomingMessage = await provider
     .getMessage(sourceMessageId)
@@ -383,11 +396,11 @@ async function processReplyMemoryDraftSendLog({
       ? getEmailForLLM(incomingMessage, {
           maxLength: 2500,
           extractReply: true,
-          removeForwarded: false,
+          removeForwarded: true,
         }).content
       : "",
     draftText,
-    sentText: draftSendLog.replyMemorySentText ?? "",
+    sentText,
     senderEmail: normalizedSenderEmail,
     existingMemories,
     writingStyle: writingContext?.writingStyle ?? null,

--- a/apps/web/utils/email.test.ts
+++ b/apps/web/utils/email.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeEmailAddress,
   formatEmailWithName,
   getNewsletterSenderDisplayName,
+  messageRepliesToSourceSender,
 } from "./email";
 
 describe("email utils", () => {
@@ -328,6 +329,82 @@ describe("email utils", () => {
     });
   });
 
+  describe("messageRepliesToSourceSender", () => {
+    it("returns true when the sent message is addressed to the source sender", () => {
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({
+            from: "Sales <sales@example.com>",
+          }),
+          sentMessage: createMessage({
+            from: "user@example.com",
+            to: "Sales <sales@example.com>",
+          }),
+        }),
+      ).toBe(true);
+    });
+
+    it("uses reply-to as the expected reply target when present", () => {
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({
+            from: "noreply@example.com",
+            "reply-to": "Ops <ops@example.com>, Support <support@example.com>",
+          }),
+          sentMessage: createMessage({
+            from: "user@example.com",
+            to: "support@example.com",
+          }),
+        }),
+      ).toBe(true);
+    });
+
+    it("matches reply targets in cc recipients", () => {
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({
+            from: "Sales <sales@example.com>",
+          }),
+          sentMessage: createMessage({
+            from: "user@example.com",
+            to: "teammate@example.com",
+            cc: "Sales <sales@example.com>",
+          }),
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when the sent message only goes to someone else", () => {
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({
+            from: "Sales <sales@example.com>",
+          }),
+          sentMessage: createMessage({
+            from: "user@example.com",
+            to: "teammate@example.com",
+          }),
+        }),
+      ).toBe(false);
+    });
+
+    it("returns null when the expected target or recipients cannot be read", () => {
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({ from: "" }),
+          sentMessage: createMessage({ to: "teammate@example.com" }),
+        }),
+      ).toBeNull();
+
+      expect(
+        messageRepliesToSourceSender({
+          sourceMessage: createMessage({ from: "sales@example.com" }),
+          sentMessage: createMessage({ to: "" }),
+        }),
+      ).toBeNull();
+    });
+  });
+
   describe("extractDomainFromEmail", () => {
     it("extracts domain from plain email", () => {
       expect(extractDomainFromEmail("john@example.com")).toBe("example.com");
@@ -598,3 +675,23 @@ describe("email utils", () => {
     });
   });
 });
+
+function createMessage(
+  headers: Partial<{
+    from: string;
+    to: string;
+    cc: string;
+    bcc: string;
+    "reply-to": string;
+  }>,
+) {
+  return {
+    headers: {
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "Subject",
+      date: "2026-03-17T10:00:00.000Z",
+      ...headers,
+    },
+  };
+}

--- a/apps/web/utils/email.ts
+++ b/apps/web/utils/email.ts
@@ -76,6 +76,30 @@ export function isSameEmailAddress(left: string, right: string) {
   );
 }
 
+export function messageRepliesToSourceSender({
+  sentMessage,
+  sourceMessage,
+}: {
+  sentMessage: Pick<ParsedMessage, "headers">;
+  sourceMessage: Pick<ParsedMessage, "headers">;
+}) {
+  const replyTargetEmails = extractEmailAddresses(
+    sourceMessage.headers["reply-to"] || sourceMessage.headers.from,
+  ).map((email) => email.toLowerCase());
+  if (!replyTargetEmails.length) return null;
+
+  const recipientEmails = [
+    ...extractEmailAddresses(sentMessage.headers.to),
+    ...extractEmailAddresses(sentMessage.headers.cc ?? ""),
+    ...extractEmailAddresses(sentMessage.headers.bcc ?? ""),
+  ].map((email) => email.toLowerCase());
+
+  if (!recipientEmails.length) return null;
+
+  const recipientEmailSet = new Set(recipientEmails);
+  return replyTargetEmails.some((email) => recipientEmailSet.has(email));
+}
+
 export function isValidEmail(email: string): boolean {
   return emailSchema.safeParse(email).success;
 }

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -3,7 +3,6 @@ import {
   getEmailClient,
   emailToContent,
   convertEmailHtmlToText,
-  hasForwardedContent,
   parseReply,
 } from "./mail";
 
@@ -132,21 +131,17 @@ describe("emailToContent", () => {
       expect(result).toBe("Regular email content without forwards");
     });
 
-    it("detects forwarded content without stripping it", () => {
-      expect(
-        hasForwardedContent(
-          "Can you check this?\n\n---------- Forwarded message ----------\nFrom: sender@example.com\nSubject: Original",
-        ),
-      ).toBe(true);
-      expect(hasForwardedContent("Regular reply content")).toBe(false);
-    });
-
     it("does not treat inline From and Subject text as a forwarded message", () => {
-      expect(
-        hasForwardedContent(
+      const email = {
+        textPlain:
           "Please update the From: field and Subject: line before sending.",
-        ),
-      ).toBe(false);
+        textHtml: undefined,
+        snippet: "",
+      };
+      const result = emailToContent(email, { removeForwarded: true });
+      expect(result).toBe(
+        "Please update the From: field and Subject: line before sending.",
+      );
     });
   });
 

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -3,6 +3,7 @@ import {
   getEmailClient,
   emailToContent,
   convertEmailHtmlToText,
+  hasForwardedContent,
   parseReply,
 } from "./mail";
 
@@ -131,6 +132,23 @@ describe("emailToContent", () => {
       };
       const result = emailToContent(email, { removeForwarded: true });
       expect(result).toBe("Regular email content without forwards");
+    });
+
+    it("detects forwarded content without stripping it", () => {
+      expect(
+        hasForwardedContent(
+          "Can you check this?\n\n---------- Forwarded message ----------\nFrom: sender@example.com\nSubject: Original",
+        ),
+      ).toBe(true);
+      expect(hasForwardedContent("Regular reply content")).toBe(false);
+    });
+
+    it("does not treat inline From and Subject text as a forwarded message", () => {
+      expect(
+        hasForwardedContent(
+          "Please update the From: field and Subject: line before sending.",
+        ),
+      ).toBe(false);
     });
   });
 

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -53,10 +53,6 @@ const FORWARDED_CONTENT_PATTERNS = [
   /(?:\r?\n|\r)?Original Message/i,
 ];
 
-export function hasForwardedContent(text: string): boolean {
-  return FORWARDED_CONTENT_PATTERNS.some((pattern) => pattern.test(text));
-}
-
 export function stripForwardedContent(text: string): string {
   for (const pattern of FORWARDED_CONTENT_PATTERNS) {
     const parts = text.split(pattern);

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -40,21 +40,25 @@ export function getEmailClient(messageId: string) {
   return emailClient;
 }
 
-function removeForwardedContent(text: string): string {
-  const forwardPatterns = [
-    // Gmail style
-    /(?:\r?\n|\r)?(?:-{3,}|_{3,})\s*Forwarded message\s*(?:-{3,}|_{3,})/i,
-    // Simple forward markers
-    /(?:\r?\n|\r)?(?:-{3,}|_{3,})\s*Forward(?:ed)?(?:\s*message)?(?:-{3,}|_{3,})/i,
-    // Email headers
-    /(?:\r?\n|\r)?From:[\s\S]*?Subject:/m,
-    // iOS/Mac style
-    /(?:\r?\n|\r)?Begin forwarded message:/im,
-    // Outlook style
-    /(?:\r?\n|\r)?Original Message/i,
-  ];
+const FORWARDED_CONTENT_PATTERNS = [
+  // Gmail style
+  /(?:\r?\n|\r)?(?:-{3,}|_{3,})\s*Forwarded message\s*(?:-{3,}|_{3,})/i,
+  // Simple forward markers
+  /(?:\r?\n|\r)?(?:-{3,}|_{3,})\s*Forward(?:ed)?(?:\s*message)?(?:-{3,}|_{3,})/i,
+  // Forwarded email header blocks
+  /(?:^|\r?\n)From:\s*[^\r\n]+(?:\r?\n(?:Date|Sent|To|Cc|Bcc|Subject):\s*[^\r\n]+){2,}/im,
+  // iOS/Mac style
+  /(?:\r?\n|\r)?Begin forwarded message:/im,
+  // Outlook style
+  /(?:\r?\n|\r)?Original Message/i,
+];
 
-  for (const pattern of forwardPatterns) {
+export function hasForwardedContent(text: string): boolean {
+  return FORWARDED_CONTENT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function stripForwardedContent(text: string): string {
+  for (const pattern of FORWARDED_CONTENT_PATTERNS) {
     const parts = text.split(pattern);
     if (parts.length > 1) {
       // Take content before the forward marker and clean it
@@ -94,7 +98,7 @@ export function emailToContent(
   }
 
   if (removeForwarded) {
-    content = removeForwardedContent(content);
+    content = stripForwardedContent(content);
   }
 
   content = removeExcessiveWhitespace(content);

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -57,12 +57,14 @@ describe("trackSentDraftStatus", () => {
       draftId: "draft-1",
       content: "Thanks for reaching out.",
       executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.52);
     vi.mocked(isMeaningfulDraftEdit).mockReturnValue(true);
 
     const provider = {
       getDraft: vi.fn().mockResolvedValue(null),
+      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
     };
 
     await trackSentDraftStatus({
@@ -108,6 +110,7 @@ describe("trackSentDraftStatus", () => {
       draftId: "draft-1",
       content: "Thanks for reaching out.",
       executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.14);
 
@@ -118,6 +121,7 @@ describe("trackSentDraftStatus", () => {
         getDraft: vi.fn().mockResolvedValue({
           id: "draft-1",
         }),
+        getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
       } as any,
       logger,
     });
@@ -141,20 +145,22 @@ describe("trackSentDraftStatus", () => {
     });
   });
 
-  it("treats forwarded sent messages as ignored drafts and skips learning", async () => {
+  it("treats sent messages to someone else as ignored drafts and skips learning", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",
       draftId: "draft-1",
       content: "Thanks for reaching out.",
       executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.08);
 
     await trackSentDraftStatus({
       emailAccountId: "account-1",
-      message: createForwardedSentMessage(),
+      message: createInternalForwardedSentMessage(),
       provider: {
         getDraft: vi.fn().mockResolvedValue(null),
+        getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
       } as any,
       logger,
     });
@@ -162,7 +168,7 @@ describe("trackSentDraftStatus", () => {
     expect(prisma.draftSendLog.create).toHaveBeenCalledWith({
       data: {
         executedActionId: "action-1",
-        sentMessageId: "sent-forward-1",
+        sentMessageId: "sent-internal-forward-1",
         similarityScore: 0.08,
       },
     });
@@ -175,12 +181,53 @@ describe("trackSentDraftStatus", () => {
     expect(syncReplyMemoriesFromDraftSendLogs).not.toHaveBeenCalled();
   });
 
+  it("keeps learning from replies with forwarded blocks when sent to the source sender", async () => {
+    vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
+      id: "action-1",
+      draftId: "draft-1",
+      content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
+    } as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.52);
+    vi.mocked(isMeaningfulDraftEdit).mockReturnValue(true);
+
+    const provider = {
+      getDraft: vi.fn().mockResolvedValue(null),
+      getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
+    };
+
+    await trackSentDraftStatus({
+      emailAccountId: "account-1",
+      message: createForwardedReplySentMessage(),
+      provider: provider as any,
+      logger,
+    });
+
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: { wasDraftSent: true },
+    });
+    expect(saveDraftSendLogReplyMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftSendLogId: "draft-send-log-1",
+        sentText: "Thanks, please use annual billing.",
+      }),
+    );
+    expect(syncReplyMemoriesFromDraftSendLogs).toHaveBeenCalledWith({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+  });
+
   it("skips reply memory learning when the edit is not meaningful", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",
       draftId: "draft-1",
       content: "Thanks for reaching out.",
       executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.98);
     vi.mocked(isMeaningfulDraftEdit).mockReturnValue(false);
@@ -190,6 +237,7 @@ describe("trackSentDraftStatus", () => {
       message: createSentMessage(),
       provider: {
         getDraft: vi.fn().mockResolvedValue(null),
+        getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
       } as any,
       logger,
     });
@@ -301,12 +349,13 @@ function createSentMessage(): ParsedMessage {
   } as ParsedMessage;
 }
 
-function createForwardedSentMessage(): ParsedMessage {
+function createInternalForwardedSentMessage(): ParsedMessage {
   return {
     ...createSentMessage(),
-    id: "sent-forward-1",
+    id: "sent-internal-forward-1",
     headers: {
       ...createSentMessage().headers,
+      to: "teammate@example.com",
       subject: "Fwd: Pricing question",
     },
     textPlain: `Can someone check this?
@@ -317,6 +366,42 @@ Subject: Pricing question
 
 Can you send pricing?`,
     textHtml: undefined,
+  } as ParsedMessage;
+}
+
+function createForwardedReplySentMessage(): ParsedMessage {
+  return {
+    ...createSentMessage(),
+    id: "sent-forward-reply-1",
+    headers: {
+      ...createSentMessage().headers,
+      subject: "Re: Pricing question",
+    },
+    textPlain: `Thanks, please use annual billing.
+
+---------- Forwarded message ----------
+From: sales@example.com
+Subject: Pricing question
+
+Can you send pricing?`,
+    textHtml: undefined,
+  } as ParsedMessage;
+}
+
+function createSourceMessage(): ParsedMessage {
+  return {
+    id: "source-1",
+    threadId: "thread-1",
+    internalDate: "1710000000000",
+    headers: {
+      from: "Sales <sales@example.com>",
+      to: "user@example.com",
+      subject: "Pricing question",
+      date: "2026-03-17T10:00:00.000Z",
+      "message-id": "<source-1@example.com>",
+    },
+    textPlain: "Can you share pricing for a larger team?",
+    textHtml: "<p>Can you share pricing for a larger team?</p>",
   } as ParsedMessage;
 }
 

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -141,6 +141,40 @@ describe("trackSentDraftStatus", () => {
     });
   });
 
+  it("treats forwarded sent messages as ignored drafts and skips learning", async () => {
+    vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
+      id: "action-1",
+      draftId: "draft-1",
+      content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
+    } as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.08);
+
+    await trackSentDraftStatus({
+      emailAccountId: "account-1",
+      message: createForwardedSentMessage(),
+      provider: {
+        getDraft: vi.fn().mockResolvedValue(null),
+      } as any,
+      logger,
+    });
+
+    expect(prisma.draftSendLog.create).toHaveBeenCalledWith({
+      data: {
+        executedActionId: "action-1",
+        sentMessageId: "sent-forward-1",
+        similarityScore: 0.08,
+      },
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: { wasDraftSent: false },
+    });
+    expect(isMeaningfulDraftEdit).not.toHaveBeenCalled();
+    expect(saveDraftSendLogReplyMemory).not.toHaveBeenCalled();
+    expect(syncReplyMemoriesFromDraftSendLogs).not.toHaveBeenCalled();
+  });
+
   it("skips reply memory learning when the edit is not meaningful", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",
@@ -264,6 +298,25 @@ function createSentMessage(): ParsedMessage {
     },
     textPlain: "Please include pricing for seat counts.",
     textHtml: "<p>Please include pricing for seat counts.</p>",
+  } as ParsedMessage;
+}
+
+function createForwardedSentMessage(): ParsedMessage {
+  return {
+    ...createSentMessage(),
+    id: "sent-forward-1",
+    headers: {
+      ...createSentMessage().headers,
+      subject: "Fwd: Pricing question",
+    },
+    textPlain: `Can someone check this?
+
+---------- Forwarded message ----------
+From: sales@example.com
+Subject: Pricing question
+
+Can you send pricing?`,
+    textHtml: undefined,
   } as ParsedMessage;
 }
 

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -15,7 +15,7 @@ import {
 import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
-import { hasForwardedContent } from "@/utils/mail";
+import { messageRepliesToSourceSender } from "@/utils/email";
 import { logReplyTrackerError } from "./error-logging";
 
 /**
@@ -60,6 +60,11 @@ export async function trackSentDraftStatus({
       content: true,
       draftId: true,
       executedRuleId: true,
+      executedRule: {
+        select: {
+          messageId: true,
+        },
+      },
     },
   });
 
@@ -68,32 +73,49 @@ export async function trackSentDraftStatus({
     return;
   }
 
-  const draftExists = await provider.getDraft(executedAction.draftId);
+  const [draftExists, sourceMessage] = await Promise.all([
+    provider.getDraft(executedAction.draftId),
+    provider
+      .getMessage(executedAction.executedRule.messageId)
+      .catch((error) => {
+        logger.warn("Failed to load source message for sent draft tracking", {
+          error,
+          executedActionId: executedAction.id,
+        });
+        return null;
+      }),
+  ]);
 
   const executedActionId = executedAction.id;
 
   // Calculate similarity between sent message and AI draft content
   // Pass full message to properly handle Outlook HTML content
   const similarityScore = calculateSimilarity(executedAction.content, message);
-  const sentMessageIsForward = isForwardedSentMessage(message);
+  const sentMessageRepliesToSource =
+    sourceMessage &&
+    messageRepliesToSourceSender({
+      sentMessage: message,
+      sourceMessage,
+    });
 
   logger.info("Calculated similarity score", {
     executedActionId,
     similarityScore,
     draftExists: !!draftExists,
-    sentMessageIsForward,
+    sentMessageRepliesToSource,
   });
 
-  if (draftExists || sentMessageIsForward) {
+  if (draftExists || sentMessageRepliesToSource === false) {
     logger.info(
-      sentMessageIsForward
-        ? "Sent message is a forward, marking AI draft as not sent."
+      sentMessageRepliesToSource === false
+        ? "Sent message did not reply to source sender, marking AI draft as not sent."
         : "Original AI draft still exists, sent message was different.",
       {
         executedActionId: executedAction.id,
         draftId: executedAction.draftId,
         similarityScore,
         draftExists: !!draftExists,
+        sentMessageRepliesToSource,
       },
     );
 
@@ -117,8 +139,8 @@ export async function trackSentDraftStatus({
     );
 
     logger.info(
-      sentMessageIsForward
-        ? "Created draft send log and marked action as not sent (sent message is a forward)"
+      sentMessageRepliesToSource === false
+        ? "Created draft send log and marked action as not sent (sent message did not reply to source sender)"
         : "Created draft send log and marked action as not sent (draft still exists)",
       { executedActionId },
     );
@@ -126,7 +148,7 @@ export async function trackSentDraftStatus({
       executedRuleId: executedAction.executedRuleId,
       logger,
     });
-    if (!sentMessageIsForward) {
+    if (sentMessageRepliesToSource !== false) {
       queueReplyMemoryLearning({
         emailAccountId,
         executedActionId,
@@ -456,19 +478,4 @@ function queueReplyMemoryLearning({
       });
     }
   });
-}
-
-function isForwardedSentMessage(message: ParsedMessage) {
-  if (/^(?:fwd?|fw):/i.test(message.headers.subject?.trim() ?? "")) {
-    return true;
-  }
-
-  // maxLength: 0 disables truncation so forward markers further down aren't missed
-  const sentText = emailToContentForAI(message, {
-    maxLength: 0,
-    extractReply: true,
-    removeForwarded: false,
-  });
-
-  return hasForwardedContent(sentText);
 }

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -15,6 +15,7 @@ import {
 import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
+import { hasForwardedContent } from "@/utils/mail";
 import { logReplyTrackerError } from "./error-logging";
 
 /**
@@ -74,19 +75,27 @@ export async function trackSentDraftStatus({
   // Calculate similarity between sent message and AI draft content
   // Pass full message to properly handle Outlook HTML content
   const similarityScore = calculateSimilarity(executedAction.content, message);
+  const sentMessageIsForward = isForwardedSentMessage(message);
 
   logger.info("Calculated similarity score", {
     executedActionId,
     similarityScore,
     draftExists: !!draftExists,
+    sentMessageIsForward,
   });
 
-  if (draftExists) {
-    logger.info("Original AI draft still exists, sent message was different.", {
-      executedActionId: executedAction.id,
-      draftId: executedAction.draftId,
-      similarityScore,
-    });
+  if (draftExists || sentMessageIsForward) {
+    logger.info(
+      sentMessageIsForward
+        ? "Sent message is a forward, marking AI draft as not sent."
+        : "Original AI draft still exists, sent message was different.",
+      {
+        executedActionId: executedAction.id,
+        draftId: executedAction.draftId,
+        similarityScore,
+        draftExists: !!draftExists,
+      },
+    );
 
     // Create DraftSendLog to record the comparison, but mark wasDraftSent as false
     const [draftSendLog] = await withPrismaRetry(
@@ -108,7 +117,9 @@ export async function trackSentDraftStatus({
     );
 
     logger.info(
-      "Created draft send log and marked action as not sent (draft still exists)",
+      sentMessageIsForward
+        ? "Created draft send log and marked action as not sent (sent message is a forward)"
+        : "Created draft send log and marked action as not sent (draft still exists)",
       { executedActionId },
     );
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
@@ -121,6 +132,7 @@ export async function trackSentDraftStatus({
       draftSendLogId: draftSendLog.id,
       draftText: executedAction.content,
       similarityScore,
+      sentMessageIsForward,
       message,
       provider,
       logger,
@@ -179,6 +191,7 @@ export async function trackSentDraftStatus({
     draftSendLogId: draftSendLog.id,
     draftText: executedAction.content,
     similarityScore,
+    sentMessageIsForward,
     message,
     provider,
     logger,
@@ -400,6 +413,7 @@ function queueReplyMemoryLearning({
   draftSendLogId,
   draftText,
   similarityScore,
+  sentMessageIsForward,
   message,
   provider,
   logger,
@@ -409,16 +423,25 @@ function queueReplyMemoryLearning({
   draftSendLogId: string;
   draftText?: string | null;
   similarityScore: number;
+  sentMessageIsForward: boolean;
   message: ParsedMessage;
   provider: EmailProvider;
   logger: Logger;
 }) {
   if (!draftText) return;
 
+  if (sentMessageIsForward) {
+    logger.info("Skipping reply memory learning for forwarded sent message", {
+      draftSendLogId,
+      executedActionId,
+    });
+    return;
+  }
+
   const sentText = emailToContentForAI(message, {
     maxLength: 4000,
     extractReply: true,
-    removeForwarded: false,
+    removeForwarded: true,
   });
 
   if (!isMeaningfulDraftEdit({ draftText, sentText, similarityScore })) {
@@ -443,4 +466,18 @@ function queueReplyMemoryLearning({
       });
     }
   });
+}
+
+function isForwardedSentMessage(message: ParsedMessage) {
+  if (/^(?:fwd?|fw):/i.test(message.headers.subject?.trim() ?? "")) {
+    return true;
+  }
+
+  const sentText = emailToContentForAI(message, {
+    maxLength: 0,
+    extractReply: true,
+    removeForwarded: false,
+  });
+
+  return hasForwardedContent(sentText);
 }

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -126,17 +126,18 @@ export async function trackSentDraftStatus({
       executedRuleId: executedAction.executedRuleId,
       logger,
     });
-    queueReplyMemoryLearning({
-      emailAccountId,
-      executedActionId,
-      draftSendLogId: draftSendLog.id,
-      draftText: executedAction.content,
-      similarityScore,
-      sentMessageIsForward,
-      message,
-      provider,
-      logger,
-    });
+    if (!sentMessageIsForward) {
+      queueReplyMemoryLearning({
+        emailAccountId,
+        executedActionId,
+        draftSendLogId: draftSendLog.id,
+        draftText: executedAction.content,
+        similarityScore,
+        message,
+        provider,
+        logger,
+      });
+    }
     return;
   }
 
@@ -191,7 +192,6 @@ export async function trackSentDraftStatus({
     draftSendLogId: draftSendLog.id,
     draftText: executedAction.content,
     similarityScore,
-    sentMessageIsForward,
     message,
     provider,
     logger,
@@ -413,7 +413,6 @@ function queueReplyMemoryLearning({
   draftSendLogId,
   draftText,
   similarityScore,
-  sentMessageIsForward,
   message,
   provider,
   logger,
@@ -423,20 +422,11 @@ function queueReplyMemoryLearning({
   draftSendLogId: string;
   draftText?: string | null;
   similarityScore: number;
-  sentMessageIsForward: boolean;
   message: ParsedMessage;
   provider: EmailProvider;
   logger: Logger;
 }) {
   if (!draftText) return;
-
-  if (sentMessageIsForward) {
-    logger.info("Skipping reply memory learning for forwarded sent message", {
-      draftSendLogId,
-      executedActionId,
-    });
-    return;
-  }
 
   const sentText = emailToContentForAI(message, {
     maxLength: 4000,
@@ -473,6 +463,7 @@ function isForwardedSentMessage(message: ParsedMessage) {
     return true;
   }
 
+  // maxLength: 0 disables truncation so forward markers further down aren't missed
   const sentText = emailToContentForAI(message, {
     maxLength: 0,
     extractReply: true,

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -139,12 +139,10 @@ export async function trackSentDraftStatus({
       { logger },
     );
 
-    logger.info(
-      sentMessageRepliesToSource === false
-        ? "Created draft send log and marked action as not sent (sent message did not reply to source sender)"
-        : "Created draft send log and marked action as not sent (draft still exists)",
-      { executedActionId },
-    );
+    logger.info("Created draft send log and marked action as not sent", {
+      executedActionId,
+      sentMessageRepliesToSource,
+    });
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: executedAction.executedRuleId,
       logger,

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -107,18 +107,13 @@ export async function trackSentDraftStatus({
   });
 
   if (draftExists || sentMessageRepliesToSource === false) {
-    logger.info(
-      sentMessageRepliesToSource === false
-        ? "Sent message did not reply to source sender, marking AI draft as not sent."
-        : "Original AI draft still exists, sent message was different.",
-      {
-        executedActionId: executedAction.id,
-        draftId: executedAction.draftId,
-        similarityScore,
-        draftExists: !!draftExists,
-        sentMessageRepliesToSource,
-      },
-    );
+    logger.info("Marking AI draft as not sent", {
+      executedActionId: executedAction.id,
+      draftId: executedAction.draftId,
+      similarityScore,
+      draftExists: !!draftExists,
+      sentMessageRepliesToSource,
+    });
 
     // Create DraftSendLog to record the comparison, but mark wasDraftSent as false
     const [draftSendLog] = await withPrismaRetry(

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -338,6 +338,20 @@ On Mon, Jan 1, 2024 at 9:00 AM <someone@example.com> wrote:
       const score = realCalculateSimilarity(originalDraft, sentMessage);
       expect(score).toBe(1.0);
     });
+
+    it("should ignore forwarded payloads below the authored reply", () => {
+      const originalDraft = "Can you take a look at this?";
+      const sentMessage = createParsedMessage(`Can you take a look at this?
+
+---------- Forwarded message ----------
+From: sender@example.com
+Subject: Original request
+
+The original request has a lot of unrelated detail.`);
+
+      const score = realCalculateSimilarity(originalDraft, sentMessage);
+      expect(score).toBe(1.0);
+    });
   });
 
   describe("Backwards compatibility with plain strings", () => {

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -1,5 +1,9 @@
 import * as stringSimilarity from "string-similarity";
-import { convertEmailHtmlToText, parseReply } from "@/utils/mail";
+import {
+  convertEmailHtmlToText,
+  parseReply,
+  stripForwardedContent,
+} from "@/utils/mail";
 import {
   stripQuotedContent,
   stripQuotedHtmlContent,
@@ -37,7 +41,9 @@ function normalizeForOutlook(content: string): string {
     htmlText: stripQuotedHtmlContent(withBr),
     includeLinks: false,
   });
-  return stripQuotedContent(plainText).toLowerCase().trim();
+  return stripForwardedContent(stripQuotedContent(plainText))
+    .toLowerCase()
+    .trim();
 }
 
 /**
@@ -75,7 +81,9 @@ function normalizeForGmail(content: string): string {
     : content;
   const reply = parseReply(plainText);
   const decoded = decodeHtmlEntities(reply);
-  return stripQuotedContent(decoded).toLowerCase().trim();
+  return stripForwardedContent(stripQuotedContent(decoded))
+    .toLowerCase()
+    .trim();
 }
 
 /**


### PR DESCRIPTION
Updates draft tracking so reply-memory learning is gated by whether the sent message is addressed to the original reply target, instead of forwarded-message markers.

It still strips quoted and forwarded payloads from similarity scoring and learning text so forwarded blocks do not drag down similarity or become memories.

Adds focused coverage for recipient matching, forwarded cleanup, similarity normalization, and queued memory processing.