### PR TITLE
outlook: Route business accounts to office.com host

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -401,13 +401,13 @@ describe("pending email handled state helpers", () => {
           expect.objectContaining({
             type: "link-button",
             label: "Open in Outlook",
-            url: "https://outlook.live.com/mail/0/inbox/id/message-1",
+            url: "https://outlook.office.com/mail/inbox/id/message-1",
           }),
         ],
       }),
     ]);
     expect(JSON.stringify(textChildren)).not.toContain(
-      "https://outlook.live.com/mail/0/inbox/id/message-1",
+      "https://outlook.office.com/mail/inbox/id/message-1",
     );
   });
 

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -892,7 +892,7 @@ describe("sendMessagingRuleNotification", () => {
 
     expect(serializedBlocks).toContain("Open in Outlook");
     expect(serializedBlocks).toContain(
-      "https://outlook.live.com/mail/0/inbox/id/message-1",
+      "https://outlook.office.com/mail/inbox/id/message-1",
     );
   });
 

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -35,25 +35,67 @@ describe("getEmailUrl", () => {
       expected: "https://mail.google.com/mail/u/0/#all/msg123",
     },
     {
-      name: "Microsoft provider with message ID",
+      name: "Microsoft provider with personal email",
       messageOrThreadId: "msg123",
       emailAddress: "user@outlook.com",
       provider: "microsoft",
       expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
     },
     {
+      name: "Microsoft provider with hotmail email",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@hotmail.com",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with business email",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@contoso.com",
+      provider: "microsoft",
+      expected: "https://outlook.office.com/mail/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with country-coded personal email",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@outlook.fr",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with live.co.uk email",
+      messageOrThreadId: "msg123",
+      emailAddress: "user@live.co.uk",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with uppercase personal email",
+      messageOrThreadId: "msg123",
+      emailAddress: "User@Outlook.com",
+      provider: "microsoft",
+      expected: "https://outlook.live.com/mail/0/inbox/id/msg123",
+    },
+    {
+      name: "Microsoft provider with no email defaults to office host",
+      messageOrThreadId: "msg123",
+      emailAddress: null,
+      provider: "microsoft",
+      expected: "https://outlook.office.com/mail/inbox/id/msg123",
+    },
+    {
       name: "Microsoft provider with special characters in message ID",
       messageOrThreadId: "msg+123/abc",
       emailAddress: null,
       provider: "microsoft",
-      expected: "https://outlook.live.com/mail/0/inbox/id/msg%2B123%2Fabc",
+      expected: "https://outlook.office.com/mail/inbox/id/msg%2B123%2Fabc",
     },
     {
       name: "Microsoft provider with spaces and special chars in message ID",
       messageOrThreadId: "msg id=abc",
       emailAddress: null,
       provider: "microsoft",
-      expected: "https://outlook.live.com/mail/0/inbox/id/msg%20id%3Dabc",
+      expected: "https://outlook.office.com/mail/inbox/id/msg%20id%3Dabc",
     },
     {
       name: "undefined provider",
@@ -101,10 +143,16 @@ describe("getEmailUrlForMessage", () => {
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/messageId123",
     },
     {
-      name: "Microsoft provider",
+      name: "Microsoft provider with personal email",
       emailAddress: "user@outlook.com",
       provider: "microsoft",
       expected: "https://outlook.live.com/mail/0/inbox/id/messageId123",
+    },
+    {
+      name: "Microsoft provider with business email",
+      emailAddress: "user@contoso.com",
+      provider: "microsoft",
+      expected: "https://outlook.office.com/mail/inbox/id/messageId123",
     },
     {
       name: "default provider",
@@ -225,11 +273,18 @@ describe("getEmailSearchUrl", () => {
         "https://mail.google.com/mail/u/?authuser=user%40gmail.com#advanced-search/from=sender%40example.com",
     },
     {
-      name: "Microsoft provider",
+      name: "Microsoft provider with personal email",
       emailAddress: "user@outlook.com",
       provider: "microsoft",
       expected:
         "https://outlook.live.com/mail/0/search/q/from%3Asender%40example.com",
+    },
+    {
+      name: "Microsoft provider with business email",
+      emailAddress: "user@contoso.com",
+      provider: "microsoft",
+      expected:
+        "https://outlook.office.com/mail/search/q/from%3Asender%40example.com",
     },
     {
       name: "empty provider",

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -1,3 +1,5 @@
+import { extractDomainFromEmail } from "@/utils/email";
+
 function getGmailUrlForFragment(
   fragment: string,
   emailAddress?: string | null,
@@ -7,8 +9,28 @@ function getGmailUrlForFragment(
   return `https://mail.google.com/mail/u/?authuser=${encodeURIComponent(emailAddress)}#${fragment}`;
 }
 
-function getOutlookBaseUrl() {
-  return "https://outlook.live.com/mail/0";
+// Personal Microsoft accounts (outlook / hotmail / live / msn) sign in at
+// outlook.live.com; everything else is an Entra ID / Microsoft 365 mailbox
+// served from outlook.office.com. The two hosts route to separate services, so
+// pointing a business user at outlook.live.com lands them on the homepage.
+// Prefix match covers country variants like outlook.fr, live.co.uk, hotmail.de.
+const PERSONAL_MICROSOFT_DOMAIN_PREFIXES = ["outlook.", "hotmail.", "live."];
+const PERSONAL_MICROSOFT_DOMAINS = new Set(["msn.com", "passport.com"]);
+
+function isPersonalMicrosoftEmail(emailAddress?: string | null) {
+  if (!emailAddress) return false;
+  const domain = extractDomainFromEmail(emailAddress).toLowerCase();
+  if (!domain) return false;
+  if (PERSONAL_MICROSOFT_DOMAINS.has(domain)) return true;
+  return PERSONAL_MICROSOFT_DOMAIN_PREFIXES.some((prefix) =>
+    domain.startsWith(prefix),
+  );
+}
+
+function getOutlookBaseUrl(emailAddress?: string | null) {
+  return isPersonalMicrosoftEmail(emailAddress)
+    ? "https://outlook.live.com/mail/0"
+    : "https://outlook.office.com/mail";
 }
 
 const PROVIDER_CONFIG: Record<
@@ -25,16 +47,14 @@ const PROVIDER_CONFIG: Record<
 > = {
   microsoft: {
     requiresMessageId: true,
-    buildUrl: (messageOrThreadId: string, _emailAddress?: string | null) => {
-      // Outlook URL format: https://outlook.live.com/mail/0/inbox/id/ENCODED_MESSAGE_ID
-      // The message ID needs to be URL-encoded for Outlook
+    buildUrl: (messageOrThreadId: string, emailAddress?: string | null) => {
       const encodedMessageId = encodeURIComponent(messageOrThreadId);
-      return `${getOutlookBaseUrl()}/inbox/id/${encodedMessageId}`;
+      return `${getOutlookBaseUrl(emailAddress)}/inbox/id/${encodedMessageId}`;
     },
     selectId: (messageId: string, _threadId: string) => messageId,
-    buildSearchUrl: (from: string, _emailAddress?: string | null) => {
+    buildSearchUrl: (from: string, emailAddress?: string | null) => {
       const query = encodeURIComponent(`from:${from}`);
-      return `${getOutlookBaseUrl()}/search/q/${query}`;
+      return `${getOutlookBaseUrl(emailAddress)}/search/q/${query}`;
     },
   },
   google: {


### PR DESCRIPTION
## Summary

The "Open in Outlook" button sent every Microsoft user to `outlook.live.com`, which is only valid for personal accounts (outlook/hotmail/live/msn). Business/Entra ID mailboxes redirected to the Outlook homepage instead of the target message.

- Detect account type from the email domain (covers country variants like `outlook.fr`, `live.co.uk`, `hotmail.de`) and route personal accounts to `outlook.live.com`, business accounts to `outlook.office.com`.
- Applies to message links and search links generated via `getEmailUrl` / `getEmailUrlForMessage` / `getEmailSearchUrl`.
- Tests updated for both hosts plus uppercase / country-variant / missing-email cases.

## Test plan

- [x] `pnpm test apps/web/utils/url.test.ts`
- [x] `pnpm test apps/web/utils/messaging/chat-sdk/bot.test.ts`
- [x] `pnpm test apps/web/utils/messaging/rule-notifications.test.ts`
- [ ] Manually verify "Open in Outlook" link on a business Microsoft account

🤖 Generated with [Claude Code](https://claude.com/claude-code)