### PR TITLE
fix: Update follow-up channel notifications

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -3,7 +3,7 @@ import {
   processAccountFollowUps,
   processAllFollowUpReminders,
 } from "./process";
-import { ThreadTrackerType } from "@/generated/prisma/enums";
+import { MessagingProvider, ThreadTrackerType } from "@/generated/prisma/enums";
 import { createTestLogger } from "@/__tests__/helpers";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
@@ -48,7 +48,10 @@ vi.mock("@/utils/follow-up/generate-draft", () => ({
 
 vi.mock("@/utils/follow-up/send-follow-up-notification", () => ({
   getFollowUpNotificationChannels: vi.fn().mockResolvedValue([]),
-  sendFollowUpNotification: vi.fn().mockResolvedValue(undefined),
+  parseFollowUpNotificationDeliveries: vi.fn((value: unknown) =>
+    Array.isArray(value) ? value : [],
+  ),
+  sendFollowUpNotification: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/utils/reply-tracker/label-helpers", () => ({
@@ -824,6 +827,59 @@ describe("processAccountFollowUps - dedup logic", () => {
         threadLinkLabel: "Open in Outlook",
       }),
     );
+  });
+
+  it("appends notification deliveries to existing tracker handles", async () => {
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-repeat-notify", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi
+        .fn()
+        .mockResolvedValue(mockAwaitingMessage("msg-repeat-notify", OLD_DATE)),
+    });
+    const previousDelivery = {
+      messagingChannelId: "channel-1",
+      provider: MessagingProvider.SLACK,
+      providerThreadId: "C123",
+      providerMessageId: "1700000000.000100",
+    };
+    const nextDelivery = {
+      messagingChannelId: "channel-2",
+      provider: MessagingProvider.TEAMS,
+      providerThreadId: "teams-thread-1",
+      providerMessageId: "teams-message-1",
+    };
+
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
+      { id: "channel-2" } as any,
+    ]);
+    vi.mocked(sendFollowUpNotification).mockResolvedValue([nextDelivery]);
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue({
+      id: "tracker-repeat-notify",
+    } as any);
+    vi.mocked(prisma.threadTracker.update)
+      .mockResolvedValueOnce({
+        id: "tracker-repeat-notify",
+        followUpNotifications: [previousDelivery],
+      } as any)
+      .mockResolvedValueOnce({ id: "tracker-repeat-notify" } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(prisma.threadTracker.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "tracker-repeat-notify" },
+      data: {
+        followUpNotifications: [previousDelivery, nextDelivery],
+      },
+    });
   });
 
   it("uses the sender as the notification counterparty for needs-reply follow-ups", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -8,6 +8,7 @@ import {
 import { generateFollowUpDraft } from "@/utils/follow-up/generate-draft";
 import {
   getFollowUpNotificationChannels,
+  parseFollowUpNotificationDeliveries,
   sendFollowUpNotification,
   type FollowUpNotificationChannel,
 } from "@/utils/follow-up/send-follow-up-notification";
@@ -416,7 +417,7 @@ async function processFollowUpsForType({
         orderBy: { createdAt: "desc" },
       });
 
-      let tracker: { id: string };
+      let tracker: { id: string; followUpNotifications: unknown };
       if (existingTracker) {
         try {
           tracker = await prisma.threadTracker.update({
@@ -521,7 +522,7 @@ async function processFollowUpsForType({
               fromHeader: lastMessage.headers.from,
               toHeader: lastMessage.headers.to,
             });
-          await sendFollowUpNotification({
+          const notificationDeliveries = await sendFollowUpNotification({
             channels: notificationChannels,
             subject: lastMessage.subject || "(no subject)",
             counterpartyName,
@@ -544,6 +545,19 @@ async function processFollowUpsForType({
             trackerId: tracker.id,
             logger: threadLogger,
           });
+          if (notificationDeliveries.length > 0) {
+            await prisma.threadTracker.update({
+              where: { id: tracker.id },
+              data: {
+                followUpNotifications: [
+                  ...parseFollowUpNotificationDeliveries(
+                    tracker.followUpNotifications,
+                  ),
+                  ...notificationDeliveries,
+                ],
+              },
+            });
+          }
         } catch (notifyError) {
           threadLogger.error(
             "Follow-up notification failed, label still applied",

--- a/apps/web/prisma/migrations/20260514120000_add_follow_up_notifications/migration.sql
+++ b/apps/web/prisma/migrations/20260514120000_add_follow_up_notifications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ThreadTracker" ADD COLUMN "followUpNotifications" JSONB;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -880,6 +880,7 @@ model ThreadTracker {
 
   followUpAppliedAt DateTime?
   followUpDraftId   String?
+  followUpNotifications Json?
 
   emailAccountId String
   emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -9,8 +9,35 @@ import {
 import { getMockMessage, createTestLogger } from "@/__tests__/helpers";
 import { createMockEmailProvider } from "@/__tests__/mocks/email-provider.mock";
 import prisma from "@/utils/__mocks__/prisma";
+import { Prisma } from "@/generated/prisma/client";
+import { MessagingProvider } from "@/generated/prisma/enums";
+
+const messagingMocks = vi.hoisted(() => ({
+  slackChatUpdate: vi.fn(),
+  teamsEditMessage: vi.fn(),
+  telegramEditMessage: vi.fn(),
+}));
 
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/messaging/providers/slack/client", () => ({
+  createSlackClient: () => ({
+    chat: {
+      update: messagingMocks.slackChatUpdate,
+    },
+  }),
+}));
+vi.mock("@/utils/messaging/chat-sdk/adapters", () => ({
+  getMessagingAdapterRegistry: () => ({
+    typedAdapters: {
+      teams: {
+        editMessage: messagingMocks.teamsEditMessage,
+      },
+      telegram: {
+        editMessage: messagingMocks.telegramEditMessage,
+      },
+    },
+  }),
+}));
 
 const logger = createTestLogger();
 
@@ -267,6 +294,7 @@ describe("hasFollowUpLabel", () => {
 describe("clearFollowUpLabel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.messagingChannel.findMany.mockResolvedValue([]);
   });
 
   it("removes label and clears followUpAppliedAt even without drafts", async () => {
@@ -459,6 +487,118 @@ describe("clearFollowUpLabel", () => {
     expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
       "thread-1",
       "label-123",
+    );
+  });
+
+  it("updates delivered follow-up notifications when a reply clears the follow-up", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "tracker-1",
+          followUpNotifications: [
+            {
+              messagingChannelId: "channel-1",
+              provider: MessagingProvider.SLACK,
+              providerThreadId: "C123",
+              providerMessageId: "1700000000.000100",
+            },
+            {
+              messagingChannelId: "channel-2",
+              provider: MessagingProvider.TEAMS,
+              providerThreadId: "teams-thread-1",
+              providerMessageId: "teams-message-1",
+            },
+            {
+              messagingChannelId: "channel-3",
+              provider: MessagingProvider.TELEGRAM,
+              providerThreadId: "telegram-thread-1",
+              providerMessageId: "telegram-message-1",
+            },
+          ],
+        },
+      ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+      },
+      {
+        id: "channel-2",
+        provider: MessagingProvider.TEAMS,
+        isConnected: true,
+        accessToken: null,
+      },
+      {
+        id: "channel-3",
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: true,
+        accessToken: null,
+      },
+    ]);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        followUpNotifications: { not: Prisma.AnyNull },
+      },
+      select: {
+        id: true,
+        followUpNotifications: true,
+      },
+    });
+    expect(prisma.messagingChannel.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["channel-1", "channel-2", "channel-3"] },
+        isConnected: true,
+      },
+      select: {
+        id: true,
+        provider: true,
+        isConnected: true,
+        accessToken: true,
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
+    expect(messagingMocks.slackChatUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        ts: "1700000000.000100",
+      }),
+    );
+    expect(messagingMocks.teamsEditMessage).toHaveBeenCalledWith(
+      "teams-thread-1",
+      "teams-message-1",
+      expect.stringMatching(/follow-up/i),
+    );
+    expect(messagingMocks.telegramEditMessage).toHaveBeenCalledWith(
+      "telegram-thread-1",
+      "telegram-message-1",
+      expect.stringMatching(/follow-up/i),
     );
   });
 });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -1,9 +1,20 @@
+import { Card, CardText, type CardElement } from "chat";
+import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import prisma from "@/utils/prisma";
 import { withPrismaRetry } from "@/utils/prisma-retry";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 import { FOLLOW_UP_LABEL } from "@/utils/label";
 import type { Logger } from "@/utils/logger";
 import { captureException } from "@/utils/error";
+import { Prisma } from "@/generated/prisma/client";
+import { MessagingProvider } from "@/generated/prisma/enums";
+import { createSlackClient } from "@/utils/messaging/providers/slack/client";
+import { disableSlackLinkUnfurls } from "@/utils/messaging/providers/slack/send";
+import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters";
+import {
+  parseFollowUpNotificationDeliveries,
+  type FollowUpNotificationDelivery,
+} from "./send-follow-up-notification";
 
 export async function getOrCreateFollowUpLabel(
   provider: EmailProvider,
@@ -193,6 +204,11 @@ export async function clearFollowUpLabel({
 
     // Always remove the label regardless of tracker state
     await removeFollowUpLabel({ provider, threadId, logger });
+    await replaceFollowUpNotificationsWithReplyReceivedState({
+      emailAccountId,
+      threadId,
+      logger,
+    });
 
     logger.info("Cleared follow-up label and cleaned up trackers", {
       threadId,
@@ -202,4 +218,156 @@ export async function clearFollowUpLabel({
     logger.error("Failed to clear follow-up label", { threadId, error });
     captureException(error, { emailAccountId });
   }
+}
+
+type FollowUpNotificationChannelForCleanup = {
+  id: string;
+  provider: MessagingProvider;
+  isConnected: boolean;
+  accessToken: string | null;
+};
+
+async function replaceFollowUpNotificationsWithReplyReceivedState({
+  emailAccountId,
+  threadId,
+  logger,
+}: {
+  emailAccountId: string;
+  threadId: string;
+  logger: Logger;
+}) {
+  try {
+    const trackers = await prisma.threadTracker.findMany({
+      where: {
+        emailAccountId,
+        threadId,
+        followUpNotifications: { not: Prisma.AnyNull },
+      },
+      select: {
+        id: true,
+        followUpNotifications: true,
+      },
+    });
+
+    const notifications = trackers.flatMap((tracker) =>
+      parseFollowUpNotificationDeliveries(tracker.followUpNotifications),
+    );
+    if (notifications.length === 0) return;
+
+    const messagingChannelIds = [
+      ...new Set(
+        notifications.map((notification) => notification.messagingChannelId),
+      ),
+    ];
+    const channels = await prisma.messagingChannel.findMany({
+      where: {
+        id: { in: messagingChannelIds },
+        isConnected: true,
+      },
+      select: {
+        id: true,
+        provider: true,
+        isConnected: true,
+        accessToken: true,
+      },
+    });
+    const channelsById = new Map(
+      channels.map((channel) => [channel.id, channel]),
+    );
+
+    const card = buildReplyReceivedFollowUpCard();
+    await Promise.all(
+      notifications.map((notification) =>
+        replaceFollowUpNotification({
+          notification,
+          channel: channelsById.get(notification.messagingChannelId),
+          card,
+          logger,
+        }),
+      ),
+    );
+
+    await prisma.threadTracker.updateMany({
+      where: {
+        id: { in: trackers.map((tracker) => tracker.id) },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
+  } catch (error) {
+    logger.warn("Failed to update follow-up notifications after reply", {
+      threadId,
+      error,
+    });
+  }
+}
+
+async function replaceFollowUpNotification({
+  notification,
+  channel,
+  card,
+  logger,
+}: {
+  notification: FollowUpNotificationDelivery;
+  channel: FollowUpNotificationChannelForCleanup | undefined;
+  card: CardElement;
+  logger: Logger;
+}) {
+  if (!channel) return;
+
+  try {
+    switch (notification.provider) {
+      case MessagingProvider.SLACK: {
+        if (!channel.accessToken) return;
+
+        await createSlackClient(channel.accessToken).chat.update(
+          disableSlackLinkUnfurls({
+            channel: notification.providerThreadId,
+            ts: notification.providerMessageId,
+            text: cardToFallbackText(card),
+            blocks: cardToBlockKit(card),
+          }),
+        );
+        return;
+      }
+      case MessagingProvider.TEAMS: {
+        const teamsAdapter = getMessagingAdapterRegistry().typedAdapters.teams;
+        if (!teamsAdapter) return;
+
+        await teamsAdapter.editMessage(
+          notification.providerThreadId,
+          notification.providerMessageId,
+          REPLY_RECEIVED_TEXT,
+        );
+        return;
+      }
+      case MessagingProvider.TELEGRAM: {
+        const telegramAdapter =
+          getMessagingAdapterRegistry().typedAdapters.telegram;
+        if (!telegramAdapter) return;
+
+        await telegramAdapter.editMessage(
+          notification.providerThreadId,
+          notification.providerMessageId,
+          REPLY_RECEIVED_TEXT,
+        );
+        return;
+      }
+    }
+  } catch (error) {
+    logger.warn("Failed to update follow-up notification after reply", {
+      provider: notification.provider,
+      error,
+    });
+  }
+}
+
+const REPLY_RECEIVED_TEXT = "Reply received. Follow-up no longer needed.";
+
+function buildReplyReceivedFollowUpCard() {
+  return Card({
+    title: "Reply received",
+    children: [CardText("Follow-up no longer needed.")],
+  });
 }

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -104,6 +104,11 @@ describe("sendFollowUpNotification", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (resolveSlackRouteDestination as any).mockResolvedValue("C1");
+    (sendFollowUpReminderToSlack as any).mockResolvedValue("1700000000.000100");
+    (sendAutomationMessage as any).mockResolvedValue({
+      channelId: "teams-thread-1",
+      messageId: "teams-message-1",
+    });
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
   });
@@ -185,6 +190,34 @@ describe("sendFollowUpNotification", () => {
     expect(sendAutomationMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("returns provider message handles for delivered notifications", async () => {
+    const deliveries = await sendFollowUpNotification({
+      channels: [slackChannel, teamsChannel, telegramChannel],
+      ...baseArgs,
+    });
+
+    expect(deliveries).toEqual([
+      {
+        messagingChannelId: "channel-1",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C1",
+        providerMessageId: "1700000000.000100",
+      },
+      {
+        messagingChannelId: "channel-2",
+        provider: MessagingProvider.TEAMS,
+        providerThreadId: "teams-thread-1",
+        providerMessageId: "teams-message-1",
+      },
+      {
+        messagingChannelId: "channel-3",
+        provider: MessagingProvider.TELEGRAM,
+        providerThreadId: "telegram-thread-1",
+        providerMessageId: "telegram-message-1",
+      },
+    ]);
+  });
+
   it("swallows per-channel failures so the caller continues", async () => {
     (sendFollowUpReminderToSlack as any).mockRejectedValue(new Error("boom"));
     (sendAutomationMessage as any).mockRejectedValue(new Error("boom"));
@@ -193,7 +226,7 @@ describe("sendFollowUpNotification", () => {
         channels: [slackChannel, teamsChannel],
         ...baseArgs,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual([]);
   });
 
   it("skips Slack channel when access token is missing", async () => {

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -1,4 +1,5 @@
 import { Actions, Card, CardText, LinkButton, type CardChild } from "chat";
+import { z } from "zod";
 import {
   MessagingProvider,
   MessagingRoutePurpose,
@@ -53,6 +54,27 @@ type FollowUpNotificationContent = {
   trackerId: string;
 };
 
+export const followUpNotificationDeliverySchema = z.object({
+  messagingChannelId: z.string(),
+  provider: z.nativeEnum(MessagingProvider),
+  providerThreadId: z.string(),
+  providerMessageId: z.string(),
+});
+
+export type FollowUpNotificationDelivery = z.infer<
+  typeof followUpNotificationDeliverySchema
+>;
+
+export const followUpNotificationDeliveriesSchema =
+  followUpNotificationDeliverySchema.array();
+
+export function parseFollowUpNotificationDeliveries(
+  value: unknown,
+): FollowUpNotificationDelivery[] {
+  const parsed = followUpNotificationDeliveriesSchema.safeParse(value);
+  return parsed.success ? parsed.data : [];
+}
+
 export async function getFollowUpNotificationChannels(
   emailAccountId: string,
 ): Promise<FollowUpNotificationChannel[]> {
@@ -83,8 +105,8 @@ export async function sendFollowUpNotification({
 }: FollowUpNotificationContent & {
   channels: FollowUpNotificationChannel[];
   logger: Logger;
-}): Promise<void> {
-  const deliveryPromises: Promise<unknown>[] = [];
+}): Promise<FollowUpNotificationDelivery[]> {
+  const deliveryPromises: Promise<FollowUpNotificationDelivery | null>[] = [];
 
   for (const channel of channels) {
     const route = getMessagingRoute(
@@ -108,6 +130,7 @@ export async function sendFollowUpNotification({
         if (!channel.accessToken) continue;
         deliveryPromises.push(
           sendFollowUpViaSlack({
+            channelId: channel.id,
             accessToken: channel.accessToken,
             route,
             content,
@@ -117,7 +140,7 @@ export async function sendFollowUpNotification({
         break;
       case MessagingProvider.TEAMS:
         deliveryPromises.push(
-          sendAutomationMessage({
+          sendFollowUpViaAutomationMessage({
             channel,
             route,
             text: formatFollowUpText(content),
@@ -138,29 +161,37 @@ export async function sendFollowUpNotification({
     }
   }
 
-  if (deliveryPromises.length === 0) return;
+  if (deliveryPromises.length === 0) return [];
 
   const results = await Promise.allSettled(deliveryPromises);
+  const deliveries: FollowUpNotificationDelivery[] = [];
   for (const result of results) {
     if (result.status === "rejected") {
       logger.error("Follow-up delivery channel failed", {
         reason: result.reason,
       });
+      continue;
     }
+
+    if (result.value) deliveries.push(result.value);
   }
+
+  return deliveries;
 }
 
 async function sendFollowUpViaSlack({
+  channelId,
   accessToken,
   route,
   content,
   logger,
 }: {
+  channelId: string;
   accessToken: string;
   route: { targetId: string; targetType: MessagingRouteTargetType };
   content: FollowUpNotificationContent;
   logger: Logger;
-}) {
+}): Promise<FollowUpNotificationDelivery | null> {
   const destination = await resolveSlackRouteDestination({
     accessToken,
     route,
@@ -168,14 +199,51 @@ async function sendFollowUpViaSlack({
 
   if (!destination) {
     logger.warn("No Slack destination resolved for follow-up notification");
-    return;
+    return null;
   }
 
-  await sendFollowUpReminderToSlack({
+  const messageId = await sendFollowUpReminderToSlack({
     accessToken,
     channelId: destination,
     ...content,
   });
+
+  if (!messageId) return null;
+
+  return {
+    messagingChannelId: channelId,
+    provider: MessagingProvider.SLACK,
+    providerThreadId: destination,
+    providerMessageId: messageId,
+  };
+}
+
+async function sendFollowUpViaAutomationMessage({
+  channel,
+  route,
+  text,
+  logger,
+}: {
+  channel: FollowUpNotificationChannel;
+  route: { targetId: string; targetType: MessagingRouteTargetType };
+  text: string;
+  logger: Logger;
+}): Promise<FollowUpNotificationDelivery | null> {
+  const response = await sendAutomationMessage({
+    channel,
+    route,
+    text,
+    logger,
+  });
+
+  if (!response.channelId || !response.messageId) return null;
+
+  return {
+    messagingChannelId: channel.id,
+    provider: channel.provider,
+    providerThreadId: response.channelId,
+    providerMessageId: response.messageId,
+  };
 }
 
 async function sendFollowUpViaTelegram({
@@ -188,13 +256,13 @@ async function sendFollowUpViaTelegram({
   route: { targetId: string; targetType: MessagingRouteTargetType };
   content: FollowUpNotificationContent;
   logger: Logger;
-}) {
+}): Promise<FollowUpNotificationDelivery | null> {
   const destination =
     route.targetId || channel.teamId || channel.providerUserId;
 
   if (!destination) {
     logger.warn("No Telegram destination resolved for follow-up notification");
-    return;
+    return null;
   }
 
   const telegramAdapter = getMessagingAdapterRegistry().typedAdapters.telegram;
@@ -203,10 +271,19 @@ async function sendFollowUpViaTelegram({
   }
 
   const threadId = await telegramAdapter.openDM(destination);
-  await telegramAdapter.postMessage(
+  const response = await telegramAdapter.postMessage(
     threadId,
     buildTelegramFollowUpCard(content),
   );
+
+  if (!response.id) return null;
+
+  return {
+    messagingChannelId: channel.id,
+    provider: MessagingProvider.TELEGRAM,
+    providerThreadId: threadId,
+    providerMessageId: response.id,
+  };
 }
 
 function formatFollowUpText({

--- a/apps/web/utils/messaging/providers/slack/send.ts
+++ b/apps/web/utils/messaging/providers/slack/send.ts
@@ -168,12 +168,12 @@ export async function sendFollowUpReminderToSlack({
   accessToken,
   channelId,
   ...blockParams
-}: SlackFollowUpReminderParams): Promise<void> {
+}: SlackFollowUpReminderParams): Promise<string | null> {
   const client = createSlackClient(accessToken);
   const blocks = buildFollowUpReminderBlocks(blockParams);
   const { emoji } = getFollowUpCopy(blockParams.trackerType);
 
-  await postMessageWithJoin(client, channelId, {
+  return postMessageWithJoin(client, channelId, {
     blocks,
     text: `${emoji} Follow-up: ${blockParams.subject}`,
   });
@@ -255,7 +255,7 @@ async function postMessageWithJoin(
   client: WebClient,
   channelId: string,
   message: { text: string; blocks?: Blocks },
-): Promise<void> {
+): Promise<string | null> {
   const args = disableSlackLinkUnfurls(
     message.blocks
       ? { channel: channelId, blocks: message.blocks, text: message.text }
@@ -263,7 +263,8 @@ async function postMessageWithJoin(
   );
 
   try {
-    await client.chat.postMessage(args);
+    const response = await client.chat.postMessage(args);
+    return response.ts ?? null;
   } catch (error: unknown) {
     if (isSlackError(error) && error.data?.error === "not_in_channel") {
       try {
@@ -279,8 +280,8 @@ async function postMessageWithJoin(
         }
         throw joinError;
       }
-      await client.chat.postMessage(args);
-      return;
+      const response = await client.chat.postMessage(args);
+      return response.ts ?? null;
     }
     throw error;
   }


### PR DESCRIPTION
Stores follow-up notification message handles on the tracker so channel messages can be updated after a follow-up is cleared. When a reply removes the follow-up state, the related Slack, Teams, and Telegram notifications are marked as no longer needed.

- Added a lightweight tracker JSON field and migration for delivered notification handles.
- Updated follow-up delivery and cleanup flows.
- Added focused unit coverage for notification handle storage and channel updates.

Validation: pnpm --filter inbox-zero-ai build:ci; pnpm test utils/follow-up/labels.test.ts; pnpm test utils/follow-up/send-follow-up-notification.test.ts utils/follow-up/labels.test.ts; pnpm test app/api/follow-up-reminders/process.test.ts; pnpm --filter inbox-zero-ai exec prisma validate; pnpm --filter inbox-zero-ai lint.