### PR TITLE
Fix outbound draft tracking

### DIFF
--- a/apps/web/__tests__/eval/judge.ts
+++ b/apps/web/__tests__/eval/judge.ts
@@ -5,7 +5,7 @@ import { getModel } from "@/utils/llms/model";
 import type { UserAIFields } from "@/utils/llms/types";
 
 export interface JudgeCriterion {
-  description: string;
+  description?: string;
   name: string;
 }
 
@@ -167,7 +167,9 @@ function buildJudgePrompt(options: {
 }): string {
   const parts = [
     "## Criterion",
-    `**${options.criterion.name}**: ${options.criterion.description}`,
+    options.criterion.description
+      ? `**${options.criterion.name}**: ${options.criterion.description}`
+      : `**${options.criterion.name}**`,
     "",
     "## Input",
     options.input,

--- a/apps/web/__tests__/eval/reply-memory.test.ts
+++ b/apps/web/__tests__/eval/reply-memory.test.ts
@@ -356,6 +356,65 @@ Actual question: I signed up for the webinar but cannot find the join link. Wher
     );
 
     test(
+      "learns a business identity correction from a misdirected product support draft",
+      async () => {
+        const incomingEmailContent =
+          "hello, i bought these shoes from https://example.com/products/runner-led-shoes and i was wondering how to change the colors of the light strip?";
+        const draftText =
+          "Check the button on the side of the shoe or the controller that came in the box. Does yours have a small switch for cycling through the colors?";
+        const sentText =
+          "Hey, we don't sell shoes. We run an AI email assistant.";
+
+        const result = await aiExtractReplyMemoriesFromDraftEdit({
+          emailAccount: replyMemoryEmailAccount,
+          incomingEmailContent,
+          draftText,
+          sentText,
+          senderEmail: "customer@example.com",
+          existingMemories: [],
+        });
+        const createdMemories = getCreatedMemoriesFromDecisions(result);
+        const summary = summarizeMemories(createdMemories);
+
+        const hasFactualBusinessIdentityMemory = createdMemories.some(
+          (memory) =>
+            memory.kind === ReplyMemoryKind.FACT &&
+            (memory.scopeType === ReplyMemoryScopeType.GLOBAL ||
+              memory.scopeType === ReplyMemoryScopeType.TOPIC),
+        );
+        const judgeResult = await judgeBinary({
+          input: buildJudgeInput({
+            incomingEmailContent,
+            draftText,
+            sentText,
+          }),
+          output: summary,
+          expected:
+            "A FACT memory that says the user does not sell shoes and runs an AI email assistant. It must not learn shoe troubleshooting advice.",
+          criterion: {
+            name: "Business identity correction",
+          },
+          judgeUserAi: getEvalJudgeUserAi(),
+        });
+        const pass = hasFactualBusinessIdentityMemory && judgeResult.pass;
+
+        evalReporter.record({
+          testName: "business identity correction extraction",
+          model: model.label,
+          pass,
+          expected:
+            "FACT memory that the user does not sell shoes and is an AI email assistant",
+          actual: formatJudgeActual(summary, judgeResult),
+          criteria: [judgeResult],
+        });
+
+        expect(hasFactualBusinessIdentityMemory).toBe(true);
+        expect(judgeResult.pass).toBe(true);
+      },
+      TIMEOUT,
+    );
+
+    test(
       "extracts a global preference memory from a strong tone edit",
       async () => {
         const result = await aiExtractReplyMemoriesFromDraftEdit({

--- a/apps/web/app/api/google/webhook/process-history-item.test.ts
+++ b/apps/web/app/api/google/webhook/process-history-item.test.ts
@@ -10,6 +10,7 @@ import { markMessageAsProcessing } from "@/utils/redis/message-processing";
 import { GmailLabel } from "@/utils/gmail/label";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
+import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
 
 const logger = createTestLogger();
 
@@ -74,6 +75,10 @@ vi.mock("@/utils/email/provider", () => ({
     blockUnsubscribedEmail: vi.fn().mockResolvedValue(undefined),
     isSentMessage: vi.fn().mockReturnValue(false),
   }),
+}));
+
+vi.mock("@/utils/reply-tracker/handle-outbound", () => ({
+  handleOutboundMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/utils/gmail/label", async () => {
@@ -164,7 +169,7 @@ describe("processHistoryItem", () => {
     await processHistoryItem(createHistoryItem(), options, logger);
   });
 
-  it("should skip if message is outbound", async () => {
+  it("handles outbound message-added events", async () => {
     const mockProvider = {
       getMessage: vi.fn().mockResolvedValue({
         id: "123",
@@ -194,6 +199,67 @@ describe("processHistoryItem", () => {
       emailAccount: getDefaultEmailAccount(),
     };
     await processHistoryItem(createHistoryItem(), options, logger);
+
+    expect(handleOutboundMessage).toHaveBeenCalledWith({
+      emailAccount: options.emailAccount,
+      message: expect.objectContaining({ id: "123" }),
+      provider: mockProvider,
+      logger: expect.anything(),
+    });
+  });
+
+  it("handles SENT label-added events as outbound messages", async () => {
+    const sentMessage = {
+      id: "sent-123",
+      threadId: "thread-123",
+      labelIds: [GmailLabel.SENT],
+      snippet: "Test email snippet",
+      historyId: "12345",
+      internalDate: "1704067200000",
+      sizeEstimate: 1024,
+      headers: {
+        from: "user@test.com",
+        to: "recipient@example.com",
+        subject: "Test Email",
+        date: "2024-01-01T00:00:00Z",
+      },
+      textPlain: "Hello World",
+      textHtml: "<b>Hello World</b>",
+    };
+    const mockProvider = {
+      getMessage: vi.fn().mockResolvedValue(sentMessage),
+      blockUnsubscribedEmail: vi.fn().mockResolvedValue(undefined),
+      isSentMessage: vi.fn().mockReturnValue(true),
+    };
+
+    vi.mocked(createEmailProvider).mockResolvedValueOnce(mockProvider as any);
+
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(
+      createHistoryItem(
+        "sent-123",
+        "thread-123",
+        HistoryEventType.LABEL_ADDED,
+        [GmailLabel.SENT],
+      ),
+      options,
+      logger,
+    );
+
+    expect(markMessageAsProcessing).toHaveBeenCalledWith({
+      userEmail: options.emailAccount.email,
+      messageId: "sent-123",
+    });
+    expect(handleOutboundMessage).toHaveBeenCalledWith({
+      emailAccount: options.emailAccount,
+      message: sentMessage,
+      provider: mockProvider,
+      logger: expect.anything(),
+    });
   });
 
   it("should skip if email is unsubscribed", async () => {

--- a/apps/web/app/api/google/webhook/process-history-item.ts
+++ b/apps/web/app/api/google/webhook/process-history-item.ts
@@ -64,18 +64,11 @@ export async function processHistoryItem(
     );
   };
 
-  if (
-    type === HistoryEventType.LABEL_ADDED &&
-    item.labelIds?.includes(GmailLabel.SENT)
-  ) {
-    return lockAndProcessShared();
-  }
-
   // Handle Google-specific label events
   if (type === HistoryEventType.LABEL_REMOVED) {
     logger.info("Processing label removed event for learning");
     return handleLabelRemovedEvent(
-      item,
+      item as gmail_v1.Schema$HistoryLabelRemoved,
       {
         emailAccount,
         provider,
@@ -83,9 +76,15 @@ export async function processHistoryItem(
       logger,
     );
   } else if (type === HistoryEventType.LABEL_ADDED) {
+    const labelAddedItem = item as gmail_v1.Schema$HistoryLabelAdded;
+
+    if (labelAddedItem.labelIds?.includes(GmailLabel.SENT)) {
+      return lockAndProcessShared();
+    }
+
     logger.info("Processing label added event for learning");
     return handleLabelAddedEvent(
-      item,
+      labelAddedItem,
       {
         emailAccount,
         provider,

--- a/apps/web/app/api/google/webhook/process-history-item.ts
+++ b/apps/web/app/api/google/webhook/process-history-item.ts
@@ -6,6 +6,7 @@ import { handleLabelRemovedEvent } from "@/app/api/google/webhook/process-label-
 import { handleLabelAddedEvent } from "@/app/api/google/webhook/process-label-added-event";
 import { processHistoryItem as processHistoryItemShared } from "@/utils/webhook/process-history-item";
 import { markMessageAsProcessing } from "@/utils/redis/message-processing";
+import { GmailLabel } from "@/utils/gmail/label";
 import type { Logger } from "@/utils/logger";
 
 export async function processHistoryItem(
@@ -38,6 +39,38 @@ export async function processHistoryItem(
     logger,
   });
 
+  const lockAndProcessShared = async () => {
+    const isFree = await markMessageAsProcessing({
+      userEmail: emailAccount.email,
+      messageId,
+    });
+    if (!isFree) {
+      logger.info("Skipping. Message already being processed.");
+      return;
+    }
+
+    logger.info("Gmail lock acquired, calling shared processor");
+
+    return processHistoryItemShared(
+      { messageId, threadId },
+      {
+        provider,
+        emailAccount,
+        hasAutomationRules,
+        hasAiAccess,
+        rules,
+        logger,
+      },
+    );
+  };
+
+  if (
+    type === HistoryEventType.LABEL_ADDED &&
+    item.labelIds?.includes(GmailLabel.SENT)
+  ) {
+    return lockAndProcessShared();
+  }
+
   // Handle Google-specific label events
   if (type === HistoryEventType.LABEL_REMOVED) {
     logger.info("Processing label removed event for learning");
@@ -61,27 +94,5 @@ export async function processHistoryItem(
     );
   }
 
-  // Lock before fetching to avoid extra API calls for duplicate webhooks
-  const isFree = await markMessageAsProcessing({
-    userEmail: emailAccount.email,
-    messageId,
-  });
-  if (!isFree) {
-    logger.info("Skipping. Message already being processed.");
-    return;
-  }
-
-  logger.info("Gmail lock acquired, calling shared processor");
-
-  return processHistoryItemShared(
-    { messageId, threadId },
-    {
-      provider,
-      emailAccount,
-      hasAutomationRules,
-      hasAiAccess,
-      rules,
-      logger,
-    },
-  );
+  return lockAndProcessShared();
 }


### PR DESCRIPTION
Fixes outbound draft tracking when a provider reports a sent message as a label-added event instead of a message-added event.

- Routes sent label-added events through outbound message handling so draft send logs can be recorded.
- Adds regression coverage for the webhook path and reply-memory learning.
- Simplifies one-off eval criteria by making criterion descriptions optional.

Tests: `pnpm --filter inbox-zero-ai test app/api/google/webhook/process-history-item.test.ts app/api/google/webhook/process-label-added-event.test.ts utils/reply-tracker/draft-tracking.test.ts`; `pnpm --filter inbox-zero-ai exec biome check __tests__/eval/judge.ts __tests__/eval/reply-memory.test.ts app/api/google/webhook/process-history-item.ts app/api/google/webhook/process-history-item.test.ts`; `EVAL_MODELS=gpt-5.4-mini pnpm --filter inbox-zero-ai test-ai eval/reply-memory -t "learns a business identity correction"`