### PR TITLE
assistant: Require searchInbox before claiming inbox is empty

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -90,6 +90,122 @@ describe.runIf(shouldRunEval)(
         );
 
         test.each(inboxWorkflowProviders)(
+          "verifies with searchInbox before claiming no unread emails on follow-up [$label]",
+          async ({ provider, label, unreadSignal }) => {
+            mockSearchMessages.mockResolvedValueOnce({
+              messages: [
+                getMockMessage({
+                  id: "msg-still-unread-1",
+                  threadId: "thread-still-unread-1",
+                  from: "vendor@partner.example",
+                  subject: "Awaiting your reply",
+                  snippet: "Following up on my earlier note.",
+                  labelIds: ["UNREAD"],
+                }),
+              ],
+              nextPageToken: undefined,
+            });
+
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount: cloneEmailAccountForProvider(
+                emailAccount,
+                provider,
+              ),
+              inboxStats: { total: 240, unread: 6 },
+              messages: [
+                {
+                  role: "user",
+                  content: "Show me anything I should reply to today.",
+                },
+                {
+                  role: "assistant",
+                  content:
+                    "I went through your inbox and replied to the urgent threads.",
+                },
+                {
+                  role: "user",
+                  content: "Do I have any other unread emails?",
+                },
+              ],
+            });
+
+            const searchCall = getFirstSearchInboxCall(toolCalls);
+
+            const pass =
+              !!searchCall &&
+              hasUnreadTriageSignal(searchCall.query, provider, unreadSignal);
+
+            evalReporter.record({
+              testName: `verifies unread on follow-up (${label})`,
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test.each(inboxWorkflowProviders)(
+          "re-runs searchInbox when user pushes back with 'look again' [$label]",
+          async ({ provider, label, unreadSignal }) => {
+            mockSearchMessages.mockResolvedValueOnce({
+              messages: [
+                getMockMessage({
+                  id: "msg-rechecked-1",
+                  threadId: "thread-rechecked-1",
+                  from: "ops@partner.example",
+                  subject: "Quick decision needed",
+                  snippet: "Can you confirm by EOD?",
+                  labelIds: ["UNREAD"],
+                }),
+              ],
+              nextPageToken: undefined,
+            });
+
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount: cloneEmailAccountForProvider(
+                emailAccount,
+                provider,
+              ),
+              inboxStats: { total: 240, unread: 6 },
+              messages: [
+                {
+                  role: "user",
+                  content: "Do I have any unread emails?",
+                },
+                {
+                  role: "assistant",
+                  content:
+                    "Your inbox looks caught up — no unread emails right now.",
+                },
+                {
+                  role: "user",
+                  content: "look again",
+                },
+              ],
+            });
+
+            const searchCall = getFirstSearchInboxCall(toolCalls);
+
+            const pass =
+              !!searchCall &&
+              hasUnreadTriageSignal(searchCall.query, provider, unreadSignal);
+
+            evalReporter.record({
+              testName: `re-runs searchInbox on look-again (${label})`,
+              model: model.label,
+              pass,
+              actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test.each(inboxWorkflowProviders)(
           "uses read-only inbox search for reply triage requests [$label]",
           async ({ provider, label }) => {
             mockSearchMessages.mockResolvedValueOnce({

--- a/apps/web/utils/ai/assistant/chat.test.ts
+++ b/apps/web/utils/ai/assistant/chat.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildResolvedSystemPrompt } from "@/utils/ai/assistant/chat";
+import {
+  buildInboxSnapshotMessage,
+  buildResolvedSystemPrompt,
+} from "@/utils/ai/assistant/chat";
 
 vi.mock("server-only", () => ({}));
 
@@ -17,5 +20,22 @@ describe("buildResolvedSystemPrompt", () => {
 
     expect(prompt).toContain("category");
     expect(prompt).not.toMatch(/\blabels?\b/i);
+  });
+});
+
+describe("buildInboxSnapshotMessage", () => {
+  it("frames the inbox snapshot as a starting point and not the live state", () => {
+    const message = buildInboxSnapshotMessage({ total: 240, unread: 6 });
+
+    expect(message).not.toBeNull();
+    expect(message?.content).toContain("240");
+    expect(message?.content).toContain("6");
+    expect(message?.content).toMatch(/searchInbox/);
+    expect(message?.content).toMatch(/stale|out of date|may have changed/i);
+  });
+
+  it("returns null when no inboxStats are available", () => {
+    expect(buildInboxSnapshotMessage(null)).toBeNull();
+    expect(buildInboxSnapshotMessage(undefined)).toBeNull();
   });
 });

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -170,15 +170,10 @@ export async function aiProcessAssistantChat({
 
   const isFirstMessage = messages.filter((m) => m.role === "user").length <= 1;
 
-  const inboxContextMessage =
-    inboxStats && isFirstMessage
-      ? [
-          {
-            role: "user" as const,
-            content: `[Automated inbox snapshot — not a message from the user] Current inbox: ${inboxStats.total} emails total, ${inboxStats.unread} unread.`,
-          },
-        ]
-      : [];
+  const snapshotMessage = isFirstMessage
+    ? buildInboxSnapshotMessage(inboxStats)
+    : null;
+  const inboxContextMessage = snapshotMessage ? [snapshotMessage] : [];
 
   const hiddenContextMessage =
     context && context.type === "fix-rule"
@@ -628,6 +623,20 @@ function getEmailCapabilitiesPolicy({
   );
 }
 
+export function buildInboxSnapshotMessage(
+  inboxStats?: { total: number; unread: number } | null,
+): { role: "user"; content: string } | null {
+  if (!inboxStats) return null;
+
+  return {
+    role: "user",
+    content:
+      `[Automated inbox snapshot — not a message from the user] At conversation start: ${inboxStats.total} emails total, ${inboxStats.unread} unread. ` +
+      "This snapshot is a starting point only — counts may have changed since then as new mail arrives or actions are taken. " +
+      "Always call searchInbox to confirm the current state before answering questions about unread, new, or recent emails; do not rely on this number alone.",
+  };
+}
+
 export function buildResolvedSystemPrompt({
   emailSendToolsEnabled,
   draftReplyActionsEnabled,
@@ -716,7 +725,8 @@ export function buildResolvedSystemPrompt({
 - For low-priority repeated senders, you may suggest bulk archive by sender as an option, but default to archiving the specific threads shown.
 - For all-matching cleanup, paginate searchInbox until hasMore=false, collect matching threadIds across pages, then write in batches.
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
-- For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.`,
+- For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.
+- Never claim or report that the inbox is empty, fully caught up, or has no unread emails without first running searchInbox in this turn to confirm — the initial inbox snapshot and prior-turn results can be stale, and earlier search pages or filters may not cover the whole mailbox. Treat zero results from a single narrow query as inconclusive: broaden or re-run searchInbox before asserting absence. If the user signals doubt about a prior conclusion or asks you to re-check, re-run searchInbox with fresh (and broader, if the prior call was narrow) parameters and report the new results rather than rephrasing the prior conclusion.`,
     providerPolicy.ruleSuggestionPolicy,
     `Rules and automation:
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.


### PR DESCRIPTION
## Summary

Fixes INB-228: the assistant was reporting "no unread emails" / "inbox caught up" on follow-up turns without actually checking, because it was anchored to the initial automated inbox snapshot.

- Reframe the inbox snapshot as a starting-point hint that may be stale, and tell the model to confirm via `searchInbox` before answering questions about unread/new/recent mail
- Add a system-prompt rule that bars empty/caught-up claims without an in-turn `searchInbox`, and requires a re-run with broader params when the user pushes back ("look again")
- Extract `buildInboxSnapshotMessage` so the framing is unit-testable
- Add eval coverage for the two regression flows (follow-up "any other unread?" and pushback "look again") across providers

## Test plan

- [ ] `pnpm test apps/web/utils/ai/assistant/chat.test.ts`
- [ ] `pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-inbox-workflows-triage.test.ts`
- [ ] Manual: ask "do I have any other unread emails?" after the assistant reports it triaged the inbox; confirm it runs `searchInbox` instead of reusing the snapshot