### PR TITLE
test: Simplify draft management tests

### DIFF
--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -21,6 +21,18 @@ vi.mock("@/utils/prisma", () => ({
   },
 }));
 
+const previousDraftAction = {
+  id: "action-111",
+  draftId: "draft-222",
+  content: "Hello, this is a test draft",
+};
+
+const executedRule = {
+  id: "rule-123",
+  threadId: "thread-456",
+  emailAccountId: "account-789",
+};
+
 describe("handlePreviousDraftDeletion", () => {
   const mockGetDraft = vi.fn();
   const mockDeleteDraft = vi.fn();
@@ -29,11 +41,6 @@ describe("handlePreviousDraftDeletion", () => {
     deleteDraft: mockDeleteDraft,
   } as unknown as EmailProvider;
   const logger = createTestLogger();
-  const mockExecutedRule = {
-    id: "rule-123",
-    threadId: "thread-456",
-    emailAccountId: "account-789",
-  };
 
   const mockFindFirst = prisma.executedAction.findFirst as Mock;
   const mockUpdate = prisma.executedAction.update as Mock;
@@ -43,39 +50,18 @@ describe("handlePreviousDraftDeletion", () => {
   });
 
   it("should delete unmodified draft and update draft status", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
-      content: "Hello, this is a test draft",
-    };
-
-    const mockCurrentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Hello, this is a test draft\n\nOn Monday wrote:\n> Previous message",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "Hello, this is a test draft",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test Subject",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    mockFindFirst.mockResolvedValue(previousDraftAction);
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain:
+          "Hello, this is a test draft\n\nOn Monday wrote:\n> Previous message",
+        snippet: "Hello, this is a test draft",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -101,49 +87,25 @@ describe("handlePreviousDraftDeletion", () => {
     });
 
     expect(mockGetDraft).toHaveBeenCalledWith("draft-222");
-    expect(mockDeleteDraft).toHaveBeenCalledWith("draft-222");
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: "action-111" },
-      data: {
-        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-      },
+    expectDraftCleanedUp({
+      mockDeleteDraft,
+      mockUpdate,
     });
   });
 
   it("should not delete modified draft", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
-      content: "Hello, this is a test draft",
-    };
-
-    const mockCurrentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Hello, this is a MODIFIED draft\n\nOn Monday wrote:\n> Previous message",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "Hello, this is a MODIFIED draft",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test Subject",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    mockFindFirst.mockResolvedValue(previousDraftAction);
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain:
+          "Hello, this is a MODIFIED draft\n\nOn Monday wrote:\n> Previous message",
+        snippet: "Hello, this is a MODIFIED draft",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -152,38 +114,20 @@ describe("handlePreviousDraftDeletion", () => {
   });
 
   it("should not delete draft when original content is missing", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
+    mockFindFirst.mockResolvedValue({
+      ...previousDraftAction,
       content: null,
-    };
-
-    const mockCurrentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Potentially user modified draft",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "Potentially user modified draft",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test Subject",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    });
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain: "Potentially user modified draft",
+        snippet: "Potentially user modified draft",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -197,7 +141,7 @@ describe("handlePreviousDraftDeletion", () => {
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -206,18 +150,12 @@ describe("handlePreviousDraftDeletion", () => {
   });
 
   it("should handle draft not found in Gmail", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
-      content: "Hello, this is a test draft",
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
+    mockFindFirst.mockResolvedValue(previousDraftAction);
     mockGetDraft.mockResolvedValue(null);
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -225,50 +163,30 @@ describe("handlePreviousDraftDeletion", () => {
   });
 
   it("should handle errors gracefully", async () => {
-    const error = new Error("Database error");
-    mockFindFirst.mockRejectedValue(error);
+    mockFindFirst.mockRejectedValue(new Error("Database error"));
 
-    // Should not throw - errors are caught and logged
     await expect(
       handlePreviousDraftDeletion({
         client: mockClient,
-        executedRule: mockExecutedRule,
+        executedRule,
         logger,
       }),
     ).resolves.not.toThrow();
   });
 
   it("should handle draft with no textPlain content", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
-      content: "Hello, this is a test draft",
-    };
-
-    const mockCurrentDraft = {
-      id: "msg-123",
-      threadId: "thread-456",
-      // No textPlain property
-      textHtml: "<p>HTML content</p>",
-      snippet: "HTML content",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test Subject",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    mockFindFirst.mockResolvedValue(previousDraftAction);
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain: undefined,
+        textHtml: "<p>HTML content</p>",
+        snippet: "HTML content",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -276,88 +194,47 @@ describe("handlePreviousDraftDeletion", () => {
   });
 
   it("should handle Outlook HTML draft with signature link", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
+    mockFindFirst.mockResolvedValue({
+      ...previousDraftAction,
       content:
         'Hello, this is a test draft\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.',
-    };
-
-    // Simulate real Outlook HTML output with proper structure
-    const mockCurrentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        '<html><head>\r\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div dir="ltr">Hello, this is a test draft<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On Tue, 11 Nov 2025 at 2:18, John wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex"><div dir="ltr">Previous message content</div></blockquote></div></body></html>',
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "Hello",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test Subject",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "html",
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    });
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain:
+          '<html><head>\r\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div dir="ltr">Hello, this is a test draft<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On Tue, 11 Nov 2025 at 2:18, John wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex"><div dir="ltr">Previous message content</div></blockquote></div></body></html>',
+        bodyContentType: "html",
+        snippet: "Hello",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
-    expect(mockDeleteDraft).toHaveBeenCalledWith("draft-222");
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: "action-111" },
-      data: {
-        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-      },
+    expectDraftCleanedUp({
+      mockDeleteDraft,
+      mockUpdate,
     });
   });
 
   it("should not delete when draft has extra user content", async () => {
-    const mockPreviousDraft = {
-      id: "action-111",
-      draftId: "draft-222",
+    mockFindFirst.mockResolvedValue({
+      ...previousDraftAction,
       content: "Original AI draft",
-    };
-
-    const mockCurrentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Original AI draft\n\nUser added this extra paragraph.\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    mockFindFirst.mockResolvedValue(mockPreviousDraft);
-    mockGetDraft.mockResolvedValue(mockCurrentDraft);
+    });
+    mockGetDraft.mockResolvedValue(
+      createParsedMessage({
+        textPlain:
+          "Original AI draft\n\nUser added this extra paragraph.\n\nOn Monday wrote:\n> Quote",
+      }),
+    );
 
     await handlePreviousDraftDeletion({
       client: mockClient,
-      executedRule: mockExecutedRule,
+      executedRule,
       logger,
     });
 
@@ -367,81 +244,36 @@ describe("handlePreviousDraftDeletion", () => {
 
 describe("extractDraftPlainText", () => {
   it("should return textPlain as-is for Gmail (no bodyContentType)", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Plain text content",
-      textHtml: "<p>HTML content</p>",
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain: "Plain text content",
+        textHtml: "<p>HTML content</p>",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
     expect(result).toBe("Plain text content");
   });
 
   it("should return textPlain as-is when bodyContentType is text", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Plain text content",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "text",
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain: "Plain text content",
+        bodyContentType: "text",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
     expect(result).toBe("Plain text content");
   });
 
   it("should convert HTML to plain text when bodyContentType is html", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        '<p>HTML content with <a href="http://example.com">link</a></p>',
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "html",
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain:
+          '<p>HTML content with <a href="http://example.com">link</a></p>',
+        bodyContentType: "html",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
-    // Should convert HTML to plain text and remove link URLs
     expect(result).toContain("HTML content");
     expect(result).toContain("link");
     expect(result).not.toContain("<p>");
@@ -449,80 +281,35 @@ describe("extractDraftPlainText", () => {
   });
 
   it("should return empty string when textPlain is undefined", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: undefined,
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "html",
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain: undefined,
+        bodyContentType: "html",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
     expect(result).toBe("");
   });
 
   it("should handle empty string textPlain", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain: "",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
     expect(result).toBe("");
   });
 
   it("should handle Outlook HTML with complex formatting", () => {
-    const draft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        '<html><body><div><strong>Bold</strong> and <em>italic</em> and <a href="http://example.com">link</a></div></body></html>',
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "html",
-    };
+    const result = extractDraftPlainText(
+      createParsedMessage({
+        textPlain:
+          '<html><body><div><strong>Bold</strong> and <em>italic</em> and <a href="http://example.com">link</a></div></body></html>',
+        bodyContentType: "html",
+      }),
+    );
 
-    const result = extractDraftPlainText(draft);
     expect(result).toContain("Bold");
     expect(result).toContain("italic");
     expect(result).toContain("link");
@@ -532,65 +319,59 @@ describe("extractDraftPlainText", () => {
 });
 
 describe("stripQuotedContent", () => {
-  it("should strip content after 'On ... wrote:' pattern", () => {
-    const text = "My reply\n\nOn Monday, John wrote:\n> Quoted content";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
-  });
-
-  it("should strip content after 'Original Message' pattern", () => {
-    const text =
-      "My reply\n\n---- Original Message ----\nFrom: test@example.com";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
-  });
-
-  it("should strip content after '>' quote pattern", () => {
-    const text = "My reply\n\n> On Monday:\n> Quoted content";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
-  });
-
-  it("should strip content after 'From:' pattern", () => {
-    const text = "My reply\n\nFrom: sender@example.com\nQuoted content";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
-  });
-
-  it("should return trimmed text when no quote patterns found", () => {
-    const text = "  Just a simple reply  ";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("Just a simple reply");
-  });
-
-  it("should handle empty string", () => {
-    const result = stripQuotedContent("");
-    expect(result).toBe("");
-  });
-
-  it("should only strip after first matching pattern", () => {
-    const text =
-      "My reply\n\nOn Monday wrote:\n> Quote 1\n\nFrom: test@example.com\n> Quote 2";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
-  });
-
-  it("should handle text with newlines but no quotes", () => {
-    const text = "Line 1\nLine 2\nLine 3";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("Line 1\nLine 2\nLine 3");
-  });
-
-  it("should handle text that looks like a quote but isn't (single newline)", () => {
-    const text = "My reply\nOn Monday wrote: something";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply\nOn Monday wrote: something");
-  });
-
-  it("should handle multiple consecutive newlines", () => {
-    const text = "My reply\n\n\n\nOn Monday wrote:\n> Quote";
-    const result = stripQuotedContent(text);
-    expect(result).toBe("My reply");
+  it.each([
+    {
+      name: "On ... wrote:",
+      text: "My reply\n\nOn Monday, John wrote:\n> Quoted content",
+      expected: "My reply",
+    },
+    {
+      name: "Original Message",
+      text: "My reply\n\n---- Original Message ----\nFrom: test@example.com",
+      expected: "My reply",
+    },
+    {
+      name: "> quote",
+      text: "My reply\n\n> On Monday:\n> Quoted content",
+      expected: "My reply",
+    },
+    {
+      name: "From:",
+      text: "My reply\n\nFrom: sender@example.com\nQuoted content",
+      expected: "My reply",
+    },
+    {
+      name: "no quote patterns",
+      text: "  Just a simple reply  ",
+      expected: "Just a simple reply",
+    },
+    {
+      name: "empty string",
+      text: "",
+      expected: "",
+    },
+    {
+      name: "first matching pattern only",
+      text: "My reply\n\nOn Monday wrote:\n> Quote 1\n\nFrom: test@example.com\n> Quote 2",
+      expected: "My reply",
+    },
+    {
+      name: "newlines without quotes",
+      text: "Line 1\nLine 2\nLine 3",
+      expected: "Line 1\nLine 2\nLine 3",
+    },
+    {
+      name: "single-newline quote-like text",
+      text: "My reply\nOn Monday wrote: something",
+      expected: "My reply\nOn Monday wrote: something",
+    },
+    {
+      name: "multiple consecutive newlines",
+      text: "My reply\n\n\n\nOn Monday wrote:\n> Quote",
+      expected: "My reply",
+    },
+  ])("should handle $name", ({ text, expected }) => {
+    expect(stripQuotedContent(text)).toBe(expected);
   });
 });
 
@@ -609,97 +390,118 @@ describe("stripQuotedHtmlContent", () => {
 describe("isDraftUnmodified", () => {
   const logger = createTestLogger();
 
-  it("should return true when content matches exactly", () => {
-    const originalContent = "Hello, this is a test";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Hello, this is a test\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
+  it.each([
+    {
+      name: "content matches exactly",
+      originalContent: "Hello, this is a test",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Hello, this is a test"),
+      }),
+      expected: true,
+    },
+    {
+      name: "content is modified",
+      originalContent: "Hello, this is a test",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Hello, this is MODIFIED"),
+      }),
+      expected: false,
+    },
+    {
+      name: "whitespace differs",
+      originalContent: "  Hello, this is a test  ",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Hello, this is a test"),
+      }),
+      expected: true,
+    },
+    {
+      name: "original content is empty",
+      originalContent: "",
+      currentDraft: createParsedMessage({
+        textPlain: "Some content",
+      }),
+      expected: false,
+    },
+    {
+      name: "different quote pattern is present",
+      originalContent: "My response",
+      currentDraft: createParsedMessage({
+        textPlain: "My response\n\n---- Original Message ----\nFrom: test",
+      }),
+      expected: true,
+    },
+    {
+      name: "special characters are present",
+      originalContent: "Reply with émojis 🎉 and spëcial çhars!",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Reply with émojis 🎉 and spëcial çhars!"),
+      }),
+      expected: true,
+    },
+    {
+      name: "content has multiple paragraph breaks",
+      originalContent: "Paragraph 1\n\nParagraph 2\n\nParagraph 3",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Paragraph 1\n\nParagraph 2\n\nParagraph 3"),
+      }),
+      expected: true,
+    },
+    {
+      name: "user added content before quote",
+      originalContent: "Original text",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("Original text\n\nUser added this"),
+      }),
+      expected: false,
+    },
+    {
+      name: "draft has no quoted content",
+      originalContent: "Just a reply",
+      currentDraft: createParsedMessage({
+        textPlain: "Just a reply",
+      }),
+      expected: true,
+    },
+    {
+      name: "case differs",
+      originalContent: "Hello World",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("hello world"),
+      }),
+      expected: false,
+    },
+    {
+      name: "reply is only whitespace",
+      originalContent: "   ",
+      currentDraft: createParsedMessage({
+        textPlain: withQuotedReply("   "),
+      }),
+      expected: true,
+    },
+  ])("should return $expected when $name", ({
+    originalContent,
+    currentDraft,
+    expected,
+  }) => {
     const result = isDraftUnmodified({
       originalContent,
       currentDraft,
       logger,
     });
 
-    expect(result).toBe(true);
-  });
-
-  it("should return false when content is modified", () => {
-    const originalContent = "Hello, this is a test";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Hello, this is MODIFIED\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(false);
+    expect(result).toBe(expected);
   });
 
   it("should handle HTML content with links (Outlook case)", () => {
-    const originalContent =
-      'My reply\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.';
-    // Real Outlook HTML structure with proper gmail_quote formatting
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        '<html><head>\r\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div dir="ltr">My reply<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On Tue, 11 Nov 2025 at 2:18, John wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex"><div dir="ltr">Quote content</div></blockquote></div></body></html>',
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-      bodyContentType: "html",
-    };
-
     const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
+      originalContent:
+        'My reply\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.',
+      currentDraft: createParsedMessage({
+        textPlain:
+          '<html><head>\r\n<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div dir="ltr">My reply<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On Tue, 11 Nov 2025 at 2:18, John wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex"><div dir="ltr">Quote content</div></blockquote></div></body></html>',
+        bodyContentType: "html",
+      }),
       logger,
     });
 
@@ -707,317 +509,63 @@ describe("isDraftUnmodified", () => {
   });
 
   it("should compare Gmail drafts using structural HTML when available", () => {
-    const originalContent =
-      'My reply\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.';
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "My reply\n\nDrafted by Inbox Zero [http://localhost:3000/?ref=ABC].\n\nLe lun. 27 avr. 2026, Sender a écrit:\nQuoted content",
-      textHtml:
-        '<div dir="ltr">My reply<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender a écrit:<br></div><blockquote class="gmail_quote"><div>Quoted content</div></blockquote></div>',
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
     const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should handle whitespace differences", () => {
-    const originalContent = "  Hello, this is a test  ";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Hello, this is a test\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should return false when original content is empty string", () => {
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Some content",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent: "",
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it("should handle different quote patterns", () => {
-    const originalContent = "My response";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "My response\n\n---- Original Message ----\nFrom: test",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should handle special characters in content", () => {
-    const originalContent = "Reply with émojis 🎉 and spëcial çhars!";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Reply with émojis 🎉 and spëcial çhars!\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should handle content with multiple paragraph breaks", () => {
-    const originalContent = "Paragraph 1\n\nParagraph 2\n\nParagraph 3";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Paragraph 1\n\nParagraph 2\n\nParagraph 3\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should detect modification when user adds content before quote", () => {
-    const originalContent = "Original text";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain:
-        "Original text\n\nUser added this\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it("should handle draft without any quoted content", () => {
-    const originalContent = "Just a reply";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "Just a reply",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should be case-sensitive", () => {
-    const originalContent = "Hello World";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "hello world\n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
-      logger,
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it("should handle draft with only whitespace as reply", () => {
-    const originalContent = "   ";
-    const currentDraft: ParsedMessage = {
-      id: "msg-123",
-      threadId: "thread-456",
-      textPlain: "   \n\nOn Monday wrote:\n> Quote",
-      textHtml: undefined,
-      subject: "subject",
-      date: new Date().toISOString(),
-      snippet: "snippet",
-      historyId: "12345",
-      internalDate: "1234567890",
-      headers: {
-        from: "test@example.com",
-        to: "recipient@example.com",
-        subject: "Test",
-        date: "Mon, 1 Jan 2024 12:00:00 +0000",
-      },
-      labelIds: [],
-      inline: [],
-    };
-
-    const result = isDraftUnmodified({
-      originalContent,
-      currentDraft,
+      originalContent:
+        'My reply\n\nDrafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.',
+      currentDraft: createParsedMessage({
+        textPlain:
+          "My reply\n\nDrafted by Inbox Zero [http://localhost:3000/?ref=ABC].\n\nLe lun. 27 avr. 2026, Sender a écrit:\nQuoted content",
+        textHtml:
+          '<div dir="ltr">My reply<br><br>Drafted by <a href="http://localhost:3000/?ref=ABC">Inbox Zero</a>.</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">Le lun. 27 avr. 2026, Sender a écrit:<br></div><blockquote class="gmail_quote"><div>Quoted content</div></blockquote></div>',
+      }),
       logger,
     });
 
     expect(result).toBe(true);
   });
 });
+
+function createParsedMessage(
+  overrides: Partial<ParsedMessage> = {},
+): ParsedMessage {
+  return {
+    id: "msg-123",
+    threadId: "thread-456",
+    textPlain: "Plain text content",
+    textHtml: undefined,
+    subject: "subject",
+    date: "2024-01-01T12:00:00.000Z",
+    snippet: "snippet",
+    historyId: "12345",
+    internalDate: "1234567890",
+    headers: {
+      from: "test@example.com",
+      to: "recipient@example.com",
+      subject: "Test Subject",
+      date: "Mon, 1 Jan 2024 12:00:00 +0000",
+    },
+    labelIds: [],
+    inline: [],
+    ...overrides,
+  };
+}
+
+function withQuotedReply(reply: string): string {
+  return `${reply}\n\nOn Monday wrote:\n> Quote`;
+}
+
+function expectDraftCleanedUp({
+  mockDeleteDraft,
+  mockUpdate,
+}: {
+  mockDeleteDraft: Mock;
+  mockUpdate: Mock;
+}) {
+  expect(mockDeleteDraft).toHaveBeenCalledWith("draft-222");
+  expect(mockUpdate).toHaveBeenCalledWith({
+    where: { id: "action-111" },
+    data: {
+      draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+    },
+  });
+}


### PR DESCRIPTION
test: Simplify draft management tests

Simplifies draft management tests by sharing repeated fixtures and table-driving repeated cases. Coverage stays focused on the same deletion, extraction, quote stripping, and modification detection behavior.

- Centralizes parsed message and cleanup assertion setup
- Converts repeated quote-stripping and draft comparison cases into table tests
- Keeps the existing focused behavior coverage while reducing test file size

Performance impact: test-only refactor; no added runtime work, database calls, or network calls.