### PR TITLE
cli: Clarify Google OAuth setup with API enablement steps

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -392,26 +392,36 @@ async function runSetupQuick(options: { name?: string }) {
 
     p.note(
       "You need a Google OAuth app to connect your Gmail.\n\n" +
-        "First, set up the OAuth consent screen:\n" +
-        "1. Open: https://console.cloud.google.com/apis/credentials/consent\n" +
-        "2. User type:\n" +
+        "First, enable the required APIs (otherwise sign-in will fail):\n" +
+        "1. Open: https://console.cloud.google.com/apis/library\n" +
+        "2. Enable each of these for your project:\n" +
+        "   - Gmail API (gmail.googleapis.com)\n" +
+        "   - People API (people.googleapis.com)\n" +
+        "   - Google Calendar API (optional)\n" +
+        "   - Google Drive API (optional)\n\n" +
+        "Then, set up the OAuth consent screen:\n" +
+        "3. Open: https://console.cloud.google.com/apis/credentials/consent\n" +
+        '4. Click "Get Started" (if shown)\n' +
+        "5. User type:\n" +
         '   - "Internal" — Google Workspace only, all org members can sign in\n' +
         '   - "External" — works with any Google account (including personal Gmail)\n' +
-        "     You'll need to add yourself as a test user (step 5)\n" +
-        "3. Fill in the app name and your email\n" +
-        '4. Click "Save and Continue" through the scopes section\n' +
-        "5. If External: add your email as a test user\n" +
-        "6. Complete the wizard\n\n" +
+        "     You'll need to add yourself as a test user (step 8)\n" +
+        "6. Fill in the app name and your email\n" +
+        '7. Click "Save and Continue" through the scopes section\n' +
+        "8. If External: add your email as a test user\n" +
+        "9. Complete the wizard\n\n" +
         "Then, create OAuth credentials:\n" +
-        "7. Open: https://console.cloud.google.com/apis/credentials\n" +
-        `8. Click "Create Credentials" → "OAuth client ID"\n` +
-        `9. Select "Web application"\n` +
-        `10. Under "Authorized redirect URIs" add:\n` +
+        "10. Open: https://console.cloud.google.com/apis/credentials\n" +
+        `11. Click "Create Credentials" → "OAuth client ID"\n` +
+        `12. Select "Web application"\n` +
+        `13. Under "Authorized redirect URIs" add:\n` +
         `    ${callbackUrl}\n` +
         `    ${linkingCallbackUrl}\n` +
-        "11. Copy the Client ID and Client Secret\n\n" +
+        "14. Copy the Client ID and Client Secret\n\n" +
         "If External: you'll see a \"This app isn't verified\" warning when\n" +
         'signing in. Click "Advanced" then "Go to [app name]" to proceed.\n\n' +
+        "Tip: if you have the gcloud CLI, run 'inbox-zero setup-google'\n" +
+        "to enable APIs and set up Pub/Sub automatically.\n\n" +
         "Full guide: https://docs.getinboxzero.com/hosting/setup-guides",
       "Google OAuth",
     );
@@ -935,12 +945,20 @@ async function runSetupAdvanced(options: { name?: string }) {
   // Google OAuth
   if (wantsGoogle) {
     p.note(
-      `1. Go to Google Cloud Console: https://console.cloud.google.com/apis/credentials
-2. Create OAuth 2.0 Client ID (Web application)
-3. Add redirect URIs:
+      `1. Enable required APIs (Gmail, People; Calendar/Drive optional):
+   https://console.cloud.google.com/apis/library
+2. Configure the OAuth consent screen:
+   https://console.cloud.google.com/apis/credentials/consent
+   Click "Get Started" if shown, then complete the wizard.
+3. Create OAuth 2.0 Client ID (Web application):
+   https://console.cloud.google.com/apis/credentials
+4. Add redirect URIs:
    - http://localhost:${webPort}/api/auth/callback/google
    - http://localhost:${webPort}/api/google/linking/callback
-4. Copy Client ID and Client Secret
+5. Copy Client ID and Client Secret
+
+Tip: with the gcloud CLI installed, run 'inbox-zero setup-google'
+to enable APIs and provision Pub/Sub automatically.
 
 Full guide: https://docs.getinboxzero.com/self-hosting/google-oauth`,
       "Google OAuth Setup",

--- a/packages/cli/src/setup-google.ts
+++ b/packages/cli/src/setup-google.ts
@@ -135,16 +135,17 @@ export async function runGoogleSetup(options: GoogleSetupOptions) {
       `Before creating OAuth credentials, you need to configure the consent screen.
 
 Steps:
-1. User type:
+1. Click "Get Started" if the banner is shown
+2. User type:
    - "Internal" — Google Workspace only, all org members can sign in
    - "External" — any Google account (including personal Gmail)
-     You'll need to add yourself as a test user (step 6)
-2. App name: "Inbox Zero" (or your preferred name)
-3. User support email: Your email
-4. Developer contact: Your email
-5. Click "Save and Continue" through the scopes section
-6. If External: add your email as a test user
-7. Complete the wizard
+     You'll need to add yourself as a test user (step 7)
+3. App name: "Inbox Zero" (or your preferred name)
+4. User support email: Your email
+5. Developer contact: Your email
+6. Click "Save and Continue" through the scopes section
+7. If External: add your email as a test user
+8. Complete the wizard
 
 The console will open in your browser.`,
       "OAuth Consent Screen",


### PR DESCRIPTION
## Summary

Improves the self-hosted Google OAuth setup flow by documenting the API enablement step (a common pain point where sign-in fails silently) and pointing gcloud users to `setup-google` as an automated alternative.

- Add Gmail/People API enablement steps to both quick and advanced setup notes
- Renumber consent screen steps to match the current Google Cloud Console UI (including the "Get Started" click)
- Surface the `inbox-zero setup-google` command for users with gcloud installed

## Test plan

- [ ] Run `inbox-zero setup` (quick mode) and verify the Google OAuth note renders correctly
- [ ] Run `inbox-zero setup --advanced` and verify the OAuth setup note renders correctly
- [ ] Run `inbox-zero setup-google` and confirm consent screen instructions read cleanly