### PR TITLE
reply tracking: Ignore signatures in draft similarity

### DIFF
--- a/apps/web/utils/email/signature-normalization.ts
+++ b/apps/web/utils/email/signature-normalization.ts
@@ -1,0 +1,91 @@
+import { load, type CheerioAPI } from "cheerio";
+import type { ParsedMessage } from "@/utils/types";
+
+const SIGNATURE_SELECTORS = [
+  ".gmail_signature",
+  ".gmail_signature_prefix",
+  "[data-smartmail='gmail_signature']",
+  "[id^='Signature']",
+  "[id^='signature']",
+];
+
+const PLAIN_TEXT_SIGNATURE_DELIMITER = /\r?\n-- ?\r?\n/;
+
+export function stripProviderSignatureHtml(html: string): string {
+  if (!html) return html;
+
+  const $ = load(html, null, looksLikeHtmlDocument(html));
+  const signatureElements = $(SIGNATURE_SELECTORS.join(", "));
+
+  if (signatureElements.length === 0) return html;
+
+  signatureElements.each((_index, element) => {
+    const $element = $(element);
+    removeAdjacentBreaks($element);
+    $element.remove();
+  });
+
+  return $.root().html() ?? html;
+}
+
+export function stripPlainTextSignature(text: string): string {
+  const delimiterMatch = text.search(PLAIN_TEXT_SIGNATURE_DELIMITER);
+  if (delimiterMatch === -1) return text;
+
+  return text.slice(0, delimiterMatch).trimEnd();
+}
+
+export function stripProviderSignatureFromParsedMessage(
+  message: ParsedMessage,
+): ParsedMessage {
+  if (message.textHtml) {
+    return {
+      ...message,
+      textHtml: stripProviderSignatureHtml(message.textHtml),
+    };
+  }
+  if (message.textPlain) {
+    return {
+      ...message,
+      textPlain: stripPlainTextSignature(message.textPlain),
+    };
+  }
+  return message;
+}
+
+function removeAdjacentBreaks(element: ReturnType<CheerioAPI>) {
+  let previous = element.prev();
+  while (isBreakOrEmptyText(previous)) {
+    const current = previous;
+    previous = previous.prev();
+    current.remove();
+  }
+
+  let next = element.next();
+  while (isBreakOrEmptyText(next)) {
+    const current = next;
+    next = next.next();
+    current.remove();
+  }
+}
+
+function isBreakOrEmptyText(element: ReturnType<CheerioAPI>) {
+  if (!element.length) return false;
+
+  const node = element.get(0);
+  if (!node) return false;
+
+  if (node.type === "tag") {
+    return node.name.toLowerCase() === "br";
+  }
+
+  if (node.type === "text") {
+    return !node.data.trim();
+  }
+
+  return false;
+}
+
+function looksLikeHtmlDocument(html: string) {
+  return /<!doctype|<html[\s>]|<head[\s>]|<body[\s>]/i.test(html);
+}

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -12,6 +12,7 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
+import { stripProviderSignatureFromParsedMessage } from "@/utils/email/signature-normalization";
 import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
@@ -415,11 +416,14 @@ function queueReplyMemoryLearning({
 }) {
   if (!draftText) return;
 
-  const sentText = emailToContentForAI(message, {
-    maxLength: 4000,
-    extractReply: true,
-    removeForwarded: false,
-  });
+  const sentText = emailToContentForAI(
+    stripProviderSignatureFromParsedMessage(message),
+    {
+      maxLength: 4000,
+      extractReply: true,
+      removeForwarded: false,
+    },
+  );
 
   if (!isMeaningfulDraftEdit({ draftText, sentText, similarityScore })) {
     return;

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -169,6 +169,17 @@ describe("calculateSimilarity - integration tests with ParsedMessage", () => {
       const score = realCalculateSimilarity(storedContent, outlookMessage);
       expect(score).toBe(1.0);
     });
+
+    it("should ignore Outlook signature containers in sent message HTML", () => {
+      const storedContent = "Short reply body.";
+      const outlookMessage = createParsedMessage(
+        `<html><body><div>Short reply body.</div><br><div id="Signature-abcd"><div>Company award line</div><div>Role and credential line</div><div>Office | 555-0100</div><div>Long confidentiality disclaimer.</div></div></body></html>`,
+        "html",
+      );
+
+      const score = realCalculateSimilarity(storedContent, outlookMessage);
+      expect(score).toBe(1.0);
+    });
   });
 
   describe("Gmail content handling (with ParsedMessage)", () => {
@@ -202,6 +213,31 @@ Drafted by <a href="https://www.getinboxzero.com/?ref=ABC123">Inbox Zero</a>.`;
         textPlain: undefined,
         textHtml: `<div dir="ltr">Checking on this now.<br><br>Drafted by <a href="https://www.getinboxzero.com/?ref=ABC123">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender &lt;<a href="mailto:sender@example.com">sender@example.com</a>&gt; a écrit:<br></div><blockquote class="gmail_quote"><div dir="ltr">Previous message</div></blockquote></div>`,
       };
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(1.0);
+    });
+
+    it("should ignore Gmail signature containers in sent message HTML", () => {
+      const storedContent = "Thanks, I handled this now.";
+      const gmailMessage = {
+        ...createParsedMessage(""),
+        textPlain: undefined,
+        textHtml: `<div dir="ltr">Thanks, I handled this now.</div><br><span class="gmail_signature_prefix">-- </span><br><div class="gmail_signature"><div>Sender Name</div><div>Company</div><div>555-0100</div><div>Street address</div></div>`,
+      };
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(1.0);
+    });
+
+    it("should ignore standard plain text signature delimiters", () => {
+      const storedContent = "Thanks, I handled this now.";
+      const gmailMessage = createParsedMessage(`Thanks, I handled this now.
+
+-- 
+Sender Name
+Company
+555-0100`);
 
       const score = realCalculateSimilarity(storedContent, gmailMessage);
       expect(score).toBe(1.0);

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -4,6 +4,10 @@ import {
   stripQuotedContent,
   stripQuotedHtmlContent,
 } from "@/utils/ai/choose-rule/draft-management";
+import {
+  stripPlainTextSignature,
+  stripProviderSignatureHtml,
+} from "@/utils/email/signature-normalization";
 import type { ParsedMessage } from "@/utils/types";
 
 const HTML_TAG_NAMES = [
@@ -31,13 +35,20 @@ const HTML_TAG_PATTERN = new RegExp(
  * Normalizes content for Outlook (HTML) comparison.
  * Converts \n to <br> and then to plain text, strips quoted content.
  */
-function normalizeForOutlook(content: string): string {
-  const withBr = content.replace(/\n/g, "<br>");
+function normalizeForOutlook(content: string, stripSignature = false): string {
+  const signatureStripped = stripSignature
+    ? stripProviderSignatureHtml(content)
+    : content;
+  const withBr = signatureStripped.replace(/\n/g, "<br>");
   const plainText = convertEmailHtmlToText({
     htmlText: stripQuotedHtmlContent(withBr),
     includeLinks: false,
   });
-  return stripQuotedContent(plainText).toLowerCase().trim();
+  const withoutQuotedContent = stripQuotedContent(plainText);
+  const withoutSignature = stripSignature
+    ? stripPlainTextSignature(withoutQuotedContent)
+    : withoutQuotedContent;
+  return withoutSignature.toLowerCase().trim();
 }
 
 /**
@@ -66,16 +77,25 @@ function decodeHtmlEntities(text: string): string {
  * Normalizes content for Gmail (plain text) comparison.
  * Uses parseReply to extract the reply, decodes HTML entities, and strips quoted content.
  */
-function normalizeForGmail(content: string): string {
-  const plainText = looksLikeHtmlContent(content)
+function normalizeForGmail(content: string, stripSignature = false): string {
+  const signatureStripped = stripSignature
+    ? stripProviderSignatureHtml(content)
+    : content;
+  const plainText = looksLikeHtmlContent(signatureStripped)
     ? convertEmailHtmlToText({
-        htmlText: stripQuotedHtmlContent(content.replace(/\n/g, "<br>")),
+        htmlText: stripQuotedHtmlContent(
+          signatureStripped.replace(/\n/g, "<br>"),
+        ),
         includeLinks: false,
       })
-    : content;
+    : signatureStripped;
   const reply = parseReply(plainText);
   const decoded = decodeHtmlEntities(reply);
-  return stripQuotedContent(decoded).toLowerCase().trim();
+  const withoutQuotedContent = stripQuotedContent(decoded);
+  const withoutSignature = stripSignature
+    ? stripPlainTextSignature(withoutQuotedContent)
+    : withoutQuotedContent;
+  return withoutSignature.toLowerCase().trim();
 }
 
 /**
@@ -94,29 +114,68 @@ export function calculateSimilarity(
     return 0.0;
   }
 
-  let normalized1: string;
-  let normalized2: string;
+  const [normalized1, normalized2] = normalizePair({
+    storedContent,
+    providerMessage,
+    stripSignature: false,
+  });
+  const baselineScore = compareNormalizedStrings(normalized1, normalized2);
+
+  const [signatureStripped1, signatureStripped2] = normalizePair({
+    storedContent,
+    providerMessage,
+    stripSignature: true,
+  });
+  const signatureStrippedScore = compareNormalizedStrings(
+    signatureStripped1,
+    signatureStripped2,
+  );
+
+  return Math.max(baselineScore, signatureStrippedScore);
+}
+
+function normalizePair({
+  storedContent,
+  providerMessage,
+  stripSignature,
+}: {
+  storedContent: string;
+  providerMessage: string | ParsedMessage;
+  stripSignature: boolean;
+}): [string, string] {
+  let normalizedStoredContent: string;
+  let normalizedProviderMessage: string;
 
   if (typeof providerMessage === "string") {
-    // Legacy: plain string - use Gmail normalization (parseReply) for both
-    normalized1 = normalizeForGmail(storedContent);
-    normalized2 = normalizeForGmail(providerMessage);
+    // Legacy: plain string from before ParsedMessage was threaded through callers
+    normalizedStoredContent = normalizeForGmail(storedContent, stripSignature);
+    normalizedProviderMessage = normalizeForGmail(
+      providerMessage,
+      stripSignature,
+    );
   } else {
-    // ParsedMessage - check bodyContentType to determine normalization strategy
     const isOutlook = providerMessage.bodyContentType === "html";
     const text = providerMessage.textHtml || providerMessage.textPlain || "";
 
     if (isOutlook) {
-      // Outlook: use HTML-aware normalization for both
-      normalized1 = normalizeForOutlook(storedContent);
-      normalized2 = normalizeForOutlook(text);
+      normalizedStoredContent = normalizeForOutlook(
+        storedContent,
+        stripSignature,
+      );
+      normalizedProviderMessage = normalizeForOutlook(text, stripSignature);
     } else {
-      // Gmail: use parseReply normalization for both
-      normalized1 = normalizeForGmail(storedContent);
-      normalized2 = normalizeForGmail(text);
+      normalizedStoredContent = normalizeForGmail(
+        storedContent,
+        stripSignature,
+      );
+      normalizedProviderMessage = normalizeForGmail(text, stripSignature);
     }
   }
 
+  return [normalizedStoredContent, normalizedProviderMessage];
+}
+
+function compareNormalizedStrings(normalized1: string, normalized2: string) {
   if (!normalized1 || !normalized2) {
     return normalized1 === normalized2 ? 1.0 : 0.0;
   }


### PR DESCRIPTION
Normalizes provider-rendered signatures out of sent-message comparisons so draft similarity and reply-memory learning focus on reply content. It handles Gmail and Outlook HTML signature containers plus standard plain-text delimiters while preserving the existing baseline score as a fallback.

- Adds shared signature stripping helpers for provider messages.
- Applies signature-stripped normalization to similarity scoring and reply-memory sent text.
- Covers HTML and plain-text signature cases in unit tests.

Tests: pnpm --filter inbox-zero-ai test --run utils/similarity-score.test.ts