### PR TITLE
Fix booking calendar default selection

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/CreateBookingLinkDialog.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/CreateBookingLinkDialog.test.tsx
@@ -1,0 +1,80 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CreateBookingLinkDialog } from "./CreateBookingLinkDialog";
+import type { BookingLinkCalendarData } from "./booking-calendar-helpers";
+
+(globalThis as { React?: typeof React }).React = React;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreateBookingLinkDialog", () => {
+  it("uses the primary calendar when calendar data loads after opening", async () => {
+    const onCreate = vi.fn(async () => {});
+    const view = render(
+      <CreateBookingLinkDialog
+        data={undefined}
+        defaultTitle="Booking link"
+        defaultSlug="booking-link"
+        onClose={() => {}}
+        onCreate={onCreate}
+        isCreating={false}
+      />,
+    );
+
+    view.rerender(
+      <CreateBookingLinkDialog
+        data={calendarData()}
+        defaultTitle="Booking link"
+        defaultSlug="booking-link"
+        onClose={() => {}}
+        onCreate={onCreate}
+        isCreating={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationCalendarId: "primary-calendar-id",
+        }),
+      );
+    });
+  });
+});
+
+function calendarData(): BookingLinkCalendarData {
+  return {
+    calendarConnections: [
+      {
+        provider: "google",
+        calendars: [
+          {
+            id: "secondary-calendar-id",
+            isEnabled: true,
+            name: "Secondary calendar",
+            primary: false,
+          },
+          {
+            id: "primary-calendar-id",
+            isEnabled: true,
+            name: "Primary calendar",
+            primary: true,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/CreateBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/CreateBookingLinkDialog.tsx
@@ -51,9 +51,10 @@ export function CreateBookingLinkDialog({
   const [slug, setSlug] = useState(defaultSlug);
   const [duration, setDuration] = useState(30);
   const defaultDestinationCalendarId = getDefaultDestinationCalendarId(data);
-  const [destinationCalendarId, setDestinationCalendarId] = useState(
-    defaultDestinationCalendarId,
-  );
+  const [selectedDestinationCalendarId, setSelectedDestinationCalendarId] =
+    useState<string | null>(null);
+  const destinationCalendarId =
+    selectedDestinationCalendarId ?? defaultDestinationCalendarId;
   const [videoEnabled, setVideoEnabled] = useState(true);
   const [description, setDescription] = useState("");
 
@@ -163,7 +164,9 @@ export function CreateBookingLinkDialog({
                 <Select
                   name="destinationCalendarId"
                   value={destinationCalendarId}
-                  onValueChange={setDestinationCalendarId}
+                  onValueChange={(value) =>
+                    setSelectedDestinationCalendarId(value)
+                  }
                 >
                   <SelectTrigger className="mt-1">
                     <SelectValue />


### PR DESCRIPTION
Fixes the booking link dialog so the derived default calendar can update after calendar data loads.

- Keeps an explicit user calendar selection separate from the derived default.
- Adds a regression test for async calendar data loading.

Tests: `pnpm --filter inbox-zero-ai exec vitest --run 'app/(app)/[emailAccountId]/calendars/CreateBookingLinkDialog.test.tsx'`