### PR TITLE
cold-email: write LEARNED_PATTERN matchMetadata on pattern hits

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -109,7 +109,15 @@ export async function findMatchingRules({
         matches: [
           {
             rule: coldRule,
-            matchReasons: [{ type: ConditionType.AI }],
+            matchReasons: coldEmailResult.patternMatch
+              ? [
+                  {
+                    type: ConditionType.LEARNED_PATTERN,
+                    group: coldEmailResult.patternMatch.group,
+                    groupItem: coldEmailResult.patternMatch.groupItem,
+                  },
+                ]
+              : [{ type: ConditionType.AI }],
           },
         ],
         reasoning: coldEmailResult.aiReason || coldEmailResult.reason,

--- a/apps/web/utils/cold-email/is-cold-email.test.ts
+++ b/apps/web/utils/cold-email/is-cold-email.test.ts
@@ -41,7 +41,10 @@ describe("isColdEmail", () => {
     // Mock groupItem lookup
     vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
       id: "group-item-id",
+      type: GroupItemType.FROM,
+      value: normalizedEmail,
       exclude: false,
+      group: { id: groupId, name: "Cold Email" },
     } as any);
 
     const email: EmailForLLM = {
@@ -62,6 +65,15 @@ describe("isColdEmail", () => {
 
     expect(result.isColdEmail).toBe(true);
     expect(result.reason).toBe("ai-already-labeled");
+    expect(result.patternMatch).toEqual({
+      group: { id: groupId, name: "Cold Email" },
+      groupItem: {
+        id: "group-item-id",
+        type: GroupItemType.FROM,
+        value: normalizedEmail,
+        exclude: false,
+      },
+    });
 
     // Verify that findFirst was called with the normalized email address
     expect(prisma.groupItem.findFirst).toHaveBeenCalledWith({
@@ -70,7 +82,13 @@ describe("isColdEmail", () => {
         type: GroupItemType.FROM,
         value: normalizedEmail,
       },
-      select: { exclude: true },
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        exclude: true,
+        group: { select: { id: true, name: true } },
+      },
     });
   });
 
@@ -82,7 +100,10 @@ describe("isColdEmail", () => {
     // Mock groupItem lookup with exclude: true
     vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
       id: "group-item-id",
+      type: GroupItemType.FROM,
+      value: normalizedEmail,
       exclude: true,
+      group: { id: groupId, name: "Cold Email" },
     } as any);
 
     const email: EmailForLLM = {
@@ -110,7 +131,13 @@ describe("isColdEmail", () => {
         type: GroupItemType.FROM,
         value: normalizedEmail,
       },
-      select: { exclude: true },
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        exclude: true,
+        group: { select: { id: true, name: true } },
+      },
     });
   });
 
@@ -136,7 +163,10 @@ describe("isColdEmail", () => {
       vi.clearAllMocks();
       vi.mocked(prisma.groupItem.findFirst).mockResolvedValue({
         id: "group-item-id",
+        type: GroupItemType.FROM,
+        value: normalizedEmail,
         exclude: false,
+        group: { id: groupId, name: "Cold Email" },
       } as any);
 
       const email: EmailForLLM = {
@@ -166,7 +196,13 @@ describe("isColdEmail", () => {
           type: GroupItemType.FROM,
           value: expectedNormalized,
         },
-        select: { exclude: true },
+        select: {
+          id: true,
+          type: true,
+          value: true,
+          exclude: true,
+          group: { select: { id: true, name: true } },
+        },
       });
     }
   });

--- a/apps/web/utils/cold-email/is-cold-email.ts
+++ b/apps/web/utils/cold-email/is-cold-email.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
-import type { Rule } from "@/generated/prisma/client";
+import type { Group, GroupItem, Rule } from "@/generated/prisma/client";
 import { GroupItemType } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { DEFAULT_COLD_EMAIL_PROMPT } from "@/utils/cold-email/prompt";
@@ -20,6 +20,11 @@ type ColdEmailBlockerReason =
   | "ai-already-labeled"
   | "excluded";
 
+export type ColdEmailPatternMatch = {
+  group: Pick<Group, "id" | "name">;
+  groupItem: Pick<GroupItem, "id" | "type" | "value" | "exclude">;
+};
+
 export async function isColdEmail({
   email,
   emailAccount,
@@ -36,6 +41,7 @@ export async function isColdEmail({
   isColdEmail: boolean;
   reason: ColdEmailBlockerReason;
   aiReason?: string | null;
+  patternMatch?: ColdEmailPatternMatch;
 }> {
   const logger = createScopedLogger("ai-cold-email").with({
     emailAccountId: emailAccount.id,
@@ -48,7 +54,11 @@ export async function isColdEmail({
 
   // Check if we marked it as a cold email already
   const groupId = coldEmailRule?.groupId;
-  let patternMatch: { exclude: boolean } | null = null;
+  let patternMatch:
+    | (Pick<GroupItem, "id" | "type" | "value" | "exclude"> & {
+        group: Pick<Group, "id" | "name"> | null;
+      })
+    | null = null;
 
   if (groupId) {
     const normalizedFrom = extractEmailAddress(email.from) || email.from;
@@ -58,13 +68,24 @@ export async function isColdEmail({
         type: GroupItemType.FROM,
         value: normalizedFrom,
       },
-      select: { exclude: true },
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        exclude: true,
+        group: { select: { id: true, name: true } },
+      },
     });
   }
 
   if (patternMatch && !patternMatch.exclude) {
     logger.info("Known cold email sender", { from: email.from });
-    return { isColdEmail: true, reason: "ai-already-labeled" };
+    const { group, ...groupItem } = patternMatch;
+    return {
+      isColdEmail: true,
+      reason: "ai-already-labeled",
+      ...(group ? { patternMatch: { group, groupItem } } : {}),
+    };
   }
 
   if (patternMatch?.exclude) {


### PR DESCRIPTION
Fixes #2664.

## Summary

Cold-email pattern hits are currently logged as `[{type: "AI"}]` in `ExecutedRule.matchMetadata` even when no LLM call was made (`isColdEmail` returned via a `GroupItem` lookup, reason `"ai-already-labeled"`). The decision and cost are correct — only the audit trail is wrong. Every other rule type emits a `LearnedPatternMatch` reason (with `group` and `groupItem`) on pattern hits via `serializeMatchReasons`; the cold-email path was the only inconsistent one.

The bug originated in #1180, which added the pattern lookup in `is-cold-email.ts` but didn't propagate the result back into the `matchReasons` shape constructed in `match-rules.ts`.

## Changes

- `utils/cold-email/is-cold-email.ts`: expand the `groupItem.findFirst` select to include `id`, `type`, `value`, `exclude`, and the `group: {id, name}` relation. Return a new optional `patternMatch: { group, groupItem }` field when `reason === "ai-already-labeled"`.
- `utils/ai/choose-rule/match-rules.ts`: when `coldEmailResult.patternMatch` is set, emit a `LearnedPatternMatch` matchReason instead of `{type: "AI"}`. Falls back to `{type: "AI"}` if the (nullable) Prisma `group` relation is missing.
- `utils/cold-email/is-cold-email.test.ts`: updated three test cases to assert the new select shape and the new `patternMatch` return value.

The emitted shape conforms to `serializedMatchReasonSchema` in `app/api/chat/validation.ts` and is already handled by the `LEARNED_PATTERN` case in `formatSerializedMatchMetadata` (`utils/ai/assistant/chat.ts`), which now renders cold-email pattern hits as e.g. `Cold Email learned pattern include on FROM: sender@example.com` instead of `Matched by AI instructions.`

## No behavior change

- No change to which emails get blocked.
- No change to LLM cost (the pattern path already skipped the LLM call — that part was correct).
- `shouldAnalyzeSenderPattern` in `run-rules.ts` already short-circuits on `SystemType.COLD_EMAIL` regardless of `matchReasons` type, so the type swap doesn't change pattern-analysis behavior.
- The new `patternMatch?` field is optional, so the other caller (`utils/actions/cold-email.ts` → `TestRules.tsx`) is unaffected.

## Test plan

- [x] `vitest run utils/cold-email/is-cold-email.test.ts utils/ai/choose-rule/match-rules.test.ts` → 111 passed
- [x] `tsc --noEmit` clean for the three changed files