### PR TITLE
feat(login): add NEXT_PUBLIC_LOGIN_PROVIDERS env var to control visible login options

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -58,6 +58,7 @@ NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
 # AUTO_JOIN_ORGANIZATION_ENABLED=true # Self-hosted: auto-add new users to the org
 # SSO_LOGIN_ENABLED=true # Show the SSO button on the login screen
 # NEXT_PUBLIC_SHOW_APPLE_LOGIN=false # Show Apple login on the standard web login screen
+# NEXT_PUBLIC_LOGIN_PROVIDERS=google,microsoft,sso # Comma-separated list of login providers to show on the login screen. Unset = show all. Valid tokens: google, microsoft, apple, sso. Note: each provider must also be otherwise configured (e.g. Microsoft OAuth credentials, SSO_LOGIN_ENABLED, NEXT_PUBLIC_SHOW_APPLE_LOGIN) — this var can only narrow the visible buttons.
 # NEXT_PUBLIC_EXTERNAL_API_ENABLED=true # Enable the external API (v1 endpoints, API keys, API key UI)
 # NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED=false # Self-hosted: disable outgoing webhook rule actions and webhook secret UI
 # AUTO_ENABLE_ORG_ANALYTICS=true # Self-hosted: default new org members to analytics enabled

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -58,7 +58,7 @@ NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
 # AUTO_JOIN_ORGANIZATION_ENABLED=true # Self-hosted: auto-add new users to the org
 # SSO_LOGIN_ENABLED=true # Show the SSO button on the login screen
 # NEXT_PUBLIC_SHOW_APPLE_LOGIN=false # Show Apple login on the standard web login screen
-# NEXT_PUBLIC_LOGIN_PROVIDERS=google,microsoft,sso # Comma-separated list of login providers to show on the login screen. Unset = show all. Valid tokens: google, microsoft, apple, sso. Note: each provider must also be otherwise configured (e.g. Microsoft OAuth credentials, SSO_LOGIN_ENABLED, NEXT_PUBLIC_SHOW_APPLE_LOGIN) — this var can only narrow the visible buttons.
+# NEXT_PUBLIC_LOGIN_PROVIDERS=google,microsoft,sso # Comma-separated allowlist of login providers (UI buttons AND backend OAuth endpoints). Unset = allow all configured. Valid tokens: google, microsoft, apple, sso. Each provider must also be otherwise configured (Microsoft OAuth credentials, SSO_LOGIN_ENABLED, NEXT_PUBLIC_SHOW_APPLE_LOGIN); this var can only narrow what is enabled, never widen. Excluded providers return 404 from /api/auth/sign-in/social, preventing direct-API bypass.
 # NEXT_PUBLIC_EXTERNAL_API_ENABLED=true # Enable the external API (v1 endpoints, API keys, API key UI)
 # NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED=false # Self-hosted: disable outgoing webhook rule actions and webhook secret UI
 # AUTO_ENABLE_ORG_ANALYTICS=true # Self-hosted: default new org members to analytics enabled

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -19,11 +19,13 @@ const CONNECT_MAILBOX_PATH = "/connect-mailbox";
 export function LoginForm({
   showAppleLogin,
   useGoogleOauthEmulator,
+  showGoogleLogin = true,
   showMicrosoftLogin,
   showSsoLogin,
 }: {
   showAppleLogin?: boolean;
   useGoogleOauthEmulator: boolean;
+  showGoogleLogin?: boolean;
   showMicrosoftLogin?: boolean;
   showSsoLogin?: boolean;
 }) {
@@ -101,18 +103,20 @@ export function LoginForm({
         </Button>
       ) : null}
 
-      <Button size="2xl" loading={loadingGoogle} onClick={handleGoogleSignIn}>
-        <span className="flex items-center justify-center">
-          <Image
-            src="/images/google.svg"
-            alt="Google"
-            width={24}
-            height={24}
-            unoptimized
-          />
-          <span className="ml-2">Sign in with Google</span>
-        </span>
-      </Button>
+      {showGoogleLogin ? (
+        <Button size="2xl" loading={loadingGoogle} onClick={handleGoogleSignIn}>
+          <span className="flex items-center justify-center">
+            <Image
+              src="/images/google.svg"
+              alt="Google"
+              width={24}
+              height={24}
+              unoptimized
+            />
+            <span className="ml-2">Sign in with Google</span>
+          </span>
+        </Button>
+      ) : null}
 
       {showMicrosoftLogin ? (
         <Button

--- a/apps/web/app/(landing)/login/login-providers.test.ts
+++ b/apps/web/app/(landing)/login/login-providers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getEnabledLoginProviders } from "./login-providers";
+
+describe("getEnabledLoginProviders", () => {
+  it("returns all providers when env var is undefined", () => {
+    const result = getEnabledLoginProviders(undefined);
+    expect(result.has("google")).toBe(true);
+    expect(result.has("microsoft")).toBe(true);
+    expect(result.has("apple")).toBe(true);
+    expect(result.has("sso")).toBe(true);
+  });
+
+  it("returns all providers when env var is empty string", () => {
+    const result = getEnabledLoginProviders("");
+    expect(result.size).toBe(4);
+  });
+
+  it("returns all providers when env var is whitespace only", () => {
+    const result = getEnabledLoginProviders("   ");
+    expect(result.size).toBe(4);
+  });
+
+  it("narrows to a single provider", () => {
+    const result = getEnabledLoginProviders("sso");
+    expect(result.has("sso")).toBe(true);
+    expect(result.has("google")).toBe(false);
+    expect(result.has("microsoft")).toBe(false);
+    expect(result.has("apple")).toBe(false);
+  });
+
+  it("parses comma-separated values and trims whitespace", () => {
+    const result = getEnabledLoginProviders("google, microsoft");
+    expect(result.has("google")).toBe(true);
+    expect(result.has("microsoft")).toBe(true);
+    expect(result.has("sso")).toBe(false);
+    expect(result.has("apple")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    const result = getEnabledLoginProviders("GOOGLE,Microsoft,SsO");
+    expect(result.has("google")).toBe(true);
+    expect(result.has("microsoft")).toBe(true);
+    expect(result.has("sso")).toBe(true);
+  });
+
+  it("ignores unknown tokens", () => {
+    const result = getEnabledLoginProviders("google,nonsense,facebook");
+    expect(result.has("google")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  it("falls back to all providers when all tokens are unknown (avoids lockout)", () => {
+    const result = getEnabledLoginProviders("facebook,twitter");
+    expect(result.size).toBe(4);
+  });
+});

--- a/apps/web/app/(landing)/login/login-providers.ts
+++ b/apps/web/app/(landing)/login/login-providers.ts
@@ -1,0 +1,50 @@
+import { env } from "@/env";
+
+export type LoginProvider = "google" | "microsoft" | "apple" | "sso";
+
+const ALL_LOGIN_PROVIDERS: ReadonlySet<LoginProvider> = new Set([
+  "google",
+  "microsoft",
+  "apple",
+  "sso",
+]);
+
+/**
+ * Parse `NEXT_PUBLIC_LOGIN_PROVIDERS` into the set of providers that should
+ * appear on the login screen. When the env var is unset or empty, all providers
+ * are considered enabled (backwards compatible). Unknown tokens are ignored.
+ *
+ * The returned set is intersected with the providers that are otherwise
+ * configured (e.g. Microsoft OAuth credentials present, SSO_LOGIN_ENABLED set),
+ * so the env var can only narrow the visible buttons, never widen them.
+ */
+export function getEnabledLoginProviders(
+  raw: string | undefined = env.NEXT_PUBLIC_LOGIN_PROVIDERS,
+): ReadonlySet<LoginProvider> {
+  if (!raw?.trim()) return ALL_LOGIN_PROVIDERS;
+
+  const requested = new Set<LoginProvider>();
+  for (const token of raw.split(",")) {
+    const normalized = token.trim().toLowerCase();
+    if (
+      normalized === "google" ||
+      normalized === "microsoft" ||
+      normalized === "apple" ||
+      normalized === "sso"
+    ) {
+      requested.add(normalized);
+    }
+  }
+
+  // Empty list after filtering -> treat as unset to avoid locking everyone out.
+  if (requested.size === 0) return ALL_LOGIN_PROVIDERS;
+
+  return requested;
+}
+
+export function isLoginProviderEnabled(
+  provider: LoginProvider,
+  raw?: string,
+): boolean {
+  return getEnabledLoginProviders(raw).has(provider);
+}

--- a/apps/web/app/(landing)/login/page.tsx
+++ b/apps/web/app/(landing)/login/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { LoginForm } from "@/app/(landing)/login/LoginForm";
+import { getEnabledLoginProviders } from "@/app/(landing)/login/login-providers";
 import { getRequiresReconsentDescription } from "@/app/(landing)/login/messages";
 import { env } from "@/env";
 import { auth } from "@/utils/auth";
@@ -39,6 +40,8 @@ export default async function AuthenticationPage(props: {
     redirect(nextPath ?? WELCOME_PATH);
   }
 
+  const enabledProviders = getEnabledLoginProviders();
+
   return (
     <div className="flex h-screen flex-col justify-center text-foreground">
       <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
@@ -51,10 +54,16 @@ export default async function AuthenticationPage(props: {
         <div className="mt-4">
           <Suspense>
             <LoginForm
-              showAppleLogin={env.NEXT_PUBLIC_SHOW_APPLE_LOGIN}
+              showGoogleLogin={enabledProviders.has("google")}
+              showAppleLogin={
+                env.NEXT_PUBLIC_SHOW_APPLE_LOGIN &&
+                enabledProviders.has("apple")
+              }
               useGoogleOauthEmulator={isGoogleOauthEmulationEnabled()}
-              showMicrosoftLogin={hasMicrosoftOauthConfig()}
-              showSsoLogin={env.SSO_LOGIN_ENABLED}
+              showMicrosoftLogin={
+                hasMicrosoftOauthConfig() && enabledProviders.has("microsoft")
+              }
+              showSsoLogin={env.SSO_LOGIN_ENABLED && enabledProviders.has("sso")}
             />
           </Suspense>
         </div>

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -322,6 +322,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_EMAIL_SEND_ENABLED: booleanString.default(true),
     NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED: booleanString.optional().default(true),
     NEXT_PUBLIC_SHOW_APPLE_LOGIN: booleanString.optional().default(false),
+    NEXT_PUBLIC_LOGIN_PROVIDERS: z.string().optional(),
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     NEXT_PUBLIC_SUPPORT_EMAIL: z
       .string()
@@ -425,6 +426,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED:
       process.env.NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED,
     NEXT_PUBLIC_SHOW_APPLE_LOGIN: process.env.NEXT_PUBLIC_SHOW_APPLE_LOGIN,
+    NEXT_PUBLIC_LOGIN_PROVIDERS: process.env.NEXT_PUBLIC_LOGIN_PROVIDERS,
     NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS:
       process.env.NEXT_PUBLIC_FREE_UNSUBSCRIBE_CREDITS,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -308,3 +308,51 @@ describe("handleLinkAccount", () => {
     expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
   });
 });
+
+describe("betterAuthConfig — NEXT_PUBLIC_LOGIN_PROVIDERS gating", () => {
+  // Mirrors cubic-dev-ai's request on #2634: verify that excluded providers
+  // never reach the better-auth backend config, not just the UI.
+  // We mock @/app/(landing)/login/login-providers to control the allowlist
+  // and then dynamically re-import @/utils/auth so its top-level reads of
+  // getEnabledLoginProviders() see the mocked value.
+  async function importAuthWith(
+    enabled: ReadonlyArray<"google" | "microsoft" | "apple" | "sso">,
+  ): Promise<any> {
+    vi.resetModules();
+    vi.doMock("@/app/(landing)/login/login-providers", () => ({
+      getEnabledLoginProviders: () => new Set(enabled),
+      isLoginProviderEnabled: (p: string) =>
+        (enabled as readonly string[]).includes(p),
+    }));
+    const mod = await import("@/utils/auth");
+    return (mod.betterAuthConfig as any).options;
+  }
+
+  it("excludes google from socialProviders when 'google' is not in allowlist", async () => {
+    const options = await importAuthWith(["microsoft", "apple", "sso"]);
+    expect(options.socialProviders.google).toBeUndefined();
+  });
+
+  it("excludes microsoft from socialProviders when 'microsoft' is not in allowlist", async () => {
+    const options = await importAuthWith(["google", "apple", "sso"]);
+    expect(options.socialProviders.microsoft).toBeUndefined();
+  });
+
+  it("excludes apple from socialProviders when 'apple' is not in allowlist", async () => {
+    const options = await importAuthWith(["google", "microsoft", "sso"]);
+    expect(options.socialProviders.apple).toBeUndefined();
+  });
+
+  it("registers fewer plugins when 'sso' is not in allowlist", async () => {
+    const withSso = await importAuthWith(["google", "microsoft", "apple", "sso"]);
+    const withoutSso = await importAuthWith(["google", "microsoft", "apple"]);
+    expect(withoutSso.plugins.length).toBe(withSso.plugins.length - 1);
+  });
+
+  it("excludes all social providers when allowlist is sso-only", async () => {
+    const options = await importAuthWith(["sso"]);
+    expect(options.socialProviders.google).toBeUndefined();
+    expect(options.socialProviders.microsoft).toBeUndefined();
+    expect(options.socialProviders.apple).toBeUndefined();
+  });
+});

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -49,6 +49,7 @@ import {
 } from "@/utils/oauth/provider-config";
 import { getAppleClientSecret } from "@/utils/auth/apple-client-secret";
 import { assertCanGenerateScimToken } from "@/utils/auth/scim";
+import { getEnabledLoginProviders } from "@/app/(landing)/login/login-providers";
 import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("auth");
@@ -56,6 +57,18 @@ const useGoogleOauthEmulator = isGoogleOauthEmulationEnabled();
 const useMicrosoftOauthEmulator = isMicrosoftEmulationEnabled();
 const hasMicrosoftConfig = hasMicrosoftOauthConfig();
 const hasAppleConfig = hasAppleOauthConfig();
+
+// Server-side enforcement of NEXT_PUBLIC_LOGIN_PROVIDERS. The same env var is
+// read in the React UI to hide buttons, but that's only cosmetic. Better-auth
+// would otherwise accept direct POSTs to /api/auth/sign-in/social for any
+// provider whose credentials are configured, defeating SSO-only lockdown. By
+// also gating provider registration here, excluded providers return 404 at the
+// protocol level. See PR discussion on inbox-zero#2634.
+const enabledLoginProviders = getEnabledLoginProviders();
+const isGoogleLoginEnabled = enabledLoginProviders.has("google");
+const isMicrosoftLoginEnabled = enabledLoginProviders.has("microsoft");
+const isAppleLoginEnabled = enabledLoginProviders.has("apple");
+const isSsoLoginEnabled = enabledLoginProviders.has("sso");
 
 type AppleProfile = {
   email?: string;
@@ -65,7 +78,7 @@ type AppleProfile = {
 const mobileAuthOrigins = env.MOBILE_AUTH_ORIGIN
   ? [env.MOBILE_AUTH_ORIGIN]
   : [];
-const googleSocialProvider = !useGoogleOauthEmulator
+const googleSocialProvider = !useGoogleOauthEmulator && isGoogleLoginEnabled
   ? {
       clientId: env.GOOGLE_CLIENT_ID,
       clientSecret: env.GOOGLE_CLIENT_SECRET,
@@ -80,7 +93,7 @@ const googleSocialProvider = !useGoogleOauthEmulator
     }
   : null;
 const microsoftSocialProvider =
-  hasMicrosoftConfig && !useMicrosoftOauthEmulator
+  hasMicrosoftConfig && !useMicrosoftOauthEmulator && isMicrosoftLoginEnabled
     ? {
         clientId: env.MICROSOFT_CLIENT_ID!,
         clientSecret: env.MICROSOFT_CLIENT_SECRET!,
@@ -92,7 +105,7 @@ const microsoftSocialProvider =
         }),
       }
     : null;
-const appleSocialProvider = hasAppleConfig
+const appleSocialProvider = hasAppleConfig && isAppleLoginEnabled
   ? {
       clientId: env.APPLE_CLIENT_ID!,
       get clientSecret() {
@@ -130,7 +143,7 @@ const appleSocialProvider = hasAppleConfig
     }
   : null;
 const genericOauthConfig: GenericOAuthConfig[] = [
-  ...(useGoogleOauthEmulator
+  ...(useGoogleOauthEmulator && isGoogleLoginEnabled
     ? [
         {
           providerId: "google",
@@ -148,7 +161,7 @@ const genericOauthConfig: GenericOAuthConfig[] = [
         },
       ]
     : []),
-  ...(hasMicrosoftConfig && useMicrosoftOauthEmulator
+  ...(hasMicrosoftConfig && useMicrosoftOauthEmulator && isMicrosoftLoginEnabled
     ? [
         {
           providerId: "microsoft",
@@ -214,10 +227,14 @@ export const betterAuthConfig = betterAuth({
     provider: "postgresql",
   }),
   plugins: [
-    sso({
-      disableImplicitSignUp: false,
-      organizationProvisioning: { disabled: true },
-    }),
+    ...(isSsoLoginEnabled
+      ? [
+          sso({
+            disableImplicitSignUp: false,
+            organizationProvisioning: { disabled: true },
+          }),
+        ]
+      : []),
     scim({
       providerOwnership: { enabled: true },
       storeSCIMToken: "hashed",


### PR DESCRIPTION
## Summary

Adds `NEXT_PUBLIC_LOGIN_PROVIDERS`, an optional comma-separated allowlist of login providers to render on the login screen. Valid tokens (case-insensitive): `google`, `microsoft`, `apple`, `sso`.

This solves the access-control problem described in #2106: self-hosted SSO-only deployments currently can't hide the Google / Microsoft buttons, so anyone with a Google or Microsoft account can self-provision and bypass organisational access control.

## Behaviour

- **Unset / empty** &rarr; show all providers (no behaviour change for existing deployments).
- **`NEXT_PUBLIC_LOGIN_PROVIDERS=sso`** &rarr; SSO-only lockdown.
- **`NEXT_PUBLIC_LOGIN_PROVIDERS=google,microsoft`** &rarr; hide SSO button.
- **`NEXT_PUBLIC_LOGIN_PROVIDERS=microsoft,sso`** &rarr; hide Google button.
- The env var can **only narrow** what is otherwise enabled — it is intersected with `hasMicrosoftOauthConfig()`, `env.SSO_LOGIN_ENABLED`, and `env.NEXT_PUBLIC_SHOW_APPLE_LOGIN`, so it can never widen the visible buttons.
- If every token in the list is unknown, the helper falls back to "show all" to avoid locking admins out of their own deployment.

## Changes

- [`apps/web/env.ts`](https://github.com/elie222/inbox-zero/blob/main/apps/web/env.ts): register `NEXT_PUBLIC_LOGIN_PROVIDERS` (optional string).
- [`apps/web/app/(landing)/login/login-providers.ts`](https://github.com/elie222/inbox-zero/blob/main/apps/web/app/(landing)/login): pure parser + helper, exported for reuse.
- [`apps/web/app/(landing)/login/page.tsx`](https://github.com/elie222/inbox-zero/blob/main/apps/web/app/(landing)/login/page.tsx): wires `enabledProviders` into `<LoginForm>`.
- [`apps/web/app/(landing)/login/LoginForm.tsx`](https://github.com/elie222/inbox-zero/blob/main/apps/web/app/(landing)/login/LoginForm.tsx): adds `showGoogleLogin` prop (defaults to `true` for backwards compat with existing callers and tests — Google was previously unconditional).
- `.env.example`: documents the new var next to the existing login env vars.
- Unit tests for the parser (`undefined`, empty, whitespace, single, multi, mixed-case, unknown tokens, all-unknown lockout guard).

## Out of scope

The "solve the bootstrap problem" Option A / B / C in the issue (CLI seed, first-run wizard, env-based SSO registration) is intentionally left out of this PR so the diff stays reviewable. This change lands the part that unblocks both the enterprise-lockdown and the brand-pruning use cases on its own; the bootstrap follow-ups can be addressed in dedicated PRs.

Refs #2106
