### PR TITLE
test: Simplify unit tests

### DIFF
--- a/apps/web/utils/action-sort.test.ts
+++ b/apps/web/utils/action-sort.test.ts
@@ -4,42 +4,36 @@ import { ActionType } from "@/generated/prisma/enums";
 
 describe("sortActionsByPriority", () => {
   describe("basic sorting", () => {
-    it("sorts LABEL before ARCHIVE", () => {
-      const actions = [
-        { type: ActionType.ARCHIVE },
-        { type: ActionType.LABEL },
-      ];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted[0].type).toBe(ActionType.LABEL);
-      expect(sorted[1].type).toBe(ActionType.ARCHIVE);
-    });
-
-    it("sorts ARCHIVE before REPLY", () => {
-      const actions = [
-        { type: ActionType.REPLY },
-        { type: ActionType.ARCHIVE },
-      ];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted[0].type).toBe(ActionType.ARCHIVE);
-      expect(sorted[1].type).toBe(ActionType.REPLY);
-    });
-
-    it("sorts draft and email actions together", () => {
-      const actions = [
-        { type: ActionType.FORWARD },
-        { type: ActionType.DRAFT_MESSAGING_CHANNEL },
-        { type: ActionType.DRAFT_EMAIL },
-        { type: ActionType.SEND_EMAIL },
-        { type: ActionType.REPLY },
-      ];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted.map((a) => a.type)).toEqual([
-        ActionType.DRAFT_EMAIL,
-        ActionType.DRAFT_MESSAGING_CHANNEL,
-        ActionType.REPLY,
-        ActionType.SEND_EMAIL,
-        ActionType.FORWARD,
-      ]);
+    it.each([
+      {
+        name: "LABEL before ARCHIVE",
+        actions: [{ type: ActionType.ARCHIVE }, { type: ActionType.LABEL }],
+        expected: [ActionType.LABEL, ActionType.ARCHIVE],
+      },
+      {
+        name: "ARCHIVE before REPLY",
+        actions: [{ type: ActionType.REPLY }, { type: ActionType.ARCHIVE }],
+        expected: [ActionType.ARCHIVE, ActionType.REPLY],
+      },
+      {
+        name: "draft and email actions together",
+        actions: [
+          { type: ActionType.FORWARD },
+          { type: ActionType.DRAFT_MESSAGING_CHANNEL },
+          { type: ActionType.DRAFT_EMAIL },
+          { type: ActionType.SEND_EMAIL },
+          { type: ActionType.REPLY },
+        ],
+        expected: [
+          ActionType.DRAFT_EMAIL,
+          ActionType.DRAFT_MESSAGING_CHANNEL,
+          ActionType.REPLY,
+          ActionType.SEND_EMAIL,
+          ActionType.FORWARD,
+        ],
+      },
+    ])("sorts $name", ({ actions, expected }) => {
+      expectSortedActionTypes(actions, expected);
     });
 
     it("sorts CALL_WEBHOOK last among known types", () => {
@@ -48,8 +42,11 @@ describe("sortActionsByPriority", () => {
         { type: ActionType.LABEL },
         { type: ActionType.ARCHIVE },
       ];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted[sorted.length - 1].type).toBe(ActionType.CALL_WEBHOOK);
+      expectSortedActionTypes(actions, [
+        ActionType.LABEL,
+        ActionType.ARCHIVE,
+        ActionType.CALL_WEBHOOK,
+      ]);
     });
   });
 
@@ -72,8 +69,7 @@ describe("sortActionsByPriority", () => {
         { type: ActionType.LABEL },
       ];
 
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted.map((a) => a.type)).toEqual([
+      expectSortedActionTypes(actions, [
         ActionType.LABEL,
         ActionType.MOVE_FOLDER,
         ActionType.ARCHIVE,
@@ -93,29 +89,28 @@ describe("sortActionsByPriority", () => {
   });
 
   describe("edge cases", () => {
-    it("handles empty array", () => {
-      const sorted = sortActionsByPriority([]);
-      expect(sorted).toEqual([]);
-    });
-
-    it("handles single action", () => {
-      const actions = [{ type: ActionType.LABEL }];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted).toEqual(actions);
-    });
-
-    it("handles already sorted array", () => {
-      const actions = [
-        { type: ActionType.LABEL },
-        { type: ActionType.ARCHIVE },
-        { type: ActionType.REPLY },
-      ];
-      const sorted = sortActionsByPriority(actions);
-      expect(sorted.map((a) => a.type)).toEqual([
-        ActionType.LABEL,
-        ActionType.ARCHIVE,
-        ActionType.REPLY,
-      ]);
+    it.each([
+      {
+        name: "empty array",
+        actions: [],
+        expected: [],
+      },
+      {
+        name: "single action",
+        actions: [{ type: ActionType.LABEL }],
+        expected: [ActionType.LABEL],
+      },
+      {
+        name: "already sorted array",
+        actions: [
+          { type: ActionType.LABEL },
+          { type: ActionType.ARCHIVE },
+          { type: ActionType.REPLY },
+        ],
+        expected: [ActionType.LABEL, ActionType.ARCHIVE, ActionType.REPLY],
+      },
+    ])("handles $name", ({ actions, expected }) => {
+      expectSortedActionTypes(actions, expected);
     });
 
     it("handles duplicate action types", () => {
@@ -162,17 +157,16 @@ describe("sortActionsByPriority", () => {
 
   describe("NOTIFY_SENDER action type", () => {
     it("places NOTIFY_SENDER before CALL_WEBHOOK", () => {
-      // NOTIFY_SENDER is in the priority list, just before CALL_WEBHOOK
       const actions = [
         { type: ActionType.CALL_WEBHOOK },
         { type: ActionType.NOTIFY_SENDER },
         { type: ActionType.LABEL },
       ];
-      const sorted = sortActionsByPriority(actions);
-      // LABEL first, NOTIFY_SENDER second, CALL_WEBHOOK last
-      expect(sorted[0].type).toBe(ActionType.LABEL);
-      expect(sorted[1].type).toBe(ActionType.NOTIFY_SENDER);
-      expect(sorted[2].type).toBe(ActionType.CALL_WEBHOOK);
+      expectSortedActionTypes(actions, [
+        ActionType.LABEL,
+        ActionType.NOTIFY_SENDER,
+        ActionType.CALL_WEBHOOK,
+      ]);
     });
   });
 
@@ -183,9 +177,8 @@ describe("sortActionsByPriority", () => {
         { type: ActionType.DIGEST },
         { type: ActionType.NOTIFY_MESSAGING_CHANNEL },
       ];
-      const sorted = sortActionsByPriority(actions);
 
-      expect(sorted.map((action) => action.type)).toEqual([
+      expectSortedActionTypes(actions, [
         ActionType.DIGEST,
         ActionType.NOTIFY_MESSAGING_CHANNEL,
         ActionType.MARK_SPAM,
@@ -193,3 +186,12 @@ describe("sortActionsByPriority", () => {
     });
   });
 });
+
+function expectSortedActionTypes(
+  actions: Array<{ type: ActionType }>,
+  expectedTypes: ActionType[],
+) {
+  expect(sortActionsByPriority(actions).map((action) => action.type)).toEqual(
+    expectedTypes,
+  );
+}

--- a/apps/web/utils/ai/choose-rule/choose-args.test.ts
+++ b/apps/web/utils/ai/choose-rule/choose-args.test.ts
@@ -10,8 +10,6 @@ import { ActionType } from "@/generated/prisma/enums";
 import type { Action } from "@/generated/prisma/client";
 import type { DraftAttribution } from "@/utils/ai/reply/draft-attribution";
 
-// Run with: pnpm test apps/web/utils/ai/choose-rule/choose-args.test.ts
-
 describe("getParameterFieldsForAction", () => {
   it("creates schema for simple field", () => {
     const action = {

--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -243,26 +243,40 @@ describe("handlePreviousDraftDeletion", () => {
 });
 
 describe("extractDraftPlainText", () => {
-  it("should return textPlain as-is for Gmail (no bodyContentType)", () => {
-    const result = extractDraftPlainText(
-      createParsedMessage({
+  it.each([
+    {
+      name: "Gmail message without bodyContentType",
+      message: createParsedMessage({
         textPlain: "Plain text content",
         textHtml: "<p>HTML content</p>",
       }),
-    );
-
-    expect(result).toBe("Plain text content");
-  });
-
-  it("should return textPlain as-is when bodyContentType is text", () => {
-    const result = extractDraftPlainText(
-      createParsedMessage({
+      expected: "Plain text content",
+    },
+    {
+      name: "message with text bodyContentType",
+      message: createParsedMessage({
         textPlain: "Plain text content",
         bodyContentType: "text",
       }),
-    );
-
-    expect(result).toBe("Plain text content");
+      expected: "Plain text content",
+    },
+    {
+      name: "HTML message without textPlain",
+      message: createParsedMessage({
+        textPlain: undefined,
+        bodyContentType: "html",
+      }),
+      expected: "",
+    },
+    {
+      name: "empty textPlain",
+      message: createParsedMessage({
+        textPlain: "",
+      }),
+      expected: "",
+    },
+  ])("should return expected text for $name", ({ message, expected }) => {
+    expect(extractDraftPlainText(message)).toBe(expected);
   });
 
   it("should convert HTML to plain text when bodyContentType is html", () => {
@@ -278,27 +292,6 @@ describe("extractDraftPlainText", () => {
     expect(result).toContain("link");
     expect(result).not.toContain("<p>");
     expect(result).not.toContain("<a href");
-  });
-
-  it("should return empty string when textPlain is undefined", () => {
-    const result = extractDraftPlainText(
-      createParsedMessage({
-        textPlain: undefined,
-        bodyContentType: "html",
-      }),
-    );
-
-    expect(result).toBe("");
-  });
-
-  it("should handle empty string textPlain", () => {
-    const result = extractDraftPlainText(
-      createParsedMessage({
-        textPlain: "",
-      }),
-    );
-
-    expect(result).toBe("");
   });
 
   it("should handle Outlook HTML with complex formatting", () => {

--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -29,9 +29,6 @@ import {
 import { isColdEmail } from "@/utils/cold-email/is-cold-email";
 import { checkSenderReplyHistory } from "@/utils/reply-tracker/check-sender-reply-history";
 
-// Run with:
-// pnpm test match-rules.test.ts
-
 const logger = createTestLogger();
 
 const provider = getProvider();

--- a/apps/web/utils/api-auth.test.ts
+++ b/apps/web/utils/api-auth.test.ts
@@ -15,15 +15,6 @@ vi.mock("@/utils/prisma");
 vi.mock("@/utils/api-key");
 vi.mock("@/utils/email/provider");
 
-function getRequest(apiKey: string | null) {
-  return {
-    headers: {
-      get: vi.fn().mockReturnValue(apiKey),
-    },
-    logger: {},
-  } as unknown as NextRequest;
-}
-
 describe("api-auth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,8 +30,7 @@ describe("api-auth", () => {
     });
 
     it("throws when the key is invalid", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue(null);
+      mockApiKeyLookup(null);
 
       await expect(
         validateApiKey(getRequest("invalid-api-key")),
@@ -48,22 +38,7 @@ describe("api-auth", () => {
     });
 
     it("returns the scoped api key and records last use", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        scopes: ["RULES_READ"],
-        emailAccount: {
-          id: "email-account-id",
-          email: "user@example.com",
-          account: {
-            id: "account-id",
-            provider: "google",
-          },
-        },
-      } as never);
+      mockApiKeyLookup(buildApiKeyRecord());
 
       const result = await validateApiKey(getRequest("valid-api-key"));
 
@@ -84,22 +59,18 @@ describe("api-auth", () => {
 
   describe("getUserFromApiKey", () => {
     it("returns null for invalid keys", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue(null);
+      mockApiKeyLookup(null);
 
       await expect(getUserFromApiKey("invalid-key")).resolves.toBeNull();
     });
 
     it("returns the scoped user shape for valid keys", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        scopes: ["RULES_READ", "RULES_WRITE"],
-        emailAccount: null,
-      } as never);
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          scopes: ["RULES_READ", "RULES_WRITE"],
+          emailAccount: null,
+        }),
+      );
 
       await expect(getUserFromApiKey("valid-key")).resolves.toEqual({
         id: "user-id",
@@ -109,15 +80,12 @@ describe("api-auth", () => {
     });
 
     it("returns null for keys without an inbox scope", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: null,
-        expiresAt: null,
-        scopes: ["RULES_READ"],
-        emailAccount: null,
-      } as never);
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          emailAccountId: null,
+          emailAccount: null,
+        }),
+      );
 
       await expect(getUserFromApiKey("legacy-key")).resolves.toBeNull();
     });
@@ -125,22 +93,7 @@ describe("api-auth", () => {
 
   describe("validateAccountApiKey", () => {
     it("rejects keys without the required scopes", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        scopes: ["RULES_READ"],
-        emailAccount: {
-          id: "email-account-id",
-          email: "user@example.com",
-          account: {
-            id: "account-id",
-            provider: "google",
-          },
-        },
-      } as never);
+      mockApiKeyLookup(buildApiKeyRecord());
 
       await expect(
         validateAccountApiKey(getRequest("valid-key"), ["RULES_WRITE"]),
@@ -148,22 +101,11 @@ describe("api-auth", () => {
     });
 
     it("returns an account-scoped principal", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        scopes: ["RULES_READ", "RULES_WRITE"],
-        emailAccount: {
-          id: "email-account-id",
-          email: "user@example.com",
-          account: {
-            id: "account-id",
-            provider: "google",
-          },
-        },
-      } as never);
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          scopes: ["RULES_READ", "RULES_WRITE"],
+        }),
+      );
 
       await expect(
         validateAccountApiKey(getRequest("valid-key"), ["RULES_WRITE"]),
@@ -181,23 +123,12 @@ describe("api-auth", () => {
 
   describe("validateApiKeyAndGetEmailProvider", () => {
     it("creates the provider for account-scoped keys", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
       vi.mocked(createEmailProvider).mockResolvedValue("provider" as never);
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        scopes: ["STATS_READ"],
-        emailAccount: {
-          id: "email-account-id",
-          email: "user@example.com",
-          account: {
-            id: "account-id",
-            provider: "google",
-          },
-        },
-      } as never);
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          scopes: ["STATS_READ"],
+        }),
+      );
 
       await expect(
         validateApiKeyAndGetEmailProvider(getRequest("valid-key") as any),
@@ -214,15 +145,13 @@ describe("api-auth", () => {
     });
 
     it("rejects keys without an inbox scope", async () => {
-      vi.mocked(hashApiKey).mockReturnValue("hashed-key");
-      prisma.apiKey.findUnique.mockResolvedValue({
-        id: "key-id",
-        userId: "user-id",
-        emailAccountId: null,
-        expiresAt: null,
-        scopes: ["STATS_READ"],
-        emailAccount: null,
-      } as never);
+      mockApiKeyLookup(
+        buildApiKeyRecord({
+          emailAccountId: null,
+          scopes: ["STATS_READ"],
+          emailAccount: null,
+        }),
+      );
 
       await expect(
         validateApiKeyAndGetEmailProvider(getRequest("legacy-key") as any),
@@ -230,3 +159,36 @@ describe("api-auth", () => {
     });
   });
 });
+
+function getRequest(apiKey: string | null) {
+  return {
+    headers: {
+      get: vi.fn().mockReturnValue(apiKey),
+    },
+    logger: {},
+  } as unknown as NextRequest;
+}
+
+function mockApiKeyLookup(record: ReturnType<typeof buildApiKeyRecord> | null) {
+  vi.mocked(hashApiKey).mockReturnValue("hashed-key");
+  prisma.apiKey.findUnique.mockResolvedValue(record as never);
+}
+
+function buildApiKeyRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "key-id",
+    userId: "user-id",
+    emailAccountId: "email-account-id",
+    expiresAt: null,
+    scopes: ["RULES_READ"],
+    emailAccount: {
+      id: "email-account-id",
+      email: "user@example.com",
+      account: {
+        id: "account-id",
+        provider: "google",
+      },
+    },
+    ...overrides,
+  };
+}

--- a/apps/web/utils/calendar/oauth-callback-helpers.test.ts
+++ b/apps/web/utils/calendar/oauth-callback-helpers.test.ts
@@ -8,145 +8,136 @@ import {
 
 describe("calendar OAuth callback helpers", () => {
   describe("extractAadstsCode", () => {
-    it("extracts AADSTS code when present", () => {
-      expect(
-        extractAadstsCode(
-          "AADSTS65004: User declined to consent to access the app.",
-        ),
-      ).toBe("AADSTS65004");
-    });
-
-    it("extracts longer AADSTS codes", () => {
-      expect(extractAadstsCode("AADSTS7000215: Invalid client secret.")).toBe(
-        "AADSTS7000215",
-      );
-    });
-
-    it("returns null when no code present", () => {
-      expect(extractAadstsCode("Some other error")).toBeNull();
-    });
-
-    it("returns null for empty descriptions", () => {
-      expect(extractAadstsCode(null)).toBeNull();
+    it.each([
+      {
+        name: "AADSTS code is present",
+        description: "AADSTS65004: User declined to consent to access the app.",
+        expected: "AADSTS65004",
+      },
+      {
+        name: "longer AADSTS code is present",
+        description: "AADSTS7000215: Invalid client secret.",
+        expected: "AADSTS7000215",
+      },
+      {
+        name: "no code is present",
+        description: "Some other error",
+        expected: null,
+      },
+      {
+        name: "description is empty",
+        description: null,
+        expected: null,
+      },
+    ])("returns expected code when $name", ({ description, expected }) => {
+      expect(extractAadstsCode(description)).toBe(expected);
     });
   });
 
   describe("mapCalendarOAuthError", () => {
-    it("maps consent declined AADSTS", () => {
-      expect(
-        mapCalendarOAuthError({
+    it.each([
+      {
+        name: "consent declined AADSTS",
+        input: {
           oauthError: "access_denied",
           errorSubcode: "cancel",
           aadstsCode: "AADSTS65004",
-        }),
-      ).toBe("consent_declined");
-    });
-
-    it("maps admin consent required AADSTS", () => {
-      expect(
-        mapCalendarOAuthError({
+        },
+        expected: "consent_declined",
+      },
+      {
+        name: "admin consent required AADSTS",
+        input: {
           oauthError: "access_denied",
           errorSubcode: null,
           aadstsCode: "AADSTS65001",
-        }),
-      ).toBe("admin_consent_required");
-    });
-
-    it("maps access_denied without subcode", () => {
-      expect(
-        mapCalendarOAuthError({
+        },
+        expected: "admin_consent_required",
+      },
+      {
+        name: "access_denied without subcode",
+        input: {
           oauthError: "access_denied",
           errorSubcode: null,
           aadstsCode: null,
-        }),
-      ).toBe("access_denied");
-    });
-
-    it("falls back to oauth_error", () => {
-      expect(
-        mapCalendarOAuthError({
+        },
+        expected: "access_denied",
+      },
+      {
+        name: "fallback OAuth error",
+        input: {
           oauthError: "server_error",
           errorSubcode: null,
           aadstsCode: null,
-        }),
-      ).toBe("oauth_error");
+        },
+        expected: "oauth_error",
+      },
+    ])("maps $name", ({ input, expected }) => {
+      expect(mapCalendarOAuthError(input)).toBe(expected);
     });
   });
 
   describe("getSafeOAuthErrorDescription", () => {
-    it("returns a sanitized message with AADSTS code", () => {
-      expect(
-        getSafeOAuthErrorDescription(
-          "AADSTS65004: User declined to consent to access the app.",
-        ),
-      ).toBe("Microsoft error AADSTS65004.");
-    });
-
-    it("returns null when no AADSTS code is present", () => {
-      expect(getSafeOAuthErrorDescription("Something else")).toBeNull();
+    it.each([
+      {
+        name: "AADSTS code is present",
+        description: "AADSTS65004: User declined to consent to access the app.",
+        expected: "Microsoft error AADSTS65004.",
+      },
+      {
+        name: "no AADSTS code is present",
+        description: "Something else",
+        expected: null,
+      },
+    ])("returns safe description when $name", ({ description, expected }) => {
+      expect(getSafeOAuthErrorDescription(description)).toBe(expected);
     });
   });
 
   describe("getCalendarRedirectPath", () => {
-    it("falls back to the calendars page when no return path is provided", () => {
-      expect(getCalendarRedirectPath("acc_123")).toBe("/acc_123/calendars");
-    });
-
-    it("uses a same-account onboarding return path", () => {
-      expect(
-        getCalendarRedirectPath(
-          "acc_123",
-          encodeURIComponent("/acc_123/onboarding-brief?step=2"),
-        ),
-      ).toBe("/acc_123/onboarding-brief?step=2");
-    });
-
-    it("ignores return paths for a different account", () => {
-      expect(
-        getCalendarRedirectPath(
-          "acc_123",
-          encodeURIComponent("/acc_456/briefs"),
-        ),
-      ).toBe("/acc_123/calendars");
-    });
-
-    it("ignores return paths that normalize into a different account", () => {
-      expect(
-        getCalendarRedirectPath(
-          "acc_123",
-          encodeURIComponent("/acc_123/../acc_456/briefs"),
-        ),
-      ).toBe("/acc_123/calendars");
-    });
-
-    it("ignores external return paths", () => {
-      expect(
-        getCalendarRedirectPath(
-          "acc_123",
-          encodeURIComponent("https://example.com/briefs"),
-        ),
-      ).toBe("/acc_123/calendars");
-    });
-
-    it("handles malformed encoded values", () => {
-      expect(getCalendarRedirectPath("acc_123", "%E0%A4%A")).toBe(
-        "/acc_123/calendars",
-      );
-    });
-
-    it("ignores control-character redirect bypass attempts", () => {
-      expect(
-        getCalendarRedirectPath("acc_123", encodeURIComponent("/\t/r3d.fi")),
-      ).toBe("/acc_123/calendars");
-    });
-
-    it("rejects overlapping account ID prefixes", () => {
-      expect(
-        getCalendarRedirectPath(
-          "acc_123",
-          encodeURIComponent("/acc_1234/briefs"),
-        ),
-      ).toBe("/acc_123/calendars");
+    it.each([
+      {
+        name: "no return path",
+        returnPath: undefined,
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "same-account onboarding return path",
+        returnPath: encodeURIComponent("/acc_123/onboarding-brief?step=2"),
+        expected: "/acc_123/onboarding-brief?step=2",
+      },
+      {
+        name: "different account return path",
+        returnPath: encodeURIComponent("/acc_456/briefs"),
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "return path that normalizes into a different account",
+        returnPath: encodeURIComponent("/acc_123/../acc_456/briefs"),
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "external return path",
+        returnPath: encodeURIComponent("https://example.com/briefs"),
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "malformed encoded value",
+        returnPath: "%E0%A4%A",
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "control-character redirect bypass attempt",
+        returnPath: encodeURIComponent("/\t/r3d.fi"),
+        expected: "/acc_123/calendars",
+      },
+      {
+        name: "overlapping account ID prefix",
+        returnPath: encodeURIComponent("/acc_1234/briefs"),
+        expected: "/acc_123/calendars",
+      },
+    ])("returns expected path for $name", ({ returnPath, expected }) => {
+      expect(getCalendarRedirectPath("acc_123", returnPath)).toBe(expected);
     });
   });
 });

--- a/apps/web/utils/date.test.ts
+++ b/apps/web/utils/date.test.ts
@@ -14,99 +14,104 @@ describe("timezone formatting", () => {
   const utcDate = new Date("2024-12-30T19:00:00Z");
 
   describe("formatTimeInUserTimezone", () => {
-    it("should format time in Brazil timezone (UTC-3)", () => {
-      // 7 PM UTC = 4 PM BRT (UTC-3)
-      const result = formatTimeInUserTimezone(utcDate, "America/Sao_Paulo");
-      expect(result).toBe("4:00 PM");
-    });
-
-    it("should format time in US Eastern timezone (UTC-5)", () => {
-      // 7 PM UTC = 2 PM EST (UTC-5)
-      const result = formatTimeInUserTimezone(utcDate, "America/New_York");
-      expect(result).toBe("2:00 PM");
-    });
-
-    it("should format time in US Pacific timezone (UTC-8)", () => {
-      // 7 PM UTC = 11 AM PST (UTC-8)
-      const result = formatTimeInUserTimezone(utcDate, "America/Los_Angeles");
-      expect(result).toBe("11:00 AM");
-    });
-
-    it("should format time in Israel timezone (UTC+2)", () => {
-      // 7 PM UTC = 9 PM IST (UTC+2)
-      const result = formatTimeInUserTimezone(utcDate, "Asia/Jerusalem");
-      expect(result).toBe("9:00 PM");
-    });
-
-    it("should format time in Japan timezone (UTC+9)", () => {
-      // 7 PM UTC = 4 AM next day JST (UTC+9)
-      const result = formatTimeInUserTimezone(utcDate, "Asia/Tokyo");
-      expect(result).toBe("4:00 AM");
-    });
-
-    it("should default to UTC when timezone is null", () => {
-      const result = formatTimeInUserTimezone(utcDate, null);
-      expect(result).toBe("7:00 PM");
-    });
-
-    it("should default to UTC when timezone is undefined", () => {
-      const result = formatTimeInUserTimezone(utcDate, undefined);
-      expect(result).toBe("7:00 PM");
+    it.each([
+      {
+        name: "Brazil timezone (UTC-3)",
+        timezone: "America/Sao_Paulo",
+        expected: "4:00 PM",
+      },
+      {
+        name: "US Eastern timezone (UTC-5)",
+        timezone: "America/New_York",
+        expected: "2:00 PM",
+      },
+      {
+        name: "US Pacific timezone (UTC-8)",
+        timezone: "America/Los_Angeles",
+        expected: "11:00 AM",
+      },
+      {
+        name: "Israel timezone (UTC+2)",
+        timezone: "Asia/Jerusalem",
+        expected: "9:00 PM",
+      },
+      {
+        name: "Japan timezone (UTC+9)",
+        timezone: "Asia/Tokyo",
+        expected: "4:00 AM",
+      },
+      {
+        name: "null timezone",
+        timezone: null,
+        expected: "7:00 PM",
+      },
+      {
+        name: "undefined timezone",
+        timezone: undefined,
+        expected: "7:00 PM",
+      },
+    ])("should format time in $name", ({ timezone, expected }) => {
+      expect(formatTimeInUserTimezone(utcDate, timezone)).toBe(expected);
     });
   });
 
   describe("formatDateTimeInUserTimezone", () => {
-    it("should format date and time in Brazil timezone", () => {
-      // 7 PM UTC = 4 PM BRT on Dec 30
-      const result = formatDateTimeInUserTimezone(utcDate, "America/Sao_Paulo");
-      expect(result).toBe("Dec 30, 2024 at 4:00 PM");
-    });
-
-    it("should format date and time in US Pacific timezone", () => {
-      // 7 PM UTC = 11 AM PST on Dec 30
-      const result = formatDateTimeInUserTimezone(
-        utcDate,
-        "America/Los_Angeles",
-      );
-      expect(result).toBe("Dec 30, 2024 at 11:00 AM");
-    });
-
-    it("should handle date change when crossing midnight (Japan)", () => {
-      // 7 PM UTC on Dec 30 = 4 AM JST on Dec 31
-      const result = formatDateTimeInUserTimezone(utcDate, "Asia/Tokyo");
-      expect(result).toBe("Dec 31, 2024 at 4:00 AM");
-    });
-
-    it("should handle date change when going backwards (Pacific)", () => {
-      // 3 AM UTC on Dec 30 = 7 PM PST on Dec 29
-      const earlyUtc = new Date("2024-12-30T03:00:00Z");
-      const result = formatDateTimeInUserTimezone(
-        earlyUtc,
-        "America/Los_Angeles",
-      );
-      expect(result).toBe("Dec 29, 2024 at 7:00 PM");
-    });
-
-    it("should default to UTC when timezone is null", () => {
-      const result = formatDateTimeInUserTimezone(utcDate, null);
-      expect(result).toBe("Dec 30, 2024 at 7:00 PM");
+    it.each([
+      {
+        name: "Brazil timezone",
+        date: utcDate,
+        timezone: "America/Sao_Paulo",
+        expected: "Dec 30, 2024 at 4:00 PM",
+      },
+      {
+        name: "US Pacific timezone",
+        date: utcDate,
+        timezone: "America/Los_Angeles",
+        expected: "Dec 30, 2024 at 11:00 AM",
+      },
+      {
+        name: "date change crossing midnight in Japan",
+        date: utcDate,
+        timezone: "Asia/Tokyo",
+        expected: "Dec 31, 2024 at 4:00 AM",
+      },
+      {
+        name: "date change going backwards in Pacific time",
+        date: new Date("2024-12-30T03:00:00Z"),
+        timezone: "America/Los_Angeles",
+        expected: "Dec 29, 2024 at 7:00 PM",
+      },
+      {
+        name: "null timezone",
+        date: utcDate,
+        timezone: null,
+        expected: "Dec 30, 2024 at 7:00 PM",
+      },
+    ])("should format date and time for $name", ({
+      date,
+      timezone,
+      expected,
+    }) => {
+      expect(formatDateTimeInUserTimezone(date, timezone)).toBe(expected);
     });
   });
 
   describe("formatInUserTimezone with custom format", () => {
-    it("should support custom format strings", () => {
-      const result = formatInUserTimezone(
-        utcDate,
-        "America/Sao_Paulo",
-        "yyyy-MM-dd HH:mm",
-      );
-      expect(result).toBe("2024-12-30 16:00");
-    });
-
-    it("should support 24-hour time format", () => {
-      // 7 PM UTC = 21:00 in Jerusalem
-      const result = formatInUserTimezone(utcDate, "Asia/Jerusalem", "HH:mm");
-      expect(result).toBe("21:00");
+    it.each([
+      {
+        name: "custom date-time format",
+        timezone: "America/Sao_Paulo",
+        format: "yyyy-MM-dd HH:mm",
+        expected: "2024-12-30 16:00",
+      },
+      {
+        name: "24-hour time format",
+        timezone: "Asia/Jerusalem",
+        format: "HH:mm",
+        expected: "21:00",
+      },
+    ])("should support $name", ({ timezone, format, expected }) => {
+      expect(formatInUserTimezone(utcDate, timezone, format)).toBe(expected);
     });
   });
 
@@ -141,17 +146,19 @@ describe("timezone formatting", () => {
   });
 
   describe("invalid timezone handling", () => {
-    it("should fall back to UTC for invalid timezone strings", () => {
-      const result = formatTimeInUserTimezone(utcDate, "Invalid/Timezone");
-      // Should not throw, and should fall back to UTC (7:00 PM)
-      expect(result).toBe("7:00 PM");
-    });
-
-    it("should handle legacy timezone abbreviations that TZDate supports", () => {
-      const result = formatTimeInUserTimezone(utcDate, "EST");
-      // TZDate supports some legacy abbreviations like "EST" (UTC-5)
-      // 7 PM UTC = 2 PM EST
-      expect(result).toBe("2:00 PM");
+    it.each([
+      {
+        name: "invalid timezone strings",
+        timezone: "Invalid/Timezone",
+        expected: "7:00 PM",
+      },
+      {
+        name: "legacy timezone abbreviations that TZDate supports",
+        timezone: "EST",
+        expected: "2:00 PM",
+      },
+    ])("should format time for $name", ({ timezone, expected }) => {
+      expect(formatTimeInUserTimezone(utcDate, timezone)).toBe(expected);
     });
 
     it("should fall back to UTC for corrupted timezone data", () => {
@@ -165,14 +172,13 @@ describe("timezone formatting", () => {
 });
 
 describe("internalDateToDate", () => {
-  it("returns invalid date when fallbackToNow is false and internalDate is missing", () => {
-    const parsed = internalDateToDate(undefined, { fallbackToNow: false });
-
-    expect(Number.isNaN(parsed.getTime())).toBe(true);
-  });
-
-  it("returns invalid date when fallbackToNow is false and internalDate is invalid", () => {
-    const parsed = internalDateToDate("not-a-date", { fallbackToNow: false });
+  it.each([
+    { name: "internalDate is missing", internalDate: undefined },
+    { name: "internalDate is invalid", internalDate: "not-a-date" },
+  ])("returns invalid date when fallbackToNow is false and $name", ({
+    internalDate,
+  }) => {
+    const parsed = internalDateToDate(internalDate, { fallbackToNow: false });
 
     expect(Number.isNaN(parsed.getTime())).toBe(true);
   });

--- a/apps/web/utils/drive/folder-utils.test.ts
+++ b/apps/web/utils/drive/folder-utils.test.ts
@@ -3,56 +3,6 @@ import { createFolderPath } from "./folder-utils";
 import type { DriveProvider, DriveFolder } from "./types";
 import { createTestLogger } from "@/__tests__/helpers";
 
-function createMockFolder(id: string, name: string): DriveFolder {
-  return {
-    id,
-    name,
-    path: name,
-    webUrl: `https://drive.example.com/${id}`,
-  };
-}
-
-function createMockProvider(
-  existingFolders: Map<string | undefined, DriveFolder[]> = new Map(),
-  providerName: DriveProvider["name"] = "google",
-): DriveProvider {
-  const createdFolders: DriveFolder[] = [];
-  let folderId = 1;
-
-  return {
-    name: providerName,
-    toJSON: () => ({ name: providerName, type: "drive" }),
-    getAccessToken: () => "mock-token",
-    listFolders: vi.fn(async (parentId?: string) => {
-      const existing = existingFolders.get(parentId) || [];
-      const created = createdFolders.filter((f) => {
-        if (parentId === undefined) return !f.path?.includes("/");
-        return f.path?.startsWith(parentId);
-      });
-      return [...existing, ...created];
-    }),
-    getFolder: vi.fn(async () => null),
-    createFolder: vi.fn(async (name: string, parentId?: string) => {
-      const folder = createMockFolder(`folder-${folderId++}`, name);
-      createdFolders.push({ ...folder, parentId });
-      return folder;
-    }),
-    uploadFile: vi.fn(async () => ({
-      id: "file-1",
-      name: "test.pdf",
-      mimeType: "application/pdf",
-      webUrl: "https://drive.example.com/file-1",
-    })),
-    getFile: vi.fn(async () => null),
-    moveFile: vi.fn(async (fileId: string, targetFolderId: string) => ({
-      id: fileId,
-      name: "moved-file",
-      mimeType: "application/pdf",
-      folderId: targetFolderId,
-    })),
-  };
-}
-
 const logger = createTestLogger();
 
 describe("createFolderPath", () => {
@@ -123,19 +73,13 @@ describe("createFolderPath", () => {
     expect(provider.createFolder).toHaveBeenCalledWith("2024", "existing-1");
   });
 
-  it("should handle path with leading slash", async () => {
+  it.each([
+    "/Receipts",
+    "Receipts/",
+  ])("should normalize path %s", async (path) => {
     const provider = createMockProvider();
 
-    const result = await createFolderPath(provider, "/Receipts", logger);
-
-    expect(result.folder.name).toBe("Receipts");
-    expect(provider.createFolder).toHaveBeenCalledTimes(1);
-  });
-
-  it("should handle path with trailing slash", async () => {
-    const provider = createMockProvider();
-
-    const result = await createFolderPath(provider, "Receipts/", logger);
+    const result = await createFolderPath(provider, path, logger);
 
     expect(result.folder.name).toBe("Receipts");
     expect(provider.createFolder).toHaveBeenCalledTimes(1);
@@ -163,3 +107,53 @@ describe("createFolderPath", () => {
     expect(provider.createFolder).not.toHaveBeenCalled();
   });
 });
+
+function createMockFolder(id: string, name: string): DriveFolder {
+  return {
+    id,
+    name,
+    path: name,
+    webUrl: `https://drive.example.com/${id}`,
+  };
+}
+
+function createMockProvider(
+  existingFolders: Map<string | undefined, DriveFolder[]> = new Map(),
+  providerName: DriveProvider["name"] = "google",
+): DriveProvider {
+  const createdFolders: DriveFolder[] = [];
+  let folderId = 1;
+
+  return {
+    name: providerName,
+    toJSON: () => ({ name: providerName, type: "drive" }),
+    getAccessToken: () => "mock-token",
+    listFolders: vi.fn(async (parentId?: string) => {
+      const existing = existingFolders.get(parentId) || [];
+      const created = createdFolders.filter((f) => {
+        if (parentId === undefined) return !f.path?.includes("/");
+        return f.path?.startsWith(parentId);
+      });
+      return [...existing, ...created];
+    }),
+    getFolder: vi.fn(async () => null),
+    createFolder: vi.fn(async (name: string, parentId?: string) => {
+      const folder = createMockFolder(`folder-${folderId++}`, name);
+      createdFolders.push({ ...folder, parentId });
+      return folder;
+    }),
+    uploadFile: vi.fn(async () => ({
+      id: "file-1",
+      name: "test.pdf",
+      mimeType: "application/pdf",
+      webUrl: "https://drive.example.com/file-1",
+    })),
+    getFile: vi.fn(async () => null),
+    moveFile: vi.fn(async (fileId: string, targetFolderId: string) => ({
+      id: fileId,
+      name: "moved-file",
+      mimeType: "application/pdf",
+      folderId: targetFolderId,
+    })),
+  };
+}

--- a/apps/web/utils/email.test.ts
+++ b/apps/web/utils/email.test.ts
@@ -15,144 +15,94 @@ import {
 
 describe("email utils", () => {
   describe("extractNameFromEmail", () => {
-    it("extracts name from email with format 'Name <email>'", () => {
-      expect(extractNameFromEmail("John Doe <john.doe@gmail.com>")).toBe(
-        "John Doe",
-      );
-    });
-
-    it("extracts email from format '<email>'", () => {
-      expect(extractNameFromEmail("<john.doe@gmail.com>")).toBe(
+    it.each([
+      ["formatted sender", "John Doe <john.doe@gmail.com>", "John Doe"],
+      [
+        "angle-bracketed address without a name",
+        "<john.doe@gmail.com>",
         "john.doe@gmail.com",
-      );
-    });
-
-    it("returns plain email as is", () => {
-      expect(extractNameFromEmail("john.doe@gmail.com")).toBe(
-        "john.doe@gmail.com",
-      );
-    });
-
-    it("handles empty input", () => {
-      expect(extractNameFromEmail("")).toBe("");
+      ],
+      ["plain email", "john.doe@gmail.com", "john.doe@gmail.com"],
+      ["empty input", "", ""],
+    ])("handles %s", (_caseName, input, expected) => {
+      expect(extractNameFromEmail(input)).toBe(expected);
     });
   });
 
   describe("extractEmailAddresses", () => {
-    it("returns empty array for empty string", () => {
-      expect(extractEmailAddresses("")).toEqual([]);
-    });
-
-    it("extracts single email address", () => {
-      expect(extractEmailAddresses("john@example.com")).toEqual([
-        "john@example.com",
-      ]);
-    });
-
-    it("extracts multiple email addresses separated by commas", () => {
-      expect(
-        extractEmailAddresses("john@example.com, jane@example.com"),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("extracts emails from format 'Name <email>'", () => {
-      expect(extractEmailAddresses("John Doe <john@example.com>")).toEqual([
-        "john@example.com",
-      ]);
-    });
-
-    it("extracts multiple emails with names", () => {
-      expect(
-        extractEmailAddresses(
-          "John Doe <john@example.com>, Jane Smith <jane@example.com>",
-        ),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("handles mixed formats (with and without names)", () => {
-      expect(
-        extractEmailAddresses("John Doe <john@example.com>, jane@example.com"),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("handles commas inside quoted names", () => {
-      expect(
-        extractEmailAddresses(
-          '"Doe, John" <john@example.com>, jane@example.com',
-        ),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("trims whitespace around email addresses", () => {
-      expect(
-        extractEmailAddresses("  john@example.com  ,  jane@example.com  "),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("filters out invalid email addresses", () => {
-      expect(extractEmailAddresses("invalid-email, valid@example.com")).toEqual(
+    const cases: Array<[string, string, string[]]> = [
+      ["empty string", "", []],
+      ["single email address", "john@example.com", ["john@example.com"]],
+      [
+        "multiple comma-separated email addresses",
+        "john@example.com, jane@example.com",
+        ["john@example.com", "jane@example.com"],
+      ],
+      ["formatted sender", "John Doe <john@example.com>", ["john@example.com"]],
+      [
+        "multiple formatted senders",
+        "John Doe <john@example.com>, Jane Smith <jane@example.com>",
+        ["john@example.com", "jane@example.com"],
+      ],
+      [
+        "mixed formatted and plain senders",
+        "John Doe <john@example.com>, jane@example.com",
+        ["john@example.com", "jane@example.com"],
+      ],
+      [
+        "commas inside quoted display names",
+        '"Doe, John" <john@example.com>, jane@example.com',
+        ["john@example.com", "jane@example.com"],
+      ],
+      [
+        "whitespace around addresses",
+        "  john@example.com  ,  jane@example.com  ",
+        ["john@example.com", "jane@example.com"],
+      ],
+      [
+        "invalid addresses mixed with valid ones",
+        "invalid-email, valid@example.com",
         ["valid@example.com"],
-      );
-    });
+      ],
+      [
+        "multiple commas and extra spaces",
+        "john@example.com , jane@example.com , bob@example.com",
+        ["john@example.com", "jane@example.com", "bob@example.com"],
+      ],
+      [
+        "empty parts between commas",
+        "john@example.com,,jane@example.com",
+        ["john@example.com", "jane@example.com"],
+      ],
+      ["trailing comma", "john@example.com,", ["john@example.com"]],
+      ["leading comma", ",john@example.com", ["john@example.com"]],
+      [
+        "complex real-world header",
+        '"Smith, John" <john.smith@example.com>, "Doe, Jane" <jane.doe@example.com>, admin@example.com',
+        ["john.smith@example.com", "jane.doe@example.com", "admin@example.com"],
+      ],
+      [
+        "plus addressing",
+        "user+tag@example.com, user+other@example.com",
+        ["user+tag@example.com", "user+other@example.com"],
+      ],
+      [
+        "hyphenated addresses",
+        "no-reply@example.com, support-team@example.com",
+        ["no-reply@example.com", "support-team@example.com"],
+      ],
+      [
+        "single address with angle brackets",
+        "<john@example.com>",
+        ["john@example.com"],
+      ],
+      ["all invalid addresses", "invalid, also-invalid", []],
+    ];
 
-    it("handles multiple commas and extra spaces", () => {
-      expect(
-        extractEmailAddresses(
-          "john@example.com , jane@example.com , bob@example.com",
-        ),
-      ).toEqual(["john@example.com", "jane@example.com", "bob@example.com"]);
-    });
-
-    it("handles empty parts between commas", () => {
-      expect(
-        extractEmailAddresses("john@example.com,,jane@example.com"),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("handles trailing comma", () => {
-      expect(extractEmailAddresses("john@example.com,")).toEqual([
-        "john@example.com",
-      ]);
-    });
-
-    it("handles leading comma", () => {
-      expect(extractEmailAddresses(",john@example.com")).toEqual([
-        "john@example.com",
-      ]);
-    });
-
-    it("handles complex real-world header format", () => {
-      expect(
-        extractEmailAddresses(
-          '"Smith, John" <john.smith@example.com>, "Doe, Jane" <jane.doe@example.com>, admin@example.com',
-        ),
-      ).toEqual([
-        "john.smith@example.com",
-        "jane.doe@example.com",
-        "admin@example.com",
-      ]);
-    });
-
-    it("handles emails with plus addressing", () => {
-      expect(
-        extractEmailAddresses("user+tag@example.com, user+other@example.com"),
-      ).toEqual(["user+tag@example.com", "user+other@example.com"]);
-    });
-
-    it("handles emails with hyphens", () => {
-      expect(
-        extractEmailAddresses("no-reply@example.com, support-team@example.com"),
-      ).toEqual(["no-reply@example.com", "support-team@example.com"]);
-    });
-
-    it("handles single email with angle brackets", () => {
-      expect(extractEmailAddresses("<john@example.com>")).toEqual([
-        "john@example.com",
-      ]);
-    });
-
-    it("handles all invalid emails", () => {
-      expect(extractEmailAddresses("invalid, also-invalid")).toEqual([]);
+    it.each(
+      cases,
+    )("extracts addresses from %s", (_caseName, input, expected) => {
+      expect(extractEmailAddresses(input)).toEqual(expected);
     });
   });
 
@@ -176,296 +126,212 @@ describe("email utils", () => {
       expect(
         extractUniqueEmailAddresses(
           ["First <Sender@example.com>", "sender@example.com"],
-          {
-            lowercase: true,
-          },
+          { lowercase: true },
         ),
       ).toEqual(["sender@example.com"]);
     });
   });
 
   describe("splitRecipientList", () => {
-    it("splits comma-separated recipients and trims whitespace", () => {
-      expect(
-        splitRecipientList("  john@example.com  ,  jane@example.com  "),
-      ).toEqual(["john@example.com", "jane@example.com"]);
-    });
-
-    it("keeps commas inside quoted display names", () => {
-      expect(
-        splitRecipientList('"Doe, John" <john@example.com>, jane@example.com'),
-      ).toEqual(['"Doe, John" <john@example.com>', "jane@example.com"]);
+    it.each([
+      [
+        "comma-separated recipients with whitespace",
+        "  john@example.com  ,  jane@example.com  ",
+        ["john@example.com", "jane@example.com"],
+      ],
+      [
+        "comma inside quoted display name",
+        '"Doe, John" <john@example.com>, jane@example.com',
+        ['"Doe, John" <john@example.com>', "jane@example.com"],
+      ],
+    ])("splits %s", (_caseName, input, expected) => {
+      expect(splitRecipientList(input)).toEqual(expected);
     });
   });
 
   describe("extractEmailAddress", () => {
-    it("extracts email from format 'Name <email>'", () => {
-      expect(extractEmailAddress("John Doe <john.doe@gmail.com>")).toBe(
+    const cases: Array<[string, string, string]> = [
+      [
+        "formatted sender",
+        "John Doe <john.doe@gmail.com>",
         "john.doe@gmail.com",
-      );
-    });
-
-    it("handles simple email format", () => {
-      expect(extractEmailAddress("hello@example.com")).toBe(
-        "hello@example.com",
-      );
-    });
-
-    it("returns empty string for invalid format", () => {
-      expect(extractEmailAddress("john.doe@gmail.com")).toBe(
-        "john.doe@gmail.com",
-      );
-    });
-
-    it("handles nested angle brackets", () => {
-      expect(
-        extractEmailAddress("Hacker <fake@email.com> <real@email.com>"),
-      ).toBe("real@email.com");
-    });
-
-    it("handles malformed angle brackets", () => {
-      expect(extractEmailAddress("Bad <<not@an@email>>")).toBe("");
-    });
-
-    it("extracts valid email when mixed with invalid ones", () => {
-      expect(
-        extractEmailAddress("Test <not@valid@email> <valid@email.com>"),
-      ).toBe("valid@email.com");
-    });
-
-    it("handles empty angle brackets", () => {
-      expect(extractEmailAddress("Test <>")).toBe("");
-    });
-
-    it("handles multiple @ symbols", () => {
-      expect(extractEmailAddress("Test <user@@domain.com>")).toBe("");
-    });
-
-    it("validates email format", () => {
-      expect(extractEmailAddress("Test <notanemail>")).toBe("");
-    });
-
-    it("extracts raw email when no valid bracketed email exists", () => {
-      expect(extractEmailAddress("Test <invalid> valid@email.com")).toBe(
+      ],
+      ["simple email", "hello@example.com", "hello@example.com"],
+      ["plain Gmail address", "john.doe@gmail.com", "john.doe@gmail.com"],
+      [
+        "nested angle brackets",
+        "Hacker <fake@email.com> <real@email.com>",
+        "real@email.com",
+      ],
+      ["malformed angle brackets", "Bad <<not@an@email>>", ""],
+      [
+        "valid bracketed email mixed with invalid ones",
+        "Test <not@valid@email> <valid@email.com>",
         "valid@email.com",
-      );
-    });
-
-    // Test cases for hyphenated email addresses (the bug we're fixing)
-    it("handles email addresses with hyphens in local part", () => {
-      expect(extractEmailAddress("no-reply@example.com")).toBe(
+      ],
+      ["empty angle brackets", "Test <>", ""],
+      ["multiple @ symbols", "Test <user@@domain.com>", ""],
+      ["non-email bracket content", "Test <notanemail>", ""],
+      [
+        "raw email after invalid bracket content",
+        "Test <invalid> valid@email.com",
+        "valid@email.com",
+      ],
+      ["hyphen in local part", "no-reply@example.com", "no-reply@example.com"],
+      [
+        "hyphen in bracketed local part",
+        "System <no-reply@example.com>",
         "no-reply@example.com",
-      );
-    });
-
-    it("handles email addresses with hyphens in bracketed format", () => {
-      expect(extractEmailAddress("System <no-reply@example.com>")).toBe(
-        "no-reply@example.com",
-      );
-    });
-
-    it("handles multiple hyphens in local part", () => {
-      expect(extractEmailAddress("do-not-reply@example.com")).toBe(
+      ],
+      [
+        "multiple hyphens in local part",
         "do-not-reply@example.com",
-      );
-    });
-
-    it("handles mixed hyphens and dots in local part", () => {
-      expect(extractEmailAddress("test-user.name@example.com")).toBe(
+        "do-not-reply@example.com",
+      ],
+      [
+        "mixed hyphens and dots in local part",
         "test-user.name@example.com",
-      );
-    });
-
-    it("handles emails with hyphens at start and end of local part", () => {
-      expect(extractEmailAddress("-test@example.com")).toBe(
+        "test-user.name@example.com",
+      ],
+      [
+        "hyphen at start of local part",
         "-test@example.com",
-      );
-      expect(extractEmailAddress("test-@example.com")).toBe(
-        "test-@example.com",
-      );
-    });
-
-    // Test cases for other potentially problematic characters
-    it("handles email addresses with underscores", () => {
-      expect(extractEmailAddress("user_name@example.com")).toBe(
+        "-test@example.com",
+      ],
+      ["hyphen at end of local part", "test-@example.com", "test-@example.com"],
+      [
+        "underscore in local part",
         "user_name@example.com",
-      );
-      expect(extractEmailAddress("System <no_reply@example.com>")).toBe(
+        "user_name@example.com",
+      ],
+      [
+        "underscore in bracketed local part",
+        "System <no_reply@example.com>",
         "no_reply@example.com",
-      );
-    });
-
-    it("handles email addresses with numbers", () => {
-      expect(extractEmailAddress("user123@example.com")).toBe(
-        "user123@example.com",
-      );
-      expect(extractEmailAddress("test2024@example.com")).toBe(
-        "test2024@example.com",
-      );
-    });
-
-    it("handles complex real-world email patterns", () => {
-      // Real patterns that might break
-      expect(extractEmailAddress("no-reply+tracking@example.com")).toBe(
+      ],
+      ["numbers in local part", "user123@example.com", "user123@example.com"],
+      ["year in local part", "test2024@example.com", "test2024@example.com"],
+      [
+        "plus addressing with tracking tag",
         "no-reply+tracking@example.com",
-      );
-      expect(extractEmailAddress("user.name+tag@example.com")).toBe(
+        "no-reply+tracking@example.com",
+      ],
+      [
+        "dots and plus addressing",
         "user.name+tag@example.com",
-      );
-      expect(extractEmailAddress("test_user-name+tag@example.com")).toBe(
+        "user.name+tag@example.com",
+      ],
+      [
+        "underscore, hyphen, and plus addressing",
         "test_user-name+tag@example.com",
-      );
-    });
-
-    // Edge cases that might expose regex limitations
-    it("handles edge cases that could break regex", () => {
-      // Test what happens with characters we might not support
-      expect(extractEmailAddress("user@sub-domain.example.com")).toBe(
+        "test_user-name+tag@example.com",
+      ],
+      [
+        "hyphenated subdomain",
         "user@sub-domain.example.com",
-      );
-      expect(extractEmailAddress("user@sub.domain-name.com")).toBe(
+        "user@sub-domain.example.com",
+      ],
+      [
+        "hyphenated nested domain",
         "user@sub.domain-name.com",
-      );
+        "user@sub.domain-name.com",
+      ],
+    ];
+
+    it.each(cases)("handles %s", (_caseName, input, expected) => {
+      expect(extractEmailAddress(input)).toBe(expected);
     });
   });
 
   describe("messageRepliesToSourceSender", () => {
-    it("returns true when the sent message is addressed to the source sender", () => {
-      expect(
-        messageRepliesToSourceSender({
-          sourceMessage: createMessage({
-            from: "Sales <sales@example.com>",
-          }),
-          sentMessage: createMessage({
-            from: "user@example.com",
-            to: "Sales <sales@example.com>",
-          }),
-        }),
-      ).toBe(true);
-    });
+    const cases: Array<
+      [string, MessageHeaders, MessageHeaders, boolean | null]
+    > = [
+      [
+        "sent message is addressed to the source sender",
+        { from: "Sales <sales@example.com>" },
+        { from: "user@example.com", to: "Sales <sales@example.com>" },
+        true,
+      ],
+      [
+        "reply-to provides the expected reply target",
+        {
+          from: "noreply@example.com",
+          "reply-to": "Ops <ops@example.com>, Support <support@example.com>",
+        },
+        { from: "user@example.com", to: "support@example.com" },
+        true,
+      ],
+      [
+        "reply target is in cc recipients",
+        { from: "Sales <sales@example.com>" },
+        {
+          from: "user@example.com",
+          to: "teammate@example.com",
+          cc: "Sales <sales@example.com>",
+        },
+        true,
+      ],
+      [
+        "sent message only goes to someone else",
+        { from: "Sales <sales@example.com>" },
+        { from: "user@example.com", to: "teammate@example.com" },
+        false,
+      ],
+      [
+        "expected target cannot be read",
+        { from: "" },
+        { to: "teammate@example.com" },
+        null,
+      ],
+      [
+        "sent recipients cannot be read",
+        { from: "sales@example.com" },
+        { to: "" },
+        null,
+      ],
+    ];
 
-    it("uses reply-to as the expected reply target when present", () => {
+    it.each(
+      cases,
+    )("handles %s", (_caseName, sourceHeaders, sentHeaders, expected) => {
       expect(
         messageRepliesToSourceSender({
-          sourceMessage: createMessage({
-            from: "noreply@example.com",
-            "reply-to": "Ops <ops@example.com>, Support <support@example.com>",
-          }),
-          sentMessage: createMessage({
-            from: "user@example.com",
-            to: "support@example.com",
-          }),
+          sourceMessage: createMessage(sourceHeaders),
+          sentMessage: createMessage(sentHeaders),
         }),
-      ).toBe(true);
-    });
-
-    it("matches reply targets in cc recipients", () => {
-      expect(
-        messageRepliesToSourceSender({
-          sourceMessage: createMessage({
-            from: "Sales <sales@example.com>",
-          }),
-          sentMessage: createMessage({
-            from: "user@example.com",
-            to: "teammate@example.com",
-            cc: "Sales <sales@example.com>",
-          }),
-        }),
-      ).toBe(true);
-    });
-
-    it("returns false when the sent message only goes to someone else", () => {
-      expect(
-        messageRepliesToSourceSender({
-          sourceMessage: createMessage({
-            from: "Sales <sales@example.com>",
-          }),
-          sentMessage: createMessage({
-            from: "user@example.com",
-            to: "teammate@example.com",
-          }),
-        }),
-      ).toBe(false);
-    });
-
-    it("returns null when the expected target or recipients cannot be read", () => {
-      expect(
-        messageRepliesToSourceSender({
-          sourceMessage: createMessage({ from: "" }),
-          sentMessage: createMessage({ to: "teammate@example.com" }),
-        }),
-      ).toBeNull();
-
-      expect(
-        messageRepliesToSourceSender({
-          sourceMessage: createMessage({ from: "sales@example.com" }),
-          sentMessage: createMessage({ to: "" }),
-        }),
-      ).toBeNull();
+      ).toBe(expected);
     });
   });
 
   describe("extractDomainFromEmail", () => {
-    it("extracts domain from plain email", () => {
-      expect(extractDomainFromEmail("john@example.com")).toBe("example.com");
-    });
-
-    it("extracts domain from email with format 'Name <email>'", () => {
-      expect(extractDomainFromEmail("John Doe <john@example.com>")).toBe(
+    it.each([
+      ["plain email", "john@example.com", "example.com"],
+      ["formatted sender", "John Doe <john@example.com>", "example.com"],
+      ["subdomain", "john@sub.example.com", "sub.example.com"],
+      ["invalid email", "invalid-email", ""],
+      ["empty input", "", ""],
+      ["multiple @ symbols", "test@foo@example.com", ""],
+      ["longer TLD", "test@example.company", "example.company"],
+      ["international domain", "user@münchen.de", "münchen.de"],
+      ["plus addressing", "user+tag@example.com", "example.com"],
+      [
+        "quoted formatted sender",
+        '"John Doe" <john@example.com>',
         "example.com",
-      );
-    });
-
-    it("handles subdomains", () => {
-      expect(extractDomainFromEmail("john@sub.example.com")).toBe(
-        "sub.example.com",
-      );
-    });
-
-    it("returns empty string for invalid email", () => {
-      expect(extractDomainFromEmail("invalid-email")).toBe("");
-    });
-
-    it("handles empty input", () => {
-      expect(extractDomainFromEmail("")).toBe("");
-    });
-
-    it("handles multiple @ symbols", () => {
-      expect(extractDomainFromEmail("test@foo@example.com")).toBe("");
-    });
-
-    it("handles longer TLDs", () => {
-      expect(extractDomainFromEmail("test@example.company")).toBe(
-        "example.company",
-      );
-    });
-
-    it("handles international domains", () => {
-      expect(extractDomainFromEmail("user@münchen.de")).toBe("münchen.de");
-    });
-
-    it("handles plus addressing", () => {
-      expect(extractDomainFromEmail("user+tag@example.com")).toBe(
-        "example.com",
-      );
-    });
-
-    it("handles quoted email addresses", () => {
-      expect(extractDomainFromEmail('"John Doe" <john@example.com>')).toBe(
-        "example.com",
-      );
-    });
-
-    it("handles domains with multiple dots", () => {
-      expect(extractDomainFromEmail("test@a.b.c.example.com")).toBe(
+      ],
+      [
+        "domain with multiple dots",
+        "test@a.b.c.example.com",
         "a.b.c.example.com",
-      );
-    });
-
-    it("handles whitespace in formatted email", () => {
-      expect(extractDomainFromEmail("John Doe    <john@example.com>")).toBe(
+      ],
+      [
+        "whitespace in formatted sender",
+        "John Doe    <john@example.com>",
         "example.com",
-      );
+      ],
+    ])("extracts domain from %s", (_caseName, input, expected) => {
+      expect(extractDomainFromEmail(input)).toBe(expected);
     });
   });
 
@@ -477,115 +343,106 @@ describe("email utils", () => {
       },
     } as const;
 
-    it("returns recipient when user is sender", () => {
-      expect(participant(message, "sender@example.com")).toBe(
-        "recipient@example.com",
-      );
-    });
-
-    it("returns sender when user is recipient", () => {
-      expect(participant(message, "recipient@example.com")).toBe(
-        "sender@example.com",
-      );
-    });
-
-    it("returns from address when no user email provided", () => {
-      expect(participant(message, "")).toBe("sender@example.com");
+    it.each([
+      ["user is sender", "sender@example.com", "recipient@example.com"],
+      ["user is recipient", "recipient@example.com", "sender@example.com"],
+      ["no user email is provided", "", "sender@example.com"],
+    ])("returns participant when %s", (_caseName, userEmail, expected) => {
+      expect(participant(message, userEmail)).toBe(expected);
     });
   });
 
   describe("normalizeEmailAddress", () => {
-    it("converts email to lowercase", () => {
-      expect(normalizeEmailAddress("John.Doe@GMAIL.com")).toBe(
+    it.each([
+      [
+        "upper-case Gmail address with dots",
+        "John.Doe@GMAIL.com",
         "johndoe@gmail.com",
-      );
-    });
-
-    it("replaces whitespace with dots in local part", () => {
-      expect(normalizeEmailAddress("john doe@example.com")).toBe(
+      ],
+      [
+        "whitespace in local part",
+        "john doe@example.com",
         "johndoe@example.com",
-      );
-    });
-
-    it("handles multiple consecutive spaces", () => {
-      expect(normalizeEmailAddress("john    doe@example.com")).toBe(
+      ],
+      [
+        "multiple consecutive spaces",
+        "john    doe@example.com",
         "johndoe@example.com",
-      );
-    });
-
-    it("preserves existing dots", () => {
-      expect(normalizeEmailAddress("john.doe@example.com")).toBe(
+      ],
+      ["existing dots", "john.doe@example.com", "johndoe@example.com"],
+      [
+        "whitespace around local part",
+        " john doe @example.com",
         "johndoe@example.com",
-      );
-    });
-
-    it("trims whitespace from local part", () => {
-      expect(normalizeEmailAddress(" john doe @example.com")).toBe(
-        "johndoe@example.com",
-      );
-    });
-
-    it("preserves domain part exactly", () => {
-      expect(normalizeEmailAddress("john@sub.example.com")).toBe(
-        "john@sub.example.com",
-      );
-    });
-
-    it("handles invalid email format gracefully", () => {
-      expect(normalizeEmailAddress("not-an-email")).toBe("not-an-email");
-    });
-
-    it("handles empty string", () => {
-      expect(normalizeEmailAddress("")).toBe("");
+      ],
+      ["subdomain", "john@sub.example.com", "john@sub.example.com"],
+      ["invalid email format", "not-an-email", "not-an-email"],
+      ["empty string", "", ""],
+    ])("normalizes %s", (_caseName, input, expected) => {
+      expect(normalizeEmailAddress(input)).toBe(expected);
     });
   });
 
   describe("formatEmailWithName", () => {
-    it("formats email with name", () => {
-      expect(formatEmailWithName("John Doe", "john.doe@example.com")).toBe(
+    const cases: Array<
+      [string, string | null | undefined, string | null | undefined, string]
+    > = [
+      [
+        "name and address",
+        "John Doe",
+        "john.doe@example.com",
         "John Doe <john.doe@example.com>",
-      );
-    });
-
-    it("returns just email when name is not provided", () => {
-      expect(formatEmailWithName(null, "john.doe@example.com")).toBe(
+      ],
+      ["null name", null, "john.doe@example.com", "john.doe@example.com"],
+      [
+        "undefined name",
+        undefined,
         "john.doe@example.com",
-      );
-      expect(formatEmailWithName(undefined, "john.doe@example.com")).toBe(
         "john.doe@example.com",
-      );
-    });
-
-    it("returns just email when name is empty string", () => {
-      expect(formatEmailWithName("", "john.doe@example.com")).toBe(
+      ],
+      ["empty name", "", "john.doe@example.com", "john.doe@example.com"],
+      [
+        "name that equals address",
         "john.doe@example.com",
-      );
-    });
-
-    it("returns just email when name equals address", () => {
-      expect(
-        formatEmailWithName("john.doe@example.com", "john.doe@example.com"),
-      ).toBe("john.doe@example.com");
-    });
-
-    it("returns empty string when address is null or undefined", () => {
-      expect(formatEmailWithName("John Doe", null)).toBe("");
-      expect(formatEmailWithName("John Doe", undefined)).toBe("");
-    });
-
-    it("returns empty string when address is empty string", () => {
-      expect(formatEmailWithName("John Doe", "")).toBe("");
-    });
-
-    it("handles both null/undefined name and address", () => {
-      expect(formatEmailWithName(null, null)).toBe("");
-      expect(formatEmailWithName(undefined, undefined)).toBe("");
-    });
-
-    it("preserves special characters in name", () => {
-      expect(formatEmailWithName("O'Brien, John", "john@example.com")).toBe(
+        "john.doe@example.com",
+        "john.doe@example.com",
+      ],
+      ["null address", "John Doe", null, ""],
+      ["undefined address", "John Doe", undefined, ""],
+      ["empty address", "John Doe", "", ""],
+      ["null name and address", null, null, ""],
+      ["undefined name and address", undefined, undefined, ""],
+      [
+        "special characters in name",
+        "O'Brien, John",
+        "john@example.com",
         "O'Brien, John <john@example.com>",
-      );
+      ],
+      [
+        "unicode name",
+        "José García",
+        "jose@example.com",
+        "José García <jose@example.com>",
+      ],
+      ["non-Latin name", "李明", "li@example.com", "李明 <li@example.com>"],
+      [
+        "hyphenated address",
+        "System",
+        "no-reply@example.com",
+        "System <no-reply@example.com>",
+      ],
+      [
+        "plus-addressed email",
+        "Support",
+        "support+tag@example.com",
+        "Support <support+tag@example.com>",
+      ],
+    ];
+
+    it.each(
+      cases,
+    )("formats %s", (_caseName, displayName, address, expected) => {
+      expect(formatEmailWithName(displayName, address)).toBe(expected);
     });
 
     it("is the inverse of extractNameFromEmail and extractEmailAddress", () => {
@@ -593,88 +450,75 @@ describe("email utils", () => {
       expect(extractNameFromEmail(formatted)).toBe("John Doe");
       expect(extractEmailAddress(formatted)).toBe("john@example.com");
     });
-
-    it("handles names with special characters and unicode", () => {
-      expect(formatEmailWithName("José García", "jose@example.com")).toBe(
-        "José García <jose@example.com>",
-      );
-      expect(formatEmailWithName("李明", "li@example.com")).toBe(
-        "李明 <li@example.com>",
-      );
-    });
-
-    it("handles email addresses with special characters", () => {
-      expect(formatEmailWithName("System", "no-reply@example.com")).toBe(
-        "System <no-reply@example.com>",
-      );
-      expect(formatEmailWithName("Support", "support+tag@example.com")).toBe(
-        "Support <support+tag@example.com>",
-      );
-    });
   });
 
   describe("getNewsletterSenderDisplayName", () => {
-    it("keeps normal sender display names", () => {
-      expect(
-        getNewsletterSenderDisplayName({
+    const cases: Array<[string, NewsletterSender, string]> = [
+      [
+        "normal sender display name",
+        {
           email: "updates@example.com",
           fromName: "Example Updates",
           minFromName: "Example Updates",
           maxFromName: "Example Updates",
-        }),
-      ).toBe("Example Updates");
-    });
-
-    it("uses the sender domain when one address has multiple display names", () => {
-      expect(
-        getNewsletterSenderDisplayName({
+        },
+        "Example Updates",
+      ],
+      [
+        "multiple display names for GitHub notifications",
+        {
           email: "notifications@github.com",
           fromName: "Some Person",
           minFromName: "Another Person",
           maxFromName: "Some Person",
-        }),
-      ).toBe("github.com");
-
-      expect(
-        getNewsletterSenderDisplayName({
+        },
+        "github.com",
+      ],
+      [
+        "multiple display names for LinkedIn invitations",
+        {
           email: "invitations@linkedin.com",
           fromName: "Some Person",
           minFromName: "Another Person",
           maxFromName: "Some Person",
-        }),
-      ).toBe("linkedin.com");
-
-      expect(
-        getNewsletterSenderDisplayName({
+        },
+        "linkedin.com",
+      ],
+      [
+        "multiple display names for LinkedIn digests",
+        {
           email: "messaging-digest-noreply@linkedin.com",
           fromName: "Some Person via LinkedIn",
           minFromName: "Another Person via LinkedIn",
           maxFromName: "Some Person via LinkedIn",
-        }),
-      ).toBe("linkedin.com");
-    });
-
-    it("keeps the selected display name when min and max names match", () => {
-      expect(
-        getNewsletterSenderDisplayName({
+        },
+        "linkedin.com",
+      ],
+      [
+        "matching min and max names",
+        {
           email: "notifications@example.com",
           fromName: "Example",
           minFromName: "Example",
           maxFromName: "Example",
-        }),
-      ).toBe("Example");
-    });
+        },
+        "Example",
+      ],
+      [
+        "missing display name",
+        { email: "updates@example.com", fromName: null },
+        "",
+      ],
+    ];
 
-    it("falls back to an empty display name when no name is available", () => {
-      expect(
-        getNewsletterSenderDisplayName({
-          email: "updates@example.com",
-          fromName: null,
-        }),
-      ).toBe("");
+    it.each(cases)("handles %s", (_caseName, sender, expected) => {
+      expect(getNewsletterSenderDisplayName(sender)).toBe(expected);
     });
   });
 });
+
+type MessageHeaders = Parameters<typeof createMessage>[0];
+type NewsletterSender = Parameters<typeof getNewsletterSenderDisplayName>[0];
 
 function createMessage(
   headers: Partial<{

--- a/apps/web/utils/email/render-safe-links.test.ts
+++ b/apps/web/utils/email/render-safe-links.test.ts
@@ -78,44 +78,51 @@ describe("renderEmailTextWithSafeLinks", () => {
     expect(result).not.toContain("<a href=");
   });
 
-  it("discloses the actual destination when the label contains a different domain", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [getinboxzero.com](https://attacker.tld/login) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://attacker.tld/login">getinboxzero.com - attacker.tld</a>',
-    );
-  });
-
-  it("discloses the actual destination when the label contains a different subdomain", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [login.example.com](https://evil.example.com/login) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://evil.example.com/login">login.example.com - evil.example.com</a>',
-    );
-  });
-
-  it("discloses the full destination when a URL label contains a different path", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [https://example.com/login](https://example.com/phish) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://example.com/phish">https://example.com/login - https://example.com/phish</a>',
-    );
-  });
-
-  it("discloses the full destination when a scheme-less URL label contains a different path", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [example.com/login](https://example.com/phish) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://example.com/phish">example.com/login - https://example.com/phish</a>',
-    );
+  it.each([
+    {
+      name: "label contains a different domain",
+      text: "Use [getinboxzero.com](https://attacker.tld/login) to continue.",
+      expected:
+        '<a href="https://attacker.tld/login">getinboxzero.com - attacker.tld</a>',
+    },
+    {
+      name: "label contains a different subdomain",
+      text: "Use [login.example.com](https://evil.example.com/login) to continue.",
+      expected:
+        '<a href="https://evil.example.com/login">login.example.com - evil.example.com</a>',
+    },
+    {
+      name: "URL label contains a different path",
+      text: "Use [https://example.com/login](https://example.com/phish) to continue.",
+      expected:
+        '<a href="https://example.com/phish">https://example.com/login - https://example.com/phish</a>',
+    },
+    {
+      name: "scheme-less URL label contains a different path",
+      text: "Use [example.com/login](https://example.com/phish) to continue.",
+      expected:
+        '<a href="https://example.com/phish">example.com/login - https://example.com/phish</a>',
+    },
+    {
+      name: "scheme-less label specifies a different port",
+      text: "Use [example.com:8080](http://example.com:9090/path) to continue.",
+      expected:
+        '<a href="http://example.com:9090/path">example.com:8080 - http://example.com:9090/path</a>',
+    },
+    {
+      name: "scheme-less label specifies a fragment",
+      text: "Use [example.com#section](https://example.com/other) to continue.",
+      expected:
+        '<a href="https://example.com/other">example.com#section - https://example.com/other</a>',
+    },
+    {
+      name: "URL label explicitly includes the root slash",
+      text: "Use [https://example.com/](https://example.com/phish) to continue.",
+      expected:
+        '<a href="https://example.com/phish">https://example.com/ - https://example.com/phish</a>',
+    },
+  ])("discloses the full destination when $name", ({ text, expected }) => {
+    expect(renderEmailTextWithSafeLinks(text)).toContain(expected);
   });
 
   it("treats scheme-less URL labels as protocol-agnostic matches", () => {
@@ -125,36 +132,6 @@ describe("renderEmailTextWithSafeLinks", () => {
 
     expect(result).toContain(
       '<a href="http://example.com/login">example.com/login</a>',
-    );
-  });
-
-  it("discloses the full destination when a scheme-less label specifies a different port", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [example.com:8080](http://example.com:9090/path) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="http://example.com:9090/path">example.com:8080 - http://example.com:9090/path</a>',
-    );
-  });
-
-  it("discloses the full destination when a scheme-less label specifies a fragment", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [example.com#section](https://example.com/other) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://example.com/other">example.com#section - https://example.com/other</a>',
-    );
-  });
-
-  it("discloses the full destination when a URL label explicitly includes the root slash", () => {
-    const result = renderEmailTextWithSafeLinks(
-      "Use [https://example.com/](https://example.com/phish) to continue.",
-    );
-
-    expect(result).toContain(
-      '<a href="https://example.com/phish">https://example.com/ - https://example.com/phish</a>',
     );
   });
 

--- a/apps/web/utils/email/rewrite-html.test.ts
+++ b/apps/web/utils/email/rewrite-html.test.ts
@@ -66,20 +66,19 @@ describe("rewriteHtmlRemoteAssetUrls", () => {
     expect(rewrittenHtml).not.toContain("&amp;s=");
   });
 
-  it("does not rewrite data-src attributes", async () => {
-    const html = '<img data-src="https://cdn.example.com/photo.png" />';
-
-    const rewrittenHtml = await rewriteHtmlRemoteAssetUrls(html, proxyOptions);
-
-    expect(rewrittenHtml).toBe(html);
-  });
-
-  it("does not rewrite attribute-like text content", async () => {
-    const html = '<p>src="https://cdn.example.com/photo.png"</p>';
-
-    const rewrittenHtml = await rewriteHtmlRemoteAssetUrls(html, proxyOptions);
-
-    expect(rewrittenHtml).toBe(html);
+  it.each([
+    {
+      name: "data-src attributes",
+      html: '<img data-src="https://cdn.example.com/photo.png" />',
+    },
+    {
+      name: "attribute-like text content",
+      html: '<p>src="https://cdn.example.com/photo.png"</p>',
+    },
+  ])("does not rewrite $name", async ({ html }) => {
+    await expect(rewriteHtmlRemoteAssetUrls(html, proxyOptions)).resolves.toBe(
+      html,
+    );
   });
 
   it("decodes numeric HTML entities before rewriting asset URLs", async () => {
@@ -110,45 +109,36 @@ describe("rewriteHtmlRemoteAssetUrls", () => {
     );
   });
 
-  it("preserves srcset candidates when a url contains commas", async () => {
-    const html =
-      '<img srcset="https://cdn.example.com/photo,name.png 1x, https://cdn.example.com/photo@2x.png 2x" />';
-
+  it.each([
+    {
+      name: "url contains commas",
+      html: '<img srcset="https://cdn.example.com/photo,name.png 1x, https://cdn.example.com/photo@2x.png 2x" />',
+      expectedUrls: [
+        "https://cdn.example.com/photo,name.png",
+        "https://cdn.example.com/photo@2x.png",
+      ],
+    },
+    {
+      name: "compact candidates omit whitespace after commas",
+      html: '<img srcset="https://cdn.example.com/photo.png 1x,https://cdn.example.com/photo@2x.png 2x" />',
+      expectedUrls: [
+        "https://cdn.example.com/photo.png",
+        "https://cdn.example.com/photo@2x.png",
+      ],
+    },
+    {
+      name: "compact list contains relative urls",
+      html: '<img srcset="https://cdn.example.com/photo.png 1x,photo@2x.png 2x,https://cdn.example.com/photo@3x.png 3x" />',
+      expectedUrls: [
+        "https://cdn.example.com/photo.png",
+        "https://cdn.example.com/photo@3x.png",
+      ],
+    },
+  ])("rewrites srcset when $name", async ({ html, expectedUrls }) => {
     const rewrittenHtml = await rewriteHtmlRemoteAssetUrls(html, proxyOptions);
 
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo,name.png"),
-    );
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo@2x.png"),
-    );
-  });
-
-  it("splits compact srcset candidates without whitespace after commas", async () => {
-    const html =
-      '<img srcset="https://cdn.example.com/photo.png 1x,https://cdn.example.com/photo@2x.png 2x" />';
-
-    const rewrittenHtml = await rewriteHtmlRemoteAssetUrls(html, proxyOptions);
-
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo.png"),
-    );
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo@2x.png"),
-    );
-  });
-
-  it("keeps splitting srcset candidates when a compact list contains relative urls", async () => {
-    const html =
-      '<img srcset="https://cdn.example.com/photo.png 1x,photo@2x.png 2x,https://cdn.example.com/photo@3x.png 3x" />';
-
-    const rewrittenHtml = await rewriteHtmlRemoteAssetUrls(html, proxyOptions);
-
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo.png"),
-    );
-    expect(rewrittenHtml).toContain(
-      encodeURIComponent("https://cdn.example.com/photo@3x.png"),
-    );
+    for (const expectedUrl of expectedUrls) {
+      expect(rewrittenHtml).toContain(encodeURIComponent(expectedUrl));
+    }
   });
 });

--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { APICallError, NoObjectGeneratedError } from "ai";
 import { createScopedLogger } from "@/utils/logger";
+
 const { mockSentryCaptureException, mockSetUser } = vi.hoisted(() => ({
   mockSentryCaptureException: vi.fn(),
   mockSetUser: vi.fn(),
@@ -29,14 +30,15 @@ import {
 } from "./error";
 
 describe("getUserFacingErrorMessage", () => {
-  it("returns plain error messages unchanged", () => {
-    const result = getUserFacingErrorMessage(new Error("Something failed"));
-
-    expect(result).toBe("Something failed");
-  });
-
-  it("formats structured JSON errors", () => {
-    const result = getUserFacingErrorMessage(
+  it.each([
+    [
+      "plain error message",
+      new Error("Something failed"),
+      undefined,
+      "Something failed",
+    ],
+    [
+      "structured JSON message",
       new Error(
         JSON.stringify({
           code: 502,
@@ -44,39 +46,33 @@ describe("getUserFacingErrorMessage", () => {
           metadata: { provider_name: "xAI" },
         }),
       ),
-    );
-
-    expect(result).toBe("Invalid arguments passed to the model.");
-  });
-
-  it("reads direct string error from structured payloads", () => {
-    const result = getUserFacingErrorMessage(
-      new Error(
-        JSON.stringify({
-          error: "Too many requests",
-        }),
-      ),
-    );
-
-    expect(result).toBe("Too many requests");
-  });
-
-  it("reads nested message from structured error payloads", () => {
-    const result = getUserFacingErrorMessage(
+      undefined,
+      "Invalid arguments passed to the model.",
+    ],
+    [
+      "direct string error from structured payload",
+      new Error(JSON.stringify({ error: "Too many requests" })),
+      undefined,
+      "Too many requests",
+    ],
+    [
+      "nested message from structured error payload",
       new Error(
         JSON.stringify({
           error: { message: "Upstream model rejected this request." },
         }),
       ),
-    );
+      undefined,
+      "Upstream model rejected this request.",
+    ],
+    ["fallback when no message can be extracted", {}, "Fallback", "Fallback"],
+  ])("returns %s", (_caseName, error, fallback, expected) => {
+    const result =
+      fallback === undefined
+        ? getUserFacingErrorMessage(error)
+        : getUserFacingErrorMessage(error, fallback);
 
-    expect(result).toBe("Upstream model rejected this request.");
-  });
-
-  it("uses fallback when no message can be extracted", () => {
-    const result = getUserFacingErrorMessage({}, "Fallback");
-
-    expect(result).toBe("Fallback");
+    expect(result).toBe(expected);
   });
 });
 
@@ -87,21 +83,9 @@ describe("captureException", () => {
 
   it("forwards attached LLM repair metadata to Sentry extra context", () => {
     const error = new Error("generation failed");
-    attachLlmRepairMetadata(error, {
-      attempted: true,
-      successful: false,
-      label: "Categorize sender",
-      provider: "openai",
-      model: "gpt-test",
-      inputLength: 12,
-      inputFingerprint: "abc123",
-      startsWithQuote: true,
-      startsWithBrace: false,
-      startsWithBracket: false,
-      looksCodeFenced: false,
-      candidateKindsTried: ["trimmed", "original"],
-    });
+    const llmRepair = createLlmRepairMetadata();
 
+    attachLlmRepairMetadata(error, llmRepair);
     captureException(error, {
       userEmail: "user@example.com",
       extra: { operation: "test" },
@@ -111,20 +95,7 @@ describe("captureException", () => {
     expect(mockSentryCaptureException).toHaveBeenCalledWith(error, {
       extra: {
         operation: "test",
-        llmRepair: {
-          attempted: true,
-          successful: false,
-          label: "Categorize sender",
-          provider: "openai",
-          model: "gpt-test",
-          inputLength: 12,
-          inputFingerprint: "abc123",
-          startsWithQuote: true,
-          startsWithBrace: false,
-          startsWithBracket: false,
-          looksCodeFenced: false,
-          candidateKindsTried: ["trimmed", "original"],
-        },
+        llmRepair,
       },
     });
   });
@@ -133,20 +104,7 @@ describe("captureException", () => {
     const error = Object.preventExtensions(new Error("generation failed"));
 
     expect(() =>
-      attachLlmRepairMetadata(error, {
-        attempted: true,
-        successful: false,
-        label: "Categorize sender",
-        provider: "openai",
-        model: "gpt-test",
-        inputLength: 12,
-        inputFingerprint: "abc123",
-        startsWithQuote: true,
-        startsWithBrace: false,
-        startsWithBracket: false,
-        looksCodeFenced: false,
-        candidateKindsTried: ["trimmed", "original"],
-      }),
+      attachLlmRepairMetadata(error, createLlmRepairMetadata()),
     ).not.toThrow();
 
     captureException(error, {
@@ -160,6 +118,418 @@ describe("captureException", () => {
     });
   });
 });
+
+describe("getActionErrorMessage", () => {
+  const cases: Array<
+    [string, ActionErrorInput, ActionErrorOptions | undefined, string]
+  > = [
+    [
+      "serverError when present",
+      { serverError: "Database connection failed" },
+      undefined,
+      "Database connection failed",
+    ],
+    [
+      "validation errors from flattened validationErrors shape",
+      {
+        validationErrors: {
+          formErrors: ["Form is invalid"],
+          fieldErrors: {
+            email: ["Email is required"],
+            password: ["Password too short"],
+          },
+        },
+      },
+      undefined,
+      "Form is invalid. Email is required. Password too short",
+    ],
+    [
+      "only field errors when no form errors",
+      {
+        validationErrors: {
+          formErrors: [],
+          fieldErrors: {
+            name: ["Name must be at least 10 characters"],
+          },
+        },
+      },
+      undefined,
+      "Name must be at least 10 characters",
+    ],
+    [
+      "bindArgsValidationErrors when validationErrors is empty",
+      {
+        validationErrors: {
+          formErrors: [],
+          fieldErrors: {},
+        },
+        bindArgsValidationErrors: [
+          {
+            formErrors: ["Invalid account ID"],
+            fieldErrors: {},
+          },
+        ],
+      },
+      undefined,
+      "Invalid account ID",
+    ],
+    [
+      "first non-empty bindArgsValidationErrors entry",
+      {
+        bindArgsValidationErrors: [
+          undefined,
+          {
+            formErrors: [],
+            fieldErrors: {},
+          },
+          {
+            formErrors: ["Third entry error"],
+            fieldErrors: {},
+          },
+        ],
+      },
+      undefined,
+      "Third entry error",
+    ],
+    [
+      "fallback when no errors are present",
+      {},
+      undefined,
+      "An unknown error occurred",
+    ],
+    [
+      "custom fallback when provided",
+      {},
+      "Something went wrong",
+      "Something went wrong",
+    ],
+    [
+      "serverError before validation errors",
+      {
+        serverError: "Server error",
+        validationErrors: {
+          formErrors: ["Validation error"],
+          fieldErrors: {},
+        },
+      },
+      undefined,
+      "Server error",
+    ],
+    [
+      "validationErrors before bindArgsValidationErrors",
+      {
+        validationErrors: {
+          formErrors: ["Input validation error"],
+          fieldErrors: {},
+        },
+        bindArgsValidationErrors: [
+          {
+            formErrors: ["Bind args error"],
+            fieldErrors: {},
+          },
+        ],
+      },
+      undefined,
+      "Input validation error",
+    ],
+  ];
+
+  it.each(cases)("returns %s", (_caseName, error, options, expected) => {
+    const result =
+      options === undefined
+        ? getActionErrorMessage(error)
+        : getActionErrorMessage(error, options);
+
+    expect(result).toBe(expected);
+  });
+
+  describe("with prefix option", () => {
+    it.each([
+      [
+        "prepended to server error",
+        { serverError: "Invalid input" },
+        { prefix: "Failed to save" },
+        "Failed to save. Invalid input",
+      ],
+      [
+        "returned alone when no error message exists",
+        {},
+        { prefix: "Failed to save" },
+        "Failed to save",
+      ],
+      [
+        "prepended to validation errors",
+        {
+          validationErrors: {
+            formErrors: [],
+            fieldErrors: { name: ["Name is required"] },
+          },
+        },
+        { prefix: "Failed to update user" },
+        "Failed to update user. Name is required",
+      ],
+      [
+        "preferred over fallback when no error exists",
+        {},
+        { prefix: "Failed to save", fallback: "Please try again" },
+        "Failed to save",
+      ],
+      [
+        "absent when only fallback is provided",
+        {},
+        { fallback: "Custom fallback message" },
+        "Custom fallback message",
+      ],
+    ] satisfies Array<
+      [string, ActionErrorInput, ActionErrorOptions, string]
+    >)("handles prefix when %s", (_caseName, error, options, expected) => {
+      expect(getActionErrorMessage(error, options)).toBe(expected);
+    });
+  });
+});
+
+describe("isInsufficientCreditsError", () => {
+  it.each([
+    ["HTTP 402 status code", 402, true],
+    ["other status codes", 429, false],
+  ])("returns %s for %s", (expectedLabel, statusCode, expected) => {
+    const error = createAPICallError({
+      message: expectedLabel,
+      statusCode,
+    });
+
+    expect(isInsufficientCreditsError(error)).toBe(expected);
+  });
+});
+
+describe("markAsHandledUserKeyError / isHandledUserKeyError", () => {
+  it("marks and detects handled user key errors", () => {
+    const error = createAPICallError({
+      message: "Insufficient credits",
+      statusCode: 402,
+    });
+    expect(isHandledUserKeyError(error)).toBe(false);
+    markAsHandledUserKeyError(error);
+    expect(isHandledUserKeyError(error)).toBe(true);
+  });
+
+  it.each([
+    ["unmarked errors", new Error("some error")],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns false for %s", (_caseName, error) => {
+    expect(isHandledUserKeyError(error)).toBe(false);
+  });
+});
+
+describe("isOutlookThrottlingError", () => {
+  it.each([
+    ["ApplicationThrottled code", { code: "ApplicationThrottled" }],
+    ["TooManyRequests code", { code: "TooManyRequests" }],
+    ["429 status code", { statusCode: 429 }],
+    [
+      "MailboxConcurrency message",
+      { message: "MailboxConcurrency limit exceeded" },
+    ],
+    [
+      "Request limit message",
+      { message: "Application is over its Request limit." },
+    ],
+  ])("detects %s", (_caseName, error) => {
+    expect(isOutlookThrottlingError(error)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isOutlookThrottlingError({ code: "NotFound" })).toBe(false);
+  });
+});
+
+describe("isOutlookAccessDeniedError", () => {
+  it.each([
+    [
+      "Access is denied message with remediation",
+      { message: "Access is denied. Check credentials and try again." },
+    ],
+    ["ErrorAccessDenied code", { code: "ErrorAccessDenied" }],
+    [
+      "string error with Access is denied remediation",
+      "Access is denied. Check credentials and try again.",
+    ],
+  ])("detects %s", (_caseName, error) => {
+    expect(isOutlookAccessDeniedError(error)).toBe(true);
+  });
+
+  it.each([
+    ["bare 403 status code", { statusCode: 403 }],
+    [
+      "generic access denied from other providers",
+      { message: "Access is denied" },
+    ],
+    ["unrelated errors", { message: "Not found" }],
+  ])("returns false for %s", (_caseName, error) => {
+    expect(isOutlookAccessDeniedError(error)).toBe(false);
+  });
+});
+
+describe("isOutlookItemNotFoundError", () => {
+  it.each([
+    ["ErrorItemNotFound code", { code: "ErrorItemNotFound" }],
+    [
+      "store ID message",
+      { message: "The store ID provided isn't an ID of an item." },
+    ],
+    ["ResourceNotFound message", { message: "ResourceNotFound" }],
+    [
+      "string error with store ID",
+      "The store ID provided isn't an ID of an item.",
+    ],
+  ])("detects %s", (_caseName, error) => {
+    expect(isOutlookItemNotFoundError(error)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isOutlookItemNotFoundError({ message: "Access denied" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isKnownOutlookError", () => {
+  it.each([
+    ["throttling errors", { code: "ApplicationThrottled" }],
+    [
+      "access denied errors",
+      { message: "Access is denied. Check credentials and try again." },
+    ],
+    ["item not found errors", { code: "ErrorItemNotFound" }],
+  ])("detects %s", (_caseName, error) => {
+    expect(isKnownOutlookError(error)).toBe(true);
+  });
+
+  it("returns false for unknown errors", () => {
+    expect(isKnownOutlookError({ message: "Something unexpected" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("isKnownApiError", () => {
+  it.each([
+    [
+      "HTTP 402 errors",
+      createAPICallError({
+        message: "Insufficient credits",
+        statusCode: 402,
+      }),
+      false,
+    ],
+    [
+      "incorrect OpenAI API key errors",
+      createAPICallError({
+        message: "Incorrect API key provided",
+        statusCode: 401,
+      }),
+      true,
+    ],
+    [
+      "provider rate-limit mode errors",
+      Object.assign(new Error("Rate-limit mode active"), {
+        name: "ProviderRateLimitModeError",
+        provider: "google",
+      }),
+      true,
+    ],
+    [
+      "LLM content-filter refusals",
+      createNoObjectGeneratedError({
+        finishReason: "content-filter",
+        text: "I'm sorry, but I cannot assist with that request.",
+      }),
+      true,
+    ],
+  ])("returns %s for %s", (_caseName, error, expected) => {
+    expect(isKnownApiError(error)).toBe(expected);
+  });
+});
+
+describe("isContentFilterRefusal", () => {
+  it("returns true for NoObjectGeneratedError with content-filter finish reason", () => {
+    const error = createNoObjectGeneratedError({
+      finishReason: "content-filter",
+      text: "I'm sorry, but I cannot assist with that request.",
+    });
+
+    expect(isContentFilterRefusal(error)).toBe(true);
+  });
+
+  it.each([
+    [
+      "NoObjectGeneratedError with stop finish reason",
+      createNoObjectGeneratedError({ finishReason: "stop", text: "not json" }),
+    ],
+    [
+      "NoObjectGeneratedError with length finish reason",
+      createNoObjectGeneratedError({
+        finishReason: "length",
+        text: "truncated",
+      }),
+    ],
+    ["unrelated errors", new Error("boom")],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns false for %s", (_caseName, error) => {
+    expect(isContentFilterRefusal(error)).toBe(false);
+  });
+});
+
+describe("checkCommonErrors", () => {
+  const logger = createScopedLogger("error-test");
+
+  it.each([
+    [
+      "Gmail",
+      createProviderRateLimitError("google"),
+      {
+        type: "Gmail Rate Limit Exceeded",
+        message:
+          "Gmail is temporarily limiting requests. Please try again shortly.",
+        code: 429,
+      },
+    ],
+    [
+      "Outlook",
+      createProviderRateLimitError("microsoft"),
+      {
+        type: "Outlook Rate Limit",
+        message:
+          "Microsoft is temporarily limiting requests. Please try again shortly.",
+        code: 429,
+      },
+    ],
+  ])("maps provider rate-limit mode errors for %s", (_caseName, error, expected) => {
+    expect(checkCommonErrors(error, "/api/test", logger)).toEqual(expected);
+  });
+});
+
+type ActionErrorInput = Parameters<typeof getActionErrorMessage>[0];
+type ActionErrorOptions = Parameters<typeof getActionErrorMessage>[1];
+
+function createLlmRepairMetadata() {
+  return {
+    attempted: true,
+    successful: false,
+    label: "Categorize sender",
+    provider: "openai",
+    model: "gpt-test",
+    inputLength: 12,
+    inputFingerprint: "abc123",
+    startsWithQuote: true,
+    startsWithBrace: false,
+    startsWithBracket: false,
+    looksCodeFenced: false,
+    candidateKindsTried: ["trimmed", "original"],
+  } as const;
+}
 
 function createAPICallError({
   message,
@@ -194,440 +564,10 @@ function createNoObjectGeneratedError({
   });
 }
 
-describe("getActionErrorMessage", () => {
-  it("returns serverError when present", () => {
-    const result = getActionErrorMessage({
-      serverError: "Database connection failed",
-    });
-
-    expect(result).toBe("Database connection failed");
+function createProviderRateLimitError(provider: "google" | "microsoft") {
+  return Object.assign(new Error("Rate-limit mode active"), {
+    name: "ProviderRateLimitModeError",
+    provider,
+    retryAt: new Date(Date.now() + 60_000).toISOString(),
   });
-
-  // This test uses the REAL flattened shape that next-safe-action returns
-  // when defaultValidationErrorsShape: "flattened" is configured
-  it("returns validation errors from flattened validationErrors shape", () => {
-    const result = getActionErrorMessage({
-      validationErrors: {
-        formErrors: ["Form is invalid"],
-        fieldErrors: {
-          email: ["Email is required"],
-          password: ["Password too short"],
-        },
-      } as any,
-    });
-
-    expect(result).toBe(
-      "Form is invalid. Email is required. Password too short",
-    );
-  });
-
-  it("returns only field errors when no form errors (flattened shape)", () => {
-    const result = getActionErrorMessage({
-      validationErrors: {
-        formErrors: [],
-        fieldErrors: {
-          name: ["Name must be at least 10 characters"],
-        },
-      } as any,
-    });
-
-    expect(result).toBe("Name must be at least 10 characters");
-  });
-
-  it("returns bindArgsValidationErrors when validationErrors is empty (flattened shape)", () => {
-    const result = getActionErrorMessage({
-      validationErrors: {
-        formErrors: [],
-        fieldErrors: {},
-      } as any,
-      bindArgsValidationErrors: [
-        {
-          formErrors: ["Invalid account ID"],
-          fieldErrors: {},
-        } as any,
-      ],
-    });
-
-    expect(result).toBe("Invalid account ID");
-  });
-
-  it("skips empty bindArgsValidationErrors entries (flattened shape)", () => {
-    const result = getActionErrorMessage({
-      bindArgsValidationErrors: [
-        undefined as any,
-        {
-          formErrors: [],
-          fieldErrors: {},
-        } as any,
-        {
-          formErrors: ["Third entry error"],
-          fieldErrors: {},
-        } as any,
-      ],
-    });
-
-    expect(result).toBe("Third entry error");
-  });
-
-  it("returns fallback when no errors present", () => {
-    const result = getActionErrorMessage({});
-
-    expect(result).toBe("An unknown error occurred");
-  });
-
-  it("returns custom fallback when provided", () => {
-    const result = getActionErrorMessage({}, "Something went wrong");
-
-    expect(result).toBe("Something went wrong");
-  });
-
-  it("prioritizes serverError over validation errors (flattened shape)", () => {
-    const result = getActionErrorMessage({
-      serverError: "Server error",
-      validationErrors: {
-        formErrors: ["Validation error"],
-        fieldErrors: {},
-      } as any,
-    });
-
-    expect(result).toBe("Server error");
-  });
-
-  it("prioritizes validationErrors over bindArgsValidationErrors (flattened shape)", () => {
-    const result = getActionErrorMessage({
-      validationErrors: {
-        formErrors: ["Input validation error"],
-        fieldErrors: {},
-      } as any,
-      bindArgsValidationErrors: [
-        {
-          formErrors: ["Bind args error"],
-          fieldErrors: {},
-        } as any,
-      ],
-    });
-
-    expect(result).toBe("Input validation error");
-  });
-
-  describe("with prefix option", () => {
-    it("prepends prefix to error message", () => {
-      const result = getActionErrorMessage(
-        { serverError: "Invalid input" },
-        { prefix: "Failed to save" },
-      );
-
-      expect(result).toBe("Failed to save. Invalid input");
-    });
-
-    it("returns only prefix when no error message", () => {
-      const result = getActionErrorMessage({}, { prefix: "Failed to save" });
-
-      expect(result).toBe("Failed to save");
-    });
-
-    it("prepends prefix to validation errors", () => {
-      const result = getActionErrorMessage(
-        {
-          validationErrors: {
-            formErrors: [],
-            fieldErrors: { name: ["Name is required"] },
-          } as any,
-        },
-        { prefix: "Failed to update user" },
-      );
-
-      expect(result).toBe("Failed to update user. Name is required");
-    });
-
-    it("uses custom fallback with prefix when no error", () => {
-      const result = getActionErrorMessage(
-        {},
-        { prefix: "Failed to save", fallback: "Please try again" },
-      );
-
-      expect(result).toBe("Failed to save");
-    });
-
-    it("uses fallback when no prefix and no error", () => {
-      const result = getActionErrorMessage(
-        {},
-        { fallback: "Custom fallback message" },
-      );
-
-      expect(result).toBe("Custom fallback message");
-    });
-  });
-});
-
-describe("isInsufficientCreditsError", () => {
-  it("returns true for HTTP 402 status code", () => {
-    const error = createAPICallError({
-      message: "Insufficient credits",
-      statusCode: 402,
-    });
-    expect(isInsufficientCreditsError(error)).toBe(true);
-  });
-
-  it("returns false for other status codes", () => {
-    const error = createAPICallError({
-      message: "Rate limit exceeded",
-      statusCode: 429,
-    });
-    expect(isInsufficientCreditsError(error)).toBe(false);
-  });
-});
-
-describe("markAsHandledUserKeyError / isHandledUserKeyError", () => {
-  it("marks and detects handled user key errors", () => {
-    const error = createAPICallError({
-      message: "Insufficient credits",
-      statusCode: 402,
-    });
-    expect(isHandledUserKeyError(error)).toBe(false);
-    markAsHandledUserKeyError(error);
-    expect(isHandledUserKeyError(error)).toBe(true);
-  });
-
-  it("returns false for unmarked errors", () => {
-    const error = new Error("some error");
-    expect(isHandledUserKeyError(error)).toBe(false);
-  });
-
-  it("returns false for non-error values", () => {
-    expect(isHandledUserKeyError(null)).toBe(false);
-    expect(isHandledUserKeyError(undefined)).toBe(false);
-  });
-});
-
-describe("isOutlookThrottlingError", () => {
-  it("detects ApplicationThrottled code", () => {
-    expect(isOutlookThrottlingError({ code: "ApplicationThrottled" })).toBe(
-      true,
-    );
-  });
-
-  it("detects TooManyRequests code", () => {
-    expect(isOutlookThrottlingError({ code: "TooManyRequests" })).toBe(true);
-  });
-
-  it("detects 429 status code", () => {
-    expect(isOutlookThrottlingError({ statusCode: 429 })).toBe(true);
-  });
-
-  it("detects MailboxConcurrency message", () => {
-    expect(
-      isOutlookThrottlingError({
-        message: "MailboxConcurrency limit exceeded",
-      }),
-    ).toBe(true);
-  });
-
-  it("detects Request limit message", () => {
-    expect(
-      isOutlookThrottlingError({
-        message: "Application is over its Request limit.",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(isOutlookThrottlingError({ code: "NotFound" })).toBe(false);
-  });
-});
-
-describe("isOutlookAccessDeniedError", () => {
-  it("detects Access is denied message", () => {
-    expect(
-      isOutlookAccessDeniedError({
-        message: "Access is denied. Check credentials and try again.",
-      }),
-    ).toBe(true);
-  });
-
-  it("detects ErrorAccessDenied code", () => {
-    expect(isOutlookAccessDeniedError({ code: "ErrorAccessDenied" })).toBe(
-      true,
-    );
-  });
-
-  it("does not match bare 403 status code (could be app misconfiguration)", () => {
-    expect(isOutlookAccessDeniedError({ statusCode: 403 })).toBe(false);
-  });
-
-  it("detects string error with Access is denied", () => {
-    expect(
-      isOutlookAccessDeniedError(
-        "Access is denied. Check credentials and try again.",
-      ),
-    ).toBe(true);
-  });
-
-  it("does not match generic access denied from other providers", () => {
-    expect(isOutlookAccessDeniedError({ message: "Access is denied" })).toBe(
-      false,
-    );
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(isOutlookAccessDeniedError({ message: "Not found" })).toBe(false);
-  });
-});
-
-describe("isOutlookItemNotFoundError", () => {
-  it("detects ErrorItemNotFound code", () => {
-    expect(isOutlookItemNotFoundError({ code: "ErrorItemNotFound" })).toBe(
-      true,
-    );
-  });
-
-  it("detects store ID message", () => {
-    expect(
-      isOutlookItemNotFoundError({
-        message: "The store ID provided isn't an ID of an item.",
-      }),
-    ).toBe(true);
-  });
-
-  it("detects ResourceNotFound message", () => {
-    expect(isOutlookItemNotFoundError({ message: "ResourceNotFound" })).toBe(
-      true,
-    );
-  });
-
-  it("detects string error with store ID", () => {
-    expect(
-      isOutlookItemNotFoundError(
-        "The store ID provided isn't an ID of an item.",
-      ),
-    ).toBe(true);
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(isOutlookItemNotFoundError({ message: "Access denied" })).toBe(
-      false,
-    );
-  });
-});
-
-describe("isKnownOutlookError", () => {
-  it("detects throttling errors", () => {
-    expect(isKnownOutlookError({ code: "ApplicationThrottled" })).toBe(true);
-  });
-
-  it("detects access denied errors", () => {
-    expect(
-      isKnownOutlookError({
-        message: "Access is denied. Check credentials and try again.",
-      }),
-    ).toBe(true);
-  });
-
-  it("detects item not found errors", () => {
-    expect(isKnownOutlookError({ code: "ErrorItemNotFound" })).toBe(true);
-  });
-
-  it("returns false for unknown errors", () => {
-    expect(isKnownOutlookError({ message: "Something unexpected" })).toBe(
-      false,
-    );
-  });
-});
-
-describe("isKnownApiError", () => {
-  it("does not treat 402 as a known API error", () => {
-    const error = createAPICallError({
-      message: "Insufficient credits",
-      statusCode: 402,
-    });
-    expect(isKnownApiError(error)).toBe(false);
-  });
-
-  it("treats incorrect OpenAI API key as a known error", () => {
-    const error = createAPICallError({
-      message: "Incorrect API key provided",
-      statusCode: 401,
-    });
-    expect(isKnownApiError(error)).toBe(true);
-  });
-
-  it("treats provider rate-limit mode errors as known errors", () => {
-    const error = Object.assign(new Error("Rate-limit mode active"), {
-      name: "ProviderRateLimitModeError",
-      provider: "google",
-    });
-    expect(isKnownApiError(error)).toBe(true);
-  });
-
-  it("treats LLM content-filter refusals as known errors", () => {
-    const error = createNoObjectGeneratedError({
-      finishReason: "content-filter",
-      text: "I'm sorry, but I cannot assist with that request.",
-    });
-    expect(isKnownApiError(error)).toBe(true);
-  });
-});
-
-describe("isContentFilterRefusal", () => {
-  it("returns true for NoObjectGeneratedError with content-filter finish reason", () => {
-    const error = createNoObjectGeneratedError({
-      finishReason: "content-filter",
-      text: "I'm sorry, but I cannot assist with that request.",
-    });
-    expect(isContentFilterRefusal(error)).toBe(true);
-  });
-
-  it("returns false for NoObjectGeneratedError with other finish reasons", () => {
-    const stopError = createNoObjectGeneratedError({
-      finishReason: "stop",
-      text: "not json",
-    });
-    expect(isContentFilterRefusal(stopError)).toBe(false);
-
-    const lengthError = createNoObjectGeneratedError({
-      finishReason: "length",
-      text: "truncated",
-    });
-    expect(isContentFilterRefusal(lengthError)).toBe(false);
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(isContentFilterRefusal(new Error("boom"))).toBe(false);
-    expect(isContentFilterRefusal(null)).toBe(false);
-    expect(isContentFilterRefusal(undefined)).toBe(false);
-  });
-});
-
-describe("checkCommonErrors", () => {
-  const logger = createScopedLogger("error-test");
-
-  it("maps provider rate-limit mode errors for Gmail", () => {
-    const error = Object.assign(new Error("Rate-limit mode active"), {
-      name: "ProviderRateLimitModeError",
-      provider: "google",
-      retryAt: new Date(Date.now() + 60_000).toISOString(),
-    });
-
-    expect(checkCommonErrors(error, "/api/test", logger)).toEqual({
-      type: "Gmail Rate Limit Exceeded",
-      message:
-        "Gmail is temporarily limiting requests. Please try again shortly.",
-      code: 429,
-    });
-  });
-
-  it("maps provider rate-limit mode errors for Outlook", () => {
-    const error = Object.assign(new Error("Rate-limit mode active"), {
-      name: "ProviderRateLimitModeError",
-      provider: "microsoft",
-      retryAt: new Date(Date.now() + 60_000).toISOString(),
-    });
-
-    expect(checkCommonErrors(error, "/api/test", logger)).toEqual({
-      type: "Outlook Rate Limit",
-      message:
-        "Microsoft is temporarily limiting requests. Please try again shortly.",
-      code: 429,
-    });
-  });
-});
+}

--- a/apps/web/utils/filebot/is-filebot-email.test.ts
+++ b/apps/web/utils/filebot/is-filebot-email.test.ts
@@ -6,124 +6,108 @@ import {
 } from "./is-filebot-email";
 
 describe("isFilebotEmail", () => {
-  it("should return true for valid filebot email", () => {
-    const result = isFilebotEmail({
+  it.each([
+    {
+      name: "valid filebot email",
       userEmail: "john@example.com",
       emailToCheck: "john+ai@example.com",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should return false when recipient is different user", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "different recipient",
       userEmail: "john@example.com",
       emailToCheck: "jane+ai@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should return false for plain email without filebot suffix", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "plain email without filebot suffix",
       userEmail: "john@example.com",
       emailToCheck: "john@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should return false for email with token suffix (old format)", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "email with old token suffix format",
       userEmail: "john@example.com",
       emailToCheck: "john+ai-abc123@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should handle email addresses with dots", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "email addresses with dots",
       userEmail: "john.doe@sub.example.com",
       emailToCheck: "john.doe+ai@sub.example.com",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should handle display name with angle brackets", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "display name with angle brackets",
       userEmail: "john@example.com",
       emailToCheck: "John Doe <john+ai@example.com>",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should reject malicious domain injection", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "domain injection attempt",
       userEmail: "john@example.com",
       emailToCheck: "john+ai@evil.com+ai@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should reject case manipulation", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "case manipulation",
       userEmail: "john@example.com",
       emailToCheck: "john+AI@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should handle invalid userEmail format gracefully", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "invalid userEmail format",
       userEmail: "notanemail",
       emailToCheck: "john+ai@example.com",
-    });
-    expect(result).toBe(false);
-  });
-
-  it("should handle domain case insensitivity", () => {
-    const result = isFilebotEmail({
+      expected: false,
+    },
+    {
+      name: "domain case insensitivity",
       userEmail: "john@example.com",
       emailToCheck: "john+ai@EXAMPLE.COM",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should detect filebot email when not first in multiple recipients", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "filebot email not first in multiple recipients",
       userEmail: "john@example.com",
       emailToCheck: "alice@example.com, john+ai@example.com",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should detect filebot email in middle of multiple recipients", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "filebot email in middle of multiple recipients",
       userEmail: "john@example.com",
       emailToCheck: "alice@example.com, john+ai@example.com, bob@example.com",
-    });
-    expect(result).toBe(true);
-  });
-
-  it("should detect filebot email with display names in multiple recipients", () => {
-    const result = isFilebotEmail({
+      expected: true,
+    },
+    {
+      name: "filebot email with display names in multiple recipients",
       userEmail: "john@example.com",
       emailToCheck: "Alice <alice@example.com>, John Doe <john+ai@example.com>",
-    });
-    expect(result).toBe(true);
+      expected: true,
+    },
+  ])("should return $expected for $name", ({
+    userEmail,
+    emailToCheck,
+    expected,
+  }) => {
+    expect(isFilebotEmail({ userEmail, emailToCheck })).toBe(expected);
   });
 });
 
 describe("getFilebotEmail", () => {
-  it("should generate correct filebot email", () => {
-    const result = getFilebotEmail({
+  it.each([
+    {
+      name: "standard email",
       userEmail: "john@example.com",
-    });
-    expect(result).toBe("john+ai@example.com");
-  });
-
-  it("should handle email with dots", () => {
-    const result = getFilebotEmail({
+      expected: "john+ai@example.com",
+    },
+    {
+      name: "email with dots",
       userEmail: "john.doe@sub.example.com",
-    });
-    expect(result).toBe("john.doe+ai@sub.example.com");
+      expected: "john.doe+ai@sub.example.com",
+    },
+  ])("should generate filebot address for $name", ({ userEmail, expected }) => {
+    expect(getFilebotEmail({ userEmail })).toBe(expected);
   });
 
   it("should throw for invalid userEmail format", () => {
@@ -136,35 +120,37 @@ describe("getFilebotEmail", () => {
 });
 
 describe("isFilebotNotificationMessage", () => {
-  it("should return true when reply-to uses the filebot address", () => {
-    const result = isFilebotNotificationMessage({
-      userEmail: "john@example.com",
-      from: "John <john@example.com>",
-      to: "john@example.com",
-      replyTo: "Inbox Zero Assistant <john+ai@example.com>",
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should return true for assistant-formatted self-email without reply-to", () => {
-    const result = isFilebotNotificationMessage({
-      userEmail: "john@example.com",
-      from: "Inbox Zero Assistant <john@example.com>",
-      to: "john@example.com",
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it("should return false for a normal outbound email", () => {
-    const result = isFilebotNotificationMessage({
-      userEmail: "john@example.com",
-      from: "John <john@example.com>",
-      to: "alice@example.com",
-      replyTo: "john@example.com",
-    });
-
-    expect(result).toBe(false);
+  it.each([
+    {
+      name: "reply-to uses the filebot address",
+      message: {
+        userEmail: "john@example.com",
+        from: "John <john@example.com>",
+        to: "john@example.com",
+        replyTo: "Inbox Zero Assistant <john+ai@example.com>",
+      },
+      expected: true,
+    },
+    {
+      name: "assistant-formatted self-email without reply-to",
+      message: {
+        userEmail: "john@example.com",
+        from: "Inbox Zero Assistant <john@example.com>",
+        to: "john@example.com",
+      },
+      expected: true,
+    },
+    {
+      name: "normal outbound email",
+      message: {
+        userEmail: "john@example.com",
+        from: "John <john@example.com>",
+        to: "alice@example.com",
+        replyTo: "john@example.com",
+      },
+      expected: false,
+    },
+  ])("should return $expected for $name", ({ message, expected }) => {
+    expect(isFilebotNotificationMessage(message)).toBe(expected);
   });
 });

--- a/apps/web/utils/group/find-matching-group.test.ts
+++ b/apps/web/utils/group/find-matching-group.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it } from "vitest";
 import { findMatchingGroupItem } from "./find-matching-group";
 import { GroupItemType } from "@/generated/prisma/enums";
 
-// Run with:
-// pnpm test utils/group/find-matching-group.test.ts
-
 describe("findMatchingGroupItem", () => {
   it("should match FROM rules", () => {
     const groupItems = [
@@ -16,29 +13,20 @@ describe("findMatchingGroupItem", () => {
       { type: GroupItemType.FROM, value: "@company.com", exclude: false },
     ];
 
-    // Full email match
-    expect(
-      findMatchingGroupItem(
-        { from: "newsletter@company.com", subject: "" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
-
-    // Partial domain match
-    expect(
-      findMatchingGroupItem(
-        { from: "support@company.com", subject: "" },
-        groupItems,
-      ),
-    ).toBe(groupItems[1]);
-
-    // No match
-    expect(
-      findMatchingGroupItem(
-        { from: "someone@other.com", subject: "" },
-        groupItems,
-      ),
-    ).toBeUndefined();
+    expectMatchResults(groupItems, [
+      {
+        email: { from: "newsletter@company.com", subject: "" },
+        expected: groupItems[0],
+      },
+      {
+        email: { from: "support@company.com", subject: "" },
+        expected: groupItems[1],
+      },
+      {
+        email: { from: "someone@other.com", subject: "" },
+        expected: undefined,
+      },
+    ]);
   });
 
   it("should match SUBJECT rules", () => {
@@ -47,34 +35,24 @@ describe("findMatchingGroupItem", () => {
       { type: GroupItemType.SUBJECT, value: "[GitHub]", exclude: false },
     ];
 
-    // Exact subject match
-    expect(
-      findMatchingGroupItem({ from: "", subject: "Invoice #123" }, groupItems),
-    ).toBe(groupItems[0]);
-
-    // Match after number removal
-    expect(
-      findMatchingGroupItem(
-        { from: "", subject: "Invoice INV-2023-001 from Company" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
-
-    // GitHub notification match
-    expect(
-      findMatchingGroupItem(
-        { from: "", subject: "[GitHub] PR #456: Fix bug" },
-        groupItems,
-      ),
-    ).toBe(groupItems[1]);
-
-    // No match
-    expect(
-      findMatchingGroupItem(
-        { from: "", subject: "Welcome to our service" },
-        groupItems,
-      ),
-    ).toBeUndefined();
+    expectMatchResults(groupItems, [
+      {
+        email: { from: "", subject: "Invoice #123" },
+        expected: groupItems[0],
+      },
+      {
+        email: { from: "", subject: "Invoice INV-2023-001 from Company" },
+        expected: groupItems[0],
+      },
+      {
+        email: { from: "", subject: "[GitHub] PR #456: Fix bug" },
+        expected: groupItems[1],
+      },
+      {
+        email: { from: "", subject: "Welcome to our service" },
+        expected: undefined,
+      },
+    ]);
   });
 
   it("should handle empty inputs", () => {
@@ -83,16 +61,13 @@ describe("findMatchingGroupItem", () => {
       { type: GroupItemType.SUBJECT, value: "Test", exclude: false },
     ];
 
-    expect(
-      findMatchingGroupItem({ from: "", subject: "" }, groupItems),
-    ).toBeUndefined();
-
-    expect(
-      findMatchingGroupItem(
-        { from: "test@example.com", subject: "" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
+    expectMatchResults(groupItems, [
+      { email: { from: "", subject: "" }, expected: undefined },
+      {
+        email: { from: "test@example.com", subject: "" },
+        expected: groupItems[0],
+      },
+    ]);
   });
 
   it("should prioritize first matching rule", () => {
@@ -115,21 +90,16 @@ describe("findMatchingGroupItem", () => {
       { type: GroupItemType.FROM, value: "@Acme-Corp.com", exclude: false },
     ];
 
-    // Lowercase email should match mixed-case pattern
-    expect(
-      findMatchingGroupItem(
-        { from: "billing@acme-corp.com", subject: "" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
-
-    // Uppercase email should match mixed-case pattern
-    expect(
-      findMatchingGroupItem(
-        { from: "BILLING@ACME-CORP.COM", subject: "" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
+    expectMatchResults(groupItems, [
+      {
+        email: { from: "billing@acme-corp.com", subject: "" },
+        expected: groupItems[0],
+      },
+      {
+        email: { from: "BILLING@ACME-CORP.COM", subject: "" },
+        expected: groupItems[0],
+      },
+    ]);
   });
 
   it("should match SUBJECT rules case-insensitively", () => {
@@ -137,20 +107,31 @@ describe("findMatchingGroupItem", () => {
       { type: GroupItemType.SUBJECT, value: "Invoice", exclude: false },
     ];
 
-    // Lowercase subject should match capitalized pattern
-    expect(
-      findMatchingGroupItem(
-        { from: "", subject: "invoice #12345" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
-
-    // Uppercase subject should match capitalized pattern
-    expect(
-      findMatchingGroupItem(
-        { from: "", subject: "INVOICE #12345" },
-        groupItems,
-      ),
-    ).toBe(groupItems[0]);
+    expectMatchResults(groupItems, [
+      {
+        email: { from: "", subject: "invoice #12345" },
+        expected: groupItems[0],
+      },
+      {
+        email: { from: "", subject: "INVOICE #12345" },
+        expected: groupItems[0],
+      },
+    ]);
   });
 });
+
+function expectMatchResults(
+  groupItems: Array<{
+    type: GroupItemType;
+    value: string;
+    exclude: boolean;
+  }>,
+  cases: Array<{
+    email: { from: string; subject: string };
+    expected?: (typeof groupItems)[number];
+  }>,
+) {
+  for (const { email, expected } of cases) {
+    expect(findMatchingGroupItem(email, groupItems)).toBe(expected);
+  }
+}

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -79,24 +79,20 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("falls back to the next provider on retryable provider failures", async () => {
-    const primaryModel = { id: "primary-model" };
-    const fallbackModel = { id: "fallback-model" };
-
-    const modelOptions: SelectModel = {
+    const primaryModel = createModel("primary-model");
+    const fallbackModel = createModel("fallback-model");
+    const modelOptions = createModelOptions({
       provider: "bedrock",
       modelName: "primary",
-      model: primaryModel as SelectModel["model"],
-      providerOptions: undefined,
+      model: primaryModel,
       fallbackModels: [
-        {
+        createResolvedModel({
           provider: "openrouter",
           modelName: "fallback",
-          model: fallbackModel as SelectModel["model"],
-          providerOptions: undefined,
-        },
+          model: fallbackModel,
+        }),
       ],
-      hasUserApiKey: false,
-    };
+    });
 
     const retryableError = new Error("rate limited");
     mockExtractLLMErrorInfo.mockReturnValueOnce({
@@ -104,29 +100,18 @@ describe("createGenerateText fallback chain", () => {
       isRateLimit: true,
       retryAfterMs: undefined,
     });
-
     mockGenerateText
       .mockRejectedValueOnce(retryableError)
-      .mockResolvedValueOnce({
-        text: "fallback success",
-        usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-        toolCalls: [],
-      });
+      .mockResolvedValueOnce(createTextResult({ text: "fallback success" }));
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Fallback Test",
       modelOptions,
-      promptHardening: { trust: "trusted" },
     });
 
     const result = await generateText({
       prompt: "hello",
-      model: primaryModel as SelectModel["model"],
+      model: primaryModel,
     });
 
     expect(result.text).toBe("fallback success");
@@ -142,37 +127,19 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("injects centralized hardening into the text generation system prompt", async () => {
-    const model = { id: "openai-model" };
-    const modelOptions: SelectModel = {
-      provider: "openai",
-      modelName: "gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
+    const model = createModel("openai-model");
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
-
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Hardening Test",
-      modelOptions,
+      modelOptions: createOpenAiModelOptions(model),
       promptHardening: { trust: "untrusted", level: "full" },
     });
 
     await generateText({
       system: "Base system prompt.",
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(mockGenerateText.mock.calls[0][0].system).toContain(
@@ -184,38 +151,19 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("reports the actual provider and model used for text generation", async () => {
-    const model = { id: "openai-model" };
-    const modelOptions: SelectModel = {
-      provider: "openai",
-      modelName: "gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
+    const model = createModel("openai-model");
+    mockGenerateText.mockResolvedValue(createTextResult());
 
     const onModelUsed = vi.fn();
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Model attribution",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenAiModelOptions(model),
       onModelUsed,
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(onModelUsed).toHaveBeenCalledWith({
@@ -225,42 +173,29 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("sets openrouter user from internal user id", async () => {
-    const model = { id: "openrouter-model" };
-    const modelOptions: SelectModel = {
-      provider: "openrouter",
-      modelName: "openrouter-primary",
-      model: model as SelectModel["model"],
-      providerOptions: {
+    const model = createModel("openrouter-model");
+    const modelOptions = createOpenRouterModelOptions(
+      model,
+      "openrouter-primary",
+      {
         openrouter: {
           provider: {
             order: ["Anthropic"],
           },
         },
       },
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
+    );
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
-
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-123",
-      },
+    const generateText = createGenerateTextForTest({
+      emailAccount: createEmailAccount({ userId: "user-123" }),
       label: "OpenRouter user metadata",
       modelOptions,
-      promptHardening: { trust: "trusted" },
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
@@ -281,36 +216,18 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("keeps explicit openrouter user and trace when request provides them", async () => {
-    const model = { id: "openrouter-model" };
-    const modelOptions: SelectModel = {
-      provider: "openrouter",
-      modelName: "openrouter-primary",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
+    const model = createModel("openrouter-model");
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
-
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "internal-user-id",
-      },
+    const generateText = createGenerateTextForTest({
+      emailAccount: createEmailAccount({ userId: "internal-user-id" }),
       label: "OpenRouter user override",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenRouterModelOptions(model, "openrouter-primary"),
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
       providerOptions: {
         openrouter: {
           user: "explicit-user-id",
@@ -334,58 +251,43 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("forwards provider costs and step metadata to usage analytics", async () => {
-    const model = { id: "openrouter-model" };
-    const modelOptions: SelectModel = {
-      provider: "openrouter",
-      modelName: "openai/gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: {
-        inputTokens: 10,
-        outputTokens: 5,
-        totalTokens: 15,
-      },
-      providerMetadata: {
-        openrouter: {
-          usage: {
-            cost: 0.42,
-            cost_details: {
-              upstream_inference_cost: 0.12,
+    const model = createModel("openrouter-model");
+    mockGenerateText.mockResolvedValue(
+      createTextResult({
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+        providerMetadata: {
+          openrouter: {
+            usage: {
+              cost: 0.42,
+              cost_details: {
+                upstream_inference_cost: 0.12,
+              },
             },
           },
         },
-      },
-      steps: [
-        {
-          toolCalls: [{ toolName: "searchEmails" }],
-        },
-        {
-          toolCalls: [{ toolName: "finalizeResults" }],
-        },
-      ],
-      toolCalls: [],
-    });
+        steps: [
+          {
+            toolCalls: [{ toolName: "searchEmails" }],
+          },
+          {
+            toolCalls: [{ toolName: "finalizeResults" }],
+          },
+        ],
+      }),
+    );
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Reply context collector",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenRouterModelOptions(model),
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
       tools: {} as Record<string, never>,
     });
 
@@ -401,61 +303,46 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("fills missing provider cost fields from step metadata", async () => {
-    const model = { id: "openrouter-model" };
-    const modelOptions: SelectModel = {
-      provider: "openrouter",
-      modelName: "openai/gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: {
-        inputTokens: 10,
-        outputTokens: 5,
-        totalTokens: 15,
-      },
-      providerMetadata: {
-        openrouter: {
-          usage: {
-            cost: 0.42,
+    const model = createModel("openrouter-model");
+    mockGenerateText.mockResolvedValue(
+      createTextResult({
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+        providerMetadata: {
+          openrouter: {
+            usage: {
+              cost: 0.42,
+            },
           },
         },
-      },
-      steps: [
-        {
-          toolCalls: [{ toolName: "searchEmails" }],
-          providerMetadata: {
-            openrouter: {
-              usage: {
-                cost_details: {
-                  upstream_inference_cost: 0.12,
+        steps: [
+          {
+            toolCalls: [{ toolName: "searchEmails" }],
+            providerMetadata: {
+              openrouter: {
+                usage: {
+                  cost_details: {
+                    upstream_inference_cost: 0.12,
+                  },
                 },
               },
             },
           },
-        },
-      ],
-      toolCalls: [],
-    });
+        ],
+      }),
+    );
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Reply context collector",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenRouterModelOptions(model),
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
       tools: {} as Record<string, never>,
     });
 
@@ -469,43 +356,29 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("counts top-level tool calls when steps are absent", async () => {
-    const model = { id: "openrouter-model" };
-    const modelOptions: SelectModel = {
-      provider: "openrouter",
-      modelName: "openai/gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
+    const model = createModel("openrouter-model");
+    mockGenerateText.mockResolvedValue(
+      createTextResult({
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+        toolCalls: [
+          { toolName: "searchEmails" },
+          { toolName: "finalizeResults" },
+        ],
+      }),
+    );
 
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: {
-        inputTokens: 10,
-        outputTokens: 5,
-        totalTokens: 15,
-      },
-      toolCalls: [
-        { toolName: "searchEmails" },
-        { toolName: "finalizeResults" },
-      ],
-    });
-
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-1",
-      },
+    const generateText = createGenerateTextForTest({
       label: "Reply context collector",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenRouterModelOptions(model),
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
       tools: {} as Record<string, never>,
     });
 
@@ -517,38 +390,20 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("adds direct PostHog tracing with privacy mode", async () => {
-    const model = { id: "openai-model" };
-    const tracedModel = { id: "posthog-traced-model" };
-    const modelOptions: SelectModel = {
-      provider: "openai",
-      modelName: "gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
+    const model = createModel("openai-model");
+    const tracedModel = createModel("posthog-traced-model");
     mockWithTracing.mockReturnValue(tracedModel);
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-123",
-      },
+    const generateText = createGenerateTextForTest({
+      emailAccount: createEmailAccount({ userId: "user-123" }),
       label: "PostHog tracing",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenAiModelOptions(model),
     });
 
     await generateText({
       prompt: "sensitive prompt",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(mockWithTracing).toHaveBeenCalledTimes(1);
@@ -576,39 +431,21 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("disables privacy mode for approved local eval accounts", async () => {
-    const model = { id: "openai-model" };
-    const tracedModel = { id: "posthog-traced-model" };
-    const modelOptions: SelectModel = {
-      provider: "openai",
-      modelName: "gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
+    const model = createModel("openai-model");
+    const tracedModel = createModel("posthog-traced-model");
     mockIsPosthogLlmEvalApproved.mockReturnValue(true);
     mockWithTracing.mockReturnValue(tracedModel);
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-123",
-      },
+    const generateText = createGenerateTextForTest({
+      emailAccount: createEmailAccount({ userId: "user-123" }),
       label: "PostHog eval tracing",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenAiModelOptions(model),
     });
 
     await generateText({
       prompt: "sensitive prompt",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(mockWithTracing).toHaveBeenCalledWith(
@@ -633,40 +470,116 @@ describe("createGenerateText fallback chain", () => {
   });
 
   it("skips direct PostHog tracing when client is unavailable", async () => {
-    const model = { id: "openai-model" };
-    const modelOptions: SelectModel = {
-      provider: "openai",
-      modelName: "gpt-5-mini",
-      model: model as SelectModel["model"],
-      providerOptions: undefined,
-      fallbackModels: [],
-      hasUserApiKey: false,
-    };
-
+    const model = createModel("openai-model");
     mockGetPosthogLlmClient.mockReturnValue(undefined);
-    mockGenerateText.mockResolvedValue({
-      text: "ok",
-      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
-      toolCalls: [],
-    });
+    mockGenerateText.mockResolvedValue(createTextResult());
 
-    const generateText = createGenerateText({
-      emailAccount: {
-        email: "user@example.com",
-        id: "email-account-1",
-        userId: "user-123",
-      },
+    const generateText = createGenerateTextForTest({
+      emailAccount: createEmailAccount({ userId: "user-123" }),
       label: "PostHog disabled",
-      modelOptions,
-      promptHardening: { trust: "trusted" },
+      modelOptions: createOpenAiModelOptions(model),
     });
 
     await generateText({
       prompt: "hello",
-      model: model as SelectModel["model"],
+      model,
     });
 
     expect(mockWithTracing).not.toHaveBeenCalled();
     expect(mockGenerateText.mock.calls[0][0].model).toBe(model);
   });
 });
+
+type GenerateTextConfig = Parameters<typeof createGenerateText>[0];
+type Model = SelectModel["model"];
+type ResolvedModel = SelectModel["fallbackModels"][number];
+
+function createGenerateTextForTest({
+  emailAccount = createEmailAccount(),
+  promptHardening = { trust: "trusted" },
+  ...config
+}: Omit<GenerateTextConfig, "emailAccount" | "promptHardening"> &
+  Partial<Pick<GenerateTextConfig, "emailAccount" | "promptHardening">>) {
+  return createGenerateText({
+    ...config,
+    emailAccount,
+    promptHardening,
+  });
+}
+
+function createEmailAccount(
+  overrides: Partial<GenerateTextConfig["emailAccount"]> = {},
+): GenerateTextConfig["emailAccount"] {
+  return {
+    email: "user@example.com",
+    id: "email-account-1",
+    userId: "user-1",
+    ...overrides,
+  };
+}
+
+function createOpenAiModelOptions(model: Model): SelectModel {
+  return createModelOptions({
+    provider: "openai",
+    modelName: "gpt-5-mini",
+    model,
+  });
+}
+
+function createOpenRouterModelOptions(
+  model: Model,
+  modelName = "openai/gpt-5-mini",
+  providerOptions?: SelectModel["providerOptions"],
+): SelectModel {
+  return createModelOptions({
+    provider: "openrouter",
+    modelName,
+    model,
+    providerOptions,
+  });
+}
+
+function createModelOptions({
+  provider = "openai",
+  modelName = "gpt-5-mini",
+  model = createModel(`${provider}-model`),
+  providerOptions,
+  fallbackModels = [],
+  hasUserApiKey = false,
+}: Partial<SelectModel> = {}): SelectModel {
+  return {
+    provider,
+    modelName,
+    model,
+    providerOptions,
+    fallbackModels,
+    hasUserApiKey,
+  };
+}
+
+function createResolvedModel({
+  provider = "openrouter",
+  modelName = "fallback",
+  model = createModel(`${provider}-model`),
+  providerOptions,
+}: Partial<ResolvedModel> = {}): ResolvedModel {
+  return {
+    provider,
+    modelName,
+    model,
+    providerOptions,
+  };
+}
+
+function createModel(id: string): Model {
+  return { id } as Model;
+}
+
+function createTextResult(overrides: Record<string, unknown> = {}) {
+  return {
+    text: "ok",
+    usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+    toolCalls: [],
+    ...overrides,
+  };
+}

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -82,71 +82,6 @@ vi.mock("@/utils/posthog", () => ({
   isPosthogLlmEvalApproved: vi.fn(() => false),
 }));
 
-async function createTestGenerateObject(
-  overrides: { provider?: string; modelName?: string } = {},
-) {
-  const { createGenerateObject } = await import("./index");
-
-  return createGenerateObject({
-    emailAccount: {
-      id: "account-1",
-      email: "user@example.com",
-      userId: "user-1",
-    },
-    label: "test",
-    modelOptions: {
-      provider: overrides.provider ?? "openai",
-      modelName: overrides.modelName ?? "gpt-test",
-      model: {} as any,
-      providerOptions: undefined,
-      hasUserApiKey: false,
-      fallbackModels: [],
-    } as any,
-    promptHardening: { trust: "untrusted", level: "full" },
-  });
-}
-
-async function createGenerateObjectWithFallback() {
-  const { createGenerateObject } = await import("./index");
-
-  return createGenerateObject({
-    emailAccount: {
-      id: "account-1",
-      email: "user@example.com",
-      userId: "user-1",
-    },
-    label: "test",
-    modelOptions: {
-      provider: "openai",
-      modelName: "gpt-test",
-      model: {} as any,
-      providerOptions: undefined,
-      hasUserApiKey: false,
-      fallbackModels: [
-        {
-          provider: "anthropic",
-          modelName: "claude-test",
-          model: {} as any,
-          providerOptions: undefined,
-        },
-      ],
-    } as any,
-    promptHardening: { trust: "untrusted", level: "full" },
-  });
-}
-
-async function getRepairText() {
-  const generateObject = await createTestGenerateObject();
-
-  await generateObject({
-    system: "Return JSON.",
-    prompt: "Return JSON.",
-    schema: {} as any,
-  } as any);
-
-  return mockGenerateObject.mock.calls[0][0].experimental_repairText;
-}
-
 describe("createGenerateObject repairText", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -158,59 +93,45 @@ describe("createGenerateObject repairText", () => {
     mockSaveAiUsage.mockResolvedValue(undefined);
   });
 
-  it("unwraps JSON wrapped in single quotes before repairing", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({ text: `'{"category":"updates",}'` });
-
-    expect(JSON.parse(repaired)).toEqual({ category: "updates" });
-  });
-
-  it("extracts JSON object when text has a prose preamble", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({
+  it.each([
+    {
+      label: "single-quoted JSON",
+      text: `'{"category":"updates",}'`,
+      expected: { category: "updates" },
+    },
+    {
+      label: "a JSON object after prose",
       text: 'Here is the answer: {"foo":"bar"}',
-    });
-
-    expect(JSON.parse(repaired)).toEqual({ foo: "bar" });
-  });
-
-  it("extracts JSON array when text has a prose preamble and trailing text", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({
+      expected: { foo: "bar" },
+    },
+    {
+      label: "a JSON array with surrounding prose",
       text: 'The JSON is: [{"a":1},{"a":2}] and more',
-    });
-
-    expect(JSON.parse(repaired)).toEqual([{ a: 1 }, { a: 2 }]);
-  });
-
-  it("skips bracketed prose tokens and extracts the actual JSON payload", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({
+      expected: [{ a: 1 }, { a: 2 }],
+    },
+    {
+      label: "JSON after bracketed prose tokens",
       text: 'Step [1]: here is the JSON {"foo":"bar"}',
-    });
-
-    expect(JSON.parse(repaired)).toEqual({ foo: "bar" });
-  });
-
-  it("extracts the longer balanced array when brackets also appear in prose", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({
+      expected: { foo: "bar" },
+    },
+    {
+      label: "the longer balanced array when prose also has brackets",
       text: "[note] The result: [1,2,3,4]",
-    });
-
-    expect(JSON.parse(repaired)).toEqual([1, 2, 3, 4]);
-  });
-
-  it("extracts nested JSON object when surrounded by prose", async () => {
-    const repairText = await getRepairText();
-    const repaired = await repairText({
+      expected: [1, 2, 3, 4],
+    },
+    {
+      label: "nested JSON surrounded by prose",
       text: 'Sure! {"category": "updates", "nested": {"x": 1}} thanks',
-    });
+      expected: {
+        category: "updates",
+        nested: { x: 1 },
+      },
+    },
+  ])("repairs $label", async ({ text, expected }) => {
+    const repairText = await getRepairText();
+    const repaired = await repairText({ text });
 
-    expect(JSON.parse(repaired)).toEqual({
-      category: "updates",
-      nested: { x: 1 },
-    });
+    expect(JSON.parse(repaired)).toEqual(expected);
   });
 
   it("injects centralized hardening into the object generation system prompt", async () => {
@@ -339,52 +260,51 @@ describe("createGenerateObject repairText", () => {
         ),
       );
 
-    it("does not warn for messages-shaped calls", async () => {
+    it.each([
+      {
+        label: "messages-shaped calls",
+        options: {
+          system: "Classify the email.",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+        warned: false,
+      },
+      {
+        label: "prompt-shaped calls with no JSON mention",
+        options: {
+          system: "Classify the email.",
+          prompt: "Hello there.",
+        },
+        warned: true,
+      },
+      {
+        label: "prompt-shaped calls where the prompt mentions JSON",
+        options: {
+          system: "Classify the email.",
+          prompt: "Return JSON.",
+        },
+        warned: false,
+      },
+      {
+        label: "prompt-shaped calls where the system mentions JSON",
+        options: {
+          system: "Return JSON.",
+          prompt: "Classify this.",
+        },
+        warned: false,
+      },
+    ])("sets missing JSON warning to $warned for $label", async ({
+      options,
+      warned,
+    }) => {
       const generateObject = await createTestGenerateObject();
 
       await generateObject({
-        system: "Classify the email.",
-        messages: [{ role: "user", content: "Hello" }],
+        ...options,
         schema: {} as any,
       } as any);
 
-      expect(wasMissingJsonWarned()).toBe(false);
-    });
-
-    it("warns when a prompt-shaped call mentions JSON nowhere", async () => {
-      const generateObject = await createTestGenerateObject();
-
-      await generateObject({
-        system: "Classify the email.",
-        prompt: "Hello there.",
-        schema: {} as any,
-      } as any);
-
-      expect(wasMissingJsonWarned()).toBe(true);
-    });
-
-    it("does not warn when the prompt mentions JSON", async () => {
-      const generateObject = await createTestGenerateObject();
-
-      await generateObject({
-        system: "Classify the email.",
-        prompt: "Return JSON.",
-        schema: {} as any,
-      } as any);
-
-      expect(wasMissingJsonWarned()).toBe(false);
-    });
-
-    it("does not warn when the system mentions JSON even if prompt doesn't", async () => {
-      const generateObject = await createTestGenerateObject();
-
-      await generateObject({
-        system: "Return JSON.",
-        prompt: "Classify this.",
-        schema: {} as any,
-      } as any);
-
-      expect(wasMissingJsonWarned()).toBe(false);
+      expect(wasMissingJsonWarned()).toBe(warned);
     });
   });
 
@@ -412,21 +332,7 @@ describe("createGenerateObject repairText", () => {
   });
 
   it("falls back to next model on content-filter refusal without retrying primary", async () => {
-    const contentFilterError = Object.assign(
-      new Error("No object generated: could not parse the response."),
-      {
-        finishReason: "content-filter",
-        text: "I'm sorry, but I cannot assist with that request.",
-      },
-    );
-    const matchesContentFilter = (error: unknown) => {
-      const unwrapped = (error as { error?: unknown })?.error ?? error;
-      return unwrapped === contentFilterError;
-    };
-    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
-      matchesContentFilter,
-    );
-    mockIsContentFilterRefusal.mockImplementation(matchesContentFilter);
+    const contentFilterError = mockContentFilterRefusal();
 
     mockGenerateObject
       .mockRejectedValueOnce(contentFilterError)
@@ -445,21 +351,7 @@ describe("createGenerateObject repairText", () => {
   });
 
   it("throws content-filter refusal without Sentry noise when no fallback is configured", async () => {
-    const contentFilterError = Object.assign(
-      new Error("No object generated: could not parse the response."),
-      {
-        finishReason: "content-filter",
-        text: "I'm sorry, but I cannot assist with that request.",
-      },
-    );
-    const matchesContentFilter = (error: unknown) => {
-      const unwrapped = (error as { error?: unknown })?.error ?? error;
-      return unwrapped === contentFilterError;
-    };
-    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
-      matchesContentFilter,
-    );
-    mockIsContentFilterRefusal.mockImplementation(matchesContentFilter);
+    const contentFilterError = mockContentFilterRefusal();
 
     mockGenerateObject.mockRejectedValue(contentFilterError);
 
@@ -486,16 +378,6 @@ describe("createGenerateObject repairText", () => {
   });
 
   it("clears stale repair metadata before trying a fallback model", async () => {
-    const createNetworkError = () => {
-      const error = new Error("read ECONNRESET");
-      (
-        error as Error & {
-          cause?: { code: string; message: string };
-        }
-      ).cause = { code: "ECONNRESET", message: "read ECONNRESET" };
-      return error;
-    };
-
     mockGenerateObject
       .mockImplementationOnce(async (options) => {
         await options.experimental_repairText({ text: "'not json" });
@@ -535,3 +417,92 @@ describe("createGenerateObject repairText", () => {
     );
   });
 });
+
+type TestModel = {
+  provider: string;
+  modelName: string;
+};
+
+type GenerateObjectOverrides = Partial<TestModel> & {
+  fallbackModels?: TestModel[];
+};
+
+async function createTestGenerateObject({
+  provider = "openai",
+  modelName = "gpt-test",
+  fallbackModels = [],
+}: GenerateObjectOverrides = {}) {
+  const { createGenerateObject } = await import("./index");
+
+  return createGenerateObject({
+    emailAccount: {
+      id: "account-1",
+      email: "user@example.com",
+      userId: "user-1",
+    },
+    label: "test",
+    modelOptions: {
+      ...createResolvedModel({ provider, modelName }),
+      hasUserApiKey: false,
+      fallbackModels: fallbackModels.map(createResolvedModel),
+    } as any,
+    promptHardening: { trust: "untrusted", level: "full" },
+  });
+}
+
+async function createGenerateObjectWithFallback() {
+  return createTestGenerateObject({
+    fallbackModels: [{ provider: "anthropic", modelName: "claude-test" }],
+  });
+}
+
+async function getRepairText() {
+  const generateObject = await createTestGenerateObject();
+
+  await generateObject({
+    system: "Return JSON.",
+    prompt: "Return JSON.",
+    schema: {} as any,
+  } as any);
+
+  return mockGenerateObject.mock.calls[0][0].experimental_repairText;
+}
+
+function createResolvedModel({ provider, modelName }: TestModel) {
+  return {
+    provider,
+    modelName,
+    model: {} as any,
+    providerOptions: undefined,
+  };
+}
+
+function mockContentFilterRefusal() {
+  const contentFilterError = Object.assign(
+    new Error("No object generated: could not parse the response."),
+    {
+      finishReason: "content-filter",
+      text: "I'm sorry, but I cannot assist with that request.",
+    },
+  );
+  const matchesContentFilter = (error: unknown) => {
+    const unwrapped = (error as { error?: unknown })?.error ?? error;
+    return unwrapped === contentFilterError;
+  };
+
+  mockNoObjectGeneratedErrorIsInstance.mockImplementation(matchesContentFilter);
+  mockIsContentFilterRefusal.mockImplementation(matchesContentFilter);
+
+  return contentFilterError;
+}
+
+function createNetworkError() {
+  const error = new Error("read ECONNRESET");
+  (
+    error as Error & {
+      cause?: { code: string; message: string };
+    }
+  ).cause = { code: "ECONNRESET", message: "read ECONNRESET" };
+
+  return error;
+}

--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -144,11 +144,7 @@ describe("Models", () => {
 
   describe("getModel", () => {
     it("should use default provider and model when user has no API key", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.OPEN_AI);
@@ -156,11 +152,7 @@ describe("Models", () => {
     });
 
     it("should use LLM_API_KEY when provider-specific OpenAI key is not set", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai";
       vi.mocked(env).OPENAI_API_KEY = undefined;
@@ -174,11 +166,11 @@ describe("Models", () => {
     });
 
     it("should use user's provider and model when API key is provided", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GOOGLE,
         aiModel: "gemini-1.5-pro-latest",
-      };
+      });
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.GOOGLE);
@@ -186,11 +178,9 @@ describe("Models", () => {
     });
 
     it("should use user's API key with default provider when only API key is provided", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
-        aiProvider: null,
-        aiModel: null,
-      };
+      });
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.OPEN_AI);
@@ -198,11 +188,11 @@ describe("Models", () => {
     });
 
     it("should configure Google model correctly", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GOOGLE,
         aiModel: "gemini-1.5-pro-latest",
-      };
+      });
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.GOOGLE);
@@ -218,11 +208,11 @@ describe("Models", () => {
     });
 
     it("should configure Gemini 3 Google model with thinking level", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GOOGLE,
         aiModel: "gemini-3-pro-preview",
-      };
+      });
 
       const result = getModel(userAi);
 
@@ -238,11 +228,11 @@ describe("Models", () => {
     });
 
     it("should allow overriding Google thinking budget via env", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GOOGLE,
         aiModel: "gemini-2.5-flash",
-      };
+      });
 
       vi.mocked(env).GOOGLE_THINKING_BUDGET = 32;
 
@@ -258,11 +248,11 @@ describe("Models", () => {
     });
 
     it("should omit Google thinking budget when the env override is 0", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GOOGLE,
         aiModel: "gemini-2.5-flash-lite",
-      };
+      });
 
       vi.mocked(env).GOOGLE_THINKING_BUDGET = 0;
 
@@ -272,11 +262,7 @@ describe("Models", () => {
     });
 
     it("should configure Vertex model correctly", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "vertex";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gemini-2.5-flash";
@@ -302,11 +288,7 @@ describe("Models", () => {
     });
 
     it("should configure Vertex model with inline service account credentials", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "vertex";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gemini-2.5-flash";
@@ -339,11 +321,7 @@ describe("Models", () => {
     });
 
     it("should configure Gemini 3 Vertex model with thinking level", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "vertex";
       vi.mocked(env).DEFAULT_LLM_MODEL = undefined;
@@ -364,11 +342,11 @@ describe("Models", () => {
     });
 
     it("should configure Groq model correctly", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.GROQ,
         aiModel: "llama-3.3-70b-versatile",
-      };
+      });
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.GROQ);
@@ -377,11 +355,11 @@ describe("Models", () => {
     });
 
     it("should configure OpenRouter model correctly", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.OPENROUTER,
         aiModel: "llama-3.3-70b-versatile",
-      };
+      });
 
       const result = getModel(userAi);
       expect(result.provider).toBe(Provider.OPENROUTER);
@@ -390,11 +368,7 @@ describe("Models", () => {
     });
 
     it("should configure AI Gateway Gemini 3 model with minimal thinking", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "aigateway";
       vi.mocked(env).DEFAULT_LLM_MODEL = "google/gemini-3-flash";
@@ -413,11 +387,7 @@ describe("Models", () => {
     });
 
     it("should configure AI Gateway Gemini 2.5 model with the configured thinking budget", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "aigateway";
       vi.mocked(env).DEFAULT_LLM_MODEL = "google/gemini-2.5-flash";
@@ -437,11 +407,7 @@ describe("Models", () => {
     });
 
     it("should configure AI Gateway OpenAI model with low reasoning effort", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "aigateway";
       vi.mocked(env).DEFAULT_LLM_MODEL = "openai/gpt-5-mini";
@@ -466,11 +432,7 @@ describe("Models", () => {
     });
 
     it("should configure AI Gateway Azure model with low reasoning effort", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "aigateway";
       vi.mocked(env).DEFAULT_LLM_MODEL = "azure/gpt-5-mini";
@@ -488,11 +450,7 @@ describe("Models", () => {
     });
 
     it("should configure Ollama model via DEFAULT_LLM_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "ollama";
       vi.mocked(env).DEFAULT_LLM_MODEL = "llama3.2";
@@ -506,11 +464,7 @@ describe("Models", () => {
     });
 
     it("should configure Ollama model via legacy OLLAMA_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "ollama";
       vi.mocked(env).DEFAULT_LLM_MODEL = undefined;
@@ -524,11 +478,11 @@ describe("Models", () => {
     });
 
     it("should configure Anthropic model correctly without Bedrock credentials", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.ANTHROPIC,
         aiModel: "claude-3-7-sonnet-20250219",
-      };
+      });
 
       vi.mocked(env).BEDROCK_ACCESS_KEY = "";
       vi.mocked(env).BEDROCK_SECRET_KEY = "";
@@ -540,11 +494,7 @@ describe("Models", () => {
     });
 
     it("should configure Bedrock model correctly via env vars", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "bedrock";
       vi.mocked(env).DEFAULT_LLM_MODEL =
@@ -561,11 +511,7 @@ describe("Models", () => {
     });
 
     it("should configure Azure model with low reasoning effort", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "azure";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5-mini";
@@ -581,11 +527,7 @@ describe("Models", () => {
     });
 
     it("should throw when Azure is selected without resource name", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "azure";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5-mini";
@@ -597,11 +539,7 @@ describe("Models", () => {
     });
 
     it("should throw when Vertex is selected without project", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "vertex";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gemini-2.5-flash";
@@ -613,58 +551,17 @@ describe("Models", () => {
     });
 
     it("should throw error for unsupported provider", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: "unsupported" as any,
         aiModel: "some-model",
-      };
+      });
 
       expect(() => getModel(userAi)).toThrow("LLM provider not supported");
     });
 
-    // it("should use chat model when modelType is 'chat'", () => {
-    //   const userAi: UserAIFields = {
-    //     aiApiKey: null,
-    //     aiProvider: null,
-    //     aiModel: null,
-    //   };
-
-    //   vi.mocked(env).CHAT_LLM_PROVIDER = "openrouter";
-    //   vi.mocked(env).CHAT_LLM_MODEL = "moonshotai/kimi-k2";
-    //   vi.mocked(env).OPENROUTER_API_KEY = "test-openrouter-key";
-
-    //   const result = getModel(userAi, "chat");
-    //   expect(result.provider).toBe(Provider.OPENROUTER);
-    //   expect(result.modelName).toBe("moonshotai/kimi-k2");
-    // });
-
-    // it("should use OpenRouter with provider options for chat", () => {
-    //   const userAi: UserAIFields = {
-    //     aiApiKey: null,
-    //     aiProvider: null,
-    //     aiModel: null,
-    //   };
-
-    //   vi.mocked(env).CHAT_LLM_PROVIDER = "openrouter";
-    //   vi.mocked(env).CHAT_LLM_MODEL = "moonshotai/kimi-k2";
-    //   vi.mocked(env).CHAT_OPENROUTER_PROVIDERS = "Google Vertex,Anthropic";
-    //   vi.mocked(env).OPENROUTER_API_KEY = "test-openrouter-key";
-
-    //   const result = getModel(userAi, "chat");
-    //   expect(result.provider).toBe(Provider.OPENROUTER);
-    //   expect(result.modelName).toBe("moonshotai/kimi-k2");
-    //   expect(result.providerOptions?.openrouter?.provider?.order).toEqual([
-    //     "Google Vertex",
-    //     "Anthropic",
-    //   ]);
-    // });
-
     it("should use economy model when modelType is 'economy'", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).ECONOMY_LLM_PROVIDER = "openrouter";
       vi.mocked(env).ECONOMY_LLM_MODEL =
@@ -677,11 +574,7 @@ describe("Models", () => {
     });
 
     it("should use nano model when modelType is 'nano' and nano model is configured", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).NANO_LLM_PROVIDER = Provider.OPEN_AI;
       vi.mocked(env).NANO_LLM_MODEL = "gpt-5-nano";
@@ -693,11 +586,7 @@ describe("Models", () => {
     });
 
     it("should use OpenRouter provider options for nano when nano provider is OpenRouter", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).NANO_LLM_PROVIDER = Provider.OPENROUTER;
       vi.mocked(env).NANO_LLM_MODEL = "openai/gpt-5-nano";
@@ -717,11 +606,7 @@ describe("Models", () => {
     });
 
     it("should fall back to economy model when nano model is not configured", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).NANO_LLM_PROVIDER = undefined;
       vi.mocked(env).NANO_LLM_MODEL = undefined;
@@ -733,11 +618,7 @@ describe("Models", () => {
     });
 
     it("should pass the configured Azure API key for economy model", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).ECONOMY_LLM_PROVIDER = "azure";
       vi.mocked(env).ECONOMY_LLM_MODEL = "gpt-5-mini";
@@ -754,11 +635,7 @@ describe("Models", () => {
     });
 
     it("should use OpenRouter with provider options for economy", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).ECONOMY_LLM_PROVIDER = "openrouter";
       vi.mocked(env).ECONOMY_LLM_MODEL =
@@ -776,11 +653,7 @@ describe("Models", () => {
     });
 
     it("should enable usage accounting for OpenRouter models", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).ECONOMY_LLM_PROVIDER = "openrouter";
       vi.mocked(env).ECONOMY_LLM_MODEL = "openai/gpt-5-mini";
@@ -803,11 +676,7 @@ describe("Models", () => {
     });
 
     it("should use default model when modelType is 'default'", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       // Reset to default
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai";
@@ -819,11 +688,7 @@ describe("Models", () => {
     });
 
     it("should use OpenRouter with provider options for default model", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openrouter";
       vi.mocked(env).DEFAULT_LLM_MODEL = "anthropic/claude-3.5-sonnet";
@@ -840,11 +705,7 @@ describe("Models", () => {
     });
 
     it("should not include OpenRouter reasoning max_tokens for Grok models", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openrouter";
       vi.mocked(env).DEFAULT_LLM_MODEL = "x-ai/grok-4.1-fast";
@@ -862,11 +723,7 @@ describe("Models", () => {
     });
 
     it("should resolve ordered fallback models for default model type", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "bedrock";
       vi.mocked(env).DEFAULT_LLM_MODEL = "global.anthropic.claude-sonnet-4-6";
@@ -892,11 +749,7 @@ describe("Models", () => {
     });
 
     it("should omit OpenRouter reasoning options for Grok fallback models", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.1";
@@ -918,11 +771,11 @@ describe("Models", () => {
     });
 
     it("should skip fallback models for users with their own API key", () => {
-      const userAi: UserAIFields = {
+      const userAi = defaultUserAi({
         aiApiKey: "user-api-key",
         aiProvider: Provider.BEDROCK,
         aiModel: "global.anthropic.claude-sonnet-4-6",
-      };
+      });
 
       vi.mocked(env).DEFAULT_LLM_FALLBACKS =
         "openrouter:anthropic/claude-sonnet-4.6,openai:gpt-5.1";
@@ -933,11 +786,7 @@ describe("Models", () => {
     });
 
     it("should skip fallback providers without configured credentials", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "bedrock";
       vi.mocked(env).DEFAULT_LLM_MODEL = "global.anthropic.claude-sonnet-4-6";
@@ -957,11 +806,7 @@ describe("Models", () => {
     });
 
     it("should use LLM_API_KEY for fallback providers when provider key is not set", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "bedrock";
       vi.mocked(env).DEFAULT_LLM_MODEL = "global.anthropic.claude-sonnet-4-6";
@@ -981,11 +826,7 @@ describe("Models", () => {
     });
 
     it("should skip fallback entries without explicit model names", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "bedrock";
       vi.mocked(env).DEFAULT_LLM_MODEL = "global.anthropic.claude-sonnet-4-6";
@@ -1005,11 +846,7 @@ describe("Models", () => {
     });
 
     it("should use explicit Ollama fallback model without OLLAMA_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_FALLBACKS = "ollama:llama3";
       vi.mocked(env).OLLAMA_MODEL = undefined;
@@ -1024,11 +861,7 @@ describe("Models", () => {
     });
 
     it("should configure OpenAI-compatible provider via DEFAULT_LLM_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai-compatible";
       vi.mocked(env).DEFAULT_LLM_MODEL = "llama-3.2-3b-instruct";
@@ -1049,11 +882,7 @@ describe("Models", () => {
     });
 
     it("should configure OpenAI-compatible provider via legacy OPENAI_COMPATIBLE_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai-compatible";
       vi.mocked(env).DEFAULT_LLM_MODEL = undefined;
@@ -1066,11 +895,7 @@ describe("Models", () => {
     });
 
     it("should use explicit OpenAI-compatible fallback model without OPENAI_COMPATIBLE_MODEL", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_FALLBACKS = "openai-compatible:llama3";
       vi.mocked(env).OPENAI_COMPATIBLE_MODEL = undefined;
@@ -1085,11 +910,7 @@ describe("Models", () => {
     });
 
     it("should require explicit enablement for CLI LLM providers", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CODEX_CLI;
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.3-codex";
@@ -1101,11 +922,7 @@ describe("Models", () => {
     });
 
     it("should configure Codex CLI provider when explicitly enabled", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CODEX_CLI;
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.3-codex";
@@ -1122,11 +939,7 @@ describe("Models", () => {
     });
 
     it("should configure Claude Code provider when explicitly enabled", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = Provider.CLAUDE_CODE;
       vi.mocked(env).DEFAULT_LLM_MODEL = "sonnet";
@@ -1143,11 +956,7 @@ describe("Models", () => {
     });
 
     it("should skip CLI fallback providers when CLI LLMs are disabled", () => {
-      const userAi: UserAIFields = {
-        aiApiKey: null,
-        aiProvider: null,
-        aiModel: null,
-      };
+      const userAi = defaultUserAi();
 
       vi.mocked(env).DEFAULT_LLM_PROVIDER = "openai";
       vi.mocked(env).DEFAULT_LLM_MODEL = "gpt-5.1";
@@ -1160,3 +969,12 @@ describe("Models", () => {
     });
   });
 });
+
+function defaultUserAi(overrides: Partial<UserAIFields> = {}): UserAIFields {
+  return {
+    aiApiKey: null,
+    aiProvider: null,
+    aiModel: null,
+    ...overrides,
+  };
+}

--- a/apps/web/utils/llms/sensitive-content.test.ts
+++ b/apps/web/utils/llms/sensitive-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
   enforceSensitiveDataPolicy,
@@ -8,8 +8,17 @@ import {
 const logger = createTestLogger();
 
 describe("Sensitive data policy enforcement", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("leaves allow-mode requests unchanged", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const secret = "a".repeat(24);
     const options = {
       prompt: `api_key=${secret}`,
@@ -23,12 +32,9 @@ describe("Sensitive data policy enforcement", () => {
         label: "test",
       }),
     ).toBe(options);
-
-    warnSpy.mockRestore();
   });
 
   it("redacts sensitive strings inside messages", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const secret = "b".repeat(24);
     const options = {
       messages: [
@@ -54,12 +60,9 @@ describe("Sensitive data policy enforcement", () => {
     expect(result).not.toBe(options);
     expect(JSON.stringify(result)).not.toContain(secret);
     expect(JSON.stringify(result)).toContain("[REDACTED:CREDENTIAL]");
-
-    warnSpy.mockRestore();
   });
 
   it("blocks requests before provider calls when configured", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const secret = "c".repeat(24);
 
     expect(() =>
@@ -72,12 +75,9 @@ describe("Sensitive data policy enforcement", () => {
         label: "test",
       }),
     ).toThrow("blocked by your account settings");
-
-    warnSpy.mockRestore();
   });
 
   it("redacts sensitive strings inside readEmail tool output", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const secret = "d".repeat(24);
     const output = {
       messageId: "message-1",
@@ -106,12 +106,9 @@ describe("Sensitive data policy enforcement", () => {
     expect(JSON.stringify(result)).not.toContain("4242 4242 4242 4242");
     expect(JSON.stringify(result)).toContain("[REDACTED:CREDENTIAL]");
     expect(JSON.stringify(result)).toContain("[REDACTED:PAYMENT_CARD]");
-
-    warnSpy.mockRestore();
   });
 
   it("blocks readEmail tool output when configured", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const privateKey = [
       `-----BEGIN ${"PRIVATE"} KEY-----`,
       "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC",
@@ -133,12 +130,9 @@ describe("Sensitive data policy enforcement", () => {
       error: expect.stringContaining("tool result was blocked"),
     });
     expect(JSON.stringify(result)).not.toContain("BEGIN PRIVATE KEY");
-
-    warnSpy.mockRestore();
   });
 
   it("redacts sensitive strings inside readAttachment tool output", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const token = `Bearer ${"e".repeat(24)}`;
     const output = {
       filename: "export.csv",
@@ -159,12 +153,9 @@ describe("Sensitive data policy enforcement", () => {
     expect(result).not.toBe(output);
     expect(JSON.stringify(result)).not.toContain(token);
     expect(JSON.stringify(result)).toContain("[REDACTED:CREDENTIAL]");
-
-    warnSpy.mockRestore();
   });
 
   it("blocks readAttachment tool output when configured", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const secret = "f".repeat(24);
 
     const result = enforceSensitiveToolOutputPolicy({
@@ -183,12 +174,9 @@ describe("Sensitive data policy enforcement", () => {
       error: expect.stringContaining("tool result was blocked"),
     });
     expect(JSON.stringify(result)).not.toContain(secret);
-
-    warnSpy.mockRestore();
   });
 
   it("redacts sensitive strings inside tool output object keys", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const sensitiveKey = `api_key=${"g".repeat(24)}`;
 
     const result = enforceSensitiveToolOutputPolicy({
@@ -204,12 +192,9 @@ describe("Sensitive data policy enforcement", () => {
     expect(JSON.stringify(result)).not.toContain(sensitiveKey);
     expect(Object.keys(result)).toContain("api_key=[REDACTED:CREDENTIAL]");
     expect(result.safe).toBe("value");
-
-    warnSpy.mockRestore();
   });
 
   it("blocks tool output when only an object key contains sensitive content", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const sensitiveKey = `client_secret=${"h".repeat(24)}`;
 
     const result = enforceSensitiveToolOutputPolicy({
@@ -226,7 +211,5 @@ describe("Sensitive data policy enforcement", () => {
       error: expect.stringContaining("tool result was blocked"),
     });
     expect(JSON.stringify(result)).not.toContain(sensitiveKey);
-
-    warnSpy.mockRestore();
   });
 });

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -8,44 +8,45 @@ import {
 
 describe("emailToContent", () => {
   describe("content source fallback", () => {
-    it("uses textHtml when available", () => {
-      const email = {
-        textHtml: "<p>Hello World</p>",
-        textPlain: "Plain text",
-        snippet: "Snippet",
-      };
-      const result = emailToContent(email);
-      expect(result).toContain("Hello World");
-    });
-
-    it("falls back to textPlain when textHtml is empty", () => {
-      const email = {
-        textHtml: "",
-        textPlain: "Plain text content",
-        snippet: "Snippet",
-      };
-      const result = emailToContent(email);
-      expect(result).toBe("Plain text content");
-    });
-
-    it("falls back to snippet when both textHtml and textPlain are empty", () => {
-      const email = {
-        textHtml: "",
-        textPlain: "",
-        snippet: "Email snippet here",
-      };
-      const result = emailToContent(email);
-      expect(result).toBe("Email snippet here");
-    });
-
-    it("returns empty string when all content sources are empty", () => {
-      const email = {
-        textHtml: "",
-        textPlain: "",
-        snippet: "",
-      };
-      const result = emailToContent(email);
-      expect(result).toBe("");
+    it.each([
+      {
+        name: "textHtml when available",
+        email: {
+          textHtml: "<p>Hello World</p>",
+          textPlain: "Plain text",
+          snippet: "Snippet",
+        },
+        expected: "Hello World",
+      },
+      {
+        name: "textPlain when textHtml is empty",
+        email: {
+          textHtml: "",
+          textPlain: "Plain text content",
+          snippet: "Snippet",
+        },
+        expected: "Plain text content",
+      },
+      {
+        name: "snippet when textHtml and textPlain are empty",
+        email: {
+          textHtml: "",
+          textPlain: "",
+          snippet: "Email snippet here",
+        },
+        expected: "Email snippet here",
+      },
+      {
+        name: "empty string when all content sources are empty",
+        email: {
+          textHtml: "",
+          textPlain: "",
+          snippet: "",
+        },
+        expected: "",
+      },
+    ])("uses $name", ({ email, expected }) => {
+      expect(emailToContent(email)).toBe(expected);
     });
   });
 
@@ -88,71 +89,55 @@ describe("emailToContent", () => {
   });
 
   describe("removeForwarded option", () => {
-    it("removes Gmail-style forwarded content", () => {
-      const email = {
+    it.each([
+      {
+        name: "Gmail-style forwarded content",
         textPlain:
           "My response here\n\n---------- Forwarded message ----------\nFrom: someone@example.com\nSubject: Original",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email, { removeForwarded: true });
-      expect(result).toBe("My response here");
-      expect(result).not.toContain("Forwarded message");
-    });
-
-    it("removes iOS-style forwarded content", () => {
-      const email = {
+        expected: "My response here",
+      },
+      {
+        name: "iOS-style forwarded content",
         textPlain:
           "Here is my reply\n\nBegin forwarded message:\n\nFrom: other@test.com",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email, { removeForwarded: true });
-      expect(result).toBe("Here is my reply");
-    });
-
-    it("removes Outlook-style forwarded content", () => {
-      const email = {
+        expected: "Here is my reply",
+      },
+      {
+        name: "Outlook-style forwarded content",
         textPlain: "My comments\n\nOriginal Message\nFrom: sender@example.com",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email, { removeForwarded: true });
-      expect(result).toBe("My comments");
-    });
-
-    it("preserves content when no forward marker found", () => {
-      const email = {
+        expected: "My comments",
+      },
+      {
+        name: "content with no forward marker",
         textPlain: "Regular email content without forwards",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email, { removeForwarded: true });
-      expect(result).toBe("Regular email content without forwards");
+        expected: "Regular email content without forwards",
+      },
+    ])("handles $name", ({ textPlain, expected }) => {
+      expect(
+        emailToContent(createPlainTextEmail(textPlain), {
+          removeForwarded: true,
+        }),
+      ).toBe(expected);
     });
 
     it("does not treat inline From and Subject text as a forwarded message", () => {
-      const email = {
-        textPlain:
-          "Please update the From: field and Subject: line before sending.",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email, { removeForwarded: true });
-      expect(result).toBe(
-        "Please update the From: field and Subject: line before sending.",
-      );
+      const textPlain =
+        "Please update the From: field and Subject: line before sending.";
+
+      expect(
+        emailToContent(createPlainTextEmail(textPlain), {
+          removeForwarded: true,
+        }),
+      ).toBe(textPlain);
     });
   });
 
   describe("whitespace handling", () => {
     it("removes excessive whitespace", () => {
-      const email = {
-        textPlain: "Hello    World\n\n\n\nTest",
-        textHtml: undefined,
-        snippet: "",
-      };
-      const result = emailToContent(email);
+      const result = emailToContent(
+        createPlainTextEmail("Hello    World\n\n\n\nTest"),
+      );
+
       expect(result).not.toContain("    ");
       expect(result).not.toContain("\n\n\n\n");
     });
@@ -250,27 +235,26 @@ On Jan 1, 2024, someone@example.com wrote:
 });
 
 describe("getEmailClient", () => {
-  it("identifies Gmail", () => {
-    expect(getEmailClient("<abc123@mail.gmail.com>")).toBe("gmail");
-  });
-
-  it("identifies Superhuman", () => {
-    expect(getEmailClient("<msg@we.are.superhuman.com>")).toBe("superhuman");
-  });
-
-  it("identifies Shortwave", () => {
-    expect(getEmailClient("<email@mail.shortwave.com>")).toBe("shortwave");
-  });
-
-  it("extracts domain for generic email clients", () => {
-    expect(getEmailClient("<message@company.com>")).toBe("company.com");
-  });
-
-  it("handles message IDs with multiple @ symbols", () => {
-    expect(getEmailClient("<test@something@domain.com>")).toBe("something");
-  });
-
-  it("extracts domain from Outlook-style message IDs", () => {
-    expect(getEmailClient("<BLUPR01MB1234@outlook.com>")).toBe("outlook.com");
+  it.each([
+    ["Gmail", "<abc123@mail.gmail.com>", "gmail"],
+    ["Superhuman", "<msg@we.are.superhuman.com>", "superhuman"],
+    ["Shortwave", "<email@mail.shortwave.com>", "shortwave"],
+    ["generic email client", "<message@company.com>", "company.com"],
+    [
+      "message IDs with multiple @ symbols",
+      "<test@something@domain.com>",
+      "something",
+    ],
+    ["Outlook-style message IDs", "<BLUPR01MB1234@outlook.com>", "outlook.com"],
+  ])("identifies %s", (_name, messageId, expected) => {
+    expect(getEmailClient(messageId)).toBe(expected);
   });
 });
+
+function createPlainTextEmail(textPlain: string) {
+  return {
+    textPlain,
+    textHtml: undefined,
+    snippet: "",
+  };
+}

--- a/apps/web/utils/mention.test.ts
+++ b/apps/web/utils/mention.test.ts
@@ -2,209 +2,120 @@ import { describe, it, expect } from "vitest";
 import { convertMentionsToLabels, convertLabelsToDisplay } from "./mention";
 
 describe("convertMentionsToLabels", () => {
-  it("converts single mention to label", () => {
-    const input = "Label this email as @[Newsletter]";
-    const expected = "Label this email as Newsletter";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("converts multiple mentions to labels", () => {
-    const input = "Label as @[Important] and @[Work] and archive";
-    const expected = "Label as Important and Work and archive";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions with spaces in label names", () => {
-    const input = "Apply @[Very Important] and @[Work Project] labels";
-    const expected = "Apply Very Important and Work Project labels";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions with special characters in label names", () => {
-    const input = "Label as @[Finance/Tax] and @[Client-A] and @[2024_Q1]";
-    const expected = "Label as Finance/Tax and Client-A and 2024_Q1";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions at the beginning of text", () => {
-    const input = "@[Newsletter] emails should be archived";
-    const expected = "Newsletter emails should be archived";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions at the end of text", () => {
-    const input = "Archive and label as @[Newsletter]";
-    const expected = "Archive and label as Newsletter";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles text with no mentions", () => {
-    const input = "Archive all newsletters automatically";
-    const expected = "Archive all newsletters automatically";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles empty string", () => {
-    const input = "";
-    const expected = "";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions in multiline text", () => {
-    const input = `When I get a newsletter, archive it and label it as @[Newsletter]
-    
-    For urgent emails from company.com, label as @[Urgent] and forward to support@company.com`;
-
-    const expected = `When I get a newsletter, archive it and label it as Newsletter
-    
-    For urgent emails from company.com, label as Urgent and forward to support@company.com`;
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("preserves regular @ symbols that are not mentions", () => {
-    const input = "Forward to support@company.com and label as @[Support]";
-    const expected = "Forward to support@company.com and label as Support";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles malformed mentions gracefully", () => {
-    const input = "Label as @[Newsletter and @Missing] and @[Complete]";
-    const expected = "Label as Newsletter and @Missing and Complete";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles nested brackets in mentions", () => {
-    const input = "Label as @[Project [Alpha]] and continue";
-    const expected = "Label as Project [Alpha] and continue";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles mentions with numbers and symbols", () => {
-    const input = "Apply @[2024-Q1] and @[Client#123] labels";
-    const expected = "Apply 2024-Q1 and Client#123 labels";
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
-  });
-
-  it("handles complex rule with multiple mentions", () => {
-    const input = `If someone asks to set up a call, draft a reply and label as @[Meeting Request]
-    
-    For newsletters from marketing@company.com, archive and label as @[Newsletter] and @[Marketing]`;
-
-    const expected = `If someone asks to set up a call, draft a reply and label as Meeting Request
-    
-    For newsletters from marketing@company.com, archive and label as Newsletter and Marketing`;
-
-    expect(convertMentionsToLabels(input)).toBe(expected);
+  it.each(getMentionConversionCases())("converts $name", ({
+    input,
+    labelText,
+  }) => {
+    expect(convertMentionsToLabels(input)).toBe(labelText);
   });
 });
 
 describe("convertLabelsToDisplay", () => {
-  it("converts single mention to quoted label", () => {
-    const input = "Label this email as @[Newsletter]";
-    const expected = 'Label this email as "Newsletter"';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("converts multiple mentions to quoted labels", () => {
-    const input = "Label as @[Important] and @[Work] and archive";
-    const expected = 'Label as "Important" and "Work" and archive';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions with spaces in label names", () => {
-    const input = "Apply @[Very Important] and @[Work Project] labels";
-    const expected = 'Apply "Very Important" and "Work Project" labels';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions with special characters in label names", () => {
-    const input = "Label as @[Finance/Tax] and @[Client-A] and @[2024_Q1]";
-    const expected = 'Label as "Finance/Tax" and "Client-A" and "2024_Q1"';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions at the beginning of text", () => {
-    const input = "@[Newsletter] emails should be archived";
-    const expected = '"Newsletter" emails should be archived';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions at the end of text", () => {
-    const input = "Archive and label as @[Newsletter]";
-    const expected = 'Archive and label as "Newsletter"';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles text with no mentions", () => {
-    const input = "Archive all newsletters automatically";
-    const expected = "Archive all newsletters automatically";
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles empty string", () => {
-    const input = "";
-    const expected = "";
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions in multiline text", () => {
-    const input = `When I get a newsletter, archive it and label it as @[Newsletter]
-    
-    For urgent emails from company.com, label as @[Urgent] and forward to support@company.com`;
-
-    const expected = `When I get a newsletter, archive it and label it as "Newsletter"
-    
-    For urgent emails from company.com, label as "Urgent" and forward to support@company.com`;
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("preserves regular @ symbols that are not mentions", () => {
-    const input = "Forward to support@company.com and label as @[Support]";
-    const expected = 'Forward to support@company.com and label as "Support"';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles malformed mentions gracefully", () => {
-    const input = "Label as @[Newsletter and @Missing] and @[Complete]";
-    const expected = 'Label as "Newsletter and @Missing" and "Complete"';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles nested brackets in mentions", () => {
-    const input = "Label as @[Project [Alpha]] and continue";
-    const expected = 'Label as "Project [Alpha]" and continue';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
-  });
-
-  it("handles mentions with numbers and symbols", () => {
-    const input = "Apply @[2024-Q1] and @[Client#123] labels";
-    const expected = 'Apply "2024-Q1" and "Client#123" labels';
-
-    expect(convertLabelsToDisplay(input)).toBe(expected);
+  it.each(getMentionConversionCases())("converts $name", ({
+    input,
+    displayText,
+  }) => {
+    expect(convertLabelsToDisplay(input)).toBe(displayText);
   });
 });
+
+function getMentionConversionCases() {
+  return [
+    {
+      name: "single mention",
+      input: "Label this email as @[Newsletter]",
+      labelText: "Label this email as Newsletter",
+      displayText: 'Label this email as "Newsletter"',
+    },
+    {
+      name: "multiple mentions",
+      input: "Label as @[Important] and @[Work] and archive",
+      labelText: "Label as Important and Work and archive",
+      displayText: 'Label as "Important" and "Work" and archive',
+    },
+    {
+      name: "mentions with spaces in label names",
+      input: "Apply @[Very Important] and @[Work Project] labels",
+      labelText: "Apply Very Important and Work Project labels",
+      displayText: 'Apply "Very Important" and "Work Project" labels',
+    },
+    {
+      name: "mentions with special characters in label names",
+      input: "Label as @[Finance/Tax] and @[Client-A] and @[2024_Q1]",
+      labelText: "Label as Finance/Tax and Client-A and 2024_Q1",
+      displayText: 'Label as "Finance/Tax" and "Client-A" and "2024_Q1"',
+    },
+    {
+      name: "mention at the beginning of text",
+      input: "@[Newsletter] emails should be archived",
+      labelText: "Newsletter emails should be archived",
+      displayText: '"Newsletter" emails should be archived',
+    },
+    {
+      name: "mention at the end of text",
+      input: "Archive and label as @[Newsletter]",
+      labelText: "Archive and label as Newsletter",
+      displayText: 'Archive and label as "Newsletter"',
+    },
+    {
+      name: "text with no mentions",
+      input: "Archive all newsletters automatically",
+      labelText: "Archive all newsletters automatically",
+      displayText: "Archive all newsletters automatically",
+    },
+    {
+      name: "empty string",
+      input: "",
+      labelText: "",
+      displayText: "",
+    },
+    {
+      name: "mentions in multiline text",
+      input: `When I get a newsletter, archive it and label it as @[Newsletter]
+    
+    For urgent emails from company.com, label as @[Urgent] and forward to support@company.com`,
+      labelText: `When I get a newsletter, archive it and label it as Newsletter
+    
+    For urgent emails from company.com, label as Urgent and forward to support@company.com`,
+      displayText: `When I get a newsletter, archive it and label it as "Newsletter"
+    
+    For urgent emails from company.com, label as "Urgent" and forward to support@company.com`,
+    },
+    {
+      name: "regular @ symbols that are not mentions",
+      input: "Forward to support@company.com and label as @[Support]",
+      labelText: "Forward to support@company.com and label as Support",
+      displayText: 'Forward to support@company.com and label as "Support"',
+    },
+    {
+      name: "malformed mentions",
+      input: "Label as @[Newsletter and @Missing] and @[Complete]",
+      labelText: "Label as Newsletter and @Missing and Complete",
+      displayText: 'Label as "Newsletter and @Missing" and "Complete"',
+    },
+    {
+      name: "nested brackets in mentions",
+      input: "Label as @[Project [Alpha]] and continue",
+      labelText: "Label as Project [Alpha] and continue",
+      displayText: 'Label as "Project [Alpha]" and continue',
+    },
+    {
+      name: "mentions with numbers and symbols",
+      input: "Apply @[2024-Q1] and @[Client#123] labels",
+      labelText: "Apply 2024-Q1 and Client#123 labels",
+      displayText: 'Apply "2024-Q1" and "Client#123" labels',
+    },
+    {
+      name: "complex rule with multiple mentions",
+      input: `If someone asks to set up a call, draft a reply and label as @[Meeting Request]
+    
+    For newsletters from marketing@company.com, archive and label as @[Newsletter] and @[Marketing]`,
+      labelText: `If someone asks to set up a call, draft a reply and label as Meeting Request
+    
+    For newsletters from marketing@company.com, archive and label as Newsletter and Marketing`,
+      displayText: `If someone asks to set up a call, draft a reply and label as "Meeting Request"
+    
+    For newsletters from marketing@company.com, archive and label as "Newsletter" and "Marketing"`,
+    },
+  ];
+}

--- a/apps/web/utils/middleware.test.ts
+++ b/apps/web/utils/middleware.test.ts
@@ -12,25 +12,26 @@ import {
 } from "./middleware";
 import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
 import prisma from "@/utils/__mocks__/prisma";
+import { auth } from "@/utils/auth";
+import { isAdmin } from "@/utils/admin";
+import { getEmailAccount } from "@/utils/redis/account-validation";
+import { captureException, checkCommonErrors, SafeError } from "@/utils/error";
+import { createEmailProvider } from "@/utils/email/provider";
+import { isProviderRateLimitModeError } from "@/utils/email/rate-limit-mode-error";
+import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
+import { getAuditContext } from "@/utils/audit/context";
 
-// --- Mocks ---
-
-// Mock external dependencies
 vi.mock("better-auth", () => {
-  // Define the mock function INSIDE the factory
   const mockAuthFn = vi.fn();
   return {
-    // Mock the default export (the betterAuth function)
     betterAuth: vi.fn(() => ({
-      // This is the object returned when betterAuth() is called
-      api: { getSession: mockAuthFn }, // Mock API methods
+      api: { getSession: mockAuthFn },
       signIn: vi.fn(),
       signOut: vi.fn(),
     })),
   };
 });
 
-// Mock the auth function from @/utils/auth
 vi.mock("@/utils/auth", () => ({
   auth: vi.fn(),
 }));
@@ -50,31 +51,18 @@ vi.mock("@/utils/email/rate-limit-mode-error", () => ({
   isProviderRateLimitModeError: vi.fn(),
 }));
 
-// Mock specific functions from @/utils/error, keep original SafeError
 vi.mock("@/utils/error", async (importActual) => {
   const actual = await importActual<typeof import("@/utils/error")>();
   return {
-    ...actual, // Keep original exports like SafeError
-    captureException: vi.fn(), // Mock only specific functions
+    ...actual,
+    captureException: vi.fn(),
     checkCommonErrors: vi.fn(),
   };
 });
 
 vi.mock("@/utils/error.server");
 
-// Import from the local path as before
-import { auth } from "@/utils/auth";
-import { isAdmin } from "@/utils/admin";
-import { getEmailAccount } from "@/utils/redis/account-validation";
-import { captureException, checkCommonErrors, SafeError } from "@/utils/error";
-import { createEmailProvider } from "@/utils/email/provider";
-import { isProviderRateLimitModeError } from "@/utils/email/rate-limit-mode-error";
-import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
-import { getAuditContext } from "@/utils/audit/context";
-
-// This should now correctly reference mockAuthFn
 const mockAuth = vi.mocked(auth);
-
 const mockGetEmailAccount = vi.mocked(getEmailAccount);
 const mockCheckCommonErrors = vi.mocked(checkCommonErrors);
 const mockCaptureException = vi.mocked(captureException);
@@ -88,22 +76,9 @@ const mockIsProviderRateLimitModeError = vi.mocked(
 );
 const mockRecordRateLimitFromApiError = vi.mocked(recordRateLimitFromApiError);
 
-// Helper to create a mock NextRequest
-const createMockRequest = (
-  method = "GET",
-  url = "http://localhost/test",
-  headers?: Record<string, string>,
-): NextRequest => {
-  const request = new NextRequest(url, {
-    method,
-    headers: new Headers(headers),
-  });
-  // Add clone method mock if needed, NextRequest handles it mostly
-  request.clone = vi.fn(() => request) as any; // Basic clone mock
-  return request;
+type RequestWithAuthAndEmail = RequestWithAuth & {
+  auth: { emailAccountId: string; email: string };
 };
-
-// --- Test Suite ---
 
 describe("Middleware", () => {
   let mockReq: NextRequest;
@@ -114,7 +89,6 @@ describe("Middleware", () => {
     mockReq = createMockRequest();
   });
 
-  // --- withError Tests ---
   describe("withError", () => {
     it("uses valid UUID v4 request IDs from the request header", async () => {
       const requestId = "123e4567-e89b-42d3-a456-426614174000";
@@ -275,7 +249,7 @@ describe("Middleware", () => {
 
     it("should return 500 and capture unhandled errors", async () => {
       const unexpectedError = new Error("Something went very wrong");
-      mockCheckCommonErrors.mockReturnValue(null); // Ensure it's not a common error
+      mockCheckCommonErrors.mockReturnValue(null);
       const handler = vi.fn().mockRejectedValue(unexpectedError);
       const wrappedHandler = withError(handler);
 
@@ -291,13 +265,11 @@ describe("Middleware", () => {
     });
   });
 
-  // --- withAuth Tests ---
   describe("withAuth", () => {
     const mockUserId = "user-123";
 
     it("should call the handler with auth info if session exists", async () => {
       mockAuth.mockResolvedValue({ user: { id: mockUserId } } as any);
-      // Adjust handler mock signature
       const handler = vi.fn(async (_req: RequestWithAuth, _ctx: any) =>
         NextResponse.json({ ok: true }),
       );
@@ -424,18 +396,12 @@ describe("Middleware", () => {
     });
   });
 
-  // --- withEmailAccount Tests ---
   describe("withEmailAccount", () => {
-    type RequestWithAuthAndEmail = RequestWithAuth & {
-      auth: { emailAccountId: string; email: string };
-    };
-
     const mockUserId = "user-123";
     const mockAccountId = "acc-456";
     const mockEmail = "test@example.com";
 
     beforeEach(() => {
-      // Mock auth middleware part for these tests
       mockAuth.mockResolvedValue({ user: { id: mockUserId } } as any);
     });
 
@@ -469,23 +435,13 @@ describe("Middleware", () => {
     });
 
     it("should return 403 if email account header is missing", async () => {
-      // No header added to mockReq in beforeEach
-      // Provide a typed mock implementation to satisfy the wrapper
-      const handler = vi.fn(
-        async (
-          _req: RequestWithAuthAndEmail,
-          _ctx: { params: Promise<Record<string, string>> },
-        ): Promise<NextResponse> => {
-          // Implementation won't run, just for types
-          return NextResponse.json({});
-        },
-      );
+      const handler = createEmailAccountHandler();
       const wrappedHandler = withEmailAccount(handler);
 
       const response = await wrappedHandler(mockReq, mockContext);
       const responseBody = await response.json();
 
-      expect(auth).toHaveBeenCalledTimes(1); // Auth middleware runs first
+      expect(auth).toHaveBeenCalledTimes(1);
       expect(getEmailAccount).not.toHaveBeenCalled();
       expect(handler).not.toHaveBeenCalled();
       expect(response.status).toBe(403);
@@ -499,18 +455,9 @@ describe("Middleware", () => {
       mockReq = createMockRequest("GET", "http://localhost/api/test", {
         [EMAIL_ACCOUNT_HEADER]: mockAccountId,
       });
-      mockGetEmailAccount.mockResolvedValue(null); // Simulate invalid account
+      mockGetEmailAccount.mockResolvedValue(null);
 
-      // Provide a typed mock implementation to satisfy the wrapper
-      const handler = vi.fn(
-        async (
-          _req: RequestWithAuthAndEmail,
-          _ctx: { params: Promise<Record<string, string>> },
-        ): Promise<NextResponse> => {
-          // Implementation won't run, just for types
-          return NextResponse.json({});
-        },
-      );
+      const handler = createEmailAccountHandler();
       const wrappedHandler = withEmailAccount(handler);
 
       const response = await wrappedHandler(mockReq, mockContext);
@@ -530,7 +477,6 @@ describe("Middleware", () => {
     });
   });
 
-  // --- withEmailProvider Tests ---
   describe("withEmailProvider", () => {
     const mockUserId = "user-123";
     const mockAccountId = "acc-456";
@@ -540,14 +486,33 @@ describe("Middleware", () => {
       mockAuth.mockResolvedValue({ user: { id: mockUserId } } as any);
     });
 
-    it("should return 429 for Gmail rate-limit mode errors from provider initialization", async () => {
+    it.each([
+      [
+        "Gmail",
+        "google",
+        {
+          type: "Gmail Rate Limit Exceeded",
+          message: "Gmail error: retry later",
+          code: 429,
+        },
+      ],
+      [
+        "Outlook",
+        "microsoft",
+        {
+          type: "Outlook Rate Limit",
+          message: "Microsoft is temporarily limiting requests.",
+          code: 429,
+        },
+      ],
+    ] as const)("should return 429 for %s rate-limit mode errors from provider initialization", async (_caseName, provider, commonError) => {
       mockReq = createMockRequest("GET", "http://localhost/api/labels", {
         [EMAIL_ACCOUNT_HEADER]: mockAccountId,
       });
       mockGetEmailAccount.mockResolvedValue(mockEmail);
       mockPrismaEmailAccountFindUnique.mockResolvedValue({
         id: mockAccountId,
-        account: { provider: "google" },
+        account: { provider },
       } as any);
 
       const rateLimitError = new Error("Rate-limit mode active");
@@ -555,62 +520,6 @@ describe("Middleware", () => {
       mockIsProviderRateLimitModeError.mockImplementation(
         (error) => error === rateLimitError,
       );
-
-      const commonError = {
-        type: "Gmail Rate Limit Exceeded",
-        message: "Gmail error: retry later",
-        code: 429,
-      } as const;
-      mockCheckCommonErrors.mockReturnValue(commonError);
-
-      const handler = vi.fn(async () => NextResponse.json({ ok: true }));
-      const wrappedHandler = withEmailProvider("labels", handler);
-
-      const response = await wrappedHandler(mockReq, mockContext);
-      const responseBody = await response.json();
-
-      expect(handler).not.toHaveBeenCalled();
-      expect(checkCommonErrors).toHaveBeenCalledWith(
-        rateLimitError,
-        mockReq.url,
-        expect.anything(),
-      );
-      expect(mockRecordRateLimitFromApiError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          apiErrorType: commonError.type,
-          error: rateLimitError,
-          emailAccountId: mockAccountId,
-          source: "labels",
-        }),
-      );
-      expect(response.status).toBe(429);
-      expect(responseBody).toEqual({
-        error: commonError.message,
-        isKnownError: true,
-      });
-    });
-
-    it("should return 429 for Outlook rate-limit mode errors from provider initialization", async () => {
-      mockReq = createMockRequest("GET", "http://localhost/api/labels", {
-        [EMAIL_ACCOUNT_HEADER]: mockAccountId,
-      });
-      mockGetEmailAccount.mockResolvedValue(mockEmail);
-      mockPrismaEmailAccountFindUnique.mockResolvedValue({
-        id: mockAccountId,
-        account: { provider: "microsoft" },
-      } as any);
-
-      const rateLimitError = new Error("Rate-limit mode active");
-      mockCreateEmailProvider.mockRejectedValue(rateLimitError);
-      mockIsProviderRateLimitModeError.mockImplementation(
-        (error) => error === rateLimitError,
-      );
-
-      const commonError = {
-        type: "Outlook Rate Limit",
-        message: "Microsoft is temporarily limiting requests.",
-        code: 429,
-      } as const;
       mockCheckCommonErrors.mockReturnValue(commonError);
 
       const handler = vi.fn(async () => NextResponse.json({ ok: true }));
@@ -641,3 +550,25 @@ describe("Middleware", () => {
     });
   });
 });
+
+function createMockRequest(
+  method = "GET",
+  url = "http://localhost/test",
+  headers?: Record<string, string>,
+): NextRequest {
+  const request = new NextRequest(url, {
+    method,
+    headers: new Headers(headers),
+  });
+  request.clone = vi.fn(() => request) as any;
+  return request;
+}
+
+function createEmailAccountHandler() {
+  return vi.fn(
+    async (
+      _req: RequestWithAuthAndEmail,
+      _ctx: { params: Promise<Record<string, string>> },
+    ): Promise<NextResponse> => NextResponse.json({}),
+  );
+}

--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -267,212 +267,117 @@ describe("queryMessagesWithAttachments", () => {
 });
 
 describe("sanitizeKqlValue", () => {
-  it("should return empty string for empty input", () => {
-    expect(sanitizeKqlValue("")).toBe("");
-    expect(sanitizeKqlValue("   ")).toBe("");
-  });
-
-  it("should replace ? with space", () => {
-    expect(sanitizeKqlValue("hello?world")).toBe("hello world");
-  });
-
-  it("should escape backslashes", () => {
-    expect(sanitizeKqlValue("path\\to\\file")).toBe("path\\\\to\\\\file");
-  });
-
-  it("should escape double quotes", () => {
-    expect(sanitizeKqlValue('say "hello"')).toBe('say \\"hello\\"');
-  });
-
-  it("should normalize multiple spaces", () => {
-    expect(sanitizeKqlValue("hello   world")).toBe("hello world");
-  });
-
-  it("should handle email addresses", () => {
-    expect(sanitizeKqlValue("user@example.com")).toBe("user@example.com");
+  it.each([
+    ["empty input", "", ""],
+    ["whitespace-only input", "   ", ""],
+    ["question marks", "hello?world", "hello world"],
+    ["backslashes", "path\\to\\file", "path\\\\to\\\\file"],
+    ["double quotes", 'say "hello"', 'say \\"hello\\"'],
+    ["multiple spaces", "hello   world", "hello world"],
+    ["email addresses", "user@example.com", "user@example.com"],
+  ])("handles %s", (_name, input, expected) => {
+    expect(sanitizeKqlValue(input)).toBe(expected);
   });
 });
 
 describe("sanitizeKqlFieldQuery", () => {
-  it("should return field:value without outer quotes", () => {
-    expect(sanitizeKqlFieldQuery("participants:user@example.com")).toBe(
+  it.each([
+    [
+      "field:value without outer quotes",
       "participants:user@example.com",
-    );
-  });
-
-  it("should quote value with spaces", () => {
-    expect(sanitizeKqlFieldQuery("subject:meeting notes")).toBe(
-      'subject:"meeting notes"',
-    );
-  });
-
-  it("should replace ? and quote if result has spaces", () => {
-    expect(sanitizeKqlFieldQuery("from:user?name")).toBe('from:"user name"');
-  });
-
-  it("should escape backslashes in value", () => {
-    expect(sanitizeKqlFieldQuery("subject:path\\file")).toBe(
-      "subject:path\\\\file",
-    );
-  });
-
-  it("should escape quotes in value", () => {
-    expect(sanitizeKqlFieldQuery('subject:say "hi"')).toBe(
-      'subject:"say \\"hi\\""',
-    );
-  });
-
-  it("should handle empty value", () => {
-    expect(sanitizeKqlFieldQuery("field:")).toBe("field:");
-  });
-
-  it("should handle query without colon", () => {
-    expect(sanitizeKqlFieldQuery("nofield")).toBe("nofield");
+      "participants:user@example.com",
+    ],
+    ["value with spaces", "subject:meeting notes", 'subject:"meeting notes"'],
+    ["question mark in value", "from:user?name", 'from:"user name"'],
+    ["backslashes in value", "subject:path\\file", "subject:path\\\\file"],
+    ["quotes in value", 'subject:say "hi"', 'subject:"say \\"hi\\""'],
+    ["empty value", "field:", "field:"],
+    ["query without colon", "nofield", "nofield"],
+  ])("handles %s", (_name, input, expected) => {
+    expect(sanitizeKqlFieldQuery(input)).toBe(expected);
   });
 });
 
 describe("sanitizeKqlTextQuery", () => {
-  it("should wrap text in quotes", () => {
-    expect(sanitizeKqlTextQuery("hello world")).toBe('"hello world"');
-  });
-
-  it("should remove internal quotes", () => {
-    expect(sanitizeKqlTextQuery('say "hello"')).toBe('"say hello"');
-  });
-
-  it("should replace ? with space", () => {
-    expect(sanitizeKqlTextQuery("hello?world")).toBe('"hello world"');
-  });
-
-  it("should escape backslashes", () => {
-    expect(sanitizeKqlTextQuery("path\\to")).toBe('"path\\\\to"');
-  });
-
-  it("should normalize multiple spaces", () => {
-    expect(sanitizeKqlTextQuery("hello    world")).toBe('"hello world"');
+  it.each([
+    ["text", "hello world", '"hello world"'],
+    ["internal quotes", 'say "hello"', '"say hello"'],
+    ["question marks", "hello?world", '"hello world"'],
+    ["backslashes", "path\\to", '"path\\\\to"'],
+    ["multiple spaces", "hello    world", '"hello world"'],
+  ])("handles %s", (_name, input, expected) => {
+    expect(sanitizeKqlTextQuery(input)).toBe(expected);
   });
 });
 
 describe("sanitizeOutlookSearchQuery", () => {
   describe("empty and whitespace inputs", () => {
-    it("should return empty string for empty input", () => {
-      const result = sanitizeOutlookSearchQuery("");
-      expect(result.sanitized).toBe("");
-      expect(result.wasSanitized).toBe(false);
-    });
-
-    it("should return empty string for whitespace-only input", () => {
-      const result = sanitizeOutlookSearchQuery("   ");
-      expect(result.sanitized).toBe("");
-      expect(result.wasSanitized).toBe(false);
+    it.each([
+      ["empty input", ""],
+      ["whitespace-only input", "   "],
+    ])("returns empty string for %s", (_name, input) => {
+      expectSanitizedSearchQuery(input, "", false);
     });
   });
 
   describe("KQL field queries (field:value syntax)", () => {
-    it("should NOT wrap participants:email in outer quotes", () => {
-      const result = sanitizeOutlookSearchQuery(
+    it.each([
+      [
+        "participants email",
         "participants:user@example.com",
-      );
-      expect(result.sanitized).toBe("participants:user@example.com");
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should handle subject field query without outer quotes", () => {
-      const result = sanitizeOutlookSearchQuery("subject:meeting");
-      expect(result.sanitized).toBe("subject:meeting");
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should quote value with spaces in field query", () => {
-      const result = sanitizeOutlookSearchQuery("subject:meeting notes");
-      expect(result.sanitized).toBe('subject:"meeting notes"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should handle ? in field query value by replacing with space", () => {
-      const result = sanitizeOutlookSearchQuery("participants:user?name");
-      expect(result.sanitized).toBe('participants:"user name"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should treat empty value after colon as text query", () => {
-      const result = sanitizeOutlookSearchQuery("field:");
-      expect(result.sanitized).toBe('"field:"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should escape backslashes in field value", () => {
-      const result = sanitizeOutlookSearchQuery("subject:path\\file");
-      expect(result.sanitized).toBe("subject:path\\\\file");
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should escape quotes in field value and wrap if needed", () => {
-      const result = sanitizeOutlookSearchQuery('subject:say "hello"');
-      expect(result.sanitized).toBe('subject:"say \\"hello\\""');
-      expect(result.wasSanitized).toBe(true);
+        "participants:user@example.com",
+      ],
+      ["subject field", "subject:meeting", "subject:meeting"],
+      [
+        "field query value with spaces",
+        "subject:meeting notes",
+        'subject:"meeting notes"',
+      ],
+      [
+        "question mark in field query value",
+        "participants:user?name",
+        'participants:"user name"',
+      ],
+      ["empty value after colon", "field:", '"field:"'],
+      [
+        "backslashes in field value",
+        "subject:path\\file",
+        "subject:path\\\\file",
+      ],
+      [
+        "quotes in field value",
+        'subject:say "hello"',
+        'subject:"say \\"hello\\""',
+      ],
+    ])("handles %s", (_name, input, expected) => {
+      expectSanitizedSearchQuery(input, expected);
     });
   });
 
   describe("regular text queries (no field:value syntax)", () => {
-    it("should wrap simple query in quotes", () => {
-      const result = sanitizeOutlookSearchQuery("simple query");
-      expect(result.sanitized).toBe('"simple query"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should remove internal double quotes and wrap in outer quotes", () => {
-      const result = sanitizeOutlookSearchQuery(
+    it.each([
+      ["simple query", "simple query", '"simple query"'],
+      [
+        "internal double quotes",
         'Reinstatement of "Universal policy" for "5161 Collins Ave"',
-      );
-      expect(result.sanitized).toBe(
         '"Reinstatement of Universal policy for 5161 Collins Ave"',
-      );
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should replace ? with space in text query", () => {
-      const result = sanitizeOutlookSearchQuery("hello? world");
-      expect(result.sanitized).toBe('"hello world"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should escape backslashes in text query", () => {
-      const result = sanitizeOutlookSearchQuery("test\\path");
-      expect(result.sanitized).toBe('"test\\\\path"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should normalize multiple spaces", () => {
-      const result = sanitizeOutlookSearchQuery("hello    world");
-      expect(result.sanitized).toBe('"hello world"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should handle single word queries", () => {
-      const result = sanitizeOutlookSearchQuery("hello");
-      expect(result.sanitized).toBe('"hello"');
-      expect(result.wasSanitized).toBe(true);
+      ],
+      ["question mark in text query", "hello? world", '"hello world"'],
+      ["backslashes in text query", "test\\path", '"test\\\\path"'],
+      ["multiple spaces", "hello    world", '"hello world"'],
+      ["single word query", "hello", '"hello"'],
+    ])("handles %s", (_name, input, expected) => {
+      expectSanitizedSearchQuery(input, expected);
     });
   });
 
   describe("edge cases", () => {
-    it("should handle colon in middle of text (not at start)", () => {
-      const result = sanitizeOutlookSearchQuery("meeting at 10:30am");
-      expect(result.sanitized).toBe('"meeting at 10:30am"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should not treat URL-like strings as KQL fields", () => {
-      const result = sanitizeOutlookSearchQuery("https://example.com");
-      expect(result.sanitized).toBe('"https://example.com"');
-      expect(result.wasSanitized).toBe(true);
-    });
-
-    it("should treat http: as text query, not KQL field", () => {
-      const result = sanitizeOutlookSearchQuery("http://test.com");
-      expect(result.sanitized).toBe('"http://test.com"');
-      expect(result.wasSanitized).toBe(true);
+    it.each([
+      ["colon in middle of text", "meeting at 10:30am", '"meeting at 10:30am"'],
+      ["URL-like string", "https://example.com", '"https://example.com"'],
+      ["http: prefix", "http://test.com", '"http://test.com"'],
+    ])("handles %s", (_name, input, expected) => {
+      expectSanitizedSearchQuery(input, expected);
     });
   });
 
@@ -518,24 +423,24 @@ describe("sanitizeOutlookSearchQuery", () => {
 });
 
 describe("buildOutlookSearchFallbackQuery", () => {
-  it("falls back from a fielded sender lookup to a plain-text sender search", () => {
-    expect(buildOutlookSearchFallbackQuery("from:sender@example.com")).toBe(
+  it.each([
+    [
+      "fielded sender lookup",
+      "from:sender@example.com",
       '"sender@example.com"',
-    );
-  });
-
-  it("drops trailing helper filters when collapsing an Outlook sender query", () => {
-    expect(
-      buildOutlookSearchFallbackQuery(
-        "from:sender@example.com received>=2026-04-20 unread",
-      ),
-    ).toBe('"sender@example.com"');
-  });
-
-  it("falls back from a subject field query to plain text", () => {
-    expect(
-      buildOutlookSearchFallbackQuery('subject:"Quarterly planning notes"'),
-    ).toBe('"Quarterly planning notes"');
+    ],
+    [
+      "Outlook sender query with trailing helper filters",
+      "from:sender@example.com received>=2026-04-20 unread",
+      '"sender@example.com"',
+    ],
+    [
+      "subject field query",
+      'subject:"Quarterly planning notes"',
+      '"Quarterly planning notes"',
+    ],
+  ])("falls back from %s", (_name, query, expected) => {
+    expect(buildOutlookSearchFallbackQuery(query)).toBe(expected);
   });
 
   it("preserves read-state words when they are part of the quoted subject text", () => {
@@ -546,16 +451,28 @@ describe("buildOutlookSearchFallbackQuery", () => {
   });
 
   it("does not strip plain keyword text that happens to contain a comparison", () => {
-    expect(buildOutlookSearchFallbackQuery('"price < 5"')).toBeNull();
     expect(sanitizeOutlookSearchQuery('"price < 5"').sanitized).toBe(
       '"price < 5"',
     );
   });
 
-  it("returns null when the fallback would not change the query", () => {
-    expect(buildOutlookSearchFallbackQuery("sender@example.com")).toBeNull();
+  it.each([
+    ["plain keyword text with comparison", '"price < 5"'],
+    ["unchanged sender query", "sender@example.com"],
+  ])("returns null for %s", (_name, query) => {
+    expect(buildOutlookSearchFallbackQuery(query)).toBeNull();
   });
 });
+
+function expectSanitizedSearchQuery(
+  query: string,
+  sanitized: string,
+  wasSanitized = true,
+) {
+  const result = sanitizeOutlookSearchQuery(query);
+  expect(result.sanitized).toBe(sanitized);
+  expect(result.wasSanitized).toBe(wasSanitized);
+}
 
 function createCachedOutlookClient(
   api: ReturnType<typeof vi.fn>,

--- a/apps/web/utils/outlook/retry.test.ts
+++ b/apps/web/utils/outlook/retry.test.ts
@@ -8,164 +8,160 @@ import {
 } from "./retry";
 
 describe("extractErrorInfo", () => {
-  it("extracts status from statusCode", () => {
-    const error = { statusCode: 429, message: "Too many requests" };
-    const info = extractErrorInfo(error);
-    expect(info.status).toBe(429);
-    expect(info.errorMessage).toBe("Too many requests");
-  });
-
-  it("extracts code from error.code", () => {
-    const error = {
-      code: "TooManyRequests",
-      message: "Rate limit exceeded",
-    };
-    const info = extractErrorInfo(error);
-    expect(info.code).toBe("TooManyRequests");
-    expect(info.errorMessage).toBe("Rate limit exceeded");
-  });
-
-  it("extracts nested error structure", () => {
-    const error = {
+  it.each([
+    {
+      name: "status from statusCode",
+      error: { statusCode: 429, message: "Too many requests" },
+      expected: { status: 429, errorMessage: "Too many requests" },
+    },
+    {
+      name: "code from error.code",
       error: {
+        code: "TooManyRequests",
+        message: "Rate limit exceeded",
+      },
+      expected: {
+        code: "TooManyRequests",
+        errorMessage: "Rate limit exceeded",
+      },
+    },
+    {
+      name: "nested error structure",
+      error: {
+        error: {
+          code: "ServiceNotAvailable",
+          message: "Service temporarily unavailable",
+        },
+        statusCode: 503,
+      },
+      expected: {
+        status: 503,
         code: "ServiceNotAvailable",
-        message: "Service temporarily unavailable",
+        errorMessage: "Service temporarily unavailable",
       },
-      statusCode: 503,
-    };
-    const info = extractErrorInfo(error);
-    expect(info.status).toBe(503);
-    expect(info.code).toBe("ServiceNotAvailable");
-    expect(info.errorMessage).toBe("Service temporarily unavailable");
-  });
-
-  it("handles response object", () => {
-    const error = {
-      response: {
-        status: 429,
+    },
+    {
+      name: "response object",
+      error: {
+        response: {
+          status: 429,
+        },
+        message: "Rate limited",
       },
-      message: "Rate limited",
-    };
-    const info = extractErrorInfo(error);
-    expect(info.status).toBe(429);
-    expect(info.errorMessage).toBe("Rate limited");
+      expected: { status: 429, errorMessage: "Rate limited" },
+    },
+  ])("extracts $name", ({ error, expected }) => {
+    expect(extractErrorInfo(error)).toMatchObject(expected);
   });
 });
 
 describe("isRetryableError", () => {
-  it("identifies 429 as rate limit", () => {
-    const errorInfo = { status: 429, errorMessage: "Too many requests" };
-    const result = isRetryableError(errorInfo);
-    expect(result.isRateLimit).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies TooManyRequests code as rate limit", () => {
-    const errorInfo = {
-      code: "TooManyRequests",
-      errorMessage: "Rate limit exceeded",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isRateLimit).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies ApplicationThrottled code as rate limit", () => {
-    const errorInfo = {
-      code: "ApplicationThrottled",
-      errorMessage: "Application is over its MailboxConcurrency limit.",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isRateLimit).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies MailboxConcurrency message as rate limit", () => {
-    const errorInfo = {
-      status: 429,
-      errorMessage: "MailboxConcurrency limit exceeded",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isRateLimit).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies server errors", () => {
-    for (const status of [502, 503, 504]) {
-      const errorInfo = { status, errorMessage: "Server error" };
-      const result = isRetryableError(errorInfo);
-      expect(result.isServerError).toBe(true);
-      expect(result.retryable).toBe(true);
-    }
-  });
-
-  it("identifies ServiceNotAvailable code as server error", () => {
-    const errorInfo = {
-      code: "ServiceNotAvailable",
-      errorMessage: "Service unavailable",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isServerError).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies ServerBusy code as server error", () => {
-    const errorInfo = { code: "ServerBusy", errorMessage: "Server busy" };
-    const result = isRetryableError(errorInfo);
-    expect(result.isServerError).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies 412 as conflict error", () => {
-    const errorInfo = { status: 412, errorMessage: "Precondition failed" };
-    const result = isRetryableError(errorInfo);
-    expect(result.isConflictError).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies ErrorIrresolvableConflict code as conflict error", () => {
-    const errorInfo = {
-      code: "ErrorIrresolvableConflict",
-      errorMessage: "Change key conflict",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isConflictError).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies conflict by message pattern", () => {
-    const errorInfo = {
-      status: 409,
-      errorMessage: "The change key passed does not match",
-    };
-    const result = isRetryableError(errorInfo);
-    expect(result.isConflictError).toBe(true);
-    expect(result.retryable).toBe(true);
-  });
-
-  it("identifies fetch failed as network error", () => {
-    const errorInfo = { errorMessage: "fetch failed" };
-    const result = isRetryableError(errorInfo);
-    expect(result.retryable).toBe(true);
-    expect(result.isRateLimit).toBe(false);
-    expect(result.isServerError).toBe(false);
-    expect(result.isConflictError).toBe(false);
-  });
-
-  it("identifies non-retryable errors", () => {
-    const errorInfo = { status: 404, errorMessage: "Not found" };
-    const result = isRetryableError(errorInfo);
-    expect(result.retryable).toBe(false);
-    expect(result.isRateLimit).toBe(false);
-    expect(result.isServerError).toBe(false);
-    expect(result.isConflictError).toBe(false);
-  });
-
-  it("identifies rate limit by message pattern", () => {
-    const errorInfo = { status: 403, errorMessage: "Rate limit exceeded" };
-    const result = isRetryableError(errorInfo);
-    expect(result.isRateLimit).toBe(true);
-    expect(result.retryable).toBe(true);
+  it.each([
+    {
+      name: "429 status as rate limit",
+      errorInfo: { status: 429, errorMessage: "Too many requests" },
+      expected: { isRateLimit: true, retryable: true },
+    },
+    {
+      name: "TooManyRequests code as rate limit",
+      errorInfo: {
+        code: "TooManyRequests",
+        errorMessage: "Rate limit exceeded",
+      },
+      expected: { isRateLimit: true, retryable: true },
+    },
+    {
+      name: "ApplicationThrottled code as rate limit",
+      errorInfo: {
+        code: "ApplicationThrottled",
+        errorMessage: "Application is over its MailboxConcurrency limit.",
+      },
+      expected: { isRateLimit: true, retryable: true },
+    },
+    {
+      name: "MailboxConcurrency message as rate limit",
+      errorInfo: {
+        status: 429,
+        errorMessage: "MailboxConcurrency limit exceeded",
+      },
+      expected: { isRateLimit: true, retryable: true },
+    },
+    {
+      name: "502 status as server error",
+      errorInfo: { status: 502, errorMessage: "Server error" },
+      expected: { isServerError: true, retryable: true },
+    },
+    {
+      name: "503 status as server error",
+      errorInfo: { status: 503, errorMessage: "Server error" },
+      expected: { isServerError: true, retryable: true },
+    },
+    {
+      name: "504 status as server error",
+      errorInfo: { status: 504, errorMessage: "Server error" },
+      expected: { isServerError: true, retryable: true },
+    },
+    {
+      name: "ServiceNotAvailable code as server error",
+      errorInfo: {
+        code: "ServiceNotAvailable",
+        errorMessage: "Service unavailable",
+      },
+      expected: { isServerError: true, retryable: true },
+    },
+    {
+      name: "ServerBusy code as server error",
+      errorInfo: { code: "ServerBusy", errorMessage: "Server busy" },
+      expected: { isServerError: true, retryable: true },
+    },
+    {
+      name: "412 status as conflict error",
+      errorInfo: { status: 412, errorMessage: "Precondition failed" },
+      expected: { isConflictError: true, retryable: true },
+    },
+    {
+      name: "ErrorIrresolvableConflict code as conflict error",
+      errorInfo: {
+        code: "ErrorIrresolvableConflict",
+        errorMessage: "Change key conflict",
+      },
+      expected: { isConflictError: true, retryable: true },
+    },
+    {
+      name: "conflict by message pattern",
+      errorInfo: {
+        status: 409,
+        errorMessage: "The change key passed does not match",
+      },
+      expected: { isConflictError: true, retryable: true },
+    },
+    {
+      name: "fetch failed as network error",
+      errorInfo: { errorMessage: "fetch failed" },
+      expected: {
+        retryable: true,
+        isRateLimit: false,
+        isServerError: false,
+        isConflictError: false,
+      },
+    },
+    {
+      name: "non-retryable errors",
+      errorInfo: { status: 404, errorMessage: "Not found" },
+      expected: {
+        retryable: false,
+        isRateLimit: false,
+        isServerError: false,
+        isConflictError: false,
+      },
+    },
+    {
+      name: "rate limit by message pattern",
+      errorInfo: { status: 403, errorMessage: "Rate limit exceeded" },
+      expected: { isRateLimit: true, retryable: true },
+    },
+  ])("identifies $name", ({ errorInfo, expected }) => {
+    expect(isRetryableError(errorInfo)).toMatchObject(expected);
   });
 });
 
@@ -193,32 +189,26 @@ describe("calculateRetryDelay", () => {
     expect(delay).toBe(30_000);
   });
 
-  it("uses exponential backoff for server errors", () => {
-    expect(calculateRetryDelay(false, true, false, 1)).toBe(5000); // 5s
-    expect(calculateRetryDelay(false, true, false, 2)).toBe(10_000); // 10s
-    expect(calculateRetryDelay(false, true, false, 3)).toBe(20_000); // 20s
-    expect(calculateRetryDelay(false, true, false, 4)).toBe(40_000); // 40s
-    expect(calculateRetryDelay(false, true, false, 5)).toBe(80_000); // 80s max
-    expect(calculateRetryDelay(false, true, false, 6)).toBe(80_000); // capped at 80s
-  });
-
-  it("uses exponential backoff for conflict errors", () => {
-    expect(calculateRetryDelay(false, false, true, 1)).toBe(500); // 500ms
-    expect(calculateRetryDelay(false, false, true, 2)).toBe(1000); // 1s
-    expect(calculateRetryDelay(false, false, true, 3)).toBe(2000); // 2s
-    expect(calculateRetryDelay(false, false, true, 4)).toBe(4000); // 4s
-    expect(calculateRetryDelay(false, false, true, 5)).toBe(8000); // 8s max
-    expect(calculateRetryDelay(false, false, true, 6)).toBe(8000); // capped at 8s
-  });
-
-  it("uses default exponential backoff for other retryable errors (e.g., network)", () => {
-    // When no specific error type matches, falls back to default
-    expect(calculateRetryDelay(false, false, false, 1)).toBe(1000); // 1s
-    expect(calculateRetryDelay(false, false, false, 2)).toBe(2000); // 2s
-    expect(calculateRetryDelay(false, false, false, 3)).toBe(4000); // 4s
-    expect(calculateRetryDelay(false, false, false, 4)).toBe(8000); // 8s
-    expect(calculateRetryDelay(false, false, false, 5)).toBe(16_000); // 16s max
-    expect(calculateRetryDelay(false, false, false, 6)).toBe(16_000); // capped at 16s
+  it.each([
+    {
+      name: "server errors",
+      args: [false, true, false] as const,
+      expectedDelays: [5000, 10_000, 20_000, 40_000, 80_000, 80_000],
+    },
+    {
+      name: "conflict errors",
+      args: [false, false, true] as const,
+      expectedDelays: [500, 1000, 2000, 4000, 8000, 8000],
+    },
+    {
+      name: "other retryable errors",
+      args: [false, false, false] as const,
+      expectedDelays: [1000, 2000, 4000, 8000, 16_000, 16_000],
+    },
+  ])("uses exponential backoff for $name", ({ args, expectedDelays }) => {
+    for (const [index, expectedDelay] of expectedDelays.entries()) {
+      expect(calculateRetryDelay(...args, index + 1)).toBe(expectedDelay);
+    }
   });
 });
 

--- a/apps/web/utils/parse/extract-reply.client.test.ts
+++ b/apps/web/utils/parse/extract-reply.client.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
 import { extractEmailReply } from "./extract-reply.client";
 
-// pnpm test utils/parse/extract-reply.client.test.ts
-
 // Setup JSDOM
 const dom = new JSDOM();
 global.DOMParser = dom.window.DOMParser;

--- a/apps/web/utils/parse/unsubscribe.test.ts
+++ b/apps/web/utils/parse/unsubscribe.test.ts
@@ -9,207 +9,80 @@ import {
 } from "./unsubscribe";
 
 describe("containsUnsubscribeKeyword", () => {
-  describe("detects unsubscribe keywords", () => {
-    it("detects 'unsubscribe'", () => {
-      expect(containsUnsubscribeKeyword("Click to unsubscribe")).toBe(true);
-    });
-
-    it("detects 'email preferences'", () => {
-      expect(
-        containsUnsubscribeKeyword("Manage your email preferences here"),
-      ).toBe(true);
-    });
-
-    it("detects 'email settings'", () => {
-      expect(containsUnsubscribeKeyword("Update email settings")).toBe(true);
-    });
-
-    it("detects 'email options'", () => {
-      expect(containsUnsubscribeKeyword("Change email options")).toBe(true);
-    });
-
-    it("detects 'notification preferences'", () => {
-      expect(containsUnsubscribeKeyword("Edit notification preferences")).toBe(
-        true,
-      );
-    });
-  });
-
-  describe("keyword matching behavior", () => {
-    it("matches keyword at start of text", () => {
-      expect(containsUnsubscribeKeyword("unsubscribe from this list")).toBe(
-        true,
-      );
-    });
-
-    it("matches keyword at end of text", () => {
-      expect(containsUnsubscribeKeyword("Click here to unsubscribe")).toBe(
-        true,
-      );
-    });
-
-    it("matches keyword in middle of text", () => {
-      expect(
-        containsUnsubscribeKeyword("You can unsubscribe at any time"),
-      ).toBe(true);
-    });
-
-    it("matches keyword as part of longer word", () => {
-      // This tests that includes() matches substrings
-      expect(containsUnsubscribeKeyword("unsubscribed")).toBe(true);
-    });
-
-    it("is case insensitive - matches uppercase", () => {
-      expect(containsUnsubscribeKeyword("UNSUBSCRIBE")).toBe(true);
-    });
-
-    it("is case insensitive - matches mixed case", () => {
-      expect(containsUnsubscribeKeyword("Unsubscribe")).toBe(true);
-    });
-
-    it("is case insensitive - matches 'Email Preferences'", () => {
-      expect(containsUnsubscribeKeyword("Email Preferences")).toBe(true);
-    });
-  });
-
-  describe("returns false for non-matching text", () => {
-    it("returns false for empty string", () => {
-      expect(containsUnsubscribeKeyword("")).toBe(false);
-    });
-
-    it("returns false for regular text", () => {
-      expect(containsUnsubscribeKeyword("Hello, how are you?")).toBe(false);
-    });
-
-    it("returns false for similar but different text", () => {
-      expect(containsUnsubscribeKeyword("subscribe to our newsletter")).toBe(
-        false,
-      );
-    });
-
-    it("returns false for partial keyword match", () => {
-      expect(containsUnsubscribeKeyword("email prefer")).toBe(false);
-    });
-
-    it("returns false for keywords with typos", () => {
-      expect(containsUnsubscribeKeyword("unsubscibe")).toBe(false);
-    });
+  it.each([
+    ["unsubscribe keyword", "Click to unsubscribe", true],
+    ["email preferences keyword", "Manage your email preferences here", true],
+    ["email settings keyword", "Update email settings", true],
+    ["email options keyword", "Change email options", true],
+    ["notification preferences keyword", "Edit notification preferences", true],
+    ["keyword at start of text", "unsubscribe from this list", true],
+    ["keyword at end of text", "Click here to unsubscribe", true],
+    ["keyword in middle of text", "You can unsubscribe at any time", true],
+    ["keyword as part of longer word", "unsubscribed", true],
+    ["uppercase keyword", "UNSUBSCRIBE", true],
+    ["mixed-case keyword", "Unsubscribe", true],
+    ["mixed-case email preferences", "Email Preferences", true],
+    ["empty string", "", false],
+    ["regular text", "Hello, how are you?", false],
+    ["similar but different text", "subscribe to our newsletter", false],
+    ["partial keyword match", "email prefer", false],
+    ["keyword with typo", "unsubscibe", false],
+  ])("returns %s for %s", (_name, text, expected) => {
+    expect(containsUnsubscribeKeyword(text)).toBe(expected);
   });
 });
 
 describe("containsUnsubscribeUrlPattern", () => {
-  describe("detects unsubscribe URL patterns", () => {
-    it("detects 'unsubscribe' in URL", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://example.com/unsubscribe?email=test",
-        ),
-      ).toBe(true);
-    });
-
-    it("detects 'unsub' in URL (short form)", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://click.example.com/campaign/unsub-email/123",
-        ),
-      ).toBe(true);
-    });
-
-    it("detects 'opt-out' in URL", () => {
-      expect(
-        containsUnsubscribeUrlPattern("https://example.com/opt-out/user123"),
-      ).toBe(true);
-    });
-
-    it("detects 'optout' in URL (no hyphen)", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://example.com/email/optout?id=abc",
-        ),
-      ).toBe(true);
-    });
-
-    it("detects 'list-manage' in URL (Mailchimp style)", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://list-manage.com/track/click?u=abc&id=123",
-        ),
-      ).toBe(true);
-    });
-  });
-
-  describe("URL pattern matching behavior", () => {
-    it("is case insensitive - matches UNSUB", () => {
-      expect(
-        containsUnsubscribeUrlPattern("https://example.com/UNSUB/email"),
-      ).toBe(true);
-    });
-
-    it("matches pattern in query string", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://example.com/email?action=unsubscribe",
-        ),
-      ).toBe(true);
-    });
-
-    it("matches pattern in path", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://example.com/unsubscribe/confirm",
-        ),
-      ).toBe(true);
-    });
-
-    it("matches Portuguese email example (unsub-email)", () => {
-      expect(
-        containsUnsubscribeUrlPattern(
-          "https://click.lindtbrasil.com/campaign/unsub-email/MTM",
-        ),
-      ).toBe(true);
-    });
-  });
-
-  describe("returns false for non-matching URLs", () => {
-    it("returns false for empty string", () => {
-      expect(containsUnsubscribeUrlPattern("")).toBe(false);
-    });
-
-    it("returns false for regular URLs", () => {
-      expect(containsUnsubscribeUrlPattern("https://example.com/about")).toBe(
-        false,
-      );
-    });
-
-    it("returns false for subscribe URLs (not unsubscribe)", () => {
-      expect(
-        containsUnsubscribeUrlPattern("https://example.com/subscribe"),
-      ).toBe(false);
-    });
-
-    it("returns false for URLs with 'sub' but not 'unsub'", () => {
-      expect(
-        containsUnsubscribeUrlPattern("https://example.com/submit-form"),
-      ).toBe(false);
-    });
+  it.each([
+    ["unsubscribe in URL", "https://example.com/unsubscribe?email=test", true],
+    [
+      "short unsub form",
+      "https://click.example.com/campaign/unsub-email/123",
+      true,
+    ],
+    ["opt-out URL", "https://example.com/opt-out/user123", true],
+    ["optout URL", "https://example.com/email/optout?id=abc", true],
+    [
+      "Mailchimp-style list-manage URL",
+      "https://list-manage.com/track/click?u=abc&id=123",
+      true,
+    ],
+    ["case-insensitive UNSUB", "https://example.com/UNSUB/email", true],
+    [
+      "pattern in query string",
+      "https://example.com/email?action=unsubscribe",
+      true,
+    ],
+    ["pattern in path", "https://example.com/unsubscribe/confirm", true],
+    [
+      "Portuguese unsub-email example",
+      "https://click.lindtbrasil.com/campaign/unsub-email/MTM",
+      true,
+    ],
+    ["empty string", "", false],
+    ["regular URL", "https://example.com/about", false],
+    ["subscribe URL", "https://example.com/subscribe", false],
+    ["sub without unsub", "https://example.com/submit-form", false],
+  ])("returns %s for %s", (_name, url, expected) => {
+    expect(containsUnsubscribeUrlPattern(url)).toBe(expected);
   });
 });
 
 describe("cleanUnsubscribeLink", () => {
-  it("removes surrounding angle brackets", () => {
-    expect(cleanUnsubscribeLink("<https://example.com/unsub>")).toBe(
+  it.each([
+    [
+      "surrounding angle brackets",
+      "<https://example.com/unsub>",
       "https://example.com/unsub",
-    );
-  });
-
-  it("trims whitespace", () => {
-    expect(cleanUnsubscribeLink("  https://example.com/unsub  ")).toBe(
+    ],
+    [
+      "surrounding whitespace",
+      "  https://example.com/unsub  ",
       "https://example.com/unsub",
-    );
-  });
-
-  it("returns undefined for empty strings", () => {
-    expect(cleanUnsubscribeLink("   ")).toBeUndefined();
+    ],
+    ["empty strings", "   ", undefined],
+  ])("cleans %s", (_name, link, expected) => {
+    expect(cleanUnsubscribeLink(link)).toBe(expected);
   });
 });
 

--- a/apps/web/utils/rate-limit.test.ts
+++ b/apps/web/utils/rate-limit.test.ts
@@ -130,42 +130,43 @@ describe("rate limit utilities", () => {
     expect(redis.eval).not.toHaveBeenCalled();
   });
 
-  it("builds safe key strings and extracts forwarded IPs", () => {
+  it("builds safe key strings", () => {
     expect(createRateLimitKey(["rate limit", "book/link", "a:b"])).toBe(
       "rate_limit:book_link:a_b",
     );
-    // Rightmost entry wins: leftmost is client-controlled on Vercel.
-    expect(
-      getClientIp(
-        new Headers({
-          "x-forwarded-for": "203.0.113.1, 10.0.0.1",
-        }),
-      ),
-    ).toBe("10.0.0.1");
-    // Provider-specific visitor IP headers are not trusted by default because
-    // they can be spoofed when the origin is directly reachable.
-    expect(
-      getClientIp(
-        new Headers({
-          "cf-connecting-ip": "198.51.100.7",
-          "x-forwarded-for": "203.0.113.1, 10.0.0.1",
-        }),
-      ),
-    ).toBe("10.0.0.1");
-    expect(
-      getClientIp(
-        new Headers({
-          "cf-connecting-ip": "198.51.100.7",
-        }),
-      ),
-    ).toBe("unknown");
-    // x-real-ip is no longer trusted.
-    expect(
-      getClientIp(
-        new Headers({
-          "x-real-ip": "203.0.113.99",
-        }),
-      ),
-    ).toBe("unknown");
+  });
+
+  it.each([
+    {
+      name: "rightmost forwarded IP",
+      headers: {
+        "x-forwarded-for": "203.0.113.1, 10.0.0.1",
+      },
+      expected: "10.0.0.1",
+    },
+    {
+      name: "rightmost forwarded IP over provider visitor IP",
+      headers: {
+        "cf-connecting-ip": "198.51.100.7",
+        "x-forwarded-for": "203.0.113.1, 10.0.0.1",
+      },
+      expected: "10.0.0.1",
+    },
+    {
+      name: "unknown when only provider visitor IP is present",
+      headers: {
+        "cf-connecting-ip": "198.51.100.7",
+      },
+      expected: "unknown",
+    },
+    {
+      name: "unknown when only x-real-ip is present",
+      headers: {
+        "x-real-ip": "203.0.113.99",
+      },
+      expected: "unknown",
+    },
+  ])("extracts $name", ({ headers, expected }) => {
+    expect(getClientIp(new Headers(headers))).toBe(expected);
   });
 });

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -20,6 +20,8 @@ vi.mock("@/utils/redis", () => ({
   },
 }));
 
+const NOW = new Date("2026-02-24T15:00:00.000Z");
+
 describe("redis usage tracking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,15 +46,10 @@ describe("redis usage tracking", () => {
   });
 
   it("migrates legacy email usage into account and user usage before reading", async () => {
-    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
-      {
-        "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
-        "usage:email-account:email-account-1": { openaiCalls: 3 },
-      };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => usageByKey[key] ?? {},
-    );
+    mockRedisHashes({
+      "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
+      "usage:email-account:email-account-1": { openaiCalls: 3 },
+    });
 
     const usage = await getUsage({
       emailAccountId: "email-account-1",
@@ -89,18 +86,13 @@ describe("redis usage tracking", () => {
 
   it("includes legacy email usage while another request owns the migration lock", async () => {
     vi.mocked(redis.set).mockResolvedValue(null);
-    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
-      {
-        "usage:email-account:email-account-1": {
-          openaiCalls: 2,
-          cost: "0.75",
-        },
-        "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
-      };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => usageByKey[key] ?? {},
-    );
+    mockRedisHashes({
+      "usage:email-account:email-account-1": {
+        openaiCalls: 2,
+        cost: "0.75",
+      },
+      "usage:user@example.com": { openaiCalls: 3, cost: "1.25" },
+    });
 
     const usage = await getUsage({
       emailAccountId: "email-account-1",
@@ -112,18 +104,13 @@ describe("redis usage tracking", () => {
   });
 
   it("sums user usage cost across the last 7 days", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
       "usage-weekly-cost:user:user-1:2026-02-23": { cost: "0.5" },
       "usage-weekly-cost:user:user-1:2026-02-22": { cost: "0.25" },
-    };
+    });
 
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
-
-    const weeklyCost = await getWeeklyUsageCost({ userId: "user-1", now });
+    const weeklyCost = await getWeeklyUsageCost({ userId: "user-1", now: NOW });
 
     expect(weeklyCost).toBeCloseTo(2.25);
     expect(redis.hgetall).toHaveBeenCalledTimes(7);
@@ -133,22 +120,17 @@ describe("redis usage tracking", () => {
   });
 
   it("migrates legacy weekly email spend into user weekly spend", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
       "usage-weekly-cost:user@example.com:2026-02-23": { cost: "0.5" },
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "2.0" },
       "usage-weekly-cost:user:user-1:2026-02-23": { cost: "0.5" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["user@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
@@ -170,20 +152,15 @@ describe("redis usage tracking", () => {
 
   it("includes legacy weekly spend while another request owns the migration lock", async () => {
     vi.mocked(redis.set).mockResolvedValue(null);
-    const now = new Date("2026-02-24T15:00:00.000Z");
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "2.0" },
       "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["user@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(weeklyCost).toBeCloseTo(3.5);
@@ -204,27 +181,22 @@ describe("redis usage tracking", () => {
       return "OK";
     });
 
-    const now = new Date("2026-02-24T15:00:00.000Z");
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:primary@example.com:2026-02-24": { cost: "1.0" },
       "usage-weekly-cost:secondary@example.com:2026-02-24": { cost: "2.0" },
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["primary@example.com"],
-      now,
+      now: NOW,
     });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["primary@example.com", "secondary@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(weeklyCost).toBeCloseTo(3);
@@ -242,27 +214,21 @@ describe("redis usage tracking", () => {
       return null;
     });
 
-    const now = new Date("2026-02-24T15:00:00.000Z");
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
       "usage-weekly-cost:user@example.com:2026-02-24": { cost: "1.5" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["user@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(weeklyCost).toBeCloseTo(1.5);
   });
 
   it("does not persist post-migration legacy weekly writes without the migration lock", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
     const legacyWeeklyCostKey = "usage-weekly-cost:user@example.com:2026-02-24";
 
     vi.mocked(redis.get).mockImplementation(async (key: string) => {
@@ -282,19 +248,15 @@ describe("redis usage tracking", () => {
       return "OK";
     });
 
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.0" },
       [legacyWeeklyCostKey]: { cost: "1.5" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["user@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(redis.set).toHaveBeenCalledWith(
@@ -311,7 +273,6 @@ describe("redis usage tracking", () => {
   });
 
   it("uses the latest weekly migration marker after claiming the migration lock", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
     const legacyWeeklyCostKey = "usage-weekly-cost:user@example.com:2026-02-24";
     let doneReads = 0;
 
@@ -328,19 +289,15 @@ describe("redis usage tracking", () => {
       });
     });
 
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
       [legacyWeeklyCostKey]: { cost: "1.5" },
-    };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
+    });
 
     const weeklyCost = await getWeeklyUsageCost({
       userId: "user-1",
       legacyEmails: ["user@example.com"],
-      now,
+      now: NOW,
     });
 
     expect(redis.set).toHaveBeenCalledWith(
@@ -357,8 +314,6 @@ describe("redis usage tracking", () => {
   });
 
   it("returns top weekly spenders from user-keyed costs only", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-
     vi.mocked(redis.scan)
       .mockResolvedValueOnce([
         "1",
@@ -377,19 +332,15 @@ describe("redis usage tracking", () => {
         ],
       ]);
 
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
       "usage-weekly-cost:user:user-1:2026-02-23": { cost: "2.0" },
       "usage-weekly-cost:user:user-2:2026-02-24": { cost: "1.2" },
       "usage-weekly-cost:user:user-2:2026-02-22": { cost: "0.4" },
       "usage-weekly-cost:user:user-3:2026-02-10": { cost: "8.0" },
-    };
+    });
 
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
-
-    const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now });
+    const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now: NOW });
 
     expect(topSpenders).toEqual([
       { userId: "user-1", cost: 3.5 },
@@ -402,8 +353,6 @@ describe("redis usage tracking", () => {
   });
 
   it("returns legacy weekly spenders before they have been migrated", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-
     vi.mocked(redis.scan).mockResolvedValueOnce([
       "0",
       [
@@ -412,16 +361,12 @@ describe("redis usage tracking", () => {
       ],
     ]);
 
-    const costsByKey: Record<string, { cost?: string }> = {
+    mockRedisHashes({
       "usage-weekly-cost:user:user-1:2026-02-24": { cost: "1.5" },
       "usage-weekly-cost:legacy@example.com:2026-02-24": { cost: "2.0" },
-    };
+    });
 
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => costsByKey[key] ?? {},
-    );
-
-    const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now });
+    const topSpenders = await getTopWeeklyUsageCosts({ limit: 2, now: NOW });
 
     expect(topSpenders).toEqual([
       { email: "legacy@example.com", cost: 2.0 },
@@ -430,8 +375,6 @@ describe("redis usage tracking", () => {
   });
 
   it("stores usage under both email account and user keys", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-
     await saveUsage({
       userId: "user-1",
       emailAccountId: "email-account-1",
@@ -441,7 +384,7 @@ describe("redis usage tracking", () => {
         outputTokens: 100,
       },
       cost: 1.25,
-      now,
+      now: NOW,
     });
 
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
@@ -483,18 +426,13 @@ describe("redis usage tracking", () => {
       return null;
     });
 
-    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
-      {
-        "usage:email-account:email-account-1": {
-          openaiCalls: 2,
-          cost: "1.0",
-        },
-        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
-      };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => usageByKey[key] ?? {},
-    );
+    mockRedisHashes({
+      "usage:email-account:email-account-1": {
+        openaiCalls: 2,
+        cost: "1.0",
+      },
+      "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+    });
 
     const usage = await getUsage({
       emailAccountId: "email-account-1",
@@ -524,18 +462,13 @@ describe("redis usage tracking", () => {
       return "OK";
     });
 
-    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
-      {
-        "usage:email-account:email-account-1": {
-          openaiCalls: 2,
-          cost: "1.0",
-        },
-        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
-      };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => usageByKey[key] ?? {},
-    );
+    mockRedisHashes({
+      "usage:email-account:email-account-1": {
+        openaiCalls: 2,
+        cost: "1.0",
+      },
+      "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+    });
 
     const usage = await getUsage({
       emailAccountId: "email-account-1",
@@ -588,18 +521,13 @@ describe("redis usage tracking", () => {
       });
     });
 
-    const usageByKey: Record<string, { openaiCalls?: number; cost?: string }> =
-      {
-        "usage:email-account:email-account-1": {
-          openaiCalls: 3,
-          cost: "1.5",
-        },
-        "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
-      };
-
-    vi.mocked(redis.hgetall).mockImplementation(
-      async (key: string) => usageByKey[key] ?? {},
-    );
+    mockRedisHashes({
+      "usage:email-account:email-account-1": {
+        openaiCalls: 3,
+        cost: "1.5",
+      },
+      "usage:user@example.com": { openaiCalls: 3, cost: "1.5" },
+    });
 
     const usage = await getUsage({
       emailAccountId: "email-account-1",
@@ -636,8 +564,6 @@ describe("redis usage tracking", () => {
   });
 
   it("stores account usage without weekly spend when user ID is missing", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-
     await saveUsage({
       emailAccountId: "email-account-1",
       usage: {
@@ -646,7 +572,7 @@ describe("redis usage tracking", () => {
         outputTokens: 100,
       },
       cost: 1.25,
-      now,
+      now: NOW,
     });
 
     expect(redis.hincrbyfloat).toHaveBeenCalledWith(
@@ -663,8 +589,6 @@ describe("redis usage tracking", () => {
   });
 
   it("skips cost updates when platform cost is zero", async () => {
-    const now = new Date("2026-02-24T15:00:00.000Z");
-
     await saveUsage({
       userId: "user-1",
       emailAccountId: "email-account-1",
@@ -672,10 +596,18 @@ describe("redis usage tracking", () => {
         totalTokens: 100,
       },
       cost: 0,
-      now,
+      now: NOW,
     });
 
     expect(redis.hincrbyfloat).not.toHaveBeenCalled();
     expect(redis.expire).not.toHaveBeenCalled();
   });
 });
+
+function mockRedisHashes(hashes: Record<string, RedisHash>) {
+  vi.mocked(redis.hgetall).mockImplementation(
+    async (key: string) => hashes[key] ?? {},
+  );
+}
+
+type RedisHash = Record<string, string | number | undefined>;

--- a/apps/web/utils/risk.test.ts
+++ b/apps/web/utils/risk.test.ts
@@ -8,9 +8,6 @@ import {
 import { ActionType } from "@/generated/prisma/enums";
 import type { RulesResponse } from "@/app/api/user/rules/route";
 
-// Run with:
-// pnpm test risk.test.ts
-
 describe("getActionRiskLevel", () => {
   const testCases = [
     {

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -61,29 +61,31 @@ import {
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
+const EMAIL_ACCOUNT_ID = "email-account-id";
+const RULE_ID = "rule-id";
+const GROUP_ID = "group-id";
+const MESSAGING_CHANNEL_ID = "cmessagingchannel1234567890123";
+
+type RuleResult = Parameters<typeof createRule>[0]["result"];
+type RuleAction = RuleResult["actions"][number];
+type ResolvedRuleAction = Parameters<
+  typeof createRuleWithResolvedActions
+>[0]["actions"][number];
 
 describe("deleteRule", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockEnv.webhookActionsEnabled = true;
-    vi.mocked(getActionRiskLevel).mockReturnValue({
-      level: "low",
-      message: "safe",
-    });
-    prisma.rule.findMany.mockResolvedValue([]);
-  });
+  beforeEach(resetRuleMocks);
 
   it("deletes the group first and relies on cascade delete for grouped rules", async () => {
     prisma.group.deleteMany.mockResolvedValue({ count: 1 });
 
     await deleteRule({
-      emailAccountId: "email-account-id",
-      ruleId: "rule-id",
-      groupId: "group-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
+      ruleId: RULE_ID,
+      groupId: GROUP_ID,
     });
 
     expect(prisma.group.deleteMany).toHaveBeenCalledWith({
-      where: { id: "group-id", emailAccountId: "email-account-id" },
+      where: { id: GROUP_ID, emailAccountId: EMAIL_ACCOUNT_ID },
     });
     expect(prisma.rule.delete).not.toHaveBeenCalled();
     expect(createRuleHistoryMock).not.toHaveBeenCalled();
@@ -91,83 +93,52 @@ describe("deleteRule", () => {
 
   it("falls back to deleting the rule when the group is already gone", async () => {
     prisma.group.deleteMany.mockResolvedValue({ count: 0 });
-    prisma.rule.delete.mockResolvedValue({ id: "rule-id" } as any);
+    prisma.rule.delete.mockResolvedValue({ id: RULE_ID } as any);
 
     await deleteRule({
-      emailAccountId: "email-account-id",
-      ruleId: "rule-id",
-      groupId: "group-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
+      ruleId: RULE_ID,
+      groupId: GROUP_ID,
     });
 
     expect(prisma.group.deleteMany).toHaveBeenCalledWith({
-      where: { id: "group-id", emailAccountId: "email-account-id" },
+      where: { id: GROUP_ID, emailAccountId: EMAIL_ACCOUNT_ID },
     });
     expect(prisma.rule.delete).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
     });
     expect(createRuleHistoryMock).not.toHaveBeenCalled();
   });
 
   it("deletes the rule directly when there is no group", async () => {
-    prisma.rule.delete.mockResolvedValue({ id: "rule-id" } as any);
+    prisma.rule.delete.mockResolvedValue({ id: RULE_ID } as any);
 
     await deleteRule({
-      emailAccountId: "email-account-id",
-      ruleId: "rule-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
+      ruleId: RULE_ID,
       groupId: null,
     });
 
     expect(prisma.group.deleteMany).not.toHaveBeenCalled();
     expect(prisma.rule.delete).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
     });
     expect(createRuleHistoryMock).not.toHaveBeenCalled();
   });
 });
 
 describe("outbound action guardrails", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockEnv.webhookActionsEnabled = true;
-    vi.mocked(getActionRiskLevel).mockReturnValue({
-      level: "low",
-      message: "safe",
-    });
-    prisma.rule.findMany.mockResolvedValue([]);
-  });
+  beforeEach(resetRuleMocks);
 
   it("rejects creating a low-trust from rule with FORWARD", async () => {
     await expect(
       createRule({
-        result: {
+        result: createRuleResult({
           name: "Forward rule",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: "Team *",
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.FORWARD,
-              fields: {
-                to: "forward@example.com",
-              } as any,
-              delayInMinutes: null,
-            },
-            {
-              type: ActionType.LABEL,
-              fields: {
-                label: "Important",
-              } as any,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: "Team *",
+          actions: [forwardAction(), labelAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         runOnThreads: true,
         logger,
@@ -206,26 +177,12 @@ describe("outbound action guardrails", () => {
 
     await expect(
       createRule({
-        result: {
+        result: createRuleResult({
           name: "Duplicate sender rule",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: "sender@example.com",
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.ARCHIVE,
-              fields: null,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: "sender@example.com",
+          actions: [archiveAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         runOnThreads: true,
         logger,
@@ -273,26 +230,12 @@ describe("outbound action guardrails", () => {
 
     await expect(
       createRule({
-        result: {
+        result: createRuleResult({
           name: "New sender rule",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: "sender@example.com",
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.ARCHIVE,
-              fields: null,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: "sender@example.com",
+          actions: [archiveAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         runOnThreads: true,
         logger,
@@ -310,36 +253,13 @@ describe("outbound action guardrails", () => {
   it("rejects updating a low-trust from rule before mapping action fields", async () => {
     await expect(
       updateRule({
-        ruleId: "rule-id",
-        result: {
+        ruleId: RULE_ID,
+        result: createRuleResult({
           name: "Forward rule",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: "Team *",
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.FORWARD,
-              fields: {
-                to: "forward@example.com",
-              } as any,
-              delayInMinutes: null,
-            },
-            {
-              type: ActionType.LABEL,
-              fields: {
-                label: "Important",
-              } as any,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: "Team *",
+          actions: [forwardAction(), labelAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         logger,
       }),
@@ -356,18 +276,10 @@ describe("outbound action guardrails", () => {
 
     await expect(
       updateRuleActions({
-        ruleId: "rule-id",
-        actions: [
-          {
-            type: ActionType.FORWARD,
-            fields: {
-              to: "forward@example.com",
-            } as any,
-            delayInMinutes: null,
-          },
-        ],
+        ruleId: RULE_ID,
+        actions: [forwardAction()],
         provider: "gmail",
-        emailAccountId: "email-account-id",
+        emailAccountId: EMAIL_ACCOUNT_ID,
         logger,
       }),
     ).rejects.toThrow("email- or domain-based From condition");
@@ -380,18 +292,10 @@ describe("outbound action guardrails", () => {
 
     await expect(
       updateRuleActions({
-        ruleId: "rule-id",
-        actions: [
-          {
-            type: ActionType.FORWARD,
-            fields: {
-              to: "forward@example.com",
-            } as any,
-            delayInMinutes: null,
-          },
-        ],
+        ruleId: RULE_ID,
+        actions: [forwardAction()],
         provider: "gmail",
-        emailAccountId: "email-account-id",
+        emailAccountId: EMAIL_ACCOUNT_ID,
         logger,
       }),
     ).rejects.toThrow("Rule not found");
@@ -404,30 +308,23 @@ describe("outbound action guardrails", () => {
       from: null,
     } as any);
     prisma.messagingChannel.findMany.mockResolvedValue([
-      { id: "cmessagingchannel1234567890123" },
+      { id: MESSAGING_CHANNEL_ID },
     ] as any);
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
     } as any);
 
     await updateRuleActions({
-      ruleId: "rule-id",
-      actions: [
-        {
-          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-          messagingChannelId: "cmessagingchannel1234567890123",
-          fields: null,
-          delayInMinutes: null,
-        } as any,
-      ],
+      ruleId: RULE_ID,
+      actions: [notifyMessagingChannelAction()],
       provider: "gmail",
-      emailAccountId: "email-account-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
       logger,
     });
 
     expect(prisma.rule.update).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
       data: {
         actions: {
           deleteMany: {},
@@ -435,8 +332,8 @@ describe("outbound action guardrails", () => {
             data: [
               expect.objectContaining({
                 type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-                messagingChannelId: "cmessagingchannel1234567890123",
-                messagingChannelEmailAccountId: "email-account-id",
+                messagingChannelId: MESSAGING_CHANNEL_ID,
+                messagingChannelEmailAccountId: EMAIL_ACCOUNT_ID,
               }),
             ],
           },
@@ -445,27 +342,22 @@ describe("outbound action guardrails", () => {
       include: { actions: true, group: true },
     });
     expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
+      rule: expect.objectContaining({ id: RULE_ID }),
       triggerType: "actions_updated",
     });
   });
 
   it("keeps nested rule action writes free of emailAccountId", async () => {
     prisma.rule.create.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
     await createRuleWithResolvedActions({
-      emailAccountId: "email-account-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { name: "Messaging rule" },
-      actions: [
-        {
-          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-          messagingChannelId: "cmessagingchannel1234567890123",
-        },
-      ],
+      actions: [resolvedNotifyMessagingChannelAction()],
     });
 
     const createArgs = prisma.rule.create.mock.calls[0]?.[0];
@@ -473,48 +365,34 @@ describe("outbound action guardrails", () => {
 
     expect(actionData).toMatchObject({
       type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-      messagingChannelId: "cmessagingchannel1234567890123",
-      messagingChannelEmailAccountId: "email-account-id",
+      messagingChannelId: MESSAGING_CHANNEL_ID,
+      messagingChannelEmailAccountId: EMAIL_ACCOUNT_ID,
     });
     expect(actionData).not.toHaveProperty("emailAccountId");
   });
 
   it("scopes full rule updates to the email account", async () => {
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
     await updateRule({
-      ruleId: "rule-id",
-      result: {
+      ruleId: RULE_ID,
+      result: createRuleResult({
         name: "Archive rule",
-        condition: {
-          aiInstructions: null,
-          conditionalOperator: null,
-          static: {
-            from: "sender@example.com",
-            to: null,
-            subject: null,
-          },
-        },
-        actions: [
-          {
-            type: ActionType.ARCHIVE,
-            fields: null,
-            delayInMinutes: null,
-          },
-        ],
-      },
-      emailAccountId: "email-account-id",
+        from: "sender@example.com",
+        actions: [archiveAction()],
+      }),
+      emailAccountId: EMAIL_ACCOUNT_ID,
       provider: "gmail",
       logger,
     });
 
     expect(prisma.rule.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "rule-id", emailAccountId: "email-account-id" },
+        where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
       }),
     );
   });
@@ -529,24 +407,24 @@ describe("outbound action guardrails", () => {
       groupId: null,
     } as any);
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
     await partialUpdateRule({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+      ruleId: RULE_ID,
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { instructions: "updated instructions" } as any,
     });
 
     expect(prisma.rule.update).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
       data: { instructions: "updated instructions" },
       include: { actions: true, group: true },
     });
     expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
+      rule: expect.objectContaining({ id: RULE_ID }),
       triggerType: "conditions_updated",
     });
   });
@@ -556,24 +434,13 @@ describe("outbound action guardrails", () => {
 
     await expect(
       createRule({
-        result: {
+        result: createRuleResult({
           name: "Webhook rule",
-          condition: {
-            aiInstructions: "Match these emails",
-            conditionalOperator: null,
-            static: null,
-          },
-          actions: [
-            {
-              type: ActionType.CALL_WEBHOOK,
-              fields: {
-                webhookUrl: "https://example.com/webhook",
-              } as any,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          aiInstructions: "Match these emails",
+          staticCondition: null,
+          actions: [webhookRuleAction("https://example.com/webhook")],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         runOnThreads: true,
         logger,
@@ -586,22 +453,14 @@ describe("outbound action guardrails", () => {
 });
 
 describe("replaceRuleWithResolvedActions", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockEnv.webhookActionsEnabled = true;
-    vi.mocked(getActionRiskLevel).mockReturnValue({
-      level: "low",
-      message: "safe",
-    });
-    prisma.rule.findMany.mockResolvedValue([]);
-  });
+  beforeEach(resetRuleMocks);
 
   it("deletes the previous learned pattern group when the rule is detached from it", async () => {
     prisma.rule.findUnique.mockResolvedValue({
       groupId: "old-group-id",
     } as any);
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       groupId: null,
       actions: [],
       group: null,
@@ -609,18 +468,18 @@ describe("replaceRuleWithResolvedActions", () => {
     prisma.group.deleteMany.mockResolvedValue({ count: 1 });
 
     await replaceRuleWithResolvedActions({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+      ruleId: RULE_ID,
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { groupId: null },
       actions: [],
     });
 
     expect(prisma.rule.findUnique).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
       select: expect.objectContaining({ groupId: true }),
     });
     expect(prisma.group.deleteMany).toHaveBeenCalledWith({
-      where: { id: "old-group-id", emailAccountId: "email-account-id" },
+      where: { id: "old-group-id", emailAccountId: EMAIL_ACCOUNT_ID },
     });
   });
 
@@ -629,15 +488,15 @@ describe("replaceRuleWithResolvedActions", () => {
       groupId: "group-id",
     } as any);
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       groupId: "group-id",
       actions: [],
       group: { id: "group-id" },
     } as any);
 
     await replaceRuleWithResolvedActions({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
+      ruleId: RULE_ID,
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { groupId: "group-id" },
       actions: [],
     });
@@ -647,132 +506,76 @@ describe("replaceRuleWithResolvedActions", () => {
 });
 
 describe("rule history snapshots", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockEnv.webhookActionsEnabled = true;
-    vi.mocked(getActionRiskLevel).mockReturnValue({
-      level: "low",
-      message: "safe",
-    });
-    prisma.rule.findMany.mockResolvedValue([]);
-  });
+  beforeEach(resetRuleMocks);
 
-  it("writes history when updating instructions", async () => {
-    prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
-      actions: [],
-      group: null,
-    } as any);
-
-    await updateRuleInstructions({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
-      instructions: "updated instructions",
-    });
-
-    expect(prisma.rule.update).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+  it.each([
+    {
+      name: "updating instructions",
       data: { instructions: "updated instructions" },
-      include: { actions: true, group: true },
-    });
-    expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
       triggerType: "instructions_updated",
-    });
-  });
-
-  it("writes history when toggling rule enablement", async () => {
-    prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
-      actions: [],
-      group: null,
-    } as any);
-
-    await setRuleEnabled({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
-      enabled: false,
-    });
-
-    expect(prisma.rule.update).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
+      run: () =>
+        updateRuleInstructions({
+          ruleId: RULE_ID,
+          emailAccountId: EMAIL_ACCOUNT_ID,
+          instructions: "updated instructions",
+        }),
+    },
+    {
+      name: "toggling rule enablement",
       data: { enabled: false },
-      include: { actions: true, group: true },
-    });
-    expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
       triggerType: "enabled_updated",
-    });
-  });
-
-  it("writes history when changing thread execution mode", async () => {
+      run: () =>
+        setRuleEnabled({
+          ruleId: RULE_ID,
+          emailAccountId: EMAIL_ACCOUNT_ID,
+          enabled: false,
+        }),
+    },
+    {
+      name: "changing thread execution mode",
+      data: { runOnThreads: false },
+      triggerType: "run_on_threads_updated",
+      run: () =>
+        setRuleRunOnThreads({
+          ruleId: RULE_ID,
+          emailAccountId: EMAIL_ACCOUNT_ID,
+          runOnThreads: false,
+        }),
+    },
+  ])("writes history when $name", async ({ data, triggerType, run }) => {
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
-    await setRuleRunOnThreads({
-      ruleId: "rule-id",
-      emailAccountId: "email-account-id",
-      runOnThreads: false,
-    });
+    await run();
 
     expect(prisma.rule.update).toHaveBeenCalledWith({
-      where: { id: "rule-id", emailAccountId: "email-account-id" },
-      data: { runOnThreads: false },
+      where: { id: RULE_ID, emailAccountId: EMAIL_ACCOUNT_ID },
+      data,
       include: { actions: true, group: true },
     });
     expect(createRuleHistoryMock).toHaveBeenCalledWith({
-      rule: expect.objectContaining({ id: "rule-id" }),
-      triggerType: "run_on_threads_updated",
+      rule: expect.objectContaining({ id: RULE_ID }),
+      triggerType,
     });
   });
 });
 
 describe("webhook URL validation at save time", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockEnv.webhookActionsEnabled = true;
-  });
+  beforeEach(resetRuleMocks);
 
-  it("rejects creating a rule with a localhost webhook URL", async () => {
+  it.each([
+    { name: "localhost", url: "https://localhost/hook" },
+    { name: "private IP", url: "https://169.254.169.254/metadata" },
+    { name: "non-http scheme", url: "file:///etc/passwd" },
+  ])("rejects creating a rule with a $name webhook URL", async ({ url }) => {
     await expect(
       createRuleWithResolvedActions({
-        emailAccountId: "email-account-id",
+        emailAccountId: EMAIL_ACCOUNT_ID,
         data: { name: "Webhook rule" },
-        actions: [
-          { type: ActionType.CALL_WEBHOOK, url: "https://localhost/hook" },
-        ],
-      }),
-    ).rejects.toThrow("Invalid webhook URL");
-
-    expect(prisma.rule.create).not.toHaveBeenCalled();
-  });
-
-  it("rejects creating a rule with a private IP webhook URL", async () => {
-    await expect(
-      createRuleWithResolvedActions({
-        emailAccountId: "email-account-id",
-        data: { name: "Webhook rule" },
-        actions: [
-          {
-            type: ActionType.CALL_WEBHOOK,
-            url: "https://169.254.169.254/metadata",
-          },
-        ],
-      }),
-    ).rejects.toThrow("Invalid webhook URL");
-
-    expect(prisma.rule.create).not.toHaveBeenCalled();
-  });
-
-  it("rejects creating a rule with a non-http scheme webhook URL", async () => {
-    await expect(
-      createRuleWithResolvedActions({
-        emailAccountId: "email-account-id",
-        data: { name: "Webhook rule" },
-        actions: [{ type: ActionType.CALL_WEBHOOK, url: "file:///etc/passwd" }],
+        actions: [resolvedWebhookAction(url)],
       }),
     ).rejects.toThrow("Invalid webhook URL");
 
@@ -782,14 +585,13 @@ describe("webhook URL validation at save time", () => {
   it("rejects updating a rule with an internal webhook URL", async () => {
     await expect(
       replaceRuleWithResolvedActions({
-        ruleId: "rule-id",
-        emailAccountId: "email-account-id",
+        ruleId: RULE_ID,
+        emailAccountId: EMAIL_ACCOUNT_ID,
         data: {},
         actions: [
-          {
-            type: ActionType.CALL_WEBHOOK,
-            url: "https://metadata.google.internal/computeMetadata/v1/",
-          },
+          resolvedWebhookAction(
+            "https://metadata.google.internal/computeMetadata/v1/",
+          ),
         ],
       }),
     ).rejects.toThrow("Invalid webhook URL");
@@ -804,19 +606,14 @@ describe("webhook URL validation at save time", () => {
 
     await expect(
       updateRuleActions({
-        ruleId: "rule-id",
+        ruleId: RULE_ID,
         actions: [
-          {
-            type: ActionType.CALL_WEBHOOK,
-            fields: {
-              webhookUrl:
-                "https://metadata.google.internal/computeMetadata/v1/",
-            } as any,
-            delayInMinutes: null,
-          },
+          webhookRuleAction(
+            "https://metadata.google.internal/computeMetadata/v1/",
+          ),
         ],
         provider: "gmail",
-        emailAccountId: "email-account-id",
+        emailAccountId: EMAIL_ACCOUNT_ID,
         logger,
       }),
     ).rejects.toThrow("Invalid webhook URL");
@@ -826,17 +623,15 @@ describe("webhook URL validation at save time", () => {
 
   it("allows a valid public webhook URL", async () => {
     prisma.rule.create.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
     await createRuleWithResolvedActions({
-      emailAccountId: "email-account-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { name: "Webhook rule" },
-      actions: [
-        { type: ActionType.CALL_WEBHOOK, url: "https://example.com/webhook" },
-      ],
+      actions: [resolvedWebhookAction("https://example.com/webhook")],
     });
 
     expect(prisma.rule.create).toHaveBeenCalled();
@@ -844,15 +639,15 @@ describe("webhook URL validation at save time", () => {
 
   it("skips validation for non-webhook actions", async () => {
     prisma.rule.create.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
 
     await createRuleWithResolvedActions({
-      emailAccountId: "email-account-id",
+      emailAccountId: EMAIL_ACCOUNT_ID,
       data: { name: "Archive rule" },
-      actions: [{ type: ActionType.ARCHIVE }],
+      actions: [resolvedArchiveAction()],
     });
 
     expect(prisma.rule.create).toHaveBeenCalled();
@@ -860,17 +655,11 @@ describe("webhook URL validation at save time", () => {
 });
 
 describe("draft messaging actions", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(getActionRiskLevel).mockReturnValue({
-      level: "low",
-      message: "safe",
-    });
-  });
+  beforeEach(resetRuleMocks);
 
   it("rejects creating a draft messaging rule with a channel from another account", async () => {
     prisma.rule.create.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
@@ -878,29 +667,12 @@ describe("draft messaging actions", () => {
 
     await expect(
       createRule({
-        result: {
+        result: createRuleResult({
           name: "To Reply",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: null,
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.DRAFT_MESSAGING_CHANNEL,
-              messagingChannelId: "cmessagingchannel1234567890123",
-              fields: {
-                content: "",
-              } as any,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: null,
+          actions: [draftMessagingChannelAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         runOnThreads: true,
         logger,
@@ -912,7 +684,7 @@ describe("draft messaging actions", () => {
 
   it("rejects updating a draft messaging rule with a channel from another account", async () => {
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
@@ -920,30 +692,13 @@ describe("draft messaging actions", () => {
 
     await expect(
       updateRule({
-        ruleId: "rule-id",
-        result: {
+        ruleId: RULE_ID,
+        result: createRuleResult({
           name: "To Reply",
-          condition: {
-            aiInstructions: null,
-            conditionalOperator: null,
-            static: {
-              from: null,
-              to: null,
-              subject: null,
-            },
-          },
-          actions: [
-            {
-              type: ActionType.DRAFT_MESSAGING_CHANNEL,
-              messagingChannelId: "cmessagingchannel1234567890123",
-              fields: {
-                content: "",
-              } as any,
-              delayInMinutes: null,
-            },
-          ],
-        },
-        emailAccountId: "email-account-id",
+          from: null,
+          actions: [draftMessagingChannelAction()],
+        }),
+        emailAccountId: EMAIL_ACCOUNT_ID,
         provider: "gmail",
         logger,
       }),
@@ -954,41 +709,24 @@ describe("draft messaging actions", () => {
 
   it("preserves messagingChannelId when updating a draft messaging rule", async () => {
     prisma.rule.update.mockResolvedValue({
-      id: "rule-id",
+      id: RULE_ID,
       actions: [],
       group: null,
     } as any);
     prisma.messagingChannel.findMany.mockResolvedValue([
       {
-        id: "cmessagingchannel1234567890123",
+        id: MESSAGING_CHANNEL_ID,
       },
     ] as any);
 
     await updateRule({
-      ruleId: "rule-id",
-      result: {
+      ruleId: RULE_ID,
+      result: createRuleResult({
         name: "To Reply",
-        condition: {
-          aiInstructions: null,
-          conditionalOperator: null,
-          static: {
-            from: null,
-            to: null,
-            subject: null,
-          },
-        },
-        actions: [
-          {
-            type: ActionType.DRAFT_MESSAGING_CHANNEL,
-            messagingChannelId: "cmessagingchannel1234567890123",
-            fields: {
-              content: "",
-            } as any,
-            delayInMinutes: null,
-          },
-        ],
-      },
-      emailAccountId: "email-account-id",
+        from: null,
+        actions: [draftMessagingChannelAction()],
+      }),
+      emailAccountId: EMAIL_ACCOUNT_ID,
       provider: "gmail",
       logger,
     });
@@ -1002,7 +740,7 @@ describe("draft messaging actions", () => {
               data: [
                 expect.objectContaining({
                   type: ActionType.DRAFT_MESSAGING_CHANNEL,
-                  messagingChannelId: "cmessagingchannel1234567890123",
+                  messagingChannelId: MESSAGING_CHANNEL_ID,
                 }),
               ],
             },
@@ -1012,3 +750,111 @@ describe("draft messaging actions", () => {
     );
   });
 });
+
+function resetRuleMocks() {
+  vi.clearAllMocks();
+  mockEnv.webhookActionsEnabled = true;
+  vi.mocked(getActionRiskLevel).mockReturnValue({
+    level: "low",
+    message: "safe",
+  });
+  prisma.rule.findMany.mockResolvedValue([]);
+}
+
+function createRuleResult({
+  name = "Archive rule",
+  aiInstructions = null,
+  staticCondition,
+  from = "sender@example.com",
+  actions = [archiveAction()],
+}: {
+  name?: string;
+  aiInstructions?: string | null;
+  staticCondition?: RuleResult["condition"]["static"];
+  from?: string | null;
+  actions?: RuleAction[];
+} = {}): RuleResult {
+  return {
+    name,
+    condition: {
+      aiInstructions,
+      conditionalOperator: null,
+      static:
+        staticCondition === undefined
+          ? { from, to: null, subject: null }
+          : staticCondition,
+    },
+    actions,
+  };
+}
+
+function archiveAction(): RuleAction {
+  return {
+    type: ActionType.ARCHIVE,
+    fields: null,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function forwardAction(): RuleAction {
+  return {
+    type: ActionType.FORWARD,
+    fields: {
+      to: "forward@example.com",
+    } as any,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function labelAction(): RuleAction {
+  return {
+    type: ActionType.LABEL,
+    fields: {
+      label: "Important",
+    } as any,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function webhookRuleAction(webhookUrl: string): RuleAction {
+  return {
+    type: ActionType.CALL_WEBHOOK,
+    fields: { webhookUrl } as any,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function notifyMessagingChannelAction(): RuleAction {
+  return {
+    type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+    messagingChannelId: MESSAGING_CHANNEL_ID,
+    fields: null,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function draftMessagingChannelAction(): RuleAction {
+  return {
+    type: ActionType.DRAFT_MESSAGING_CHANNEL,
+    messagingChannelId: MESSAGING_CHANNEL_ID,
+    fields: {
+      content: "",
+    } as any,
+    delayInMinutes: null,
+  } as RuleAction;
+}
+
+function resolvedArchiveAction(): ResolvedRuleAction {
+  return { type: ActionType.ARCHIVE } as ResolvedRuleAction;
+}
+
+function resolvedWebhookAction(url: string): ResolvedRuleAction {
+  return { type: ActionType.CALL_WEBHOOK, url } as ResolvedRuleAction;
+}
+
+function resolvedNotifyMessagingChannelAction(): ResolvedRuleAction {
+  return {
+    type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+    messagingChannelId: MESSAGING_CHANNEL_ID,
+  } as ResolvedRuleAction;
+}

--- a/apps/web/utils/schedule.test.ts
+++ b/apps/web/utils/schedule.test.ts
@@ -19,29 +19,41 @@ import {
   dayOfWeekToBitmask,
 } from "./schedule";
 
-// Store original timezone
 const originalTimezone = process.env.TZ;
+const DAY_CASES = [
+  ["Sunday", 0, DAYS.SUNDAY, 0b100_0000],
+  ["Monday", 1, DAYS.MONDAY, 0b010_0000],
+  ["Tuesday", 2, DAYS.TUESDAY, 0b001_0000],
+  ["Wednesday", 3, DAYS.WEDNESDAY, 0b000_1000],
+  ["Thursday", 4, DAYS.THURSDAY, 0b000_0100],
+  ["Friday", 5, DAYS.FRIDAY, 0b000_0010],
+  ["Saturday", 6, DAYS.SATURDAY, 0b000_0001],
+] as const;
+const ALL_DAYS =
+  DAYS.SUNDAY |
+  DAYS.MONDAY |
+  DAYS.TUESDAY |
+  DAYS.WEDNESDAY |
+  DAYS.THURSDAY |
+  DAYS.FRIDAY |
+  DAYS.SATURDAY;
 
-// Set timezone to UTC for all tests to ensure consistent behavior
 beforeAll(() => {
   process.env.TZ = "UTC";
 });
 
 afterAll(() => {
-  // Restore original timezone
   process.env.TZ = originalTimezone || "UTC";
 });
 
-// Helper function to create timezone-independent test dates
 function createTestDate(isoString: string): Date {
   return new Date(isoString);
 }
 
-// Test to verify timezone setup is working
 describe("timezone setup", () => {
   it("should use UTC timezone for consistent test behavior", () => {
     const testDate = new Date("2024-01-15T10:00:00Z");
-    expect(testDate.getTimezoneOffset()).toBe(0); // UTC has 0 offset
+    expect(testDate.getTimezoneOffset()).toBe(0);
   });
 });
 
@@ -74,14 +86,10 @@ describe("createCanonicalTimeOfDay", () => {
 });
 
 describe("DAYS constant", () => {
-  it("should have correct bitmask values", () => {
-    expect(DAYS.SUNDAY).toBe(0b100_0000); // 64
-    expect(DAYS.MONDAY).toBe(0b010_0000); // 32
-    expect(DAYS.TUESDAY).toBe(0b001_0000); // 16
-    expect(DAYS.WEDNESDAY).toBe(0b000_1000); // 8
-    expect(DAYS.THURSDAY).toBe(0b000_0100); // 4
-    expect(DAYS.FRIDAY).toBe(0b000_0010); // 2
-    expect(DAYS.SATURDAY).toBe(0b000_0001); // 1
+  it.each(
+    DAY_CASES,
+  )("should have correct bitmask value for %s", (_, __, bitmask, expected) => {
+    expect(bitmask).toBe(expected);
   });
 
   it("should allow combining days with bitwise OR", () => {
@@ -94,14 +102,10 @@ describe("DAYS constant", () => {
 });
 
 describe("dayOfWeekToBitmask", () => {
-  it("should convert JavaScript day of week to correct bitmask", () => {
-    expect(dayOfWeekToBitmask(0)).toBe(DAYS.SUNDAY); // 64
-    expect(dayOfWeekToBitmask(1)).toBe(DAYS.MONDAY); // 32
-    expect(dayOfWeekToBitmask(2)).toBe(DAYS.TUESDAY); // 16
-    expect(dayOfWeekToBitmask(3)).toBe(DAYS.WEDNESDAY); // 8
-    expect(dayOfWeekToBitmask(4)).toBe(DAYS.THURSDAY); // 4
-    expect(dayOfWeekToBitmask(5)).toBe(DAYS.FRIDAY); // 2
-    expect(dayOfWeekToBitmask(6)).toBe(DAYS.SATURDAY); // 1
+  it.each(
+    DAY_CASES,
+  )("should convert %s to the correct bitmask", (_, day, bitmask) => {
+    expect(dayOfWeekToBitmask(day)).toBe(bitmask);
   });
 
   it("should throw error for invalid day values", () => {
@@ -118,14 +122,10 @@ describe("dayOfWeekToBitmask", () => {
 });
 
 describe("bitmaskToDayOfWeek", () => {
-  it("should convert individual day bitmasks to JavaScript day of week", () => {
-    expect(bitmaskToDayOfWeek(DAYS.SUNDAY)).toBe(0);
-    expect(bitmaskToDayOfWeek(DAYS.MONDAY)).toBe(1);
-    expect(bitmaskToDayOfWeek(DAYS.TUESDAY)).toBe(2);
-    expect(bitmaskToDayOfWeek(DAYS.WEDNESDAY)).toBe(3);
-    expect(bitmaskToDayOfWeek(DAYS.THURSDAY)).toBe(4);
-    expect(bitmaskToDayOfWeek(DAYS.FRIDAY)).toBe(5);
-    expect(bitmaskToDayOfWeek(DAYS.SATURDAY)).toBe(6);
+  it.each(
+    DAY_CASES,
+  )("should convert %s bitmask to JavaScript day of week", (_, day, bitmask) => {
+    expect(bitmaskToDayOfWeek(bitmask)).toBe(day);
   });
 
   it("should return null for empty bitmask", () => {
@@ -146,27 +146,15 @@ describe("bitmaskToDayOfWeek", () => {
   });
 
   it("should handle all days set", () => {
-    const allDays =
-      DAYS.SUNDAY |
-      DAYS.MONDAY |
-      DAYS.TUESDAY |
-      DAYS.WEDNESDAY |
-      DAYS.THURSDAY |
-      DAYS.FRIDAY |
-      DAYS.SATURDAY;
-    expect(bitmaskToDayOfWeek(allDays)).toBe(0); // Should return Sunday (first day)
+    expect(bitmaskToDayOfWeek(ALL_DAYS)).toBe(0);
   });
 });
 
 describe("bitmaskToDaysOfWeek", () => {
-  it("should convert individual day bitmasks to array with single day", () => {
-    expect(bitmaskToDaysOfWeek(DAYS.SUNDAY)).toEqual([0]);
-    expect(bitmaskToDaysOfWeek(DAYS.MONDAY)).toEqual([1]);
-    expect(bitmaskToDaysOfWeek(DAYS.TUESDAY)).toEqual([2]);
-    expect(bitmaskToDaysOfWeek(DAYS.WEDNESDAY)).toEqual([3]);
-    expect(bitmaskToDaysOfWeek(DAYS.THURSDAY)).toEqual([4]);
-    expect(bitmaskToDaysOfWeek(DAYS.FRIDAY)).toEqual([5]);
-    expect(bitmaskToDaysOfWeek(DAYS.SATURDAY)).toEqual([6]);
+  it.each(
+    DAY_CASES,
+  )("should convert %s bitmask to array with single day", (_, day, bitmask) => {
+    expect(bitmaskToDaysOfWeek(bitmask)).toEqual([day]);
   });
 
   it("should return empty array for empty bitmask", () => {
@@ -187,15 +175,7 @@ describe("bitmaskToDaysOfWeek", () => {
   });
 
   it("should handle all days set", () => {
-    const allDays =
-      DAYS.SUNDAY |
-      DAYS.MONDAY |
-      DAYS.TUESDAY |
-      DAYS.WEDNESDAY |
-      DAYS.THURSDAY |
-      DAYS.FRIDAY |
-      DAYS.SATURDAY;
-    expect(bitmaskToDaysOfWeek(allDays)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(bitmaskToDaysOfWeek(ALL_DAYS)).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
   it("should return days in order from Sunday to Saturday", () => {
@@ -242,10 +222,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(16);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 16, hours: 0, minutes: 0 });
     });
 
     it("should calculate next occurrence for weekly schedule", () => {
@@ -259,10 +236,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next week's same day at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(22);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 22, hours: 0, minutes: 0 });
     });
 
     it("should handle multiple occurrences within interval", () => {
@@ -276,10 +250,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be 3.5 days from start of interval
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(18);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 18, hours: 0, minutes: 0 });
     });
 
     it("should set specific time of day when provided", () => {
@@ -311,10 +282,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day at 9:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(16);
-      expect(result!.getHours()).toBe(9);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 16, hours: 9, minutes: 0 });
     });
   });
 
@@ -333,10 +301,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be same day at 10:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(15);
-      expect(result!.getHours()).toBe(10);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 15, hours: 10, minutes: 0 });
     });
 
     it("should find next occurrence on next week when time has passed today", () => {
@@ -353,10 +318,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Current time is 2 PM UTC, but 10 AM scheduled time has already passed today, so schedule for next Monday at 10:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(22); // Next Monday
-      expect(result!.getHours()).toBe(10);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 22, hours: 10, minutes: 0 });
     });
 
     it("should handle multiple days of week", () => {
@@ -373,10 +335,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be Wednesday at 9:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(17);
-      expect(result!.getHours()).toBe(9);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 17, hours: 9, minutes: 0 });
     });
 
     it("should default to midnight when no timeOfDay is set", () => {
@@ -392,10 +351,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be Tuesday at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(16);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 16, hours: 0, minutes: 0 });
     });
 
     it("should skip to next week when current day midnight has passed", () => {
@@ -411,10 +367,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next Monday at midnight (since it's 10 AM, midnight has already passed today)
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(22);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 22, hours: 0, minutes: 0 });
     });
 
     it("should handle weekend schedule", () => {
@@ -431,10 +384,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be Saturday at 11:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(20);
-      expect(result!.getHours()).toBe(11);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 20, hours: 11, minutes: 0 });
     });
   });
 
@@ -451,11 +401,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day (Feb 29) at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(1); // February
-      expect(result!.getDate()).toBe(29);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 1,
+        date: 29,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle year boundary", () => {
@@ -470,12 +421,13 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day (Jan 1) at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getFullYear()).toBe(2025);
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(1);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        year: 2025,
+        month: 0,
+        date: 1,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle daylight saving time transitions", () => {
@@ -507,10 +459,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be 3 days later at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(18);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 18, hours: 0, minutes: 0 });
     });
   });
 
@@ -528,10 +477,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be same day at 9:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(15);
-      expect(result!.getHours()).toBe(9);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 15, hours: 9, minutes: 0 });
     });
 
     it("should handle weekly digest on Monday mornings", () => {
@@ -547,10 +493,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be Monday at 8:00 AM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(15);
-      expect(result!.getHours()).toBe(8);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 15, hours: 8, minutes: 0 });
     });
 
     it("should handle bi-weekly schedule with 2 occurrences", () => {
@@ -565,10 +508,7 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be 7 days later at midnight
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(22);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 22, hours: 0, minutes: 0 });
     });
 
     it("should handle monthly schedule when time has passed today", () => {
@@ -585,11 +525,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Current time is 4 PM UTC, but 9 AM scheduled time has already passed today, so schedule for next interval (30 days later)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(1); // February
-      expect(result!.getDate()).toBe(9);
-      expect(result!.getHours()).toBe(9);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 1,
+        date: 9,
+        hours: 9,
+        minutes: 0,
+      });
     });
 
     it("should handle monthly schedule when current day is past the 15th", () => {
@@ -605,11 +546,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Current time is 10 AM UTC, but 3:30 PM scheduled time hasn't passed yet, so schedule for same day at 3:30 PM
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(20);
-      expect(result!.getHours()).toBe(15);
-      expect(result!.getMinutes()).toBe(30);
+      expectScheduleDate(result, {
+        month: 0,
+        date: 20,
+        hours: 15,
+        minutes: 30,
+      });
     });
 
     it("should handle monthly schedule with time that has passed today", () => {
@@ -625,11 +567,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be February 14th at 10:00 AM (30 days later, since 10 AM has passed today)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(1); // February
-      expect(result!.getDate()).toBe(14);
-      expect(result!.getHours()).toBe(10);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 1,
+        date: 14,
+        hours: 10,
+        minutes: 0,
+      });
     });
 
     it("should handle monthly schedule across year boundary", () => {
@@ -644,12 +587,13 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be January 14th at midnight (30 days later, crosses year boundary)
-      expect(result).not.toBeNull();
-      expect(result!.getFullYear()).toBe(2025);
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(14);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        year: 2025,
+        month: 0,
+        date: 14,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle monthly schedule with leap year", () => {
@@ -664,11 +608,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be February 14th at midnight (30 days later, accounting for leap year)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(1); // February
-      expect(result!.getDate()).toBe(14);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 1,
+        date: 14,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle monthly schedule with multiple occurrences", () => {
@@ -683,11 +628,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be January 30th at midnight (15 days later, first occurrence)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(30);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 0,
+        date: 30,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle very long intervals efficiently", () => {
@@ -702,12 +648,13 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next year at midnight (365 days later, accounting for leap year)
-      expect(result).not.toBeNull();
-      expect(result!.getFullYear()).toBe(2025);
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(14); // 365 days from Jan 15 = Jan 14 (leap year)
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        year: 2025,
+        month: 0,
+        date: 14,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle very long intervals with many occurrences", () => {
@@ -722,11 +669,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day at midnight (first occurrence within the year)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(16); // Next day
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 0,
+        date: 16,
+        hours: 0,
+        minutes: 0,
+      });
     });
 
     it("should handle extreme intervals efficiently", () => {
@@ -741,11 +689,12 @@ describe("calculateNextScheduleDate", () => {
       });
 
       // Should be next day at midnight (first occurrence within the interval)
-      expect(result).not.toBeNull();
-      expect(result!.getMonth()).toBe(0); // January
-      expect(result!.getDate()).toBe(16); // Next day
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, {
+        month: 0,
+        date: 16,
+        hours: 0,
+        minutes: 0,
+      });
     });
   });
 });
@@ -768,11 +717,12 @@ describe("calculateNextScheduleDate - Bug Fix Tests", () => {
       const result = calculateNextScheduleDate(schedule);
 
       // Should be next day at midnight (2024-01-16T00:00:00Z)
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(16);
-      expect(result!.getHours()).toBe(0);
-      expect(result!.getMinutes()).toBe(0);
-      expect(result!.getSeconds()).toBe(0);
+      expectScheduleDate(result, {
+        date: 16,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      });
     });
 
     it("should handle missing lastOccurrenceAt by using current time", () => {
@@ -808,9 +758,7 @@ describe("calculateNextScheduleDate - Bug Fix Tests", () => {
 
       // Both calls should produce the same result
       expect(result1).toEqual(result2);
-      expect(result1!.getDate()).toBe(16); // Next day
-      expect(result1!.getHours()).toBe(14);
-      expect(result1!.getMinutes()).toBe(30);
+      expectScheduleDate(result1, { date: 16, hours: 14, minutes: 30 });
     });
 
     it("should prevent schedule drift in digest processing scenario", () => {
@@ -828,13 +776,44 @@ describe("calculateNextScheduleDate - Bug Fix Tests", () => {
       const result = calculateNextScheduleDate(schedule);
 
       // Should be next day at midnight, NOT at 12:36 PM
-      expect(result).not.toBeNull();
-      expect(result!.getDate()).toBe(16); // Next day
-      expect(result!.getHours()).toBe(0); // Midnight, not 12:36 PM
-      expect(result!.getMinutes()).toBe(0);
+      expectScheduleDate(result, { date: 16, hours: 0, minutes: 0 });
 
       // This prevents the 30-minute cron from finding the account "due" again
       // because the next occurrence is at midnight, not at 12:36 PM
     });
   });
 });
+
+function expectScheduleDate(
+  result: Date | null | undefined,
+  expected: {
+    year?: number;
+    month?: number;
+    date?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+  },
+) {
+  expect(result).not.toBeNull();
+  expect(result).toBeDefined();
+
+  if (expected.year !== undefined) {
+    expect(result!.getFullYear()).toBe(expected.year);
+  }
+  if (expected.month !== undefined) {
+    expect(result!.getMonth()).toBe(expected.month);
+  }
+  if (expected.date !== undefined) {
+    expect(result!.getDate()).toBe(expected.date);
+  }
+  if (expected.hours !== undefined) {
+    expect(result!.getHours()).toBe(expected.hours);
+  }
+  if (expected.minutes !== undefined) {
+    expect(result!.getMinutes()).toBe(expected.minutes);
+  }
+  if (expected.seconds !== undefined) {
+    expect(result!.getSeconds()).toBe(expected.seconds);
+  }
+}

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -4,8 +4,6 @@ import { executeScheduledAction } from "./executor";
 import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 
-// Run with: pnpm test utils/scheduled-actions/executor.test.ts
-
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -2,30 +2,79 @@ import { describe, it, expect, vi, beforeAll } from "vitest";
 import { calculateSimilarity } from "./similarity-score";
 
 describe("calculateSimilarity - basic tests", () => {
-  it("should return 0.0 if either text is null or undefined", () => {
-    expect(calculateSimilarity(null, "text2")).toBe(0.0);
-    expect(calculateSimilarity("text1", undefined)).toBe(0.0);
-    expect(calculateSimilarity(null, null)).toBe(0.0);
-  });
-
-  it("should return 1.0 for identical texts", () => {
-    const score = calculateSimilarity("Hello world", "Hello world");
-    expect(score).toBe(1.0);
-  });
-
-  it("should be case-insensitive", () => {
-    const score = calculateSimilarity("Hello World", "hello world");
-    expect(score).toBe(1.0);
-  });
-
-  it("should return 0.0 for completely different texts", () => {
-    const score = calculateSimilarity("abc", "xyz");
-    expect(score).toBe(0.0);
-  });
-
-  it("should handle whitespace normalization", () => {
-    const score = calculateSimilarity("  Hello world  ", "Hello world");
-    expect(score).toBe(1.0);
+  it.each([
+    {
+      name: "first text is null",
+      firstText: null,
+      secondText: "text2",
+      expected: 0.0,
+    },
+    {
+      name: "second text is undefined",
+      firstText: "text1",
+      secondText: undefined,
+      expected: 0.0,
+    },
+    {
+      name: "both texts are null",
+      firstText: null,
+      secondText: null,
+      expected: 0.0,
+    },
+    {
+      name: "texts are identical",
+      firstText: "Hello world",
+      secondText: "Hello world",
+      expected: 1.0,
+    },
+    {
+      name: "texts differ only by case",
+      firstText: "Hello World",
+      secondText: "hello world",
+      expected: 1.0,
+    },
+    {
+      name: "texts are completely different",
+      firstText: "abc",
+      secondText: "xyz",
+      expected: 0.0,
+    },
+    {
+      name: "texts differ only by surrounding whitespace",
+      firstText: "  Hello world  ",
+      secondText: "Hello world",
+      expected: 1.0,
+    },
+    {
+      name: "texts differ only by special character case",
+      firstText: "Text with $pecial chars!",
+      secondText: "text with $pecial chars!",
+      expected: 1.0,
+    },
+    {
+      name: "first text is empty after normalization",
+      firstText: "",
+      secondText: "text2",
+      expected: 0.0,
+    },
+    {
+      name: "second text is empty after normalization",
+      firstText: "text1",
+      secondText: "",
+      expected: 0.0,
+    },
+    {
+      name: "both texts are whitespace-only",
+      firstText: "   ",
+      secondText: "   ",
+      expected: 1.0,
+    },
+  ])("should return $expected when $name", ({
+    firstText,
+    secondText,
+    expected,
+  }) => {
+    expect(calculateSimilarity(firstText, secondText)).toBe(expected);
   });
 
   it("should return partial score for similar texts", () => {
@@ -35,30 +84,6 @@ describe("calculateSimilarity - basic tests", () => {
     );
     expect(score).toBeGreaterThan(0.5);
     expect(score).toBeLessThan(1.0);
-  });
-
-  it("should handle special characters", () => {
-    const score = calculateSimilarity(
-      "Text with $pecial chars!",
-      "text with $pecial chars!",
-    );
-    expect(score).toBe(1.0);
-  });
-
-  it("should return 0.0 if first text is empty after normalization", () => {
-    const score = calculateSimilarity("", "text2");
-    expect(score).toBe(0.0);
-  });
-
-  it("should return 0.0 if second text is empty after normalization", () => {
-    const score = calculateSimilarity("text1", "");
-    expect(score).toBe(0.0);
-  });
-
-  it("should return 1.0 if both normalized texts are empty", () => {
-    // Both whitespace-only strings should normalize to empty and match
-    const score = calculateSimilarity("   ", "   ");
-    expect(score).toBe(1.0);
   });
 
   it("should handle a realistic email with minor changes", () => {

--- a/apps/web/utils/string.test.ts
+++ b/apps/web/utils/string.test.ts
@@ -8,157 +8,218 @@ import {
   trimToNonEmptyString,
 } from "./string";
 
-// Run with:
-// pnpm test utils/string.test.ts
-
 describe("string utils", () => {
   describe("truncate", () => {
-    it("should truncate strings longer than specified length", () => {
-      expect(truncate("hello world", 5)).toBe("hello...");
-    });
-
-    it("should not truncate strings shorter than specified length", () => {
-      expect(truncate("hello", 10)).toBe("hello");
+    it.each([
+      {
+        name: "strings longer than the limit",
+        input: "hello world",
+        length: 5,
+        expected: "hello...",
+      },
+      {
+        name: "strings shorter than the limit",
+        input: "hello",
+        length: 10,
+        expected: "hello",
+      },
+    ])("handles $name", ({ input, length, expected }) => {
+      expect(truncate(input, length)).toBe(expected);
     });
   });
 
   describe("trimToNonEmptyString", () => {
-    it("returns trimmed text when non-empty", () => {
-      expect(trimToNonEmptyString("  hello  ")).toBe("hello");
-    });
-
-    it("returns undefined for empty or whitespace-only strings", () => {
-      expect(trimToNonEmptyString("")).toBeUndefined();
-      expect(trimToNonEmptyString("   ")).toBeUndefined();
-    });
-
-    it("returns undefined for non-string values", () => {
-      expect(trimToNonEmptyString(null)).toBeUndefined();
-      expect(trimToNonEmptyString(123)).toBeUndefined();
-      expect(trimToNonEmptyString({})).toBeUndefined();
+    it.each([
+      { name: "non-empty text", input: "  hello  ", expected: "hello" },
+      { name: "empty string", input: "", expected: undefined },
+      { name: "whitespace-only string", input: "   ", expected: undefined },
+      { name: "null", input: null, expected: undefined },
+      { name: "number", input: 123, expected: undefined },
+      { name: "object", input: {}, expected: undefined },
+    ])("returns expected value for $name", ({ input, expected }) => {
+      expect(trimToNonEmptyString(input)).toBe(expected);
     });
   });
 
   describe("removeExcessiveWhitespace", () => {
-    it("should collapse multiple spaces into single space", () => {
-      expect(removeExcessiveWhitespace("hello    world")).toBe("hello world");
-    });
-
-    it("should preserve single newlines", () => {
-      expect(removeExcessiveWhitespace("hello\nworld")).toBe("hello\nworld");
-    });
-
-    it("should collapse multiple newlines into double newlines", () => {
-      expect(removeExcessiveWhitespace("hello\n\n\n\nworld")).toBe(
-        "hello\n\nworld",
-      );
-    });
-
-    it("should remove zero-width spaces", () => {
-      expect(removeExcessiveWhitespace("hello\u200Bworld")).toBe("hello world");
-    });
-
-    it("should handle complex cases with multiple types of whitespace", () => {
-      const input = "hello   world\n\n\n\n  next    line\u200B\u200B  test";
-      expect(removeExcessiveWhitespace(input)).toBe(
-        "hello world\n\nnext line test",
-      );
-    });
-
-    it("should trim leading and trailing whitespace", () => {
-      expect(removeExcessiveWhitespace("  hello world  ")).toBe("hello world");
-    });
-
-    it("should handle empty string", () => {
-      expect(removeExcessiveWhitespace("")).toBe("");
-    });
-
-    it("should handle string with only whitespace", () => {
-      expect(removeExcessiveWhitespace("   \n\n   \u200B   ")).toBe("");
-    });
-
-    it("should handle soft hyphens and other special characters", () => {
-      const input = "hello\u00ADworld\u034Ftest\u200B\u200Cspace";
-      expect(removeExcessiveWhitespace(input)).toBe("hello world test space");
-    });
-
-    it("should handle mixed special characters and whitespace", () => {
-      const input = "hello\u00AD   world\n\n\u034F\n\u200B  test";
-      expect(removeExcessiveWhitespace(input)).toBe("hello world\n\ntest");
+    it.each([
+      {
+        name: "multiple spaces",
+        input: "hello    world",
+        expected: "hello world",
+      },
+      {
+        name: "single newlines",
+        input: "hello\nworld",
+        expected: "hello\nworld",
+      },
+      {
+        name: "multiple newlines",
+        input: "hello\n\n\n\nworld",
+        expected: "hello\n\nworld",
+      },
+      {
+        name: "zero-width spaces",
+        input: "hello\u200Bworld",
+        expected: "hello world",
+      },
+      {
+        name: "mixed whitespace",
+        input: "hello   world\n\n\n\n  next    line\u200B\u200B  test",
+        expected: "hello world\n\nnext line test",
+      },
+      {
+        name: "leading and trailing whitespace",
+        input: "  hello world  ",
+        expected: "hello world",
+      },
+      {
+        name: "empty string",
+        input: "",
+        expected: "",
+      },
+      {
+        name: "only whitespace",
+        input: "   \n\n   \u200B   ",
+        expected: "",
+      },
+      {
+        name: "soft hyphens and other special characters",
+        input: "hello\u00ADworld\u034Ftest\u200B\u200Cspace",
+        expected: "hello world test space",
+      },
+      {
+        name: "mixed special characters and whitespace",
+        input: "hello\u00AD   world\n\n\u034F\n\u200B  test",
+        expected: "hello world\n\ntest",
+      },
+    ])("handles $name", ({ input, expected }) => {
+      expect(removeExcessiveWhitespace(input)).toBe(expected);
     });
   });
-  describe("generalizeSubject", () => {
-    it("should remove numbers and IDs", () => {
-      expect(generalizeSubject("Order #123")).toBe("Order");
-      expect(generalizeSubject("Invoice 456")).toBe("Invoice");
-      expect(generalizeSubject("[org/repo] PR #789: Fix bug (abc123)")).toBe(
-        "[org/repo] PR : Fix bug",
-      );
-    });
 
-    it("should preserve normal text", () => {
-      expect(generalizeSubject("Welcome to our service")).toBe(
-        "Welcome to our service",
-      );
-      expect(generalizeSubject("Your account has been created")).toBe(
-        "Your account has been created",
-      );
+  describe("generalizeSubject", () => {
+    it.each([
+      { input: "Order #123", expected: "Order" },
+      { input: "Invoice 456", expected: "Invoice" },
+      {
+        input: "[org/repo] PR #789: Fix bug (abc123)",
+        expected: "[org/repo] PR : Fix bug",
+      },
+      {
+        input: "Welcome to our service",
+        expected: "Welcome to our service",
+      },
+      {
+        input: "Your account has been created",
+        expected: "Your account has been created",
+      },
+    ])("returns expected subject for $input", ({ input, expected }) => {
+      expect(generalizeSubject(input)).toBe(expected);
     });
   });
 
   describe("convertNewlinesToBr", () => {
-    it("should convert LF to <br>", () => {
-      expect(convertNewlinesToBr("line one\nline two")).toBe(
-        "line one<br>line two",
-      );
-    });
-
-    it("should convert CRLF to <br>", () => {
-      expect(convertNewlinesToBr("line one\r\nline two")).toBe(
-        "line one<br>line two",
-      );
-    });
-
-    it("should handle mixed line endings", () => {
-      expect(convertNewlinesToBr("line one\r\nline two\nline three")).toBe(
-        "line one<br>line two<br>line three",
-      );
-    });
-
-    it("should preserve multiple newlines for paragraph spacing", () => {
-      expect(convertNewlinesToBr("para one\n\npara two")).toBe(
-        "para one<br><br>para two",
-      );
-    });
-
-    it("should handle empty string", () => {
-      expect(convertNewlinesToBr("")).toBe("");
-    });
-
-    it("should handle text without newlines", () => {
-      expect(convertNewlinesToBr("no newlines here")).toBe("no newlines here");
+    it.each([
+      {
+        name: "LF line endings",
+        input: "line one\nline two",
+        expected: "line one<br>line two",
+      },
+      {
+        name: "CRLF line endings",
+        input: "line one\r\nline two",
+        expected: "line one<br>line two",
+      },
+      {
+        name: "mixed line endings",
+        input: "line one\r\nline two\nline three",
+        expected: "line one<br>line two<br>line three",
+      },
+      {
+        name: "paragraph spacing",
+        input: "para one\n\npara two",
+        expected: "para one<br><br>para two",
+      },
+      {
+        name: "empty string",
+        input: "",
+        expected: "",
+      },
+      {
+        name: "text without newlines",
+        input: "no newlines here",
+        expected: "no newlines here",
+      },
+    ])("handles $name", ({ input, expected }) => {
+      expect(convertNewlinesToBr(input)).toBe(expected);
     });
   });
 
   describe("escapeHtml", () => {
-    it("should escape basic HTML characters", () => {
-      expect(escapeHtml("<script>alert('xss')</script>")).toBe(
-        "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;",
-      );
-    });
-
-    it("should escape angle brackets in email addresses", () => {
-      expect(escapeHtml("John <john@example.com>")).toBe(
-        "John &lt;john@example.com&gt;",
-      );
-    });
-
-    it("should escape ampersands", () => {
-      expect(escapeHtml("Tom & Jerry")).toBe("Tom &amp; Jerry");
-    });
-
-    it("should escape quotes", () => {
-      expect(escapeHtml('Say "hello"')).toBe("Say &quot;hello&quot;");
+    it.each([
+      {
+        name: "basic HTML characters",
+        input: "<script>alert('xss')</script>",
+        expected: "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;",
+      },
+      {
+        name: "angle brackets in email addresses",
+        input: "John <john@example.com>",
+        expected: "John &lt;john@example.com&gt;",
+      },
+      {
+        name: "ampersands",
+        input: "Tom & Jerry",
+        expected: "Tom &amp; Jerry",
+      },
+      {
+        name: "quotes",
+        input: 'Say "hello"',
+        expected: "Say &quot;hello&quot;",
+      },
+      {
+        name: "normal text",
+        input: "Hello, how are you?",
+        expected: "Hello, how are you?",
+      },
+      {
+        name: "empty string",
+        input: "",
+        expected: "",
+      },
+      {
+        name: "Polish diacritics",
+        input: "Dziękuję za wiadomość. Proszę o odpowiedź.",
+        expected: "Dziękuję za wiadomość. Proszę o odpowiedź.",
+      },
+      {
+        name: "all Polish special characters",
+        input: "ą ę ó ś ć ż ź ń ł Ą Ę Ó Ś Ć Ż Ź Ń Ł",
+        expected: "ą ę ó ś ć ż ź ń ł Ą Ę Ó Ś Ć Ż Ź Ń Ł",
+      },
+      {
+        name: "German unicode",
+        input: "Größe",
+        expected: "Größe",
+      },
+      {
+        name: "Latin accents",
+        input: "café résumé",
+        expected: "café résumé",
+      },
+      {
+        name: "Japanese text",
+        input: "日本語",
+        expected: "日本語",
+      },
+      {
+        name: "Cyrillic text",
+        input: "Привет",
+        expected: "Привет",
+      },
+    ])("handles $name", ({ input, expected }) => {
+      expect(escapeHtml(input)).toBe(expected);
     });
 
     it("should handle prompt injection attempts with hidden divs", () => {
@@ -178,31 +239,6 @@ describe("string utils", () => {
       const injection = '<p style="opacity:0">invisible text</p>';
       const result = escapeHtml(injection);
       expect(result).not.toContain("<p");
-    });
-
-    it("should preserve normal text without changes", () => {
-      expect(escapeHtml("Hello, how are you?")).toBe("Hello, how are you?");
-    });
-
-    it("should handle empty string", () => {
-      expect(escapeHtml("")).toBe("");
-    });
-
-    it("should preserve Polish diacritics", () => {
-      const polishText = "Dziękuję za wiadomość. Proszę o odpowiedź.";
-      expect(escapeHtml(polishText)).toBe(polishText);
-    });
-
-    it("should preserve all Polish special characters", () => {
-      const allPolishChars = "ą ę ó ś ć ż ź ń ł Ą Ę Ó Ś Ć Ż Ź Ń Ł";
-      expect(escapeHtml(allPolishChars)).toBe(allPolishChars);
-    });
-
-    it("should preserve other Unicode characters", () => {
-      expect(escapeHtml("Größe")).toBe("Größe");
-      expect(escapeHtml("café résumé")).toBe("café résumé");
-      expect(escapeHtml("日本語")).toBe("日本語");
-      expect(escapeHtml("Привет")).toBe("Привет");
     });
 
     it("should escape HTML while preserving Polish characters", () => {

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -11,265 +11,295 @@ import {
 } from "./url";
 
 describe("getEmailUrl", () => {
-  describe("Google provider", () => {
-    it("builds Gmail URL with email address", () => {
-      const result = getEmailUrl("msg123", "user@gmail.com", "google");
-      expect(result).toBe(
+  it.each([
+    {
+      name: "Google provider with email address",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
-      );
-    });
-
-    it("builds Gmail URL without email address", () => {
-      const result = getEmailUrl("msg123", null, "google");
-      expect(result).toBe("https://mail.google.com/mail/u/0/#all/msg123");
-    });
-
-    it("builds Gmail URL with undefined email address", () => {
-      const result = getEmailUrl("msg123", undefined, "google");
-      expect(result).toBe("https://mail.google.com/mail/u/0/#all/msg123");
-    });
-  });
-
-  describe("Microsoft provider", () => {
-    it("builds Outlook URL with encoded message ID", () => {
-      const result = getEmailUrl("msg123", "user@outlook.com", "microsoft");
-      expect(result).toBe("https://outlook.live.com/mail/0/inbox/id/msg123");
-    });
-
-    it("encodes special characters in message ID", () => {
-      const result = getEmailUrl("msg+123/abc", null, "microsoft");
-      expect(result).toBe(
-        "https://outlook.live.com/mail/0/inbox/id/msg%2B123%2Fabc",
-      );
-    });
-
-    it("encodes message ID with spaces and special chars", () => {
-      const result = getEmailUrl("msg id=abc", null, "microsoft");
-      expect(result).toBe(
-        "https://outlook.live.com/mail/0/inbox/id/msg%20id%3Dabc",
-      );
-    });
-  });
-
-  describe("Default provider", () => {
-    it("uses Gmail format when provider is undefined", () => {
-      const result = getEmailUrl("msg123", "user@gmail.com");
-      expect(result).toBe(
+    },
+    {
+      name: "Google provider without email address",
+      messageOrThreadId: "msg123",
+      emailAddress: null,
+      provider: "google",
+      expected: "https://mail.google.com/mail/u/0/#all/msg123",
+    },
+    {
+      name: "Google provider with undefined email address",
+      messageOrThreadId: "msg123",
+      emailAddress: undefined,
+      provider: "google",
+      expected: "https://mail.google.com/mail/u/0/#all/msg123",
+    },
+    {
+      name: "Microsoft provider with message ID",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@outlook.com",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with special characters in message ID",
+      messageOrThreadId: "msg+123/abc",
+      emailAddress: null,
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg%2B123%2Fabc",
+    },
+    {
+      name: "Microsoft provider with spaces and special chars in message ID",
+      messageOrThreadId: "msg id=abc",
+      emailAddress: null,
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg%20id%3Dabc",
+    },
+    {
+      name: "undefined provider",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@gmail.com",
+      provider: undefined,
+      expected:
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
-      );
-    });
-
-    it("falls back to default for unknown provider", () => {
-      const result = getEmailUrl("msg123", "user@gmail.com", "unknown");
-      expect(result).toBe(
+    },
+    {
+      name: "unknown provider",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@gmail.com",
+      provider: "unknown",
+      expected:
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
-      );
-    });
-
-    it("falls back to default for empty provider", () => {
-      const result = getEmailUrl("msg123", "user@gmail.com", "");
-      expect(result).toBe(
+    },
+    {
+      name: "empty provider",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@gmail.com",
+      provider: "",
+      expected:
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
-      );
-    });
+    },
+  ])("builds email URL for $name", ({
+    messageOrThreadId,
+    emailAddress,
+    provider,
+    expected,
+  }) => {
+    expect(getEmailUrl(messageOrThreadId, emailAddress, provider)).toBe(
+      expected,
+    );
   });
 });
 
 describe("getEmailUrlForMessage", () => {
-  describe("Google provider", () => {
-    it("uses messageId for Google", () => {
-      const result = getEmailUrlForMessage(
+  it.each([
+    {
+      name: "Google provider",
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/messageId123",
+    },
+    {
+      name: "Microsoft provider",
+      emailAddress: "user@outlook.com",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/messageId123",
+    },
+    {
+      name: "default provider",
+      emailAddress: "user@example.com",
+      provider: undefined,
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40example.com#all/threadId456",
+    },
+  ])("selects the expected id for $name", ({
+    emailAddress,
+    provider,
+    expected,
+  }) => {
+    expect(
+      getEmailUrlForMessage(
         "messageId123",
         "threadId456",
-        "user@gmail.com",
-        "google",
-      );
-      expect(result).toContain("messageId123");
-      expect(result).not.toContain("threadId456");
-    });
-  });
-
-  describe("Microsoft provider", () => {
-    it("uses messageId for Microsoft", () => {
-      const result = getEmailUrlForMessage(
-        "messageId123",
-        "threadId456",
-        "user@outlook.com",
-        "microsoft",
-      );
-      expect(result).toContain("messageId123");
-      expect(result).not.toContain("threadId456");
-    });
-  });
-
-  describe("Default provider", () => {
-    it("uses threadId for default/unknown provider", () => {
-      const result = getEmailUrlForMessage(
-        "messageId123",
-        "threadId456",
-        "user@example.com",
-      );
-      expect(result).toContain("threadId456");
-    });
+        emailAddress,
+        provider,
+      ),
+    ).toBe(expected);
   });
 });
 
 describe("getEmailUrlForOptionalMessage", () => {
-  it("returns null for Microsoft when messageId is missing", () => {
-    const result = getEmailUrlForOptionalMessage({
-      threadId: "threadId456",
-      emailAddress: "user@outlook.com",
-      provider: "microsoft",
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("falls back to threadId for default providers", () => {
-    const result = getEmailUrlForOptionalMessage({
-      threadId: "threadId456",
-      emailAddress: "user@example.com",
-    });
-
-    expect(result).toContain("threadId456");
-  });
-
-  it("uses messageId when available", () => {
-    const result = getEmailUrlForOptionalMessage({
-      messageId: "messageId123",
-      threadId: "threadId456",
-      emailAddress: "user@gmail.com",
-      provider: "google",
-    });
-
-    expect(result).toContain("messageId123");
-    expect(result).not.toContain("threadId456");
+  it.each([
+    {
+      name: "Microsoft without messageId",
+      options: {
+        threadId: "threadId456",
+        emailAddress: "user@outlook.com",
+        provider: "microsoft",
+      },
+      expected: null,
+    },
+    {
+      name: "default provider without messageId",
+      options: {
+        threadId: "threadId456",
+        emailAddress: "user@example.com",
+      },
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40example.com#all/threadId456",
+    },
+    {
+      name: "Google with messageId",
+      options: {
+        messageId: "messageId123",
+        threadId: "threadId456",
+        emailAddress: "user@gmail.com",
+        provider: "google",
+      },
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/messageId123",
+    },
+  ])("returns expected URL for $name", ({ options, expected }) => {
+    expect(getEmailUrlForOptionalMessage(options)).toBe(expected);
   });
 });
 
 describe("getGmailUrl", () => {
-  it("is an alias for getEmailUrl with google provider", () => {
-    const result = getGmailUrl("msg123", "user@gmail.com");
-    const expected = getEmailUrl("msg123", "user@gmail.com", "google");
-    expect(result).toBe(expected);
-  });
-
-  it("works without email address", () => {
-    const result = getGmailUrl("msg123");
-    expect(result).toBe("https://mail.google.com/mail/u/0/#all/msg123");
+  it.each([
+    {
+      name: "with email address",
+      emailAddress: "user@gmail.com",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/msg123",
+    },
+    {
+      name: "without email address",
+      emailAddress: undefined,
+      expected: "https://mail.google.com/mail/u/0/#all/msg123",
+    },
+  ])("builds Gmail URL $name", ({ emailAddress, expected }) => {
+    expect(getGmailUrl("msg123", emailAddress)).toBe(expected);
   });
 });
 
 describe("getGmailSearchUrl", () => {
-  it("builds advanced search URL with from parameter", () => {
-    const result = getGmailSearchUrl("sender@example.com", "user@gmail.com");
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
-    );
-  });
-
-  it("encodes special characters in from", () => {
-    const result = getGmailSearchUrl("test+user@example.com", null);
-    expect(result).toContain("from=test%2Buser%40example.com");
-  });
-
-  it("handles from with display name", () => {
-    const result = getGmailSearchUrl(
-      "John Doe <john@example.com>",
-      "user@gmail.com",
-    );
-    expect(result).toContain("from=John%20Doe%20%3Cjohn%40example.com%3E");
+  it.each([
+    {
+      name: "sender email and authenticated user",
+      from: "sender@example.com",
+      emailAddress: "user@gmail.com",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
+    },
+    {
+      name: "sender with special characters",
+      from: "test+user@example.com",
+      emailAddress: null,
+      expected:
+        "https://mail.google.com/mail/u/0/#advanced-search/from=test%2Buser%40example.com",
+    },
+    {
+      name: "sender with display name",
+      from: "John Doe <john@example.com>",
+      emailAddress: "user@gmail.com",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=John%20Doe%20%3Cjohn%40example.com%3E",
+    },
+  ])("builds advanced search URL for $name", ({
+    from,
+    emailAddress,
+    expected,
+  }) => {
+    expect(getGmailSearchUrl(from, emailAddress)).toBe(expected);
   });
 });
 
 describe("getEmailSearchUrl", () => {
-  it("builds Gmail sender search URL for Google provider", () => {
-    const result = getEmailSearchUrl(
-      "sender@example.com",
-      "user@gmail.com",
-      "google",
-    );
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
-    );
-  });
-
-  it("builds Outlook sender search URL for Microsoft provider", () => {
-    const result = getEmailSearchUrl(
-      "sender@example.com",
-      "user@outlook.com",
-      "microsoft",
-    );
-    expect(result).toBe(
-      "https://outlook.live.com/mail/0/search/q/from%3Asender%40example.com",
-    );
-  });
-
-  it("falls back to default provider when provider is empty", () => {
-    const result = getEmailSearchUrl(
-      "sender@example.com",
-      "user@gmail.com",
-      "",
-    );
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
-    );
-  });
-
-  it("falls back to default provider when provider is unknown", () => {
-    const result = getEmailSearchUrl(
-      "sender@example.com",
-      "user@gmail.com",
-      "unknown-provider",
-    );
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
-    );
+  it.each([
+    {
+      name: "Google provider",
+      emailAddress: "user@gmail.com",
+      provider: "google",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
+    },
+    {
+      name: "Microsoft provider",
+      emailAddress: "user@outlook.com",
+      provider: "microsoft",
+      expected:
+        "https://outlook.live.com/mail/0/search/q/from%3Asender%40example.com",
+    },
+    {
+      name: "empty provider",
+      emailAddress: "user@gmail.com",
+      provider: "",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
+    },
+    {
+      name: "unknown provider",
+      emailAddress: "user@gmail.com",
+      provider: "unknown-provider",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
+    },
+  ])("builds sender search URL for $name", ({
+    emailAddress,
+    provider,
+    expected,
+  }) => {
+    expect(
+      getEmailSearchUrl("sender@example.com", emailAddress, provider),
+    ).toBe(expected);
   });
 });
 
 describe("getGmailBasicSearchUrl", () => {
-  it("builds search URL with query", () => {
-    const result = getGmailBasicSearchUrl("user@gmail.com", "is:unread");
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#search/is%3Aunread",
-    );
-  });
-
-  it("encodes complex queries", () => {
-    const result = getGmailBasicSearchUrl(
-      "user@gmail.com",
-      "from:sender@test.com subject:hello",
-    );
-    expect(result).toContain("#search/");
-    expect(result).toContain("from%3Asender%40test.com");
-    expect(result).toContain("subject%3Ahello");
-  });
-
-  it("handles queries with special characters", () => {
-    const result = getGmailBasicSearchUrl(
-      "user@gmail.com",
-      "label:inbox/important",
-    );
-    expect(result).toContain("label%3Ainbox%2Fimportant");
+  it.each([
+    {
+      name: "simple query",
+      query: "is:unread",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#search/is%3Aunread",
+    },
+    {
+      name: "complex query",
+      query: "from:sender@test.com subject:hello",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#search/from%3Asender%40test.com%20subject%3Ahello",
+    },
+    {
+      name: "query with special characters",
+      query: "label:inbox/important",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#search/label%3Ainbox%2Fimportant",
+    },
+  ])("builds search URL for $name", ({ query, expected }) => {
+    expect(getGmailBasicSearchUrl("user@gmail.com", query)).toBe(expected);
   });
 });
 
 describe("getGmailFilterSettingsUrl", () => {
-  it("builds filter settings URL with email address", () => {
-    const result = getGmailFilterSettingsUrl("user@gmail.com");
-    expect(result).toBe(
-      "https://mail.google.com/mail/u/?authuser=user%40gmail.com#settings/filters",
-    );
-  });
-
-  it("builds filter settings URL without email address", () => {
-    const result = getGmailFilterSettingsUrl();
-    expect(result).toBe("https://mail.google.com/mail/u/0/#settings/filters");
-  });
-
-  it("builds filter settings URL with null email", () => {
-    const result = getGmailFilterSettingsUrl(null);
-    expect(result).toBe("https://mail.google.com/mail/u/0/#settings/filters");
+  it.each([
+    {
+      name: "with email address",
+      emailAddress: "user@gmail.com",
+      expected:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#settings/filters",
+    },
+    {
+      name: "without email address",
+      emailAddress: undefined,
+      expected: "https://mail.google.com/mail/u/0/#settings/filters",
+    },
+    {
+      name: "with null email",
+      emailAddress: null,
+      expected: "https://mail.google.com/mail/u/0/#settings/filters",
+    },
+  ])("builds filter settings URL $name", ({ emailAddress, expected }) => {
+    expect(getGmailFilterSettingsUrl(emailAddress)).toBe(expected);
   });
 });


### PR DESCRIPTION
test: Simplify unit tests

Simplifies repeated setup and assertion patterns across unit tests while keeping behavior coverage intact. The cleanup reduces fixture and assertion noise so scenario-specific details are easier to scan.

- Centralizes repeated rule test setup and table-drives repeated rule cases
- Shares default model test setup and removes stale commented test code
- Table-drives repeated schedule conversion and date assertion cases
- Table-drives repeated email parsing, normalization, formatting, and display-name cases
- Centralizes repeated LLM fallback test fixtures and generation result setup
- Table-drives error and middleware utility cases and consolidates repeated Redis hash mock setup
- Table-drives repeated utility input/output tests for action sorting, dates, strings, mentions, filebot addresses, similarity scoring, safe links, and draft text extraction
- Consolidates repeated API key, LLM object-generation, and sensitive-content test setup
- Table-drives repeated URL, mail, unsubscribe, Outlook, calendar OAuth, drive folder, group matching, and HTML rewrite helper tests
- Removes stale per-file unit-test command comments now covered by repo testing docs

Performance impact: test-only refactor; no added runtime work, database calls, network calls, or hot-path risk.