### PR TITLE
admin: Add per-user billing sync control

### DIFF
--- a/apps/web/app/(app)/admin/AdminUserControls.tsx
+++ b/apps/web/app/(app)/admin/AdminUserControls.tsx
@@ -17,6 +17,7 @@ import {
   adminDisableAllRulesAction,
   adminCleanupDraftsAction,
   adminLoadResponseTimeDataAction,
+  adminSyncStripeForUserAction,
 } from "@/utils/actions/admin";
 import { adminCheckPermissionsAction } from "@/utils/actions/permissions";
 import { toastError, toastSuccess } from "@/components/Toast";
@@ -86,6 +87,23 @@ export const AdminUserControls = () => {
       onError: (error) => {
         toastError({
           title: "Error watching emails",
+          description: getActionErrorMessage(error.error),
+        });
+      },
+    },
+  );
+  const { execute: syncStripe, isExecuting: isSyncingStripe } = useAction(
+    adminSyncStripeForUserAction,
+    {
+      onSuccess: (result) => {
+        toastSuccess({
+          title: "Stripe synced",
+          description: `Status: ${result.data?.stripeSubscriptionStatus ?? "none"}`,
+        });
+      },
+      onError: (error) => {
+        toastError({
+          title: "Error syncing Stripe",
           description: getActionErrorMessage(error.error),
         });
       },
@@ -215,6 +233,16 @@ export const AdminUserControls = () => {
           }}
         >
           Watch
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          loading={isSyncingStripe}
+          onClick={() => {
+            syncStripe({ email: getValues("email") });
+          }}
+        >
+          Sync Stripe
         </Button>
         <Button
           variant="outline"

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -17,6 +17,7 @@ import {
   convertGmailUrlBody,
   getLabelsBody,
   watchEmailsBody,
+  syncStripeForUserBody,
   getUserInfoBody,
   loadResponseTimeDataBody,
   disableAllRulesBody,
@@ -139,6 +140,56 @@ export const adminSyncStripeForAllUsersAction = adminActionClient
         logger,
       });
     }
+  });
+
+export const adminSyncStripeForUserAction = adminActionClient
+  .metadata({ name: "adminSyncStripeForUser" })
+  .inputSchema(syncStripeForUserBody)
+  .action(async ({ parsedInput: { email }, ctx: { logger } }) => {
+    const normalizedEmail = email.toLowerCase();
+
+    const user = await findUserByUserOrAccountEmail(normalizedEmail);
+
+    if (!user?.premium) {
+      throw new SafeError("Premium record not found");
+    }
+
+    if (!user.premium.stripeCustomerId) {
+      throw new SafeError("Stripe customer ID not found");
+    }
+
+    logger.info("Starting admin Stripe sync for user", {
+      userId: user.id,
+      premiumId: user.premium.id,
+      stripeCustomerId: user.premium.stripeCustomerId,
+    });
+
+    await syncStripeDataToDb({
+      customerId: user.premium.stripeCustomerId,
+      logger,
+    });
+
+    const premium = await prisma.premium.findUnique({
+      where: { id: user.premium.id },
+      select: {
+        stripeSubscriptionStatus: true,
+        stripeRenewsAt: true,
+        tier: true,
+      },
+    });
+
+    logger.info("Finished admin Stripe sync for user", {
+      userId: user.id,
+      premiumId: user.premium.id,
+      stripeCustomerId: user.premium.stripeCustomerId,
+      stripeSubscriptionStatus: premium?.stripeSubscriptionStatus,
+    });
+
+    return {
+      stripeSubscriptionStatus: premium?.stripeSubscriptionStatus ?? null,
+      stripeRenewsAt: premium?.stripeRenewsAt ?? null,
+      tier: premium?.tier ?? null,
+    };
   });
 
 export const adminSyncAllStripeCustomersToDbAction = adminActionClient
@@ -616,4 +667,40 @@ async function findUserWithDetails(email?: string, userId?: string) {
       },
     },
   });
+}
+
+async function findUserByUserOrAccountEmail(email: string) {
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: {
+      id: true,
+      premium: {
+        select: {
+          id: true,
+          stripeCustomerId: true,
+        },
+      },
+    },
+  });
+
+  if (user) return user;
+
+  const emailAccount = await prisma.emailAccount.findUnique({
+    where: { email },
+    select: {
+      user: {
+        select: {
+          id: true,
+          premium: {
+            select: {
+              id: true,
+              stripeCustomerId: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return emailAccount?.user ?? null;
 }

--- a/apps/web/utils/actions/admin.validation.ts
+++ b/apps/web/utils/actions/admin.validation.ts
@@ -21,6 +21,11 @@ export const watchEmailsBody = z.object({
 });
 export type WatchEmailsBody = z.infer<typeof watchEmailsBody>;
 
+export const syncStripeForUserBody = z.object({
+  email: z.string().trim().email("Valid email address is required"),
+});
+export type SyncStripeForUserBody = z.infer<typeof syncStripeForUserBody>;
+
 export const getUserInfoBody = z.object({
   email: z.string().trim().email("Valid email address is required"),
 });


### PR DESCRIPTION
Adds an admin action to refresh billing data for a single user from the payment processor.

- Adds validated admin input for per-user billing sync by email.
- Reuses the existing billing sync path and returns the refreshed status.
- Adds a Sync Stripe button to the admin user controls.

Runtime impact: only admin-triggered; each use performs user lookup queries plus one payment processor fetch/sync.