### PR TITLE
docker: Fix pnpm workspace manifests in image build

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -23,6 +23,8 @@ COPY apps/web/package.json apps/web/package.json
 COPY apps/worker/package.json apps/worker/package.json
 COPY apps/image-proxy/package.json apps/image-proxy/package.json
 COPY apps/image-proxy-aws/package.json apps/image-proxy-aws/package.json
+COPY packages/api/package.json packages/api/package.json
+COPY packages/cli/package.json packages/cli/package.json
 COPY packages/image-proxy/package.json packages/image-proxy/package.json
 COPY packages/loops/package.json packages/loops/package.json
 COPY packages/resend/package.json packages/resend/package.json

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -12,6 +12,8 @@ COPY apps/web/package.json apps/web/package.json
 COPY apps/worker/package.json apps/worker/package.json
 COPY apps/image-proxy/package.json apps/image-proxy/package.json
 COPY apps/image-proxy-aws/package.json apps/image-proxy-aws/package.json
+COPY packages/api/package.json packages/api/package.json
+COPY packages/cli/package.json packages/cli/package.json
 COPY packages/image-proxy/package.json packages/image-proxy/package.json
 COPY packages/loops/package.json packages/loops/package.json
 COPY packages/resend/package.json packages/resend/package.json


### PR DESCRIPTION
Fix the Docker build layer so pnpm sees the same workspace package graph during install and build. This prevents pnpm from trying to repair node_modules from a non-TTY Docker layer.\n\n- Add missing packages/api and packages/cli manifests to the Docker install cache layer\n- Keep prod and local Dockerfiles aligned\n- Statically verified both Dockerfiles now include every apps/* and packages/* package manifest