### PR TITLE
reply-context: Improve thread context selection

### DIFF
--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 13;
+export const DRAFT_PIPELINE_VERSION = 14;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/reply-context-collector.test.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, vi } from "vitest";
+import { searchReplyContextEmails } from "./reply-context-collector";
+import type { EmailProvider } from "@/utils/email/types";
+import type { ParsedMessage } from "@/utils/types";
+
+vi.mock("server-only", () => ({}));
+
+describe("searchReplyContextEmails", () => {
+  test("prioritizes search hits, nearby context, and sent replies in long threads", async () => {
+    const threadMessages = Array.from({ length: 100 }, (_, index) =>
+      getMessage({
+        id: `message-${index + 1}`,
+        textPlain: `Generic thread message ${index + 1}`,
+      }),
+    );
+    const matchingMessage = getMessage({
+      id: "message-70",
+      textPlain: "The customer asks about a matching product issue.",
+    });
+    const sentReply = getMessage({
+      id: "message-71",
+      from: "account@example.com",
+      labelIds: ["SENT"],
+      textPlain: "The user explains the correct support path.",
+    });
+
+    threadMessages[69] = matchingMessage;
+    threadMessages[70] = sentReply;
+
+    const provider = getProvider({
+      searchResults: [matchingMessage],
+      threadMessages,
+    });
+
+    const results = await searchReplyContextEmails({
+      emailProvider: provider,
+      query: "product issue",
+      after: new Date("2026-01-01T00:00:00Z"),
+      currentThread: [
+        {
+          id: "current-message",
+          threadId: "current-thread",
+          from: "customer@example.com",
+          to: "account@example.com",
+          subject: "Current request",
+          content: "Current request body",
+        },
+      ],
+    });
+    const resultIds = results.map((email) => email.id);
+
+    expect(resultIds).toContain("message-70");
+    expect(resultIds).toContain("message-71");
+    expect(resultIds).toContain("message-69");
+    expect(resultIds).not.toContain("message-1");
+    expect(resultIds).not.toContain("message-40");
+    expect(results.length).toBeLessThanOrEqual(12);
+  });
+
+  test("keeps short historical threads intact", async () => {
+    const threadMessages = [
+      getMessage({ id: "message-1", textPlain: "Matching request" }),
+      getMessage({
+        id: "message-2",
+        from: "account@example.com",
+        labelIds: ["SENT"],
+        textPlain: "Useful answer",
+      }),
+      getMessage({ id: "message-3", textPlain: "Follow-up" }),
+    ];
+    const provider = getProvider({
+      searchResults: [threadMessages[0]],
+      threadMessages,
+    });
+
+    const results = await searchReplyContextEmails({
+      emailProvider: provider,
+      query: "request",
+      after: new Date("2026-01-01T00:00:00Z"),
+      currentThread: [],
+    });
+
+    expect(results.map((email) => email.id)).toEqual([
+      "message-1",
+      "message-2",
+      "message-3",
+    ]);
+  });
+});
+
+function getProvider({
+  searchResults,
+  threadMessages,
+}: {
+  searchResults: ParsedMessage[];
+  threadMessages: ParsedMessage[];
+}) {
+  return {
+    name: "google",
+    getMessagesWithPagination: vi.fn().mockResolvedValue({
+      messages: searchResults,
+    }),
+    getThreadMessages: vi.fn().mockResolvedValue(threadMessages),
+  } as unknown as EmailProvider;
+}
+
+function getMessage({
+  id,
+  from = "customer@example.com",
+  labelIds = ["INBOX"],
+  parentFolderId,
+  textPlain,
+}: {
+  id: string;
+  from?: string;
+  labelIds?: string[];
+  parentFolderId?: string;
+  textPlain: string;
+}): ParsedMessage {
+  return {
+    id,
+    threadId: "thread-1",
+    historyId: "history-1",
+    date: "2026-05-01T00:00:00.000Z",
+    internalDate: "1777593600000",
+    subject: "Test thread",
+    snippet: textPlain,
+    textPlain,
+    textHtml: "",
+    labelIds,
+    parentFolderId,
+    attachments: [],
+    inline: [],
+    headers: {
+      from,
+      to: "account@example.com",
+      subject: "Test thread",
+      date: "2026-05-01T00:00:00.000Z",
+      "message-id": `<${id}@example.com>`,
+    },
+  };
+}

--- a/apps/web/utils/ai/reply/reply-context-collector.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.ts
@@ -317,12 +317,10 @@ function selectThreadContextMessages({
   }
 
   const rankedMessages = messages
-    .map((message, index) => ({
-      index,
-      message,
-      rank: getThreadContextRank({ message, index, matchIndexes }),
-    }))
-    .filter(({ rank }) => rank !== null)
+    .flatMap((message, index) => {
+      const rank = getThreadContextRank({ message, index, matchIndexes });
+      return rank === null ? [] : [{ index, message, rank }];
+    })
     .sort((a, b) => a.rank - b.rank || a.index - b.index)
     .slice(0, MAX_CONTEXT_EMAILS_PER_THREAD)
     .sort((a, b) => a.index - b.index);

--- a/apps/web/utils/ai/reply/reply-context-collector.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.ts
@@ -22,6 +22,9 @@ const logger = createScopedLogger("reply-context-collector");
 const SEARCH_RESULTS_PER_QUERY = 20;
 const MAX_EXPANDED_THREADS_PER_QUERY = 5;
 const MAX_EXPANDED_EMAILS_PER_QUERY = 40;
+const MAX_CONTEXT_EMAILS_PER_THREAD = 12;
+const THREAD_CONTEXT_BEFORE_MATCH = 2;
+const THREAD_CONTEXT_AFTER_MATCH = 4;
 
 const resultSchema = z.object({
   notes: z
@@ -231,15 +234,21 @@ export async function searchReplyContextEmails({
   if (threadIds.length === 0) return [];
 
   const threadMessages = await Promise.all(
-    threadIds.map((threadId) =>
-      getHistoricalThreadMessages({
+    threadIds.map(async (threadId) => {
+      const matchingMessages = historicalMatches.filter(
+        (message) => message.threadId === threadId,
+      );
+      const messages = await getHistoricalThreadMessages({
         emailProvider,
         threadId,
-        fallbackMessages: historicalMatches.filter(
-          (message) => message.threadId === threadId,
-        ),
-      }),
-    ),
+        fallbackMessages: matchingMessages,
+      });
+
+      return selectThreadContextMessages({
+        messages,
+        matchingMessages,
+      });
+    }),
   );
 
   return uniqBy(
@@ -286,5 +295,73 @@ function filterCurrentThreadMessages(
     (message) =>
       !currentMessageIds.has(message.id) &&
       !currentThreadIds.has(message.threadId),
+  );
+}
+
+function selectThreadContextMessages({
+  messages,
+  matchingMessages,
+}: {
+  messages: ParsedMessage[];
+  matchingMessages: ParsedMessage[];
+}) {
+  if (messages.length <= MAX_CONTEXT_EMAILS_PER_THREAD) return messages;
+
+  const matchIds = new Set(matchingMessages.map((message) => message.id));
+  const matchIndexes = messages.flatMap((message, index) =>
+    matchIds.has(message.id) ? [index] : [],
+  );
+
+  if (matchIndexes.length === 0) {
+    return messages.slice(0, MAX_CONTEXT_EMAILS_PER_THREAD);
+  }
+
+  const rankedMessages = messages
+    .map((message, index) => ({
+      index,
+      message,
+      rank: getThreadContextRank({ message, index, matchIndexes }),
+    }))
+    .filter(({ rank }) => rank !== null)
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .slice(0, MAX_CONTEXT_EMAILS_PER_THREAD)
+    .sort((a, b) => a.index - b.index);
+
+  return rankedMessages.map(({ message }) => message);
+}
+
+function getThreadContextRank({
+  message,
+  index,
+  matchIndexes,
+}: {
+  message: ParsedMessage;
+  index: number;
+  matchIndexes: number[];
+}) {
+  const distanceFromMatch = Math.min(
+    ...matchIndexes.map((matchIndex) => Math.abs(index - matchIndex)),
+  );
+
+  if (distanceFromMatch === 0) return 0;
+
+  const inContextWindow = matchIndexes.some(
+    (matchIndex) =>
+      index >= matchIndex - THREAD_CONTEXT_BEFORE_MATCH &&
+      index <= matchIndex + THREAD_CONTEXT_AFTER_MATCH,
+  );
+
+  if (inContextWindow && isSentMessage(message)) return 1;
+  if (inContextWindow) return 2 + distanceFromMatch;
+  if (isSentMessage(message)) return 100 + distanceFromMatch;
+
+  return null;
+}
+
+function isSentMessage(message: ParsedMessage) {
+  return (
+    message.labelIds?.some((label) => label.toLowerCase() === "sent") ||
+    message.parentFolderId?.toLowerCase().includes("sent") ||
+    false
   );
 }


### PR DESCRIPTION
Selects a smaller, more relevant subset from expanded historical threads by prioritizing search hits, nearby context, and sent replies.

Adds focused unit coverage for long-thread selection while preserving short-thread behavior.

Bumps the draft pipeline attribution version for the retrieval behavior change.