### PR TITLE
refactor: Simplify rule matching code

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { filterMultipleSystemRules } from "./match-rules";
 import {
+  evaluateRuleConditions,
+  filterConversationStatusRules,
+  filterMultipleSystemRules,
   findMatchingRules,
   matchesStaticRule,
-  filterConversationStatusRules,
-  evaluateRuleConditions,
 } from "./match-rules";
 import {
   GroupItemType,
@@ -27,15 +27,14 @@ import {
   isColdEmailRuleEnabled,
 } from "@/utils/cold-email/cold-email-rule";
 import { isColdEmail } from "@/utils/cold-email/is-cold-email";
+import { checkSenderReplyHistory } from "@/utils/reply-tracker/check-sender-reply-history";
 
 // Run with:
 // pnpm test match-rules.test.ts
 
 const logger = createTestLogger();
 
-const provider = {
-  isReplyInThread: vi.fn().mockReturnValue(false),
-} as unknown as EmailProvider;
+const provider = getProvider();
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/ai/choose-rule/ai-choose-rule", () => ({
@@ -1477,7 +1476,7 @@ describe("findMatchingRule", () => {
   });
 });
 
-describe("filterToReplyPreset", () => {
+describe("filterConversationStatusRules", () => {
   it("should filter out no-reply emails from TO_REPLY rules", async () => {
     const toReplyRule = {
       ...getRule({
@@ -1543,16 +1542,10 @@ describe("filterToReplyPreset", () => {
   });
 
   it("should filter out TO_REPLY rule when sender has high received count and no replies", async () => {
-    const { checkSenderReplyHistory } = await import(
-      "@/utils/reply-tracker/check-sender-reply-history"
-    );
-
-    (checkSenderReplyHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        hasReplied: false,
-        receivedCount: 15, // Above threshold of 10
-      },
-    );
+    vi.mocked(checkSenderReplyHistory).mockResolvedValueOnce({
+      hasReplied: false,
+      receivedCount: 15,
+    });
 
     const toReplyRule = {
       ...getRule({
@@ -1593,16 +1586,10 @@ describe("filterToReplyPreset", () => {
   });
 
   it("should keep TO_REPLY rule when sender has prior replies", async () => {
-    const { checkSenderReplyHistory } = await import(
-      "@/utils/reply-tracker/check-sender-reply-history"
-    );
-
-    (checkSenderReplyHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        hasReplied: true,
-        receivedCount: 20, // High count but has replies
-      },
-    );
+    vi.mocked(checkSenderReplyHistory).mockResolvedValueOnce({
+      hasReplied: true,
+      receivedCount: 20,
+    });
 
     const toReplyRule = {
       ...getRule({
@@ -1637,16 +1624,10 @@ describe("filterToReplyPreset", () => {
   });
 
   it("should keep TO_REPLY rule when received count is below threshold", async () => {
-    const { checkSenderReplyHistory } = await import(
-      "@/utils/reply-tracker/check-sender-reply-history"
-    );
-
-    (checkSenderReplyHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      {
-        hasReplied: false,
-        receivedCount: 5, // Below threshold of 10
-      },
-    );
+    vi.mocked(checkSenderReplyHistory).mockResolvedValueOnce({
+      hasReplied: false,
+      receivedCount: 5,
+    });
 
     const toReplyRule = {
       ...getRule({
@@ -1708,11 +1689,7 @@ describe("filterToReplyPreset", () => {
   });
 
   it("should handle errors from checkSenderReplyHistory gracefully", async () => {
-    const { checkSenderReplyHistory } = await import(
-      "@/utils/reply-tracker/check-sender-reply-history"
-    );
-
-    (checkSenderReplyHistory as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+    vi.mocked(checkSenderReplyHistory).mockRejectedValueOnce(
       new Error("API error"),
     );
 
@@ -1767,6 +1744,20 @@ describe("filterToReplyPreset", () => {
     expect(result).toContain(toReplyRule);
   });
 });
+
+function getProvider({ isThread = false }: { isThread?: boolean } = {}) {
+  return {
+    isReplyInThread: vi.fn().mockReturnValue(isThread),
+  } as unknown as EmailProvider;
+}
+
+function getRuleSelectionCandidate(name: string, systemType: string | null) {
+  return {
+    name,
+    instructions: "",
+    systemType,
+  };
+}
 
 function getRule(overrides: Partial<RuleWithActions> = {}): RuleWithActions {
   const {
@@ -2211,10 +2202,7 @@ describe("findMatchingRules - Integration Tests", () => {
       runOnThreads: false,
     });
 
-    // Mock provider to return true for isReplyInThread
-    const threadProvider = {
-      isReplyInThread: vi.fn().mockReturnValue(true),
-    } as unknown as EmailProvider;
+    const threadProvider = getProvider({ isThread: true });
 
     // Mock no previously executed rules in thread
     prisma.executedRule.findMany.mockResolvedValue([]);
@@ -2244,33 +2232,9 @@ describe("findMatchingRules - Integration Tests", () => {
 
   describe("filterMultipleSystemRules branches", () => {
     it("returns all system rules when none marked primary (plus conversation rules)", () => {
-      const sysA: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Sys A",
-        instructions: "",
-        systemType: "TO_REPLY",
-      };
-      const sysB: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Sys B",
-        instructions: "",
-        systemType: "AWAITING_REPLY",
-      };
-      const conv: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Conv",
-        instructions: "",
-        systemType: null,
-      };
+      const sysA = getRuleSelectionCandidate("Sys A", "TO_REPLY");
+      const sysB = getRuleSelectionCandidate("Sys B", "AWAITING_REPLY");
+      const conv = getRuleSelectionCandidate("Conv", null);
 
       const result = filterMultipleSystemRules([
         { rule: sysA, isPrimary: false },
@@ -2282,33 +2246,9 @@ describe("findMatchingRules - Integration Tests", () => {
     });
 
     it("keeps only the primary system rule when multiple system rules present", () => {
-      const sysA: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Sys A",
-        instructions: "",
-        systemType: "TO_REPLY",
-      };
-      const sysB: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Sys B",
-        instructions: "",
-        systemType: "AWAITING_REPLY",
-      };
-      const conv: {
-        name: string;
-        instructions: string;
-        systemType: string | null;
-      } = {
-        name: "Conv",
-        instructions: "",
-        systemType: null,
-      };
+      const sysA = getRuleSelectionCandidate("Sys A", "TO_REPLY");
+      const sysB = getRuleSelectionCandidate("Sys B", "AWAITING_REPLY");
+      const conv = getRuleSelectionCandidate("Conv", null);
 
       const result = filterMultipleSystemRules([
         { rule: sysA, isPrimary: false },
@@ -2345,9 +2285,7 @@ describe("findMatchingRules - Integration Tests", () => {
       // No previously executed rules in this thread
       prisma.executedRule.findMany.mockResolvedValue([]);
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       const rules = [marketingRule];
       const message = getMessage({
@@ -2393,9 +2331,7 @@ describe("findMatchingRules - Integration Tests", () => {
         { ruleId: "notif-rule" },
       ] as any);
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       const rules = [notifRule];
       const message = getMessage({
@@ -2440,10 +2376,7 @@ describe("findMatchingRules - Integration Tests", () => {
         }),
       ]);
 
-      // First message: isReplyInThread=false, so runOnThreads check doesn't apply
-      const nonThreadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(false),
-      } as unknown as EmailProvider;
+      const nonThreadProvider = getProvider();
 
       const rules = [marketingRule];
       const message = getMessage({
@@ -2492,9 +2425,7 @@ describe("findMatchingRules - Integration Tests", () => {
         }),
       ]);
 
-      const providerNoThread = {
-        isReplyInThread: vi.fn().mockReturnValue(false),
-      } as unknown as EmailProvider;
+      const providerNoThread = getProvider();
 
       const result = await findMatchingRules({
         rules: [notificationRule],
@@ -2541,9 +2472,7 @@ describe("findMatchingRules - Integration Tests", () => {
         }),
       ]);
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       const rules = [rule];
       const message = getMessage({
@@ -2575,9 +2504,7 @@ describe("findMatchingRules - Integration Tests", () => {
 
       prisma.executedRule.findMany.mockResolvedValue([]);
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       const rules = [marketingRule];
       const message = getMessage({
@@ -2612,10 +2539,7 @@ describe("findMatchingRules - Integration Tests", () => {
         groupId: "g1",
       });
 
-      // Ensure provider treats this as non-thread
-      const providerNoThread = {
-        isReplyInThread: vi.fn().mockReturnValue(false),
-      } as unknown as EmailProvider;
+      const providerNoThread = getProvider();
 
       // Mock groups to be empty so the code path skips learned pattern branch
       const groupModule = await import("@/utils/group/find-matching-group");
@@ -2649,10 +2573,7 @@ describe("findMatchingRules - Integration Tests", () => {
         runOnThreads: false,
       });
 
-      // Mock provider to indicate this is a thread
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       // Mock DB to return previously executed rule id
       prisma.executedRule.findMany.mockResolvedValue([
@@ -2691,9 +2612,7 @@ describe("findMatchingRules - Integration Tests", () => {
         runOnThreads: false,
       });
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       prisma.executedRule.findMany.mockResolvedValue([
         { ruleId: "rule-a" },
@@ -2729,9 +2648,7 @@ describe("findMatchingRules - Integration Tests", () => {
         runOnThreads: false,
       });
 
-      const providerNotThread = {
-        isReplyInThread: vi.fn().mockReturnValue(false),
-      } as unknown as EmailProvider;
+      const providerNotThread = getProvider();
 
       const rules = [notifRule];
       const message = getMessage({
@@ -2761,9 +2678,7 @@ describe("findMatchingRules - Integration Tests", () => {
         runOnThreads: true,
       });
 
-      const threadProvider = {
-        isReplyInThread: vi.fn().mockReturnValue(true),
-      } as unknown as EmailProvider;
+      const threadProvider = getProvider({ isThread: true });
 
       const rules = [threadRule];
       const message = getMessage({

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -50,6 +50,16 @@ import {
 const MODULE = "match-rules";
 
 const TO_REPLY_RECEIVED_THRESHOLD = 10;
+const NO_REPLY_PREFIXES = [
+  "noreply@",
+  "no-reply@",
+  "notifications@",
+  "notif@",
+  "info@",
+  "newsletter@",
+  "updates@",
+  "account@",
+];
 
 type MatchingRulesResult = {
   matches: {
@@ -281,6 +291,18 @@ async function findPotentialMatchingRules({
   const hasLearnedPatternMatch = matches.some((m) =>
     m.matchReasons.some((r) => r.type === ConditionType.LEARNED_PATTERN),
   );
+  const remainingAiRuleNames = filteredPotentialAiMatches.map(
+    (rule) => rule.name,
+  );
+  const selectionMetadata = createRuleSelectionMetadata({
+    isThread,
+    skippedThreadRuleNames,
+    continuedThreadRuleNames,
+    learnedPatternExcludedRules,
+    filteredConversationRuleNames: conversationStatusFilter.filteredRuleNames,
+    conversationFilterReason: conversationStatusFilter.filterReason,
+    remainingAiRuleNames,
+  });
 
   if (
     potentialAiMatches.length ||
@@ -291,18 +313,7 @@ async function findPotentialMatchingRules({
     !matches.length
   ) {
     const selectionMetadataSummary = summarizeSelectionMetadata([
-      createRuleSelectionMetadata({
-        isThread,
-        skippedThreadRuleNames,
-        continuedThreadRuleNames,
-        learnedPatternExcludedRules,
-        filteredConversationRuleNames:
-          conversationStatusFilter.filteredRuleNames,
-        conversationFilterReason: conversationStatusFilter.filterReason,
-        remainingAiRuleNames: filteredPotentialAiMatches.map(
-          (rule) => rule.name,
-        ),
-      }),
+      selectionMetadata,
     ]);
 
     logger.info("Built rule candidates", {
@@ -325,29 +336,14 @@ async function findPotentialMatchingRules({
       ),
       conversationFilterReason: conversationStatusFilter.filterReason,
       remainingAiRuleCount: filteredPotentialAiMatches.length,
-      remainingAiRuleNames: joinLogValues(
-        filteredPotentialAiMatches.map((rule) => rule.name),
-      ),
+      remainingAiRuleNames: joinLogValues(remainingAiRuleNames),
       hasLearnedPatternMatch,
       learnedPatternExcludedRules:
         selectionMetadataSummary.learnedPatternExcludedRules,
     });
 
     logger.trace("Built rule candidate details", {
-      ...getSelectionMetadataTraceDetails([
-        createRuleSelectionMetadata({
-          isThread,
-          skippedThreadRuleNames,
-          continuedThreadRuleNames,
-          learnedPatternExcludedRules,
-          filteredConversationRuleNames:
-            conversationStatusFilter.filteredRuleNames,
-          conversationFilterReason: conversationStatusFilter.filterReason,
-          remainingAiRuleNames: filteredPotentialAiMatches.map(
-            (rule) => rule.name,
-          ),
-        }),
-      ]),
+      ...getSelectionMetadataTraceDetails([selectionMetadata]),
     });
   }
 
@@ -358,15 +354,7 @@ async function findPotentialMatchingRules({
     potentialAiMatches: hasLearnedPatternMatch
       ? []
       : filteredPotentialAiMatches,
-    selectionMetadata: createRuleSelectionMetadata({
-      isThread,
-      skippedThreadRuleNames,
-      continuedThreadRuleNames,
-      learnedPatternExcludedRules,
-      filteredConversationRuleNames: conversationStatusFilter.filteredRuleNames,
-      conversationFilterReason: conversationStatusFilter.filterReason,
-      remainingAiRuleNames: filteredPotentialAiMatches.map((rule) => rule.name),
-    }),
+    selectionMetadata,
   };
 }
 
@@ -557,63 +545,62 @@ async function findMatchingRulesWithReasons(
       classificationFeedback,
     });
 
-    const result = {
-      rules: filterMultipleSystemRules(fullResult.rules),
-      reason: fullResult.reason,
-    };
-
-    // Build combined matches: update existing matches with AI reasons if AI also chose them,
-    // and append new AI-selected matches
-    const aiRuleIds = new Set(result.rules.map((r) => r.id));
-
-    const combinedMatches = [
-      // Map existing matches, appending AI match reason if AI also chose this rule
-      ...matches.map((match) => ({
-        rule: match.rule,
-        matchReasons: aiRuleIds.has(match.rule.id)
-          ? [...(match.matchReasons || []), { type: ConditionType.AI }]
-          : match.matchReasons || [],
-      })),
-      // Append AI-selected matches that weren't already in matches
-      ...result.rules
-        .filter(
-          (aiRule) =>
-            !matches.some(
-              (existingMatch) => existingMatch.rule.id === aiRule.id,
-            ),
-        )
-        .map((rule) => ({
-          rule,
-          matchReasons: [{ type: ConditionType.AI }],
-        })),
-    ];
-
-    // Combine reasoning: existing reasoning plus AI reasoning
-    const existingReasoning = matches
-      .map((m) => getMatchReason(m.matchReasons))
-      .filter((r): r is string => !!r)
-      .join(", ");
-
-    const aiReason = result.reason?.trim();
-    const combinedReasoning = [existingReasoning, aiReason]
-      .filter((r): r is string => !!r)
-      .join("; ");
+    const aiRules = filterMultipleSystemRules(fullResult.rules);
 
     return {
-      matches: combinedMatches,
-      reasoning: combinedReasoning,
-      selectionMetadata,
-    };
-  } else {
-    return {
-      matches,
-      reasoning: matches
-        .map((m) => getMatchReason(m.matchReasons))
-        .filter((r): r is string => !!r)
-        .join(", "),
+      matches: mergeMatchesWithAiResults(matches, aiRules),
+      reasoning: combineReasoning(
+        getMatchesReasoning(matches),
+        fullResult.reason,
+      ),
       selectionMetadata,
     };
   }
+
+  return {
+    matches,
+    reasoning: getMatchesReasoning(matches),
+    selectionMetadata,
+  };
+}
+
+function mergeMatchesWithAiResults(
+  matches: { rule: RuleWithActions; matchReasons?: MatchReason[] }[],
+  aiRules: RuleWithActions[],
+) {
+  const aiRuleIds = new Set(aiRules.map((rule) => rule.id));
+  const existingRuleIds = new Set(matches.map((match) => match.rule.id));
+
+  return [
+    ...matches.map((match) => ({
+      rule: match.rule,
+      matchReasons: aiRuleIds.has(match.rule.id)
+        ? [...(match.matchReasons || []), { type: ConditionType.AI }]
+        : match.matchReasons || [],
+    })),
+    ...aiRules
+      .filter((rule) => !existingRuleIds.has(rule.id))
+      .map((rule) => ({
+        rule,
+        matchReasons: [{ type: ConditionType.AI }],
+      })),
+  ];
+}
+
+function getMatchesReasoning(
+  matches: { matchReasons?: MatchReason[] }[],
+): string {
+  return matches
+    .map((match) => getMatchReason(match.matchReasons))
+    .filter((reason): reason is string => !!reason)
+    .join(", ");
+}
+
+function combineReasoning(...reasons: (string | undefined)[]) {
+  return reasons
+    .map((reason) => reason?.trim())
+    .filter((reason): reason is string => !!reason)
+    .join("; ");
 }
 
 export function matchesStaticRule(
@@ -626,52 +613,12 @@ export function matchesStaticRule(
 
   if (!from && !to && !subject && !body) return false;
 
-  const safeRegexTest = (
-    pattern: string,
-    text: string,
-    allowPipeAsOr = false,
-  ) => {
-    try {
-      // Split by pipe, comma, or " OR " to handle OR conditions only for email fields (from/to)
-      // Supports: "@a.com|@b.com", "@a.com, @b.com", "@a.com OR @b.com"
-      const patterns = allowPipeAsOr ? splitEmailPatterns(pattern) : [pattern];
-
-      // Test each pattern individually
-      for (const individualPattern of patterns) {
-        // Escape regex special characters except for * which we want to support as wildcards
-        const escapedPattern = individualPattern.replace(
-          /[.+?^${}()[\]\\]/g,
-          "\\$&",
-        );
-
-        // Convert all * to .* for wildcard matching
-        const regexPattern = escapedPattern.replace(/\*/g, ".*");
-
-        if (new RegExp(regexPattern).test(text)) {
-          return true;
-        }
-      }
-
-      return false;
-    } catch (error) {
-      log.error("Invalid regex pattern", { pattern, error });
-      return false;
-    }
-  };
-
-  const fromAddressHeader = normalizeEmailHeaderForRuleMatching(
-    message.headers.from,
-  );
-  const toAddressHeader = normalizeEmailHeaderForRuleMatching(
-    message.headers.to,
-    true,
-  );
-  const fromDisplayNameHeader = normalizeEmailDisplayNameHeaderForRuleMatching(
-    message.headers.from,
-  );
-  const toDisplayNameHeader = normalizeEmailDisplayNameHeaderForRuleMatching(
-    message.headers.to,
-  );
+  const {
+    fromAddressHeader,
+    toAddressHeader,
+    fromDisplayNameHeader,
+    toDisplayNameHeader,
+  } = getNormalizedEmailMatchHeaders(message);
 
   const fromMatch = from
     ? matchesEmailFieldPattern({
@@ -700,10 +647,10 @@ export function matchesStaticRule(
       })
     : true;
   const subjectMatch = subject
-    ? safeRegexTest(subject, message.headers.subject, false)
+    ? matchesTextPattern(subject, message.headers.subject, log)
     : true;
   const bodyMatch = body
-    ? safeRegexTest(body, message.textPlain || "", false)
+    ? matchesTextPattern(body, message.textPlain || "", log)
     : true;
 
   return fromMatch && toMatch && subjectMatch && bodyMatch;
@@ -797,17 +744,6 @@ async function filterConversationStatusRulesWithMetadata<
 
   const extractedSenderEmail = extractEmailAddress(senderEmail);
 
-  const noReplyPrefixes = [
-    "noreply@",
-    "no-reply@",
-    "notifications@",
-    "notif@",
-    "info@",
-    "newsletter@",
-    "updates@",
-    "account@",
-  ];
-
   const filteredConversationRuleNames = potentialMatches
     .filter((r) => isConversationStatusType(r.systemType))
     .map((r) => r.name);
@@ -819,7 +755,7 @@ async function filterConversationStatusRulesWithMetadata<
   }
 
   if (
-    noReplyPrefixes.some((prefix) => extractedSenderEmail.startsWith(prefix))
+    NO_REPLY_PREFIXES.some((prefix) => extractedSenderEmail.startsWith(prefix))
   ) {
     return {
       rules: filteredOutConversationStatusRules(),
@@ -923,6 +859,24 @@ function normalizeEmailHeaderForRuleMatching(
   return extractEmailAddress(header);
 }
 
+function getNormalizedEmailMatchHeaders(message: ParsedMessage) {
+  return {
+    fromAddressHeader: normalizeEmailHeaderForRuleMatching(
+      message.headers.from,
+    ),
+    toAddressHeader: normalizeEmailHeaderForRuleMatching(
+      message.headers.to,
+      true,
+    ),
+    fromDisplayNameHeader: normalizeEmailDisplayNameHeaderForRuleMatching(
+      message.headers.from,
+    ),
+    toDisplayNameHeader: normalizeEmailDisplayNameHeaderForRuleMatching(
+      message.headers.to,
+    ),
+  };
+}
+
 function normalizeEmailDisplayNameHeaderForRuleMatching(header: string) {
   if (!header) return "";
 
@@ -938,6 +892,26 @@ function normalizeEmailDisplayNameHeaderForRuleMatching(header: string) {
     })
     .filter(Boolean)
     .join(", ");
+}
+
+function matchesTextPattern(pattern: string, text: string, logger: Logger) {
+  try {
+    return matchesRulePattern(pattern, text);
+  } catch (error) {
+    logger.error("Invalid regex pattern", { pattern, error });
+    return false;
+  }
+}
+
+function matchesRulePattern(pattern: string, text: string) {
+  return createRulePatternRegex(pattern).test(text);
+}
+
+function createRulePatternRegex(pattern: string) {
+  const escapedPattern = pattern.replace(/[.+?^${}()[\]\\]/g, "\\$&");
+  const regexPattern = escapedPattern.replace(/\*/g, ".*");
+
+  return new RegExp(regexPattern);
 }
 
 function matchesEmailFieldPattern({
@@ -956,10 +930,7 @@ function matchesEmailFieldPattern({
 
     for (const patternPart of patterns) {
       const normalizedPattern = patternPart.trim().toLowerCase();
-      const regexPattern = normalizedPattern
-        .replace(/[.+?^${}()[\]\\]/g, "\\$&")
-        .replace(/\*/g, ".*");
-      const regex = new RegExp(regexPattern);
+      const regex = createRulePatternRegex(normalizedPattern);
 
       if (isAddressLikeEmailPattern(patternPart)) {
         if (regex.test(addressText)) return true;


### PR DESCRIPTION
Refactors rule matching internals and related tests without changing matching behavior.

- Reuses candidate selection metadata instead of rebuilding it for logging and return values
- Extracts AI match merging, reasoning composition, and static pattern helpers
- Simplifies repeated rule matching test fixtures

Validation:
- pnpm --dir apps/web test --run utils/ai/choose-rule/match-rules.test.ts utils/ai/choose-rule/run-rules.test.ts utils/ai/choose-rule/execute.test.ts