### PR TITLE
slack: Render assistant slash command output as mrkdwn

### DIFF
--- a/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
+import { markdownToSlackMrkdwn } from "@/utils/messaging/providers/slack/format";
 import { processSlackSlashCommand } from "@/utils/messaging/providers/slack/slash-commands";
 
 const {
@@ -142,5 +143,29 @@ describe("processSlackSlashCommand", () => {
         },
       }),
     );
+  });
+
+  it("converts markdown in the assistant response to Slack mrkdwn", async () => {
+    const assistantText =
+      "### Action Required\n\n**Important:** review these items.\n\n* First item";
+    mockReadUIMessageStream.mockImplementationOnce(async function* () {
+      yield {
+        id: "assistant-message",
+        role: "assistant",
+        parts: [{ type: "text", text: assistantText }],
+      };
+    });
+
+    await processSlackSlashCommand({
+      command: "/summary",
+      userId: "slack-user",
+      teamId: "slack-team",
+      responseUrl: "https://hooks.slack.com/commands/response",
+      logger,
+    });
+
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.text).toBe(markdownToSlackMrkdwn(assistantText));
   });
 });

--- a/apps/web/utils/messaging/providers/slack/slash-commands.ts
+++ b/apps/web/utils/messaging/providers/slack/slash-commands.ts
@@ -17,6 +17,7 @@ import {
 import type { Logger } from "@/utils/logger";
 import { normalizeMessagingAssistantText } from "@/utils/messaging/chat-sdk/bot";
 import { PROMPT_COMMANDS } from "@/utils/messaging/prompt-commands";
+import { markdownToSlackMrkdwn } from "@/utils/messaging/providers/slack/format";
 import { disableSlackLinkUnfurls } from "@/utils/messaging/providers/slack/send";
 import prisma from "@/utils/prisma";
 import { getEmailAccountWithAi } from "@/utils/user/get";
@@ -91,7 +92,7 @@ export async function processSlackSlashCommand({
 
     await postToSlackResponseUrl(responseUrl, {
       response_type: "ephemeral",
-      text: responseText,
+      text: markdownToSlackMrkdwn(responseText),
     });
   } catch (error) {
     logger.error("Slack slash command AI processing failed", {


### PR DESCRIPTION
## Summary

Slack slash command responses were being posted as raw markdown, so headings, bold, and lists displayed unformatted in the channel. Convert the assistant response through `markdownToSlackMrkdwn` before posting to the response URL so it renders correctly.

- Pipe `responseText` through `markdownToSlackMrkdwn` in `processSlackSlashCommand`
- Add a unit test covering markdown → mrkdwn conversion in the slash command flow

## Test plan

- [x] `pnpm test apps/web/utils/messaging/providers/slack/slash-commands.test.ts`
- [ ] Trigger a slash command in Slack and confirm the assistant response renders with proper formatting

Closes INB-212