### PR TITLE
calendar: Refetch Microsoft event to capture Teams join URL

### DIFF
--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -5,6 +5,7 @@ import { MicrosoftCalendarEventProvider } from "@/utils/calendar/providers/micro
 const graphMocks = vi.hoisted(() => ({
   api: vi.fn(),
   post: vi.fn(),
+  get: vi.fn(),
 }));
 
 vi.mock("@/utils/outlook/calendar-client", () => ({
@@ -18,6 +19,7 @@ describe("MicrosoftCalendarEventProvider", () => {
     vi.clearAllMocks();
     graphMocks.api.mockReturnValue({
       post: graphMocks.post,
+      get: graphMocks.get,
     });
   });
 
@@ -74,6 +76,85 @@ describe("MicrosoftCalendarEventProvider", () => {
       eventUrl: "https://outlook.example.com/event",
       videoConferenceLink: "https://teams.example.com/join",
     });
+  });
+
+  it("refetches the event when Graph initializes the Teams join URL asynchronously", async () => {
+    // Graph sometimes returns the created event before onlineMeeting is
+    // populated; a follow-up GET on the event resolves to the join URL.
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
+      onlineMeeting: null,
+      webLink: "https://outlook.example.com/event",
+    });
+    graphMocks.get.mockResolvedValue({
+      id: "event-id",
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
+      onlineMeeting: { joinUrl: "https://teams.example.com/join" },
+      webLink: "https://outlook.example.com/event",
+    });
+
+    const provider = new MicrosoftCalendarEventProvider(
+      {
+        accessToken: "access-token",
+        emailAccountId: "email-account-id",
+        expiresAt: null,
+        refreshToken: "refresh-token",
+      },
+      createTestLogger(),
+    );
+
+    const result = await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    expect(graphMocks.api).toHaveBeenCalledWith(
+      "/me/calendars/calendar-id/events",
+    );
+    expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id");
+    expect(graphMocks.get).toHaveBeenCalled();
+    expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
+  });
+
+  it("does not refetch when Teams was not requested", async () => {
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      webLink: "https://outlook.example.com/event",
+    });
+
+    const provider = new MicrosoftCalendarEventProvider(
+      {
+        accessToken: "access-token",
+        emailAccountId: "email-account-id",
+        expiresAt: null,
+        refreshToken: "refresh-token",
+      },
+      createTestLogger(),
+    );
+
+    await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "CUSTOM",
+      locationValue: "Office",
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    expect(graphMocks.get).not.toHaveBeenCalled();
   });
 
   it("cancels events through the Graph cancel action so attendees are notified", async () => {

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -160,12 +160,30 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
             : undefined,
       });
 
+    let videoConferenceLink = getJoinUrl(response);
+
+    // Graph initializes the Teams meeting after the event is created, so the
+    // POST response sometimes returns before `onlineMeeting` is populated.
+    // Refetch the event to retrieve the join URL when we asked for Teams.
+    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+      try {
+        const refetched: MicrosoftEvent = await client
+          .api(`/me/events/${response.id}`)
+          .get();
+        videoConferenceLink = getJoinUrl(refetched);
+      } catch (error) {
+        this.logger.warn(
+          "Failed to refetch Microsoft event for Teams join URL",
+          { eventId: response.id, error },
+        );
+      }
+    }
+
     return {
       id: response.id || "",
       providerCalendarId: input.calendarId,
       eventUrl: response.webLink,
-      videoConferenceLink:
-        response.onlineMeeting?.joinUrl || response.onlineMeetingUrl,
+      videoConferenceLink,
     };
   }
 
@@ -184,8 +202,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       description: event.bodyPreview || undefined,
       location: event.location?.displayName || undefined,
       eventUrl: event.webLink || undefined,
-      videoConferenceLink:
-        event.onlineMeeting?.joinUrl || event.onlineMeetingUrl || undefined,
+      videoConferenceLink: getJoinUrl(event),
       startTime: new Date(event.start?.dateTime || Date.now()),
       endTime: new Date(event.end?.dateTime || Date.now()),
       attendees:
@@ -200,4 +217,8 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
 function formatMicrosoftUtcDateTime(date: Date) {
   // Graph DateTimeTimeZone expects a local datetime for the supplied timezone.
   return date.toISOString().replace(/Z$/, "0000");
+}
+
+function getJoinUrl(event: MicrosoftEvent): string | undefined {
+  return event.onlineMeeting?.joinUrl || event.onlineMeetingUrl;
 }


### PR DESCRIPTION
## Summary

Microsoft Graph sometimes returns a newly created event before `onlineMeeting` is populated, so the Teams join URL was missing from booking-link calendar events. When Teams is requested but no join URL is present, refetch the event by id to retrieve it.

- Add `getJoinUrl` helper to centralize Teams join URL extraction
- Refetch event by id when Teams is requested but join URL is absent on create
- Cover both the async-populated and non-Teams paths with tests

Fixes INB-264.

## Test plan

- [x] `pnpm test apps/web/utils/calendar/providers/microsoft-events.test.ts`
- [ ] Create a booking-link event in Outlook with Teams selected and confirm the Teams join URL is included