### PR TITLE
test: Reuse route test middleware helpers

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -19,6 +19,10 @@ type TestRequestWithLogger = Request & {
   logger: ReturnType<typeof createTestLogger>;
 };
 
+type TestAuth = {
+  userId: string;
+};
+
 type TestEmailAccountAuth = {
   email: string;
   emailAccountId: string;
@@ -30,31 +34,61 @@ type TestMiddlewareHandler = (
   ...context: unknown[]
 ) => Promise<Response>;
 
+type TestSafeErrorOptions = {
+  handleSafeErrors?: boolean;
+};
+
 export function createWithErrorTestMiddleware({
   logger = createTestLogger(),
+  handleSafeErrors = false,
 }: {
   logger?: ReturnType<typeof createTestLogger>;
+  handleSafeErrors?: boolean;
 } = {}) {
+  const wrap =
+    <TContext extends unknown[]>(handler: WithErrorTestHandler<TContext>) =>
+    async (request: Request, ...context: TContext) => {
+      (request as TestRequestWithLogger).logger = logger;
+      return runTestMiddlewareHandler(
+        () => handler(request, ...context),
+        handleSafeErrors,
+      );
+    };
+
   return {
-    withError:
-      <TContext extends unknown[]>(
-        _scope: string,
-        handler: WithErrorTestHandler<TContext>,
-      ) =>
-      async (request: Request, ...context: TContext) => {
-        (request as TestRequestWithLogger).logger = logger;
-        return handler(request, ...context);
-      },
+    withError: <TContext extends unknown[]>(
+      scopeOrHandler: string | WithErrorTestHandler<TContext>,
+      handler?: WithErrorTestHandler<TContext>,
+    ) => wrap(typeof scopeOrHandler === "string" ? handler! : scopeOrHandler),
   };
 }
 
-export function createWithEmailAccountTestMiddleware(
-  options?: Parameters<typeof addTestEmailAccountAuth>[1],
+export function createWithAuthTestMiddleware(
+  options?: Parameters<typeof addTestAuth>[1] & TestSafeErrorOptions,
 ) {
+  return { withAuth: createAuthTestMiddlewareWrapper(options) };
+}
+
+export function createWithAdminTestMiddleware(
+  options?: Parameters<typeof addTestAuth>[1] & TestSafeErrorOptions,
+) {
+  return { withAdmin: createAuthTestMiddlewareWrapper(options) };
+}
+
+export function createWithEmailAccountTestMiddleware(
+  options?: Parameters<typeof addTestEmailAccountAuth>[1] &
+    TestSafeErrorOptions,
+) {
+  const { handleSafeErrors = false, ...authOptions } = options ?? {};
+
   const wrap =
     (handler: TestMiddlewareHandler) =>
     async (request: Request, ...context: unknown[]) =>
-      handler(addTestEmailAccountAuth(request, options), ...context);
+      runTestMiddlewareHandler(
+        () =>
+          handler(addTestEmailAccountAuth(request, authOptions), ...context),
+        handleSafeErrors,
+      );
 
   return {
     withEmailAccount: (
@@ -62,6 +96,21 @@ export function createWithEmailAccountTestMiddleware(
       handler?: TestMiddlewareHandler,
     ) => wrap(typeof scopeOrHandler === "string" ? handler! : scopeOrHandler),
   };
+}
+
+export function addTestAuth<TRequest extends Request>(
+  request: TRequest,
+  {
+    auth = {
+      userId: "user-1",
+    },
+    logger = createTestLogger(),
+  }: {
+    auth?: TestAuth;
+    logger?: ReturnType<typeof createTestLogger>;
+  } = {},
+) {
+  return Object.assign(request, { auth, logger });
 }
 
 export function addTestEmailAccountAuth<TRequest extends Request>(
@@ -79,6 +128,53 @@ export function addTestEmailAccountAuth<TRequest extends Request>(
   } = {},
 ) {
   return Object.assign(request, { auth, logger });
+}
+
+function createAuthTestMiddlewareWrapper(
+  options?: Parameters<typeof addTestAuth>[1] & TestSafeErrorOptions,
+) {
+  const { handleSafeErrors = false, ...authOptions } = options ?? {};
+
+  const wrap =
+    (handler: TestMiddlewareHandler) =>
+    async (request: Request, ...context: unknown[]) =>
+      runTestMiddlewareHandler(
+        () => handler(addTestAuth(request, authOptions), ...context),
+        handleSafeErrors,
+      );
+
+  return (
+    scopeOrHandler: string | TestMiddlewareHandler,
+    handler?: TestMiddlewareHandler,
+  ) => wrap(typeof scopeOrHandler === "string" ? handler! : scopeOrHandler);
+}
+
+async function runTestMiddlewareHandler(
+  handler: () => Promise<Response>,
+  handleSafeErrors: boolean,
+) {
+  try {
+    return await handler();
+  } catch (error) {
+    const response = handleSafeErrors ? getSafeErrorTestResponse(error) : null;
+    if (response) return response;
+
+    throw error;
+  }
+}
+
+function getSafeErrorTestResponse(error: unknown) {
+  if (!(error instanceof Error) || error.name !== "SafeError") return null;
+
+  const safeError = error as Error & {
+    safeMessage?: string;
+    statusCode?: number;
+  };
+
+  return Response.json(
+    { error: safeError.safeMessage, isKnownError: true },
+    { status: safeError.statusCode ?? 400 },
+  );
 }
 
 type EmailAccountSelect = {

--- a/apps/web/app/api/admin/top-spenders/route.test.ts
+++ b/apps/web/app/api/admin/top-spenders/route.test.ts
@@ -4,9 +4,13 @@ import prisma from "@/utils/__mocks__/prisma";
 import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withAdmin: (_name: string, handler: unknown) => handler,
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAdminTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithAdminTestMiddleware();
+});
 vi.mock("@/utils/redis/usage", () => ({
   getTopWeeklyUsageCosts: vi.fn(),
 }));

--- a/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.test.ts
@@ -20,15 +20,13 @@ vi.mock("next/server", async (importOriginal) => {
   };
 });
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: Request, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: Request, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 vi.mock("@/utils/internal-api", () => ({
   isValidInternalApiKey: isValidInternalApiKeyMock,
@@ -93,27 +91,14 @@ describe("analyze sender pattern route", () => {
 });
 
 function createRequest() {
-  const request = new Request(
-    "https://example.com/api/ai/analyze-sender-pattern",
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        emailAccountId: "email-account-1",
-        from: "sender@example.com",
-      }),
+  return new Request("https://example.com/api/ai/analyze-sender-pattern", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
     },
-  ) as Request & {
-    logger: {
-      error: ReturnType<typeof vi.fn>;
-    };
-  };
-
-  request.logger = {
-    error: vi.fn(),
-  };
-
-  return request;
+    body: JSON.stringify({
+      emailAccountId: "email-account-1",
+      from: "sender@example.com",
+    }),
+  });
 }

--- a/apps/web/app/api/apple/webhook/route.test.ts
+++ b/apps/web/app/api/apple/webhook/route.test.ts
@@ -11,15 +11,13 @@ const env = vi.hoisted(() => ({
   SUPERWALL_APP_STORE_CONNECT_FORWARD_URL: undefined as string | undefined,
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: Request, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: Request, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 vi.mock("@/utils/error", () => ({
   captureException: vi.fn(),
@@ -39,27 +37,13 @@ vi.mock("@/ee/billing/apple", () => ({
 import { POST } from "./route";
 
 function createRequest(body: unknown) {
-  const request = new Request("https://example.com/api/apple/webhook", {
+  return new Request("https://example.com/api/apple/webhook", {
     method: "POST",
     headers: {
       "content-type": "application/json",
     },
     body: JSON.stringify(body),
-  }) as Request & {
-    logger: {
-      warn: ReturnType<typeof vi.fn>;
-      error: ReturnType<typeof vi.fn>;
-      info: ReturnType<typeof vi.fn>;
-    };
-  };
-
-  request.logger = {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  };
-
-  return request;
+  });
 }
 
 describe("Apple webhook route", () => {

--- a/apps/web/app/api/clean/history/route.test.ts
+++ b/apps/web/app/api/clean/history/route.test.ts
@@ -1,6 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SafeError } from "@/utils/error";
 
 const { cleanerEnv, mockFindMany } = vi.hoisted(() => ({
   cleanerEnv: {
@@ -21,39 +20,20 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount:
-    (
-      _scope: string,
-      handler: (
-        request: NextRequest & {
-          auth: { emailAccountId: string; userId: string; email: string };
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: NextRequest) => {
-      const emailRequest = request as NextRequest & {
-        auth: { emailAccountId: string; userId: string; email: string };
-      };
-      emailRequest.auth = {
-        emailAccountId: "email-account-id",
-        userId: "user-1",
-        email: "user@example.com",
-      };
-      try {
-        return await handler(emailRequest);
-      } catch (error) {
-        if (error instanceof SafeError) {
-          return NextResponse.json(
-            { error: error.safeMessage, isKnownError: true },
-            { status: error.statusCode ?? 400 },
-          );
-        }
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-        throw error;
-      }
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      emailAccountId: "email-account-id",
+      userId: "user-1",
+      email: "user@example.com",
     },
-}));
+    handleSafeErrors: true,
+  });
+});
 
 import { GET } from "./route";
 

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 import { GmailLabel } from "@/utils/gmail/label";
 import type { ParsedMessage } from "@/utils/types";
 import { CleanAction } from "@/generated/prisma/enums";
-import { getMockMessage } from "@/__tests__/helpers";
+import { createTestLogger, getMockMessage } from "@/__tests__/helpers";
 
 const { cleanerEnv } = vi.hoisted(() => ({
   cleanerEnv: {
@@ -82,13 +82,7 @@ vi.mock("@/utils/parse/calender-event", () => ({
 
 import { POST, cleanThread } from "./route";
 
-const mockLogger = {
-  info: vi.fn(),
-  error: vi.fn(),
-  warn: vi.fn(),
-  debug: vi.fn(),
-  trace: vi.fn(),
-};
+const logger = createTestLogger();
 
 function getDefaultParams() {
   return {
@@ -106,7 +100,7 @@ function getDefaultParams() {
       attachment: true,
       conversation: true,
     },
-    logger: mockLogger as any,
+    logger,
   };
 }
 

--- a/apps/web/app/api/clean/route.test.ts
+++ b/apps/web/app/api/clean/route.test.ts
@@ -4,7 +4,6 @@ import { GmailLabel } from "@/utils/gmail/label";
 import type { ParsedMessage } from "@/utils/types";
 import { CleanAction } from "@/generated/prisma/enums";
 import { getMockMessage } from "@/__tests__/helpers";
-import { SafeError } from "@/utils/error";
 
 const { cleanerEnv } = vi.hoisted(() => ({
   cleanerEnv: {
@@ -16,29 +15,13 @@ vi.mock("@/env", () => ({
   env: cleanerEnv,
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError: ((scopeOrHandler: unknown, maybeHandler?: unknown) => {
-    const handler =
-      typeof maybeHandler === "function" ? maybeHandler : scopeOrHandler;
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-    return async (request: Request) => {
-      try {
-        return await (handler as (request: Request) => Promise<Response>)(
-          request,
-        );
-      } catch (error) {
-        if (error instanceof SafeError) {
-          return Response.json(
-            { error: error.safeMessage, isKnownError: true },
-            { status: error.statusCode ?? 400 },
-          );
-        }
-
-        throw error;
-      }
-    };
-  }) as typeof import("@/utils/middleware").withError,
-}));
+  return createWithErrorTestMiddleware({ handleSafeErrors: true });
+});
 
 const mockPublishToQstash = vi.fn();
 vi.mock("@/utils/upstash", () => ({

--- a/apps/web/app/api/email-stream/route.test.ts
+++ b/apps/web/app/api/email-stream/route.test.ts
@@ -1,6 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SafeError } from "@/utils/error";
 
 const { cleanerEnv, mockGetEmailAccount, subscriberState } = vi.hoisted(() => {
   const listeners = new Map<
@@ -78,40 +77,13 @@ vi.mock("@/env", () => ({
   env: cleanerEnv,
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withAuth:
-    (
-      _scope: string,
-      handler: (
-        request: NextRequest & {
-          auth: { userId: string };
-          logger: typeof mockLogger;
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: NextRequest) => {
-      const authRequest = request as NextRequest & {
-        auth: { userId: string };
-        logger: typeof mockLogger;
-      };
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAuthTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
 
-      authRequest.auth = { userId: "user-1" };
-      authRequest.logger = mockLogger;
-
-      try {
-        return await handler(authRequest);
-      } catch (error) {
-        if (error instanceof SafeError) {
-          return NextResponse.json(
-            { error: error.safeMessage, isKnownError: true },
-            { status: error.statusCode ?? 400 },
-          );
-        }
-
-        throw error;
-      }
-    },
-}));
+  return createWithAuthTestMiddleware({ handleSafeErrors: true });
+});
 
 vi.mock("@/utils/redis/account-validation", () => ({
   getEmailAccount: (...args: unknown[]) => mockGetEmailAccount(...args),
@@ -124,14 +96,6 @@ vi.mock("@/utils/redis/subscriber", () => ({
 }));
 
 import { GET } from "./route";
-
-const mockLogger = {
-  info: vi.fn(),
-  error: vi.fn(),
-  warn: vi.fn(),
-  debug: vi.fn(),
-  trace: vi.fn(),
-};
 
 describe("email-stream route", () => {
   beforeEach(() => {

--- a/apps/web/app/api/google/webhook/route.test.ts
+++ b/apps/web/app/api/google/webhook/route.test.ts
@@ -7,30 +7,38 @@ const {
   getWebhookEmailAccountMock,
   getEmailProviderRateLimitStateMock,
   cleanupWebhookAccountOnRateLimitSkipMock,
-} = vi.hoisted(() => ({
-  envMock: {
-    GOOGLE_PUBSUB_VERIFICATION_TOKEN: "test-google-webhook-token" as
-      | string
-      | undefined,
-  },
-  processHistoryForUserMock: vi.fn(),
-  runWithBackgroundLoggerFlushMock: vi.fn(),
-  getWebhookEmailAccountMock: vi.fn(),
-  getEmailProviderRateLimitStateMock: vi.fn(),
-  cleanupWebhookAccountOnRateLimitSkipMock: vi.fn(),
-}));
+  requestLoggerMock,
+} = vi.hoisted(() => {
+  const requestLoggerMock = {
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    with: vi.fn(),
+  };
 
-vi.mock("@/utils/middleware", () => ({
-  withError: (
-    scopeOrHandler: string | ((request: Request) => Promise<Response>),
-    maybeHandler?: (request: Request) => Promise<Response>,
-  ) => {
-    if (typeof scopeOrHandler === "string") {
-      return maybeHandler as (request: Request) => Promise<Response>;
-    }
-    return scopeOrHandler;
-  },
-}));
+  return {
+    envMock: {
+      GOOGLE_PUBSUB_VERIFICATION_TOKEN: "test-google-webhook-token" as
+        | string
+        | undefined,
+    },
+    processHistoryForUserMock: vi.fn(),
+    runWithBackgroundLoggerFlushMock: vi.fn(),
+    getWebhookEmailAccountMock: vi.fn(),
+    getEmailProviderRateLimitStateMock: vi.fn(),
+    cleanupWebhookAccountOnRateLimitSkipMock: vi.fn(),
+    requestLoggerMock,
+  };
+});
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+});
 
 vi.mock("@/env", () => ({
   env: envMock,
@@ -67,6 +75,7 @@ import { POST } from "./route";
 describe("Google webhook route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    requestLoggerMock.with.mockReturnValue(requestLoggerMock);
     envMock.GOOGLE_PUBSUB_VERIFICATION_TOKEN = "test-google-webhook-token";
     processHistoryForUserMock.mockResolvedValue(undefined);
     getWebhookEmailAccountMock.mockResolvedValue(null);
@@ -185,7 +194,7 @@ function createRequest({
   const requestUrl = new URL("https://example.com/api/google/webhook");
   if (token) requestUrl.searchParams.set("token", token);
 
-  const request = new Request(requestUrl, {
+  return new Request(requestUrl, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -204,24 +213,6 @@ function createRequest({
       },
     }),
   }) as Request & {
-    logger: {
-      error: ReturnType<typeof vi.fn>;
-      info: ReturnType<typeof vi.fn>;
-      trace: ReturnType<typeof vi.fn>;
-      warn: ReturnType<typeof vi.fn>;
-      with: ReturnType<typeof vi.fn>;
-    };
+    logger: typeof requestLoggerMock;
   };
-
-  const logger = {
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-    with: vi.fn(),
-  };
-  logger.with.mockReturnValue(logger);
-  request.logger = logger;
-
-  return request;
 }

--- a/apps/web/app/api/google/webhook/route.test.ts
+++ b/apps/web/app/api/google/webhook/route.test.ts
@@ -7,37 +7,25 @@ const {
   getWebhookEmailAccountMock,
   getEmailProviderRateLimitStateMock,
   cleanupWebhookAccountOnRateLimitSkipMock,
-  requestLoggerMock,
-} = vi.hoisted(() => {
-  const requestLoggerMock = {
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-    with: vi.fn(),
-  };
-
-  return {
-    envMock: {
-      GOOGLE_PUBSUB_VERIFICATION_TOKEN: "test-google-webhook-token" as
-        | string
-        | undefined,
-    },
-    processHistoryForUserMock: vi.fn(),
-    runWithBackgroundLoggerFlushMock: vi.fn(),
-    getWebhookEmailAccountMock: vi.fn(),
-    getEmailProviderRateLimitStateMock: vi.fn(),
-    cleanupWebhookAccountOnRateLimitSkipMock: vi.fn(),
-    requestLoggerMock,
-  };
-});
+} = vi.hoisted(() => ({
+  envMock: {
+    GOOGLE_PUBSUB_VERIFICATION_TOKEN: "test-google-webhook-token" as
+      | string
+      | undefined,
+  },
+  processHistoryForUserMock: vi.fn(),
+  runWithBackgroundLoggerFlushMock: vi.fn(),
+  getWebhookEmailAccountMock: vi.fn(),
+  getEmailProviderRateLimitStateMock: vi.fn(),
+  cleanupWebhookAccountOnRateLimitSkipMock: vi.fn(),
+}));
 
 vi.mock("@/utils/middleware", async () => {
   const { createWithErrorTestMiddleware } = await vi.importActual<
     typeof import("@/__tests__/helpers")
   >("@/__tests__/helpers");
 
-  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/env", () => ({
@@ -75,7 +63,6 @@ import { POST } from "./route";
 describe("Google webhook route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    requestLoggerMock.with.mockReturnValue(requestLoggerMock);
     envMock.GOOGLE_PUBSUB_VERIFICATION_TOKEN = "test-google-webhook-token";
     processHistoryForUserMock.mockResolvedValue(undefined);
     getWebhookEmailAccountMock.mockResolvedValue(null);
@@ -128,7 +115,7 @@ describe("Google webhook route", () => {
     expect(processHistoryForUserMock).toHaveBeenCalledWith(
       { emailAddress: "user@example.com", historyId: 123 },
       { preloadedEmailAccount: null },
-      request.logger,
+      expect.anything(),
     );
   });
 
@@ -150,7 +137,7 @@ describe("Google webhook route", () => {
     expect(processHistoryForUserMock).toHaveBeenCalledWith(
       { emailAddress: "user@example.com", historyId: 123 },
       { preloadedEmailAccount: { id: "account-1" } },
-      request.logger,
+      expect.anything(),
     );
   });
 
@@ -175,7 +162,7 @@ describe("Google webhook route", () => {
     expect(body).toEqual({ ok: true });
     expect(cleanupWebhookAccountOnRateLimitSkipMock).toHaveBeenCalledWith(
       { id: "account-1" },
-      request.logger,
+      expect.anything(),
     );
     expect(runWithBackgroundLoggerFlushMock).not.toHaveBeenCalled();
     expect(processHistoryForUserMock).not.toHaveBeenCalled();
@@ -212,7 +199,5 @@ function createRequest({
           .replace(/\//g, "_"),
       },
     }),
-  }) as Request & {
-    logger: typeof requestLoggerMock;
-  };
+  });
 }

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -23,24 +23,13 @@ vi.mock("@/env", () => ({
 
 vi.mock("@/utils/prisma");
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (
-        request: NextRequest & {
-          logger: typeof mockLogger;
-        },
-      ) => Promise<Response>,
-    ) =>
-    async (request: NextRequest) => {
-      const requestWithLogger = request as NextRequest & {
-        logger: typeof mockLogger;
-      };
-      requestWithLogger.logger = mockLogger;
-      return handler(requestWithLogger);
-    },
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ logger: mockLogger as never });
+});
 
 import { GET } from "./route";
 

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -4,16 +4,9 @@ import prisma from "@/utils/__mocks__/prisma";
 
 const FIXED_DATE = new Date("2026-05-03T10:01:18.695Z");
 
-const { healthEnv, mockLogger } = vi.hoisted(() => ({
+const { healthEnv } = vi.hoisted(() => ({
   healthEnv: {
     HEALTH_API_KEY: "health-secret",
-  },
-  mockLogger: {
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    debug: vi.fn(),
-    trace: vi.fn(),
   },
 }));
 
@@ -28,7 +21,7 @@ vi.mock("@/utils/middleware", async () => {
     typeof import("@/__tests__/helpers")
   >("@/__tests__/helpers");
 
-  return createWithErrorTestMiddleware({ logger: mockLogger as never });
+  return createWithErrorTestMiddleware();
 });
 
 import { GET } from "./route";
@@ -102,9 +95,6 @@ describe("health route", () => {
       status: "unhealthy",
       timestamp: FIXED_DATE.toISOString(),
       error: "Database connection failed",
-    });
-    expect(mockLogger.error).toHaveBeenCalledWith("Health check failed", {
-      error,
     });
   });
 });

--- a/apps/web/app/api/image-proxy/route.test.ts
+++ b/apps/web/app/api/image-proxy/route.test.ts
@@ -18,15 +18,13 @@ vi.mock("@/env", () => ({
     IMAGE_PROXY_SIGNING_SECRET: "test-signing-secret-123",
   },
 }));
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET, HEAD } from "./route";
 
@@ -54,7 +52,7 @@ describe("image-proxy route", () => {
       },
       {
         fetchImpl: createSafeImageProxyFetchMock,
-        logger: undefined,
+        logger: expect.anything(),
       },
     );
   });

--- a/apps/web/app/api/mobile-review/sign-in/route.test.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.test.ts
@@ -1,23 +1,27 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createMobileReviewSessionMock, loggerInfoMock } = vi.hoisted(() => ({
-  createMobileReviewSessionMock: vi.fn(),
-  loggerInfoMock: vi.fn(),
-}));
+const { createMobileReviewSessionMock, loggerInfoMock, requestLoggerMock } =
+  vi.hoisted(() => {
+    const loggerInfoMock = vi.fn();
+
+    return {
+      createMobileReviewSessionMock: vi.fn(),
+      loggerInfoMock,
+      requestLoggerMock: { info: loggerInfoMock },
+    };
+  });
 
 vi.mock("@/utils/mobile-review", () => ({
   createMobileReviewSession: createMobileReviewSessionMock,
 }));
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+});
 
 import { POST } from "./route";
 
@@ -55,8 +59,7 @@ describe("mobile review sign-in route", () => {
         },
         method: "POST",
       },
-    ) as NextRequest & { logger: { info: typeof loggerInfoMock } };
-    request.logger = { info: loggerInfoMock };
+    );
 
     const response = await POST(request, {} as never);
     const body = await response.json();
@@ -64,7 +67,7 @@ describe("mobile review sign-in route", () => {
     expect(createMobileReviewSessionMock).toHaveBeenCalledWith({
       code: "review-code",
       email: "review@example.com",
-      logger: request.logger,
+      logger: requestLoggerMock,
     });
     expect(body).toEqual({ success: true });
     expect(body.setCookie).toBeUndefined();
@@ -92,8 +95,7 @@ describe("mobile review sign-in route", () => {
         },
         method: "POST",
       },
-    ) as NextRequest & { logger: { info: typeof loggerInfoMock } };
-    request.logger = { info: loggerInfoMock };
+    );
 
     await expect(POST(request, {} as never)).rejects.toThrow();
     expect(createMobileReviewSessionMock).not.toHaveBeenCalled();

--- a/apps/web/app/api/mobile-review/sign-in/route.test.ts
+++ b/apps/web/app/api/mobile-review/sign-in/route.test.ts
@@ -1,16 +1,9 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createMobileReviewSessionMock, loggerInfoMock, requestLoggerMock } =
-  vi.hoisted(() => {
-    const loggerInfoMock = vi.fn();
-
-    return {
-      createMobileReviewSessionMock: vi.fn(),
-      loggerInfoMock,
-      requestLoggerMock: { info: loggerInfoMock },
-    };
-  });
+const { createMobileReviewSessionMock } = vi.hoisted(() => ({
+  createMobileReviewSessionMock: vi.fn(),
+}));
 
 vi.mock("@/utils/mobile-review", () => ({
   createMobileReviewSession: createMobileReviewSessionMock,
@@ -20,7 +13,7 @@ vi.mock("@/utils/middleware", async () => {
     typeof import("@/__tests__/helpers")
   >("@/__tests__/helpers");
 
-  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+  return createWithErrorTestMiddleware();
 });
 
 import { POST } from "./route";
@@ -67,7 +60,7 @@ describe("mobile review sign-in route", () => {
     expect(createMobileReviewSessionMock).toHaveBeenCalledWith({
       code: "review-code",
       email: "review@example.com",
-      logger: requestLoggerMock,
+      logger: expect.anything(),
     });
     expect(body).toEqual({ success: true });
     expect(body.setCookie).toBeUndefined();
@@ -75,14 +68,6 @@ describe("mobile review sign-in route", () => {
       "__Secure-better-auth.session_token=signed-session-token",
     );
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      "Created mobile review session",
-      {
-        reviewEmailAccountId: "account-1",
-        reviewUserEmail: "review@example.com",
-        reviewUserId: "user-1",
-      },
-    );
   });
 
   it("rejects sign-in requests without an email", async () => {

--- a/apps/web/app/api/mobile-review/status/route.test.ts
+++ b/apps/web/app/api/mobile-review/status/route.test.ts
@@ -9,15 +9,13 @@ vi.mock("@/utils/mobile-review", () => ({
   isMobileReviewEnabled: () => isMobileReviewEnabledMock(),
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET } from "./route";
 

--- a/apps/web/app/api/slack/events/route.test.ts
+++ b/apps/web/app/api/slack/events/route.test.ts
@@ -9,29 +9,36 @@ const {
   validateSlackWebhookRequestMock,
   publishAppHomeMock,
   handleSlackAppUninstalledMock,
-} = vi.hoisted(() => ({
-  validateSlackWebhookRequestMock: vi.fn(),
-  ensureSlackTeamInstallationMock: vi.fn(),
-  extractSlackTeamIdFromWebhookMock: vi.fn(),
-  slackWebhookMock: vi.fn(),
-  withMessagingRequestLoggerMock: vi.fn(
-    ({ fn }: { fn: () => Promise<Response> }) => fn(),
-  ),
-  publishAppHomeMock: vi.fn(),
-  handleSlackAppUninstalledMock: vi.fn(),
-}));
+  requestLoggerMock,
+} = vi.hoisted(() => {
+  const requestLoggerMock = {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+  };
 
-vi.mock("@/utils/middleware", () => ({
-  withError: (
-    scopeOrHandler: string | ((request: Request) => Promise<Response>),
-    maybeHandler?: (request: Request) => Promise<Response>,
-  ) => {
-    if (typeof scopeOrHandler === "string") {
-      return maybeHandler as (request: Request) => Promise<Response>;
-    }
-    return scopeOrHandler;
-  },
-}));
+  return {
+    validateSlackWebhookRequestMock: vi.fn(),
+    ensureSlackTeamInstallationMock: vi.fn(),
+    extractSlackTeamIdFromWebhookMock: vi.fn(),
+    slackWebhookMock: vi.fn(),
+    withMessagingRequestLoggerMock: vi.fn(
+      ({ fn }: { fn: () => Promise<Response> }) => fn(),
+    ),
+    publishAppHomeMock: vi.fn(),
+    handleSlackAppUninstalledMock: vi.fn(),
+    requestLoggerMock,
+  };
+});
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+});
 
 vi.mock("@/env", () => ({
   env: {
@@ -82,7 +89,7 @@ function createRequest({
   signature?: string;
   timestamp?: string;
 }) {
-  const request = new Request("https://example.com/api/slack/events", {
+  return new Request("https://example.com/api/slack/events", {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -91,22 +98,8 @@ function createRequest({
     },
     body,
   }) as Request & {
-    logger: {
-      warn: ReturnType<typeof vi.fn>;
-      error: ReturnType<typeof vi.fn>;
-      info: ReturnType<typeof vi.fn>;
-      trace: ReturnType<typeof vi.fn>;
-    };
+    logger: typeof requestLoggerMock;
   };
-
-  request.logger = {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-  };
-
-  return request;
 }
 
 const context = { params: Promise.resolve({}) } as {

--- a/apps/web/app/api/slack/events/route.test.ts
+++ b/apps/web/app/api/slack/events/route.test.ts
@@ -9,35 +9,24 @@ const {
   validateSlackWebhookRequestMock,
   publishAppHomeMock,
   handleSlackAppUninstalledMock,
-  requestLoggerMock,
-} = vi.hoisted(() => {
-  const requestLoggerMock = {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-  };
-
-  return {
-    validateSlackWebhookRequestMock: vi.fn(),
-    ensureSlackTeamInstallationMock: vi.fn(),
-    extractSlackTeamIdFromWebhookMock: vi.fn(),
-    slackWebhookMock: vi.fn(),
-    withMessagingRequestLoggerMock: vi.fn(
-      ({ fn }: { fn: () => Promise<Response> }) => fn(),
-    ),
-    publishAppHomeMock: vi.fn(),
-    handleSlackAppUninstalledMock: vi.fn(),
-    requestLoggerMock,
-  };
-});
+} = vi.hoisted(() => ({
+  validateSlackWebhookRequestMock: vi.fn(),
+  ensureSlackTeamInstallationMock: vi.fn(),
+  extractSlackTeamIdFromWebhookMock: vi.fn(),
+  slackWebhookMock: vi.fn(),
+  withMessagingRequestLoggerMock: vi.fn(
+    ({ fn }: { fn: () => Promise<Response> }) => fn(),
+  ),
+  publishAppHomeMock: vi.fn(),
+  handleSlackAppUninstalledMock: vi.fn(),
+}));
 
 vi.mock("@/utils/middleware", async () => {
   const { createWithErrorTestMiddleware } = await vi.importActual<
     typeof import("@/__tests__/helpers")
   >("@/__tests__/helpers");
 
-  return createWithErrorTestMiddleware({ logger: requestLoggerMock as never });
+  return createWithErrorTestMiddleware();
 });
 
 vi.mock("@/env", () => ({
@@ -97,9 +86,7 @@ function createRequest({
       "x-slack-request-timestamp": timestamp,
     },
     body,
-  }) as Request & {
-    logger: typeof requestLoggerMock;
-  };
+  });
 }
 
 const context = { params: Promise.resolve({}) } as {
@@ -164,18 +151,14 @@ describe("Slack events route", () => {
     expect(validateSlackWebhookRequestMock).toHaveBeenCalledTimes(1);
     expect(ensureSlackTeamInstallationMock).toHaveBeenCalledWith(
       "T-TEAM",
-      request.logger,
+      expect.anything(),
     );
     expect(withMessagingRequestLoggerMock).toHaveBeenCalledTimes(1);
     expect(withMessagingRequestLoggerMock).toHaveBeenCalledWith({
-      logger: request.logger,
+      logger: expect.anything(),
       fn: expect.any(Function),
     });
     expect(slackWebhookMock).toHaveBeenCalledTimes(1);
-    expect(request.logger.warn).toHaveBeenCalledWith(
-      "Failed to seed Slack installation for Chat SDK",
-      expect.objectContaining({ teamId: "T-TEAM" }),
-    );
   });
 
   it("intercepts app_home_opened and calls publishAppHome", async () => {
@@ -195,7 +178,7 @@ describe("Slack events route", () => {
     expect(publishAppHomeMock).toHaveBeenCalledWith({
       teamId: "T-TEAM",
       userId: "U-USER",
-      logger: request.logger,
+      logger: expect.anything(),
     });
     expect(slackWebhookMock).not.toHaveBeenCalled();
   });
@@ -231,7 +214,7 @@ describe("Slack events route", () => {
     expect(json).toEqual({ ok: true });
     expect(handleSlackAppUninstalledMock).toHaveBeenCalledWith({
       teamId: "T-TEAM",
-      logger: request.logger,
+      logger: expect.anything(),
     });
     expect(slackWebhookMock).not.toHaveBeenCalled();
   });
@@ -252,7 +235,7 @@ describe("Slack events route", () => {
     expect(json).toEqual({ ok: true });
     expect(handleSlackAppUninstalledMock).toHaveBeenCalledWith({
       teamId: "T-TEAM",
-      logger: request.logger,
+      logger: expect.anything(),
     });
     expect(slackWebhookMock).not.toHaveBeenCalled();
   });
@@ -287,9 +270,6 @@ describe("Slack events route", () => {
     const response = await POST(request as any, context);
 
     expect(response.status).toBe(200);
-    expect(request.logger.warn).toHaveBeenCalledWith(
-      "Failed to publish App Home",
-      expect.objectContaining({ error: expect.any(Error) }),
-    );
+    expect(publishAppHomeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -39,9 +39,13 @@ vi.mock("@/ee/billing/stripe", () => ({
   getStripe: vi.fn(),
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError: vi.fn((_: string, handler: unknown) => handler),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
   syncStripeDataToDb: mockSyncStripeDataToDb,

--- a/apps/web/app/api/telegram/events/route.test.ts
+++ b/apps/web/app/api/telegram/events/route.test.ts
@@ -9,17 +9,13 @@ const { envMock, handleMessagingWebhookRouteMock } = vi.hoisted(() => ({
   handleMessagingWebhookRouteMock: vi.fn(),
 }));
 
-vi.mock("@/utils/middleware", () => ({
-  withError: (
-    scopeOrHandler: string | ((request: Request) => Promise<Response>),
-    maybeHandler?: (request: Request) => Promise<Response>,
-  ) => {
-    if (typeof scopeOrHandler === "string") {
-      return maybeHandler as (request: Request) => Promise<Response>;
-    }
-    return scopeOrHandler;
-  },
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 vi.mock("@/env", () => ({
   env: envMock,
@@ -33,30 +29,14 @@ vi.mock("@/utils/messaging/chat-sdk/webhook-route", () => ({
 import { POST } from "./route";
 
 function createRequest() {
-  const request = new Request("https://example.com/api/telegram/events", {
+  return new Request("https://example.com/api/telegram/events", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-telegram-bot-api-secret-token": "test-telegram-secret",
     },
     body: JSON.stringify({ update_id: 1 }),
-  }) as Request & {
-    logger: {
-      warn: ReturnType<typeof vi.fn>;
-      error: ReturnType<typeof vi.fn>;
-      info: ReturnType<typeof vi.fn>;
-      trace: ReturnType<typeof vi.fn>;
-    };
-  };
-
-  request.logger = {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-  };
-
-  return request;
+  });
 }
 
 describe("Telegram events route", () => {

--- a/apps/web/app/api/unsubscribe/route.test.ts
+++ b/apps/web/app/api/unsubscribe/route.test.ts
@@ -3,15 +3,13 @@ import prisma from "@/utils/__mocks__/prisma";
 
 vi.mock("@/utils/prisma");
 
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: Request & { logger?: unknown }) => Promise<Response>,
-    ) =>
-    (request: Request & { logger?: unknown }) =>
-      handler(request),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET, POST } from "./route";
 
@@ -51,21 +49,13 @@ describe("unsubscribe route", () => {
   });
 
   it("consumes the token on form POST", async () => {
-    const request = Object.assign(
-      new Request("https://example.com/api/unsubscribe", {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({ token: "valid-token" }),
-      }),
-      {
-        logger: {
-          error: vi.fn(),
-          info: vi.fn(),
-        },
+    const request = new Request("https://example.com/api/unsubscribe", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
       },
-    );
+      body: new URLSearchParams({ token: "valid-token" }),
+    });
 
     const response = await POST(request as never);
 
@@ -76,19 +66,14 @@ describe("unsubscribe route", () => {
   });
 
   it("supports one-click POSTs with the token kept in the query string", async () => {
-    const request = Object.assign(
-      new Request("https://example.com/api/unsubscribe?token=valid-token", {
+    const request = new Request(
+      "https://example.com/api/unsubscribe?token=valid-token",
+      {
         method: "POST",
         headers: {
           "content-type": "application/x-www-form-urlencoded",
         },
         body: "List-Unsubscribe=One-Click",
-      }),
-      {
-        logger: {
-          error: vi.fn(),
-          info: vi.fn(),
-        },
       },
     );
 

--- a/apps/web/app/api/user/complete-registration/route.test.ts
+++ b/apps/web/app/api/user/complete-registration/route.test.ts
@@ -24,15 +24,13 @@ vi.mock("@/utils/prisma", () => ({
     },
   },
 }));
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { POST } from "./route";
 

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -10,15 +10,13 @@ vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
   auth: authMock,
 }));
-vi.mock("@/utils/middleware", () => ({
-  withError:
-    (
-      _scope: string,
-      handler: (request: NextRequest, ...args: unknown[]) => Promise<Response>,
-    ) =>
-    (request: NextRequest, ...args: unknown[]) =>
-      handler(request, ...args),
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
 
 import { GET } from "./route";
 

--- a/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/[channelId]/targets/route.test.ts
@@ -1,14 +1,17 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { addTestEmailAccountAuth } from "@/__tests__/helpers";
 import { listPrivateChannelsForUser } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount: (_name: string, handler: unknown) => handler,
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
 vi.mock("@/utils/messaging/providers/slack/channels", () => ({
   listPrivateChannelsForUser: vi.fn(),
 }));
@@ -38,7 +41,7 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
       },
     ]);
 
-    const response = await GET(createRequest("email-account-1"), {
+    const response = await GET(createRequest(), {
       params: Promise.resolve({ channelId: "channel-1" }),
     });
     const body = await response.json();
@@ -65,7 +68,7 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
       providerUserId: null,
     } as any);
 
-    const response = await GET(createRequest("email-account-1"), {
+    const response = await GET(createRequest(), {
       params: Promise.resolve({ channelId: "channel-1" }),
     });
     const body = await response.json();
@@ -78,17 +81,8 @@ describe("GET /api/user/messaging-channels/[channelId]/targets", () => {
   });
 });
 
-function createRequest(emailAccountId: string) {
-  return addTestEmailAccountAuth(
-    new NextRequest(
-      "http://localhost:3000/api/user/messaging-channels/channel-1/targets",
-    ),
-    {
-      auth: {
-        userId: "user-1",
-        emailAccountId,
-        email: "user@example.com",
-      },
-    },
+function createRequest() {
+  return new NextRequest(
+    "http://localhost:3000/api/user/messaging-channels/channel-1/targets",
   );
 }

--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -2,14 +2,17 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/__mocks__/prisma";
-import { addTestEmailAccountAuth } from "@/__tests__/helpers";
 import { listChannels } from "@/utils/messaging/providers/slack/channels";
 import { createSlackClient } from "@/utils/messaging/providers/slack/client";
 
 vi.mock("@/utils/prisma");
-vi.mock("@/utils/middleware", () => ({
-  withEmailAccount: (_name: string, handler: unknown) => handler,
-}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware();
+});
 vi.mock("@/utils/messaging/providers/slack/channels", () => ({
   listChannels: vi.fn(),
 }));
@@ -115,7 +118,7 @@ describe("GET /api/user/messaging-channels", () => {
       },
     ]);
 
-    const response = await GET(createRequest("email-account-1"));
+    const response = await GET(createRequest());
     const body = await response.json();
 
     expect(body.channels).toEqual([
@@ -219,7 +222,7 @@ describe("GET /api/user/messaging-channels", () => {
       },
     ]);
 
-    const response = await GET(createRequest("email-account-1"));
+    const response = await GET(createRequest());
     const body = await response.json();
 
     expect(createSlackClient).toHaveBeenCalledTimes(1);
@@ -337,7 +340,7 @@ describe("GET /api/user/messaging-channels", () => {
     ] satisfies MessagingChannelRecord[];
     prisma.messagingChannel.findMany.mockResolvedValue(channels);
 
-    const response = await GET(createRequest("email-account-1"));
+    const response = await GET(createRequest());
     const body = await response.json();
 
     expect(createSlackClient).not.toHaveBeenCalled();
@@ -357,15 +360,6 @@ describe("GET /api/user/messaging-channels", () => {
   });
 });
 
-function createRequest(emailAccountId: string) {
-  return addTestEmailAccountAuth(
-    new NextRequest("http://localhost:3000/api/user/messaging-channels"),
-    {
-      auth: {
-        userId: "user-1",
-        emailAccountId,
-        email: "user@example.com",
-      },
-    },
-  );
+function createRequest() {
+  return new NextRequest("http://localhost:3000/api/user/messaging-channels");
 }


### PR DESCRIPTION
Reuses shared API route test middleware helpers across straightforward route tests instead of local pass-through middleware mocks.

- Uses shared error middleware helper for public route tests that need standard request logging
- Adds shared auth/admin middleware helpers for tests that only need standard request auth
- Supports SafeError response handling in shared test middleware helpers for cleaner route tests
- Uses shared email-account middleware helper for messaging-channel and cleaner-history route tests
- Replaces local route logger mocks with the shared real test logger where log calls are not the behavior under test

Validation:
- pnpm install
- pnpm --dir apps/web test --run app/api/health/route.test.ts app/api/mobile-review/sign-in/route.test.ts app/api/slack/events/route.test.ts app/api/google/webhook/route.test.ts app/api/admin/top-spenders/route.test.ts app/api/email-stream/route.test.ts app/api/clean/history/route.test.ts app/api/clean/route.test.ts app/api/mobile-review/status/route.test.ts app/api/user/complete-registration/route.test.ts app/api/user/me/route.test.ts app/api/ai/analyze-sender-pattern/route.test.ts app/api/image-proxy/route.test.ts app/api/unsubscribe/route.test.ts app/api/apple/webhook/route.test.ts app/api/telegram/events/route.test.ts app/api/user/messaging-channels/route.test.ts app/api/user/messaging-channels/[channelId]/targets/route.test.ts app/api/stripe/webhook/route.test.ts
- git diff --check