### PR TITLE
docker: Align pnpm version with package manager

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -15,7 +15,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache openssl
-RUN npm install -g pnpm@10.33.0
+RUN npm install -g pnpm@11.0.9
 
 # Docker build layers are non-interactive; let pnpm handle module purges without a TTY.
 ENV CI=true

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -4,7 +4,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache openssl
-RUN npm install -g pnpm@10.33.0
+RUN npm install -g pnpm@11.0.9
 
 # Docker build layers are non-interactive; let pnpm handle module purges without a TTY.
 ENV CI=true

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk add --no-cache openssl
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@11.0.9
 
 COPY . .
 


### PR DESCRIPTION
Align Docker pnpm installs with the repository packageManager version.\n\n- Update prod and local Dockerfiles from pnpm 10.33.0 to pnpm 11.0.9\n- Pin Dockerfile.web to pnpm 11.0.9 instead of installing the latest pnpm\n- Verified pinned pnpm references now match package.json