### PR TITLE
assistant: Add provider-specific chat folder tools

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
@@ -49,6 +49,8 @@ const writeToolNames = new Set([
   "sendEmail",
   "replyEmail",
   "forwardEmail",
+  "createOrGetFolder",
+  "moveThreadsToFolder",
   "saveMemory",
   "addToKnowledgeBase",
 ]);
@@ -76,6 +78,9 @@ const hoisted = vi.hoisted(() => ({
   mockArchiveThreadWithLabel: vi.fn(),
   mockMarkReadThread: vi.fn(),
   mockBulkArchiveFromSenders: vi.fn(),
+  mockGetFolders: vi.fn(),
+  mockGetOrCreateFolderIdByName: vi.fn(),
+  mockMoveThreadToFolder: vi.fn(),
 }));
 
 const {
@@ -91,6 +96,10 @@ const {
 } = hoisted;
 
 export const mockSearchMessages = hoisted.mockSearchMessages;
+export const mockGetFolders = hoisted.mockGetFolders;
+export const mockGetOrCreateFolderIdByName =
+  hoisted.mockGetOrCreateFolderIdByName;
+export const mockMoveThreadToFolder = hoisted.mockMoveThreadToFolder;
 
 vi.mock("@/utils/rule/rule", () => ({
   createRule: hoisted.mockCreateRule,
@@ -175,6 +184,19 @@ export function setupInboxWorkflowEval() {
       messages: getDefaultSearchMessages(),
       nextPageToken: undefined,
     });
+    mockGetFolders.mockResolvedValue(getDefaultFolders());
+    mockGetOrCreateFolderIdByName.mockImplementation(async (folderName) => {
+      const folder = flattenFolders(getDefaultFolders()).find(
+        (candidate) =>
+          candidate.displayName.toLowerCase() ===
+            String(folderName).trim().toLowerCase() ||
+          candidate.path.toLowerCase() ===
+            String(folderName).trim().toLowerCase(),
+      );
+
+      return folder?.id ?? "folder-created";
+    });
+    mockMoveThreadToFolder.mockResolvedValue(undefined);
 
     mockGetMessage.mockImplementation(async (messageId: string) =>
       getMessageById(messageId),
@@ -187,6 +209,9 @@ export function setupInboxWorkflowEval() {
       archiveThreadWithLabel: mockArchiveThreadWithLabel,
       markReadThread: mockMarkReadThread,
       bulkArchiveFromSenders: mockBulkArchiveFromSenders,
+      getFolders: mockGetFolders,
+      getOrCreateFolderIdByName: mockGetOrCreateFolderIdByName,
+      moveThreadToFolder: mockMoveThreadToFolder,
       getMessagesWithPagination: vi.fn().mockResolvedValue({
         messages: [],
         nextPageToken: undefined,
@@ -420,6 +445,43 @@ function getDefaultLabels() {
     { id: "Label_To Reply", name: "To Reply" },
     { id: "Label_FYI", name: "FYI" },
   ];
+}
+
+function getDefaultFolders() {
+  return [
+    {
+      id: "folder-operations",
+      displayName: "Operations",
+      childFolderCount: 1,
+      childFolders: [
+        {
+          id: "folder-operations-reports",
+          displayName: "Reports",
+          childFolderCount: 0,
+          childFolders: [],
+        },
+      ],
+    },
+    {
+      id: "folder-vendor-updates",
+      displayName: "Vendor Updates",
+      childFolderCount: 0,
+      childFolders: [],
+    },
+  ];
+}
+
+function flattenFolders(
+  folders: ReturnType<typeof getDefaultFolders>,
+  parentPath?: string,
+): Array<ReturnType<typeof getDefaultFolders>[number] & { path: string }> {
+  return folders.flatMap((folder) => {
+    const path = parentPath
+      ? `${parentPath} / ${folder.displayName}`
+      : folder.displayName;
+
+    return [{ ...folder, path }, ...flattenFolders(folder.childFolders, path)];
+  });
 }
 
 function getDefaultSearchMessages() {

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
@@ -11,6 +11,7 @@ import { shouldRunEvalTests } from "@/__tests__/eval/models";
 import { judgeEvalOutput } from "@/__tests__/eval/semantic-judge";
 import { getMockMessage } from "@/__tests__/helpers";
 import type { getEmailAccount } from "@/__tests__/helpers";
+import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";
 
@@ -477,7 +478,7 @@ function flattenFolders(
 ): Array<ReturnType<typeof getDefaultFolders>[number] & { path: string }> {
   return folders.flatMap((folder) => {
     const path = parentPath
-      ? `${parentPath} / ${folder.displayName}`
+      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
       : folder.displayName;
 
     return [{ ...folder, path }, ...flattenFolders(folder.childFolders, path)];

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, describe, expect, test } from "vitest";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { getMockMessage } from "@/__tests__/helpers";
+import {
+  cloneEmailAccountForProvider,
+  getLastMatchingToolCall,
+  hasSearchBeforeTool,
+  mockMoveThreadToFolder,
+  mockSearchMessages,
+  runAssistantChat,
+  setupInboxWorkflowEval,
+  TIMEOUT,
+} from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+
+// pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-outlook-folders.test.ts
+// Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-outlook-folders.test.ts
+
+const shouldRunEval = shouldRunEvalTests();
+const evalReporter = createEvalReporter();
+
+describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
+  setupInboxWorkflowEval();
+
+  describeEvalMatrix(
+    "assistant-chat outlook folders",
+    (model, emailAccount) => {
+      test(
+        "moves searched messages to an Outlook folder",
+        async () => {
+          mockSearchMessages.mockResolvedValueOnce({
+            messages: [
+              getMockMessage({
+                id: "msg-folder-move-1",
+                threadId: "thread-folder-move-1",
+                from: "updates@vendor.example",
+                subject: "Release update",
+                snippet: "A release note for review.",
+                labelIds: ["INBOX"],
+              }),
+              getMockMessage({
+                id: "msg-folder-move-2",
+                threadId: "thread-folder-move-2",
+                from: "updates@vendor.example",
+                subject: "Maintenance update",
+                snippet: "A maintenance notice for review.",
+                labelIds: ["INBOX"],
+              }),
+            ],
+            nextPageToken: undefined,
+          });
+
+          const { toolCalls, actual } = await runAssistantChat({
+            emailAccount: cloneEmailAccountForProvider(
+              emailAccount,
+              "microsoft",
+            ),
+            messages: [
+              {
+                role: "user",
+                content:
+                  "Move the two vendor update emails to my Operations / Reports Outlook folder.",
+              },
+            ],
+          });
+
+          const moveCall = getLastMatchingToolCall(
+            toolCalls,
+            "moveThreadsToFolder",
+            isMoveThreadsToFolderInput,
+          )?.input;
+          const movedThreadIds = new Set(moveCall?.threadIds ?? []);
+          const movedToNestedFolder = mockMoveThreadToFolder.mock.calls.every(
+            ([, , folderId]) => folderId === "folder-operations-reports",
+          );
+          const pass =
+            !!moveCall &&
+            hasSearchBeforeTool(toolCalls, "moveThreadsToFolder") &&
+            movedThreadIds.has("thread-folder-move-1") &&
+            movedThreadIds.has("thread-folder-move-2") &&
+            normalizeFolderName(moveCall.folderName).includes("reports") &&
+            mockMoveThreadToFolder.mock.calls.length === 2 &&
+            movedToNestedFolder &&
+            !toolCalls.some((toolCall) => toolCall.toolName === "manageInbox");
+
+          evalReporter.record({
+            testName: "outlook folder move uses folder tool after search",
+            model: model.label,
+            pass,
+            actual: `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
+              movedThreadIds,
+            ).join(",")}`,
+          });
+
+          expect(
+            pass,
+            `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
+              movedThreadIds,
+            ).join(",")}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "creates or reuses an Outlook folder when explicitly asked",
+        async () => {
+          const { toolCalls, actual } = await runAssistantChat({
+            emailAccount: cloneEmailAccountForProvider(
+              emailAccount,
+              "microsoft",
+            ),
+            messages: [
+              {
+                role: "user",
+                content:
+                  "Make sure I have an Outlook folder called Vendor Updates.",
+              },
+            ],
+          });
+
+          const folderCall = getLastMatchingToolCall(
+            toolCalls,
+            "createOrGetFolder",
+            isCreateOrGetFolderInput,
+          )?.input;
+          const pass =
+            normalizeFolderName(folderCall?.name) === "vendor updates" &&
+            !toolCalls.some(
+              (toolCall) => toolCall.toolName === "createOrGetCategory",
+            );
+
+          evalReporter.record({
+            testName: "outlook explicit folder create uses folder tool",
+            model: model.label,
+            pass,
+            actual: `${actual} | folderName=${folderCall?.name ?? "none"}`,
+          });
+
+          expect(
+            pass,
+            `${actual} | folderName=${folderCall?.name ?? "none"}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "lists Outlook folders without exposing internal folder ids",
+        async () => {
+          const { toolCalls, actual } = await runAssistantChat({
+            emailAccount: cloneEmailAccountForProvider(
+              emailAccount,
+              "microsoft",
+            ),
+            messages: [
+              {
+                role: "user",
+                content: "Show me my Outlook folders.",
+              },
+            ],
+          });
+
+          const listCall = toolCalls.find(
+            (toolCall) => toolCall.toolName === "listFolders",
+          );
+          const outputText = JSON.stringify(listCall?.output ?? {});
+          const pass =
+            !!listCall &&
+            outputText.includes("Operations / Reports") &&
+            !outputText.includes("folder-operations") &&
+            !outputText.includes("folder-vendor-updates") &&
+            !toolCalls.some(
+              (toolCall) =>
+                toolCall.toolName === "listCategories" ||
+                toolCall.toolName === "createOrGetCategory",
+            );
+
+          evalReporter.record({
+            testName: "outlook folder listing hides internal ids",
+            model: model.label,
+            pass,
+            actual: `${actual} | output=${outputText}`,
+          });
+
+          expect(pass, `${actual} | output=${outputText}`).toBe(true);
+        },
+        TIMEOUT,
+      );
+    },
+  );
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});
+
+function isMoveThreadsToFolderInput(
+  input: unknown,
+): input is { threadIds: string[]; folderName: string } {
+  if (!input || typeof input !== "object") return false;
+
+  const value = input as {
+    threadIds?: unknown;
+    folderName?: unknown;
+  };
+
+  return Array.isArray(value.threadIds) && typeof value.folderName === "string";
+}
+
+function isCreateOrGetFolderInput(input: unknown): input is { name: string } {
+  return (
+    !!input &&
+    typeof input === "object" &&
+    typeof (input as { name?: unknown }).name === "string"
+  );
+}
+
+function normalizeFolderName(value: unknown) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
+import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 import {
   cloneEmailAccountForProvider,
   getLastMatchingToolCall,
@@ -61,8 +62,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
             messages: [
               {
                 role: "user",
-                content:
-                  "Move the two vendor update emails to my Operations / Reports Outlook folder.",
+                content: `Move the two vendor update emails to my Operations${FOLDER_SEPARATOR}Reports Outlook folder.`,
               },
             ],
           });
@@ -170,7 +170,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
           const outputText = JSON.stringify(listCall?.output ?? {});
           const pass =
             !!listCall &&
-            outputText.includes("Operations / Reports") &&
+            outputText.includes(`Operations${FOLDER_SEPARATOR}Reports`) &&
             !outputText.includes("folder-operations") &&
             !outputText.includes("folder-vendor-updates") &&
             !toolCalls.some(

--- a/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
+import { createTestLogger } from "@/__tests__/helpers";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { OutlookFolder } from "@/utils/outlook/folders";
+import {
+  createOrGetFolderTool,
+  listFoldersTool,
+  moveThreadsToFolderTool,
+} from "./chat-folder-tools";
+
+vi.mock("@/utils/email/provider");
+vi.mock("@/utils/posthog", () => ({
+  posthogCaptureEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const logger = createTestLogger();
+const TEST_EMAIL = "user@test.com";
+const toolOptions = {
+  email: TEST_EMAIL,
+  emailAccountId: "email-account-1",
+  provider: "microsoft",
+  logger,
+};
+
+describe("chat folder tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists nested Outlook folders without exposing folder IDs", async () => {
+    const folders: OutlookFolder[] = [
+      {
+        id: "folder-1",
+        displayName: "Operations",
+        childFolderCount: 1,
+        childFolders: [
+          {
+            id: "folder-2",
+            displayName: "Reports",
+            childFolderCount: 0,
+            childFolders: [],
+          },
+        ],
+      },
+    ];
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue(folders),
+      }),
+    );
+
+    const toolInstance = listFoldersTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({});
+
+    expect(result).toEqual({
+      count: 2,
+      folders: [
+        {
+          name: "Operations",
+          path: "Operations",
+          childFolderCount: 1,
+        },
+        {
+          name: "Reports",
+          path: "Operations / Reports",
+          childFolderCount: 0,
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain("folder-1");
+    expect(JSON.stringify(result)).not.toContain("folder-2");
+  });
+
+  it("reuses an existing Outlook folder by normalized name", async () => {
+    const getFolders = vi.fn().mockResolvedValue([
+      {
+        id: "folder-1",
+        displayName: "Operations",
+        childFolderCount: 0,
+        childFolders: [],
+      },
+    ] satisfies OutlookFolder[]);
+    const getOrCreateFolderIdByName = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders,
+        getOrCreateFolderIdByName,
+      }),
+    );
+
+    const toolInstance = createOrGetFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      name: " operations ",
+    });
+
+    expect(result).toEqual({
+      created: false,
+      folder: {
+        name: "Operations",
+        path: "Operations",
+        childFolderCount: 0,
+      },
+    });
+    expect(getOrCreateFolderIdByName).not.toHaveBeenCalled();
+  });
+
+  it("creates a root Outlook folder when no normalized match exists", async () => {
+    const getOrCreateFolderIdByName = vi.fn().mockResolvedValue("folder-1");
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue([]),
+        getOrCreateFolderIdByName,
+      }),
+    );
+
+    const toolInstance = createOrGetFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      name: "Finance",
+    });
+
+    expect(getOrCreateFolderIdByName).toHaveBeenCalledWith("Finance");
+    expect(result).toEqual({
+      created: true,
+      folder: {
+        name: "Finance",
+        path: "Finance",
+        childFolderCount: 0,
+      },
+    });
+  });
+
+  it("moves deduped Outlook thread IDs to the resolved folder", async () => {
+    const getOrCreateFolderIdByName = vi.fn().mockResolvedValue("folder-1");
+    const moveThreadToFolder = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getOrCreateFolderIdByName,
+        moveThreadToFolder,
+      }),
+    );
+
+    const toolInstance = moveThreadsToFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      threadIds: ["thread-1", "thread-1", "thread-2"],
+      folderName: "Finance",
+    });
+
+    expect(getOrCreateFolderIdByName).toHaveBeenCalledWith("Finance");
+    expect(moveThreadToFolder).toHaveBeenCalledTimes(2);
+    expect(moveThreadToFolder).toHaveBeenNthCalledWith(
+      1,
+      "thread-1",
+      TEST_EMAIL,
+      "folder-1",
+    );
+    expect(moveThreadToFolder).toHaveBeenNthCalledWith(
+      2,
+      "thread-2",
+      TEST_EMAIL,
+      "folder-1",
+    );
+    expect(result).toEqual({
+      success: true,
+      folderName: "Finance",
+      requestedCount: 2,
+      successCount: 2,
+      failedCount: 0,
+      failedThreadIds: [],
+    });
+  });
+
+  it("moves Outlook threads to an existing nested folder by path", async () => {
+    const getOrCreateFolderIdByName = vi.fn();
+    const moveThreadToFolder = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue([
+          {
+            id: "folder-1",
+            displayName: "Operations",
+            childFolderCount: 1,
+            childFolders: [
+              {
+                id: "folder-2",
+                displayName: "Reports",
+                childFolderCount: 0,
+                childFolders: [],
+              },
+            ],
+          },
+        ] satisfies OutlookFolder[]),
+        getOrCreateFolderIdByName,
+        moveThreadToFolder,
+      }),
+    );
+
+    const toolInstance = moveThreadsToFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      threadIds: ["thread-1"],
+      folderName: "Operations / Reports",
+    });
+
+    expect(getOrCreateFolderIdByName).not.toHaveBeenCalled();
+    expect(moveThreadToFolder).toHaveBeenCalledWith(
+      "thread-1",
+      TEST_EMAIL,
+      "folder-2",
+    );
+    expect(result).toEqual({
+      success: true,
+      folderName: "Operations / Reports",
+      requestedCount: 1,
+      successCount: 1,
+      failedCount: 0,
+      failedThreadIds: [],
+    });
+  });
+});

--- a/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import { createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
-import type { OutlookFolder } from "@/utils/outlook/folders";
+import { FOLDER_SEPARATOR, type OutlookFolder } from "@/utils/outlook/folders";
 import {
   createOrGetFolderTool,
   listFoldersTool,
@@ -65,7 +65,7 @@ describe("chat folder tools", () => {
         },
         {
           name: "Reports",
-          path: "Operations / Reports",
+          path: `Operations${FOLDER_SEPARATOR}Reports`,
           childFolderCount: 0,
         },
       ],
@@ -133,6 +133,137 @@ describe("chat folder tools", () => {
         path: "Finance",
         childFolderCount: 0,
       },
+    });
+  });
+
+  it("does not treat folder names containing slashes as paths", async () => {
+    const getOrCreateFolderIdByName = vi.fn().mockResolvedValue("folder-1");
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue([]),
+        getOrCreateFolderIdByName,
+      }),
+    );
+
+    const toolInstance = createOrGetFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      name: "Client / invoices",
+    });
+
+    expect(getOrCreateFolderIdByName).toHaveBeenCalledWith("Client / invoices");
+    expect(result).toEqual({
+      created: true,
+      folder: {
+        name: "Client / invoices",
+        path: "Client / invoices",
+        childFolderCount: 0,
+      },
+    });
+  });
+
+  it("prefers an exact slash-containing folder name over a slash path alias", async () => {
+    const getOrCreateFolderIdByName = vi.fn();
+    const moveThreadToFolder = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue([
+          {
+            id: "folder-root-slash",
+            displayName: "Operations / Reports",
+            childFolderCount: 0,
+            childFolders: [],
+          },
+          {
+            id: "folder-operations",
+            displayName: "Operations",
+            childFolderCount: 1,
+            childFolders: [
+              {
+                id: "folder-reports",
+                displayName: "Reports",
+                childFolderCount: 0,
+                childFolders: [],
+              },
+            ],
+          },
+        ] satisfies OutlookFolder[]),
+        getOrCreateFolderIdByName,
+        moveThreadToFolder,
+      }),
+    );
+
+    const toolInstance = moveThreadsToFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      threadIds: ["thread-1"],
+      folderName: "Operations / Reports",
+    });
+
+    expect(getOrCreateFolderIdByName).not.toHaveBeenCalled();
+    expect(moveThreadToFolder).toHaveBeenCalledWith(
+      "thread-1",
+      TEST_EMAIL,
+      "folder-root-slash",
+    );
+    expect(result).toEqual({
+      success: true,
+      folderName: "Operations / Reports",
+      requestedCount: 1,
+      successCount: 1,
+      failedCount: 0,
+      failedThreadIds: [],
+    });
+  });
+
+  it("accepts slash path aliases for nested folders after exact name matching", async () => {
+    const getOrCreateFolderIdByName = vi.fn();
+    const moveThreadToFolder = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getFolders: vi.fn().mockResolvedValue([
+          {
+            id: "folder-operations",
+            displayName: "Operations",
+            childFolderCount: 1,
+            childFolders: [
+              {
+                id: "folder-reports",
+                displayName: "Reports",
+                childFolderCount: 0,
+                childFolders: [],
+              },
+            ],
+          },
+        ] satisfies OutlookFolder[]),
+        getOrCreateFolderIdByName,
+        moveThreadToFolder,
+      }),
+    );
+
+    const toolInstance = moveThreadsToFolderTool(toolOptions);
+
+    const result = await (toolInstance.execute as any)({
+      threadIds: ["thread-1"],
+      folderName: "Operations / Reports",
+    });
+
+    expect(getOrCreateFolderIdByName).not.toHaveBeenCalled();
+    expect(moveThreadToFolder).toHaveBeenCalledWith(
+      "thread-1",
+      TEST_EMAIL,
+      "folder-reports",
+    );
+    expect(result).toEqual({
+      success: true,
+      folderName: "Operations / Reports",
+      requestedCount: 1,
+      successCount: 1,
+      failedCount: 0,
+      failedThreadIds: [],
     });
   });
 
@@ -208,7 +339,7 @@ describe("chat folder tools", () => {
 
     const result = await (toolInstance.execute as any)({
       threadIds: ["thread-1"],
-      folderName: "Operations / Reports",
+      folderName: `Operations${FOLDER_SEPARATOR}Reports`,
     });
 
     expect(getOrCreateFolderIdByName).not.toHaveBeenCalled();
@@ -219,7 +350,7 @@ describe("chat folder tools", () => {
     );
     expect(result).toEqual({
       success: true,
-      folderName: "Operations / Reports",
+      folderName: `Operations${FOLDER_SEPARATOR}Reports`,
       requestedCount: 1,
       successCount: 1,
       failedCount: 0,

--- a/apps/web/utils/ai/assistant/chat-folder-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.ts
@@ -1,0 +1,287 @@
+import { type InferUITool, tool } from "ai";
+import { z } from "zod";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { Logger } from "@/utils/logger";
+import type { OutlookFolder } from "@/utils/outlook/folders";
+import { posthogCaptureEvent } from "@/utils/posthog";
+
+type FolderToolOptions = {
+  email: string;
+  emailAccountId: string;
+  provider: string;
+  logger: Logger;
+};
+
+const threadIdsSchema = z
+  .array(z.string())
+  .min(1)
+  .max(100)
+  .transform((ids) => [...new Set(ids)]);
+
+const folderNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .describe(
+    "Exact Outlook mail folder name, or a folder path from listFolders.",
+  );
+
+export const listFoldersTool = ({
+  email,
+  emailAccountId,
+  provider,
+  logger,
+}: FolderToolOptions) =>
+  tool({
+    description:
+      "List Outlook mail folders for this account. Use this before moving threads to a folder when the exact folder name is unclear. Returns folder names and paths only; internal folder IDs are not shown.",
+    inputSchema: z.object({}),
+    execute: async () => {
+      trackToolCall({ tool: "list_folders", email, logger });
+
+      try {
+        const emailProvider = await createEmailProvider({
+          emailAccountId,
+          provider,
+          logger,
+        });
+        const folders = await emailProvider.getFolders();
+        const flattenedFolders = flattenFolders(folders).map(toVisibleFolder);
+
+        return {
+          folders: flattenedFolders,
+          count: flattenedFolders.length,
+        };
+      } catch (error) {
+        logger.error("Failed to list folders", { error });
+        return {
+          error: "Failed to list folders",
+        };
+      }
+    },
+  });
+
+export const createOrGetFolderTool = ({
+  email,
+  emailAccountId,
+  provider,
+  logger,
+}: FolderToolOptions) =>
+  tool({
+    description:
+      "Reuse an existing Outlook mail folder by exact name or create a root mail folder if it does not exist yet. Use this when the user asks to create a folder or before using a new folder in automation.",
+    inputSchema: z.object({
+      name: folderNameSchema,
+    }),
+    execute: async ({ name }) => {
+      trackToolCall({ tool: "create_or_get_folder", email, logger });
+
+      try {
+        const emailProvider = await createEmailProvider({
+          emailAccountId,
+          provider,
+          logger,
+        });
+        const folderMatch = findFolderMatch(
+          flattenFolders(await emailProvider.getFolders()),
+          name,
+        );
+
+        if (folderMatch.ambiguous) {
+          return {
+            error:
+              "Multiple folders match that name. Use the folder path from listFolders.",
+          };
+        }
+
+        if (folderMatch.folder) {
+          return {
+            created: false,
+            folder: toVisibleFolder(folderMatch.folder),
+          };
+        }
+
+        if (isFolderPath(name)) {
+          return {
+            error:
+              "Folder path not found. Use an existing path from listFolders.",
+          };
+        }
+
+        await emailProvider.getOrCreateFolderIdByName(name);
+
+        return {
+          created: true,
+          folder: {
+            name,
+            path: name,
+            childFolderCount: 0,
+          },
+        };
+      } catch (error) {
+        logger.error("Failed to create or get folder", { error });
+        return {
+          error: "Failed to create or get folder",
+        };
+      }
+    },
+  });
+
+export const moveThreadsToFolderTool = ({
+  email,
+  emailAccountId,
+  provider,
+  logger,
+}: FolderToolOptions) =>
+  tool({
+    description:
+      "Move existing Outlook threads to an Outlook mail folder. Use threadIds returned by searchInbox. Use listFolders first when the exact folder name or path is unclear. This reuses an existing folder by exact path/name, or creates a root folder when no existing folder matches the name.",
+    inputSchema: z.object({
+      threadIds: threadIdsSchema.describe(
+        "Thread IDs from searchInbox results or thread IDs the user already provided.",
+      ),
+      folderName: folderNameSchema,
+    }),
+    execute: async ({ threadIds, folderName }) => {
+      trackToolCall({ tool: "move_threads_to_folder", email, logger });
+
+      try {
+        const emailProvider = await createEmailProvider({
+          emailAccountId,
+          provider,
+          logger,
+        });
+        const uniqueThreadIds = [...new Set(threadIds)];
+        const folderMatch = findFolderMatch(
+          flattenFolders(await emailProvider.getFolders()),
+          folderName,
+        );
+
+        if (folderMatch.ambiguous) {
+          return {
+            error:
+              "Multiple folders match that name. Use the folder path from listFolders.",
+          };
+        }
+
+        if (!folderMatch.folder && isFolderPath(folderName)) {
+          return {
+            error:
+              "Folder path not found. Use an existing path from listFolders.",
+          };
+        }
+
+        const folderId =
+          folderMatch.folder?.id ??
+          (await emailProvider.getOrCreateFolderIdByName(folderName));
+        const results = await Promise.allSettled(
+          uniqueThreadIds.map((threadId) =>
+            emailProvider.moveThreadToFolder(threadId, email, folderId),
+          ),
+        );
+        const failedThreadIds = results
+          .map((result, index) =>
+            result.status === "rejected" ? uniqueThreadIds[index] : null,
+          )
+          .filter((threadId): threadId is string => Boolean(threadId));
+
+        return {
+          success: failedThreadIds.length === 0,
+          folderName,
+          requestedCount: uniqueThreadIds.length,
+          successCount: uniqueThreadIds.length - failedThreadIds.length,
+          failedCount: failedThreadIds.length,
+          failedThreadIds,
+        };
+      } catch (error) {
+        logger.error("Failed to move threads to folder", { error });
+        return {
+          error: "Failed to move threads to folder",
+        };
+      }
+    },
+  });
+
+export type ListFoldersTool = InferUITool<ReturnType<typeof listFoldersTool>>;
+export type CreateOrGetFolderTool = InferUITool<
+  ReturnType<typeof createOrGetFolderTool>
+>;
+export type MoveThreadsToFolderTool = InferUITool<
+  ReturnType<typeof moveThreadsToFolderTool>
+>;
+
+type FlattenedFolder = {
+  name: string;
+  path: string;
+  childFolderCount: number;
+};
+
+type FolderReference = FlattenedFolder & {
+  id: string;
+};
+
+function flattenFolders(
+  folders: OutlookFolder[],
+  parentPath?: string,
+): FolderReference[] {
+  return folders.flatMap((folder) => {
+    const path = parentPath
+      ? `${parentPath} / ${folder.displayName}`
+      : folder.displayName;
+    return [
+      {
+        id: folder.id,
+        name: folder.displayName,
+        path,
+        childFolderCount: folder.childFolderCount ?? folder.childFolders.length,
+      },
+      ...flattenFolders(folder.childFolders, path),
+    ];
+  });
+}
+
+function toVisibleFolder(folder: FolderReference): FlattenedFolder {
+  return {
+    name: folder.name,
+    path: folder.path,
+    childFolderCount: folder.childFolderCount,
+  };
+}
+
+function findFolderMatch(folders: FolderReference[], nameOrPath: string) {
+  const normalizedInput = normalizeFolderText(nameOrPath);
+  const pathMatch = folders.find(
+    (folder) => normalizeFolderText(folder.path) === normalizedInput,
+  );
+
+  if (pathMatch) return { folder: pathMatch };
+
+  const nameMatches = folders.filter(
+    (folder) => normalizeFolderText(folder.name) === normalizedInput,
+  );
+
+  if (nameMatches.length > 1) return { ambiguous: true };
+  return { folder: nameMatches[0] };
+}
+
+function isFolderPath(nameOrPath: string) {
+  return nameOrPath.includes(" / ");
+}
+
+function normalizeFolderText(value: string) {
+  return value.trim().toLowerCase();
+}
+
+async function trackToolCall({
+  tool,
+  email,
+  logger,
+}: {
+  tool: string;
+  email: string;
+  logger: Logger;
+}) {
+  logger.trace("Tracking tool call", { tool, email });
+  return posthogCaptureEvent(email, "AI Assistant Chat Tool Call", { tool });
+}

--- a/apps/web/utils/ai/assistant/chat-folder-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-folder-tools.ts
@@ -2,7 +2,7 @@ import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { Logger } from "@/utils/logger";
-import type { OutlookFolder } from "@/utils/outlook/folders";
+import { FOLDER_SEPARATOR, type OutlookFolder } from "@/utils/outlook/folders";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
 type FolderToolOptions = {
@@ -227,7 +227,7 @@ function flattenFolders(
 ): FolderReference[] {
   return folders.flatMap((folder) => {
     const path = parentPath
-      ? `${parentPath} / ${folder.displayName}`
+      ? `${parentPath}${FOLDER_SEPARATOR}${folder.displayName}`
       : folder.displayName;
     return [
       {
@@ -262,11 +262,24 @@ function findFolderMatch(folders: FolderReference[], nameOrPath: string) {
   );
 
   if (nameMatches.length > 1) return { ambiguous: true };
-  return { folder: nameMatches[0] };
+  if (nameMatches[0]) return { folder: nameMatches[0] };
+
+  const slashPathMatches = folders.filter(
+    (folder) =>
+      normalizeFolderText(toSlashSeparatedPath(folder.path)) ===
+      normalizedInput,
+  );
+
+  if (slashPathMatches.length > 1) return { ambiguous: true };
+  return { folder: slashPathMatches[0] };
 }
 
 function isFolderPath(nameOrPath: string) {
-  return nameOrPath.includes(" / ");
+  return nameOrPath.includes(FOLDER_SEPARATOR);
+}
+
+function toSlashSeparatedPath(path: string) {
+  return path.split(FOLDER_SEPARATOR).join(" / ");
 }
 
 function normalizeFolderText(value: string) {

--- a/apps/web/utils/ai/assistant/chat-provider-microsoft.ts
+++ b/apps/web/utils/ai/assistant/chat-provider-microsoft.ts
@@ -1,4 +1,9 @@
 import {
+  createOrGetFolderTool,
+  listFoldersTool,
+  moveThreadsToFolderTool,
+} from "./chat-folder-tools";
+import {
   createOrGetCategoryTool,
   listCategoriesTool,
 } from "./chat-label-tools";
@@ -11,7 +16,7 @@ export const microsoftChatProviderConfig: AssistantChatProviderConfig = {
     entity: "category or folder",
     plural: "categories",
     scopePlural: "categories and folders",
-    hiddenIdName: "categoryId",
+    hiddenIdName: "categoryId or folderId",
     ruleCardActionEncoding:
       "boolean actions in archive/draft/markread, the notification provider in notify, and use do for category/folder actions or any action that cannot be represented by those attributes",
   },
@@ -29,5 +34,8 @@ export const microsoftChatProviderConfig: AssistantChatProviderConfig = {
   getTaxonomyTools: (options) => ({
     listCategories: listCategoriesTool(options),
     createOrGetCategory: createOrGetCategoryTool(options),
+    listFolders: listFoldersTool(options),
+    createOrGetFolder: createOrGetFolderTool(options),
+    moveThreadsToFolder: moveThreadsToFolderTool(options),
   }),
 };


### PR DESCRIPTION
Adds Outlook-specific chat tools for listing folders, creating or reusing folders, and moving threads to folders without exposing internal folder IDs. Wires the tools through the Microsoft provider config so shared chat behavior stays provider-agnostic. Adds focused unit and eval coverage for nested folder paths, deduped thread moves, folder reuse, and folder listing.