### PR TITLE
docker: Run pnpm image builds in CI mode

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -17,6 +17,9 @@ WORKDIR /app
 RUN apk add --no-cache openssl
 RUN npm install -g pnpm@10.33.0
 
+# Docker build layers are non-interactive; let pnpm handle module purges without a TTY.
+ENV CI=true
+
 # Copy lockfiles/workspace manifests for better caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc* ./
 COPY apps/web/package.json apps/web/package.json

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -6,6 +6,9 @@ WORKDIR /app
 RUN apk add --no-cache openssl
 RUN npm install -g pnpm@10.33.0
 
+# Docker build layers are non-interactive; let pnpm handle module purges without a TTY.
+ENV CI=true
+
 # Copy lockfiles/workspace manifests for better caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc* ./
 COPY apps/web/package.json apps/web/package.json


### PR DESCRIPTION
The Docker image build still failed after the workspace manifest fix because pnpm tried to repair node_modules from a non-interactive Docker layer and aborted without a TTY.\n\n- Set CI=true in prod and local Docker builder stages before pnpm runs\n- Lets pnpm handle required module purges during image builds without prompting\n- Verified against the post-merge failure log from run 25767670277