### PR TITLE
Fix assistant inline markup rendering

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -9,7 +9,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AssistantInlineEmailResponse } from "@/components/assistant-chat/assistant-inline-email-response";
+import {
+  AssistantInlineEmailResponse,
+  normalizeAssistantInlineMarkup,
+} from "@/components/assistant-chat/assistant-inline-email-response";
 import { getEmailUrlForMessage } from "@/utils/url";
 
 const mockUseAccount = vi.fn();
@@ -123,52 +126,76 @@ describe("AssistantInlineEmailResponse", () => {
   });
 
   it("renders inline email detail views", () => {
-    mockUseThread.mockReturnValue({
-      data: {
-        thread: {
-          id: "thread-1",
-          messages: [
-            {
-              id: "message-1",
-              threadId: "thread-1",
-              subject: "Rendered detail subject",
-              snippet: "Rendered detail snippet",
-              date: "2026-03-11T11:00:00.000Z",
-              historyId: "history-1",
-              inline: [],
-              headers: {
-                from: "Sender <sender@example.com>",
-                to: "user@example.com",
-                date: "2026-03-11T11:00:00.000Z",
-                subject: "Rendered detail subject",
-              },
-              textPlain: "Rendered detail body",
-            },
-          ],
-        },
-      },
-      isLoading: false,
-      error: null,
-    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
-    render(
+    mockRenderedThread();
+
+    try {
+      render(
+        createElement(
+          AssistantInlineEmailResponse,
+          null,
+          '\n<email-detail threadid="thread-1">Focus on the action item.</email-detail>\n',
+        ),
+      );
+
+      expect(screen.getByText("Subject")).toBeTruthy();
+      expect(screen.getByText("Focus on the action item.")).toBeTruthy();
+      expect(screen.getByText("Rendered detail body")).toBeTruthy();
+      expect(screen.getByRole("link").getAttribute("href")).toBe(
+        getEmailUrlForMessage(
+          "msg-thread-1",
+          "thread-1",
+          "user@example.com",
+          "google",
+        ),
+      );
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("renders inline email detail views inside numbered lists", () => {
+    mockRenderedThread();
+
+    const { container } = render(
       createElement(
         AssistantInlineEmailResponse,
         null,
-        '\n<email-detail threadid="thread-1">Focus on the action item.</email-detail>\n',
+        [
+          "Apart from the booking confirmations, the most recent emails are:",
+          "",
+          '1. **water bill receipt** (May 13, 2026, 11:31 AM)\n   <email-detail threadid="thread-1">A receipt for a water bill with an attachment.</email-detail>',
+        ].join("\n"),
       ),
     );
 
     expect(screen.getByText("Subject")).toBeTruthy();
-    expect(screen.getByText("Focus on the action item.")).toBeTruthy();
+    expect(
+      screen.getByText("A receipt for a water bill with an attachment."),
+    ).toBeTruthy();
     expect(screen.getByText("Rendered detail body")).toBeTruthy();
-    expect(screen.getByRole("link").getAttribute("href")).toBe(
-      getEmailUrlForMessage(
-        "msg-thread-1",
-        "thread-1",
-        "user@example.com",
-        "google",
+    expect(container.textContent).not.toContain("<email-detail");
+    expect(container.textContent).not.toContain("</email-detail>");
+  });
+
+  it("normalizes assistant inline markup that appears in list continuation lines", () => {
+    expect(
+      normalizeAssistantInlineMarkup(
+        [
+          "1. **water bill receipt**",
+          "   <email-detail",
+          "   threadid=\u201Cthread-1\u201D>Receipt attached.</email-detail>",
+        ].join("\n"),
       ),
+    ).toBe(
+      [
+        "1. **water bill receipt**",
+        '<email-detail threadid="thread-1">Receipt attached.</email-detail>',
+      ].join("\n"),
     );
   });
 
@@ -248,5 +275,35 @@ function openMoreActions() {
   fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }), {
     button: 0,
     ctrlKey: false,
+  });
+}
+
+function mockRenderedThread() {
+  mockUseThread.mockReturnValue({
+    data: {
+      thread: {
+        id: "thread-1",
+        messages: [
+          {
+            id: "message-1",
+            threadId: "thread-1",
+            subject: "Rendered detail subject",
+            snippet: "Rendered detail snippet",
+            date: "2026-03-11T11:00:00.000Z",
+            historyId: "history-1",
+            inline: [],
+            headers: {
+              from: "Sender <sender@example.com>",
+              to: "user@example.com",
+              date: "2026-03-11T11:00:00.000Z",
+              subject: "Rendered detail subject",
+            },
+            textPlain: "Rendered detail body",
+          },
+        ],
+      },
+    },
+    isLoading: false,
+    error: null,
   });
 }

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { cn } from "@/utils/index";
-import { createElement, memo, type ComponentProps } from "react";
+import {
+  Children,
+  Fragment,
+  createElement,
+  isValidElement,
+  memo,
+  type ComponentProps,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import { Streamdown } from "streamdown";
 import {
   InlineEmailCard,
@@ -31,7 +40,9 @@ const allowedTags = {
     "markread",
   ],
 };
+const assistantBlockTagNames = new Set(Object.keys(allowedTags));
 const components = {
+  p: AssistantParagraph,
   emails: InlineEmailList,
   email: InlineEmailCard,
   "email-detail": InlineEmailDetail,
@@ -39,24 +50,94 @@ const components = {
   "rule-suggestion": InlineRuleSuggestionCard,
 };
 const literalTagContent = ["email", "email-detail", "rule-suggestion"];
+const tagAlternation = Object.keys(allowedTags).join("|");
+const assistantTagPattern = new RegExp(
+  `<\\/?(?:${tagAlternation})(?=[\\s>/])[^>]*>`,
+  "gi",
+);
+const indentedAssistantTagLinePattern = new RegExp(
+  `(^|\\n)[ \\t]+(?=<\\/?(?:${tagAlternation})(?=[\\s>/]))`,
+  "gi",
+);
+const tagWhitespaceRunPattern = /\s*\n\s*/g;
+const leftDoubleQuotePattern = /[“”]/g;
+const leftSingleQuotePattern = /[‘’]/g;
 
 export const AssistantInlineEmailResponse = memo(
-  ({ className, ...props }: AssistantInlineEmailResponseProps) =>
-    createElement(Streamdown, {
-      className: cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-        "[&_[data-streamdown='heading-1']]:!mt-8",
-        "[&_[data-streamdown='heading-2']]:!mt-8",
-        "[&_[data-streamdown='heading-3']]:!mt-7",
-        "[&_a]:!text-inherit [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80",
-        className,
-      ),
-      allowedTags,
-      components,
-      literalTagContent,
-      normalizeHtmlIndentation: true,
-      ...props,
-    }),
+  ({ className, children, ...props }: AssistantInlineEmailResponseProps) => {
+    const normalizedChildren =
+      typeof children === "string"
+        ? normalizeAssistantInlineMarkup(children)
+        : children;
+
+    return createElement(
+      Streamdown,
+      {
+        className: cn(
+          "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          "[&_[data-streamdown='heading-1']]:!mt-8",
+          "[&_[data-streamdown='heading-2']]:!mt-8",
+          "[&_[data-streamdown='heading-3']]:!mt-7",
+          "[&_a]:!text-inherit [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80",
+          className,
+        ),
+        allowedTags,
+        components,
+        literalTagContent,
+        normalizeHtmlIndentation: true,
+        ...props,
+      },
+      normalizedChildren,
+    );
+  },
 );
 
 AssistantInlineEmailResponse.displayName = "AssistantInlineEmailResponse";
+
+export function normalizeAssistantInlineMarkup(content: string) {
+  return content
+    .replace(indentedAssistantTagLinePattern, "$1")
+    .replace(assistantTagPattern, (tag) =>
+      tag
+        .replace(tagWhitespaceRunPattern, " ")
+        .replace(leftDoubleQuotePattern, '"')
+        .replace(leftSingleQuotePattern, "'"),
+    );
+}
+
+function AssistantParagraph({
+  children,
+  node: _node,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement> & {
+  children?: ReactNode;
+  node?: unknown;
+}) {
+  const meaningfulChildren = Children.toArray(children).filter(
+    (child) => child !== "",
+  );
+
+  if (
+    meaningfulChildren.length === 1 &&
+    shouldUnwrapParagraphChild(meaningfulChildren[0])
+  ) {
+    return createElement(Fragment, null, children);
+  }
+
+  return createElement("p", props, children);
+}
+
+function shouldUnwrapParagraphChild(child: ReactNode) {
+  if (!isValidElement(child)) return false;
+
+  const childProps = child.props as {
+    node?: { tagName?: string };
+    "data-block"?: string;
+  };
+  const tagName = childProps.node?.tagName?.toLowerCase();
+
+  if (tagName && assistantBlockTagNames.has(tagName)) return true;
+  if (tagName === "img") return true;
+
+  return tagName === "code" && "data-block" in childProps;
+}


### PR DESCRIPTION
Normalize streamed assistant inline markup before rendering so structured email cards do not appear as raw tags in list responses. Also unwrap block-style assistant components from markdown paragraphs to avoid invalid nesting.

- Normalizes assistant tag indentation, smart quotes, and line breaks before Streamdown parsing
- Unwraps block assistant components and block code from generated paragraphs
- Adds focused coverage for inline detail rendering inside numbered lists

Tests:
- `pnpm exec vitest run components/assistant-chat/assistant-inline-email-response.test.tsx` (fails in this environment before assertions with `React.act is not a function`)
- `pnpm --filter inbox-zero-ai test -- --run components/assistant-chat/assistant-inline-email-response.test.tsx` (mis-forwarded by package script and ran the broader suite; unrelated existing environment failures include `React.act is not a function` and missing `@/utils/hash`)

Performance impact: Adds small string normalization and child inspection only while rendering assistant responses. No new database or network calls; low hot-path risk because work is scoped to chat response rendering.