### PR TITLE
test: Reuse route middleware helpers

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -25,7 +25,16 @@ type TestEmailAccountAuth = {
   userId: string;
 };
 
-export function createWithErrorTestMiddleware() {
+type TestMiddlewareHandler = (
+  request: Request,
+  ...context: unknown[]
+) => Promise<Response>;
+
+export function createWithErrorTestMiddleware({
+  logger = createTestLogger(),
+}: {
+  logger?: ReturnType<typeof createTestLogger>;
+} = {}) {
   return {
     withError:
       <TContext extends unknown[]>(
@@ -33,9 +42,25 @@ export function createWithErrorTestMiddleware() {
         handler: WithErrorTestHandler<TContext>,
       ) =>
       async (request: Request, ...context: TContext) => {
-        (request as TestRequestWithLogger).logger = createTestLogger();
+        (request as TestRequestWithLogger).logger = logger;
         return handler(request, ...context);
       },
+  };
+}
+
+export function createWithEmailAccountTestMiddleware(
+  options?: Parameters<typeof addTestEmailAccountAuth>[1],
+) {
+  const wrap =
+    (handler: TestMiddlewareHandler) =>
+    async (request: Request, ...context: unknown[]) =>
+      handler(addTestEmailAccountAuth(request, options), ...context);
+
+  return {
+    withEmailAccount: (
+      scopeOrHandler: string | TestMiddlewareHandler,
+      handler?: TestMiddlewareHandler,
+    ) => wrap(typeof scopeOrHandler === "string" ? handler! : scopeOrHandler),
   };
 }
 

--- a/apps/web/app/api/chat/confirm-email-action/route.test.ts
+++ b/apps/web/app/api/chat/confirm-email-action/route.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestLogger } from "@/__tests__/helpers";
+import { addTestEmailAccountAuth } from "@/__tests__/helpers";
 import type { ConfirmAssistantEmailActionBody } from "@/utils/actions/assistant-chat.validation";
 
 const { mockConfirmAssistantEmailActionForAccount, mockGetEmailAccountWithAi } =
@@ -8,12 +8,19 @@ const { mockConfirmAssistantEmailActionForAccount, mockGetEmailAccountWithAi } =
     mockGetEmailAccountWithAi: vi.fn(),
   }));
 
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (_scope: string, handler: (request: Request) => Promise<Response>) =>
-    async (request: Request) =>
-      handler(request),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      email: "user@example.com",
+    },
+  });
+});
 
 vi.mock("@/utils/actions/assistant-chat-confirmation", () => ({
   confirmAssistantEmailActionForAccount:
@@ -35,15 +42,18 @@ describe("confirm email action route", () => {
   });
 
   it("returns 400 when the request body is malformed JSON", async () => {
-    const request = Object.assign(
+    const request = addTestEmailAccountAuth(
       new Request("http://localhost/api/chat/confirm-email-action", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: "{invalid",
       }),
       {
-        auth: { emailAccountId: "email-account-1" },
-        logger: createTestLogger(),
+        auth: {
+          userId: "user-1",
+          emailAccountId: "email-account-1",
+          email: "user@example.com",
+        },
       },
     );
 
@@ -68,15 +78,18 @@ describe("confirm email action route", () => {
       success: true,
     });
 
-    const request = Object.assign(
+    const request = addTestEmailAccountAuth(
       new Request("http://localhost/api/chat/confirm-email-action", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(body),
       }),
       {
-        auth: { emailAccountId: "email-account-1" },
-        logger: createTestLogger(),
+        auth: {
+          userId: "user-1",
+          emailAccountId: "email-account-1",
+          email: "user@example.com",
+        },
       },
     );
 

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestLogger, getEmailAccount } from "@/__tests__/helpers";
+import { getEmailAccount } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 
 const {
@@ -45,31 +45,19 @@ vi.mock("ai", () => ({
   createUIMessageStreamResponse: mockCreateUIMessageStreamResponse,
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (
-        request: NextRequest & {
-          auth: { userId: string; emailAccountId: string; email: string };
-          logger: ReturnType<typeof createTestLogger>;
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: NextRequest) => {
-      const authRequest = request as NextRequest & {
-        auth: { userId: string; emailAccountId: string; email: string };
-        logger: ReturnType<typeof createTestLogger>;
-      };
-      authRequest.auth = {
-        userId: "user-1",
-        emailAccountId: "email-account-id",
-        email: "user@test.com",
-      };
-      authRequest.logger = createTestLogger();
-      return handler(authRequest);
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      userId: "user-1",
+      emailAccountId: "email-account-id",
+      email: "user@test.com",
     },
-}));
+  });
+});
 
 vi.mock("@/utils/prisma");
 

--- a/apps/web/app/api/chats/[chatId]/route.test.ts
+++ b/apps/web/app/api/chats/[chatId]/route.test.ts
@@ -3,26 +3,13 @@ import prisma from "@/utils/__mocks__/prisma";
 
 vi.mock("@/utils/prisma");
 
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (
-        request: Request & { auth: { emailAccountId: string } },
-        context: { params: Promise<{ chatId: string }> },
-      ) => Promise<Response>,
-    ) =>
-    async (
-      request: Request,
-      context: { params: Promise<{ chatId: string }> },
-    ) =>
-      handler(
-        Object.assign(request, {
-          auth: { emailAccountId: "email-account-1" },
-        }),
-        context,
-      ),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
 
 import { PATCH } from "./route";
 

--- a/apps/web/app/api/cron/draft-cleanup/route.test.ts
+++ b/apps/web/app/api/cron/draft-cleanup/route.test.ts
@@ -1,7 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestLogger } from "@/__tests__/helpers";
-
-const testLogger = createTestLogger();
 
 const { envMock, captureExceptionMock, cleanupDraftsMock } = vi.hoisted(() => ({
   envMock: {
@@ -23,24 +20,13 @@ vi.mock("@/utils/ai/draft-cleanup", () => ({
   cleanupConfiguredAIDrafts: (...args: unknown[]) => cleanupDraftsMock(...args),
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (
-        request: Request & {
-          logger: typeof testLogger;
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: Request) => {
-      const requestWithLogger = request as Request & {
-        logger: typeof testLogger;
-      };
-      requestWithLogger.logger = testLogger;
-      return handler(requestWithLogger);
-    },
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET, POST } from "./route";
 
@@ -78,7 +64,7 @@ describe("draft cleanup cron route", () => {
       skippedDrafts: 1,
     });
     expect(cleanupDraftsMock).toHaveBeenCalledWith({
-      logger: testLogger,
+      logger: expect.anything(),
     });
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
@@ -111,7 +97,7 @@ describe("draft cleanup cron route", () => {
       skippedDrafts: 1,
     });
     expect(cleanupDraftsMock).toHaveBeenCalledWith({
-      logger: testLogger,
+      logger: expect.anything(),
     });
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/cron/reasoning-retention/route.test.ts
+++ b/apps/web/app/api/cron/reasoning-retention/route.test.ts
@@ -1,7 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestLogger } from "@/__tests__/helpers";
-
-const testLogger = createTestLogger();
 
 const { envMock, captureExceptionMock, enforceRetentionMock } = vi.hoisted(
   () => ({
@@ -27,24 +24,13 @@ vi.mock("@/utils/privacy/reasoning-retention", () => ({
     enforceRetentionMock(...args),
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (
-        request: Request & {
-          logger: typeof testLogger;
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: Request) => {
-      const requestWithLogger = request as Request & {
-        logger: typeof testLogger;
-      };
-      requestWithLogger.logger = testLogger;
-      return handler(requestWithLogger);
-    },
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET, POST } from "./route";
 
@@ -84,7 +70,7 @@ describe("reasoning retention cron route", () => {
     });
     expect(enforceRetentionMock).toHaveBeenCalledWith({
       days: 30,
-      logger: testLogger,
+      logger: expect.anything(),
     });
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
@@ -118,7 +104,7 @@ describe("reasoning retention cron route", () => {
     });
     expect(enforceRetentionMock).toHaveBeenCalledWith({
       days: 30,
-      logger: testLogger,
+      logger: expect.anything(),
     });
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/user/debug/memories/route.test.ts
+++ b/apps/web/app/api/user/debug/memories/route.test.ts
@@ -3,20 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(
-        request as NextRequest & {
-          auth: { emailAccountId: string };
-        },
-        ...args,
-      ),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
 
 import { GET } from "./route";
 
@@ -58,11 +51,6 @@ describe("user/debug/memories route", () => {
     const request = new NextRequest(
       "http://localhost:3000/api/user/debug/memories",
     );
-    (
-      request as NextRequest & {
-        auth: { emailAccountId: string };
-      }
-    ).auth = { emailAccountId: "email-account-1" };
 
     const response = await GET(request, {} as never);
     const body = await response.json();

--- a/apps/web/app/api/user/digest-settings/route.test.ts
+++ b/apps/web/app/api/user/digest-settings/route.test.ts
@@ -13,29 +13,19 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (
-        request: NextRequest & {
-          auth: { emailAccountId: string; userId: string; email: string };
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: NextRequest) => {
-      const emailRequest = request as NextRequest & {
-        auth: { emailAccountId: string; userId: string; email: string };
-      };
-      emailRequest.auth = {
-        emailAccountId: "missing-email-account-id",
-        userId: "user-1",
-        email: "user@example.com",
-      };
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-      return handler(emailRequest);
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      emailAccountId: "missing-email-account-id",
+      userId: "user-1",
+      email: "user@example.com",
     },
-}));
+  });
+});
 
 import { GET } from "./route";
 

--- a/apps/web/app/api/user/drive/filings/route.test.ts
+++ b/apps/web/app/api/user/drive/filings/route.test.ts
@@ -3,19 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(
-        request as NextRequest & {
-          auth: { emailAccountId: string };
-        },
-        ...args,
-      ),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
 
 import { GET } from "./route";
 
@@ -31,11 +25,6 @@ describe("GET /api/user/drive/filings", () => {
     const request = new NextRequest(
       "http://localhost:3000/api/user/drive/filings",
     );
-    (
-      request as NextRequest & {
-        auth: { emailAccountId: string };
-      }
-    ).auth = { emailAccountId: "email-account-1" };
 
     const response = await GET(request, {} as never);
     const body = await response.json();

--- a/apps/web/app/api/user/group/route.test.ts
+++ b/apps/web/app/api/user/group/route.test.ts
@@ -3,20 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(
-        request as NextRequest & {
-          auth: { emailAccountId: string };
-        },
-        ...args,
-      ),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      userId: "user-1",
+      emailAccountId: "account-1",
+      email: "user@example.com",
+    },
+  });
+});
 
 import { GET } from "./route";
 
@@ -41,11 +40,6 @@ describe("user/group route", () => {
     ] as Awaited<ReturnType<typeof prisma.group.findMany>>);
 
     const request = new NextRequest("http://localhost:3000/api/user/group");
-    (
-      request as NextRequest & {
-        auth: { emailAccountId: string };
-      }
-    ).auth = { emailAccountId: "account-1" };
 
     const response = await GET(request, {} as never);
     const body = await response.json();


### PR DESCRIPTION
Reuses shared middleware test helpers across API route tests instead of repeating request auth and logger setup.

- Adds a shared email-account middleware helper for tests
- Lets the shared error middleware helper accept a stable logger when needed
- Updates chat, cron, and user API route tests to use the shared helpers

Validation:
- pnpm --dir apps/web test --run app/api/chat/confirm-email-action/route.test.ts app/api/chat/route.test.ts app/api/user/debug/memories/route.test.ts app/api/chats/[chatId]/route.test.ts app/api/user/drive/filings/route.test.ts app/api/user/group/route.test.ts app/api/user/digest-settings/route.test.ts app/api/cron/draft-cleanup/route.test.ts app/api/cron/reasoning-retention/route.test.ts
- git diff --check