### PR TITLE
follow-up: Replace Slack notification card on Mark done

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -405,6 +405,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
 
       const postEphemeral = vi.fn().mockResolvedValue(undefined);
       const post = vi.fn().mockResolvedValue(undefined);
+      const editMessage = vi.fn().mockResolvedValue(undefined);
+
+      const threadId = postedCall![0].channel ?? notifChannelId;
+      const messageId = "1700000000.000100";
 
       await handleFollowUpReminderAction({
         event: {
@@ -412,9 +416,9 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           value: markDoneButton.value,
           user: { userId: "U_USER" },
           raw: { team: { id: "T_TEAM" } },
-          threadId: postedCall![0].channel ?? notifChannelId,
-          messageId: "1700000000.000100",
-          adapter: { name: "slack" },
+          threadId,
+          messageId,
+          adapter: { name: "slack", editMessage },
           thread: { postEphemeral, post },
         } as any,
         logger,
@@ -437,6 +441,12 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         where: { id: trackerId },
         data: { resolved: true },
       });
+
+      expect(editMessage).toHaveBeenCalledTimes(1);
+      const editArgs = editMessage.mock.calls[0];
+      expect(editArgs?.[0]).toBe(threadId);
+      expect(editArgs?.[1]).toBe(messageId);
+      expect(JSON.stringify(editArgs?.[2])).toMatch(/done/i);
 
       // User saw an ephemeral confirmation.
       expect(postEphemeral).toHaveBeenCalled();

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -21,6 +21,7 @@ function makeEvent(
 ) {
   const postEphemeral = vi.fn().mockResolvedValue(undefined);
   const post = vi.fn().mockResolvedValue(undefined);
+  const editMessage = vi.fn().mockResolvedValue(undefined);
   const value = "value" in overrides ? overrides.value : "tracker-1";
   const event = {
     actionId: overrides.actionId ?? FOLLOW_UP_MARK_DONE_ACTION_ID,
@@ -30,14 +31,14 @@ function makeEvent(
       overrides.teamId === null
         ? {}
         : { team: { id: overrides.teamId ?? "T_TEAM" } },
-    threadId: "ts-1",
-    messageId: "ts-1",
-    adapter: { name: "slack" } as any,
+    threadId: "slack:C_CHANNEL:1700000000.000100",
+    messageId: "1700000000.000100",
+    adapter: { name: "slack", editMessage } as any,
     thread: { postEphemeral, post } as any,
     triggerId: undefined,
     openModal: vi.fn(),
   };
-  return { event: event as any, postEphemeral, post };
+  return { event: event as any, postEphemeral, post, editMessage };
 }
 
 describe("handleFollowUpReminderAction", () => {
@@ -67,6 +68,27 @@ describe("handleFollowUpReminderAction", () => {
     const text = postEphemeral.mock.calls[0]?.[1];
     expect(typeof text).toBe("string");
     expect(text).toMatch(/done/i);
+  });
+
+  it("replaces the original Slack message so the nudge reflects the resolved state", async () => {
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: false,
+      emailAccountId: "account-1",
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: "channel-1",
+    } as any);
+    prisma.threadTracker.update.mockResolvedValue({} as any);
+
+    const { event, editMessage } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [threadId, messageId, card] = editMessage.mock.calls[0] ?? [];
+    expect(threadId).toBe("slack:C_CHANNEL:1700000000.000100");
+    expect(messageId).toBe("1700000000.000100");
+    expect(JSON.stringify(card)).toMatch(/done/i);
   });
 
   it("scopes the channel auth lookup to the tracker's email account, slack, the slack team and the clicker", async () => {

--- a/apps/web/utils/follow-up/follow-up-actions.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.ts
@@ -1,4 +1,4 @@
-import type { ActionEvent } from "chat";
+import { Card, CardText, type ActionEvent } from "chat";
 import { MessagingProvider } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
@@ -54,21 +54,44 @@ export async function handleFollowUpReminderAction({
     return;
   }
 
-  if (tracker.resolved) {
-    await postFeedback(event, logger, "This follow-up is already done.");
-    return;
+  if (!tracker.resolved) {
+    await prisma.threadTracker.update({
+      where: { id: trackerId },
+      data: { resolved: true },
+    });
   }
 
-  await prisma.threadTracker.update({
-    where: { id: trackerId },
-    data: { resolved: true },
-  });
+  const feedback = tracker.resolved
+    ? "This follow-up is already done."
+    : "Marked done. We won't follow up on this thread again.";
 
-  await postFeedback(
-    event,
-    logger,
-    "Marked done. We won't follow up on this thread again.",
-  );
+  await Promise.all([
+    replaceWithResolvedCard(event, logger),
+    postFeedback(event, logger, feedback),
+  ]);
+}
+
+async function replaceWithResolvedCard(
+  event: ActionEvent,
+  logger: Logger,
+): Promise<void> {
+  if (!event.threadId || !event.messageId) return;
+
+  try {
+    await event.adapter.editMessage(
+      event.threadId,
+      event.messageId,
+      Card({
+        title: "✅ Follow-up marked done",
+        children: [CardText("We won't follow up on this thread again.")],
+      }),
+    );
+  } catch (error) {
+    logger.warn("Failed to update follow-up notification after Mark done", {
+      actionId: event.actionId,
+      error,
+    });
+  }
 }
 
 async function postFeedback(


### PR DESCRIPTION
## Summary

Clicking "Mark done" on a follow-up Slack nudge now edits the original message into a resolved card, so the notification reflects the new state instead of looking unchanged after the click.

- Edit the original Slack message with a resolved card alongside the ephemeral confirmation
- Surface "already done" feedback even when the tracker is already resolved, without duplicating the DB write

Closes INB-258

## Test plan

- [ ] Integration test covers editMessage being called with the resolved card
- [ ] Unit test covers the new edit path
- [ ] Manually click "Mark done" on a Slack follow-up and verify the card is replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)