### PR TITLE
fix(web): improve public booking page on mobile

### DIFF
--- a/apps/web/app/book/[slug]/BookingPageClient.tsx
+++ b/apps/web/app/book/[slug]/BookingPageClient.tsx
@@ -234,14 +234,14 @@ function PickTimeStep({
     detectDefaultHourFormat(),
   );
   return (
-    <div className="grid grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_240px]">
+    <div className="grid min-w-0 grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_240px]">
       <BookingSidebar
         bookingLink={bookingLink}
         timezone={timezone}
         onTimezoneChange={onTimezoneChange}
         showDescription
       />
-      <div className="border-t p-6 md:border-l md:border-t-0 md:p-7">
+      <div className="min-w-0 border-t p-4 sm:p-6 md:border-l md:border-t-0 md:p-7">
         <BookingCalendar
           visibleMonth={visibleMonth}
           onMonthChange={onMonthChange}
@@ -251,9 +251,9 @@ function PickTimeStep({
           timezone={timezone}
         />
       </div>
-      <div className="border-t bg-muted/30 p-6 md:border-l md:border-t-0">
-        <div className="mb-3 flex items-center justify-between gap-2">
-          <div className="text-sm font-semibold text-foreground">
+      <div className="min-w-0 border-t bg-muted/30 p-4 sm:p-6 md:max-h-none md:border-l md:border-t-0 md:p-7">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="min-w-0 text-sm font-semibold text-foreground">
             {selectedDateKey
               ? formatSelectedDateHeading(selectedDateKey)
               : "Pick a date"}
@@ -269,7 +269,7 @@ function PickTimeStep({
             No slots available on this day.
           </p>
         ) : (
-          <div className="flex flex-col gap-1.5">
+          <div className="flex max-h-[min(50vh,22rem)] flex-col gap-1.5 overflow-y-auto pr-1 md:max-h-none">
             {slotsForDay.map((slot) => (
               <button
                 key={slot.startTime}
@@ -333,17 +333,17 @@ function BookingCalendar({
         available:
           "bg-blue-50 font-semibold text-blue-700 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300",
       }}
-      className="mx-auto w-fit"
+      className="mx-auto w-fit max-w-full"
       classNames={{
         month: "space-y-4",
         table: "w-full border-collapse space-y-1",
-        head_row: "flex gap-1.5",
+        head_row: "flex gap-0.5 sm:gap-1 md:gap-1.5",
         head_cell:
-          "w-14 text-muted-foreground font-normal text-[0.7rem] uppercase tracking-wider",
-        row: "flex w-full mt-1.5 gap-1.5",
-        cell: "h-14 w-14 p-0 text-center text-sm",
+          "w-9 text-muted-foreground font-normal text-[0.6rem] uppercase tracking-wider sm:w-10 sm:text-[0.65rem] md:w-14 md:text-[0.7rem]",
+        row: "flex w-full mt-1 gap-0.5 sm:mt-1.5 sm:gap-1 md:gap-1.5",
+        cell: "size-9 p-0 text-center text-xs sm:size-10 sm:text-sm md:size-14",
         day: cn(
-          "h-14 w-14 rounded-lg p-0 font-normal tabular-nums aria-selected:opacity-100",
+          "size-9 rounded-lg p-0 text-xs font-normal tabular-nums aria-selected:opacity-100 sm:size-10 sm:text-sm md:size-14",
         ),
         day_selected:
           "bg-blue-600 text-white hover:bg-blue-600 hover:text-white focus:bg-blue-600 focus:text-white",
@@ -389,7 +389,7 @@ function DetailsStep({
   };
 
   return (
-    <div className="grid grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)]">
+    <div className="grid min-w-0 grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)]">
       <BookingSidebar
         bookingLink={bookingLink}
         timezone={timezone}
@@ -407,7 +407,7 @@ function DetailsStep({
       />
       <form
         onSubmit={handleSubmit}
-        className="border-t p-7 md:border-l md:border-t-0"
+        className="min-w-0 border-t p-4 sm:p-6 md:border-l md:border-t-0 md:p-7"
       >
         <h2 className="text-xl font-medium tracking-tight text-foreground">
           Enter your details
@@ -447,11 +447,16 @@ function DetailsStep({
 
         {error ? <p className="mt-4 text-sm text-red-500">{error}</p> : null}
 
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <p className="text-xs text-muted-foreground">
+        <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+          <p className="text-xs text-muted-foreground sm:min-w-0 sm:flex-1 sm:pr-2">
             By confirming, you agree to receive a calendar invite and reminders.
           </p>
-          <Button type="submit" loading={isSubmitting} variant="primaryBlack">
+          <Button
+            type="submit"
+            loading={isSubmitting}
+            variant="primaryBlack"
+            className="w-full shrink-0 sm:w-auto"
+          >
             Confirm booking
             <ArrowRight className="ml-2 size-3.5" />
           </Button>
@@ -471,15 +476,15 @@ function BookingSuccessCard({
   timezone: string;
 }) {
   return (
-    <div className="grid grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)]">
+    <div className="grid min-w-0 grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)]">
       <BookingSidebar
         bookingLink={bookingLink}
         timezone={timezone}
         slot={success}
       />
-      <div className="border-t p-7 md:border-l md:border-t-0">
-        <div className="flex items-center gap-2.5 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300">
-          <Check className="size-4" />
+      <div className="min-w-0 border-t p-4 sm:p-6 md:border-l md:border-t-0 md:p-7">
+        <div className="flex items-start gap-2.5 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300">
+          <Check className="mt-0.5 size-4 shrink-0" />
           You're booked. A calendar invite is on its way.
         </div>
         <h2 className="mt-6 text-xl font-medium tracking-tight text-foreground">
@@ -555,10 +560,10 @@ export function BookingShell({
   size?: "compact" | "wide";
 }) {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-muted/30 px-4 py-10">
+    <main className="flex min-h-screen items-center justify-center bg-muted/30 px-3 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom,0px))] pt-[max(1.5rem,env(safe-area-inset-top,0px))] sm:px-4 sm:py-10">
       <div
         className={cn(
-          "w-full overflow-hidden rounded-2xl border bg-background shadow-lg",
+          "w-full min-w-0 overflow-hidden rounded-xl border bg-background shadow-lg sm:rounded-2xl",
           size === "compact" ? "max-w-3xl" : "max-w-5xl",
         )}
       >

--- a/apps/web/app/book/[slug]/BookingSidebar.tsx
+++ b/apps/web/app/book/[slug]/BookingSidebar.tsx
@@ -59,14 +59,14 @@ export function BookingSidebar({
   const hostName = bookingLink.hostName || bookingLink.title;
   const initial = (hostName || "?").trim().charAt(0).toUpperCase();
   return (
-    <div className="flex flex-col gap-4 p-7">
+    <div className="flex min-h-0 flex-col gap-4 p-4 sm:p-6 md:p-7">
       {backButton}
       <div className="flex size-12 items-center justify-center rounded-full bg-blue-50 text-lg font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300">
         {initial}
       </div>
       <div>
         <div className="text-sm text-muted-foreground">{hostName}</div>
-        <h1 className="mt-0.5 text-2xl font-medium tracking-tight text-foreground">
+        <h1 className="mt-0.5 break-words text-2xl font-medium tracking-tight text-foreground">
           {bookingLink.title}
         </h1>
       </div>
@@ -166,7 +166,10 @@ function TimezonePicker({
           <ChevronsUpDown className="size-3 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-[320px] p-0" align="start">
+      <PopoverContent
+        className="w-[min(20rem,calc(100vw-1.5rem))] max-w-[calc(100vw-1.5rem)] p-0 sm:w-[320px] sm:max-w-none"
+        align="start"
+      >
         <Command>
           <CommandInput placeholder="Search timezone..." />
           <CommandList>
@@ -209,9 +212,9 @@ function SidebarRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-muted-foreground/70">{icon}</span>
-      <span>{children}</span>
+    <div className="flex min-w-0 items-start gap-2">
+      <span className="mt-0.5 shrink-0 text-muted-foreground/70">{icon}</span>
+      <span className="min-w-0 break-words">{children}</span>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Calendar**: Smaller day cells and gaps on narrow viewports; scales up from `md` to match desktop.
- **Layout**: `min-w-0` on grid columns and shell to avoid horizontal overflow; reduced padding on small screens.
- **Slots panel**: Scrollable list on mobile (`max-h`) so long days don’t push the page endlessly.
- **Details step**: Full-width confirm button stacked above disclaimer text on small screens.
- **Shell**: Safe-area padding for notched devices; slightly tighter outer padding on phones.
- **Sidebar**: `break-words` on title; sidebar rows align top with wrapping; responsive padding.
- **Timezone picker**: Popover width uses `min()` / viewport cap so it doesn’t clip off-screen.

## Test plan
- [ ] Open `/book/{slug}` on a ~320px-wide viewport: no horizontal scroll; calendar and slots usable.
- [ ] Confirm booking step: button is tappable and layout doesn’t overlap disclaimer.
- [ ] Timezone popover opens fully within the viewport.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34785892-b45d-4cca-9181-593cdbdce937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34785892-b45d-4cca-9181-593cdbdce937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

