### PR TITLE
filing: Thread Outlook notifications into source conversation

### DIFF
--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -108,6 +108,33 @@ describe("processAttachment", () => {
     expect(sendAskNotification).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { kind: "filed", confidence: 0.95, mock: () => sendFiledNotification },
+    { kind: "ask", confidence: 0.4, mock: () => sendAskNotification },
+  ])("passes the platform message id in sourceMessage for $kind notifications so Outlook can thread the reply", async ({
+    confidence,
+    mock,
+  }) => {
+    const { attachment, emailAccount, emailProvider, message } =
+      setupSuccessfulFiling({ confidence });
+
+    await processAttachment({
+      attachment,
+      emailAccount,
+      emailProvider,
+      logger,
+      message,
+    });
+
+    expect(mock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceMessage: expect.objectContaining({
+          messageId: message.id,
+        }),
+      }),
+    );
+  });
+
   it("skips filed confirmation emails when disabled", async () => {
     const { attachment, emailAccount, emailProvider, message, uploadFile } =
       setupSuccessfulFiling({

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -307,6 +307,7 @@ export async function processAttachment({
         threadId: message.threadId,
         headerMessageId: message.headers["message-id"] || "",
         references: message.headers.references,
+        messageId: message.id,
       };
 
       try {

--- a/apps/web/utils/drive/filing-notifications.ts
+++ b/apps/web/utils/drive/filing-notifications.ts
@@ -13,6 +13,10 @@ import { escapeHtml } from "@/utils/string";
 
 interface SourceMessageInfo {
   headerMessageId: string;
+  // Platform-specific message ID (e.g. Microsoft Graph ID) — required so
+  // Outlook's createReply can thread the notification into the source
+  // conversation instead of starting a new thread.
+  messageId?: string;
   references?: string;
   threadId: string;
 }


### PR DESCRIPTION
## Summary

Pass the platform message ID through `SourceMessageInfo` so Outlook's `createReply` can thread filing notifications into the original conversation instead of starting a new thread (INB-250).

- Add `messageId` to `SourceMessageInfo` for the platform-native id (e.g. Microsoft Graph id)
- Populate it from `message.id` in `processAttachment` before sending filed/ask notifications
- Cover both notification kinds with a parameterized test

## Test plan

- [x] `pnpm test apps/web/utils/drive/filing-engine.test.ts`
- [ ] Verify in Outlook that filing notifications appear as replies in the original thread