### PR TITLE
rule: Bring create-rule schema under Anthropic 24-optional-param limit

### DIFF
--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { z } from "zod";
+import { z } from "zod";
 import { ActionType } from "@/generated/prisma/enums";
 import {
   createRuleSchema,
@@ -389,6 +389,58 @@ describe("getExtraActions", () => {
 
     expect(getExtraActions([ActionType.CALL_WEBHOOK])).not.toContain(
       ActionType.CALL_WEBHOOK,
+    );
+  });
+});
+
+// Anthropic's structured-outputs grammar compiler rejects schemas with more
+// than 24 optional parameters per tool. See issue #2323 — `aiPromptToRules`
+// uses `generateObject` whose schema is `z.array(createRuleSchema(provider))`,
+// so any growth in optional fields across the action union flows directly
+// into that limit. This test is the regression guard.
+const ANTHROPIC_STRICT_OPTIONAL_LIMIT = 24;
+
+function countOptionalParams(node: unknown): number {
+  if (!node || typeof node !== "object") return 0;
+  const schema = node as Record<string, unknown>;
+  let count = 0;
+
+  if (schema.type === "object" && schema.properties) {
+    const required = new Set((schema.required as string[]) ?? []);
+    for (const [key, child] of Object.entries(
+      schema.properties as Record<string, unknown>,
+    )) {
+      if (!required.has(key)) count += 1;
+      count += countOptionalParams(child);
+    }
+  }
+  if (schema.items) count += countOptionalParams(schema.items);
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    if (Array.isArray(schema[key])) {
+      for (const child of schema[key] as unknown[]) {
+        count += countOptionalParams(child);
+      }
+    }
+  }
+  return count;
+}
+
+describe("createRuleSchema JSON schema budget (Anthropic strict-mode)", () => {
+  it("keeps optional-param count under Anthropic's 24 limit when used as a generateObject schema", () => {
+    const provider = "google";
+    const wrapper = z.object({
+      rules: z.array(createRuleSchema(provider)),
+    });
+
+    // Mirror the exact serialization the AI SDK uses to send schemas to
+    // Anthropic (see @ai-sdk/provider-utils → zod4Schema).
+    const jsonSchema = z.toJSONSchema(wrapper, {
+      target: "draft-7",
+      io: "input",
+      reused: "inline",
+    });
+    expect(countOptionalParams(jsonSchema)).toBeLessThanOrEqual(
+      ANTHROPIC_STRICT_OPTIONAL_LIMIT,
     );
   });
 });

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -262,9 +262,7 @@ function createActionFieldShape(provider: string) {
 
 function optionalStringField(description: string) {
   return z
-    .string()
-    .nullish()
-    .transform((value) => value ?? null)
+    .preprocess((value) => value ?? null, z.string().nullable())
     .describe(description);
 }
 


### PR DESCRIPTION
## Summary

Anthropic's structured-outputs grammar compiler rejects tool schemas with more than 24 optional parameters. `aiPromptToRules` builds its `generateObject` schema from `createRuleSchema`, whose action union currently emits ~89 optional params across 11 variants × 7–8 nullish fields — well over the cap. The call fails with:

> Schemas contains too many optional parameters (87), which would make grammar compilation inefficient. Reduce the number of optional parameters in your tool schemas (limit: 24).

## The fix

Swap the `optionalStringField` helper from `.nullish() + transform(v => v ?? null)` to `z.preprocess(v => v ?? null, z.string().nullable())`.

- **Same runtime tolerance.** `preprocess` coerces `undefined` → `null` before validation, so call sites and tests that omit fields still parse.
- **Same output type.** Both yield `string | null`, so consumers (`shared.ts`, `rule.ts`, API serializers) are unaffected.
- **Tighter JSON schema.** `.nullable()` puts each field in `required` (with `null` allowed in `type`), moving them out of Anthropic's optional-param tally.

Optional-param count for `z.object({ rules: z.array(createRuleSchema('google')) })`: **89 → 22**.

I deliberately scoped the fix to `optionalStringField` rather than also porting `aiInstructions` / `static.*` / `delayInMinutes` (which still use `.nullish()`). 22 is comfortably under 24, the diff stays minimal, and the same swap can be applied later if the schema grows.

## Test plan

Added a regression guard in `create-rule-schema.test.ts` that mirrors the AI SDK's exact zod → JSON schema serialization (`target: "draft-7"`, `io: "input"`, `reused: "inline"` — see `@ai-sdk/provider-utils → zod4Schema`) and walks the schema counting fields not in `required` across nested objects, `items`, and `anyOf`/`oneOf`/`allOf` branches.

- [x] `pnpm --filter inbox-zero test utils/ai/rule/create-rule-schema` — 20/20 pass
- [x] `pnpm --filter inbox-zero test utils/ai` — 480/480 pass
- [x] `pnpm check` (ultracite) — clean
- [ ] Manual: trigger `aiPromptToRules` with `DEFAULT_LLM_PROVIDER=anthropic` (deferred — needs prod-flavoured env)

## Why this instead of splitting the tool?

The issue suggested splitting the giant tool into smaller composable tools, or using `oneOf`/`anyOf`. The schema *is* already a `z.union` (= `oneOf`); only the field-level nullish chains were inflating the count. The preprocess swap is 3 lines and doesn't touch any consumer — a tool split would also need to restructure `aiPromptToRules` and every consumer of its output. Happy to do the larger restructure if you'd prefer.

Closes #2323