### PR TITLE
docs: Refresh documentation references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,23 +2,28 @@
 
 The initial version of this document was created by Google Gemini 2.0 Flash Thinking Experimental 01-21.
 
-The Inbox Zero repository is structured as a monorepo, consisting of one main application (`apps/web`) and several packages (`packages/*`).
+The Inbox Zero repository is structured as a monorepo, consisting of the main web application (`apps/web`), supporting deployable apps, and shared packages.
 
 ```txt
 ├── apps/
-│ └── web/ // Main Next.js Web Application (Frontend and Backend)
+│ ├── web/ // Main Next.js web application (frontend and backend)
+│ ├── worker/ // Background worker process
+│ ├── image-proxy/ // Cloudflare Worker image proxy
+│ └── image-proxy-aws/ // AWS image proxy
 ├── packages/ // Reusable libraries and configurations
-│ ├── eslint-config/
+│ ├── api/
+│ ├── cli/
+│ ├── image-proxy/
 │ ├── loops/
 │ ├── resend/
+│ ├── scheduling/
 │ ├── tinybird/
 │ ├── tinybird-ai-analytics/
 │ └── tsconfig/
-├── prisma/ // Database schema and migrations
-├── sanity/ // Sanity CMS configuration
-├── store/ // Jotai-based state management and queues
-├── utils/ // Utility functions, server actions, and AI logic
-├── docker/ // Docker configurations
+├── charts/ // Helm chart for Kubernetes deployments
+├── docker/ // Docker configurations and deployment scripts
+├── docs/ // Public documentation site
+├── qa/ // Browser QA flow definitions
 └── ... // Other configuration and documentation files
 ```
 
@@ -33,41 +38,36 @@ The Inbox Zero repository is structured as a monorepo, consisting of one main ap
   - `styles/`: Global CSS and styling configurations (Tailwind CSS).
   - `providers/`: React Context providers for state management and service integration.
   - `store/`: Jotai atoms for application-wide state management and queue handling.
-  - `sanity/`: Integration with Sanity CMS for blog and content management.
+  - `prisma/`: Database schema and migrations.
 - **Key Functionalities:**
   - User interface for all features (AI assistant, unsubscriber, analytics, settings).
   - User authentication and session management (Better Auth).
-  - API endpoints for interacting with Gmail API, AI models, and other services.
+  - API endpoints for interacting with Gmail, Outlook, AI models, and other services.
   - Server-side rendering and data fetching.
-  - Integration with payment processing (Lemon Squeezy) and analytics (Tinybird, PostHog).
+  - Integration with payment processing (Stripe, Lemon Squeezy, Apple IAP) and analytics/logging (Tinybird, PostHog, Axiom).
 
 ### 2. `packages` - Reusable Packages
 
 - **Purpose:** Contains reusable libraries, configurations, and utilities shared by the web app.
 - **Key Packages:**
-  - `eslint-config`: ESLint configurations for consistent code linting.
+  - `api`: CLI wrapper for the public API.
+  - `cli`: Self-hosting and deployment CLI.
+  - `image-proxy`: Shared image proxy utilities.
   - `loops`: Related to marketing email automation.
   - `resend`: Integration with Resend for transactional email sending.
+  - `scheduling`: Shared scheduling helpers.
   - `tinybird`: Integration with Tinybird for real-time analytics.
   - `tinybird-ai-analytics`: Integration with Tinybird for AI usage analytics.
   - `tsconfig`: Shared TypeScript configurations.
 
-### 3. `prisma` - Database Layer
+### 3. `apps/web/prisma` - Database Layer
 
 - **Purpose:** Manages the PostgreSQL database schema and migrations.
 - **Key Files:**
   - `schema.prisma`: Defines the database schema using Prisma Schema Language.
   - `migrations/`: Contains database migration files for schema updates.
 
-### 4. `sanity` - Content Management System
-
-- **Purpose:** Integrates Sanity.io as a headless CMS for managing blog posts and potentially other content.
-- **Key Files:**
-  - `sanity.config.ts`: Sanity Studio configuration.
-  - `schemaTypes/`: Defines the schema types for Sanity content.
-  - `lib/`: Contains utility functions for interacting with the Sanity API.
-
-### 5. `store` - State Management and Queues
+### 4. `apps/web/store` - State Management and Queues
 
 - **Purpose:** Implements client-side state management using Jotai and defines queues for background task processing.
 - **Key Files:**
@@ -77,7 +77,7 @@ The Inbox Zero repository is structured as a monorepo, consisting of one main ap
   - `archive-sender-queue.ts`: Queue for bulk sender archiving.
   - `ai-categorize-sender-queue.ts`: Queue for AI-based sender categorization.
 
-### 6. `utils` - Utilities and Core Logic
+### 5. `apps/web/utils` - Utilities and Core Logic
 
 - **Purpose:** Houses utility functions, shared logic, and server actions.
 - **Key Directories:**
@@ -89,7 +89,7 @@ The Inbox Zero repository is structured as a monorepo, consisting of one main ap
   - `rule/`: Rule-related utilities (prompt file parsing, rule fixing, etc.).
   - `scripts/`: Scripts for database migrations, data manipulation, and other maintenance tasks.
 
-### 7. `docker` - Docker Configuration
+### 6. `docker` - Docker Configuration
 
 - **Purpose:** Contains Dockerfile for containerizing the web application.
 - **Key Files:**
@@ -106,17 +106,17 @@ The application exposes the following API endpoints under `apps/web/app/api/`:
 - `/api/lemon-squeezy/*`: Lemon Squeezy webhook and API integration endpoints.
 - `/api/resend/*`: Resend API integration endpoints (email sending, summary emails, all emails).
 - `/api/user/*`: User-specific data and actions endpoints (planned rules, history, settings, categories, groups, cold emails, bulk archive, usage, me).
-- `/api/v1/*`: Versioned API endpoints, for external integrations (group emails, OpenAPI documentation).
+- `/api/v1/*`: Versioned API endpoints for external integrations (rules, stats, OpenAPI documentation).
 
 ## Key Data Flows
 
 1.  **Email Processing and AI Automation:**
 
-    - Gmail webhook receives email notifications.
-    - Webhook handler (`/api/google/webhook`) fetches email details from Gmail API.
+    - Gmail or Outlook webhooks receive email notifications.
+    - Provider webhook handlers fetch email details from Gmail or Microsoft Graph.
     - Email data is passed to AI rule engine (`utils/ai/choose-rule`) to find matching rules.
     - Matching rules are executed, potentially involving AI-generated actions (`utils/ai/actions`).
-    - Actions (archive, label, reply, etc.) are performed via Gmail API.
+    - Actions (archive, label, reply, etc.) are performed through the active email provider.
     - Executed rules and actions are stored in the database (Prisma).
 
 2.  **Bulk Unsubscriber:**

--- a/docs/api-reference/endpoint/get-group-emails.mdx
+++ b/docs/api-reference/endpoint/get-group-emails.mdx
@@ -1,4 +1,0 @@
----
-title: "Get learned pattern emails"
-openapi: "GET /group/{groupId}/emails"
----

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -28,7 +28,7 @@ API keys are scoped to a specific inbox account and only grant access to the per
 
 ### Self-Hosting
 
-If you are self-hosting Inbox Zero, set the `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true` environment variable and rebuild the app to enable the API. Use your deployment URL as the base URL for requests (for example, `https://your-domain.com/api/v1`).
+If you are self-hosting Inbox Zero, set `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true` and `API_KEY_SALT` before rebuilding the app. Generate the salt with `openssl rand -hex 32`. Use your deployment URL as the base URL for requests (for example, `https://your-domain.com/api/v1`).
 
 ## Base URL
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -172,8 +172,8 @@ To test a production build locally:
 
 ```bash
 # Without Docker
-pnpm run build
-pnpm start --filter=web
+pnpm build
+pnpm --filter inbox-zero-ai start
 
 # With Docker (includes Postgres and Redis)
 NEXT_PUBLIC_BASE_URL=http://localhost:3000 docker compose --profile all up --build

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,7 +138,6 @@
               "api-reference/cli",
               "api-reference/endpoint/get-statsby-period",
               "api-reference/endpoint/get-statsresponse-time",
-              "api-reference/endpoint/get-group-emails",
               "api-reference/endpoint/get-rules",
               "api-reference/endpoint/post-rules",
               "api-reference/endpoint/get-rules-id",
@@ -180,7 +179,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "mailto:elie@getinboxzero.com"
+        "href": "mailto:support@getinboxzero.com"
       }
     ],
     "primary": {

--- a/docs/essentials/inbox-zero-tabs-extension.mdx
+++ b/docs/essentials/inbox-zero-tabs-extension.mdx
@@ -85,5 +85,4 @@ The extension runs entirely in your browser. No data is collected, no account is
 
 ## Support
 
-Need help? Contact us at [elie@getinboxzero.com](mailto:elie@getinboxzero.com) or visit our [support page](https://getinboxzero.com).
- 
+Need help? Contact us at [support@getinboxzero.com](mailto:support@getinboxzero.com) or visit our [support page](https://getinboxzero.com).

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -1,16 +1,18 @@
 ---
 title: 'Environment Variables'
-description: 'Reference for all environment variables used in Inbox Zero'
+description: 'Reference for self-hosting environment variables used in Inbox Zero'
 ---
 
-Comprehensive reference for all environment variables relevant to self-hosting Inbox Zero.
+Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-only billing, analytics, and internal operations variables are intentionally omitted unless they affect common self-hosted deployments.
 
-## All Environment Variables
+## Self-Hosting Environment Variables
 
 | Variable | Required | Description | Default |
 |----------|----------|-------------|---------|
 | **Core** ||||
 | `DATABASE_URL` | Yes | PostgreSQL connection string | — |
+| `DIRECT_URL` | No* | Direct PostgreSQL connection used by Prisma migrations. Set this when your pooled `DATABASE_URL` cannot run migrations. Docker Compose sets it automatically. | `DATABASE_URL` |
+| `DATABASE_URL_UNPOOLED` | No | Alternative unpooled PostgreSQL URL used by the app runtime in preview-style environments | — |
 | `NEXT_PUBLIC_BASE_URL` | Yes | Public URL where app is hosted (e.g., `https://yourdomain.com`) | — |
 | `INTERNAL_API_KEY` | Yes | Secret key for internal API calls. Generate with `openssl rand -hex 32` | — |
 | `AUTH_SECRET` | Yes | better-auth secret. Generate with `openssl rand -hex 32` | — |
@@ -24,7 +26,13 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | **Microsoft OAuth** ||||
 | `MICROSOFT_CLIENT_ID` | No | OAuth client ID from Azure Portal | — |
 | `MICROSOFT_CLIENT_SECRET` | No | OAuth client secret from Azure Portal | — |
+| `MICROSOFT_TENANT_ID` | No | Microsoft tenant used for OAuth (`common` for multi-tenant/personal-account support, or your tenant ID for single tenant) | `common` |
 | `MICROSOFT_WEBHOOK_CLIENT_STATE` | No | Secret for Microsoft webhook verification. Generate with `openssl rand -hex 32` | — |
+| **Slack** ||||
+| `SLACK_CLIENT_ID` | No | Slack OAuth client ID | — |
+| `SLACK_CLIENT_SECRET` | No | Slack OAuth client secret | — |
+| `SLACK_SIGNING_SECRET` | No | Slack signing secret used to verify requests | — |
+| `NEXT_PUBLIC_SLACK_BOT_NAME` | No | Bot display name shown in the app | `Inbox Zero` |
 | **Messaging Adapters** ||||
 | `TEAMS_BOT_APP_ID` | No | Microsoft Teams bot app ID | — |
 | `TEAMS_BOT_APP_PASSWORD` | No | Microsoft Teams bot app password/secret | — |
@@ -56,10 +64,15 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `CHAT_LLM_MODEL` | No | Model for chat provider | — |
 | `CHAT_LLM_FALLBACKS` | No | Fallback chain for chat model type (`provider:model`, explicit model required) | — |
 | `CHAT_OPENROUTER_PROVIDERS` | No | OpenRouter providers for chat | — |
+| `NANO_LLM_PROVIDER` | No | Provider for lightweight classification/extraction tasks | Falls back to economy/default |
+| `NANO_LLM_MODEL` | No | Model for nano provider | — |
+| `DRAFT_LLM_PROVIDER` | No | Provider for drafting replies | Falls back to default |
+| `DRAFT_LLM_MODEL` | No | Model for draft provider | — |
 | **LLM Provider Credentials** ||||
 | `LLM_API_KEY` | No | Shared fallback API key for LLM providers. Used when a provider-specific key is not set. | — |
 | `ANTHROPIC_API_KEY` | No | Anthropic API key | — |
 | `OPENAI_API_KEY` | No | OpenAI API key | — |
+| `OPENAI_ZERO_DATA_RETENTION` | No | Pass OpenAI zero-data-retention provider options when your OpenAI account is approved for it | `false` |
 | `GOOGLE_API_KEY` | No | Google Gemini API key | — |
 | `GOOGLE_THINKING_BUDGET` | No | Override the thinking budget for Gemini 2.x/2.5 models used through Google, Vertex, or AI Gateway. Set to `0` to omit the budget. Gemini 3 models still use minimal thinking. | `128` |
 | `GROQ_API_KEY` | No | Groq API key | — |
@@ -82,8 +95,10 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `BEDROCK_REGION` | No | AWS region for Bedrock | `us-west-2` |
 | **Ollama (Local LLM)** ||||
 | `OLLAMA_BASE_URL` | No | Ollama API endpoint (e.g., `http://localhost:11434/api`) | — |
+| `OLLAMA_MODEL` | No | Ollama model name when configured separately from the selected LLM tier model | — |
 | **OpenAI-Compatible (Local LLM)** ||||
 | `OPENAI_COMPATIBLE_BASE_URL` | No | Base URL for an OpenAI-compatible server (e.g. LM Studio: `http://localhost:1234/v1`) | `http://localhost:1234/v1` |
+| `OPENAI_COMPATIBLE_MODEL` | No | OpenAI-compatible model name when configured separately from the selected LLM tier model | — |
 | **CLI LLM Providers (Experimental)** ||||
 | `CLI_LLM_ENABLED` | No | Enables community CLI-backed LLM providers (`codex-cli`, `claude-code`). Self-host only; requires installing optional provider packages. | `false` |
 | `CODEX_CLI_ALLOW_NPX` | No | Allows the Codex community provider to fall back to `npx @openai/codex` if `codex` is not on PATH. Leave disabled unless you trust that install path. | `false` |
@@ -110,9 +125,14 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | `RESEND_FROM_EMAIL` | No | From email address | `Inbox Zero <updates@transactional.getinboxzero.com>` |
 | `NEXT_PUBLIC_IS_RESEND_CONFIGURED` | No | Client-side flag indicating if Resend is configured | — |
 | **Other** ||||
+| `API_KEY_SALT` | No* | Salt used to hash external API keys. Generate with `openssl rand -hex 32`. Required when `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true`. | — |
 | `CRON_SECRET` | No | Secret for cron job authentication | — |
 | `HEALTH_API_KEY` | No | API key for health checks | — |
 | `WEBHOOK_URL` | No | External webhook URL | — |
+| `INTERNAL_API_URL` | No | Preferred callback base URL for QStash and server-side internal callbacks | `NEXT_PUBLIC_BASE_URL` |
+| `OAUTH_PROXY_URL` | No | OAuth proxy deployment URL used when callbacks should route through a separate proxy server | — |
+| `IS_OAUTH_PROXY_SERVER` | No | Marks this deployment as the OAuth proxy server | `false` |
+| `ADDITIONAL_TRUSTED_ORIGINS` | No | Comma-separated additional trusted origins for auth/CORS, including wildcard origins such as `https://*.vercel.app` | — |
 | **Digest Controls** ||||
 | `DIGEST_MAX_SUMMARIES_PER_24H` | No | Maximum digest summaries per email account in a rolling 24-hour window. Set to `0` to disable the cap. | `50` |
 | **Admin & Access Control** ||||
@@ -125,24 +145,33 @@ Comprehensive reference for all environment variables relevant to self-hosting I
 | **Feature Flags** ||||
 | `NEXT_PUBLIC_CONTACTS_ENABLED` | No | Enable contacts feature | `false` |
 | `NEXT_PUBLIC_EMAIL_SEND_ENABLED` | No | Enable email sending | `true` |
+| `NEXT_PUBLIC_EXTERNAL_API_ENABLED` | No | Enable external API endpoints, API keys, and API key UI. Also set `API_KEY_SALT`. | `false` |
+| `NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED` | No | Enable outgoing webhook rule actions and the webhook-secret UI | `true` |
 | `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS` | No | Bypass premium checks (recommended for self-hosting) | `true` |
 | `NEXT_PUBLIC_DIGEST_ENABLED` | No | Enable email digest feature, which sends periodic summaries of emails. Works without QStash (no retries). | `false` |
 | `NEXT_PUBLIC_MEETING_BRIEFS_ENABLED` | No | Enable meeting briefs, which automatically sends pre-meeting briefings to users. Requires the meeting briefs cron job to be running. | `false` |
 | `NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED` | No | Enable follow-up reminders, which allows users to add labels to emails for automatic follow-up tracking. Requires the follow-up reminders cron job to be running. | `false` |
 | `NEXT_PUBLIC_INTEGRATIONS_ENABLED` | No | Enable the integrations feature, allowing users to connect external services. | `false` |
 | `NEXT_PUBLIC_SMART_FILING_ENABLED` | No | Enable the Smart Filing feature for automatic document organization from email attachments. | `false` |
+| `NEXT_PUBLIC_CLEANER_ENABLED` | No | Enable the newer cleaner/bulk cleanup experience | `false` |
+| `NEXT_PUBLIC_BOOKING_LINKS_ENABLED` | No | Enable booking-link functionality. This is beta and is not actively being worked on. | `false` |
 | `NEXT_PUBLIC_AUTO_DRAFT_DISABLED` | No | Disable the auto-drafting feature, which automatically drafts replies based on assistant rules. | `false` |
+| `NEXT_PUBLIC_TABS_EXTENSION_ID` | No | Chrome extension ID used for Inbox Zero Tabs sync | Built-in extension ID |
 | **White Labeling (Optional)** ||||
 | `NEXT_PUBLIC_BRAND_NAME` | No | Brand name used in UI text and metadata | `Inbox Zero` |
 | `NEXT_PUBLIC_BRAND_LOGO_URL` | No | Custom logo URL or public asset path (for example `/images/brand-logo.svg`) | Built-in Inbox Zero logo |
 | `NEXT_PUBLIC_BRAND_ICON_URL` | No | Custom app icon URL or public asset path | `/icon.png` |
-| `NEXT_PUBLIC_SUPPORT_EMAIL` | No | Contact email shown in support links and error messages | `elie@getinboxzero.com` |
+| `NEXT_PUBLIC_SUPPORT_EMAIL` | No | Contact email shown in support links and error messages | `support@getinboxzero.com` |
 | **Debugging** ||||
 | `DISABLE_LOG_ZOD_ERRORS` | No | Disable logging Zod validation errors | — |
 | `ENABLE_DEBUG_LOGS` | No | Enable debug logging | `false` |
 | `NEXT_PUBLIC_LOG_SCOPES` | No | Comma-separated log scopes | — |
 
-\* `GOOGLE_PUBSUB_VERIFICATION_TOKEN` is required when Gmail Pub/Sub push is enabled. If your deployment authenticates `/api/google/webhook` upstream, you can set it to an empty string to intentionally disable query-parameter verification.
+\* Conditional requirements:
+
+- `DIRECT_URL` is required only when Prisma migrations need a direct/unpooled database URL that differs from `DATABASE_URL`.
+- `API_KEY_SALT` is required only when external API keys are enabled with `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true`.
+- `GOOGLE_PUBSUB_VERIFICATION_TOKEN` is required when Gmail Pub/Sub push is enabled. If your deployment authenticates `/api/google/webhook` upstream, you can set it to an empty string to intentionally disable query-parameter verification.
 
 ## Setup Guides
 

--- a/docs/hosting/llm-setup.mdx
+++ b/docs/hosting/llm-setup.mdx
@@ -40,15 +40,18 @@ For most self-hosted setups, configure these two tiers:
 
 - `DEFAULT_LLM_*` (required): primary model used for normal AI tasks.
 - `ECONOMY_LLM_*` (optional): lower-cost model for high-volume tasks. If unset, it falls back to `DEFAULT`.
+- `CHAT_LLM_*` (optional): model used for assistant chat. If unset, it falls back to `DEFAULT`.
+- `DRAFT_LLM_*` (optional): model used for drafting replies. If unset, it falls back to `DEFAULT`.
+- `NANO_LLM_*` (optional): very low-cost model for lightweight classification and extraction. If unset, it falls back to economy/default behavior.
 
 Minimal example:
 
 ```env
 DEFAULT_LLM_PROVIDER=openai
-DEFAULT_LLM_MODEL=gpt-4o
+DEFAULT_LLM_MODEL=gpt-5.4-mini
 
 ECONOMY_LLM_PROVIDER=openai
-ECONOMY_LLM_MODEL=gpt-4o-mini
+ECONOMY_LLM_MODEL=gpt-5.4-nano
 
 LLM_API_KEY=sk-...
 ```
@@ -73,6 +76,19 @@ NEXT_PUBLIC_SENSITIVE_DATA_POLICY_LOCKED=false
 ## Provider-specific details
 
 - `openai-compatible` also requires `OPENAI_COMPATIBLE_BASE_URL`.
+- `ollama` can use `OLLAMA_BASE_URL` and `OLLAMA_MODEL`.
+
+## Fallbacks
+
+You can configure ordered provider fallbacks for default, economy, and chat tiers:
+
+```env
+DEFAULT_LLM_FALLBACKS=openrouter:anthropic/claude-sonnet-4.6,openai:gpt-5.4-mini
+ECONOMY_LLM_FALLBACKS=openrouter:google/gemini-2.5-flash
+CHAT_LLM_FALLBACKS=openrouter:anthropic/claude-haiku-4.5
+```
+
+Each fallback entry must include both provider and model as `provider:model`.
 
 ### CLI LLM providers
 

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -57,10 +57,12 @@ The setup wizard will walk you through configuring Google and/or Microsoft OAuth
 If you have the [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed, you can automate API enabling and Pub/Sub setup:
 
 ```bash
-npx inbox-zero setup-google --project-id YOUR_PROJECT_ID --domain yourdomain.com
+npx @inbox-zero/cli setup-google --project-id YOUR_PROJECT_ID --domain yourdomain.com
 ```
 
-This command enables required APIs, creates the Pub/Sub topic and subscription, and guides you through OAuth credential creation.
+This works whether or not you have cloned the repository. If you installed the CLI globally, use `inbox-zero setup-google` with the same flags.
+
+The command enables required APIs, creates the Pub/Sub topic and subscription, and guides you through OAuth credential creation. It prints environment variables for you to add to your `.env`; it does not require a repo checkout.
 
 You can also copy `.env.example` to `.env` and set the values yourself.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -34,7 +34,9 @@
           "LABEL",
           "ARCHIVE",
           "MARK_READ",
+          "STAR",
           "DRAFT_EMAIL",
+          "DRAFT_MESSAGING_CHANNEL",
           "REPLY",
           "FORWARD",
           "SEND_EMAIL",
@@ -42,6 +44,7 @@
           "DIGEST",
           "CALL_WEBHOOK",
           "MOVE_FOLDER",
+          "NOTIFY_MESSAGING_CHANNEL",
           "NOTIFY_SENDER"
         ]
       },
@@ -85,6 +88,7 @@
         "type": "object",
         "properties": {
           "type": { "$ref": "#/components/schemas/ActionType" },
+          "messagingChannelId": { "type": "string", "nullable": true },
           "fields": { "$ref": "#/components/schemas/RuleActionFields" },
           "delayInMinutes": { "type": "number", "nullable": true }
         },
@@ -125,155 +129,6 @@
     "parameters": {}
   },
   "paths": {
-    "/group/{groupId}/emails": {
-      "get": {
-        "description": "Get group emails",
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "You can find the group id by going to `https://www.getinboxzero.com/automation?tab=groups`, clicking `Matching Emails`, and then copying the id from the URL."
-            },
-            "required": true,
-            "description": "You can find the group id by going to `https://www.getinboxzero.com/automation?tab=groups`, clicking `Matching Emails`, and then copying the id from the URL.",
-            "name": "groupId",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "pageToken",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "number",
-              "nullable": true
-            },
-            "required": false,
-            "name": "from",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "number",
-              "nullable": true
-            },
-            "required": false,
-            "name": "to",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "email",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "messages": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "threadId": {
-                            "type": "string"
-                          },
-                          "labelIds": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "snippet": {
-                            "type": "string"
-                          },
-                          "historyId": {
-                            "type": "string"
-                          },
-                          "attachments": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {}
-                            }
-                          },
-                          "inline": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {}
-                            }
-                          },
-                          "headers": {
-                            "type": "object",
-                            "properties": {}
-                          },
-                          "textPlain": {
-                            "type": "string"
-                          },
-                          "textHtml": {
-                            "type": "string"
-                          },
-                          "matchingGroupItem": {
-                            "type": "object",
-                            "nullable": true,
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "type": "string",
-                                "enum": ["FROM", "SUBJECT", "BODY"]
-                              },
-                              "value": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["id", "type", "value"]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "threadId",
-                          "snippet",
-                          "historyId",
-                          "inline",
-                          "headers"
-                        ]
-                      }
-                    },
-                    "nextPageToken": {
-                      "type": "string"
-                    }
-                  },
-                  "required": ["messages"]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/stats/by-period": {
       "get": {
         "description": "Get email statistics grouped by time period. Returns counts of emails by status (all, sent, read, unread, archived, unarchived) for each period.",


### PR DESCRIPTION
Refresh documentation to match the current repository and public API surface.

- Remove stale API endpoint docs and update the OpenAPI reference.
- Update self-hosting, environment variable, LLM, and architecture docs.
- Update docs navigation and support contact references.

Validation: jq empty docs/openapi.json docs/docs.json; docs navigation target check; git diff --check.