### PR TITLE
messages: Fix message body fallback

### DIFF
--- a/apps/web/app/api/messages/batch/route.test.ts
+++ b/apps/web/app/api/messages/batch/route.test.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+const mockEmailProvider = vi.hoisted(() => ({
+  getMessagesBatch: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailProvider:
+    (_name: string, handler: (request: any) => Promise<Response>) =>
+    (request: NextRequest) =>
+      handler({
+        ...request,
+        url: request.url,
+        emailProvider: mockEmailProvider,
+      }),
+}));
+
+describe("GET /api/messages/batch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses HTML content as the parsed plain text fallback", async () => {
+    mockEmailProvider.getMessagesBatch.mockResolvedValue([
+      {
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "",
+        textHtml:
+          '<div>Sent reply body.</div><br><div class="gmail_quote">Previous message</div>',
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/messages/batch?ids=message-1&parseReplies=true",
+      ),
+    );
+
+    const body = await response.json();
+
+    expect(body.messages[0].textPlain).toBe("Sent reply body.");
+  });
+});

--- a/apps/web/app/api/messages/batch/route.ts
+++ b/apps/web/app/api/messages/batch/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
 import { messagesBatchQuery } from "@/app/api/messages/validation";
-import { parseReply } from "@/utils/mail";
+import { convertEmailHtmlToText, parseReply } from "@/utils/mail";
 import type { EmailProvider } from "@/utils/email/types";
+import { stripQuotedHtmlContent } from "@/utils/ai/choose-rule/draft-management";
 
 export type MessagesBatchResponse = {
   messages: Awaited<ReturnType<typeof getMessagesBatch>>;
@@ -20,11 +21,23 @@ async function getMessagesBatch({
   const messages = await emailProvider.getMessagesBatch(messageIds);
 
   if (parseReplies) {
-    return messages.map((message) => ({
-      ...message,
-      textPlain: parseReply(message.textPlain || ""),
-      textHtml: parseReply(message.textHtml || ""),
-    }));
+    return messages.map((message) => {
+      const parsedTextPlain = parseReply(message.textPlain || "").trim();
+      const parsedTextHtml = message.textHtml
+        ? parseReply(
+            convertEmailHtmlToText({
+              htmlText: stripQuotedHtmlContent(message.textHtml),
+              includeLinks: false,
+            }),
+          ).trim()
+        : "";
+
+      return {
+        ...message,
+        textPlain: parsedTextPlain || parsedTextHtml,
+        textHtml: parsedTextHtml,
+      };
+    });
   }
 
   return messages;

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -316,6 +316,19 @@ On Tue, 1 Apr 2026 at 10:00, Sender <sender@example.com> wrote:
       expect(score).toBe(1.0);
     });
 
+    it("should return 0.0 when the sent message has no comparable body", () => {
+      const storedContent = `Thanks, I handled this now.
+
+--
+Sender Name
+Company
+555-0100`;
+      const gmailMessage = createParsedMessage("");
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(0.0);
+    });
+
     it("should preserve plain text angle brackets that are not real HTML", () => {
       const storedContent = "Daily Updates <updates@example.com>";
       const gmailMessage = createParsedMessage("Daily Updates <attachment>");


### PR DESCRIPTION
Ensures parsed batch message responses fall back to converted HTML when plain text is empty.

- Strips quoted HTML before converting message bodies for parsed replies.
- Adds regression coverage for HTML-only message display and empty comparable similarity input.