### PR TITLE
drafts: Prefer booking links for scheduling

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -180,6 +180,181 @@ Solutions Engineer, DataBridge`,
 
     describe("genuine scheduling (may suggest times with calendar data)", () => {
       test(
+        "booking-link-first scheduling request with availability",
+        async () => {
+          const schedulingEmailAccount = {
+            ...emailAccountWithBookingLink,
+            timezone: "Asia/Jerusalem",
+          };
+          const messages = [
+            {
+              ...getEmail({
+                from: "Alex Rivera <alex@example.com>",
+                to: schedulingEmailAccount.email,
+                subject: "Re: Intro",
+                content: `Hi,
+
+Thanks for the details. A quick call could be helpful.
+
+Feel free to send over the easiest way to book.
+
+Best,
+Alex`,
+              }),
+              date: new Date("2026-05-12T08:30:00Z"),
+            },
+          ];
+          const calendarAvailability = {
+            suggestedTimes: [
+              { start: "2026-05-13 10:00", end: "2026-05-13 10:30" },
+              { start: "2026-05-13 14:00", end: "2026-05-13 14:30" },
+              { start: "2026-05-14 16:00", end: "2026-05-14 16:30" },
+            ],
+          };
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount: schedulingEmailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "booking-link-first scheduling request";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Booking Link",
+              bookingLink,
+              "",
+              "## Calendar Availability",
+              JSON.stringify(calendarAvailability, null, 2),
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A concise scheduling reply that shares the user's booking link as the easiest way to book, without listing specific calendar slots or IANA timezone names.",
+            criterion: {
+              name: "Booking link preferred over time slots",
+              description:
+                "When the sender asks for the easiest way to book and the user has a booking link, the draft should share the booking link instead of listing specific calendar slots. It should not include IANA timezone identifiers such as Asia/Jerusalem.",
+            },
+          });
+          const pass =
+            judgeResult.pass &&
+            hasExactUrl(result.reply, bookingLink) &&
+            !mentionsAnySpecificSlot(result.reply, calendarAvailability) &&
+            !result.reply.includes("Asia/Jerusalem");
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "booking link included; no specific slots or IANA timezone",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should prefer the booking link and avoid listing slots.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "explicit time request uses human-friendly timezone wording",
+        async () => {
+          const schedulingEmailAccount = {
+            ...emailAccount,
+            timezone: "Asia/Jerusalem",
+          };
+          const messages = [
+            {
+              ...getEmail({
+                from: "Morgan Lee <morgan@example.com>",
+                to: schedulingEmailAccount.email,
+                subject: "Call next week",
+                content: `Hi,
+
+Could you send over two or three times that work for a 30-minute call next week?
+
+Thanks,
+Morgan`,
+              }),
+              date: new Date("2026-05-12T09:00:00Z"),
+            },
+          ];
+          const calendarAvailability = {
+            timezone: "Asia/Jerusalem",
+            suggestedTimes: [
+              { start: "2026-05-13 10:00", end: "2026-05-13 10:30" },
+              { start: "2026-05-13 14:00", end: "2026-05-13 14:30" },
+            ],
+          };
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount: schedulingEmailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "human-friendly timezone for suggested times";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Calendar Availability",
+              JSON.stringify(calendarAvailability, null, 2),
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A concrete scheduling reply with suggested times. If a timezone is mentioned, it should use a human-friendly abbreviation or label rather than an IANA timezone identifier.",
+            criterion: {
+              name: "Human-friendly timezone wording",
+              description:
+                "When the sender explicitly asks for times and calendar availability is provided, the draft may suggest slots, but it should not write raw IANA timezone identifiers such as Asia/Jerusalem. It should use a normal user-facing timezone abbreviation or label if timezone context is needed.",
+            },
+          });
+          const pass =
+            judgeResult.pass && !result.reply.includes("Asia/Jerusalem");
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "suggested times without IANA timezone wording",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should avoid raw IANA timezone wording.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
         "personal scheduling request with calendar availability",
         async () => {
           const messages = [
@@ -1497,6 +1672,18 @@ function hasExactUrl(text: string, expectedUrl: string): boolean {
   return extractUrls(text).some(
     (url) => normalizeUrlForComparison(url) === normalizedExpected,
   );
+}
+
+function mentionsAnySpecificSlot(
+  text: string,
+  calendarAvailability: { suggestedTimes: { start: string; end: string }[] },
+): boolean {
+  return calendarAvailability.suggestedTimes.some(({ start, end }) => {
+    const startTime = start.slice(11);
+    const endTime = end.slice(11);
+
+    return text.includes(startTime) || text.includes(endTime);
+  });
 }
 
 function formatThreadForJudge(messages: { content: string }[]): string {

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -115,7 +115,9 @@ describe("aiGetCalendarAvailability", () => {
 
     expect(mockGenerateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        system: expect.stringContaining("BOOKING_LINK_AVAILABLE: yes"),
+        system: expect.stringContaining(
+          "The user has a booking link available for scheduling.",
+        ),
       }),
     );
     expect(mockGenerateText).toHaveBeenCalledWith(

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -92,4 +92,38 @@ describe("aiGetCalendarAvailability", () => {
       ],
     });
   });
+
+  it("tells the model to skip manual availability when a booking link can handle scheduling", async () => {
+    await aiGetCalendarAvailability({
+      emailAccount: {
+        ...getEmailAccount(),
+        timezone: "America/Los_Angeles",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Call",
+          content: "What is the easiest way to book a call?",
+          date: new Date("2026-04-30T08:48:00.000Z"),
+        },
+      ],
+      logger: createTestLogger(),
+      bookingLinkAvailable: true,
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining("BOOKING_LINK_AVAILABLE: yes"),
+      }),
+    );
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining(
+          "do not call checkCalendarAvailability or returnSuggestedTimes",
+        ),
+      }),
+    );
+  });
 });

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -85,7 +85,7 @@ export async function aiGetCalendarAvailability({
   const system = `You are an AI assistant that analyzes email threads to determine if they contain meeting or scheduling requests, and returns available meeting time slots.
 
 TIMEZONE: All times (busy periods, suggested times) are in ${userTimezone}.
-BOOKING_LINK_AVAILABLE: ${bookingLinkAvailable ? "yes" : "no"}.
+The user ${bookingLinkAvailable ? "has" : "does not have"} a booking link available for scheduling.
 
 Your task is to:
 1. Analyze if the email is scheduling-related (meeting, call, appointment)
@@ -101,7 +101,7 @@ Example: If busy all day (00:00 to 23:59), return empty array and set noAvailabi
 
 Format: "YYYY-MM-DD HH:MM"
 If email mentions timezone (e.g., "5pm PST"), convert to ${userTimezone}.
-If BOOKING_LINK_AVAILABLE is yes and the sender is only asking for a general way to schedule, do not call checkCalendarAvailability or returnSuggestedTimes; finish without tool calls so the draft can use the booking link instead.
+When the user has a booking link and the sender is only asking for a general way to schedule, do not call checkCalendarAvailability or returnSuggestedTimes; finish without tool calls so the draft can use the booking link instead.
 Only check calendar availability when manual calendar information is actually needed, such as when the sender explicitly asks for specific times, asks whether a proposed date/time works, or the booking link would not answer the scheduling request.
 Call "returnSuggestedTimes" only once.`;
 

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -36,10 +36,12 @@ export async function aiGetCalendarAvailability({
   emailAccount,
   messages,
   logger,
+  bookingLinkAvailable = false,
 }: {
   emailAccount: EmailAccountWithAI;
   messages: EmailForLLM[];
   logger: Logger;
+  bookingLinkAvailable?: boolean;
 }): Promise<CalendarAvailabilityContext | null> {
   if (!messages?.length) {
     logger.warn("No messages provided for calendar availability check");
@@ -83,6 +85,7 @@ export async function aiGetCalendarAvailability({
   const system = `You are an AI assistant that analyzes email threads to determine if they contain meeting or scheduling requests, and returns available meeting time slots.
 
 TIMEZONE: All times (busy periods, suggested times) are in ${userTimezone}.
+BOOKING_LINK_AVAILABLE: ${bookingLinkAvailable ? "yes" : "no"}.
 
 Your task is to:
 1. Analyze if the email is scheduling-related (meeting, call, appointment)
@@ -98,6 +101,8 @@ Example: If busy all day (00:00 to 23:59), return empty array and set noAvailabi
 
 Format: "YYYY-MM-DD HH:MM"
 If email mentions timezone (e.g., "5pm PST"), convert to ${userTimezone}.
+If BOOKING_LINK_AVAILABLE is yes and the sender is only asking for a general way to schedule, do not call checkCalendarAvailability or returnSuggestedTimes; finish without tool calls so the draft can use the booking link instead.
+Only check calendar availability when manual calendar information is actually needed, such as when the sender explicitly asks for specific times, asks whether a proposed date/time works, or the booking link would not answer the scheduling request.
 Call "returnSuggestedTimes" only once.`;
 
   const prompt = `${getUserInfoPrompt({ emailAccount })}

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 12;
+export const DRAFT_PIPELINE_VERSION = 13;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
+++ b/apps/web/utils/ai/reply/draft-reply.formatting.test.ts
@@ -289,6 +289,42 @@ describe("aiDraftReply formatting", () => {
     expect(callArgs.prompt).not.toContain("https://cal.com/user");
   });
 
+  it("formats each available slot with its own timezone label", async () => {
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        reply: "Here are a couple of times.",
+        confidence: DraftReplyConfidence.STANDARD,
+      },
+    });
+
+    const params = getDraftParams();
+
+    await aiDraftReplyWithConfidence({
+      ...params,
+      emailAccount: {
+        ...params.emailAccount,
+        timezone: "America/New_York",
+      },
+      calendarAvailability: {
+        suggestedTimes: [
+          { start: "2026-01-15 10:00", end: "2026-01-15 10:30" },
+          { start: "2026-07-15 10:00", end: "2026-07-15 10:30" },
+        ],
+        timezone: "America/New_York",
+      },
+    });
+
+    const [callArgs] = mockGenerateObject.mock.calls.at(-1)!;
+
+    expect(callArgs.prompt).toContain(
+      "2026-01-15 10:00 to 2026-01-15 10:30 (EST;",
+    );
+    expect(callArgs.prompt).toContain(
+      "2026-07-15 10:00 to 2026-07-15 10:30 (EDT;",
+    );
+    expect(callArgs.prompt).toContain("Available time slots are in EST/EDT");
+  });
+
   it("uses learned writing style as the primary style block when explicit style is absent", async () => {
     mockGenerateObject.mockResolvedValueOnce({
       object: {

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -505,10 +505,6 @@ function getSchedulingContext({
 }): string {
   const parts: string[] = [];
   const timezone = userTimezone || "UTC";
-  const timezoneLabel = getTimezoneLabel(
-    timezone,
-    calendarAvailability?.suggestedTimes[0]?.start,
-  );
 
   if (calendarBookingLink) {
     parts.push(`<booking_link>
@@ -519,18 +515,28 @@ When scheduling with the user is clearly needed, prefer sharing this booking lin
   }
 
   if (calendarAvailability?.noAvailability) {
+    const timezoneLabel = getTimezoneLabel(timezone);
+
     parts.push(`The user has no available time slots in the requested timeframe in ${timezoneLabel}.
 Do not suggest specific times. Acknowledge the request and suggest alternatives (e.g., "I'm fully booked tomorrow, but let's find another day that works"${calendarBookingLink ? " or share the booking link" : ""}).`);
   } else if (calendarAvailability?.suggestedTimes.length) {
     const times = calendarAvailability.suggestedTimes
       .map((slot) =>
-        formatAvailableSlotForPrompt(slot, timezone, timezoneLabel),
+        formatAvailableSlotForPrompt(
+          slot,
+          timezone,
+          getTimezoneLabel(timezone, slot.start),
+        ),
       )
       .join("\n");
+    const timezoneLabels = getTimezoneLabelsForSlots(
+      timezone,
+      calendarAvailability.suggestedTimes,
+    );
 
-    parts.push(`Available time slots are in ${timezoneLabel}.
+    parts.push(`Available time slots are in ${timezoneLabels}.
 If the sender requested or uses another timezone, express proposed times in that timezone after converting from the user's available slots.
-If you list specific times, include the user-facing timezone label (${timezoneLabel}) and do not write raw timezone identifiers such as ${timezone}.
+If you list specific times, include the user-facing timezone label shown for each slot and do not write raw timezone identifiers such as ${timezone}.
 
 Available time slots:
 ${times}
@@ -610,6 +616,17 @@ function getTimezoneLabel(timezone: string, localTime?: string): string {
     getIntlTimezoneName(timezone, date, "shortOffset");
 
   return label && label !== timezone ? label : timezone;
+}
+
+function getTimezoneLabelsForSlots(
+  timezone: string,
+  slots: { start: string }[],
+): string {
+  const labels = [
+    ...new Set(slots.map((slot) => getTimezoneLabel(timezone, slot.start))),
+  ];
+
+  return labels.join("/");
 }
 
 function createDateFromLocalTime(localTime: string, timezone: string): Date {

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -505,30 +505,37 @@ function getSchedulingContext({
 }): string {
   const parts: string[] = [];
   const timezone = userTimezone || "UTC";
+  const timezoneLabel = getTimezoneLabel(
+    timezone,
+    calendarAvailability?.suggestedTimes[0]?.start,
+  );
 
   if (calendarBookingLink) {
     parts.push(`<booking_link>
 ${calendarBookingLink}
 </booking_link>
 
-Share this booking link when scheduling with the user is clearly needed, not as a default call-to-action.`);
+When scheduling with the user is clearly needed, prefer sharing this booking link over listing specific availability. Do not use it as a default call-to-action for non-scheduling emails.`);
   }
 
   if (calendarAvailability?.noAvailability) {
-    parts.push(`The user has no available time slots in the requested timeframe in ${timezone}.
+    parts.push(`The user has no available time slots in the requested timeframe in ${timezoneLabel}.
 Do not suggest specific times. Acknowledge the request and suggest alternatives (e.g., "I'm fully booked tomorrow, but let's find another day that works"${calendarBookingLink ? " or share the booking link" : ""}).`);
   } else if (calendarAvailability?.suggestedTimes.length) {
     const times = calendarAvailability.suggestedTimes
-      .map((slot) => formatAvailableSlotForPrompt(slot, timezone))
+      .map((slot) =>
+        formatAvailableSlotForPrompt(slot, timezone, timezoneLabel),
+      )
       .join("\n");
 
-    parts.push(`Available time slots are in ${timezone}.
+    parts.push(`Available time slots are in ${timezoneLabel}.
 If the sender requested or uses another timezone, express proposed times in that timezone after converting from the user's available slots.
+If you list specific times, include the user-facing timezone label (${timezoneLabel}) and do not write raw timezone identifiers such as ${timezone}.
 
 Available time slots:
 ${times}
 
-${calendarBookingLink ? "If scheduling with the user is clearly needed, you may share the booking link and optionally suggest a few of these times as alternatives." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Format suggested times as a bulleted list.`);
+${calendarBookingLink ? "Because the user has a booking link, share the booking link instead of listing specific times unless the sender explicitly asks the user to provide times, asks about a specific proposed time/date, or the booking link would not answer the scheduling request." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Format suggested times as a bulleted list.`);
   }
 
   if (parts.length === 0) return "";
@@ -554,6 +561,7 @@ function getCalendarBookingLinkForDraft(emailAccount: DraftEmailAccount) {
 function formatAvailableSlotForPrompt(
   slot: { start: string; end: string },
   timezone: string,
+  timezoneLabel: string,
 ): string {
   const utcStart = formatLocalSlotTimeAsUtc(slot.start, timezone);
   const utcEnd = formatLocalSlotTimeAsUtc(slot.end, timezone);
@@ -562,7 +570,7 @@ function formatAvailableSlotForPrompt(
     return `- ${slot.start} to ${slot.end}`;
   }
 
-  return `- ${slot.start} to ${slot.end} (${timezone}; UTC ${utcStart} to ${utcEnd})`;
+  return `- ${slot.start} to ${slot.end} (${timezoneLabel}; UTC ${utcStart} to ${utcEnd})`;
 }
 
 function formatLocalSlotTimeAsUtc(
@@ -589,6 +597,57 @@ function formatLocalSlotTimeAsUtc(
   if (Number.isNaN(utcDate.getTime())) return null;
 
   return utcDate.toISOString().slice(0, 16).replace("T", " ");
+}
+
+function getTimezoneLabel(timezone: string, localTime?: string): string {
+  if (timezone === "UTC") return "UTC";
+
+  const date = localTime
+    ? createDateFromLocalTime(localTime, timezone)
+    : new Date();
+  const label =
+    getIntlTimezoneName(timezone, date, "short") ||
+    getIntlTimezoneName(timezone, date, "shortOffset");
+
+  return label && label !== timezone ? label : timezone;
+}
+
+function createDateFromLocalTime(localTime: string, timezone: string): Date {
+  const match = localTime.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/);
+
+  if (!match) return new Date();
+
+  const [, year, month, day, hour, minute] = match;
+
+  return new TZDate(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    0,
+    0,
+    timezone,
+  );
+}
+
+function getIntlTimezoneName(
+  timezone: string,
+  date: Date,
+  timeZoneName: "short" | "shortOffset",
+): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName,
+    }).formatToParts(date);
+
+    return (
+      parts.find((part) => part.type === "timeZoneName")?.value.trim() || null
+    );
+  } catch {
+    return null;
+  }
 }
 
 const OLLAMA_DRAFT_RESPONSE_GUIDANCE = [

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -94,6 +94,7 @@ vi.mock("@/env", () => ({
 }));
 
 import { aiDraftReplyWithConfidence } from "@/utils/ai/reply/draft-reply";
+import { aiGetCalendarAvailability } from "@/utils/ai/calendar/availability";
 import { getReplyMemoriesForPrompt } from "@/utils/ai/reply/reply-memory";
 import { selectDraftAttachmentsForRule } from "@/utils/attachments/draft-attachments";
 import { aiExtractFromEmailHistory } from "@/utils/ai/knowledge/extract-from-email-history";
@@ -613,6 +614,39 @@ describe("fetchMessagesAndGenerateDraft - thread ordering", () => {
         senderHistory: expect.objectContaining({
           sameSenderReplyExamplesInjected: true,
           sameSenderReplyExampleCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it("passes booking link availability into calendar availability analysis", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "Draft reply",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+      attribution: null,
+    });
+    vi.mocked(prisma.bookingLink.findMany).mockResolvedValue([
+      { slug: "user-booking-link" },
+    ] as any);
+
+    await fetchMessagesAndGenerateDraftWithConfidenceThreshold(
+      createMockEmailAccount(),
+      "thread-1",
+      createMockClient(),
+      createMockMessage(),
+      logger,
+      DraftReplyConfidence.ALL_EMAILS,
+    );
+
+    expect(aiGetCalendarAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingLinkAvailable: true,
+      }),
+    );
+    expect(aiDraftReplyWithConfidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccount: expect.objectContaining({
+          bookingLinks: [{ slug: "user-booking-link" }],
         }),
       }),
     );

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -272,6 +272,14 @@ async function generateDraftContent(
         selectedAttachments: [],
         attachmentContext: null,
       });
+  const activeBookingLinks = await prisma.bookingLink.findMany({
+    where: { emailAccountId: emailAccount.id, isActive: true },
+    orderBy: { createdAt: "desc" },
+    take: 1,
+    select: { slug: true },
+  });
+  const bookingLinkAvailable =
+    activeBookingLinks.length > 0 || !!emailAccount.calendarBookingLink;
   const [
     knowledgeResult,
     replyMemorySelection,
@@ -283,7 +291,6 @@ async function generateDraftContent(
     upcomingMeetings,
     emailHistorySummary,
     attachmentSelection,
-    activeBookingLinks,
     senderReplyExamples,
   ] = await Promise.all([
     aiExtractRelevantKnowledge({
@@ -303,7 +310,12 @@ async function generateDraftContent(
       emailAccount,
       emailProvider,
     }),
-    aiGetCalendarAvailability({ emailAccount, messages, logger }),
+    aiGetCalendarAvailability({
+      emailAccount,
+      messages,
+      logger,
+      bookingLinkAvailable,
+    }),
     getWritingStyle({ emailAccountId: emailAccount.id }),
     prisma.emailAccount.findUnique({
       where: { id: emailAccount.id },
@@ -332,12 +344,6 @@ async function generateDraftContent(
         })
       : Promise.resolve(null),
     attachmentSelectionPromise,
-    prisma.bookingLink.findMany({
-      where: { emailAccountId: emailAccount.id, isActive: true },
-      orderBy: { createdAt: "desc" },
-      take: 1,
-      select: { slug: true },
-    }),
     collectSenderReplyExamples({
       emailAccount,
       emailProvider,

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -272,14 +272,22 @@ async function generateDraftContent(
         selectedAttachments: [],
         attachmentContext: null,
       });
-  const activeBookingLinks = await prisma.bookingLink.findMany({
+  const activeBookingLinksPromise = prisma.bookingLink.findMany({
     where: { emailAccountId: emailAccount.id, isActive: true },
     orderBy: { createdAt: "desc" },
     take: 1,
     select: { slug: true },
   });
-  const bookingLinkAvailable =
-    activeBookingLinks.length > 0 || !!emailAccount.calendarBookingLink;
+  const calendarAvailabilityPromise = activeBookingLinksPromise.then(
+    (activeBookingLinks) =>
+      aiGetCalendarAvailability({
+        emailAccount,
+        messages,
+        logger,
+        bookingLinkAvailable:
+          activeBookingLinks.length > 0 || !!emailAccount.calendarBookingLink,
+      }),
+  );
   const [
     knowledgeResult,
     replyMemorySelection,
@@ -291,6 +299,7 @@ async function generateDraftContent(
     upcomingMeetings,
     emailHistorySummary,
     attachmentSelection,
+    activeBookingLinks,
     senderReplyExamples,
   ] = await Promise.all([
     aiExtractRelevantKnowledge({
@@ -310,12 +319,7 @@ async function generateDraftContent(
       emailAccount,
       emailProvider,
     }),
-    aiGetCalendarAvailability({
-      emailAccount,
-      messages,
-      logger,
-      bookingLinkAvailable,
-    }),
+    calendarAvailabilityPromise,
     getWritingStyle({ emailAccountId: emailAccount.id }),
     prisma.emailAccount.findUnique({
       where: { id: emailAccount.id },
@@ -344,6 +348,7 @@ async function generateDraftContent(
         })
       : Promise.resolve(null),
     attachmentSelectionPromise,
+    activeBookingLinksPromise,
     collectSenderReplyExamples({
       emailAccount,
       emailProvider,


### PR DESCRIPTION
Updates draft scheduling context to prefer booking links when they can resolve scheduling, while preserving manual availability for explicit time requests.

- Passes booking-link availability into calendar availability analysis so unnecessary availability lookup can be skipped.
- Uses user-facing timezone labels when suggesting times.
- Adds focused unit and eval coverage for booking-link-first scheduling behavior.