### PR TITLE
test: Use shared logger helper

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelMessage } from "ai";
-import { getEmailAccount, getMockMessage } from "@/__tests__/helpers";
+import {
+  createTestLogger,
+  getEmailAccount,
+  getMockMessage,
+} from "@/__tests__/helpers";
 import { ActionType, GroupItemType } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
 
 const {
   envState,
@@ -110,7 +113,7 @@ vi.mock("@/env", () => ({
   },
 }));
 
-const logger = createScopedLogger("ai-assistant-chat-test");
+const logger = createTestLogger();
 
 const baseMessages: ModelMessage[] = [
   {

--- a/apps/web/app/api/chat/confirm-email-action/route.test.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { ConfirmAssistantEmailActionBody } from "@/utils/actions/assistant-chat.validation";
 
 const { mockConfirmAssistantEmailActionForAccount, mockGetEmailAccountWithAi } =
@@ -43,7 +43,7 @@ describe("confirm email action route", () => {
       }),
       {
         auth: { emailAccountId: "email-account-1" },
-        logger: createScopedLogger("test/confirm-email-action"),
+        logger: createTestLogger(),
       },
     );
 
@@ -76,7 +76,7 @@ describe("confirm email action route", () => {
       }),
       {
         auth: { emailAccountId: "email-account-1" },
-        logger: createScopedLogger("test/confirm-email-action"),
+        logger: createTestLogger(),
       },
     );
 

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getEmailAccount } from "@/__tests__/helpers";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger, getEmailAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 
 const {
@@ -53,21 +52,21 @@ vi.mock("@/utils/middleware", () => ({
       handler: (
         request: NextRequest & {
           auth: { userId: string; emailAccountId: string; email: string };
-          logger: ReturnType<typeof createScopedLogger>;
+          logger: ReturnType<typeof createTestLogger>;
         },
       ) => Promise<Response>,
     ) =>
     async (request: NextRequest) => {
       const authRequest = request as NextRequest & {
         auth: { userId: string; emailAccountId: string; email: string };
-        logger: ReturnType<typeof createScopedLogger>;
+        logger: ReturnType<typeof createTestLogger>;
       };
       authRequest.auth = {
         userId: "user-1",
         emailAccountId: "email-account-id",
         email: "user@test.com",
       };
-      authRequest.logger = createScopedLogger("test/chat-route");
+      authRequest.logger = createTestLogger();
       return handler(authRequest);
     },
 }));

--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -4,7 +4,7 @@ import {
   processAllFollowUpReminders,
 } from "./process";
 import { ThreadTrackerType } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 
@@ -98,7 +98,7 @@ import {
 } from "@/utils/follow-up/send-follow-up-notification";
 import { getLabelsFromDb } from "@/utils/reply-tracker/label-helpers";
 
-const logger = createScopedLogger("test-follow-up");
+const logger = createTestLogger();
 
 const OLD_DATE = "1700000000000"; // Nov 2023 - well past any threshold
 const RECENT_DATE = String(Date.now()); // Now - within threshold

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -1,6 +1,6 @@
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { getStripeCancellationInitiatedAt } from "./cancellation-initiated";
 import { processEvent } from "./route";
 import { getStripeTrialConvertedAt } from "./trial-conversion";
@@ -86,7 +86,7 @@ vi.mock("@/utils/error", () => ({
   captureException: mockCaptureException,
 }));
 
-const logger = createScopedLogger("stripe-webhook-route-test");
+const logger = createTestLogger();
 
 describe("processEvent", () => {
   beforeEach(() => {

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { RequestWithEmailAccount } from "@/utils/middleware";
 import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
@@ -19,7 +19,7 @@ vi.mock("@/utils/messaging/providers/slack/client", () => ({
 
 import { GET } from "./route";
 
-const logger = createScopedLogger("test");
+const logger = createTestLogger();
 
 describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
   beforeEach(() => {

--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { RequestWithEmailAccount } from "@/utils/middleware";
 import { listChannels } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
@@ -66,7 +66,7 @@ type MessagingChannelRecord = Prisma.MessagingChannelGetPayload<{
   select: typeof messagingChannelSelect;
 }>;
 
-const logger = createScopedLogger("test");
+const logger = createTestLogger();
 
 describe("GET /api/user/messaging-channels", () => {
   beforeEach(() => {

--- a/apps/web/utils/actions/assistant-chat-create-rule.test.ts
+++ b/apps/web/utils/actions/assistant-chat-create-rule.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const createRuleMock = vi.hoisted(() => vi.fn());
 
@@ -111,7 +111,7 @@ describe("confirmAssistantCreateRule", () => {
       waitForPersistence: true,
       emailAccountId: "ea_1",
       provider: "google",
-      logger: createScopedLogger("assistant-chat-create-rule.test"),
+      logger: createTestLogger(),
     });
 
     await vi.runAllTimersAsync();
@@ -224,7 +224,7 @@ describe("confirmAssistantCreateRule", () => {
   });
 
   it("returns an error when confirmation persistence fails", async () => {
-    const logger = createScopedLogger("assistant-chat-create-rule.test");
+    const logger = createTestLogger();
 
     prisma.chatMessage.findFirst.mockResolvedValue({
       id: "cm-1",
@@ -255,7 +255,7 @@ describe("confirmAssistantCreateRule", () => {
   });
 
   it("does not clear processing when a newer confirmed state already exists", async () => {
-    const logger = createScopedLogger("assistant-chat-create-rule.test");
+    const logger = createTestLogger();
     const pendingPart = buildPendingCreateRulePart();
     const processingAt = "2026-02-23T00:01:00.000Z";
     const processingPart = buildPendingCreateRulePart({

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -9,7 +9,7 @@ import {
   confirmAssistantEmailActionForAccount,
   confirmAssistantSaveMemoryForAccount,
 } from "@/utils/actions/assistant-chat-confirmation";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/email/provider");
@@ -801,7 +801,7 @@ describe("confirmAssistantEmailAction", () => {
       waitForPersistence: true,
       emailAccountId: "ea_1",
       provider: "google",
-      logger: createScopedLogger("test/assistant-email-confirmation"),
+      logger: createTestLogger(),
     });
 
     await vi.runAllTimersAsync();
@@ -861,7 +861,7 @@ describe("confirmAssistantEmailAction", () => {
       persistenceWaitMs: 10_000,
       emailAccountId: "ea_1",
       provider: "google",
-      logger: createScopedLogger("test/assistant-email-confirmation"),
+      logger: createTestLogger(),
     });
 
     await vi.runAllTimersAsync();
@@ -978,7 +978,7 @@ describe("confirmAssistantEmailAction", () => {
       waitForPersistence: true,
       emailAccountId: "ea_1",
       provider: "google",
-      logger: createScopedLogger("test/assistant-email-confirmation"),
+      logger: createTestLogger(),
     });
 
     await vi.runAllTimersAsync();
@@ -1277,7 +1277,7 @@ describe("confirmAssistantSaveMemory", () => {
       toolCallId: "tool-1",
       waitForPersistence: true,
       emailAccountId: "ea_1",
-      logger: createScopedLogger("test/assistant-save-memory-confirmation"),
+      logger: createTestLogger(),
     });
 
     await vi.runAllTimersAsync();

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
 import {
   forwardEmailTool,
@@ -61,7 +61,7 @@ vi.mock("@/utils/redis/categorization-progress", () => ({
 }));
 
 const TEST_EMAIL = "user@test.com";
-const logger = createScopedLogger("chat-inbox-tools-test");
+const logger = createTestLogger();
 
 describe("chat inbox tools", () => {
   beforeEach(() => {

--- a/apps/web/utils/ai/assistant/chat-label-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
 import { createOrGetLabelTool, listLabelsTool } from "./chat-label-tools";
 
@@ -9,7 +9,7 @@ vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-const logger = createScopedLogger("chat-label-tools-test");
+const logger = createTestLogger();
 const TEST_EMAIL = "user@test.com";
 
 describe("chat label tools", () => {

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -4,7 +4,7 @@ import {
   GroupItemType,
   SystemType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { createRuleTool } from "./tools/rules/create-rule-tool";
 import { updateRuleTool } from "./tools/rules/update-rule-tool";
 import { updateRuleStateTool } from "./tools/rules/update-rule-state-tool";
@@ -45,7 +45,7 @@ vi.mock("@/utils/rule/rule", async (importOriginal) => {
   };
 });
 
-const logger = createScopedLogger("chat-rule-tools-test");
+const logger = createTestLogger();
 
 const defaultActions = [
   {

--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -4,7 +4,7 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { isActivePremium } from "@/utils/premium";
 import { getUserPremium } from "@/utils/user/get";
 import { getAssistantCapabilitiesTool } from "./tools/settings/get-assistant-capabilities-tool";
@@ -21,7 +21,7 @@ vi.mock("@/utils/user/get", () => ({
   getUserPremium: vi.fn(),
 }));
 
-const logger = createScopedLogger("chat-settings-tools-test");
+const logger = createTestLogger();
 const mockGetUserPremium = vi.mocked(getUserPremium);
 const mockIsActivePremium = vi.mocked(isActivePremium);
 const slackRulesRoute = {

--- a/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-learned-patterns-tool.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { saveLearnedPatterns } from "@/utils/rule/learned-patterns";
 import { updateLearnedPatternsTool } from "./update-learned-patterns-tool";
 
@@ -12,7 +12,7 @@ vi.mock("@/utils/rule/learned-patterns", () => ({
   saveLearnedPatterns: vi.fn(),
 }));
 
-const logger = createScopedLogger("update-learned-patterns-tool-test");
+const logger = createTestLogger();
 
 describe("updateLearnedPatternsTool", () => {
   beforeEach(() => {

--- a/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-personal-instructions-tool.test.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@/generated/prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { updatePersonalInstructionsTool } from "./update-personal-instructions-tool";
 
 vi.mock("@/utils/prisma");
@@ -9,7 +9,7 @@ vi.mock("@/utils/posthog", () => ({
   posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
-const logger = createScopedLogger("update-personal-instructions-tool-test");
+const logger = createTestLogger();
 
 describe("updatePersonalInstructionsTool", () => {
   beforeEach(() => {

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   ReplyMemoryKind,
   ReplyMemoryScopeType,
@@ -54,7 +54,7 @@ vi.mock("@/utils/user/get", () => ({
   }),
 }));
 
-const logger = createScopedLogger("reply-memory-test");
+const logger = createTestLogger();
 
 describe("reply-memory", () => {
   beforeEach(() => {
@@ -552,7 +552,7 @@ describe("reply-memory", () => {
     const provider = {
       getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
     };
-    const testLogger = createScopedLogger("reply-memory-test-unknown-id");
+    const testLogger = createTestLogger();
     const warnSpy = vi.spyOn(testLogger, "warn").mockImplementation(() => {});
 
     await syncReplyMemoriesFromDraftSendLogs({

--- a/apps/web/utils/automation-jobs/execute.test.ts
+++ b/apps/web/utils/automation-jobs/execute.test.ts
@@ -6,7 +6,7 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { isActivePremium } from "@/utils/premium";
 import { getUserPremium } from "@/utils/user/get";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -31,7 +31,7 @@ vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: vi.fn(),
 }));
 
-const logger = createScopedLogger("automation-job-execute-test");
+const logger = createTestLogger();
 const mockGetUserPremium = vi.mocked(getUserPremium);
 const mockIsActivePremium = vi.mocked(isActivePremium);
 const mockCreateEmailProvider = vi.mocked(createEmailProvider);

--- a/apps/web/utils/automation-jobs/message.test.ts
+++ b/apps/web/utils/automation-jobs/message.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount, getMockEmailProvider } from "@/__tests__/helpers";
 import type { AutomationCheckInEmailAccount } from "@/utils/ai/automation-jobs/generate-check-in-message";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const { mockAiGenerateAutomationCheckInMessage } = vi.hoisted(() => {
   const mockAiGenerateAutomationCheckInMessage = vi.fn();
@@ -14,7 +14,7 @@ vi.mock("@/utils/ai/automation-jobs/generate-check-in-message", () => ({
 
 import { getAutomationJobMessage } from "./message";
 
-const logger = createScopedLogger("automation-jobs-message-test");
+const logger = createTestLogger();
 const emailAccount: AutomationCheckInEmailAccount = {
   ...getEmailAccount({
     email: "user@example.com",

--- a/apps/web/utils/automation-jobs/slack.test.ts
+++ b/apps/web/utils/automation-jobs/slack.test.ts
@@ -3,7 +3,7 @@ import {
   MessagingProvider,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const {
   mockCreateSlackClient,
@@ -34,7 +34,7 @@ vi.mock("@/utils/messaging/providers/slack/send", async () => {
 
 import { sendAutomationMessageToSlack } from "./slack";
 
-const logger = createScopedLogger("automation-jobs-slack-test");
+const logger = createTestLogger();
 
 describe("sendAutomationMessageToSlack", () => {
   beforeEach(() => {

--- a/apps/web/utils/categorize/senders/archive-category.test.ts
+++ b/apps/web/utils/categorize/senders/archive-category.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { archiveCategory } from "./archive-category";
 
 vi.mock("@/utils/prisma");
 
-const logger = createScopedLogger("archive-category-test");
+const logger = createTestLogger();
 
 describe("archiveCategory", () => {
   beforeEach(() => {

--- a/apps/web/utils/categorize/senders/start-bulk-categorization.test.ts
+++ b/apps/web/utils/categorize/senders/start-bulk-categorization.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { startBulkCategorization } from "./start-bulk-categorization";
 
 vi.mock("@/utils/prisma");
@@ -63,7 +63,7 @@ vi.mock("@/utils/actions/stats-loading", () => ({
     mockLoadEmails(...args),
 }));
 
-const logger = createScopedLogger("start-bulk-categorization-test");
+const logger = createTestLogger();
 
 describe("startBulkCategorization", () => {
   beforeEach(() => {

--- a/apps/web/utils/digest/send-digest.test.ts
+++ b/apps/web/utils/digest/send-digest.test.ts
@@ -5,7 +5,7 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { sendDigest } from "./send-digest";
 import {
   resolveSlackRouteDestination,
@@ -26,7 +26,7 @@ vi.mock("@inboxzero/resend", () => ({
   sendDigestEmail: vi.fn(),
 }));
 
-const logger = createScopedLogger("send-digest-test");
+const logger = createTestLogger();
 
 const baseArgs = {
   emailAccountId: "email-account-1",

--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -6,7 +6,7 @@ import {
   getMockParsedMessage,
 } from "@/__tests__/mocks/email-provider.mock";
 import { Prisma } from "@/generated/prisma/client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { getFilableAttachments, processAttachment } from "./filing-engine";
 
 vi.mock("@/utils/prisma");
@@ -36,7 +36,7 @@ import {
 import { sendFilingMessagingNotifications } from "@/utils/drive/filing-messaging-notifications";
 import { createDriveProviderWithRefresh } from "@/utils/drive/provider";
 
-const logger = createScopedLogger("filing-engine-test");
+const logger = createTestLogger();
 
 describe("processAttachment", () => {
   beforeEach(() => {

--- a/apps/web/utils/drive/filing-messaging-notifications.test.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.test.ts
@@ -5,7 +5,7 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { sendFilingMessagingNotifications } from "./filing-messaging-notifications";
 import {
   resolveSlackRouteDestination,
@@ -24,7 +24,7 @@ vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: vi.fn(),
 }));
 
-const logger = createScopedLogger("filing-messaging-notifications-test");
+const logger = createTestLogger();
 
 describe("sendFilingMessagingNotifications", () => {
   beforeEach(() => {

--- a/apps/web/utils/drive/filing-notifications.test.ts
+++ b/apps/web/utils/drive/filing-notifications.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createMockEmailProvider } from "@/__tests__/mocks/email-provider.mock";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   sendAskNotification,
   sendFiledNotification,
@@ -9,7 +9,7 @@ import {
 
 vi.mock("@/utils/prisma");
 
-const logger = createScopedLogger("filing-notifications-test");
+const logger = createTestLogger();
 
 const sourceMessage = {
   headerMessageId: "<original@example.com>",

--- a/apps/web/utils/drive/handle-filing-reply.test.ts
+++ b/apps/web/utils/drive/handle-filing-reply.test.ts
@@ -5,7 +5,7 @@ import {
   createMockEmailProvider,
   getMockParsedMessage,
 } from "@/__tests__/mocks/email-provider.mock";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { processFilingReply } from "./handle-filing-reply";
 
 vi.mock("@/utils/prisma");
@@ -18,7 +18,7 @@ vi.mock("@/utils/ai/content-sanitizer", () => ({
 
 import { aiParseFilingReply } from "@/utils/ai/document-filing/parse-filing-reply";
 
-const logger = createScopedLogger("handle-filing-reply-test");
+const logger = createTestLogger();
 
 const emailAccountId = "email-account-id";
 const userEmail = "user@example.com";

--- a/apps/web/utils/drive/providers/microsoft.test.ts
+++ b/apps/web/utils/drive/providers/microsoft.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@microsoft/microsoft-graph-client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { OneDriveProvider } from "./microsoft";
 
 vi.mock("@microsoft/microsoft-graph-client", () => ({
@@ -30,10 +30,7 @@ describe("OneDriveProvider", () => {
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
-    const provider = new OneDriveProvider(
-      "token",
-      createScopedLogger("onedrive-provider-test"),
-    );
+    const provider = new OneDriveProvider("token", createTestLogger());
 
     await provider.createFolder("Plans:2026", "parent-1");
 
@@ -59,10 +56,7 @@ describe("OneDriveProvider", () => {
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
-    const provider = new OneDriveProvider(
-      "token",
-      createScopedLogger("onedrive-provider-test"),
-    );
+    const provider = new OneDriveProvider("token", createTestLogger());
 
     await provider.uploadFile({
       filename: "Agenda - Plans 2025:2026.pdf",
@@ -92,10 +86,7 @@ describe("OneDriveProvider", () => {
 
     vi.mocked(Client.init).mockReturnValue({ api } as any);
 
-    const provider = new OneDriveProvider(
-      "token",
-      createScopedLogger("onedrive-provider-test"),
-    );
+    const provider = new OneDriveProvider("token", createTestLogger());
 
     await provider.uploadFile({
       filename: "   ",

--- a/apps/web/utils/email/image-proxy.server.test.ts
+++ b/apps/web/utils/email/image-proxy.server.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 describe("rewriteHtmlForImageProxy", () => {
   beforeEach(() => {
@@ -11,10 +11,7 @@ describe("rewriteHtmlForImageProxy", () => {
     const { rewriteHtmlForImageProxy } = await loadModule({});
     const html = '<img src="https://cdn.example.com/photo.png" />';
 
-    const rewritten = await rewriteHtmlForImageProxy(
-      html,
-      createScopedLogger("image-proxy-test"),
-    );
+    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
 
     expect(rewritten).toBe(html);
   });
@@ -27,7 +24,7 @@ describe("rewriteHtmlForImageProxy", () => {
 
     const html = '<img src="https://cdn.example.com/photo.png" />';
 
-    const logger = createScopedLogger("image-proxy-test");
+    const logger = createTestLogger();
     const firstRewrite = await rewriteHtmlForImageProxy(html, logger);
     const secondRewrite = await rewriteHtmlForImageProxy(html, logger);
 
@@ -49,7 +46,7 @@ describe("rewriteHtmlForImageProxy", () => {
 
     const rewritten = await rewriteHtmlForImageProxy(
       '<img src="https://cdn.example.com/photo.png" />',
-      createScopedLogger("image-proxy-test"),
+      createTestLogger(),
     );
 
     expect(rewritten).toContain(
@@ -69,7 +66,7 @@ describe("rewriteHtmlForImageProxy", () => {
 
     const rewritten = await rewriteHtmlForImageProxy(
       '<img src="https://cdn.example.com/photo.png" />',
-      createScopedLogger("image-proxy-test"),
+      createTestLogger(),
     );
 
     expect(rewritten).toContain(
@@ -86,10 +83,7 @@ describe("rewriteHtmlForImageProxy", () => {
     });
 
     const html = '<img src="https://cdn.example.com/photo.png" />';
-    const rewritten = await rewriteHtmlForImageProxy(
-      html,
-      createScopedLogger("image-proxy-test"),
-    );
+    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
 
     expect(rewritten).toBe(html);
     expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -103,10 +97,7 @@ describe("rewriteHtmlForImageProxy", () => {
     });
 
     const html = '<img src="https://cdn.example.com/photo.png" />';
-    const rewritten = await rewriteHtmlForImageProxy(
-      html,
-      createScopedLogger("image-proxy-test"),
-    );
+    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
 
     expect(rewritten).toBe(html);
     expect(warnSpy).toHaveBeenCalledTimes(1);

--- a/apps/web/utils/email/rate-limit.test.ts
+++ b/apps/web/utils/email/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { redis } from "@/utils/redis";
 import { ProviderRateLimitModeError } from "@/utils/email/rate-limit-mode-error";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   assertProviderNotRateLimited,
   getEmailProviderRateLimitState,
@@ -19,7 +19,7 @@ vi.mock("@/utils/redis", () => ({
   },
 }));
 
-const logger = createScopedLogger("test-rate-limit");
+const logger = createTestLogger();
 
 describe("email provider rate-limit state", () => {
   beforeEach(() => {

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { MessagingProvider } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   FOLLOW_UP_MARK_DONE_ACTION_ID,
   handleFollowUpReminderAction,
@@ -9,7 +9,7 @@ import {
 
 vi.mock("@/utils/prisma");
 
-const logger = createScopedLogger("follow-up-actions-test");
+const logger = createTestLogger();
 
 function makeEvent(
   overrides: Partial<{

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -5,7 +5,7 @@ import {
   MessagingRouteTargetType,
   ThreadTrackerType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   sendFollowUpNotification,
   type FollowUpNotificationChannel,
@@ -38,7 +38,7 @@ vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
   }),
 }));
 
-const logger = createScopedLogger("send-follow-up-test");
+const logger = createTestLogger();
 
 const baseArgs = {
   subject: "Project update",

--- a/apps/web/utils/llms/sensitive-content.test.ts
+++ b/apps/web/utils/llms/sensitive-content.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   enforceSensitiveDataPolicy,
   enforceSensitiveToolOutputPolicy,
 } from "@/utils/llms/sensitive-content";
 
-const logger = createScopedLogger("llms-sensitive-content-test");
+const logger = createTestLogger();
 
 describe("Sensitive data policy enforcement", () => {
   it("leaves allow-mode requests unchanged", () => {

--- a/apps/web/utils/meeting-briefs/send-briefing.test.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.test.ts
@@ -6,7 +6,7 @@ import {
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
 import type { CalendarEvent } from "@/utils/calendar/event-types";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { sendBriefing } from "./send-briefing";
 import {
   resolveSlackRouteDestination,
@@ -26,7 +26,7 @@ vi.mock("@/utils/date", () => ({
   formatTimeInUserTimezone: vi.fn(() => "Monday, Jan 1 at 10:00 AM"),
 }));
 
-const logger = createScopedLogger("send-briefing-test");
+const logger = createTestLogger();
 
 const event: CalendarEvent = {
   id: "event-1",

--- a/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { processSlackSlashCommand } from "@/utils/messaging/providers/slack/slash-commands";
 
 const {
@@ -47,7 +47,7 @@ vi.mock("@/utils/user/get", () => ({
   getEmailAccountWithAi: mockGetEmailAccountWithAi,
 }));
 
-const logger = createScopedLogger("slack-slash-command-test");
+const logger = createTestLogger();
 
 describe("processSlackSlashCommand", () => {
   beforeEach(() => {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -8,7 +8,7 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { ParsedMessage } from "@/utils/types";
 
 vi.mock("@/utils/prisma");
@@ -159,7 +159,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
@@ -290,7 +290,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
@@ -407,7 +407,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
@@ -446,7 +446,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.trashThread).toHaveBeenCalledWith(
@@ -492,7 +492,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.markSpam).toHaveBeenCalledWith("thread-1");
@@ -529,7 +529,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
@@ -567,7 +567,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(prisma.executedAction.findUnique).not.toHaveBeenCalled();
@@ -611,7 +611,7 @@ describe("handleRuleNotificationAction", () => {
 
     await handleRuleNotificationAction({
       event,
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(provider.trashThread).toHaveBeenCalledWith(
@@ -728,7 +728,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -802,7 +802,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -851,7 +851,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -896,7 +896,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -938,7 +938,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -974,7 +974,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1013,7 +1013,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1049,7 +1049,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1139,7 +1139,7 @@ describe("sendMessagingRuleNotification", () => {
         snippet: "Short snippet",
         textPlain: longBody,
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1177,7 +1177,7 @@ describe("sendMessagingRuleNotification", () => {
         textHtml:
           '<div><p>HTML only body</p><p>Second line</p><img src="image.png" /></div>',
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1218,7 +1218,7 @@ describe("sendMessagingRuleNotification", () => {
         textPlain: "Plain fallback body",
         textHtml: "<p>Rendered HTML body</p>",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1257,7 +1257,7 @@ describe("sendMessagingRuleNotification", () => {
         textPlain:
           "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1304,7 +1304,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1365,7 +1365,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "First line\nSecond line",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1424,7 +1424,7 @@ describe("sendMessagingRuleNotification", () => {
         textPlain:
           "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1475,7 +1475,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1547,7 +1547,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1600,7 +1600,7 @@ describe("sendMessagingRuleNotification", () => {
         snippet:
           "Quoted reply said A &gt; B, C &lt; D, and Tom &amp; Jerry replied.",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1657,7 +1657,7 @@ describe("sendMessagingRuleNotification", () => {
         textPlain:
           "Fresh request line.\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line that should not be shown.",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1710,7 +1710,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Can you review item_name before 5 * 6?",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(true);
@@ -1764,7 +1764,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(false);
@@ -1804,7 +1804,7 @@ describe("sendMessagingRuleNotification", () => {
         },
         snippet: "Preview text",
       },
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(delivered).toBe(false);
@@ -1892,7 +1892,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
@@ -1958,7 +1958,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(mockTeamsOpenDm).toHaveBeenCalledWith("29:teams-user");
@@ -2005,7 +2005,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(mockTelegramOpenDm).toHaveBeenCalledWith("telegram-chat-1");
@@ -2037,7 +2037,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
@@ -2093,7 +2093,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
@@ -2147,7 +2147,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
 
     await replaceMessagingDraftNotificationsWithHandledOnWebState({
       executedRuleId: "executed-rule-1",
-      logger: createScopedLogger("test"),
+      logger: createTestLogger(),
     });
 
     expect(mockTeamsOpenDm).toHaveBeenCalledWith("29:teams-user");
@@ -2197,7 +2197,7 @@ describe("replaceMessagingDraftNotificationsWithHandledOnWebState", () => {
     await expect(
       replaceMessagingDraftNotificationsWithHandledOnWebState({
         executedRuleId: "executed-rule-1",
-        logger: createScopedLogger("test"),
+        logger: createTestLogger(),
       }),
     ).resolves.toBeUndefined();
 

--- a/apps/web/utils/outlook/batch.test.ts
+++ b/apps/web/utils/outlook/batch.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { moveMessagesForSenders } from "./batch";
 
 const mockGetFolderIds = vi.fn();
@@ -61,7 +61,7 @@ describe("moveMessagesForSenders", () => {
         ownerEmail: "owner@example.com",
         emailAccountId: "account-1",
         continueOnError: false,
-        logger: createScopedLogger("outlook-batch-test"),
+        logger: createTestLogger(),
       }),
     ).rejects.toThrow("Graph batch returned one or more error responses.");
 

--- a/apps/web/utils/outlook/folders.test.ts
+++ b/apps/web/utils/outlook/folders.test.ts
@@ -5,9 +5,9 @@ import {
   getOutlookChildFolders,
 } from "./folders";
 import type { OutlookClient } from "./client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
-const logger = createScopedLogger("outlook/folders");
+const logger = createTestLogger();
 
 // Mock the retry wrapper to just execute the function directly
 vi.mock("@/utils/outlook/retry", () => ({

--- a/apps/web/utils/outlook/label.test.ts
+++ b/apps/web/utils/outlook/label.test.ts
@@ -1,7 +1,7 @@
 import type { OutlookCategory } from "@microsoft/microsoft-graph-types";
 import { describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { createLabel, getLabel, getOrCreateLabels } from "./label";
 
 describe("createLabel", () => {
@@ -17,7 +17,7 @@ describe("createLabel", () => {
     const created = await createLabel({
       client,
       name: "Notification, property update",
-      logger: createScopedLogger("outlook-label-test"),
+      logger: createTestLogger(),
     });
 
     expect(post).toHaveBeenCalledWith(
@@ -62,7 +62,7 @@ describe("getOrCreateLabels", () => {
       getOrCreateLabels({
         client,
         names: ["Finance, Updates", "Finance Updates"],
-        logger: createScopedLogger("outlook-label-test"),
+        logger: createTestLogger(),
       }),
     ).rejects.toThrow("normalize to the same value");
 
@@ -84,7 +84,7 @@ describe("getOrCreateLabels", () => {
       getOrCreateLabels({
         client,
         names: ["Finance Updates"],
-        logger: createScopedLogger("outlook-label-test"),
+        logger: createTestLogger(),
       }),
     ).rejects.toThrow("Ambiguous Outlook category match");
 

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -1,7 +1,7 @@
 import type { Message } from "@microsoft/microsoft-graph-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { EmailForAction } from "@/utils/ai/types";
 import { draftEmail, forwardEmail, sendEmailWithHtml } from "./mail";
 
@@ -42,7 +42,7 @@ describe("sendEmailWithHtml", () => {
         subject: "Subject",
         messageHtml: "<p>Hello</p>",
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(draftPost).toHaveBeenCalledWith(
@@ -108,7 +108,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(attachmentPost).toHaveBeenCalledWith(
@@ -155,7 +155,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(attachmentPost).toHaveBeenCalledWith(
@@ -202,7 +202,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(attachmentPost).toHaveBeenCalledWith(
@@ -264,7 +264,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(createUploadSessionPost).toHaveBeenCalledWith(
@@ -375,7 +375,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     const statusCallIndex = fetchMock.mock.calls.findIndex(
@@ -451,7 +451,7 @@ describe("sendEmailWithHtml", () => {
           },
         ],
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     const statusCallIndex = fetchMock.mock.calls.findIndex(
@@ -519,7 +519,7 @@ describe("sendEmailWithHtml", () => {
             },
           ],
         },
-        createScopedLogger("outlook-mail-test"),
+        createTestLogger(),
       ),
     ).rejects.toMatchObject({
       error: expect.objectContaining({
@@ -595,7 +595,7 @@ describe("forwardEmail", () => {
         content: "Forwarding this",
         from: "Owner Name <owner@example.com>",
       },
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(createForwardDraft).toHaveBeenCalledWith({});
@@ -700,7 +700,7 @@ describe("draftEmail", () => {
         content: "Draft body",
       },
       "owner@example.com",
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(updateDraft).toHaveBeenCalledWith(
@@ -757,7 +757,7 @@ describe("draftEmail", () => {
         content: "Draft body",
       },
       "user@example.com",
-      createScopedLogger("outlook-mail-test"),
+      createTestLogger(),
     );
 
     expect(createReplyAllDraft).toHaveBeenCalledWith({});

--- a/apps/web/utils/outlook/retry.test.ts
+++ b/apps/web/utils/outlook/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   extractErrorInfo,
   isRetryableError,
@@ -232,12 +232,7 @@ describe("withOutlookRetry", () => {
     );
 
     await expect(
-      withOutlookRetry(
-        operation,
-        createScopedLogger("test-outlook-retry"),
-        5,
-        1,
-      ),
+      withOutlookRetry(operation, createTestLogger(), 5, 1),
     ).rejects.toBeDefined();
 
     expect(operation).toHaveBeenCalledTimes(1);

--- a/apps/web/utils/qstash.test.ts
+++ b/apps/web/utils/qstash.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
-const logger = createScopedLogger("qstash-test");
+const logger = createTestLogger();
 
 function createRequest(headers?: Record<string, string>) {
   const request = new Request("https://example.com/api/test", {

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { ActionType } from "@/generated/prisma/enums";
 import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 
@@ -35,7 +35,7 @@ import {
 } from "@/utils/ai/reply/reply-memory";
 import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 
-const logger = createScopedLogger("draft-tracking-test");
+const logger = createTestLogger();
 
 describe("trackSentDraftStatus", () => {
   beforeEach(() => {

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -8,7 +8,7 @@ import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { DraftReplyConfidence } from "@/generated/prisma/enums";
 import { DRAFT_PIPELINE_VERSION } from "@/utils/ai/reply/draft-attribution";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/ai/reply/draft-reply", () => ({
   aiDraftReplyWithConfidence: vi.fn(),
@@ -97,7 +97,7 @@ import { aiExtractFromEmailHistory } from "@/utils/ai/knowledge/extract-from-ema
 import prisma from "@/utils/prisma";
 import { getReplyWithConfidence, saveReply } from "@/utils/redis/reply";
 
-const logger = createScopedLogger("reply-tracker/generate-draft-test");
+const logger = createTestLogger();
 
 type EmailAccountSignatureSettings = {
   allowHiddenAiDraftLinks: boolean;

--- a/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
+++ b/apps/web/utils/reply-tracker/sender-reply-examples.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { collectSenderReplyExamples } from "./sender-reply-examples";
 import type { EmailProvider } from "@/utils/email/types";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import type { ParsedMessage } from "@/utils/types";
 
-const logger = createScopedLogger("sender-reply-examples-test");
+const logger = createTestLogger();
 
 describe("collectSenderReplyExamples", () => {
   it("returns recent sent replies to the sender and excludes current-thread messages", async () => {

--- a/apps/web/utils/rule/classification-feedback.test.ts
+++ b/apps/web/utils/rule/classification-feedback.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./classification-feedback";
 import { ClassificationFeedbackEventType } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/prisma", () => ({
   default: {
@@ -20,7 +20,7 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-const logger = createScopedLogger("test");
+const logger = createTestLogger();
 
 describe("saveClassificationFeedback", () => {
   beforeEach(() => {

--- a/apps/web/utils/senders/unsubscribe.test.ts
+++ b/apps/web/utils/senders/unsubscribe.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NewsletterStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/prisma");
 
@@ -25,7 +25,7 @@ vi.mock("node:https", () => ({
 import { setSenderStatus, unsubscribeSenderAndMark } from "./unsubscribe";
 
 describe("sender-unsubscribe", () => {
-  const logger = createScopedLogger("sender-unsubscribe-test");
+  const logger = createTestLogger();
 
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Updates related unit and API tests to use the shared test logger helper instead of constructing scoped loggers directly.

- Standardizes logger setup across Outlook, follow-up, meeting-brief, assistant, automation, drive, email, messaging, reply-tracker, and related utility tests
- Keeps production logger behavior unchanged
- Leaves evals, E2E/integration flows, logger/error behavior tests, and callback tests with middleware-local logger setup unchanged

Validation:
- Focused test batches covering all 46 changed test files: 46 passed, 446 tests passed
- git diff --check