### PR TITLE
test: Share callback middleware helper

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -10,6 +10,29 @@ export function createTestLogger() {
   return createScopedLogger("test");
 }
 
+type WithErrorTestHandler<TContext extends unknown[]> = (
+  request: Request,
+  ...context: TContext
+) => Promise<Response>;
+
+type TestRequestWithLogger = Request & {
+  logger: ReturnType<typeof createTestLogger>;
+};
+
+export function createWithErrorTestMiddleware() {
+  return {
+    withError:
+      <TContext extends unknown[]>(
+        _scope: string,
+        handler: WithErrorTestHandler<TContext>,
+      ) =>
+      async (request: Request, ...context: TContext) => {
+        (request as TestRequestWithLogger).logger = createTestLogger();
+        return handler(request, ...context);
+      },
+  };
+}
+
 type EmailAccountSelect = {
   id: string;
   email: string;

--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -36,21 +36,11 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("@/utils/middleware", async () => {
-  const { createScopedLogger } =
-    await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-  return {
-    withError:
-      (_name: string, handler: (request: NextRequest) => Promise<Response>) =>
-      async (request: NextRequest) => {
-        (
-          request as NextRequest & {
-            logger: ReturnType<typeof createScopedLogger>;
-          }
-        ).logger = createScopedLogger("test/google-linking-callback");
-        return handler(request);
-      },
-  };
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/utils/prisma");

--- a/apps/web/app/api/mcp/[integration]/callback/route.test.ts
+++ b/apps/web/app/api/mcp/[integration]/callback/route.test.ts
@@ -17,30 +17,11 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("@/utils/middleware", async () => {
-  const { createScopedLogger } =
-    await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-  return {
-    withError:
-      (
-        _name: string,
-        handler: (
-          request: NextRequest,
-          context: { params: Promise<{ integration: string }> },
-        ) => Promise<Response>,
-      ) =>
-      async (
-        request: NextRequest,
-        context: { params: Promise<{ integration: string }> },
-      ) => {
-        (
-          request as NextRequest & {
-            logger: ReturnType<typeof createScopedLogger>;
-          }
-        ).logger = createScopedLogger("test/mcp-callback");
-        return handler(request, context);
-      },
-  };
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/utils/prisma");

--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -34,21 +34,11 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("@/utils/middleware", async () => {
-  const { createScopedLogger } =
-    await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-  return {
-    withError:
-      (_name: string, handler: (request: NextRequest) => Promise<Response>) =>
-      async (request: NextRequest) => {
-        (
-          request as NextRequest & {
-            logger: ReturnType<typeof createScopedLogger>;
-          }
-        ).logger = createScopedLogger("test/outlook-linking-callback");
-        return handler(request);
-      },
-  };
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/utils/prisma");

--- a/apps/web/app/api/slack/callback/route.test.ts
+++ b/apps/web/app/api/slack/callback/route.test.ts
@@ -33,21 +33,11 @@ vi.mock("@/env", () => ({
 }));
 
 vi.mock("@/utils/middleware", async () => {
-  const { createScopedLogger } =
-    await vi.importActual<typeof import("@/utils/logger")>("@/utils/logger");
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-  return {
-    withError:
-      (_name: string, handler: (request: NextRequest) => Promise<Response>) =>
-      async (request: NextRequest) => {
-        (
-          request as NextRequest & {
-            logger: ReturnType<typeof createScopedLogger>;
-          }
-        ).logger = createScopedLogger("test/slack-callback");
-        return handler(request);
-      },
-  };
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/utils/prisma");


### PR DESCRIPTION
Centralizes the repeated callback route test middleware mock behind a shared helper.

- Adds a shared test middleware helper that attaches the standard test logger
- Updates callback route tests to reuse the helper while preserving route context forwarding
- Removes duplicated logger setup from callback test mocks

Validation:
- pnpm --dir apps/web test --run app/api/google/linking/callback/route.test.ts app/api/outlook/linking/callback/route.test.ts app/api/slack/callback/route.test.ts app/api/mcp/[integration]/callback/route.test.ts
- git diff --check