### PR TITLE
test: Reuse messaging test fixtures

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -19,6 +19,12 @@ type TestRequestWithLogger = Request & {
   logger: ReturnType<typeof createTestLogger>;
 };
 
+type TestEmailAccountAuth = {
+  email: string;
+  emailAccountId: string;
+  userId: string;
+};
+
 export function createWithErrorTestMiddleware() {
   return {
     withError:
@@ -31,6 +37,23 @@ export function createWithErrorTestMiddleware() {
         return handler(request, ...context);
       },
   };
+}
+
+export function addTestEmailAccountAuth<TRequest extends Request>(
+  request: TRequest,
+  {
+    auth = {
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      email: "user@example.com",
+    },
+    logger = createTestLogger(),
+  }: {
+    auth?: TestEmailAccountAuth;
+    logger?: ReturnType<typeof createTestLogger>;
+  } = {},
+) {
+  return Object.assign(request, { auth, logger });
 }
 
 type EmailAccountSelect = {

--- a/apps/web/__tests__/integration/helpers.ts
+++ b/apps/web/__tests__/integration/helpers.ts
@@ -9,6 +9,8 @@
 import { createEmulator, type Emulator } from "emulate";
 import { gmail, auth } from "@googleapis/gmail";
 import { Client } from "@microsoft/microsoft-graph-client";
+import { WebClient } from "@slack/web-api";
+import { createHmac } from "node:crypto";
 import { createServer } from "node:net";
 import { createTestLogger } from "@/__tests__/helpers";
 import { GmailProvider } from "@/utils/email/google";
@@ -44,6 +46,20 @@ type OutlookSeedMessage = {
   sent_date_time?: string;
 };
 
+type SlackSeedUser = {
+  name: string;
+  real_name?: string;
+  email?: string;
+  is_admin?: boolean;
+};
+
+type SlackSeedChannel = {
+  name: string;
+  is_private?: boolean;
+  topic?: string;
+  purpose?: string;
+};
+
 export type GmailTestHarness = {
   emulator: Emulator;
   gmailClient: ReturnType<typeof gmail>;
@@ -58,6 +74,14 @@ export type OutlookTestHarness = {
   provider: OutlookProvider;
   /** Call in afterAll to restore globalThis.fetch */
   restoreFetch: () => void;
+};
+
+export type SlackTestHarness = {
+  emulator: Emulator;
+  client: WebClient;
+  teamId: string;
+  channelsByName: Record<string, string>;
+  usersByName: Record<string, string>;
 };
 
 /** Common harness shape for provider-agnostic tests */
@@ -218,6 +242,86 @@ export async function createOutlookTestHarness({
   const provider = new OutlookProvider(outlookClient, logger);
 
   return { emulator, graphClient, provider, restoreFetch };
+}
+
+export async function createSlackTestHarness({
+  port,
+  team,
+  users = [],
+  channels = [],
+  token = "emulator-token",
+}: {
+  port?: number;
+  team: { name: string; domain: string };
+  users?: SlackSeedUser[];
+  channels?: SlackSeedChannel[];
+  token?: string;
+}): Promise<SlackTestHarness> {
+  const emulatorPort = port ?? (await getAvailablePort());
+  const emulator = await createEmulator({
+    service: "slack",
+    port: emulatorPort,
+    seed: {
+      slack: {
+        team,
+        users,
+        channels,
+      },
+    },
+  });
+
+  const client = new WebClient(token, {
+    slackApiUrl: `${emulator.url}/api/`,
+  });
+
+  const auth = await client.auth.test();
+  const listedChannels = await client.conversations.list({
+    types: "public_channel,private_channel",
+  });
+  const listedUsers = await client.users.list();
+
+  return {
+    emulator,
+    client,
+    teamId: auth.team_id!,
+    channelsByName: Object.fromEntries(
+      (listedChannels.channels ?? [])
+        .filter((channel) => channel.name && channel.id)
+        .map((channel) => [channel.name!, channel.id!]),
+    ),
+    usersByName: Object.fromEntries(
+      (listedUsers.members ?? [])
+        .filter((user) => user.name && user.id)
+        .map((user) => [user.name!, user.id!]),
+    ),
+  };
+}
+
+export function createSignedSlackRequest({
+  body,
+  signingSecret = "test-signing-secret",
+  timestamp = `${Math.floor(Date.now() / 1000)}`,
+  url = "https://example.com/api/slack/events",
+}: {
+  body: string | Record<string, unknown>;
+  signingSecret?: string;
+  timestamp?: string;
+  url?: string;
+}) {
+  const requestBody = typeof body === "string" ? body : JSON.stringify(body);
+  const signature = `v0=${createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${requestBody}`)
+    .digest("hex")}`;
+
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+    body: requestBody,
+  });
 }
 
 async function getAvailablePort() {

--- a/apps/web/__tests__/integration/slack-chat.test.ts
+++ b/apps/web/__tests__/integration/slack-chat.test.ts
@@ -1,6 +1,4 @@
-import { createHmac } from "node:crypto";
 import { createUIMessageStream } from "ai";
-import { createEmulator, type Emulator } from "emulate";
 import { WebClient } from "@slack/web-api";
 import {
   afterAll,
@@ -16,7 +14,12 @@ import {
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
+import {
+  createSignedSlackRequest,
+  createSlackTestHarness,
+  type SlackTestHarness,
+} from "./helpers";
 
 vi.mock("@/utils/prisma");
 
@@ -70,13 +73,13 @@ vi.mock("@/utils/messaging/rule-notifications", () => ({
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
 const TEST_PORT = 4118;
-const logger = createScopedLogger("test");
+const logger = createTestLogger();
 
 describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Slack chat webhook",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
+    let slackHarness: SlackTestHarness;
     let emulatorClient: WebClient;
     let teamId: string;
     let userId: string;
@@ -88,53 +91,35 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     beforeAll(async () => {
       originalSlackApiUrl = process.env.SLACK_API_URL;
 
-      emulator = await createEmulator({
-        service: "slack",
+      slackHarness = await createSlackTestHarness({
         port: TEST_PORT,
-        seed: {
-          slack: {
-            team: { name: "TestWorkspace", domain: "test-workspace" },
-            users: [
-              {
-                name: "alice",
-                real_name: "Alice Smith",
-                email: "alice@example.com",
-              },
-            ],
-            channels: [
-              {
-                name: "assistant-chat",
-                is_private: false,
-                topic: "Assistant chat tests",
-              },
-            ],
+        team: { name: "TestWorkspace", domain: "test-workspace" },
+        users: [
+          {
+            name: "alice",
+            real_name: "Alice Smith",
+            email: "alice@example.com",
           },
-        },
+        ],
+        channels: [
+          {
+            name: "assistant-chat",
+            is_private: false,
+            topic: "Assistant chat tests",
+          },
+        ],
       });
-      process.env.SLACK_API_URL = `${emulator.url}/api/`;
 
-      emulatorClient = new WebClient("emulator-token", {
-        slackApiUrl: `${emulator.url}/api/`,
-      });
+      process.env.SLACK_API_URL = `${slackHarness.emulator.url}/api/`;
+      emulatorClient = slackHarness.client;
 
-      const auth = await emulatorClient.auth.test();
-      teamId = auth.team_id!;
-
-      const users = await emulatorClient.users.list();
-      const alice = users.members?.find((member) => member.name === "alice");
-      if (!alice?.id) throw new Error("Slack emulator user not found");
-      userId = alice.id;
-
-      const channels = await emulatorClient.conversations.list({
-        types: "public_channel,private_channel",
-      });
-      const assistantChannel = channels.channels?.find(
-        (channel) => channel.name === "assistant-chat",
-      );
-      if (!assistantChannel?.id) {
+      teamId = slackHarness.teamId;
+      userId = slackHarness.usersByName.alice;
+      channelId = slackHarness.channelsByName["assistant-chat"];
+      if (!userId) throw new Error("Slack emulator user not found");
+      if (!channelId) {
         throw new Error("Slack emulator channel not found");
       }
-      channelId = assistantChannel.id;
     });
 
     afterAll(async () => {
@@ -145,7 +130,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       } else {
         process.env.SLACK_API_URL = originalSlackApiUrl;
       }
-      await emulator?.close();
+      await slackHarness?.emulator.close();
     });
 
     beforeEach(async () => {
@@ -200,7 +185,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           if (url.startsWith("https://slack.com/api/")) {
             const rewrittenUrl = url.replace(
               "https://slack.com/api/",
-              `${emulator.url}/api/`,
+              `${slackHarness.emulator.url}/api/`,
             );
 
             if (input instanceof Request) {
@@ -316,7 +301,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const { bot } = getMessagingChatSdkBot();
       const backgroundTasks: Promise<unknown>[] = [];
       const response = await bot.webhooks.slack(
-        createSignedSlackRequest(body),
+        createSignedSlackRequest({ body }),
         {
           waitUntil: (promise) => {
             backgroundTasks.push(promise);
@@ -382,7 +367,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       const { bot } = getMessagingChatSdkBot();
       const backgroundTasks: Promise<unknown>[] = [];
       const response = await bot.webhooks.slack(
-        createSignedSlackRequest(body),
+        createSignedSlackRequest({ body }),
         {
           waitUntil: (promise) => {
             backgroundTasks.push(promise);
@@ -403,23 +388,6 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
     });
   },
 );
-
-function createSignedSlackRequest(body: string) {
-  const timestamp = `${Math.floor(Date.now() / 1000)}`;
-  const signature = `v0=${createHmac("sha256", "test-signing-secret")
-    .update(`v0:${timestamp}:${body}`)
-    .digest("hex")}`;
-
-  return new Request("https://example.com/api/slack/events", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-slack-request-timestamp": timestamp,
-      "x-slack-signature": signature,
-    },
-    body,
-  });
-}
 
 function mockUnsupportedSlackApiCall({
   channelId,

--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -17,11 +17,10 @@ import {
   beforeEach,
   vi,
 } from "vitest";
-import { createEmulator, type Emulator } from "emulate";
 import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
-import { WebClient } from "@slack/web-api";
+import type { WebClient } from "@slack/web-api";
 import prisma from "@/utils/__mocks__/prisma";
-import { createScopedLogger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   ActionType,
   MessagingMessageStatus,
@@ -29,7 +28,11 @@ import {
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
-import { createGmailTestHarness } from "./helpers";
+import {
+  createGmailTestHarness,
+  createSlackTestHarness,
+  type SlackTestHarness,
+} from "./helpers";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/rule/rule-history", () => ({
@@ -49,63 +52,51 @@ vi.mock("@/utils/email/provider", () => ({
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS === "true";
 const TEST_PORT = 4098;
-const logger = createScopedLogger("test");
+const logger = createTestLogger();
 
 describe.skipIf(!RUN_INTEGRATION_TESTS)(
   "Slack notification flows",
   { timeout: 30_000 },
   () => {
-    let emulator: Emulator;
+    let slackHarness: SlackTestHarness;
     let notifChannelId: string;
     let engChannelId: string;
 
     beforeAll(async () => {
-      emulator = await createEmulator({
-        service: "slack",
+      slackHarness = await createSlackTestHarness({
         port: TEST_PORT,
-        seed: {
-          slack: {
-            team: { name: "TestWorkspace", domain: "test-workspace" },
-            users: [
-              {
-                name: "alice",
-                real_name: "Alice Smith",
-                email: "alice@example.com",
-              },
-            ],
-            channels: [
-              {
-                name: "inbox-zero-notifications",
-                is_private: true,
-                topic: "Inbox Zero alerts",
-              },
-              {
-                name: "engineering",
-                is_private: false,
-                topic: "Engineering discussion",
-              },
-            ],
+        team: { name: "TestWorkspace", domain: "test-workspace" },
+        users: [
+          {
+            name: "alice",
+            real_name: "Alice Smith",
+            email: "alice@example.com",
           },
-        },
+        ],
+        channels: [
+          {
+            name: "inbox-zero-notifications",
+            is_private: true,
+            topic: "Inbox Zero alerts",
+          },
+          {
+            name: "engineering",
+            is_private: false,
+            topic: "Engineering discussion",
+          },
+        ],
       });
 
-      emulatorClient = new WebClient("emulator-token", {
-        slackApiUrl: `${emulator.url}/api/`,
-      });
-
-      // Resolve channel IDs once for all tests
-      const { listChannels } = await import(
-        "@/utils/messaging/providers/slack/channels"
-      );
-      const channels = await listChannels(emulatorClient);
-      notifChannelId = channels.find(
-        (c) => c.name === "inbox-zero-notifications",
-      )!.id;
-      engChannelId = channels.find((c) => c.name === "engineering")!.id;
+      emulatorClient = slackHarness.client;
+      notifChannelId = slackHarness.channelsByName["inbox-zero-notifications"];
+      engChannelId = slackHarness.channelsByName.engineering;
+      if (!notifChannelId || !engChannelId) {
+        throw new Error("Slack emulator channels not found");
+      }
     });
 
     afterAll(async () => {
-      await emulator?.close();
+      await slackHarness?.emulator.close();
     });
 
     beforeEach(() => {

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -1,8 +1,7 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createTestLogger } from "@/__tests__/helpers";
-import type { RequestWithEmailAccount } from "@/utils/middleware";
+import { addTestEmailAccountAuth } from "@/__tests__/helpers";
 import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
@@ -18,8 +17,6 @@ vi.mock("@/utils/messaging/providers/slack/client", () => ({
 }));
 
 import { GET } from "./route";
-
-const logger = createTestLogger();
 
 describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
   beforeEach(() => {
@@ -81,13 +78,12 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
   });
 });
 
-function createRequest(emailAccountId: string): RequestWithEmailAccount {
-  return Object.assign(
+function createRequest(emailAccountId: string) {
+  return addTestEmailAccountAuth(
     new NextRequest(
       "http://localhost:3000/api/user/messaging-channels/channel-1/targets",
     ),
     {
-      logger,
       auth: {
         userId: "user-1",
         emailAccountId,

--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -2,8 +2,7 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/__mocks__/prisma";
-import { createTestLogger } from "@/__tests__/helpers";
-import type { RequestWithEmailAccount } from "@/utils/middleware";
+import { addTestEmailAccountAuth } from "@/__tests__/helpers";
 import { listChannels } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
@@ -65,8 +64,6 @@ const messagingChannelSelect = {
 type MessagingChannelRecord = Prisma.MessagingChannelGetPayload<{
   select: typeof messagingChannelSelect;
 }>;
-
-const logger = createTestLogger();
 
 describe("GET /api/user/messaging-channels", () => {
   beforeEach(() => {
@@ -360,11 +357,10 @@ describe("GET /api/user/messaging-channels", () => {
   });
 });
 
-function createRequest(emailAccountId: string): RequestWithEmailAccount {
-  return Object.assign(
+function createRequest(emailAccountId: string) {
+  return addTestEmailAccountAuth(
     new NextRequest("http://localhost:3000/api/user/messaging-channels"),
     {
-      logger,
       auth: {
         userId: "user-1",
         emailAccountId,


### PR DESCRIPTION
Reuses shared helpers across messaging-focused tests instead of repeating local setup.

- Adds a shared email-account request helper for route tests
- Adds a Slack integration harness and signed Slack request helper
- Updates Slack integration and messaging-channel route tests to use the shared fixtures

Validation:
- RUN_INTEGRATION_TESTS=true pnpm --dir apps/web exec vitest --run __tests__/integration/slack-notifications.test.ts __tests__/integration/slack-chat.test.ts
- pnpm --dir apps/web test --run app/api/user/messaging-channels/route.test.ts app/api/user/messaging-channels/[channelId]/targets/route.test.ts
- git diff --check