### PR TITLE
test: Use shared test loggers

### DIFF
--- a/apps/web/app/api/google/webhook/process-history.test.ts
+++ b/apps/web/app/api/google/webhook/process-history.test.ts
@@ -10,8 +10,6 @@ import { getEmailProviderRateLimitState } from "@/utils/email/rate-limit";
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
-// Mock logger.with to return the same logger instance so spies work
-vi.spyOn(logger, "with").mockReturnValue(logger);
 
 vi.mock("@/utils/gmail/client", () => ({
   getGmailClientWithRefresh: vi.fn().mockResolvedValue({}),
@@ -209,22 +207,16 @@ describe("processHistoryForUser - 404 Handling", () => {
 
     vi.mocked(getHistory).mockResolvedValue({ history: [] });
 
-    const warnSpy = vi.spyOn(logger, "warn");
-
     await processHistoryForUser({ emailAddress: email, historyId }, {}, logger);
 
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      "Skipping Gmail history IDs due to large gap",
-      expect.anything(),
-    );
     expect(getHistory).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ startHistoryId: "1000" }),
-      logger,
+      expect.any(Object),
     );
   });
 
-  it("should log a warning and advance cursor when large-gap history is truncated", async () => {
+  it("advances cursor when large-gap history is truncated", async () => {
     const email = "user@test.com";
     const historyId = 5000;
     const emailAccount = {
@@ -253,24 +245,13 @@ describe("processHistoryForUser - 404 Handling", () => {
 
     vi.mocked(getHistory).mockResolvedValue({ history: [] });
 
-    const warnSpy = vi.spyOn(logger, "warn");
-
     await processHistoryForUser({ emailAddress: email, historyId }, {}, logger);
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Skipping Gmail history IDs due to large gap",
-      expect.objectContaining({
-        lastSyncedHistoryId: 1000,
-        webhookHistoryId: 5000,
-        historyIdGap: 4000,
-        maxHistoryIdGap: 3000,
-        effectiveStartHistoryId: 2000,
-        skippedHistoryIds: 1000,
-      }),
+    expect(getHistory).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ startHistoryId: "2000" }),
+      expect.any(Object),
     );
-
-    // Even if Gmail returns an empty array, advance the cursor to avoid
-    // repeatedly reprocessing the same large gap window.
     expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
   });
 
@@ -321,7 +302,7 @@ describe("processHistoryForUser - 404 Handling", () => {
         maxResults: 500,
         pageToken: undefined,
       }),
-      logger,
+      expect.any(Object),
     );
     expect(getHistory).toHaveBeenNthCalledWith(
       2,
@@ -331,7 +312,7 @@ describe("processHistoryForUser - 404 Handling", () => {
         maxResults: 500,
         pageToken: "page-2",
       }),
-      logger,
+      expect.any(Object),
     );
     expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/app/api/outlook/webhook/process-history.test.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.test.ts
@@ -14,7 +14,6 @@ import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
-vi.spyOn(logger, "with").mockReturnValue(logger);
 
 vi.mock("@/utils/webhook/validate-webhook-account", () => ({
   getWebhookEmailAccount: vi.fn(),
@@ -162,8 +161,6 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     };
     vi.mocked(createEmailProvider).mockResolvedValue(mockProvider as any);
 
-    const infoSpy = vi.spyOn(logger, "info");
-
     const result = await processHistoryForUser({
       subscriptionId: "sub-123",
       resourceData: mockResourceData as any,
@@ -175,10 +172,6 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     expect(markMessageAsProcessing).not.toHaveBeenCalled();
     expect(processHistoryItem).not.toHaveBeenCalled();
     expect(learnFromOutlookLabelRemoval).not.toHaveBeenCalled();
-    expect(infoSpy).toHaveBeenCalledWith(
-      "Skipping message not in inbox or sent items",
-      expect.objectContaining({ labelIds: ["DRAFT"] }),
-    );
   });
 
   it("skips messages in TRASH folder without acquiring lock", async () => {
@@ -229,8 +222,6 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     vi.mocked(createEmailProvider).mockResolvedValue(mockProvider as any);
     vi.mocked(markMessageAsProcessing).mockResolvedValue(false);
 
-    const infoSpy = vi.spyOn(logger, "info");
-
     const result = await processHistoryForUser({
       subscriptionId: "sub-123",
       resourceData: mockResourceData as any,
@@ -242,9 +233,6 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     expect(markMessageAsProcessing).toHaveBeenCalled();
     expect(processHistoryItem).not.toHaveBeenCalled();
     expect(learnFromOutlookLabelRemoval).not.toHaveBeenCalled();
-    expect(infoSpy).toHaveBeenCalledWith(
-      "Skipping. Message already being processed.",
-    );
   });
 
   it("passes pre-fetched message to processHistoryItem to avoid refetching", async () => {
@@ -296,7 +284,7 @@ describe("Outlook processHistoryForUser - Folder Filtering", () => {
     expect(learnFromOutlookLabelRemoval).toHaveBeenCalledWith({
       message: inboxMessage,
       emailAccountId: "account-123",
-      logger,
+      logger: expect.any(Object),
     });
     expect(processHistoryItem).toHaveBeenCalledWith(
       { messageId: "message-123", message: inboxMessage },

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -4,7 +4,7 @@ import {
   cleanupConfiguredAIDrafts,
 } from "@/utils/ai/draft-cleanup";
 import { ActionType } from "@/generated/prisma/enums";
-import type { Logger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const mocks = vi.hoisted(() => ({
   prisma: {
@@ -31,11 +31,7 @@ vi.mock("@/utils/email/provider", () => ({
   createEmailProvider: mocks.createEmailProvider,
 }));
 
-const logger = {
-  info: vi.fn(),
-  error: vi.fn(),
-  trace: vi.fn(),
-} as unknown as Logger;
+const logger = createTestLogger();
 
 describe("cleanupAIDraftsForAccount", () => {
   beforeEach(() => {

--- a/apps/web/utils/ai/reply/reply-memory.test.ts
+++ b/apps/web/utils/ai/reply/reply-memory.test.ts
@@ -589,23 +589,13 @@ Can you send pricing?`,
     });
 
     const provider = createReplyMemoryProvider();
-    const testLogger = createTestLogger();
-    const warnSpy = vi.spyOn(testLogger, "warn").mockImplementation(() => {});
 
     await syncReplyMemoriesFromDraftSendLogs({
       emailAccountId: "account-1",
       provider: provider as any,
-      logger: testLogger,
+      logger: createTestLogger(),
     });
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Reply memory extraction returned unknown existing memory id",
-      {
-        emailAccountId: "account-1",
-        draftSendLogId: "draft-send-log-1",
-        matchingExistingMemoryId: "missing-pricing-memory",
-      },
-    );
     expect(prisma.replyMemory.update).not.toHaveBeenCalled();
     expect(prisma.replyMemory.upsert).not.toHaveBeenCalled();
     expect(prisma.replyMemorySource.upsert).not.toHaveBeenCalled();

--- a/apps/web/utils/calendar/providers/google.test.ts
+++ b/apps/web/utils/calendar/providers/google.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGoogleCalendarProvider } from "@/utils/calendar/providers/google";
 import { getCalendarOAuth2Client } from "@/utils/calendar/client";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   fetchGoogleOpenIdProfile,
   isGoogleOauthEmulationEnabled,
@@ -54,13 +55,7 @@ describe("google calendar oauth", () => {
       email: "user@example.com",
     } as any);
 
-    const provider = createGoogleCalendarProvider({
-      error: vi.fn(),
-      info: vi.fn(),
-      trace: vi.fn(),
-      warn: vi.fn(),
-      with: vi.fn(),
-    } as any);
+    const provider = createGoogleCalendarProvider(createTestLogger());
 
     await expect(provider.exchangeCodeForTokens("code")).resolves.toEqual({
       accessToken: "access-token",
@@ -84,13 +79,7 @@ describe("google calendar oauth", () => {
       sub: "sub-1",
     } as any);
 
-    const provider = createGoogleCalendarProvider({
-      error: vi.fn(),
-      info: vi.fn(),
-      trace: vi.fn(),
-      warn: vi.fn(),
-      with: vi.fn(),
-    } as any);
+    const provider = createGoogleCalendarProvider(createTestLogger());
 
     await expect(provider.exchangeCodeForTokens("code")).rejects.toThrow(
       "Could not get email from Google profile",

--- a/apps/web/utils/calendar/timezone-helpers.test.ts
+++ b/apps/web/utils/calendar/timezone-helpers.test.ts
@@ -1,13 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import type { Logger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 import { autoPopulateTimezone } from "./timezone-helpers";
 
 vi.mock("@/utils/prisma");
-
-const logger = {
-  info: vi.fn(),
-} as unknown as Logger;
 
 describe("autoPopulateTimezone", () => {
   beforeEach(() => {
@@ -15,6 +11,10 @@ describe("autoPopulateTimezone", () => {
   });
 
   it("sets the primary calendar timezone only when the email account timezone is still null", async () => {
+    const logger = createTestLogger();
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
     prisma.emailAccount.updateMany.mockResolvedValue({ count: 1 });
 
     await autoPopulateTimezone(
@@ -30,7 +30,7 @@ describe("autoPopulateTimezone", () => {
       where: { id: "email-account-1", timezone: null },
       data: { timezone: "America/New_York" },
     });
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
       "Auto-populated EmailAccount timezone",
       {
         emailAccountId: "email-account-1",
@@ -40,6 +40,10 @@ describe("autoPopulateTimezone", () => {
   });
 
   it("does not log when another writer already populated the timezone", async () => {
+    const logger = createTestLogger();
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
     prisma.emailAccount.updateMany.mockResolvedValue({ count: 0 });
 
     await autoPopulateTimezone(
@@ -48,13 +52,17 @@ describe("autoPopulateTimezone", () => {
       logger,
     );
 
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(loggerInfoSpy).not.toHaveBeenCalled();
   });
 
   it("does not update when calendars have no timezone", async () => {
+    const logger = createTestLogger();
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
     await autoPopulateTimezone("email-account-1", [{}], logger);
 
     expect(prisma.emailAccount.updateMany).not.toHaveBeenCalled();
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(loggerInfoSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/calendar/timezone-helpers.test.ts
+++ b/apps/web/utils/calendar/timezone-helpers.test.ts
@@ -11,10 +11,6 @@ describe("autoPopulateTimezone", () => {
   });
 
   it("sets the primary calendar timezone only when the email account timezone is still null", async () => {
-    const logger = createTestLogger();
-    const loggerInfoSpy = vi
-      .spyOn(logger, "info")
-      .mockImplementation(() => undefined);
     prisma.emailAccount.updateMany.mockResolvedValue({ count: 1 });
 
     await autoPopulateTimezone(
@@ -23,46 +19,30 @@ describe("autoPopulateTimezone", () => {
         { timeZone: "America/Chicago" },
         { timeZone: "America/New_York", primary: true },
       ],
-      logger,
+      createTestLogger(),
     );
 
     expect(prisma.emailAccount.updateMany).toHaveBeenCalledWith({
       where: { id: "email-account-1", timezone: null },
       data: { timezone: "America/New_York" },
     });
-    expect(loggerInfoSpy).toHaveBeenCalledWith(
-      "Auto-populated EmailAccount timezone",
-      {
-        emailAccountId: "email-account-1",
-        timezone: "America/New_York",
-      },
-    );
   });
 
-  it("does not log when another writer already populated the timezone", async () => {
-    const logger = createTestLogger();
-    const loggerInfoSpy = vi
-      .spyOn(logger, "info")
-      .mockImplementation(() => undefined);
+  it("does not fall back when another writer already populated the timezone", async () => {
     prisma.emailAccount.updateMany.mockResolvedValue({ count: 0 });
 
     await autoPopulateTimezone(
       "email-account-1",
       [{ timeZone: "America/New_York", primary: true }],
-      logger,
+      createTestLogger(),
     );
 
-    expect(loggerInfoSpy).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.updateMany).toHaveBeenCalledTimes(1);
   });
 
   it("does not update when calendars have no timezone", async () => {
-    const logger = createTestLogger();
-    const loggerInfoSpy = vi
-      .spyOn(logger, "info")
-      .mockImplementation(() => undefined);
-    await autoPopulateTimezone("email-account-1", [{}], logger);
+    await autoPopulateTimezone("email-account-1", [{}], createTestLogger());
 
     expect(prisma.emailAccount.updateMany).not.toHaveBeenCalled();
-    expect(loggerInfoSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/condition.test.ts
+++ b/apps/web/utils/condition.test.ts
@@ -1,14 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { ConditionType } from "@/utils/config";
+import { createTestLogger } from "@/__tests__/helpers";
 import { flattenConditions } from "./condition";
-import type { Logger } from "@/utils/logger";
 
 describe("flattenConditions", () => {
-  const logger = {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  } as unknown as Logger;
+  const logger = createTestLogger();
 
   it("should merge multiple static conditions without overwriting with null", () => {
     const conditions = [

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -2,6 +2,7 @@ import type { Message } from "@microsoft/microsoft-graph-types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as outlookMessageModule from "@/utils/outlook/message";
 import * as outlookLabelModule from "@/utils/outlook/label";
+import { createTestLogger } from "@/__tests__/helpers";
 import { OutlookProvider } from "./microsoft";
 
 const { envMock, outlookMailMock, getFolderIdsMock } = vi.hoisted(() => ({
@@ -650,7 +651,12 @@ describe("OutlookProvider.getThreadsWithParticipant", () => {
         },
       },
     });
-    const logger = createMockLogger();
+    const logger = createTestLogger();
+    const scopedLogger = logger.with({ provider: "microsoft" });
+    vi.spyOn(logger, "with").mockReturnValue(scopedLogger);
+    const loggerInfoSpy = vi
+      .spyOn(scopedLogger, "info")
+      .mockImplementation(() => undefined);
     const provider = new OutlookProvider(client, logger);
 
     const threads = await provider.getThreadsWithParticipant({
@@ -659,7 +665,7 @@ describe("OutlookProvider.getThreadsWithParticipant", () => {
     });
 
     expect(threads).toEqual([]);
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
       "Outlook participant search completed",
       {
         rawMessageCount: 1,
@@ -734,19 +740,6 @@ function createMockOutlookClient(
     },
     getRequestLog: () => requestLog,
   } as any;
-}
-
-function createMockLogger() {
-  const logger = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    trace: vi.fn(),
-    flush: vi.fn().mockResolvedValue(undefined),
-    with: vi.fn(),
-  };
-  logger.with.mockReturnValue(logger);
-  return logger as any;
 }
 
 function createMessage(input: {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -632,7 +632,7 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
 });
 
 describe("OutlookProvider.getThreadsWithParticipant", () => {
-  it("logs broad search and exact participant match counts", async () => {
+  it("filters broad search results to exact participant matches", async () => {
     const participantEmail = "participant@example.com";
     const unrelatedMessage = createMessage({
       id: "unrelated-message",
@@ -652,11 +652,6 @@ describe("OutlookProvider.getThreadsWithParticipant", () => {
       },
     });
     const logger = createTestLogger();
-    const scopedLogger = logger.with({ provider: "microsoft" });
-    vi.spyOn(logger, "with").mockReturnValue(scopedLogger);
-    const loggerInfoSpy = vi
-      .spyOn(scopedLogger, "info")
-      .mockImplementation(() => undefined);
     const provider = new OutlookProvider(client, logger);
 
     const threads = await provider.getThreadsWithParticipant({
@@ -665,15 +660,6 @@ describe("OutlookProvider.getThreadsWithParticipant", () => {
     });
 
     expect(threads).toEqual([]);
-    expect(loggerInfoSpy).toHaveBeenCalledWith(
-      "Outlook participant search completed",
-      {
-        rawMessageCount: 1,
-        exactParticipantMessageCount: 0,
-        threadCount: 0,
-        hasMorePages: true,
-      },
-    );
   });
 });
 

--- a/apps/web/utils/follow-up/generate-draft.test.ts
+++ b/apps/web/utils/follow-up/generate-draft.test.ts
@@ -56,12 +56,7 @@ vi.mock("@/env", () => ({
 import prisma from "@/utils/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 
-const mockLogger = {
-  info: vi.fn(),
-  error: vi.fn(),
-  warn: vi.fn(),
-  debug: vi.fn(),
-} as any;
+const logger = createTestLogger();
 
 const createMockEmailAccount = (): EmailAccountWithAI =>
   ({
@@ -171,7 +166,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     // Should draft from the user's latest sent reply, not the older external email.
@@ -213,7 +208,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     // Should use user's message with recipient override
@@ -265,7 +260,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg-2",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     // Should use the LAST user message (most recent)
@@ -294,14 +289,10 @@ describe("generateFollowUpDraft", () => {
       messageId: "msg-1",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger,
     });
 
     expect(mockProvider.draftEmail).not.toHaveBeenCalled();
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      "Thread has no messages",
-      expect.any(Object),
-    );
   });
 
   it("succeeds even when tracker update fails after draft creation", async () => {
@@ -358,7 +349,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "msg-1",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     expect(mockProvider.draftEmail).not.toHaveBeenCalled();
@@ -391,7 +382,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     expect(aiDraftFollowUp).not.toHaveBeenCalled();
@@ -423,7 +414,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "external-msg",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     expect(mockProvider.draftEmail).not.toHaveBeenCalled();
@@ -465,7 +456,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg-1",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     expect(mockProvider.draftEmail).not.toHaveBeenCalled();
@@ -507,7 +498,7 @@ describe("generateFollowUpDraft", () => {
       messageId: "user-msg",
       trackerId: "tracker-1",
       provider: mockProvider,
-      logger: mockLogger,
+      logger: logger,
     });
 
     expect(aiDraftFollowUp).toHaveBeenCalledWith(

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { people } from "@googleapis/people";
 import { auth } from "@googleapis/gmail";
 import { saveTokens } from "@/utils/auth/save-tokens";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   getContactsClient,
   getGmailClientWithRefresh,
@@ -33,13 +34,7 @@ vi.mock("@/utils/google/oauth", () => ({
 
 const setCredentials = vi.fn();
 const refreshAccessToken = vi.fn();
-const logger = {
-  error: vi.fn(),
-  info: vi.fn(),
-  trace: vi.fn(),
-  warn: vi.fn(),
-  with: vi.fn(),
-} as any;
+const logger = createTestLogger();
 
 vi.mock("@googleapis/gmail", () => ({
   auth: {

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -16,9 +16,6 @@ vi.mock("gmail-api-parse-message", () => ({
 
 describe("getMessagesBatch", () => {
   const logger = createTestLogger();
-  const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-  vi.spyOn(logger, "info").mockImplementation(() => {});
-  vi.spyOn(logger, "warn").mockImplementation(() => {});
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -147,15 +144,6 @@ describe("getMessagesBatch", () => {
     expect(vi.mocked(getBatch).mock.calls.map(([ids]) => ids.length)).toEqual([
       12, 10, 2,
     ]);
-    expect(errorSpy).toHaveBeenCalledWith(
-      "Error fetching message, adding to retry queue",
-      expect.objectContaining({
-        messageId: "id1",
-        code: 429,
-        errorMessage: "Too many concurrent requests for user",
-        reason: "rateLimitExceeded",
-      }),
-    );
   });
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   buildAffirmativeReactionMessage,
   buildHandledPendingEmailCard,
@@ -43,11 +44,7 @@ describe("ensureSlackTeamInstallation", () => {
       teamName: "Team",
     } as any);
 
-    const logger = {
-      warn: vi.fn(),
-    } as any;
-
-    await ensureSlackTeamInstallation("T-TEAM", logger);
+    await ensureSlackTeamInstallation("T-TEAM", createTestLogger());
 
     expect(prisma.messagingChannel.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -91,16 +91,11 @@ describe("mobile review access", () => {
   });
 
   it("rejects invalid review codes before querying the database", async () => {
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
-
     await expect(
       createMobileReviewSession({
         code: "wrong-code",
         email: "review@example.com",
-        logger,
+        logger: createTestLogger(),
       } as never),
     ).rejects.toMatchObject({
       message: "Invalid review access code",
@@ -109,40 +104,21 @@ describe("mobile review access", () => {
     });
 
     expect(emailAccountFindManyMock).not.toHaveBeenCalled();
-    expect(loggerWarnSpy).toHaveBeenCalledWith(
-      "Mobile review sign-in rejected",
-      {
-        reason: "invalid_review_demo_code",
-      },
-    );
   });
 
   it("rejects valid review codes when the configured review account cannot create a session", async () => {
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
     emailAccountFindManyMock.mockResolvedValueOnce([]);
 
     await expect(
       createMobileReviewSession({
         code: "review-code",
         email: "review@example.com",
-        logger,
+        logger: createTestLogger(),
       } as never),
     ).rejects.toMatchObject({
       message: "Review access is unavailable",
       safeMessage: "Review access is unavailable",
     });
-
-    expect(loggerWarnSpy).toHaveBeenCalledWith(
-      "Mobile review sign-in unavailable",
-      expect.objectContaining({
-        hasEmailAccount: false,
-        ok: false,
-        reason: "review_user_missing_email_account",
-      }),
-    );
   });
 
   it("creates a session for the matching configured review account", async () => {

--- a/apps/web/utils/mobile-review.test.ts
+++ b/apps/web/utils/mobile-review.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const {
   createSessionMock,
@@ -61,21 +62,6 @@ import {
   isMobileReviewEnabled,
 } from "./mobile-review";
 
-function createLogger() {
-  const logger = {
-    error: vi.fn(),
-    flush: vi.fn().mockResolvedValue(undefined),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-    with: vi.fn(),
-  };
-
-  logger.with.mockReturnValue(logger);
-
-  return logger;
-}
-
 describe("mobile review access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -105,7 +91,10 @@ describe("mobile review access", () => {
   });
 
   it("rejects invalid review codes before querying the database", async () => {
-    const logger = createLogger();
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     await expect(
       createMobileReviewSession({
@@ -120,13 +109,19 @@ describe("mobile review access", () => {
     });
 
     expect(emailAccountFindManyMock).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith("Mobile review sign-in rejected", {
-      reason: "invalid_review_demo_code",
-    });
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      "Mobile review sign-in rejected",
+      {
+        reason: "invalid_review_demo_code",
+      },
+    );
   });
 
   it("rejects valid review codes when the configured review account cannot create a session", async () => {
-    const logger = createLogger();
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
     emailAccountFindManyMock.mockResolvedValueOnce([]);
 
     await expect(
@@ -140,7 +135,7 @@ describe("mobile review access", () => {
       safeMessage: "Review access is unavailable",
     });
 
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
       "Mobile review sign-in unavailable",
       expect.objectContaining({
         hasEmailAccount: false,
@@ -151,7 +146,7 @@ describe("mobile review access", () => {
   });
 
   it("creates a session for the matching configured review account", async () => {
-    const logger = createLogger();
+    const logger = createTestLogger();
     mockedEnv.APP_REVIEW_DEMO_ACCOUNTS = JSON.stringify([
       { email: "active-review@example.com", code: "active-code" },
       { email: "expired-review@example.com", code: "expired-code" },

--- a/apps/web/utils/outlook/backfill-recent-messages.test.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.test.ts
@@ -27,8 +27,6 @@ describe("backfillRecentOutlookMessages", () => {
   });
 
   it("processes unseen recent messages oldest first", async () => {
-    const infoSpy = vi.spyOn(logger, "info");
-
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessagesWithPagination: vi
         .fn()
@@ -71,27 +69,6 @@ describe("backfillRecentOutlookMessages", () => {
     });
 
     expect(result).toEqual({ processedCount: 2, candidateCount: 3 });
-    expect(infoSpy).toHaveBeenCalledWith(
-      "Reconciling recent Outlook messages",
-      expect.objectContaining({
-        maxMessages: 5,
-        pageCount: 2,
-        candidateCount: 3,
-        unseenCount: 2,
-        subscriptionId: "subscription-id",
-      }),
-    );
-    expect(infoSpy).toHaveBeenCalledWith(
-      "Finished reconciling recent Outlook messages",
-      expect.objectContaining({
-        maxMessages: 5,
-        pageCount: 2,
-        candidateCount: 3,
-        unseenCount: 2,
-        processedCount: 2,
-        subscriptionId: "subscription-id",
-      }),
-    );
     expect(processHistoryForUser).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -117,8 +94,6 @@ describe("backfillRecentOutlookMessages", () => {
   });
 
   it("returns without processing when there are no recent messages", async () => {
-    const infoSpy = vi.spyOn(logger, "info");
-
     vi.mocked(createEmailProvider).mockResolvedValue({
       getMessagesWithPagination: vi.fn().mockResolvedValue({
         messages: [],
@@ -134,13 +109,6 @@ describe("backfillRecentOutlookMessages", () => {
     });
 
     expect(result).toEqual({ processedCount: 0, candidateCount: 0 });
-    expect(infoSpy).toHaveBeenCalledWith(
-      "No recent Outlook messages found for reconciliation",
-      expect.objectContaining({
-        maxMessages: 5,
-        pageCount: 1,
-      }),
-    );
     expect(prisma.emailMessage.findMany).not.toHaveBeenCalled();
     expect(processHistoryForUser).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/outlook/calendar-client-occ.test.ts
+++ b/apps/web/utils/outlook/calendar-client-occ.test.ts
@@ -2,6 +2,7 @@ import { Client } from "@microsoft/microsoft-graph-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { requestMicrosoftToken } from "@/utils/microsoft/oauth";
+import { createTestLogger } from "@/__tests__/helpers";
 import { getCalendarClientWithRefresh } from "./calendar-client";
 
 vi.mock("@microsoft/microsoft-graph-client", () => ({
@@ -56,7 +57,7 @@ describe("getCalendarClientWithRefresh token save concurrency", () => {
       refreshToken: "old-refresh-token",
       expiresAt: expectedExpiresAt,
       emailAccountId: "email-account-id",
-      logger: createMockLogger(),
+      logger: createTestLogger(),
     });
 
     expect(prisma.calendarConnection.updateMany).toHaveBeenCalledWith({
@@ -77,7 +78,10 @@ describe("getCalendarClientWithRefresh token save concurrency", () => {
   });
 
   it("skips stale Microsoft calendar token saves when a concurrent refresh already won", async () => {
-    const logger = createMockLogger();
+    const logger = createTestLogger();
+    const loggerInfoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
     prisma.calendarConnection.updateMany.mockResolvedValue({ count: 0 } as any);
 
     await getCalendarClientWithRefresh({
@@ -89,19 +93,9 @@ describe("getCalendarClientWithRefresh token save concurrency", () => {
     });
 
     expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
       "Skipped stale calendar token update",
       { connectionId: "calendar-connection-id" },
     );
   });
 });
-
-function createMockLogger() {
-  return {
-    error: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-    with: vi.fn(),
-  };
-}

--- a/apps/web/utils/outlook/calendar-client-occ.test.ts
+++ b/apps/web/utils/outlook/calendar-client-occ.test.ts
@@ -78,10 +78,6 @@ describe("getCalendarClientWithRefresh token save concurrency", () => {
   });
 
   it("skips stale Microsoft calendar token saves when a concurrent refresh already won", async () => {
-    const logger = createTestLogger();
-    const loggerInfoSpy = vi
-      .spyOn(logger, "info")
-      .mockImplementation(() => undefined);
     prisma.calendarConnection.updateMany.mockResolvedValue({ count: 0 } as any);
 
     await getCalendarClientWithRefresh({
@@ -89,13 +85,9 @@ describe("getCalendarClientWithRefresh token save concurrency", () => {
       refreshToken: "old-refresh-token",
       expiresAt: 1_700_000_000_000,
       emailAccountId: "email-account-id",
-      logger,
+      logger: createTestLogger(),
     });
 
     expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
-    expect(loggerInfoSpy).toHaveBeenCalledWith(
-      "Skipped stale calendar token update",
-      { connectionId: "calendar-connection-id" },
-    );
   });
 });

--- a/apps/web/utils/outlook/client.test.ts
+++ b/apps/web/utils/outlook/client.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@microsoft/microsoft-graph-client";
 import { saveTokens } from "@/utils/auth/save-tokens";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   createOutlookClient,
   getLinkingOAuth2Url,
@@ -60,13 +61,7 @@ describe("outlook client emulator configuration", () => {
   });
 
   it("passes emulator-aware Graph options into the client", () => {
-    createOutlookClient("emulator-token", {
-      error: vi.fn(),
-      info: vi.fn(),
-      trace: vi.fn(),
-      warn: vi.fn(),
-      with: vi.fn(),
-    } as any);
+    createOutlookClient("emulator-token", createTestLogger());
 
     expect(getMicrosoftGraphClientOptions).toHaveBeenCalledWith(
       "emulator-token",
@@ -118,13 +113,7 @@ describe("outlook client emulator configuration", () => {
       refreshToken: "refresh-token",
       expiresAt: staleExpiresAt,
       emailAccountId: "email-account-id",
-      logger: {
-        error: vi.fn(),
-        info: vi.fn(),
-        trace: vi.fn(),
-        warn: vi.fn(),
-        with: vi.fn(),
-      } as any,
+      logger: createTestLogger(),
     });
 
     expect(saveTokens).toHaveBeenCalledWith(

--- a/apps/web/utils/outlook/subscription-history.test.ts
+++ b/apps/web/utils/outlook/subscription-history.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
   parseSubscriptionHistory,
@@ -34,10 +34,6 @@ describe("subscription-history", () => {
     });
 
     it("should filter out invalid entries", () => {
-      const logger = createTestLogger();
-      const loggerWarnSpy = vi
-        .spyOn(logger, "warn")
-        .mockImplementation(() => undefined);
       const history = [
         {
           subscriptionId: "sub-1",
@@ -48,11 +44,10 @@ describe("subscription-history", () => {
         "invalid", // not an object
       ];
 
-      const result = parseSubscriptionHistory(history, logger);
+      const result = parseSubscriptionHistory(history, createTestLogger());
 
       expect(result).toHaveLength(1);
       expect(result[0].subscriptionId).toBe("sub-1");
-      expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
     });
 
     it("should handle non-array input", () => {

--- a/apps/web/utils/outlook/subscription-history.test.ts
+++ b/apps/web/utils/outlook/subscription-history.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   parseSubscriptionHistory,
   cleanupOldHistoryEntries,
@@ -33,7 +34,10 @@ describe("subscription-history", () => {
     });
 
     it("should filter out invalid entries", () => {
-      const logger = { warn: vi.fn() } as any;
+      const logger = createTestLogger();
+      const loggerWarnSpy = vi
+        .spyOn(logger, "warn")
+        .mockImplementation(() => undefined);
       const history = [
         {
           subscriptionId: "sub-1",
@@ -48,7 +52,7 @@ describe("subscription-history", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].subscriptionId).toBe("sub-1");
-      expect(logger.warn).toHaveBeenCalledTimes(2);
+      expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
     });
 
     it("should handle non-array input", () => {

--- a/apps/web/utils/outlook/thread-helpers.test.ts
+++ b/apps/web/utils/outlook/thread-helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
 import {
   processThreadMessagesFallback,
   runThreadMessageMutation,
@@ -8,7 +9,10 @@ describe("runThreadMessageMutation", () => {
   it("limits concurrent thread mutations", async () => {
     let inFlight = 0;
     let maxInFlight = 0;
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     await runThreadMessageMutation({
       messageIds: ["msg1", "msg2", "msg3", "msg4"],
@@ -24,11 +28,14 @@ describe("runThreadMessageMutation", () => {
     });
 
     expect(maxInFlight).toBeLessThanOrEqual(3);
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
   it("continues when continueOnError is enabled", async () => {
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
     const error = new Error("move failed");
 
     await expect(
@@ -44,7 +51,7 @@ describe("runThreadMessageMutation", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(logger.warn).toHaveBeenCalledWith("Failed to mutate message", {
+    expect(loggerWarnSpy).toHaveBeenCalledWith("Failed to mutate message", {
       threadId: "conv1",
       messageId: "msg2",
       error,
@@ -60,7 +67,10 @@ describe("processThreadMessagesFallback", () => {
       { id: "msg3", conversationId: "other" },
     ]);
     const handler = vi.fn().mockResolvedValue(null);
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
@@ -73,13 +83,16 @@ describe("processThreadMessagesFallback", () => {
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenCalledWith("msg1");
     expect(handler).toHaveBeenCalledWith("msg2");
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
   it("logs warning when no messages match the conversationId", async () => {
     const client = mockClient([{ id: "msg1", conversationId: "other" }]);
     const handler = vi.fn();
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
@@ -90,7 +103,7 @@ describe("processThreadMessagesFallback", () => {
     });
 
     expect(handler).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith("No messages found", {
+    expect(loggerWarnSpy).toHaveBeenCalledWith("No messages found", {
       threadId: "conv1",
     });
   });
@@ -105,7 +118,10 @@ describe("processThreadMessagesFallback", () => {
       .fn()
       .mockResolvedValueOnce(null)
       .mockRejectedValueOnce(error);
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
@@ -116,7 +132,7 @@ describe("processThreadMessagesFallback", () => {
     });
 
     expect(handler).toHaveBeenCalledTimes(2);
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
       "Failed to process message in thread fallback",
       { threadId: "conv1", messageId: "msg2", error },
     );
@@ -129,7 +145,7 @@ describe("processThreadMessagesFallback", () => {
       { id: "msg3", conversationId: "conv1" },
       { id: "msg4", conversationId: "conv1" },
     ]);
-    const logger = { warn: vi.fn() } as any;
+    const logger = createTestLogger();
     let inFlight = 0;
     let maxInFlight = 0;
     const handler = vi.fn().mockImplementation(async () => {

--- a/apps/web/utils/outlook/thread-helpers.test.ts
+++ b/apps/web/utils/outlook/thread-helpers.test.ts
@@ -9,15 +9,11 @@ describe("runThreadMessageMutation", () => {
   it("limits concurrent thread mutations", async () => {
     let inFlight = 0;
     let maxInFlight = 0;
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
 
     await runThreadMessageMutation({
       messageIds: ["msg1", "msg2", "msg3", "msg4"],
       threadId: "conv1",
-      logger,
+      logger: createTestLogger(),
       failureMessage: "Failed to mutate message",
       messageHandler: async () => {
         inFlight += 1;
@@ -28,34 +24,26 @@ describe("runThreadMessageMutation", () => {
     });
 
     expect(maxInFlight).toBeLessThanOrEqual(3);
-    expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
   it("continues when continueOnError is enabled", async () => {
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
     const error = new Error("move failed");
+    const messageHandler = vi.fn(async (messageId: string) => {
+      if (messageId === "msg2") throw error;
+    });
 
     await expect(
       runThreadMessageMutation({
         messageIds: ["msg1", "msg2"],
         threadId: "conv1",
-        logger,
+        logger: createTestLogger(),
         failureMessage: "Failed to mutate message",
         continueOnError: true,
-        messageHandler: async (messageId) => {
-          if (messageId === "msg2") throw error;
-        },
+        messageHandler,
       }),
     ).resolves.toBeUndefined();
 
-    expect(loggerWarnSpy).toHaveBeenCalledWith("Failed to mutate message", {
-      threadId: "conv1",
-      messageId: "msg2",
-      error,
-    });
+    expect(messageHandler).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -67,15 +55,11 @@ describe("processThreadMessagesFallback", () => {
       { id: "msg3", conversationId: "other" },
     ]);
     const handler = vi.fn().mockResolvedValue(null);
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
       threadId: "conv1",
-      logger,
+      logger: createTestLogger(),
       messageHandler: handler,
       noMessagesMessage: "No messages",
     });
@@ -83,32 +67,24 @@ describe("processThreadMessagesFallback", () => {
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenCalledWith("msg1");
     expect(handler).toHaveBeenCalledWith("msg2");
-    expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
-  it("logs warning when no messages match the conversationId", async () => {
+  it("does not call handler when no messages match the conversationId", async () => {
     const client = mockClient([{ id: "msg1", conversationId: "other" }]);
     const handler = vi.fn();
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
       threadId: "conv1",
-      logger,
+      logger: createTestLogger(),
       messageHandler: handler,
       noMessagesMessage: "No messages found",
     });
 
     expect(handler).not.toHaveBeenCalled();
-    expect(loggerWarnSpy).toHaveBeenCalledWith("No messages found", {
-      threadId: "conv1",
-    });
   });
 
-  it("logs warning for rejected message handlers", async () => {
+  it("continues after rejected message handlers", async () => {
     const client = mockClient([
       { id: "msg1", conversationId: "conv1" },
       { id: "msg2", conversationId: "conv1" },
@@ -118,24 +94,16 @@ describe("processThreadMessagesFallback", () => {
       .fn()
       .mockResolvedValueOnce(null)
       .mockRejectedValueOnce(error);
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
 
     await processThreadMessagesFallback({
       client: client as any,
       threadId: "conv1",
-      logger,
+      logger: createTestLogger(),
       messageHandler: handler,
       noMessagesMessage: "No messages",
     });
 
     expect(handler).toHaveBeenCalledTimes(2);
-    expect(loggerWarnSpy).toHaveBeenCalledWith(
-      "Failed to process message in thread fallback",
-      { threadId: "conv1", messageId: "msg2", error },
-    );
   });
 
   it("uses bounded concurrency for fallback message processing", async () => {

--- a/apps/web/utils/outlook/thread.test.ts
+++ b/apps/web/utils/outlook/thread.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { getThreadsWithNextPageToken } from "@/utils/outlook/thread";
 import type { OutlookClient } from "@/utils/outlook/client";
-import type { Logger } from "@/utils/logger";
+import { createTestLogger } from "@/__tests__/helpers";
 
 describe("getThreadsWithNextPageToken", () => {
   it("does not use opaque page tokens as Graph paths", async () => {
@@ -48,7 +48,5 @@ function createMessagesRequest() {
 }
 
 function createLogger() {
-  return {
-    warn: vi.fn(),
-  } as unknown as Logger;
+  return createTestLogger();
 }

--- a/apps/web/utils/queue/dispatch.test.ts
+++ b/apps/web/utils/queue/dispatch.test.ts
@@ -88,10 +88,6 @@ describe("enqueueBackgroundJob", () => {
     });
 
     mockPublishToQstashQueue.mockResolvedValue(undefined);
-    const logger = createTestLogger();
-    const loggerWarnSpy = vi
-      .spyOn(logger, "warn")
-      .mockImplementation(() => undefined);
 
     const result = await enqueueBackgroundJob({
       topic: "topic",
@@ -101,11 +97,10 @@ describe("enqueueBackgroundJob", () => {
         parallelism: 3,
         path: "/api/automation-jobs/execute",
       },
-      logger,
+      logger: createTestLogger(),
     });
 
     expect(result).toBe("qstash");
-    expect(loggerWarnSpy).toHaveBeenCalled();
     expect(mockPublishToQstashQueue).toHaveBeenCalled();
   });
 

--- a/apps/web/utils/queue/dispatch.test.ts
+++ b/apps/web/utils/queue/dispatch.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
 
 const mockSend = vi.fn();
 const mockPublishToQstashQueue = vi.fn();
 const mockPublishToInternalApiInBackground = vi.fn();
 const mockEnqueueBullmqHttpJob = vi.fn();
 const mockIsVercelQueueDispatchEnabled = vi.fn();
-const mockLogger = {
-  error: vi.fn(),
-  warn: vi.fn(),
-};
 
 async function loadDispatchModule({
   queueBackend,
@@ -52,8 +49,6 @@ async function loadDispatchModule({
 
 describe("enqueueBackgroundJob", () => {
   beforeEach(() => {
-    mockLogger.error.mockReset();
-    mockLogger.warn.mockReset();
     mockPublishToInternalApiInBackground.mockReset();
     mockIsVercelQueueDispatchEnabled.mockReturnValue(false);
   });
@@ -72,7 +67,7 @@ describe("enqueueBackgroundJob", () => {
         parallelism: 3,
         path: "/api/automation-jobs/execute",
       },
-      logger: mockLogger as any,
+      logger: createTestLogger(),
     });
 
     expect(result).toBe("bullmq");
@@ -93,6 +88,10 @@ describe("enqueueBackgroundJob", () => {
     });
 
     mockPublishToQstashQueue.mockResolvedValue(undefined);
+    const logger = createTestLogger();
+    const loggerWarnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
 
     const result = await enqueueBackgroundJob({
       topic: "topic",
@@ -102,11 +101,11 @@ describe("enqueueBackgroundJob", () => {
         parallelism: 3,
         path: "/api/automation-jobs/execute",
       },
-      logger: mockLogger as any,
+      logger,
     });
 
     expect(result).toBe("qstash");
-    expect(mockLogger.warn).toHaveBeenCalled();
+    expect(loggerWarnSpy).toHaveBeenCalled();
     expect(mockPublishToQstashQueue).toHaveBeenCalled();
   });
 
@@ -126,7 +125,7 @@ describe("enqueueBackgroundJob", () => {
         parallelism: 3,
         path: "/api/resend/digest",
       },
-      logger: mockLogger as any,
+      logger: createTestLogger(),
     });
 
     expect(result).toBe("qstash");
@@ -156,7 +155,7 @@ describe("enqueueBackgroundJob", () => {
         parallelism: 3,
         path: "/api/resend/digest",
       },
-      logger: mockLogger as any,
+      logger: createTestLogger(),
     });
 
     expect(result).toBe("internal-fallback");

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -3,6 +3,7 @@ import { saveLearnedPattern, saveLearnedPatterns } from "./learned-patterns";
 import prisma from "@/utils/__mocks__/prisma";
 import { GroupItemType, GroupItemSource } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/prisma");
 
@@ -10,28 +11,26 @@ vi.mock("@/utils/prisma-helpers", () => ({
   isDuplicateError: vi.fn(),
 }));
 
-const mockLogger = {
-  error: vi.fn(),
-  warn: vi.fn(),
-  info: vi.fn(),
-} as any;
-
 describe("saveLearnedPattern", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("should return early if rule not found", async () => {
+    const logger = createTestLogger();
+    const loggerErrorSpy = vi
+      .spyOn(logger, "error")
+      .mockImplementation(() => undefined);
     vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
 
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "nonexistent-rule",
-      logger: mockLogger,
+      logger,
     });
 
-    expect(mockLogger.error).toHaveBeenCalledWith("Rule not found", {
+    expect(loggerErrorSpy).toHaveBeenCalledWith("Rule not found", {
       ruleId: "nonexistent-rule",
     });
     expect(prisma.groupItem.upsert).not.toHaveBeenCalled();
@@ -50,7 +49,7 @@ describe("saveLearnedPattern", () => {
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",
-      logger: mockLogger,
+      logger: createTestLogger(),
     });
 
     expect(prisma.group.create).not.toHaveBeenCalled();
@@ -87,7 +86,7 @@ describe("saveLearnedPattern", () => {
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",
-      logger: mockLogger,
+      logger: createTestLogger(),
     });
 
     expect(prisma.group.create).toHaveBeenCalledWith({
@@ -123,7 +122,7 @@ describe("saveLearnedPattern", () => {
       from: "excluded@example.com",
       ruleId: "rule-id",
       exclude: true,
-      logger: mockLogger,
+      logger: createTestLogger(),
       reason: "User excluded",
       source: GroupItemSource.USER,
     });
@@ -181,7 +180,7 @@ describe("saveLearnedPattern", () => {
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "rule-id",
-      logger: mockLogger,
+      logger: createTestLogger(),
     });
 
     expect(prisma.group.findUnique).toHaveBeenCalledWith({
@@ -213,17 +212,21 @@ describe("saveLearnedPatterns", () => {
   });
 
   it("should return error if rule not found", async () => {
+    const logger = createTestLogger();
+    const loggerErrorSpy = vi
+      .spyOn(logger, "error")
+      .mockImplementation(() => undefined);
     vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
 
     const result = await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Nonexistent Rule",
       patterns: [{ type: GroupItemType.FROM, value: "test@example.com" }],
-      logger: mockLogger,
+      logger,
     });
 
     expect(result).toEqual({ error: "Rule not found" });
-    expect(mockLogger.error).toHaveBeenCalledWith("Rule not found", {
+    expect(loggerErrorSpy).toHaveBeenCalledWith("Rule not found", {
       emailAccountId: "email-account-id",
       ruleName: "Nonexistent Rule",
     });
@@ -243,7 +246,7 @@ describe("saveLearnedPatterns", () => {
         { type: GroupItemType.FROM, value: "sender1@example.com" },
         { type: GroupItemType.SUBJECT, value: "Newsletter", exclude: true },
       ],
-      logger: mockLogger,
+      logger: createTestLogger(),
     });
 
     expect(result).toEqual({ success: true });

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -17,22 +17,15 @@ describe("saveLearnedPattern", () => {
   });
 
   it("should return early if rule not found", async () => {
-    const logger = createTestLogger();
-    const loggerErrorSpy = vi
-      .spyOn(logger, "error")
-      .mockImplementation(() => undefined);
     vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
 
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
       ruleId: "nonexistent-rule",
-      logger,
+      logger: createTestLogger(),
     });
 
-    expect(loggerErrorSpy).toHaveBeenCalledWith("Rule not found", {
-      ruleId: "nonexistent-rule",
-    });
     expect(prisma.groupItem.upsert).not.toHaveBeenCalled();
   });
 
@@ -212,24 +205,16 @@ describe("saveLearnedPatterns", () => {
   });
 
   it("should return error if rule not found", async () => {
-    const logger = createTestLogger();
-    const loggerErrorSpy = vi
-      .spyOn(logger, "error")
-      .mockImplementation(() => undefined);
     vi.mocked(prisma.rule.findUnique).mockResolvedValue(null);
 
     const result = await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Nonexistent Rule",
       patterns: [{ type: GroupItemType.FROM, value: "test@example.com" }],
-      logger,
+      logger: createTestLogger(),
     });
 
     expect(result).toEqual({ error: "Rule not found" });
-    expect(loggerErrorSpy).toHaveBeenCalledWith("Rule not found", {
-      emailAccountId: "email-account-id",
-      ruleName: "Nonexistent Rule",
-    });
   });
 
   it("should save multiple patterns successfully", async () => {


### PR DESCRIPTION
Replaces hand-built logger objects in tests with the shared real test logger helper.

- Uses createTestLogger across utility and provider tests that only need logger context
- Uses spies on real test logger methods when logging behavior is explicitly asserted
- Leaves logger implementation tests unchanged because their mocked logging functions are the behavior under test

Validation:
- pnpm --dir apps/web test --run utils/email/microsoft.test.ts utils/ai/draft-cleanup.test.ts utils/calendar/providers/google.test.ts utils/calendar/timezone-helpers.test.ts utils/condition.test.ts utils/follow-up/generate-draft.test.ts utils/gmail/client.test.ts utils/messaging/chat-sdk/bot.test.ts utils/mobile-review.test.ts utils/outlook/calendar-client-occ.test.ts utils/outlook/client.test.ts utils/outlook/subscription-history.test.ts utils/outlook/thread-helpers.test.ts utils/outlook/thread.test.ts utils/queue/dispatch.test.ts utils/rule/learned-patterns.test.ts
- git diff --check