### PR TITLE
Fix draft similarity scoring

### DIFF
--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -153,6 +153,48 @@ describe("trackSentDraftStatus", () => {
     });
   });
 
+  it("passes the saved account signature to similarity scoring", async () => {
+    vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
+      id: "action-1",
+      draftId: "draft-1",
+      content: "Generated reply.\n\nSaved account signature",
+      executedRuleId: "executed-rule-1",
+      executedRule: {
+        messageId: "source-1",
+        emailAccount: { signature: "Saved account signature" },
+      },
+    } as any);
+    vi.mocked(calculateSimilarity).mockReturnValue(0.12);
+
+    await trackSentDraftStatus({
+      emailAccountId: "account-1",
+      message: createSentMessage(),
+      provider: {
+        getDraft: vi.fn().mockResolvedValue({ id: "draft-1" }),
+        getMessage: vi.fn().mockResolvedValue(createSourceMessage()),
+      } as any,
+      logger,
+    });
+
+    expect(prisma.executedAction.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          executedRule: {
+            select: {
+              messageId: true,
+              emailAccount: { select: { signature: true } },
+            },
+          },
+        }),
+      }),
+    );
+    expect(calculateSimilarity).toHaveBeenCalledWith(
+      "Generated reply.\n\nSaved account signature",
+      expect.objectContaining({ id: "sent-1" }),
+      { excludedSignatures: ["Saved account signature"] },
+    );
+  });
+
   it("marks missing drafts as likely sent when the sent reply is similar enough", async () => {
     vi.mocked(prisma.executedAction.findFirst).mockResolvedValue({
       id: "action-1",

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -65,6 +65,11 @@ export async function trackSentDraftStatus({
       executedRule: {
         select: {
           messageId: true,
+          emailAccount: {
+            select: {
+              signature: true,
+            },
+          },
         },
       },
     },
@@ -92,7 +97,10 @@ export async function trackSentDraftStatus({
 
   // Calculate similarity between sent message and AI draft content
   // Pass full message to properly handle Outlook HTML content
-  const similarityScore = calculateSimilarity(executedAction.content, message);
+  const accountSignature = executedAction.executedRule.emailAccount?.signature;
+  const similarityScore = calculateSimilarity(executedAction.content, message, {
+    excludedSignatures: accountSignature ? [accountSignature] : [],
+  });
   const sentMessageRepliesToSource =
     sourceMessage &&
     messageRepliesToSourceSender({

--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -411,6 +411,36 @@ On Mon, Jan 1, 2024 at 9:00 AM <someone@example.com> wrote:
       expect(score).toBe(1.0);
     });
 
+    it("should exclude the account signature from the comparison score", () => {
+      const signature = Array.from(
+        { length: 40 },
+        (_value, index) =>
+          `Generic signature policy line ${index + 1}: this footer is not authored reply content.`,
+      ).join("\n");
+      const originalDraft = `There are three files total.
+
+${signature}`;
+      const sentMessage = createParsedMessage(`There will not be another file.
+
+The three runs are grouped into one export.
+
+${signature}
+
+------------------------------------------------------------
+
+Repeated gateway footer. This repeated footer is added outside the user's authored reply.
+
+------------------------------------------------------------
+
+Repeated gateway footer. This repeated footer is added outside the user's authored reply.`);
+
+      const score = realCalculateSimilarity(originalDraft, sentMessage, {
+        excludedSignatures: [signature],
+      });
+
+      expect(score).toBeLessThan(0.5);
+    });
+
     it("should ignore forwarded payloads below the authored reply", () => {
       const originalDraft = "Can you take a look at this?";
       const sentMessage = createParsedMessage(`Can you take a look at this?

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -35,6 +35,12 @@ const HTML_TAG_PATTERN = new RegExp(
   "i",
 );
 
+type SimilarityOptions = {
+  excludedSignatures?: string[];
+};
+
+type ContentNormalizer = (content: string, stripSignature: boolean) => string;
+
 /**
  * Normalizes content for Outlook (HTML) comparison.
  * Converts \n to <br> and then to plain text, strips quoted content.
@@ -115,6 +121,7 @@ function normalizeForGmail(content: string, stripSignature = false): string {
 export function calculateSimilarity(
   storedContent?: string | null,
   providerMessage?: string | ParsedMessage | null,
+  options: SimilarityOptions = {},
 ): number {
   if (!storedContent || !providerMessage) {
     return 0.0;
@@ -124,6 +131,7 @@ export function calculateSimilarity(
     storedContent,
     providerMessage,
     stripSignature: false,
+    excludedSignatures: options.excludedSignatures,
   });
   const baselineScore = compareNormalizedStrings(normalized1, normalized2);
 
@@ -131,6 +139,7 @@ export function calculateSimilarity(
     storedContent,
     providerMessage,
     stripSignature: true,
+    excludedSignatures: options.excludedSignatures,
   });
   const signatureStrippedScore = compareNormalizedStrings(
     signatureStripped1,
@@ -144,41 +153,52 @@ function normalizePair({
   storedContent,
   providerMessage,
   stripSignature,
+  excludedSignatures,
 }: {
   storedContent: string;
   providerMessage: string | ParsedMessage;
   stripSignature: boolean;
+  excludedSignatures?: string[];
 }): [string, string] {
   let normalizedStoredContent: string;
   let normalizedProviderMessage: string;
+  let normalizeContent: ContentNormalizer;
 
   if (typeof providerMessage === "string") {
     // Legacy: plain string from before ParsedMessage was threaded through callers
-    normalizedStoredContent = normalizeForGmail(storedContent, stripSignature);
-    normalizedProviderMessage = normalizeForGmail(
+    normalizeContent = normalizeForGmail;
+    normalizedStoredContent = normalizeContent(storedContent, stripSignature);
+    normalizedProviderMessage = normalizeContent(
       providerMessage,
       stripSignature,
     );
   } else {
     const isOutlook = providerMessage.bodyContentType === "html";
     const text = providerMessage.textHtml || providerMessage.textPlain || "";
+    normalizeContent = isOutlook ? normalizeForOutlook : normalizeForGmail;
 
-    if (isOutlook) {
-      normalizedStoredContent = normalizeForOutlook(
-        storedContent,
-        stripSignature,
-      );
-      normalizedProviderMessage = normalizeForOutlook(text, stripSignature);
-    } else {
-      normalizedStoredContent = normalizeForGmail(
-        storedContent,
-        stripSignature,
-      );
-      normalizedProviderMessage = normalizeForGmail(text, stripSignature);
-    }
+    normalizedStoredContent = normalizeContent(storedContent, stripSignature);
+    normalizedProviderMessage = normalizeContent(text, stripSignature);
   }
 
-  return [normalizedStoredContent, normalizedProviderMessage];
+  const normalizedExcludedSignatures = excludedSignatures
+    ?.map((signature) => normalizeContent(signature, stripSignature))
+    .filter(Boolean);
+
+  if (!normalizedExcludedSignatures?.length) {
+    return [normalizedStoredContent, normalizedProviderMessage];
+  }
+
+  return [
+    removeExcludedSignatures(
+      normalizedStoredContent,
+      normalizedExcludedSignatures,
+    ),
+    removeExcludedSignatures(
+      normalizedProviderMessage,
+      normalizedExcludedSignatures,
+    ),
+  ];
 }
 
 function compareNormalizedStrings(normalized1: string, normalized2: string) {
@@ -187,6 +207,19 @@ function compareNormalizedStrings(normalized1: string, normalized2: string) {
   }
 
   return stringSimilarity.compareTwoStrings(normalized1, normalized2);
+}
+
+function removeExcludedSignatures(
+  content: string,
+  excludedSignatures: string[],
+): string {
+  let result = content;
+
+  for (const signature of excludedSignatures) {
+    result = result.split(signature).join("");
+  }
+
+  return result.replace(/\n{3,}/g, "\n\n").trim();
 }
 
 function looksLikeHtmlContent(content: string): boolean {

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -35,12 +35,6 @@ const HTML_TAG_PATTERN = new RegExp(
   "i",
 );
 
-type SimilarityOptions = {
-  excludedSignatures?: string[];
-};
-
-type ContentNormalizer = (content: string, stripSignature: boolean) => string;
-
 /**
  * Normalizes content for Outlook (HTML) comparison.
  * Converts \n to <br> and then to plain text, strips quoted content.
@@ -121,7 +115,7 @@ function normalizeForGmail(content: string, stripSignature = false): string {
 export function calculateSimilarity(
   storedContent?: string | null,
   providerMessage?: string | ParsedMessage | null,
-  options: SimilarityOptions = {},
+  options: { excludedSignatures?: string[] } = {},
 ): number {
   if (!storedContent || !providerMessage) {
     return 0.0;
@@ -162,7 +156,7 @@ function normalizePair({
 }): [string, string] {
   let normalizedStoredContent: string;
   let normalizedProviderMessage: string;
-  let normalizeContent: ContentNormalizer;
+  let normalizeContent: (content: string, stripSignature: boolean) => string;
 
   if (typeof providerMessage === "string") {
     // Legacy: plain string from before ParsedMessage was threaded through callers
@@ -181,8 +175,11 @@ function normalizePair({
     normalizedProviderMessage = normalizeContent(text, stripSignature);
   }
 
+  // Normalize excluded signatures with stripSignature=false so the signature
+  // strippers don't reduce the user's saved signature to empty before we use
+  // it to remove that signature from the body.
   const normalizedExcludedSignatures = excludedSignatures
-    ?.map((signature) => normalizeContent(signature, stripSignature))
+    ?.map((signature) => normalizeContent(signature, false))
     .filter(Boolean);
 
   if (!normalizedExcludedSignatures?.length) {
@@ -216,7 +213,7 @@ function removeExcludedSignatures(
   let result = content;
 
   for (const signature of excludedSignatures) {
-    result = result.split(signature).join("");
+    result = result.replaceAll(signature, "");
   }
 
   return result.replace(/\n{3,}/g, "\n\n").trim();


### PR DESCRIPTION
Adjust draft similarity scoring so configured signature content is excluded before comparison. This keeps reusable footer text from affecting the score.

- Pass configured account signatures into draft comparison
- Remove excluded signatures after normalizing both draft and sent content
- Add regression coverage for signature-heavy comparisons and tracking wiring

Validation:
- pnpm test utils/similarity-score.test.ts
- pnpm test utils/reply-tracker/draft-tracking.test.ts
- pnpm check