### PR TITLE
assistant: Pin follow-up replies to the source email

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -542,6 +542,11 @@ async function processFollowUpsForType({
               }) ?? undefined,
             threadLinkLabel: getThreadLinkLabel(providerName),
             trackerId: tracker.id,
+            emailReference: {
+              emailAccountId: emailAccount.id,
+              threadId: thread.id,
+              messageId: lastMessage.id,
+            },
             logger: threadLogger,
           });
         } catch (notifyError) {

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -15,6 +15,7 @@ import {
   sendFollowUpReminderToSlack,
 } from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
+import { saveMessagingFollowUpContext } from "@/utils/redis/messaging-follow-up-context";
 
 const mockTelegramOpenDm = vi.fn();
 const mockTelegramPostMessage = vi.fn();
@@ -33,9 +34,13 @@ vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
       telegram: {
         openDM: (...args: unknown[]) => mockTelegramOpenDm(...args),
         postMessage: (...args: unknown[]) => mockTelegramPostMessage(...args),
+        decodeThreadId: (threadId: string) => ({ chatId: threadId }),
       },
     },
   }),
+}));
+vi.mock("@/utils/redis/messaging-follow-up-context", () => ({
+  saveMessagingFollowUpContext: vi.fn(),
 }));
 
 const logger = createTestLogger();
@@ -49,6 +54,11 @@ const baseArgs = {
   snippet: "Following up on the items we discussed.",
   threadLink: "https://mail.example/thread",
   trackerId: "tracker-1",
+  emailReference: {
+    emailAccountId: "email-account-1",
+    threadId: "thread-1",
+    messageId: "message-1",
+  },
   logger,
 };
 
@@ -104,6 +114,10 @@ describe("sendFollowUpNotification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (resolveSlackRouteDestination as any).mockResolvedValue("C1");
+    (sendFollowUpReminderToSlack as any).mockResolvedValue({
+      channelId: "C1",
+      messageTs: "1700000000.000100",
+    });
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
@@ -202,5 +216,44 @@ describe("sendFollowUpNotification", () => {
       ...baseArgs,
     });
     expect(sendFollowUpReminderToSlack).not.toHaveBeenCalled();
+  });
+
+  it("persists the email reference against the Slack notification thread for reply lookup", async () => {
+    await sendFollowUpNotification({ channels: [slackChannel], ...baseArgs });
+
+    expect(saveMessagingFollowUpContext).toHaveBeenCalledWith(
+      {
+        provider: "slack",
+        channelId: "C1",
+        messageTs: "1700000000.000100",
+      },
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        threadId: "thread-1",
+        messageId: "message-1",
+        trackerId: "tracker-1",
+      }),
+    );
+  });
+
+  it("persists the email reference against the Telegram notification message", async () => {
+    await sendFollowUpNotification({
+      channels: [telegramChannel],
+      ...baseArgs,
+    });
+
+    expect(saveMessagingFollowUpContext).toHaveBeenCalledWith(
+      {
+        provider: "telegram",
+        channelId: "telegram-thread-1",
+        messageTs: "telegram-message-1",
+      },
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        threadId: "thread-1",
+        messageId: "message-1",
+        trackerId: "tracker-1",
+      }),
+    );
   });
 });

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -24,6 +24,10 @@ import {
   normalizeFollowUpText,
   truncateSnippet,
 } from "@/utils/follow-up/copy";
+import {
+  saveMessagingFollowUpContext,
+  type MessagingFollowUpContext,
+} from "@/utils/redis/messaging-follow-up-context";
 
 const TELEGRAM_SNIPPET_MAX_CHARS = 3000;
 
@@ -53,6 +57,11 @@ type FollowUpNotificationContent = {
   trackerId: string;
 };
 
+type FollowUpEmailReference = Pick<
+  MessagingFollowUpContext,
+  "emailAccountId" | "threadId" | "messageId"
+>;
+
 export async function getFollowUpNotificationChannels(
   emailAccountId: string,
 ): Promise<FollowUpNotificationChannel[]> {
@@ -78,10 +87,12 @@ export async function getFollowUpNotificationChannels(
 
 export async function sendFollowUpNotification({
   channels,
+  emailReference,
   logger,
   ...content
 }: FollowUpNotificationContent & {
   channels: FollowUpNotificationChannel[];
+  emailReference: FollowUpEmailReference;
   logger: Logger;
 }): Promise<void> {
   const deliveryPromises: Promise<unknown>[] = [];
@@ -111,6 +122,7 @@ export async function sendFollowUpNotification({
             accessToken: channel.accessToken,
             route,
             content,
+            emailReference,
             logger,
           }),
         );
@@ -131,6 +143,7 @@ export async function sendFollowUpNotification({
             channel,
             route,
             content,
+            emailReference,
             logger,
           }),
         );
@@ -154,11 +167,13 @@ async function sendFollowUpViaSlack({
   accessToken,
   route,
   content,
+  emailReference,
   logger,
 }: {
   accessToken: string;
   route: { targetId: string; targetType: MessagingRouteTargetType };
   content: FollowUpNotificationContent;
+  emailReference: FollowUpEmailReference;
   logger: Logger;
 }) {
   const destination = await resolveSlackRouteDestination({
@@ -171,22 +186,36 @@ async function sendFollowUpViaSlack({
     return;
   }
 
-  await sendFollowUpReminderToSlack({
+  const { channelId, messageTs } = await sendFollowUpReminderToSlack({
     accessToken,
     channelId: destination,
     ...content,
   });
+
+  if (!messageTs) {
+    logger.warn(
+      "Slack follow-up notification sent but no message ts returned; thread reply context will be unavailable",
+    );
+    return;
+  }
+
+  await saveMessagingFollowUpContext(
+    { provider: "slack", channelId, messageTs },
+    buildFollowUpContextValue(content, emailReference),
+  );
 }
 
 async function sendFollowUpViaTelegram({
   channel,
   route,
   content,
+  emailReference,
   logger,
 }: {
   channel: FollowUpNotificationChannel;
   route: { targetId: string; targetType: MessagingRouteTargetType };
   content: FollowUpNotificationContent;
+  emailReference: FollowUpEmailReference;
   logger: Logger;
 }) {
   const destination =
@@ -203,9 +232,23 @@ async function sendFollowUpViaTelegram({
   }
 
   const threadId = await telegramAdapter.openDM(destination);
-  await telegramAdapter.postMessage(
+  const sentMessage = await telegramAdapter.postMessage(
     threadId,
     buildTelegramFollowUpCard(content),
+  );
+
+  const telegramChatId = telegramAdapter.decodeThreadId(threadId).chatId;
+  const messageTs = sentMessage?.id;
+  if (!messageTs) {
+    logger.warn(
+      "Telegram follow-up notification sent but no message id returned; thread reply context will be unavailable",
+    );
+    return;
+  }
+
+  await saveMessagingFollowUpContext(
+    { provider: "telegram", channelId: telegramChatId, messageTs },
+    buildFollowUpContextValue(content, emailReference),
   );
 }
 
@@ -286,4 +329,18 @@ function formatQuotedSnippet(snippet: string, maxChars?: number): string {
     .split("\n")
     .map((line) => (line ? `> ${line}` : ">"))
     .join("\n");
+}
+
+function buildFollowUpContextValue(
+  content: FollowUpNotificationContent,
+  emailReference: FollowUpEmailReference,
+): MessagingFollowUpContext {
+  return {
+    emailAccountId: emailReference.emailAccountId,
+    threadId: emailReference.threadId,
+    messageId: emailReference.messageId,
+    trackerId: content.trackerId,
+    subject: content.subject,
+    counterpartyEmail: content.counterpartyEmail,
+  };
 }

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -3,6 +3,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
   buildAffirmativeReactionMessage,
+  buildFollowUpHiddenContextMessage,
   buildHandledPendingEmailCard,
   buildPendingEmailConfirmationCard,
   buildPendingEmailCardFallbackText,
@@ -189,6 +190,44 @@ describe("buildPendingEmailCardFallbackText", () => {
     const input =
       "This draft is pending confirmation.\n\nI couldn't show the Send button right now. Ask me to prepare the draft again.";
     expect(buildPendingEmailCardFallbackText(input)).toBe(input);
+  });
+});
+
+describe("buildFollowUpHiddenContextMessage", () => {
+  it("returns null when no follow-up context is provided", () => {
+    expect(
+      buildFollowUpHiddenContextMessage({
+        followUpContext: null,
+        userMessageId: "slack-msg-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a hidden user message that pins the email context to the agent", () => {
+    const message = buildFollowUpHiddenContextMessage({
+      followUpContext: {
+        emailAccountId: "email-account-1",
+        threadId: "thread-abc",
+        messageId: "message-xyz",
+        trackerId: "tracker-1",
+        subject: "Q3 contract renewal",
+        counterpartyEmail: "alex@example.com",
+      },
+      userMessageId: "slack-msg-1",
+    });
+
+    expect(message).not.toBeNull();
+    expect(message?.role).toBe("user");
+    expect(message?.id).toBe("slack-msg-1-follow-up-context");
+
+    const text = (message?.parts[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("Hidden context");
+    expect(text).toContain("threadId: thread-abc");
+    expect(text).toContain("messageId: message-xyz");
+    expect(text).toContain("Q3 contract renewal");
+    expect(text).toContain("alex@example.com");
+    expect(text.toLowerCase()).toContain("replyemail");
+    expect(text.toLowerCase()).toContain("do not call searchinbox");
   });
 });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -76,6 +76,10 @@ import {
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import prisma from "@/utils/prisma";
 import {
+  getMessagingFollowUpContext,
+  type MessagingFollowUpContext,
+} from "@/utils/redis/messaging-follow-up-context";
+import {
   getEmailUrlForMessage,
   getEmailUrlForOptionalMessage,
 } from "@/utils/url";
@@ -162,6 +166,7 @@ type ResolvedMessagingContext = {
   messageText: string;
   provider: SupportedPlatform;
   threadLogContext: Record<string, unknown>;
+  followUpContext: MessagingFollowUpContext | null;
 };
 
 type MessagingUserMessagesInput = {
@@ -659,6 +664,11 @@ async function processMessagingAssistantMessage({
         provider: context.provider,
       });
 
+    const followUpContextMessage = buildFollowUpHiddenContextMessage({
+      followUpContext: context.followUpContext,
+      userMessageId,
+    });
+
     await prisma.chatMessage.upsert({
       where: { id: userMessageId },
       create: {
@@ -709,6 +719,7 @@ async function processMessagingAssistantMessage({
       const result = await aiProcessAssistantChat({
         messages: await convertToModelMessages([
           ...existingMessages,
+          ...(followUpContextMessage ? [followUpContextMessage] : []),
           modelUserMessage,
         ]),
         emailAccountId: context.emailAccountId,
@@ -2097,6 +2108,15 @@ async function resolveSlackMessagingContext({
     return null;
   }
 
+  const followUpContext =
+    threadTs && candidates.length > 1
+      ? await getMessagingFollowUpContext({
+          provider: "slack",
+          channelId: channel,
+          messageTs: threadTs,
+        })
+      : null;
+
   const messagingChannel = await resolveSlackMessagingChannel({
     candidates,
     channel,
@@ -2105,6 +2125,7 @@ async function resolveSlackMessagingContext({
     logger,
     teamId,
     thread,
+    preferredEmailAccountId: followUpContext?.emailAccountId,
   });
 
   if (!messagingChannel) return null;
@@ -2137,6 +2158,7 @@ async function resolveSlackMessagingContext({
     messageText,
     chatId: getSlackChatId({ channel, threadTs: threadTs || undefined }),
     threadLogContext: { teamId, channel },
+    followUpContext,
   };
 }
 
@@ -2204,12 +2226,18 @@ async function resolveLinkedProviderMessagingContext({
     return null;
   }
 
+  const followUpContext =
+    provider === "telegram" && candidates.length > 1
+      ? await lookupTelegramFollowUpContext({ message })
+      : null;
+
   const linkedChannel = await resolveLinkedProviderCandidate({
     candidates,
     chatId,
     logger,
     provider,
     teamId: identity.teamId,
+    preferredEmailAccountId: followUpContext?.emailAccountId,
   });
 
   const imageParts = await extractImagePartsFromMessage({ message, logger });
@@ -2229,7 +2257,32 @@ async function resolveLinkedProviderMessagingContext({
       teamId: identity.teamId,
       providerUserId: identity.providerUserId,
     },
+    followUpContext,
   };
+}
+
+type TelegramRawMessageWithReply = TelegramRawMessage & {
+  reply_to_message?: { message_id?: number };
+};
+
+async function lookupTelegramFollowUpContext({
+  message,
+}: {
+  message: Message;
+}): Promise<MessagingFollowUpContext | null> {
+  const rawMessage = message.raw as TelegramRawMessageWithReply;
+
+  const replyToMessageId = rawMessage.reply_to_message?.message_id;
+  if (!replyToMessageId) return null;
+
+  const chatId = rawMessage.chat?.id;
+  if (chatId === undefined || chatId === null) return null;
+
+  return getMessagingFollowUpContext({
+    provider: "telegram",
+    channelId: String(chatId),
+    messageTs: String(replyToMessageId),
+  });
 }
 
 function resolveTeamsIdentity({
@@ -2423,13 +2476,21 @@ async function resolveLinkedProviderCandidate({
   logger,
   provider,
   teamId,
+  preferredEmailAccountId,
 }: {
   candidates: LinkedProviderCandidate[];
   chatId: string;
   logger: Logger;
   provider: "teams" | "telegram";
   teamId: string;
+  preferredEmailAccountId?: string;
 }): Promise<LinkedProviderCandidate> {
+  const preferred = findCandidateByEmailAccountId(
+    candidates,
+    preferredEmailAccountId,
+  );
+  if (preferred) return preferred;
+
   return selectCandidateFromExistingChat({
     candidates,
     chatId,
@@ -2448,6 +2509,7 @@ async function resolveSlackMessagingChannel({
   logger,
   teamId,
   thread,
+  preferredEmailAccountId,
 }: {
   candidates: SlackCandidate[];
   channel: string;
@@ -2456,7 +2518,14 @@ async function resolveSlackMessagingChannel({
   logger: Logger;
   teamId?: string | null;
   thread: MessagingThread;
+  preferredEmailAccountId?: string;
 }): Promise<SlackCandidate | null> {
+  const preferred = findCandidateByEmailAccountId(
+    candidates,
+    preferredEmailAccountId,
+  );
+  if (preferred) return preferred;
+
   if (!isDirectMessage) {
     const channelMatch = candidates.find((candidate) =>
       hasMessagingChannelTargetRoute(candidate.routes, channel),
@@ -2482,6 +2551,18 @@ async function resolveSlackMessagingChannel({
     warningMessage: "Multiple accounts in Slack DM, using first match",
     warningMeta: { teamId },
   });
+}
+
+function findCandidateByEmailAccountId<
+  TCandidate extends { emailAccountId: string },
+>(
+  candidates: TCandidate[],
+  preferredEmailAccountId: string | undefined,
+): TCandidate | undefined {
+  if (!preferredEmailAccountId) return;
+  return candidates.find(
+    (candidate) => candidate.emailAccountId === preferredEmailAccountId,
+  );
 }
 
 async function selectCandidateFromExistingChat<
@@ -2731,6 +2812,28 @@ export function buildPendingEmailCardFallbackText(normalizedText: string) {
   }
 
   return `${normalizedText}\n\n${failureGuidance}`;
+}
+
+export function buildFollowUpHiddenContextMessage({
+  followUpContext,
+  userMessageId,
+}: {
+  followUpContext: MessagingFollowUpContext | null;
+  userMessageId: string;
+}): UIMessage | null {
+  if (!followUpContext) return null;
+
+  const text = [
+    '[Hidden context — not user-typed] This chat is happening inside a follow-up notification thread for a specific email. When the user refers to "this email", "the email", "the follow-up", "reply", or similar without naming another message, treat it as the email below.',
+    `Referenced email — threadId: ${followUpContext.threadId}, messageId: ${followUpContext.messageId}, subject: ${followUpContext.subject}, counterparty: ${followUpContext.counterpartyEmail}.`,
+    "When the user asks you to draft, send, or modify a reply for this email, call replyEmail with this messageId directly. Do not call searchInbox to find it; you already have the correct messageId. Only call searchInbox if the user references a different email.",
+  ].join("\n");
+
+  return {
+    id: `${userMessageId}-follow-up-context`,
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
 }
 
 export function buildMessagingUserMessages({

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -168,15 +168,23 @@ export async function sendFollowUpReminderToSlack({
   accessToken,
   channelId,
   ...blockParams
-}: SlackFollowUpReminderParams): Promise<void> {
+}: SlackFollowUpReminderParams): Promise<{
+  channelId: string;
+  messageTs: string | null;
+}> {
   const client = createSlackClient(accessToken);
   const blocks = buildFollowUpReminderBlocks(blockParams);
   const { emoji } = getFollowUpCopy(blockParams.trackerType);
 
-  await postMessageWithJoin(client, channelId, {
+  const response = await postMessageWithJoin(client, channelId, {
     blocks,
     text: `${emoji} Follow-up: ${blockParams.subject}`,
   });
+
+  return {
+    channelId: response?.channel ?? channelId,
+    messageTs: response?.ts ?? null,
+  };
 }
 
 /**
@@ -255,7 +263,7 @@ async function postMessageWithJoin(
   client: WebClient,
   channelId: string,
   message: { text: string; blocks?: Blocks },
-): Promise<void> {
+): Promise<{ ts?: string; channel?: string } | undefined> {
   const args = disableSlackLinkUnfurls(
     message.blocks
       ? { channel: channelId, blocks: message.blocks, text: message.text }
@@ -263,7 +271,7 @@ async function postMessageWithJoin(
   );
 
   try {
-    await client.chat.postMessage(args);
+    return await client.chat.postMessage(args);
   } catch (error: unknown) {
     if (isSlackError(error) && error.data?.error === "not_in_channel") {
       try {
@@ -279,8 +287,7 @@ async function postMessageWithJoin(
         }
         throw joinError;
       }
-      await client.chat.postMessage(args);
-      return;
+      return await client.chat.postMessage(args);
     }
     throw error;
   }

--- a/apps/web/utils/redis/messaging-follow-up-context.test.ts
+++ b/apps/web/utils/redis/messaging-follow-up-context.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getMessagingFollowUpContext,
+  saveMessagingFollowUpContext,
+} from "@/utils/redis/messaging-follow-up-context";
+
+vi.mock("@/env", () => ({
+  env: {
+    UPSTASH_REDIS_URL: "https://redis.example",
+    UPSTASH_REDIS_TOKEN: "token",
+  },
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+import { redis } from "@/utils/redis";
+
+describe("messaging-follow-up-context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("saves and reads back the email reference for a Slack notification thread", async () => {
+    const stored: Record<string, unknown> = {};
+    vi.mocked(redis.set).mockImplementation(async (key: string, value: any) => {
+      stored[key] = value;
+      return "OK" as any;
+    });
+    vi.mocked(redis.get).mockImplementation(
+      async (key: string) => (stored[key] as any) ?? null,
+    );
+
+    const key = {
+      provider: "slack" as const,
+      channelId: "C123",
+      messageTs: "1700000000.000100",
+    };
+
+    await saveMessagingFollowUpContext(key, {
+      emailAccountId: "email-account-1",
+      threadId: "thread-abc",
+      messageId: "message-xyz",
+      trackerId: "tracker-1",
+      subject: "Q3 renewal",
+      counterpartyEmail: "alex@example.com",
+    });
+
+    const result = await getMessagingFollowUpContext(key);
+
+    expect(result).toEqual({
+      emailAccountId: "email-account-1",
+      threadId: "thread-abc",
+      messageId: "message-xyz",
+      trackerId: "tracker-1",
+      subject: "Q3 renewal",
+      counterpartyEmail: "alex@example.com",
+    });
+  });
+
+  it("returns null when no context is stored for the lookup key", async () => {
+    vi.mocked(redis.get).mockResolvedValueOnce(null);
+
+    const result = await getMessagingFollowUpContext({
+      provider: "telegram",
+      channelId: "12345",
+      messageTs: "67",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("partitions keys by provider and message identifier", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK" as any);
+
+    await saveMessagingFollowUpContext(
+      { provider: "slack", channelId: "C1", messageTs: "111" },
+      {
+        emailAccountId: "ea-1",
+        threadId: "t-1",
+        messageId: "m-1",
+        trackerId: "tr-1",
+        subject: "s",
+        counterpartyEmail: "a@b",
+      },
+    );
+    await saveMessagingFollowUpContext(
+      { provider: "telegram", channelId: "C1", messageTs: "111" },
+      {
+        emailAccountId: "ea-2",
+        threadId: "t-2",
+        messageId: "m-2",
+        trackerId: "tr-2",
+        subject: "s",
+        counterpartyEmail: "a@b",
+      },
+    );
+
+    const slackKey = vi.mocked(redis.set).mock.calls[0][0] as string;
+    const telegramKey = vi.mocked(redis.set).mock.calls[1][0] as string;
+
+    expect(slackKey).not.toBe(telegramKey);
+    expect(slackKey).toContain(":slack:");
+    expect(telegramKey).toContain(":telegram:");
+    expect(slackKey).toContain(":111");
+    expect(telegramKey).toContain(":111");
+  });
+
+  it("does not throw when Redis is not configured", async () => {
+    vi.resetModules();
+    vi.doMock("@/env", () => ({
+      env: {
+        UPSTASH_REDIS_URL: "",
+        UPSTASH_REDIS_TOKEN: "",
+      },
+    }));
+    const { getMessagingFollowUpContext: getWithoutRedis } = await import(
+      "@/utils/redis/messaging-follow-up-context"
+    );
+
+    await expect(
+      getWithoutRedis({
+        provider: "slack",
+        channelId: "C1",
+        messageTs: "1",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/web/utils/redis/messaging-follow-up-context.ts
+++ b/apps/web/utils/redis/messaging-follow-up-context.ts
@@ -1,0 +1,69 @@
+import { env } from "@/env";
+import { createScopedLogger } from "@/utils/logger";
+import type { MessagingPlatform } from "@/utils/messaging/platforms";
+import { redis } from "@/utils/redis";
+
+const logger = createScopedLogger("redis/messaging-follow-up-context");
+
+const CACHE_KEY_PREFIX = "messaging:follow-up-context";
+const CACHE_TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
+
+type MessagingFollowUpProvider = Extract<
+  MessagingPlatform,
+  "slack" | "telegram"
+>;
+
+export type MessagingFollowUpContext = {
+  emailAccountId: string;
+  threadId: string;
+  messageId: string;
+  trackerId: string;
+  subject: string;
+  counterpartyEmail: string;
+};
+
+type ContextLookupKey = {
+  provider: MessagingFollowUpProvider;
+  channelId: string;
+  messageTs: string;
+};
+
+function isRedisConfigured(): boolean {
+  return Boolean(env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN);
+}
+
+function getContextKey({ provider, channelId, messageTs }: ContextLookupKey) {
+  return `${CACHE_KEY_PREFIX}:${provider}:${channelId}:${messageTs}`;
+}
+
+export async function saveMessagingFollowUpContext(
+  key: ContextLookupKey,
+  context: MessagingFollowUpContext,
+): Promise<void> {
+  if (!isRedisConfigured()) return;
+
+  try {
+    await redis.set(getContextKey(key), context, { ex: CACHE_TTL_SECONDS });
+  } catch (error) {
+    logger.warn("Failed to save messaging follow-up context", {
+      provider: key.provider,
+      error,
+    });
+  }
+}
+
+export async function getMessagingFollowUpContext(
+  key: ContextLookupKey,
+): Promise<MessagingFollowUpContext | null> {
+  if (!isRedisConfigured()) return null;
+
+  try {
+    return await redis.get<MessagingFollowUpContext>(getContextKey(key));
+  } catch (error) {
+    logger.warn("Failed to read messaging follow-up context", {
+      provider: key.provider,
+      error,
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- When a user replies to a follow-up notification in Slack/Telegram, the agent was sometimes drafting against the wrong email because it would run `searchInbox` and pick the most recent thread. We now persist the originating email reference at notification time and inject it as hidden chat context on reply, so the agent calls `replyEmail` with the correct `messageId` directly.
- The same context also disambiguates which connected email account to use when the chat is linked to multiple accounts.

## Changes
- Add `messaging-follow-up-context` Redis store keyed by `provider:channelId:messageTs` (14-day TTL).
- Save the email reference (account, thread, message, tracker, subject, counterparty) when sending Slack and Telegram follow-up notifications.
- On incoming Slack thread replies and Telegram replies (`reply_to_message_id`), look up the stored context, prefer the matching email account when candidates are ambiguous, and prepend a hidden user message that pins the referenced email for the model.
- `sendFollowUpReminderToSlack` now returns the resolved channel + message ts so we can key the context.

## Performance impact
- Adds 1 Redis `SET` per follow-up notification sent and 1 Redis `GET` per reply on a multi-candidate follow-up thread. Both are guarded behind `isRedisConfigured()` and only fire on the existing notification/reply path, so no impact on hot inbox routes.

## Test plan
- [x] `pnpm test apps/web/utils/redis/messaging-follow-up-context.test.ts`
- [x] `pnpm test apps/web/utils/follow-up/send-follow-up-notification.test.ts`
- [x] `pnpm test apps/web/utils/messaging/chat-sdk/bot.test.ts`
- [ ] Manual: trigger a follow-up reminder in Slack, reply in the thread asking "draft a reply", confirm the agent uses the correct `messageId`.
- [ ] Manual: same flow in Telegram with `reply_to_message` on the bot's notification.