### PR TITLE
assistant: Hide internal thread and message IDs from chat replies

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -39,6 +39,7 @@ import {
   requiresThreadIds,
 } from "@/utils/ai/assistant/manage-inbox-actions";
 import { getUserVisibleToolFailureMessage } from "@/utils/ai/assistant/chat-response-guard";
+import { stripInlineThreadIds } from "@/utils/ai/assistant/strip-inline-thread-ids";
 import { pluralize } from "@/utils/string";
 
 interface MessagePartProps {
@@ -124,7 +125,7 @@ export function MessagePart({
     if (!text) return null;
     return (
       <AssistantInlineEmailResponse key={key}>
-        {text}
+        {stripInlineThreadIds(text)}
       </AssistantInlineEmailResponse>
     );
   }

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -741,7 +741,7 @@ export function buildResolvedSystemPrompt({
 - If you are unable to complete a requested action, say so and explain why.
 - Keep responses concise by default.
 - Don't tell the user which tools you're using. The tools you use will be displayed in the UI anyway.
-- Never show internal IDs like threadId, messageId, or ${providerPolicy.hiddenTaxonomyIdName} to the user. These are for tool calls only.`,
+- Never show internal IDs like threadId, messageId, or ${providerPolicy.hiddenTaxonomyIdName} to the user, including inside parentheses or prose. These are for tool calls only. When you need to refer to a specific email, render an <email> or <email-detail> card instead — never write phrases like "(thread 19d693041ceba74e)" or "messageId abc123".`,
     getFormattingRules(responseSurface),
   ];
 

--- a/apps/web/utils/ai/assistant/strip-inline-thread-ids.test.ts
+++ b/apps/web/utils/ai/assistant/strip-inline-thread-ids.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { stripInlineThreadIds } from "@/utils/ai/assistant/strip-inline-thread-ids";
+
+describe("stripInlineThreadIds", () => {
+  it("removes a parenthesized Gmail thread reference", () => {
+    const input =
+      "I also saw that recording from your team (thread 19d693041ceba74e). It seems like a good idea.";
+
+    expect(stripInlineThreadIds(input)).toBe(
+      "I also saw that recording from your team. It seems like a good idea.",
+    );
+  });
+
+  it("removes a parenthesized thread id label form", () => {
+    const input = "Found one match (threadId: 19d693041ceba74e).";
+
+    expect(stripInlineThreadIds(input)).toBe("Found one match.");
+  });
+
+  it("removes an inline thread reference without parentheses", () => {
+    const input = "Open thread 19d693041ceba74e for context.";
+
+    expect(stripInlineThreadIds(input)).toBe("Open for context.");
+  });
+
+  it("removes long Outlook-style ids", () => {
+    const input =
+      "See the trip notes (thread AAQkAGI1ZTM3ZjAwLTUzNjQtNGMzNi04ZTQ4LTQ4MmNkNzg4N2ZlNQAQAA1=). It mentions Friday.";
+
+    expect(stripInlineThreadIds(input)).toBe(
+      "See the trip notes. It mentions Friday.",
+    );
+  });
+
+  it("removes a message id reference", () => {
+    const input = "Check the invoice (messageId 19d693041ceba74e) for details.";
+
+    expect(stripInlineThreadIds(input)).toBe("Check the invoice for details.");
+  });
+
+  it("removes multiple references in one string", () => {
+    const input =
+      "Two emails (thread 19d693041ceba74e) and (thread 18c592030bcda63d) match.";
+
+    expect(stripInlineThreadIds(input)).toBe("Two emails and match.");
+  });
+
+  it("leaves text without thread ids untouched", () => {
+    const input = "Started a new thread about the project plan.";
+
+    expect(stripInlineThreadIds(input)).toBe(input);
+  });
+
+  it("does not strip the threadid attribute inside email tags", () => {
+    const input =
+      '<emails>\n<email threadid="19d693041ceba74e">Trip notes</email>\n</emails>';
+
+    expect(stripInlineThreadIds(input)).toBe(input);
+  });
+
+  it("leaves short ambiguous tokens alone", () => {
+    const input = "Reply in thread 5 or thread A.";
+
+    expect(stripInlineThreadIds(input)).toBe(input);
+  });
+});

--- a/apps/web/utils/ai/assistant/strip-inline-thread-ids.ts
+++ b/apps/web/utils/ai/assistant/strip-inline-thread-ids.ts
@@ -1,0 +1,19 @@
+const ID_LABEL = "(?:thread\\s*id|threadid|thread|message\\s*id|messageid)";
+// 12+ alnum chars avoids matching short words like "thread 5"; real Gmail IDs
+// are 16 hex chars and Outlook IDs are much longer.
+const ID_VALUE = "[A-Za-z0-9_=+/-]{12,}";
+
+const PARENTHESIZED = new RegExp(
+  `\\s*\\(\\s*${ID_LABEL}\\s*:?\\s*${ID_VALUE}\\s*\\)`,
+  "gi",
+);
+
+const INLINE = new RegExp(`\\s*\\b${ID_LABEL}\\s*:?\\s+${ID_VALUE}\\b`, "gi");
+
+export function stripInlineThreadIds(text: string): string {
+  return text
+    .replace(PARENTHESIZED, "")
+    .replace(INLINE, "")
+    .replace(/[ \t]+([.,;:!?])/g, "$1")
+    .replace(/[ \t]{2,}/g, " ");
+}


### PR DESCRIPTION
## Summary
- Strengthens the assistant system prompt with explicit examples of what not to render (e.g. "(thread 19d693041ceba74e)", "messageId abc123"), directing the model to use `<email>` / `<email-detail>` cards instead.
- Adds a client-side `stripInlineThreadIds` safety net that removes parenthesized and inline thread/message ID references from rendered text in `AssistantInlineEmailResponse`.
- Covers Gmail (16-hex) and longer Outlook-style IDs, both label forms (`thread`, `threadId`, `messageId`), and avoids stripping short ambiguous tokens or the `threadid="…"` attribute used inside `<email>` tags.

Closes INB-214.

## Test plan
- [x] `pnpm --filter inbox-zero-ai test utils/ai/assistant/strip-inline-thread-ids.test.ts` (9 passed)
- [ ] Manual: trigger an assistant reply that previously included "(thread …)" and confirm it no longer renders the ID