### PR TITLE
fix(outlook): strip Gmail-style prefixes in searchMessages and participant queries

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as outlookMessageModule from "@/utils/outlook/message";
 import * as outlookLabelModule from "@/utils/outlook/label";
 import { createTestLogger } from "@/__tests__/helpers";
-import { OutlookProvider } from "./microsoft";
+import { OutlookProvider, stripGmailPrefixes } from "./microsoft";
 
 const { envMock, outlookMailMock, getFolderIdsMock } = vi.hoisted(() => ({
   envMock: {
@@ -788,3 +788,32 @@ function createMessage(input: {
     hasAttachments: false,
   };
 }
+
+
+describe("stripGmailPrefixes", () => {
+  it("strips quoted from: prefix to avoid Outlook `Syntax error: character ':' is not valid`", () => {
+    expect(stripGmailPrefixes('from:"John Doe"')).toBe("John Doe");
+  });
+
+  it("strips unquoted single-word prefixes", () => {
+    expect(stripGmailPrefixes("subject:invoice")).toBe("invoice");
+  });
+
+  it("strips participants: prefix used by the chat assistant on Outlook accounts", () => {
+    expect(stripGmailPrefixes("participants:foo@bar.com")).toBe("foo@bar.com");
+  });
+
+  it("strips multiple prefixes in the same query and collapses whitespace", () => {
+    expect(
+      stripGmailPrefixes('from:"John Doe" subject:invoice label:work'),
+    ).toBe("John Doe invoice work");
+  });
+
+  it("leaves text without prefixes unchanged", () => {
+    expect(stripGmailPrefixes("hello world")).toBe("hello world");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripGmailPrefixes("")).toBe("");
+  });
+});

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -81,6 +81,30 @@ import { withOutlookRetry } from "@/utils/outlook/retry";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
 
+/**
+ * Strip Gmail-style query prefixes (e.g. `from:"John Doe"`, `subject:foo`,
+ * `participants:bar@baz.com`) so the remaining text can be passed to
+ * Microsoft Graph `$search`, which does not support field-specific syntax
+ * and rejects raw colons with `Syntax error: character ':' is not valid`.
+ *
+ * This is intentionally lossy: the resulting query searches subject + body
+ * rather than the specific field. Callers that need exact field filtering
+ * should use `$filter` paths that don't combine with `$search`.
+ */
+export function stripGmailPrefixes(query: string): string {
+  return query
+    .replace(
+      /\b(subject|from|to|label|participants):(?:"[^"]*"|\S+)/gi,
+      (match) => {
+        const colonIndex = match.indexOf(":");
+        const value = match.slice(colonIndex + 1);
+        return value.replace(/^"|"$/g, "");
+      },
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export class OutlookProvider implements EmailProvider {
   readonly name = "microsoft";
   private readonly client: OutlookClient;
@@ -1049,29 +1073,6 @@ export class OutlookProvider implements EmailProvider {
       query: options.query,
     });
 
-    // IMPORTANT: This is intentionally lossy!
-    // Gmail-style prefixes like "subject:" can't be translated to Microsoft Graph because:
-    // 1. $filter with contains(subject, ...) can't be combined with $search or date filters
-    //    (causes "InefficientFilter" error)
-    // 2. $search doesn't support field-specific syntax like "subject:term"
-    //
-    // We strip the prefixes and use plain $search which searches subject AND body.
-    // This is broader than intended but still finds relevant messages.
-    // If subject-specific search is needed in the future, add a dedicated method
-    // that uses only $filter without $search or date filters.
-    function stripGmailPrefixes(query: string): string {
-      return query
-        .replace(/\b(subject|from|to|label):(?:"[^"]*"|\S+)/gi, (match) => {
-          // Extract the value without the prefix for searching
-          const colonIndex = match.indexOf(":");
-          const value = match.slice(colonIndex + 1);
-          // Remove quotes if present
-          return value.replace(/^"|"$/g, "");
-        })
-        .replace(/\s+/g, " ")
-        .trim();
-    }
-
     const searchQuery = stripGmailPrefixes(options.query || "");
 
     let inboxFolderId: string | undefined;
@@ -1135,10 +1136,15 @@ export class OutlookProvider implements EmailProvider {
     readState?: "read" | "unread";
     labelName?: string;
   }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
+    // Strip Gmail-style prefixes (e.g. `from:"Foo"`) that Microsoft Graph $search
+    // rejects with `Syntax error: character ':' is not valid`. See microsoft.ts
+    // module-level `stripGmailPrefixes` for details.
+    const searchQuery = stripGmailPrefixes(options.query || "");
+
     const response = await queryBatchMessages(
       this.client,
       {
-        searchQuery: options.query,
+        searchQuery,
         maxResults: options.maxResults || 20,
         pageToken: options.pageToken,
         readState: options.readState,
@@ -1213,8 +1219,13 @@ export class OutlookProvider implements EmailProvider {
     // (e.g. `toRecipients/any(...)`) and will error with:
     // "The query filter contains one or more invalid nodes."
     //
+    // Microsoft Graph $search does not support KQL field-specific syntax like
+    // `participants:foo@bar.com` (it errors with `Syntax error: character ':'
+    // is not valid`). We pass the bare sanitized email as a plain $search term
+    // and rely on `filterMessagesForParticipant` below to narrow down to
+    // messages where the address is actually a participant.
     const sanitizedEmail = sanitizeKqlValue(participantEmail);
-    const searchQuery = `participants:${sanitizedEmail}`;
+    const searchQuery = sanitizedEmail;
 
     const { messages, nextPageToken } = await queryBatchMessages(
       this.client,


### PR DESCRIPTION
## Summary

Microsoft Graph `$search` does not support KQL field-specific syntax (`from:`, `subject:`, `participants:`, etc.) and rejects raw colons with:

```
Syntax error: character ':' is not valid at position N in 'from:"John Doe"'.
```

This breaks the AI chat assistant for Outlook accounts (issue #2195) and meeting-brief participant search, because both paths hand an LLM-generated Gmail-style query straight to Outlook. `getMessagesWithPagination` already had a local `stripGmailPrefixes` helper for this, but it wasn't reused by the other call sites.

## Changes

- **Hoist `stripGmailPrefixes`** from inside `getMessagesWithPagination` to module scope, export it, and add `participants:` to the recognised prefix set (in addition to the existing `subject|from|to|label`).
- **`searchMessages`** now strips Gmail-style prefixes before calling `queryBatchMessages` — fixes the chat assistant `BadRequest` on Outlook reported in #2195.
- **`getThreadsWithParticipant`** no longer constructs `participants:${email}` for `$search`; it passes the bare sanitized email instead. Results are still narrowed to exact-participant matches by the existing `filterMessagesForParticipant` post-filter, so the runtime semantics are preserved. This fixes the meeting-brief failure shown in #2195's follow-up logs (`Syntax error: character ':' is not valid at position 12 in 'participants:johndoe@example.com'`).
- **Tests** for `stripGmailPrefixes` covering quoted/unquoted prefixes, the `participants:` case, mixed prefixes with whitespace collapse, no-op input, and empty input.

## How this matches the issue's suggested fix

The reporter pointed at the existing `stripGmailPrefixes` and noted *"this function is only called in `getMessagesWithPagination`, not in `searchMessages` which also takes a `query` parameter"*. This PR closes that gap and extends the same treatment to the participants code path that the follow-up comment surfaced.

## Notes / trade-offs

- The fix keeps the existing **intentionally lossy** behaviour documented in the original helper: stripped queries search subject + body rather than the specific field. If subject-only search is needed in the future, a separate `$filter`-only method (without `$search` or date filters) would be required, as the original comment notes.
- No new dependencies, no schema changes, no env-var changes.

Closes #2195
