### PR TITLE
reply-context: Expand historical thread retrieval

### DIFF
--- a/apps/web/__tests__/integration/helpers.ts
+++ b/apps/web/__tests__/integration/helpers.ts
@@ -21,23 +21,36 @@ import type { EmailProvider } from "@/utils/email/types";
 type GmailSeedMessage = {
   id: string;
   user_email: string;
+  thread_id?: string;
+  message_id?: string;
+  references?: string;
+  in_reply_to?: string;
   from: string;
   to: string;
+  cc?: string;
+  bcc?: string;
+  reply_to?: string;
   subject: string;
   body_text: string;
   body_html?: string;
+  snippet?: string;
   label_ids: string[];
   internal_date: string;
+  date?: string;
 };
 
 type OutlookSeedMessage = {
   id?: string;
+  microsoft_id?: string;
+  conversation_id?: string;
+  internet_message_id?: string;
   user_email: string;
   from: { address: string; name?: string };
   to_recipients: Array<{ address: string; name?: string }>;
   cc_recipients?: Array<{ address: string; name?: string }>;
   subject: string;
   body_content: string;
+  body_content_type?: "html" | "text";
   body_text_content?: string;
   parent_folder_id: string;
   is_read: boolean;

--- a/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
+++ b/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Integration test: reply-context historical search should expose thread-level precedent.
+ *
+ * This reproduces the furniture-support confusion case against the Google and
+ * Microsoft emulators. The old message-level retrieval shape can miss the prior
+ * answer when only the customer's message matches the search terms and the
+ * user's correction lives later in the thread.
+ *
+ * Usage:
+ *   pnpm test-integration reply-context-search-thread-precedent
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { searchReplyContextEmails } from "@/utils/ai/reply/reply-context-collector";
+import type { EmailProvider } from "@/utils/email/types";
+import { getEmailForLLM } from "@/utils/get-email-from-message";
+import type { ParsedMessage } from "@/utils/types";
+import {
+  createGmailTestHarness,
+  createOutlookTestHarness,
+  type GmailTestHarness,
+  type OutlookTestHarness,
+} from "./helpers";
+
+const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
+const GMAIL_EMAIL = "reply-context-precedent@example.com";
+const OUTLOOK_EMAIL = "reply-context-precedent@outlook.com";
+const FURNITURE_THREAD_ID = "thread-furniture-wrong-address";
+const FURNITURE_CONVERSATION_ID = "conversation-furniture-wrong-address";
+const CURRENT_THREAD_ID = "thread-current-wayfair-question";
+const CURRENT_MESSAGE_ID = "current-wayfair-question";
+const SEARCH_QUERY = "WayFair";
+const SEARCH_AFTER = new Date("2026-01-01T00:00:00Z");
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "reply-context search thread precedent — Gmail",
+  { timeout: 30_000 },
+  () => {
+    let harness: GmailTestHarness;
+
+    beforeAll(async () => {
+      harness = await createGmailTestHarness({
+        email: GMAIL_EMAIL,
+        messages: gmailFurniturePrecedentSeed(GMAIL_EMAIL),
+      });
+    });
+
+    afterAll(async () => {
+      await harness?.emulator.close();
+    });
+
+    providerPrecedentSuite(() => harness.provider, GMAIL_EMAIL);
+  },
+);
+
+describe.skipIf(!RUN_INTEGRATION_TESTS)(
+  "reply-context search thread precedent — Outlook",
+  { timeout: 30_000 },
+  () => {
+    let harness: OutlookTestHarness;
+
+    beforeAll(async () => {
+      harness = await createOutlookTestHarness({
+        email: OUTLOOK_EMAIL,
+        messages: outlookFurniturePrecedentSeed(OUTLOOK_EMAIL),
+      });
+    });
+
+    afterAll(async () => {
+      harness?.restoreFetch();
+      await harness?.emulator.close();
+    });
+
+    providerPrecedentSuite(() => harness.provider, OUTLOOK_EMAIL);
+  },
+);
+
+function providerPrecedentSuite(
+  getProvider: () => EmailProvider,
+  accountEmail: string,
+) {
+  test("message-level historical search misses the prior correction", async () => {
+    const messageLevelContext = await collectMessageLevelSearchContext(
+      getProvider(),
+      SEARCH_QUERY,
+    );
+    const senders = messageLevelContext.map((email) => email.from);
+
+    expect(messageLevelContext.length).toBeGreaterThan(0);
+    expect(senders.some((sender) => sender.includes(accountEmail))).toBe(false);
+  });
+
+  test("production historical search expands matching hits and excludes the current thread", async () => {
+    const threadLevelContext = await searchReplyContextEmails({
+      emailProvider: getProvider(),
+      query: SEARCH_QUERY,
+      after: SEARCH_AFTER,
+      currentThread: getCurrentWayfairThreadContext(accountEmail),
+    });
+    const senders = threadLevelContext.map((email) => email.from);
+
+    expect(threadLevelContext.length).toBeGreaterThanOrEqual(3);
+    expect(senders.some((sender) => sender.includes(accountEmail))).toBe(true);
+    expect(
+      countEmailSendersContaining(threadLevelContext, "customer@example.com"),
+    ).toBe(2);
+    expect(
+      senders.some((sender) => sender.includes("new-customer@example.com")),
+    ).toBe(false);
+  });
+}
+
+async function collectMessageLevelSearchContext(
+  provider: EmailProvider,
+  query: string,
+) {
+  const { messages } = await provider.getMessagesWithPagination({
+    query,
+    maxResults: 20,
+    after: SEARCH_AFTER,
+  });
+
+  return messages.map(toCollectorEmail);
+}
+
+function getCurrentWayfairThreadContext(accountEmail: string) {
+  return [
+    {
+      id: CURRENT_MESSAGE_ID,
+      threadId: CURRENT_THREAD_ID,
+      from: "new-customer@example.com",
+      to: accountEmail,
+      subject: "Light strip colors",
+      content:
+        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+      date: new Date("2026-05-12T12:00:00Z"),
+    },
+  ];
+}
+
+function toCollectorEmail(message: ParsedMessage) {
+  return getEmailForLLM(message, {
+    maxLength: 2000,
+  });
+}
+
+function countEmailSendersContaining(
+  emails: Array<{ from: string }>,
+  senderEmail: string,
+) {
+  return emails.filter((email) => email.from.includes(senderEmail)).length;
+}
+
+function gmailFurniturePrecedentSeed(email: string) {
+  return [
+    {
+      id: CURRENT_MESSAGE_ID,
+      user_email: email,
+      thread_id: CURRENT_THREAD_ID,
+      message_id: "<current-wayfair-question@example.com>",
+      from: "new-customer@example.com",
+      to: email,
+      subject: "Light strip colors",
+      body_text:
+        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+      label_ids: ["INBOX"],
+      internal_date: "1778600000000",
+    },
+    {
+      id: "gmail-furniture-customer-question",
+      user_email: email,
+      thread_id: FURNITURE_THREAD_ID,
+      message_id: "<gmail-furniture-customer-question@example.com>",
+      from: "customer@example.com",
+      to: email,
+      subject: "Inbox Zero Support Request",
+      body_text: `Good evening!
+
+I just bought from WayFair your Farmhouse L Shaped Standing Desk, 55 Inch Height Adjustable Corner Desk With Storage Drawers, Standing Computer Desks With Power Outlets For Home Office.
+
+I've assembled it all and the control panel for the rising desk just reads "RsT". I'm unable to raise or lower the desk.
+
+Could you please advise me on how I can clear the code?`,
+      label_ids: ["INBOX"],
+      internal_date: "1778131920000",
+    },
+    {
+      id: "gmail-furniture-user-correction",
+      user_email: email,
+      thread_id: FURNITURE_THREAD_ID,
+      message_id: "<gmail-furniture-user-correction@example.com>",
+      in_reply_to: "<gmail-furniture-customer-question@example.com>",
+      references: "<gmail-furniture-customer-question@example.com>",
+      from: email,
+      to: "customer@example.com",
+      subject: "Re: Inbox Zero Support Request",
+      body_text:
+        "Hey, we don't sell furniture. This is the wrong email address. We're an email company: https://getinboxzero.com",
+      label_ids: ["SENT"],
+      internal_date: "1778156940000",
+    },
+    {
+      id: "gmail-furniture-customer-thanks",
+      user_email: email,
+      thread_id: FURNITURE_THREAD_ID,
+      message_id: "<gmail-furniture-customer-thanks@example.com>",
+      in_reply_to: "<gmail-furniture-user-correction@example.com>",
+      references:
+        "<gmail-furniture-customer-question@example.com> <gmail-furniture-user-correction@example.com>",
+      from: "customer@example.com",
+      to: email,
+      subject: "Re: Inbox Zero Support Request",
+      body_text: "Thx for letting me know!",
+      label_ids: ["INBOX"],
+      internal_date: "1778188620000",
+    },
+    {
+      id: "gmail-unrelated-wayfair-receipt",
+      user_email: email,
+      thread_id: "thread-unrelated-wayfair-receipt",
+      message_id: "<gmail-unrelated-wayfair-receipt@example.com>",
+      from: "receipts@example.com",
+      to: email,
+      subject: "Receipt",
+      body_text: "A generic WayFair receipt with no support precedent.",
+      label_ids: ["INBOX"],
+      internal_date: "1778000000000",
+    },
+  ];
+}
+
+function outlookFurniturePrecedentSeed(email: string) {
+  return [
+    {
+      microsoft_id: CURRENT_MESSAGE_ID,
+      conversation_id: CURRENT_THREAD_ID,
+      internet_message_id: "<current-wayfair-question@example.com>",
+      user_email: email,
+      from: { address: "new-customer@example.com", name: "New Customer" },
+      to_recipients: [{ address: email }],
+      subject: "Light strip colors",
+      body_content_type: "text" as const,
+      body_content:
+        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+      body_text_content:
+        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+      parent_folder_id: "inbox",
+      is_read: true,
+      received_date_time: "2026-05-12T12:00:00Z",
+    },
+    {
+      microsoft_id: "outlook-furniture-customer-question",
+      conversation_id: FURNITURE_CONVERSATION_ID,
+      internet_message_id: "<outlook-furniture-customer-question@example.com>",
+      user_email: email,
+      from: { address: "customer@example.com", name: "Customer" },
+      to_recipients: [{ address: email }],
+      subject: "Inbox Zero Support Request",
+      body_content_type: "text" as const,
+      body_content: `Good evening!
+
+I just bought from WayFair your Farmhouse L Shaped Standing Desk, 55 Inch Height Adjustable Corner Desk With Storage Drawers, Standing Computer Desks With Power Outlets For Home Office.
+
+I've assembled it all and the control panel for the rising desk just reads "RsT". I'm unable to raise or lower the desk.
+
+Could you please advise me on how I can clear the code?`,
+      body_text_content: `Good evening!
+
+I just bought from WayFair your Farmhouse L Shaped Standing Desk, 55 Inch Height Adjustable Corner Desk With Storage Drawers, Standing Computer Desks With Power Outlets For Home Office.
+
+I've assembled it all and the control panel for the rising desk just reads "RsT". I'm unable to raise or lower the desk.
+
+Could you please advise me on how I can clear the code?`,
+      parent_folder_id: "inbox",
+      is_read: true,
+      received_date_time: "2026-05-07T02:52:00Z",
+    },
+    {
+      microsoft_id: "outlook-furniture-user-correction",
+      conversation_id: FURNITURE_CONVERSATION_ID,
+      internet_message_id: "<outlook-furniture-user-correction@example.com>",
+      user_email: email,
+      from: { address: email, name: "Test User" },
+      to_recipients: [{ address: "customer@example.com" }],
+      subject: "Re: Inbox Zero Support Request",
+      body_content_type: "text" as const,
+      body_content:
+        "Hey, we don't sell furniture. This is the wrong email address. We're an email company: https://getinboxzero.com",
+      body_text_content:
+        "Hey, we don't sell furniture. This is the wrong email address. We're an email company: https://getinboxzero.com",
+      parent_folder_id: "sentitems",
+      is_read: true,
+      received_date_time: "2026-05-07T09:29:00Z",
+      sent_date_time: "2026-05-07T09:29:00Z",
+    },
+    {
+      microsoft_id: "outlook-furniture-customer-thanks",
+      conversation_id: FURNITURE_CONVERSATION_ID,
+      internet_message_id: "<outlook-furniture-customer-thanks@example.com>",
+      user_email: email,
+      from: { address: "customer@example.com", name: "Customer" },
+      to_recipients: [{ address: email }],
+      subject: "Re: Inbox Zero Support Request",
+      body_content_type: "text" as const,
+      body_content: "Thx for letting me know!",
+      body_text_content: "Thx for letting me know!",
+      parent_folder_id: "inbox",
+      is_read: true,
+      received_date_time: "2026-05-07T17:17:00Z",
+    },
+    {
+      microsoft_id: "outlook-unrelated-wayfair-receipt",
+      conversation_id: "conversation-unrelated-wayfair-receipt",
+      internet_message_id: "<outlook-unrelated-wayfair-receipt@example.com>",
+      user_email: email,
+      from: { address: "receipts@example.com", name: "Receipts" },
+      to_recipients: [{ address: email }],
+      subject: "Receipt",
+      body_content_type: "text" as const,
+      body_content: "A generic WayFair receipt with no support precedent.",
+      body_text_content: "A generic WayFair receipt with no support precedent.",
+      parent_folder_id: "inbox",
+      is_read: true,
+      received_date_time: "2026-05-06T12:00:00Z",
+    },
+  ];
+}

--- a/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
+++ b/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
@@ -1,15 +1,3 @@
-/**
- * Integration test: reply-context historical search should expose thread-level precedent.
- *
- * This reproduces the furniture-support confusion case against the Google and
- * Microsoft emulators. The old message-level retrieval shape can miss the prior
- * answer when only the customer's message matches the search terms and the
- * user's correction lives later in the thread.
- *
- * Usage:
- *   pnpm test-integration reply-context-search-thread-precedent
- */
-
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { searchReplyContextEmails } from "@/utils/ai/reply/reply-context-collector";
 import type { EmailProvider } from "@/utils/email/types";

--- a/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
+++ b/apps/web/__tests__/integration/reply-context-search-thread-precedent.test.ts
@@ -11,12 +11,12 @@ import {
 } from "./helpers";
 
 const RUN_INTEGRATION_TESTS = process.env.RUN_INTEGRATION_TESTS;
-const GMAIL_EMAIL = "reply-context-precedent@example.com";
-const OUTLOOK_EMAIL = "reply-context-precedent@outlook.com";
-const FURNITURE_THREAD_ID = "thread-furniture-wrong-address";
-const FURNITURE_CONVERSATION_ID = "conversation-furniture-wrong-address";
-const CURRENT_THREAD_ID = "thread-current-wayfair-question";
-const CURRENT_MESSAGE_ID = "current-wayfair-question";
+const GMAIL_EMAIL = "account@example.com";
+const OUTLOOK_EMAIL = "account@outlook.example.com";
+const HISTORICAL_THREAD_ID = "thread-1";
+const HISTORICAL_CONVERSATION_ID = "conversation-1";
+const CURRENT_THREAD_ID = "thread-2";
+const CURRENT_MESSAGE_ID = "message-1";
 const SEARCH_QUERY = "WayFair";
 const SEARCH_AFTER = new Date("2026-01-01T00:00:00Z");
 
@@ -120,7 +120,7 @@ function getCurrentWayfairThreadContext(accountEmail: string) {
       to: accountEmail,
       subject: "Light strip colors",
       content:
-        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+        "I bought a WayFair desk and need help changing the light strip colors.",
       date: new Date("2026-05-12T12:00:00Z"),
     },
   ];
@@ -145,20 +145,20 @@ function gmailFurniturePrecedentSeed(email: string) {
       id: CURRENT_MESSAGE_ID,
       user_email: email,
       thread_id: CURRENT_THREAD_ID,
-      message_id: "<current-wayfair-question@example.com>",
+      message_id: "<message-1@example.com>",
       from: "new-customer@example.com",
       to: email,
       subject: "Light strip colors",
       body_text:
-        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+        "I bought a WayFair desk and need help changing the light strip colors.",
       label_ids: ["INBOX"],
       internal_date: "1778600000000",
     },
     {
-      id: "gmail-furniture-customer-question",
+      id: "message-2",
       user_email: email,
-      thread_id: FURNITURE_THREAD_ID,
-      message_id: "<gmail-furniture-customer-question@example.com>",
+      thread_id: HISTORICAL_THREAD_ID,
+      message_id: "<message-2@example.com>",
       from: "customer@example.com",
       to: email,
       subject: "Inbox Zero Support Request",
@@ -173,12 +173,12 @@ Could you please advise me on how I can clear the code?`,
       internal_date: "1778131920000",
     },
     {
-      id: "gmail-furniture-user-correction",
+      id: "message-3",
       user_email: email,
-      thread_id: FURNITURE_THREAD_ID,
-      message_id: "<gmail-furniture-user-correction@example.com>",
-      in_reply_to: "<gmail-furniture-customer-question@example.com>",
-      references: "<gmail-furniture-customer-question@example.com>",
+      thread_id: HISTORICAL_THREAD_ID,
+      message_id: "<message-3@example.com>",
+      in_reply_to: "<message-2@example.com>",
+      references: "<message-2@example.com>",
       from: email,
       to: "customer@example.com",
       subject: "Re: Inbox Zero Support Request",
@@ -188,13 +188,12 @@ Could you please advise me on how I can clear the code?`,
       internal_date: "1778156940000",
     },
     {
-      id: "gmail-furniture-customer-thanks",
+      id: "message-4",
       user_email: email,
-      thread_id: FURNITURE_THREAD_ID,
-      message_id: "<gmail-furniture-customer-thanks@example.com>",
-      in_reply_to: "<gmail-furniture-user-correction@example.com>",
-      references:
-        "<gmail-furniture-customer-question@example.com> <gmail-furniture-user-correction@example.com>",
+      thread_id: HISTORICAL_THREAD_ID,
+      message_id: "<message-4@example.com>",
+      in_reply_to: "<message-3@example.com>",
+      references: "<message-2@example.com> <message-3@example.com>",
       from: "customer@example.com",
       to: email,
       subject: "Re: Inbox Zero Support Request",
@@ -203,10 +202,10 @@ Could you please advise me on how I can clear the code?`,
       internal_date: "1778188620000",
     },
     {
-      id: "gmail-unrelated-wayfair-receipt",
+      id: "message-5",
       user_email: email,
-      thread_id: "thread-unrelated-wayfair-receipt",
-      message_id: "<gmail-unrelated-wayfair-receipt@example.com>",
+      thread_id: "thread-3",
+      message_id: "<message-5@example.com>",
       from: "receipts@example.com",
       to: email,
       subject: "Receipt",
@@ -222,24 +221,24 @@ function outlookFurniturePrecedentSeed(email: string) {
     {
       microsoft_id: CURRENT_MESSAGE_ID,
       conversation_id: CURRENT_THREAD_ID,
-      internet_message_id: "<current-wayfair-question@example.com>",
+      internet_message_id: "<message-1@example.com>",
       user_email: email,
       from: { address: "new-customer@example.com", name: "New Customer" },
       to_recipients: [{ address: email }],
       subject: "Light strip colors",
       body_content_type: "text" as const,
       body_content:
-        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+        "I bought a WayFair desk and need help changing the light strip colors.",
       body_text_content:
-        "CURRENT_THREAD_MARKER I bought a WayFair desk and need help changing the light strip colors.",
+        "I bought a WayFair desk and need help changing the light strip colors.",
       parent_folder_id: "inbox",
       is_read: true,
       received_date_time: "2026-05-12T12:00:00Z",
     },
     {
-      microsoft_id: "outlook-furniture-customer-question",
-      conversation_id: FURNITURE_CONVERSATION_ID,
-      internet_message_id: "<outlook-furniture-customer-question@example.com>",
+      microsoft_id: "message-2",
+      conversation_id: HISTORICAL_CONVERSATION_ID,
+      internet_message_id: "<message-2@example.com>",
       user_email: email,
       from: { address: "customer@example.com", name: "Customer" },
       to_recipients: [{ address: email }],
@@ -264,9 +263,9 @@ Could you please advise me on how I can clear the code?`,
       received_date_time: "2026-05-07T02:52:00Z",
     },
     {
-      microsoft_id: "outlook-furniture-user-correction",
-      conversation_id: FURNITURE_CONVERSATION_ID,
-      internet_message_id: "<outlook-furniture-user-correction@example.com>",
+      microsoft_id: "message-3",
+      conversation_id: HISTORICAL_CONVERSATION_ID,
+      internet_message_id: "<message-3@example.com>",
       user_email: email,
       from: { address: email, name: "Test User" },
       to_recipients: [{ address: "customer@example.com" }],
@@ -282,9 +281,9 @@ Could you please advise me on how I can clear the code?`,
       sent_date_time: "2026-05-07T09:29:00Z",
     },
     {
-      microsoft_id: "outlook-furniture-customer-thanks",
-      conversation_id: FURNITURE_CONVERSATION_ID,
-      internet_message_id: "<outlook-furniture-customer-thanks@example.com>",
+      microsoft_id: "message-4",
+      conversation_id: HISTORICAL_CONVERSATION_ID,
+      internet_message_id: "<message-4@example.com>",
       user_email: email,
       from: { address: "customer@example.com", name: "Customer" },
       to_recipients: [{ address: email }],
@@ -297,9 +296,9 @@ Could you please advise me on how I can clear the code?`,
       received_date_time: "2026-05-07T17:17:00Z",
     },
     {
-      microsoft_id: "outlook-unrelated-wayfair-receipt",
-      conversation_id: "conversation-unrelated-wayfair-receipt",
-      internet_message_id: "<outlook-unrelated-wayfair-receipt@example.com>",
+      microsoft_id: "message-5",
+      conversation_id: "conversation-2",
+      internet_message_id: "<message-5@example.com>",
       user_email: email,
       from: { address: "receipts@example.com", name: "Receipts" },
       to_recipients: [{ address: email }],

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 12;
+export const DRAFT_PIPELINE_VERSION = 13;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/reply-context-collector.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.ts
@@ -1,5 +1,7 @@
 import { tool } from "ai";
 import { subMonths } from "date-fns/subMonths";
+import uniq from "lodash/uniq";
+import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 import { createScopedLogger } from "@/utils/logger";
 import { createGenerateText } from "@/utils/llms";
@@ -11,6 +13,10 @@ import type { EmailProvider } from "@/utils/email/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { captureException } from "@/utils/error";
 import { getEmailListPrompt, getUserInfoPrompt } from "@/utils/ai/helpers";
+
+type ReplyContextThreadEmail = EmailForLLM & {
+  threadId?: string | null;
+};
 
 const logger = createScopedLogger("reply-context-collector");
 const SEARCH_RESULTS_PER_QUERY = 20;
@@ -206,7 +212,7 @@ export async function searchReplyContextEmails({
   query: string;
   after: Date;
   currentThread: ReplyContextThreadEmail[];
-}) {
+}): Promise<EmailForLLM[]> {
   const { messages } = await emailProvider.getMessagesWithPagination({
     query,
     maxResults: SEARCH_RESULTS_PER_QUERY,
@@ -217,7 +223,7 @@ export async function searchReplyContextEmails({
     messages,
     currentThread,
   );
-  const threadIds = getUniqueThreadIds(historicalMatches).slice(
+  const threadIds = uniq(historicalMatches.map((m) => m.threadId)).slice(
     0,
     MAX_EXPANDED_THREADS_PER_QUERY,
   );
@@ -236,8 +242,9 @@ export async function searchReplyContextEmails({
     ),
   );
 
-  return dedupeMessages(
+  return uniqBy(
     filterCurrentThreadMessages(threadMessages.flat(), currentThread),
+    "id",
   )
     .slice(0, MAX_EXPANDED_EMAILS_PER_QUERY)
     .map((message) => getEmailForLLM(message, { maxLength: 2000 }));
@@ -251,7 +258,7 @@ async function getHistoricalThreadMessages({
   emailProvider: EmailProvider;
   threadId: string;
   fallbackMessages: ParsedMessage[];
-}) {
+}): Promise<ParsedMessage[]> {
   try {
     return await emailProvider.getThreadMessages(threadId);
   } catch (error) {
@@ -268,9 +275,7 @@ function filterCurrentThreadMessages(
   messages: ParsedMessage[],
   currentThread: ReplyContextThreadEmail[],
 ) {
-  const currentMessageIds = new Set(
-    currentThread.map((message) => message.id).filter(Boolean),
-  );
+  const currentMessageIds = new Set(currentThread.map((message) => message.id));
   const currentThreadIds = new Set(
     currentThread
       .map((message) => message.threadId)
@@ -283,30 +288,3 @@ function filterCurrentThreadMessages(
       !currentThreadIds.has(message.threadId),
   );
 }
-
-function dedupeMessages(messages: ParsedMessage[]) {
-  const seenMessageIds = new Set<string>();
-
-  return messages.filter((message) => {
-    if (seenMessageIds.has(message.id)) return false;
-    seenMessageIds.add(message.id);
-    return true;
-  });
-}
-
-function getUniqueThreadIds(messages: ParsedMessage[]) {
-  const threadIds: string[] = [];
-  const seenThreadIds = new Set<string>();
-
-  for (const message of messages) {
-    if (seenThreadIds.has(message.threadId)) continue;
-    seenThreadIds.add(message.threadId);
-    threadIds.push(message.threadId);
-  }
-
-  return threadIds;
-}
-
-type ReplyContextThreadEmail = EmailForLLM & {
-  threadId?: string | null;
-};

--- a/apps/web/utils/ai/reply/reply-context-collector.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { createScopedLogger } from "@/utils/logger";
 import { createGenerateText } from "@/utils/llms";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
-import type { EmailForLLM } from "@/utils/types";
+import type { EmailForLLM, ParsedMessage } from "@/utils/types";
 import { getTodayForLLM } from "@/utils/ai/helpers";
 import { getModel } from "@/utils/llms/model";
 import type { EmailProvider } from "@/utils/email/types";
@@ -13,6 +13,9 @@ import { captureException } from "@/utils/error";
 import { getEmailListPrompt, getUserInfoPrompt } from "@/utils/ai/helpers";
 
 const logger = createScopedLogger("reply-context-collector");
+const SEARCH_RESULTS_PER_QUERY = 20;
+const MAX_EXPANDED_THREADS_PER_QUERY = 5;
+const MAX_EXPANDED_EMAILS_PER_QUERY = 40;
 
 const resultSchema = z.object({
   notes: z
@@ -72,7 +75,7 @@ export async function aiCollectReplyContext({
   emailAccount,
   emailProvider,
 }: {
-  currentThread: EmailForLLM[];
+  currentThread: ReplyContextThreadEmail[];
   emailAccount: EmailAccountWithAI;
   emailProvider: EmailProvider;
 }): Promise<ReplyContextCollectorResult | null> {
@@ -120,16 +123,12 @@ ${getTodayForLLM()}`;
           execute: async ({ query }) => {
             logger.info("Searching emails", { query });
             try {
-              const { messages } =
-                await emailProvider.getMessagesWithPagination({
-                  query,
-                  maxResults: 20,
-                  after: sixMonthsAgo,
-                });
-
-              const emails = messages.map((message) =>
-                getEmailForLLM(message, { maxLength: 2000 }),
-              );
+              const emails = await searchReplyContextEmails({
+                emailProvider,
+                query,
+                after: sixMonthsAgo,
+                currentThread,
+              });
 
               logger.info("Found emails", { emails: emails.length });
               // logger.trace("Found emails", { emails });
@@ -196,3 +195,118 @@ ${getTodayForLLM()}`;
     return null;
   }
 }
+
+export async function searchReplyContextEmails({
+  emailProvider,
+  query,
+  after,
+  currentThread,
+}: {
+  emailProvider: EmailProvider;
+  query: string;
+  after: Date;
+  currentThread: ReplyContextThreadEmail[];
+}) {
+  const { messages } = await emailProvider.getMessagesWithPagination({
+    query,
+    maxResults: SEARCH_RESULTS_PER_QUERY,
+    after,
+  });
+
+  const historicalMatches = filterCurrentThreadMessages(
+    messages,
+    currentThread,
+  );
+  const threadIds = getUniqueThreadIds(historicalMatches).slice(
+    0,
+    MAX_EXPANDED_THREADS_PER_QUERY,
+  );
+
+  if (threadIds.length === 0) return [];
+
+  const threadMessages = await Promise.all(
+    threadIds.map((threadId) =>
+      getHistoricalThreadMessages({
+        emailProvider,
+        threadId,
+        fallbackMessages: historicalMatches.filter(
+          (message) => message.threadId === threadId,
+        ),
+      }),
+    ),
+  );
+
+  return dedupeMessages(
+    filterCurrentThreadMessages(threadMessages.flat(), currentThread),
+  )
+    .slice(0, MAX_EXPANDED_EMAILS_PER_QUERY)
+    .map((message) => getEmailForLLM(message, { maxLength: 2000 }));
+}
+
+async function getHistoricalThreadMessages({
+  emailProvider,
+  threadId,
+  fallbackMessages,
+}: {
+  emailProvider: EmailProvider;
+  threadId: string;
+  fallbackMessages: ParsedMessage[];
+}) {
+  try {
+    return await emailProvider.getThreadMessages(threadId);
+  } catch (error) {
+    logger.warn("Failed to expand search result thread", {
+      error,
+      threadId,
+      emailProvider: emailProvider.name,
+    });
+    return fallbackMessages;
+  }
+}
+
+function filterCurrentThreadMessages(
+  messages: ParsedMessage[],
+  currentThread: ReplyContextThreadEmail[],
+) {
+  const currentMessageIds = new Set(
+    currentThread.map((message) => message.id).filter(Boolean),
+  );
+  const currentThreadIds = new Set(
+    currentThread
+      .map((message) => message.threadId)
+      .filter((threadId): threadId is string => !!threadId),
+  );
+
+  return messages.filter(
+    (message) =>
+      !currentMessageIds.has(message.id) &&
+      !currentThreadIds.has(message.threadId),
+  );
+}
+
+function dedupeMessages(messages: ParsedMessage[]) {
+  const seenMessageIds = new Set<string>();
+
+  return messages.filter((message) => {
+    if (seenMessageIds.has(message.id)) return false;
+    seenMessageIds.add(message.id);
+    return true;
+  });
+}
+
+function getUniqueThreadIds(messages: ParsedMessage[]) {
+  const threadIds: string[] = [];
+  const seenThreadIds = new Set<string>();
+
+  for (const message of messages) {
+    if (seenThreadIds.has(message.threadId)) continue;
+    seenThreadIds.add(message.threadId);
+    threadIds.push(message.threadId);
+  }
+
+  return threadIds;
+}
+
+type ReplyContextThreadEmail = EmailForLLM & {
+  threadId?: string | null;
+};

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -214,6 +214,7 @@ async function generateDraftContent(
 
   const messages = threadMessages.map((msg, index) => ({
     date: internalDateToDate(msg.internalDate),
+    threadId: msg.threadId,
     ...getEmailForLLM(msg, {
       // give more context for the message we're processing
       maxLength: index === threadMessages.length - 1 ? 2000 : 500,


### PR DESCRIPTION
Expands reply-context searches so historical matches are expanded to their full threads while current-thread messages are excluded.

Adds provider-backed integration coverage for thread expansion and updates test seed helpers for explicit thread metadata.

Bumps the draft pipeline attribution version for the behavior change.