### PR TITLE
Fix attendee partitioning for meeting briefs

### DIFF
--- a/apps/web/utils/meeting-briefs/attendees.test.ts
+++ b/apps/web/utils/meeting-briefs/attendees.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "@/utils/calendar/event-types";
+import { partitionAttendeesForBriefing } from "./attendees";
+
+describe("partitionAttendeesForBriefing", () => {
+  it.each([
+    "gmail.com",
+    "outlook.com",
+  ])("treats other %s attendees as external for personal accounts", (domain) => {
+    const event = createEvent({
+      attendees: [
+        { email: `user@${domain}` },
+        { email: `guest@${domain}`, name: "Guest" },
+      ],
+    });
+
+    const { external, internal } = partitionAttendeesForBriefing(
+      event,
+      `user@${domain}`,
+    );
+
+    expect(external).toEqual([{ email: `guest@${domain}`, name: "Guest" }]);
+    expect(internal).toEqual([]);
+  });
+
+  it("treats same-company-domain attendees as internal team members", () => {
+    const event = createEvent({
+      attendees: [
+        { email: "user@company.com" },
+        { email: "teammate@company.com", name: "Teammate" },
+        { email: "client@example.com", name: "Client" },
+      ],
+    });
+
+    const { external, internal } = partitionAttendeesForBriefing(
+      event,
+      "user@company.com",
+    );
+
+    expect(external).toEqual([{ email: "client@example.com", name: "Client" }]);
+    expect(internal).toEqual([
+      { email: "teammate@company.com", name: "Teammate" },
+    ]);
+  });
+
+  it("excludes the user from both partitions", () => {
+    const event = createEvent({
+      attendees: [
+        { email: "user@company.com" },
+        { email: "USER@company.com" },
+        { email: "  user@company.com  " },
+      ],
+    });
+
+    const { external, internal } = partitionAttendeesForBriefing(
+      event,
+      "user@company.com",
+    );
+
+    expect(external).toEqual([]);
+    expect(internal).toEqual([]);
+  });
+});
+
+function createEvent(overrides: Partial<CalendarEvent>): CalendarEvent {
+  const startTime = overrides.startTime ?? new Date("2026-05-14T10:00:00Z");
+  return {
+    id: overrides.id ?? "event-1",
+    title: overrides.title ?? "Meeting",
+    description: overrides.description,
+    location: overrides.location,
+    eventUrl: overrides.eventUrl,
+    videoConferenceLink: overrides.videoConferenceLink,
+    startTime,
+    endTime:
+      overrides.endTime ?? new Date(startTime.getTime() + 30 * 60 * 1000),
+    attendees: overrides.attendees ?? [],
+  };
+}

--- a/apps/web/utils/meeting-briefs/attendees.ts
+++ b/apps/web/utils/meeting-briefs/attendees.ts
@@ -1,0 +1,40 @@
+import type {
+  CalendarEvent,
+  CalendarEventAttendee,
+} from "@/utils/calendar/event-types";
+import { extractDomainFromEmail, isPublicEmailDomain } from "@/utils/email";
+
+interface PartitionedAttendees {
+  external: CalendarEventAttendee[];
+  internal: CalendarEventAttendee[];
+}
+
+// Personal-email accounts (gmail, outlook, etc.) share their domain with strangers,
+// so we cannot treat same-domain attendees as an internal team.
+export function partitionAttendeesForBriefing(
+  event: CalendarEvent,
+  userEmail: string,
+): PartitionedAttendees {
+  const normalizedUserEmail = userEmail.trim().toLowerCase();
+  const userDomain = extractDomainFromEmail(normalizedUserEmail).toLowerCase();
+  const userDomainIsPublic = !userDomain || isPublicEmailDomain(userDomain);
+
+  const external: CalendarEventAttendee[] = [];
+  const internal: CalendarEventAttendee[] = [];
+
+  for (const attendee of event.attendees) {
+    const attendeeEmail = attendee.email.trim().toLowerCase();
+    if (!attendeeEmail || attendeeEmail === normalizedUserEmail) continue;
+
+    const attendeeDomain = extractDomainFromEmail(attendeeEmail).toLowerCase();
+    if (!attendeeDomain) continue;
+
+    if (userDomainIsPublic || attendeeDomain !== userDomain) {
+      external.push(attendee);
+    } else {
+      internal.push(attendee);
+    }
+  }
+
+  return { external, internal };
+}

--- a/apps/web/utils/meeting-briefs/fetch-upcoming-events.ts
+++ b/apps/web/utils/meeting-briefs/fetch-upcoming-events.ts
@@ -1,8 +1,8 @@
 import { addMinutes } from "date-fns/addMinutes";
 import { createCalendarEventProviders } from "@/utils/calendar/event-provider";
 import type { CalendarEvent } from "@/utils/calendar/event-types";
-import { extractDomainFromEmail } from "@/utils/email";
 import type { Logger } from "@/utils/logger";
+import { partitionAttendeesForBriefing } from "./attendees";
 
 const MAX_EVENTS_PER_PROVIDER = 20;
 
@@ -59,20 +59,9 @@ export function filterEventsWithExternalGuests(
   events: CalendarEvent[],
   userEmail: string,
 ): CalendarEvent[] {
-  const userDomain = extractDomainFromEmail(userEmail).toLowerCase();
-  const normalizedUserEmail = userEmail.toLowerCase();
-
-  return events.filter((event) =>
-    event.attendees.some((attendee) => {
-      const attendeeEmail = attendee.email.toLowerCase();
-      if (attendeeEmail === normalizedUserEmail) {
-        return false;
-      }
-      const attendeeDomain = extractDomainFromEmail(
-        attendee.email,
-      ).toLowerCase();
-      return attendeeDomain !== userDomain;
-    }),
+  return events.filter(
+    (event) =>
+      partitionAttendeesForBriefing(event, userEmail).external.length > 0,
   );
 }
 

--- a/apps/web/utils/meeting-briefs/gather-context.ts
+++ b/apps/web/utils/meeting-briefs/gather-context.ts
@@ -8,7 +8,6 @@ import type {
   CalendarEventAttendee,
   CalendarEventProvider,
 } from "@/utils/calendar/event-types";
-import { extractDomainFromEmail } from "@/utils/email";
 
 const MAX_THREADS = 10;
 const MAX_MESSAGES_PER_THREAD = 10;
@@ -39,27 +38,21 @@ export interface MeetingBriefingData {
 export async function gatherContextForEvent({
   event,
   emailAccountId,
-  userEmail,
-  userDomain,
+  externalAttendees,
+  internalAttendees,
   provider,
   logger,
 }: {
   event: CalendarEvent;
   emailAccountId: string;
-  userEmail: string;
-  userDomain: string;
+  externalAttendees: CalendarEventAttendee[];
+  internalAttendees: CalendarEventAttendee[];
   provider: string;
   logger: Logger;
 }): Promise<MeetingBriefingData> {
-  const externalAttendees = getExternalAttendees(event, userEmail, userDomain);
-  const internalAttendees = getInternalTeamMembers(
-    event,
-    userEmail,
-    userDomain,
-  );
   const participantEmails = externalAttendees.map((a) => a.email);
 
-  logger.info("Gathering context for external guests", {
+  logger.info("Gathering context for meeting attendees", {
     guestCount: externalAttendees.length,
     internalTeamCount: internalAttendees.length,
   });
@@ -158,48 +151,6 @@ async function fetchEmailThreadsWithParticipants({
   }
 
   return allThreads;
-}
-
-function getExternalAttendees(
-  event: CalendarEvent,
-  userEmail: string,
-  userDomain: string,
-): CalendarEventAttendee[] {
-  const normalizedUserEmail = userEmail.trim().toLowerCase();
-  const normalizedUserDomain = userDomain.trim().toLowerCase();
-
-  return event.attendees.filter((attendee) => {
-    const normalizedAttendeeEmail = attendee.email.trim().toLowerCase();
-    const attendeeDomain = extractDomainFromEmail(normalizedAttendeeEmail);
-
-    if (!attendeeDomain) return false;
-
-    return (
-      attendeeDomain !== normalizedUserDomain &&
-      normalizedAttendeeEmail !== normalizedUserEmail
-    );
-  });
-}
-
-function getInternalTeamMembers(
-  event: CalendarEvent,
-  userEmail: string,
-  userDomain: string,
-): CalendarEventAttendee[] {
-  const normalizedUserEmail = userEmail.trim().toLowerCase();
-  const normalizedUserDomain = userDomain.trim().toLowerCase();
-
-  return event.attendees.filter((attendee) => {
-    const normalizedAttendeeEmail = attendee.email.trim().toLowerCase();
-    const attendeeDomain = extractDomainFromEmail(normalizedAttendeeEmail);
-
-    // Internal team members share the same domain but are not the user themselves
-    return (
-      attendeeDomain &&
-      attendeeDomain === normalizedUserDomain &&
-      normalizedAttendeeEmail !== normalizedUserEmail
-    );
-  });
 }
 
 async function fetchPastMeetingsWithParticipants({

--- a/apps/web/utils/meeting-briefs/process.ts
+++ b/apps/web/utils/meeting-briefs/process.ts
@@ -10,7 +10,7 @@ import { aiGenerateMeetingBriefing } from "@/utils/ai/meeting-briefs/generate-br
 import { sendBriefing } from "./send-briefing";
 import type { Logger } from "@/utils/logger";
 import type { CalendarEvent } from "@/utils/calendar/event-types";
-import { extractDomainFromEmail } from "@/utils/email";
+import { partitionAttendeesForBriefing } from "./attendees";
 
 export type EmailAccountForBrief = {
   id: string;
@@ -155,11 +155,9 @@ export async function runMeetingBrief({
 
   const eventLog = logger.with({ eventId: event.id });
 
-  const userDomain = extractDomainFromEmail(userEmail);
-  const externalGuestCount = event.attendees.filter((attendee) => {
-    const attendeeDomain = extractDomainFromEmail(attendee.email ?? "");
-    return attendeeDomain && attendeeDomain !== userDomain;
-  }).length;
+  const { external: externalAttendees, internal: internalAttendees } =
+    partitionAttendeesForBriefing(event, userEmail);
+  const externalGuestCount = externalAttendees.length;
 
   if (!isTestSend) {
     const claimed = await claimMeetingBriefing({
@@ -180,8 +178,8 @@ export async function runMeetingBrief({
     const briefingData = await gatherContextForEvent({
       event,
       emailAccountId,
-      userEmail,
-      userDomain,
+      externalAttendees,
+      internalAttendees,
       provider,
       logger: eventLog,
     });


### PR DESCRIPTION
Updates meeting brief attendee classification so shared personal-provider domains are handled correctly without duplicating participant logic. This keeps context gathering and event filtering aligned through one shared partitioning path.

- Added a shared meeting-brief attendee partitioning helper.
- Reused the helper for event filtering, context gathering, and brief processing.
- Added focused unit coverage for personal-provider and organization-domain attendees.

Tests:
- pnpm test utils/meeting-briefs/attendees.test.ts

Performance impact: Minimal runtime work: one linear pass over event attendees per brief/filter path. No new database or network calls; low hot-path risk because the change replaces duplicated attendee scans with centralized in-memory logic.