### PR TITLE
messaging: Show destination account in chat notifications

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -542,6 +542,7 @@ async function processFollowUpsForType({
               }) ?? undefined,
             threadLinkLabel: getThreadLinkLabel(providerName),
             trackerId: tracker.id,
+            userEmail: emailAccount.email,
             logger: threadLogger,
           });
         } catch (notifyError) {

--- a/apps/web/utils/automation-jobs/messaging.ts
+++ b/apps/web/utils/automation-jobs/messaging.ts
@@ -7,12 +7,14 @@ import {
   sendAutomationMessageToSlack,
 } from "@/utils/automation-jobs/slack";
 import type { Logger } from "@/utils/logger";
+import { formatAccountHeader } from "@/utils/messaging/account-header";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 
 export async function sendAutomationMessage({
   channel,
   route,
   text,
+  accountEmail,
   logger,
 }: {
   channel: {
@@ -27,6 +29,7 @@ export async function sendAutomationMessage({
     targetType: MessagingRouteTargetType;
   } | null;
   text: string;
+  accountEmail?: string | null;
   logger: Logger;
 }) {
   switch (channel.provider) {
@@ -58,7 +61,9 @@ export async function sendAutomationMessage({
           route?.targetType === MessagingRouteTargetType.DIRECT_MESSAGE
             ? route.targetId
             : (channel.providerUserId ?? null),
-        text,
+        text: accountEmail
+          ? `${formatAccountHeader(accountEmail)}\n\n${text}`
+          : text,
         logger,
       });
     }

--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -123,6 +123,7 @@ export async function sendDigest({
             date,
             ruleNames,
             itemsByRule,
+            accountEmail: userEmail,
             logger,
           }),
         );
@@ -236,6 +237,7 @@ async function sendDigestViaMessagingApp({
   date,
   ruleNames,
   itemsByRule,
+  accountEmail,
   logger,
 }: {
   channel: {
@@ -248,6 +250,7 @@ async function sendDigestViaMessagingApp({
   date: Date;
   ruleNames: Record<string, string>;
   itemsByRule: ItemsByRule;
+  accountEmail: string;
   logger: Logger;
 }) {
   logger.info("Sending digest to messaging app", {
@@ -258,6 +261,7 @@ async function sendDigestViaMessagingApp({
     channel,
     route,
     text: formatDigestText({ date, ruleNames, itemsByRule }),
+    accountEmail,
     logger,
   });
 

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -337,6 +337,7 @@ export async function processAttachment({
     try {
       await sendFilingMessagingNotifications({
         emailAccountId: emailAccount.id,
+        userEmail: emailAccount.email,
         filingId: filing.id,
         senderEmail: extractEmailAddress(message.headers.from),
         logger: log,

--- a/apps/web/utils/drive/filing-messaging-notifications.test.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.test.ts
@@ -61,6 +61,7 @@ describe("sendFilingMessagingNotifications", () => {
 
     await sendFilingMessagingNotifications({
       emailAccountId: "email-account-1",
+      userEmail: "user@example.com",
       filingId: "filing-1",
       logger,
     });
@@ -91,6 +92,7 @@ describe("sendFilingMessagingNotifications", () => {
 
     await sendFilingMessagingNotifications({
       emailAccountId: "email-account-1",
+      userEmail: "user@example.com",
       filingId: "filing-1",
       logger,
     });

--- a/apps/web/utils/drive/filing-messaging-notifications.ts
+++ b/apps/web/utils/drive/filing-messaging-notifications.ts
@@ -18,11 +18,13 @@ import { isMessagingChannelOperational } from "@/utils/messaging/channel-validit
 
 export async function sendFilingMessagingNotifications({
   emailAccountId,
+  userEmail,
   filingId,
   senderEmail,
   logger,
 }: {
   emailAccountId: string;
+  userEmail: string;
   filingId: string;
   senderEmail?: string | null;
   logger: Logger;
@@ -139,6 +141,7 @@ export async function sendFilingMessagingNotifications({
                   folderPath: filing.folderPath,
                   senderEmail,
                 }),
+            accountEmail: userEmail,
             logger: log,
           }),
         );

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -49,6 +49,7 @@ const baseArgs = {
   snippet: "Following up on the items we discussed.",
   threadLink: "https://mail.example/thread",
   trackerId: "tracker-1",
+  userEmail: "user@example.com",
   logger,
 };
 
@@ -143,6 +144,7 @@ describe("sendFollowUpNotification", () => {
     expect(serializedCard).toContain("Follow-up nudge");
     expect(serializedCard).toContain("Open in Outlook");
     expect(serializedCard).toContain(threadLink);
+    expect(serializedCard).toContain("Account: user@example.com");
     expect(serializedCard).not.toContain(`Open: ${threadLink}`);
   });
 

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -7,6 +7,7 @@ import {
 } from "@/generated/prisma/enums";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
 import type { Logger } from "@/utils/logger";
+import { telegramAccountHeaderCardChild } from "@/utils/messaging/account-header";
 import {
   resolveSlackRouteDestination,
   sendFollowUpReminderToSlack,
@@ -78,10 +79,12 @@ export async function getFollowUpNotificationChannels(
 
 export async function sendFollowUpNotification({
   channels,
+  userEmail,
   logger,
   ...content
 }: FollowUpNotificationContent & {
   channels: FollowUpNotificationChannel[];
+  userEmail: string;
   logger: Logger;
 }): Promise<void> {
   const deliveryPromises: Promise<unknown>[] = [];
@@ -121,6 +124,7 @@ export async function sendFollowUpNotification({
             channel,
             route,
             text: formatFollowUpText(content),
+            accountEmail: userEmail,
             logger,
           }),
         );
@@ -130,7 +134,7 @@ export async function sendFollowUpNotification({
           sendFollowUpViaTelegram({
             channel,
             route,
-            content,
+            content: { ...content, accountEmail: userEmail },
             logger,
           }),
         );
@@ -186,7 +190,7 @@ async function sendFollowUpViaTelegram({
 }: {
   channel: FollowUpNotificationChannel;
   route: { targetId: string; targetType: MessagingRouteTargetType };
-  content: FollowUpNotificationContent;
+  content: FollowUpNotificationContent & { accountEmail?: string | null };
   logger: Logger;
 }) {
   const destination =
@@ -243,10 +247,15 @@ function buildTelegramFollowUpCard({
   snippet,
   threadLink,
   threadLinkLabel,
-}: FollowUpNotificationContent) {
+  accountEmail,
+}: FollowUpNotificationContent & { accountEmail?: string | null }) {
   const { directionLine, counterpartyPrefix, snippetLabel, emoji } =
     getFollowUpCopy(trackerType);
-  const children: CardChild[] = [
+  const children: CardChild[] = [];
+  if (accountEmail) {
+    children.push(telegramAccountHeaderCardChild(accountEmail));
+  }
+  children.push(
     CardText(
       [
         directionLine,
@@ -254,7 +263,7 @@ function buildTelegramFollowUpCard({
         `${counterpartyPrefix} ${normalizeFollowUpText(counterpartyName)} <${counterpartyEmail}> · ${daysSinceSent} ${pluralize(daysSinceSent, "day")} ago`,
       ].join("\n\n"),
     ),
-  ];
+  );
 
   const formattedSnippet = snippet
     ? formatQuotedSnippet(snippet, TELEGRAM_SNIPPET_MAX_CHARS)

--- a/apps/web/utils/meeting-briefs/send-briefing.ts
+++ b/apps/web/utils/meeting-briefs/send-briefing.ts
@@ -146,6 +146,7 @@ export async function sendBriefing({
             videoConferenceLink: event.videoConferenceLink ?? undefined,
             eventUrl: event.eventUrl ?? undefined,
             briefingContent: briefingContentWithTeam,
+            accountEmail: userEmail,
             logger,
           }),
         );
@@ -293,6 +294,7 @@ async function sendBriefingViaMessagingApp({
   videoConferenceLink,
   eventUrl,
   briefingContent,
+  accountEmail,
   logger,
 }: {
   channel: {
@@ -316,6 +318,7 @@ async function sendBriefingViaMessagingApp({
   videoConferenceLink?: string;
   eventUrl?: string;
   briefingContent: BriefingContent;
+  accountEmail: string;
   logger: Logger;
 }) {
   logger.info("Sending briefing to messaging app", {
@@ -332,6 +335,7 @@ async function sendBriefingViaMessagingApp({
       eventUrl,
       briefingContent,
     }),
+    accountEmail,
     logger,
   });
 

--- a/apps/web/utils/messaging/account-header.ts
+++ b/apps/web/utils/messaging/account-header.ts
@@ -1,0 +1,12 @@
+import { CardText, type CardChild } from "chat";
+import { escapeTelegramMarkdown } from "@/utils/messaging/providers/telegram/format";
+
+const ACCOUNT_HEADER_PREFIX = "📬 Account:";
+
+export function formatAccountHeader(email: string): string {
+  return `${ACCOUNT_HEADER_PREFIX} ${email}`;
+}
+
+export function telegramAccountHeaderCardChild(email: string): CardChild {
+  return CardText(`${ACCOUNT_HEADER_PREFIX} ${escapeTelegramMarkdown(email)}`);
+}

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1214,6 +1214,7 @@ describe("sendMessagingRuleNotification", () => {
       text: expect.stringContaining(
         "Quick actions like archive and mark read are Slack-only right now",
       ),
+      accountEmail: "user@example.com",
       logger: expect.anything(),
     });
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
@@ -1271,6 +1272,7 @@ describe("sendMessagingRuleNotification", () => {
         targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
       },
       text: expect.stringContaining("💬 They wrote:\nFirst line\nSecond line"),
+      accountEmail: "user@example.com",
       logger: expect.anything(),
     });
 
@@ -1376,6 +1378,8 @@ describe("sendMessagingRuleNotification", () => {
     expect(serializedCard).toContain("Send reply");
     expect(serializedCard).toContain("Open in Gmail");
     expect(serializedCard).not.toContain("Edit draft");
+    expect(serializedCard).toContain("Account:");
+    expect(serializedCard).toContain("user@example.com");
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -66,6 +66,7 @@ import {
   isMessagingChannelOperational,
   isOperationalSlackChannel,
 } from "@/utils/messaging/channel-validity";
+import { telegramAccountHeaderCardChild } from "@/utils/messaging/account-header";
 import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
 import {
   escapeTelegramMarkdown,
@@ -462,6 +463,7 @@ async function sendLinkedRuleNotification({
       channel: context.messagingChannel,
       route,
       text,
+      accountEmail: context.executedRule.emailAccount.email,
       logger,
     });
 
@@ -562,6 +564,7 @@ async function sendTelegramRuleNotificationWithContext({
         actionId: context.id,
         content,
         openLink: getNotificationOpenLink(context),
+        accountEmail: context.executedRule.emailAccount.email,
       }),
     );
 
@@ -1745,13 +1748,19 @@ function buildTelegramNotificationCard({
   actionId,
   content,
   openLink,
+  accountEmail,
 }: {
   actionId: string;
   content: NotificationContent;
   openLink?: NotificationOpenLink | null;
+  accountEmail?: string | null;
 }): CardElement {
-  const children = buildNotificationCardBody(
-    sanitizeTelegramNotificationContent(content),
+  const children: CardChild[] = [];
+  if (accountEmail) {
+    children.push(telegramAccountHeaderCardChild(accountEmail));
+  }
+  children.push(
+    ...buildNotificationCardBody(sanitizeTelegramNotificationContent(content)),
   );
   children.push(
     Actions([


### PR DESCRIPTION
## Summary

Adds an account email header to Telegram and chat-SDK messaging notifications so users with multiple connected accounts can tell which inbox a message belongs to. Closes INB-211.

- New `formatAccountHeader` / `telegramAccountHeaderCardChild` helpers in `utils/messaging/account-header.ts`
- Threaded `accountEmail` through `sendAutomationMessage`, follow-up notifications, digests, meeting briefs, and drive filing notifications
- Telegram cards prepend the account header as a separate card child; chat-SDK text channels prepend it inline

## Test plan

- [ ] `pnpm test apps/web/utils/messaging/rule-notifications.test.ts`
- [ ] `pnpm test apps/web/utils/follow-up/send-follow-up-notification.test.ts`
- [ ] `pnpm test apps/web/utils/drive/filing-messaging-notifications.test.ts`
- [ ] Smoke test Telegram + chat-SDK notifications with a multi-account user