### PR TITLE
drafts: Add draft lifecycle status

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelMessage } from "ai";
 import { getEmailAccount, getMockMessage } from "@/__tests__/helpers";
-import { ActionType, GroupItemType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  DraftEmailStatus,
+  GroupItemType,
+} from "@/generated/prisma/enums";
 import { createScopedLogger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
@@ -1506,7 +1510,7 @@ describe("aiProcessAssistantChat", () => {
             url: null,
             folderName: null,
             draftId: "draft-1",
-            wasDraftSent: false,
+            draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
           },
           {
             type: "LABEL",
@@ -1519,7 +1523,7 @@ describe("aiProcessAssistantChat", () => {
             url: null,
             folderName: null,
             draftId: null,
-            wasDraftSent: null,
+            draftStatus: null,
           },
         ],
         rule: {
@@ -1572,7 +1576,7 @@ describe("aiProcessAssistantChat", () => {
             url: true,
             folderName: true,
             draftId: true,
-            wasDraftSent: true,
+            draftStatus: true,
           },
         },
         rule: {
@@ -1608,7 +1612,7 @@ describe("aiProcessAssistantChat", () => {
               url: null,
               folderName: null,
               draftId: "draft-1",
-              wasDraftSent: false,
+              draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
             },
             {
               type: "LABEL",
@@ -1621,7 +1625,7 @@ describe("aiProcessAssistantChat", () => {
               url: null,
               folderName: null,
               draftId: null,
-              wasDraftSent: null,
+              draftStatus: null,
             },
           ],
         },

--- a/apps/web/__tests__/e2e/flows/helpers/polling.ts
+++ b/apps/web/__tests__/e2e/flows/helpers/polling.ts
@@ -13,7 +13,10 @@ import { logStep } from "./logging";
 import { sleep } from "@/utils/sleep";
 import { extractEmailAddress } from "@/utils/email";
 import { getOrCreateFollowUpLabel } from "@/utils/follow-up/labels";
-import type { ThreadTrackerType } from "@/generated/prisma/enums";
+import {
+  DraftEmailStatus,
+  type ThreadTrackerType,
+} from "@/generated/prisma/enums";
 
 interface PollOptions {
   description?: string;
@@ -543,7 +546,7 @@ export async function waitForDraftSendLog(options: {
           executedAction: {
             select: {
               draftId: true,
-              wasDraftSent: true,
+              draftStatus: true,
             },
           },
         },
@@ -559,7 +562,7 @@ export async function waitForDraftSendLog(options: {
         sentMessageId: log.sentMessageId,
         similarityScore: log.similarityScore,
         draftId: log.executedAction.draftId,
-        wasSentFromDraft: log.executedAction.wasDraftSent,
+        wasSentFromDraft: isSentDraftStatus(log.executedAction.draftStatus),
       };
     },
     {
@@ -714,5 +717,12 @@ export async function waitForThreadMessageCount(options: {
       timeout,
       description: `Thread ${threadId} to have at least ${minCount} messages`,
     },
+  );
+}
+
+function isSentDraftStatus(status?: DraftEmailStatus | null) {
+  return (
+    status === DraftEmailStatus.SENT ||
+    status === DraftEmailStatus.SENT_WITH_EDITS
   );
 }

--- a/apps/web/__tests__/e2e/flows/helpers/polling.ts
+++ b/apps/web/__tests__/e2e/flows/helpers/polling.ts
@@ -721,8 +721,5 @@ export async function waitForThreadMessageCount(options: {
 }
 
 function isSentDraftStatus(status?: DraftEmailStatus | null) {
-  return (
-    status === DraftEmailStatus.SENT ||
-    status === DraftEmailStatus.SENT_WITH_EDITS
-  );
+  return status === DraftEmailStatus.LIKELY_SENT;
 }

--- a/apps/web/__tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@/__tests__/eval/semantic-judge";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
+import { DraftEmailStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import type { getEmailAccount } from "@/__tests__/helpers";
@@ -593,7 +594,7 @@ describe.runIf(shouldRunEval)(
                     url: null,
                     folderName: null,
                     draftId: "draft-contract-terms-1",
-                    wasDraftSent: false,
+                    draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
                   },
                 ],
                 rule: {
@@ -740,7 +741,7 @@ describe.runIf(shouldRunEval)(
                     url: null,
                     folderName: null,
                     draftId: "draft-renewal-quote-1",
-                    wasDraftSent: false,
+                    draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
                   },
                 ],
                 rule: {

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -24,6 +24,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 import {
   ActionType,
+  DraftEmailStatus,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -603,7 +604,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           draftId: createdDraft.id,
           subject: `Re: ${subject}`,
           content: "Initial draft body.",
-          wasDraftSent: false,
+          draftStatus: DraftEmailStatus.PENDING as DraftEmailStatus | null,
         };
 
         const slackActionState = {
@@ -619,7 +620,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           messagingChannelId: "channel-1",
           messagingMessageId: null as string | null,
           messagingMessageStatus: null as MessagingMessageStatus | null,
-          wasDraftSent: false,
+          draftStatus: null as DraftEmailStatus | null,
           executedRule: {
             id: "executed-rule-edit-send",
             ruleId: "rule-1",
@@ -727,8 +728,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
               if (typeof data?.content === "string") {
                 slackActionState.content = data.content;
               }
-              if (typeof data?.wasDraftSent === "boolean") {
-                slackActionState.wasDraftSent = data.wasDraftSent;
+              if (data?.draftStatus) {
+                slackActionState.draftStatus =
+                  data.draftStatus as DraftEmailStatus;
               }
             }
 
@@ -736,8 +738,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
               if (typeof data?.content === "string") {
                 siblingDraftActionState.content = data.content;
               }
-              if (typeof data?.wasDraftSent === "boolean") {
-                siblingDraftActionState.wasDraftSent = data.wasDraftSent;
+              if (data?.draftStatus) {
+                siblingDraftActionState.draftStatus =
+                  data.draftStatus as DraftEmailStatus;
               }
             }
 
@@ -830,8 +833,8 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         expect(slackActionState.messagingMessageStatus).toBe(
           MessagingMessageStatus.DRAFT_SENT,
         );
-        expect(slackActionState.wasDraftSent).toBe(true);
-        expect(siblingDraftActionState.wasDraftSent).toBe(true);
+        expect(slackActionState.draftStatus).toBe(DraftEmailStatus.SENT);
+        expect(siblingDraftActionState.draftStatus).toBe(DraftEmailStatus.SENT);
         expect(
           await gmailHarness.provider.getDraft(createdDraft.id),
         ).toBeNull();

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -832,8 +832,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         expect(slackActionState.messagingMessageStatus).toBe(
           MessagingMessageStatus.DRAFT_SENT,
         );
-        expect(slackActionState.draftStatus).toBe(DraftEmailStatus.SENT);
-        expect(siblingDraftActionState.draftStatus).toBe(DraftEmailStatus.SENT);
+        expect(slackActionState.draftStatus).toBe(DraftEmailStatus.LIKELY_SENT);
+        expect(siblingDraftActionState.draftStatus).toBe(
+          DraftEmailStatus.LIKELY_SENT,
+        );
         expect(
           await gmailHarness.provider.getDraft(createdDraft.id),
         ).toBeNull();

--- a/apps/web/app/(app)/[emailAccountId]/debug/drafts/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/drafts/page.tsx
@@ -68,14 +68,16 @@ export default function DebugDraftsPage() {
                     <TableCell>
                       <Badge
                         variant={
-                          executedAction.wasDraftSent ? "default" : "secondary"
+                          isDraftSentStatus(executedAction.draftStatus)
+                            ? "default"
+                            : "secondary"
                         }
                       >
-                        {executedAction.wasDraftSent ? "Sent" : "Not Sent"}
+                        {formatDraftStatus(executedAction.draftStatus)}
                       </Badge>
                     </TableCell>
                     <TableCell>
-                      {executedAction.wasDraftSent &&
+                      {isDraftSentStatus(executedAction.draftStatus) &&
                       executedAction.draftSendLog?.sentMessageId ? (
                         <Link
                           href={getGmailUrl(
@@ -139,4 +141,13 @@ export default function DebugDraftsPage() {
       </LoadingContent>
     </div>
   );
+}
+
+function formatDraftStatus(draftStatus?: string | null) {
+  if (draftStatus) return draftStatus.replaceAll("_", " ");
+  return "Pending";
+}
+
+function isDraftSentStatus(draftStatus?: string | null) {
+  return draftStatus === "SENT" || draftStatus === "SENT_WITH_EDITS";
 }

--- a/apps/web/app/(app)/[emailAccountId]/debug/drafts/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/debug/drafts/page.tsx
@@ -149,5 +149,5 @@ function formatDraftStatus(draftStatus?: string | null) {
 }
 
 function isDraftSentStatus(draftStatus?: string | null) {
-  return draftStatus === "SENT" || draftStatus === "SENT_WITH_EDITS";
+  return draftStatus === "LIKELY_SENT";
 }

--- a/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
+++ b/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
@@ -51,7 +51,7 @@ describe("disableUnusedAutoDrafts", () => {
       id: `exec-${i + 1}`,
       draftStatus:
         i === 5
-          ? DraftEmailStatus.SENT_WITH_EDITS
+          ? DraftEmailStatus.LIKELY_SENT
           : DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
     }));
     (prisma.executedAction.findMany as any).mockResolvedValueOnce(mockDrafts);
@@ -112,7 +112,7 @@ describe("disableUnusedAutoDrafts", () => {
             id: `exec-u1-${i}`,
             draftStatus:
               i === 0
-                ? DraftEmailStatus.SENT
+                ? DraftEmailStatus.LIKELY_SENT
                 : DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
           }));
         }

--- a/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
+++ b/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { disableUnusedAutoDrafts } from "./disable-unused-auto-drafts";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
@@ -24,7 +24,7 @@ describe("disableUnusedAutoDrafts", () => {
     (prisma.action.findMany as any).mockResolvedValueOnce(autoDraftActions);
     const mockDrafts = Array.from({ length: 10 }, (_, i) => ({
       id: `exec-${i + 1}`,
-      wasDraftSent: false,
+      draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
     }));
     (prisma.executedAction.findMany as any).mockResolvedValueOnce(mockDrafts);
 
@@ -50,7 +50,10 @@ describe("disableUnusedAutoDrafts", () => {
     (prisma.action.findMany as any).mockResolvedValueOnce(autoDraftActions);
     const mockDrafts = Array.from({ length: 10 }, (_, i) => ({
       id: `exec-${i + 1}`,
-      wasDraftSent: i === 5, // one is true
+      draftStatus:
+        i === 5
+          ? DraftEmailStatus.SENT_WITH_EDITS
+          : DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
     }));
     (prisma.executedAction.findMany as any).mockResolvedValueOnce(mockDrafts);
 
@@ -69,7 +72,7 @@ describe("disableUnusedAutoDrafts", () => {
     ];
     (prisma.action.findMany as any).mockResolvedValueOnce(autoDraftActions);
     (prisma.executedAction.findMany as any).mockResolvedValueOnce([
-      { id: "exec-1", wasDraftSent: false },
+      { id: "exec-1", draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT },
     ]);
 
     const result = await disableUnusedAutoDrafts(logger);
@@ -108,14 +111,17 @@ describe("disableUnusedAutoDrafts", () => {
           // User 1 sent a draft
           return Array.from({ length: 10 }, (_, i) => ({
             id: `exec-u1-${i}`,
-            wasDraftSent: i === 0,
+            draftStatus:
+              i === 0
+                ? DraftEmailStatus.SENT
+                : DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
           }));
         }
         if (ruleIds.includes("rule-user-2")) {
           // User 2 did not
           return Array.from({ length: 10 }, (_, i) => ({
             id: `exec-u2-${i}`,
-            wasDraftSent: false,
+            draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
           }));
         }
         return [];
@@ -144,7 +150,7 @@ describe("disableUnusedAutoDrafts", () => {
     (prisma.executedAction.findMany as any).mockResolvedValueOnce(
       Array.from({ length: 10 }, (_, i) => ({
         id: `exec-${i}`,
-        wasDraftSent: false,
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
       })),
     );
 

--- a/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.ts
+++ b/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.ts
@@ -123,10 +123,7 @@ async function findExecutedDraftActions(ruleIds: string[]) {
 }
 
 function isSentDraftStatus(status: DraftEmailStatus | null): boolean {
-  return (
-    status === DraftEmailStatus.SENT ||
-    status === DraftEmailStatus.SENT_WITH_EDITS
-  );
+  return status === DraftEmailStatus.LIKELY_SENT;
 }
 
 async function deleteAutoDraftActions(actionIds: string[]) {

--- a/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.ts
+++ b/apps/web/app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.ts
@@ -1,7 +1,7 @@
 import groupBy from "lodash/groupBy";
 import { subDays } from "date-fns/subDays";
 import prisma from "@/utils/prisma";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 
 const MAX_DRAFTS_TO_CHECK = 10;
@@ -55,8 +55,8 @@ export async function disableUnusedAutoDrafts(logger: Logger) {
         count: executedDraftActions.length,
       });
 
-      const anyDraftsSent = executedDraftActions.some(
-        (action) => action.wasDraftSent === true,
+      const anyDraftsSent = executedDraftActions.some((action) =>
+        isSentDraftStatus(action.draftStatus),
       );
 
       if (anyDraftsSent) {
@@ -113,13 +113,20 @@ async function findExecutedDraftActions(ruleIds: string[]) {
     },
     select: {
       id: true,
-      wasDraftSent: true,
+      draftStatus: true,
     },
     orderBy: {
       createdAt: "desc",
     },
     take: MAX_DRAFTS_TO_CHECK,
   });
+}
+
+function isSentDraftStatus(status: DraftEmailStatus | null): boolean {
+  return (
+    status === DraftEmailStatus.SENT ||
+    status === DraftEmailStatus.SENT_WITH_EDITS
+  );
 }
 
 async function deleteAutoDraftActions(actionIds: string[]) {

--- a/apps/web/app/api/user/draft-actions/route.ts
+++ b/apps/web/app/api/user/draft-actions/route.ts
@@ -24,7 +24,7 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
       createdAt: true,
       content: true,
       draftId: true,
-      wasDraftSent: true,
+      draftStatus: true,
       draftSendLog: {
         select: {
           sentMessageId: true,

--- a/apps/web/prisma/migrations/20260511120000_add_draft_email_status/migration.sql
+++ b/apps/web/prisma/migrations/20260511120000_add_draft_email_status/migration.sql
@@ -1,0 +1,26 @@
+CREATE TYPE "DraftEmailStatus" AS ENUM (
+  'PENDING',
+  'SENT',
+  'SENT_WITH_EDITS',
+  'REPLIED_WITHOUT_DRAFT',
+  'CLEANED_UP_UNUSED',
+  'DELETED_OR_GONE'
+);
+
+ALTER TABLE "ExecutedAction"
+ADD COLUMN "draftStatus" "DraftEmailStatus";
+
+UPDATE "ExecutedAction"
+SET "draftStatus" = CASE
+  WHEN "wasDraftSent" = true THEN 'SENT'::"DraftEmailStatus"
+  WHEN "type" = 'DRAFT_EMAIL' AND "wasDraftSent" = false AND EXISTS (
+    SELECT 1
+    FROM "DraftSendLog"
+    WHERE "DraftSendLog"."executedActionId" = "ExecutedAction"."id"
+  ) THEN 'REPLIED_WITHOUT_DRAFT'::"DraftEmailStatus"
+  WHEN "type" = 'DRAFT_EMAIL' AND "wasDraftSent" = false THEN 'CLEANED_UP_UNUSED'::"DraftEmailStatus"
+  WHEN "type" = 'DRAFT_EMAIL' AND "draftId" IS NOT NULL THEN 'PENDING'::"DraftEmailStatus"
+  WHEN "wasDraftSent" = false THEN 'PENDING'::"DraftEmailStatus"
+  ELSE NULL
+END
+WHERE "wasDraftSent" IS NOT NULL OR ("type" = 'DRAFT_EMAIL' AND "draftId" IS NOT NULL);

--- a/apps/web/prisma/migrations/20260511120000_add_draft_email_status/migration.sql
+++ b/apps/web/prisma/migrations/20260511120000_add_draft_email_status/migration.sql
@@ -1,10 +1,9 @@
 CREATE TYPE "DraftEmailStatus" AS ENUM (
   'PENDING',
-  'SENT',
-  'SENT_WITH_EDITS',
+  'LIKELY_SENT',
   'REPLIED_WITHOUT_DRAFT',
   'CLEANED_UP_UNUSED',
-  'DELETED_OR_GONE'
+  'MISSING_FROM_PROVIDER'
 );
 
 ALTER TABLE "ExecutedAction"
@@ -12,7 +11,7 @@ ADD COLUMN "draftStatus" "DraftEmailStatus";
 
 UPDATE "ExecutedAction"
 SET "draftStatus" = CASE
-  WHEN "wasDraftSent" = true THEN 'SENT'::"DraftEmailStatus"
+  WHEN "wasDraftSent" = true THEN 'LIKELY_SENT'::"DraftEmailStatus"
   WHEN "type" = 'DRAFT_EMAIL' AND "wasDraftSent" = false AND EXISTS (
     SELECT 1
     FROM "DraftSendLog"

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -642,12 +642,13 @@ model ExecutedAction {
 
   // additional fields as a result of the action
   draftId              String? // Gmail draft ID created by DRAFT_EMAIL action
-  wasDraftSent         Boolean? // Tracks if the corresponding draft was sent (true) or ignored/superseded (false)
+  draftStatus          DraftEmailStatus?
+  wasDraftSent         Boolean? // @deprecated Use draftStatus. Kept for historical compatibility only.
   draftModelProvider   String?
   draftModelName       String?
   draftPipelineVersion Int?
   draftContextMetadata Json?
-  draftSendLog         DraftSendLog? // Will exist if the draft was sent
+  draftSendLog         DraftSendLog? // Exists when an outbound reply was compared against this draft
   digestItems          DigestItem[] // Relation to digest items created by this action
   scheduledAction      ScheduledAction? // Reverse relation for delayed actions
 
@@ -1538,6 +1539,15 @@ enum DraftReplyConfidence {
   ALL_EMAILS
   STANDARD
   HIGH_CONFIDENCE
+}
+
+enum DraftEmailStatus {
+  PENDING
+  SENT
+  SENT_WITH_EDITS
+  REPLIED_WITHOUT_DRAFT
+  CLEANED_UP_UNUSED
+  DELETED_OR_GONE
 }
 
 enum ReplyMemoryKind {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -642,7 +642,7 @@ model ExecutedAction {
 
   // additional fields as a result of the action
   draftId              String? // Gmail draft ID created by DRAFT_EMAIL action
-  draftStatus          DraftEmailStatus?
+  draftStatus          DraftEmailStatus? // Last observed/inferred draft lifecycle status; provider state may be stale or ambiguous.
   wasDraftSent         Boolean? // @deprecated Use draftStatus. Kept for historical compatibility only.
   draftModelProvider   String?
   draftModelName       String?
@@ -1543,11 +1543,10 @@ enum DraftReplyConfidence {
 
 enum DraftEmailStatus {
   PENDING
-  SENT
-  SENT_WITH_EDITS
+  LIKELY_SENT
   REPLIED_WITHOUT_DRAFT
   CLEANED_UP_UNUSED
-  DELETED_OR_GONE
+  MISSING_FROM_PROVIDER
 }
 
 enum ReplyMemoryKind {

--- a/apps/web/utils/ai/assistant/tools/rules/get-rule-execution-for-message-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/get-rule-execution-for-message-tool.ts
@@ -40,7 +40,7 @@ type GetRuleExecutionForMessageOutput =
           url: string | null;
           folderName: string | null;
           draftId: string | null;
-          wasDraftSent: boolean | null;
+          draftStatus: string | null;
         }>;
       }>;
     }
@@ -100,7 +100,7 @@ export const getRuleExecutionForMessageTool = ({
                 url: true,
                 folderName: true,
                 draftId: true,
-                wasDraftSent: true,
+                draftStatus: true,
               },
             },
             rule: {
@@ -134,7 +134,7 @@ export const getRuleExecutionForMessageTool = ({
             url: action.url,
             folderName: action.folderName,
             draftId: action.draftId,
-            wasDraftSent: action.wasDraftSent,
+            draftStatus: action.draftStatus,
           })),
         }));
 

--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -7,7 +7,7 @@ import {
   isDraftUnmodified,
 } from "@/utils/ai/choose-rule/draft-management";
 import prisma from "@/utils/prisma";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
 import type { EmailProvider } from "@/utils/email/types";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -44,7 +44,7 @@ describe("handlePreviousDraftDeletion", () => {
     vi.clearAllMocks();
   });
 
-  it("should delete unmodified draft and update wasDraftSent", async () => {
+  it("should delete unmodified draft and update draft status", async () => {
     const mockPreviousDraft = {
       id: "action-111",
       draftId: "draft-222",
@@ -106,7 +106,9 @@ describe("handlePreviousDraftDeletion", () => {
     expect(mockDeleteDraft).toHaveBeenCalledWith("draft-222");
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: "action-111" },
-      data: { wasDraftSent: false },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
     });
   });
 
@@ -318,7 +320,9 @@ describe("handlePreviousDraftDeletion", () => {
     expect(mockDeleteDraft).toHaveBeenCalledWith("draft-222");
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: "action-111" },
-      data: { wasDraftSent: false },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
     });
   });
 

--- a/apps/web/utils/ai/choose-rule/draft-management.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.ts
@@ -1,6 +1,6 @@
 import { load } from "cheerio";
 import prisma from "@/utils/prisma";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { ExecutedRule } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
 import type { EmailProvider } from "@/utils/email/types";
@@ -81,7 +81,9 @@ export async function handlePreviousDraftDeletion({
         client.deleteDraft(previousDraftAction.draftId),
         prisma.executedAction.update({
           where: { id: previousDraftAction.id },
-          data: { wasDraftSent: false },
+          data: {
+            draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+          },
         }),
       ]);
 
@@ -111,7 +113,7 @@ export async function updateExecutedActionWithDraftId({
   try {
     await prisma.executedAction.update({
       where: { id: actionId },
-      data: { draftId },
+      data: { draftId, draftStatus: DraftEmailStatus.PENDING },
     });
     logger.info("Updated executed action with draft ID", { actionId, draftId });
   } catch (error) {

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -3,7 +3,7 @@ import {
   cleanupAIDraftsForAccount,
   cleanupConfiguredAIDrafts,
 } from "@/utils/ai/draft-cleanup";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 
 vi.mock("server-only", () => ({}));
@@ -112,7 +112,9 @@ describe("cleanupAIDraftsForAccount", () => {
     expect(mocks.provider.deleteDraft).not.toHaveBeenCalledWith("draft-2");
     expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
-      data: { wasDraftSent: false },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
     });
     expect(result).toMatchObject({
       total: 2,
@@ -151,7 +153,12 @@ describe("cleanupConfiguredAIDrafts", () => {
               some: {
                 type: ActionType.DRAFT_EMAIL,
                 draftId: { not: null },
-                OR: [{ draftSendLog: null }, { wasDraftSent: false }],
+                draftStatus: {
+                  in: [
+                    DraftEmailStatus.PENDING,
+                    DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+                  ],
+                },
               },
             },
           },

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -121,6 +121,58 @@ describe("cleanupAIDraftsForAccount", () => {
       cleanupDays: 14,
     });
   });
+
+  it("transitions replied-without-draft records after cleanup", async () => {
+    mocks.prisma.executedAction.findMany.mockResolvedValue([
+      {
+        id: "action-deleted",
+        draftId: "draft-deleted",
+        content: "Generated reply.",
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+        draftSendLog: { id: "draft-send-log-1" },
+      },
+      {
+        id: "action-missing",
+        draftId: "draft-missing",
+        content: "Missing reply.",
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+        draftSendLog: { id: "draft-send-log-2" },
+      },
+    ]);
+    mocks.provider.getDraft
+      .mockResolvedValueOnce({
+        textPlain: "Generated reply.",
+        textHtml: null,
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await cleanupAIDraftsForAccount({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+      cleanupDays: 14,
+    });
+
+    expect(mocks.provider.deleteDraft).toHaveBeenCalledWith("draft-deleted");
+    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-deleted" },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
+    });
+    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-missing" },
+      data: {
+        draftStatus: DraftEmailStatus.MISSING_FROM_PROVIDER,
+      },
+    });
+    expect(result).toMatchObject({
+      total: 2,
+      deleted: 1,
+      alreadyGone: 1,
+      cleanupDays: 14,
+    });
+  });
 });
 
 describe("cleanupConfiguredAIDrafts", () => {

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -33,7 +33,6 @@ export async function cleanupAIDraftsForAccount({
       id: true,
       draftId: true,
       draftStatus: true,
-      draftSendLog: { select: { id: true } },
       content: true,
     },
     orderBy: { createdAt: "asc" },
@@ -69,7 +68,6 @@ export async function cleanupAIDraftsForAccount({
 
       if (!draftDetails?.textPlain && !draftDetails?.textHtml) {
         const statusData = getDraftCleanupStatusData({
-          draftSendLog: action.draftSendLog,
           draftStatus: action.draftStatus,
           status: DraftEmailStatus.MISSING_FROM_PROVIDER,
         });
@@ -98,7 +96,6 @@ export async function cleanupAIDraftsForAccount({
 
       await provider.deleteDraft(action.draftId);
       const statusData = getDraftCleanupStatusData({
-        draftSendLog: action.draftSendLog,
         draftStatus: action.draftStatus,
         status: DraftEmailStatus.CLEANED_UP_UNUSED,
       });
@@ -224,15 +221,18 @@ export async function getConfiguredDraftCleanupDays(emailAccountId: string) {
 }
 
 function getDraftCleanupStatusData({
-  draftSendLog,
   draftStatus,
   status,
 }: {
-  draftSendLog?: { id: string } | null;
   draftStatus?: DraftEmailStatus | null;
   status: DraftEmailStatus;
 }): { draftStatus: DraftEmailStatus } | null {
-  if (draftSendLog) return null;
-  if (draftStatus && draftStatus !== DraftEmailStatus.PENDING) return null;
+  if (
+    draftStatus &&
+    draftStatus !== DraftEmailStatus.PENDING &&
+    draftStatus !== DraftEmailStatus.REPLIED_WITHOUT_DRAFT
+  ) {
+    return null;
+  }
   return { draftStatus: status };
 }

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -1,5 +1,5 @@
 import prisma from "@/utils/prisma";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import { createEmailProvider } from "@/utils/email/provider";
 import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import type { Logger } from "@/utils/logger";
@@ -24,12 +24,16 @@ export async function cleanupAIDraftsForAccount({
       executedRule: { emailAccountId },
       type: ActionType.DRAFT_EMAIL,
       draftId: { not: null },
-      OR: [{ draftSendLog: null }, { wasDraftSent: false }],
+      draftStatus: {
+        in: [DraftEmailStatus.PENDING, DraftEmailStatus.REPLIED_WITHOUT_DRAFT],
+      },
       createdAt: { lt: cutoffDate },
     },
     select: {
       id: true,
       draftId: true,
+      draftStatus: true,
+      draftSendLog: { select: { id: true } },
       content: true,
     },
     orderBy: { createdAt: "asc" },
@@ -64,10 +68,17 @@ export async function cleanupAIDraftsForAccount({
       const draftDetails = await provider.getDraft(action.draftId);
 
       if (!draftDetails?.textPlain && !draftDetails?.textHtml) {
-        await prisma.executedAction.update({
-          where: { id: action.id },
-          data: { wasDraftSent: false },
+        const statusData = getDraftCleanupStatusData({
+          draftSendLog: action.draftSendLog,
+          draftStatus: action.draftStatus,
+          status: DraftEmailStatus.DELETED_OR_GONE,
         });
+        if (statusData) {
+          await prisma.executedAction.update({
+            where: { id: action.id },
+            data: statusData,
+          });
+        }
         alreadyGone++;
         continue;
       }
@@ -86,10 +97,17 @@ export async function cleanupAIDraftsForAccount({
       }
 
       await provider.deleteDraft(action.draftId);
-      await prisma.executedAction.update({
-        where: { id: action.id },
-        data: { wasDraftSent: false },
+      const statusData = getDraftCleanupStatusData({
+        draftSendLog: action.draftSendLog,
+        draftStatus: action.draftStatus,
+        status: DraftEmailStatus.CLEANED_UP_UNUSED,
       });
+      if (statusData) {
+        await prisma.executedAction.update({
+          where: { id: action.id },
+          data: statusData,
+        });
+      }
       deleted++;
     } catch (error) {
       logger.error("Error cleaning up draft", {
@@ -134,7 +152,12 @@ export async function cleanupConfiguredAIDrafts({
             some: {
               type: ActionType.DRAFT_EMAIL,
               draftId: { not: null },
-              OR: [{ draftSendLog: null }, { wasDraftSent: false }],
+              draftStatus: {
+                in: [
+                  DraftEmailStatus.PENDING,
+                  DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+                ],
+              },
             },
           },
         },
@@ -198,4 +221,18 @@ export async function getConfiguredDraftCleanupDays(emailAccountId: string) {
   });
 
   return emailAccount?.draftCleanupDays ?? DEFAULT_AI_DRAFT_CLEANUP_DAYS;
+}
+
+function getDraftCleanupStatusData({
+  draftSendLog,
+  draftStatus,
+  status,
+}: {
+  draftSendLog?: { id: string } | null;
+  draftStatus?: DraftEmailStatus | null;
+  status: DraftEmailStatus;
+}): { draftStatus: DraftEmailStatus } | null {
+  if (draftSendLog) return null;
+  if (draftStatus && draftStatus !== DraftEmailStatus.PENDING) return null;
+  return { draftStatus: status };
 }

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -71,7 +71,7 @@ export async function cleanupAIDraftsForAccount({
         const statusData = getDraftCleanupStatusData({
           draftSendLog: action.draftSendLog,
           draftStatus: action.draftStatus,
-          status: DraftEmailStatus.DELETED_OR_GONE,
+          status: DraftEmailStatus.MISSING_FROM_PROVIDER,
         });
         if (statusData) {
           await prisma.executedAction.update({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -960,7 +960,7 @@ async function sendDraftReplyFromNotification({
   await prisma.executedAction.update({
     where: { id: context.id },
     data: {
-      draftStatus: DraftEmailStatus.SENT,
+      draftStatus: DraftEmailStatus.LIKELY_SENT,
       messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
     },
   });
@@ -969,7 +969,7 @@ async function sendDraftReplyFromNotification({
     await prisma.executedAction.update({
       where: { id: mailboxDraftAction.id },
       data: {
-        draftStatus: DraftEmailStatus.SENT,
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
       },
     });
   }

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -28,6 +28,7 @@ import {
 import {
   ActionType,
   AttachmentSourceType,
+  DraftEmailStatus,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -959,8 +960,8 @@ async function sendDraftReplyFromNotification({
   await prisma.executedAction.update({
     where: { id: context.id },
     data: {
+      draftStatus: DraftEmailStatus.SENT,
       messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
-      wasDraftSent: true,
     },
   });
 
@@ -968,7 +969,7 @@ async function sendDraftReplyFromNotification({
     await prisma.executedAction.update({
       where: { id: mailboxDraftAction.id },
       data: {
-        wasDraftSent: true,
+        draftStatus: DraftEmailStatus.SENT,
       },
     });
   }

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -99,7 +99,7 @@ describe("trackSentDraftStatus", () => {
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {
-        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
       },
     });
     expect(syncReplyMemoriesFromDraftSendLogs).toHaveBeenCalledWith({
@@ -158,6 +158,7 @@ describe("trackSentDraftStatus", () => {
       draftId: "draft-1",
       content: "Thanks for reaching out.",
       executedRuleId: "executed-rule-1",
+      executedRule: { messageId: "source-1" },
     } as any);
     vi.mocked(calculateSimilarity).mockReturnValue(0.72);
     vi.mocked(isMeaningfulDraftEdit).mockReturnValue(true);
@@ -167,6 +168,7 @@ describe("trackSentDraftStatus", () => {
       message: createSentMessage(),
       provider: {
         getDraft: vi.fn().mockResolvedValue(null),
+        getMessage: vi.fn().mockRejectedValue(new Error("missing source")),
       } as any,
       logger,
     });
@@ -208,7 +210,7 @@ describe("trackSentDraftStatus", () => {
     });
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
-      data: { wasDraftSent: false },
+      data: { draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT },
     });
     expect(isMeaningfulDraftEdit).not.toHaveBeenCalled();
     expect(saveDraftSendLogReplyMemory).not.toHaveBeenCalled();
@@ -240,7 +242,7 @@ describe("trackSentDraftStatus", () => {
 
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
-      data: { wasDraftSent: true },
+      data: { draftStatus: DraftEmailStatus.LIKELY_SENT },
     });
     expect(saveDraftSendLogReplyMemory).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -343,6 +343,44 @@ describe("cleanupThreadAIDrafts", () => {
     });
   });
 
+  it("transitions replied-without-draft records after deleting stale drafts", async () => {
+    const draftDetails = createDraftMessage({
+      textPlain: "Generated reply",
+    });
+    vi.mocked(prisma.executedAction.findMany).mockResolvedValue([
+      {
+        id: "action-1",
+        draftId: "draft-1",
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+        draftSendLog: { id: "draft-send-log-1" },
+        content: "Generated reply",
+      },
+    ] as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(1);
+    vi.mocked(isDraftUnmodified).mockReturnValue(true);
+
+    const provider = {
+      getDraft: vi.fn().mockResolvedValue(draftDetails),
+      deleteDraft: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await cleanupThreadAIDrafts({
+      threadId: "thread-1",
+      emailAccountId: "account-1",
+      provider: provider as any,
+      logger,
+      excludeMessageId: "message-2",
+    });
+
+    expect(provider.deleteDraft).toHaveBeenCalledWith("draft-1");
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
+    });
+  });
+
   it("keeps stale drafts when the generated reply was edited", async () => {
     vi.mocked(prisma.executedAction.findMany).mockResolvedValue([
       {

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -148,7 +148,7 @@ describe("trackSentDraftStatus", () => {
     });
   });
 
-  it("marks missing drafts as sent with edits when the sent reply is similar enough", async () => {
+  it("marks missing drafts as likely sent when the sent reply is similar enough", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",
       draftId: "draft-1",
@@ -170,7 +170,7 @@ describe("trackSentDraftStatus", () => {
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {
-        draftStatus: DraftEmailStatus.SENT_WITH_EDITS,
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
       },
     });
   });
@@ -205,7 +205,7 @@ describe("trackSentDraftStatus", () => {
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {
-        draftStatus: DraftEmailStatus.SENT,
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
       },
     });
   });

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 
 vi.mock("server-only", () => ({}));
@@ -95,6 +95,12 @@ describe("trackSentDraftStatus", () => {
       executedRuleId: "executed-rule-1",
       logger,
     });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+      },
+    });
     expect(syncReplyMemoriesFromDraftSendLogs).toHaveBeenCalledWith({
       emailAccountId: "account-1",
       provider,
@@ -137,7 +143,36 @@ describe("trackSentDraftStatus", () => {
     });
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
-      data: { wasDraftSent: false },
+      data: {
+        draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+      },
+    });
+  });
+
+  it("marks missing drafts as sent with edits when the sent reply is similar enough", async () => {
+    vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
+      id: "action-1",
+      draftId: "draft-1",
+      content: "Thanks for reaching out.",
+      executedRuleId: "executed-rule-1",
+    } as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.72);
+    vi.mocked(isMeaningfulDraftEdit).mockReturnValue(true);
+
+    await trackSentDraftStatus({
+      emailAccountId: "account-1",
+      message: createSentMessage(),
+      provider: {
+        getDraft: vi.fn().mockResolvedValue(null),
+      } as any,
+      logger,
+    });
+
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.SENT_WITH_EDITS,
+      },
     });
   });
 
@@ -167,6 +202,12 @@ describe("trackSentDraftStatus", () => {
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.SENT,
+      },
     });
   });
 });
@@ -213,7 +254,9 @@ describe("cleanupThreadAIDrafts", () => {
     expect(provider.deleteDraft).toHaveBeenCalledWith("draft-1");
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
-      data: { wasDraftSent: false },
+      data: {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+      },
     });
   });
 

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -170,8 +170,13 @@ export async function trackSentDraftStatus({
   );
 
   // Gmail and Outlook both make "missing draft" ambiguous: it can mean sent,
-  // deleted, moved, or no longer reachable under the stored draft ID.
-  const draftStatus = getSentDraftStatus(similarityScore);
+  // deleted, moved, or no longer reachable under the stored draft ID. When the
+  // sent message targets the original sender, record the lifecycle as likely
+  // sent and leave edit strength to similarityScore.
+  const draftStatus = getSentDraftStatus({
+    similarityScore,
+    sentMessageRepliesToSource,
+  });
   const wasLikelyDraftSent = isDraftSentStatus(draftStatus);
 
   const [draftSendLog] = await withPrismaRetry(
@@ -503,8 +508,17 @@ function queueReplyMemoryLearning({
   });
 }
 
-function getSentDraftStatus(similarityScore: number): DraftEmailStatus {
-  if (similarityScore >= DRAFT_SENT_SIMILARITY_THRESHOLD) {
+function getSentDraftStatus({
+  similarityScore,
+  sentMessageRepliesToSource,
+}: {
+  similarityScore: number;
+  sentMessageRepliesToSource: boolean | null;
+}): DraftEmailStatus {
+  if (
+    sentMessageRepliesToSource ||
+    similarityScore >= DRAFT_SENT_SIMILARITY_THRESHOLD
+  ) {
     return DraftEmailStatus.LIKELY_SENT;
   }
   return DraftEmailStatus.REPLIED_WITHOUT_DRAFT;

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -18,8 +18,6 @@ import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { logReplyTrackerError } from "./error-logging";
 
 const DRAFT_SENT_SIMILARITY_THRESHOLD = 0.7;
-const UNEDITED_DRAFT_SENT_SIMILARITY_THRESHOLD = 0.95;
-
 /**
  * Checks if a sent message originated from an AI draft and logs its similarity.
  */
@@ -347,7 +345,7 @@ export async function cleanupThreadAIDrafts({
           const statusData = getDraftCleanupStatusData({
             draftSendLog: action.draftSendLog,
             draftStatus: action.draftStatus,
-            status: DraftEmailStatus.DELETED_OR_GONE,
+            status: DraftEmailStatus.MISSING_FROM_PROVIDER,
           });
           if (statusData) {
             await withPrismaRetry(
@@ -474,20 +472,14 @@ function queueReplyMemoryLearning({
 }
 
 function getSentDraftStatus(similarityScore: number): DraftEmailStatus {
-  if (similarityScore >= UNEDITED_DRAFT_SENT_SIMILARITY_THRESHOLD) {
-    return DraftEmailStatus.SENT;
-  }
   if (similarityScore >= DRAFT_SENT_SIMILARITY_THRESHOLD) {
-    return DraftEmailStatus.SENT_WITH_EDITS;
+    return DraftEmailStatus.LIKELY_SENT;
   }
   return DraftEmailStatus.REPLIED_WITHOUT_DRAFT;
 }
 
 function isDraftSentStatus(status: DraftEmailStatus): boolean {
-  return (
-    status === DraftEmailStatus.SENT ||
-    status === DraftEmailStatus.SENT_WITH_EDITS
-  );
+  return status === DraftEmailStatus.LIKELY_SENT;
 }
 
 function getDraftCleanupStatusData({

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -1,5 +1,5 @@
 import { after } from "next/server";
-import { ActionType } from "@/generated/prisma/enums";
+import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/prisma";
 import { withPrismaRetry } from "@/utils/prisma-retry";
@@ -16,6 +16,9 @@ import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { logReplyTrackerError } from "./error-logging";
+
+const DRAFT_SENT_SIMILARITY_THRESHOLD = 0.7;
+const UNEDITED_DRAFT_SENT_SIMILARITY_THRESHOLD = 0.95;
 
 /**
  * Checks if a sent message originated from an AI draft and logs its similarity.
@@ -88,7 +91,7 @@ export async function trackSentDraftStatus({
       similarityScore,
     });
 
-    // Create DraftSendLog to record the comparison, but mark wasDraftSent as false
+    // Create DraftSendLog to record the comparison.
     const [draftSendLog] = await withPrismaRetry(
       () =>
         prisma.$transaction([
@@ -101,7 +104,9 @@ export async function trackSentDraftStatus({
           }),
           prisma.executedAction.update({
             where: { id: executedActionId },
-            data: { wasDraftSent: false },
+            data: {
+              draftStatus: DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+            },
           }),
         ]),
       { logger },
@@ -137,6 +142,11 @@ export async function trackSentDraftStatus({
     },
   );
 
+  // Gmail and Outlook both make "missing draft" ambiguous: it can mean sent,
+  // deleted, moved, or no longer reachable under the stored draft ID.
+  const draftStatus = getSentDraftStatus(similarityScore);
+  const wasLikelyDraftSent = isDraftSentStatus(draftStatus);
+
   const [draftSendLog] = await withPrismaRetry(
     () =>
       prisma.$transaction([
@@ -147,10 +157,11 @@ export async function trackSentDraftStatus({
             similarityScore: similarityScore,
           },
         }),
-        // Mark that the draft was sent
         prisma.executedAction.update({
           where: { id: executedActionId },
-          data: { wasDraftSent: true },
+          data: {
+            draftStatus,
+          },
         }),
       ]),
     { logger },
@@ -161,12 +172,14 @@ export async function trackSentDraftStatus({
     { executedActionId },
   );
 
-  after(() =>
-    trackFirstTimeEvent({
-      emailAccountId,
-      event: FIRST_TIME_EVENTS.FIRST_DRAFT_SENT,
-    }),
-  );
+  if (wasLikelyDraftSent) {
+    after(() =>
+      trackFirstTimeEvent({
+        emailAccountId,
+        event: FIRST_TIME_EVENTS.FIRST_DRAFT_SENT,
+      }),
+    );
+  }
 
   await replaceMessagingDraftNotificationsWithHandledOnWebState({
     executedRuleId: executedAction.executedRuleId,
@@ -207,9 +220,8 @@ export async function cleanupThreadAIDrafts({
   logger.info("Starting cleanup of old AI drafts for thread");
 
   try {
-    // Find all draft actions for this thread that:
-    // 1. Haven't been logged yet (draftSendLog is null), OR
-    // 2. Were logged but the user sent a different reply (wasDraftSent is false)
+    // Find draft actions that are still pending, or where the user replied
+    // without using the draft and the old draft may still need cleanup.
     // Excludes drafts for the current message to avoid deleting a draft that was just created
     const potentialDraftsToClean = await prisma.executedAction.findMany({
       where: {
@@ -220,11 +232,18 @@ export async function cleanupThreadAIDrafts({
         },
         type: ActionType.DRAFT_EMAIL,
         draftId: { not: null },
-        OR: [{ draftSendLog: null }, { wasDraftSent: false }],
+        draftStatus: {
+          in: [
+            DraftEmailStatus.PENDING,
+            DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+          ],
+        },
       },
       select: {
         id: true,
         draftId: true,
+        draftStatus: true,
+        draftSendLog: { select: { id: true } },
         content: true,
       },
     });
@@ -295,22 +314,25 @@ export async function cleanupThreadAIDrafts({
               draftEmbeddedMessageId: draftDetails.id,
               draftThreadId: draftDetails.threadId,
             });
+            const statusData = getDraftCleanupStatusData({
+              draftSendLog: action.draftSendLog,
+              draftStatus: action.draftStatus,
+              status: DraftEmailStatus.CLEANED_UP_UNUSED,
+            });
             await Promise.all([
               provider.deleteDraft(action.draftId),
-              // Mark as not sent (cleaned up because ignored/superseded)
-              withPrismaRetry(
-                () =>
-                  prisma.executedAction.update({
-                    where: { id: action.id },
-                    data: { wasDraftSent: false },
-                  }),
-                { logger },
-              ),
+              statusData
+                ? withPrismaRetry(
+                    () =>
+                      prisma.executedAction.update({
+                        where: { id: action.id },
+                        data: statusData,
+                      }),
+                    { logger },
+                  )
+                : Promise.resolve(),
             ]);
-            logger.info(
-              "Deleted unmodified draft and updated action status.",
-              actionLoggerOptions,
-            );
+            logger.info("Deleted unmodified draft.", actionLoggerOptions);
           } else {
             logger.info(
               "Draft has been modified, skipping deletion.",
@@ -319,18 +341,24 @@ export async function cleanupThreadAIDrafts({
           }
         } else {
           logger.info(
-            "Draft no longer exists, marking as not sent.",
+            "Draft no longer exists, tracking cleanup status.",
             actionLoggerOptions,
           );
-          // Draft doesn't exist anymore, mark as not sent
-          await withPrismaRetry(
-            () =>
-              prisma.executedAction.update({
-                where: { id: action.id },
-                data: { wasDraftSent: false },
-              }),
-            { logger },
-          );
+          const statusData = getDraftCleanupStatusData({
+            draftSendLog: action.draftSendLog,
+            draftStatus: action.draftStatus,
+            status: DraftEmailStatus.DELETED_OR_GONE,
+          });
+          if (statusData) {
+            await withPrismaRetry(
+              () =>
+                prisma.executedAction.update({
+                  where: { id: action.id },
+                  data: statusData,
+                }),
+              { logger },
+            );
+          }
         }
       } catch (error) {
         await logReplyTrackerError({
@@ -443,4 +471,35 @@ function queueReplyMemoryLearning({
       });
     }
   });
+}
+
+function getSentDraftStatus(similarityScore: number): DraftEmailStatus {
+  if (similarityScore >= UNEDITED_DRAFT_SENT_SIMILARITY_THRESHOLD) {
+    return DraftEmailStatus.SENT;
+  }
+  if (similarityScore >= DRAFT_SENT_SIMILARITY_THRESHOLD) {
+    return DraftEmailStatus.SENT_WITH_EDITS;
+  }
+  return DraftEmailStatus.REPLIED_WITHOUT_DRAFT;
+}
+
+function isDraftSentStatus(status: DraftEmailStatus): boolean {
+  return (
+    status === DraftEmailStatus.SENT ||
+    status === DraftEmailStatus.SENT_WITH_EDITS
+  );
+}
+
+function getDraftCleanupStatusData({
+  draftSendLog,
+  draftStatus,
+  status,
+}: {
+  draftSendLog?: { id: string } | null;
+  draftStatus?: DraftEmailStatus | null;
+  status: DraftEmailStatus;
+}): { draftStatus: DraftEmailStatus } | null {
+  if (draftSendLog) return null;
+  if (draftStatus && draftStatus !== DraftEmailStatus.PENDING) return null;
+  return { draftStatus: status };
 }

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -275,7 +275,6 @@ export async function cleanupThreadAIDrafts({
         id: true,
         draftId: true,
         draftStatus: true,
-        draftSendLog: { select: { id: true } },
         content: true,
       },
     });
@@ -347,7 +346,6 @@ export async function cleanupThreadAIDrafts({
               draftThreadId: draftDetails.threadId,
             });
             const statusData = getDraftCleanupStatusData({
-              draftSendLog: action.draftSendLog,
               draftStatus: action.draftStatus,
               status: DraftEmailStatus.CLEANED_UP_UNUSED,
             });
@@ -377,7 +375,6 @@ export async function cleanupThreadAIDrafts({
             actionLoggerOptions,
           );
           const statusData = getDraftCleanupStatusData({
-            draftSendLog: action.draftSendLog,
             draftStatus: action.draftStatus,
             status: DraftEmailStatus.MISSING_FROM_PROVIDER,
           });
@@ -529,15 +526,18 @@ function isDraftSentStatus(status: DraftEmailStatus): boolean {
 }
 
 function getDraftCleanupStatusData({
-  draftSendLog,
   draftStatus,
   status,
 }: {
-  draftSendLog?: { id: string } | null;
   draftStatus?: DraftEmailStatus | null;
   status: DraftEmailStatus;
 }): { draftStatus: DraftEmailStatus } | null {
-  if (draftSendLog) return null;
-  if (draftStatus && draftStatus !== DraftEmailStatus.PENDING) return null;
+  if (
+    draftStatus &&
+    draftStatus !== DraftEmailStatus.PENDING &&
+    draftStatus !== DraftEmailStatus.REPLIED_WITHOUT_DRAFT
+  ) {
+    return null;
+  }
   return { draftStatus: status };
 }

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -88,7 +88,7 @@ describe("executor", () => {
         bcc: null,
         url: null,
         draftId: null,
-        wasDraftSent: null,
+        draftStatus: null,
       });
       prisma.executedRule.findUnique.mockResolvedValue({
         id: "rule-123",
@@ -192,7 +192,7 @@ describe("executor", () => {
         bcc: null,
         url: null,
         draftId: null,
-        wasDraftSent: null,
+        draftStatus: null,
         selectedAttachments: [
           {
             fileId: "drive-file-1",
@@ -294,7 +294,7 @@ describe("executor", () => {
         bcc: null,
         url: null,
         draftId: null,
-        wasDraftSent: null,
+        draftStatus: null,
       });
       prisma.executedRule.findUnique.mockResolvedValue({
         id: "rule-123",


### PR DESCRIPTION
Tracks draft lifecycle state with an enum so cleanup and usage checks no longer depend on a deprecated boolean. Existing rows are backfilled and active code paths read/write the new status field.

- Add a draft status enum and migration with conservative backfill
- Update draft scoring, cleanup, notification send, debug, and assistant history paths to use draft status
- Keep the old boolean deprecated for historical compatibility

Tests:
- pnpm test utils/reply-tracker/draft-tracking.test.ts utils/ai/draft-cleanup.test.ts utils/ai/choose-rule/draft-management.test.ts app/api/reply-tracker/disable-unused-auto-draft/disable-unused-auto-drafts.test.ts utils/messaging/rule-notifications.test.ts __tests__/ai-assistant-chat.test.ts utils/scheduled-actions/executor.test.ts
- pnpm test __tests__/integration/slack-notifications.test.ts __tests__/eval/assistant-chat-microsoft-search-feedback.test.ts
- pnpm --filter inbox-zero-ai exec prisma validate
- pnpm --filter inbox-zero-ai exec biome check ...
- git diff --check

Performance impact:
- Adds one nullable enum column and updates existing queries to select/use it instead of a boolean.
- No new provider calls in hot paths.
- Cleanup paths keep their existing provider draft checks and use the enum to narrow candidates.