### PR TITLE
Fix inbox sender search filtering

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -706,10 +706,156 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     expect(result.hasMore).toBe(false);
   });
 
-  it("searchInbox retries Microsoft fielded sender searches with a plain-text fallback", async () => {
+  it("searchInbox uses exact Outlook sender filtering for fielded sender queries", async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "m1",
+          threadId: "t1",
+          snippet: "Can you take a look?",
+          historyId: "",
+          inline: [],
+          headers: {
+            from: "sender@example.com",
+            to: TEST_EMAIL,
+            subject: "Review request",
+            date: "2026-01-01T00:00:00.000Z",
+          },
+          subject: "Review request",
+          textPlain: "",
+          textHtml: "",
+          labelIds: [],
+          internalDate: "0",
+        },
+      ],
+      nextPageToken: undefined,
+    });
+
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages,
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      logger,
+    });
+
+    const result: any = await (toolInstance.execute as any)({
+      query: "from:sender@example.com",
+      limit: 20,
+    });
+
+    expect(searchMessages).toHaveBeenCalledWith({
+      query: "",
+      fromEmail: "sender@example.com",
+      maxResults: 20,
+      pageToken: undefined,
+      readState: undefined,
+      labelName: undefined,
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.queryUsed).toBe("from:sender@example.com");
+  });
+
+  it("searchInbox uses exact Outlook sender filtering for bare sender email queries", async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "m1",
+          threadId: "t1",
+          snippet: "Can you take a look?",
+          historyId: "",
+          inline: [],
+          headers: {
+            from: "Sender <sender@example.com>",
+            to: TEST_EMAIL,
+            subject: "Review request",
+            date: "2026-01-01T00:00:00.000Z",
+          },
+          subject: "Review request",
+          textPlain: "",
+          textHtml: "",
+          labelIds: [],
+          internalDate: "0",
+        },
+      ],
+      nextPageToken: "PAGE_TOKEN_2",
+    });
+
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages,
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      logger,
+    });
+
+    const result: any = await (toolInstance.execute as any)({
+      query: "sender@example.com",
+      limit: 20,
+    });
+
+    expect(searchMessages).toHaveBeenCalledWith({
+      query: "",
+      fromEmail: "sender@example.com",
+      maxResults: 20,
+      pageToken: undefined,
+      readState: undefined,
+      labelName: undefined,
+    });
+    expect(result.queryUsed).toBe("from:sender@example.com");
+    expect(result.nextPageToken).toBe("PAGE_TOKEN_2");
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("searchInbox forwards explicit Outlook sender filters across pages", async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      messages: [],
+      nextPageToken: undefined,
+    });
+
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages,
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      logger,
+    });
+
+    await (toolInstance.execute as any)({
+      fromEmail: "sender@example.com",
+      limit: 20,
+      pageToken: "PAGE_TOKEN_2",
+    });
+
+    expect(searchMessages).toHaveBeenCalledWith({
+      query: "",
+      fromEmail: "sender@example.com",
+      maxResults: 20,
+      pageToken: "PAGE_TOKEN_2",
+      readState: undefined,
+      labelName: undefined,
+    });
+  });
+
+  it("searchInbox preserves structured Outlook sender filters when skipping empty pages", async () => {
     const searchMessages = vi
       .fn()
-      .mockRejectedValueOnce(new Error("Search syntax failed"))
+      .mockResolvedValueOnce({
+        messages: [],
+        nextPageToken: "PAGE_TOKEN_2",
+      })
       .mockResolvedValueOnce({
         messages: [
           {
@@ -719,7 +865,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
             historyId: "",
             inline: [],
             headers: {
-              from: "sender@example.com",
+              from: "Sender <sender@example.com>",
               to: TEST_EMAIL,
               subject: "Review request",
               date: "2026-01-01T00:00:00.000Z",
@@ -752,21 +898,23 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     expect(searchMessages).toHaveBeenNthCalledWith(1, {
-      query: "from:sender@example.com",
+      query: "",
+      fromEmail: "sender@example.com",
       maxResults: 20,
       pageToken: undefined,
       readState: undefined,
       labelName: undefined,
     });
     expect(searchMessages).toHaveBeenNthCalledWith(2, {
-      query: '"sender@example.com"',
+      query: "",
+      fromEmail: "sender@example.com",
       maxResults: 20,
-      pageToken: undefined,
+      pageToken: "PAGE_TOKEN_2",
       readState: undefined,
       labelName: undefined,
     });
     expect(result.messages).toHaveLength(1);
-    expect(result.queryUsed).toBe('"sender@example.com"');
+    expect(result.queryUsed).toBe("from:sender@example.com");
   });
 
   it("searchInbox passes structured Outlook category and read-state filters", async () => {
@@ -1138,45 +1286,22 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
 
     const result: any = await (toolInstance.execute as any)({
-      query: "from:sender@example.com",
+      query: 'from:sender@example.com subject:"weekly report"',
       limit: 20,
     });
 
     expect(result).toMatchObject({
-      queryUsed: "from:sender@example.com",
       error: "Failed to search inbox",
       provider: "microsoft",
       microsoftSearchFeedback: {
         failureType: "query_failed",
-        summary:
-          "Outlook did not return results for the attempted search query. Retry with one simpler Outlook clause at a time.",
         fallbackAttempted: true,
-        likelyCause: "Retry with one simpler Outlook clause at a time.",
-        removedTerms: [],
-        retryQueries: [],
       },
     });
-    expect(result.microsoftSearchFeedback.attempts).toEqual([
-      {
-        query: "from:sender@example.com",
-        status: 400,
-        code: "BadRequest",
-        message: "Unsupported search clause",
-      },
-      {
-        query: '"sender@example.com"',
-        status: 400,
-        code: "BadRequest",
-        message: "Unsupported search clause",
-      },
-      {
-        query: "sender@example.com",
-        status: 400,
-        code: "BadRequest",
-        message: "Unsupported search clause",
-      },
-    ]);
-    expect(searchMessages).toHaveBeenCalledTimes(3);
+    expect(result.microsoftSearchFeedback.attempts.length).toBeGreaterThan(1);
+    expect(searchMessages).toHaveBeenCalledTimes(
+      result.microsoftSearchFeedback.attempts.length,
+    );
   });
 
   it("searchInbox suggests concrete simpler retries for complex Microsoft queries", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -484,6 +484,14 @@ export type ManageSenderCategoryTool = InferUITool<
 >;
 
 const searchInboxBaseFields = {
+  fromEmail: z
+    .string()
+    .trim()
+    .email()
+    .nullish()
+    .describe(
+      "Exact sender email address to search by. Use this instead of a broad text query when the sender address is known.",
+    ),
   limit: z
     .number()
     .int()
@@ -496,17 +504,21 @@ const searchInboxBaseFields = {
   ),
 };
 
-const gmailSearchInboxInputSchema = z.object({
-  query: z
-    .string()
-    .trim()
-    .min(1)
-    .max(500)
-    .describe(
-      "Search query using Gmail syntax. Supports: from:, to:, subject:, in:inbox, is:unread, has:attachment, after:YYYY/MM/DD, before:YYYY/MM/DD, label:, newer_than:, older_than:.",
-    ),
-  ...searchInboxBaseFields,
-});
+const gmailSearchInboxInputSchema = z
+  .object({
+    query: z
+      .string()
+      .trim()
+      .max(500)
+      .default("")
+      .describe(
+        "Search query using Gmail syntax. Supports: from:, to:, subject:, in:inbox, is:unread, has:attachment, after:YYYY/MM/DD, before:YYYY/MM/DD, label:, newer_than:, older_than:.",
+      ),
+    ...searchInboxBaseFields,
+  })
+  .refine((value) => Boolean(value.query || value.fromEmail), {
+    message: "query or fromEmail is required",
+  });
 
 const outlookSearchInboxInputSchema = z
   .object({
@@ -535,9 +547,12 @@ const outlookSearchInboxInputSchema = z
       ),
   })
   .refine(
-    (value) => Boolean(value.query || value.readState || value.categoryName),
+    (value) =>
+      Boolean(
+        value.query || value.fromEmail || value.readState || value.categoryName,
+      ),
     {
-      message: "query, readState, or categoryName is required",
+      message: "query, fromEmail, readState, or categoryName is required",
     },
   );
 
@@ -554,7 +569,7 @@ const gmailSearchInboxTool = ({
     execute: async (input) => {
       trackToolCall({ tool: "search_inbox", email, logger });
 
-      const { query, limit, pageToken } = input;
+      const { query = "", fromEmail, limit, pageToken } = input;
 
       try {
         const emailProvider = await createEmailProvider({
@@ -566,6 +581,7 @@ const gmailSearchInboxTool = ({
         const [searchResult, labels] = await Promise.all([
           emailProvider.searchMessages({
             query,
+            fromEmail: fromEmail ?? undefined,
             maxResults: limit ?? SEARCH_INBOX_MAX_RESULTS,
             pageToken: pageToken ?? undefined,
           }),
@@ -574,12 +590,12 @@ const gmailSearchInboxTool = ({
 
         return formatSearchInboxResult({
           searchResult,
-          queryUsed: query,
+          queryUsed: formatQueryWithFromEmail(query, fromEmail),
           labels,
           taxonomyNamesKey: "labelNames",
         });
       } catch (error) {
-        logger.error("Failed to search inbox", { error, query });
+        logger.error("Failed to search inbox", { error, query, fromEmail });
         return { queryUsed: query, error: "Failed to search inbox" };
       }
     },
@@ -598,7 +614,14 @@ const outlookSearchInboxTool = ({
     execute: async (input) => {
       trackToolCall({ tool: "search_inbox", email, logger });
 
-      const { query = "", limit, pageToken, readState, categoryName } = input;
+      const {
+        query = "",
+        fromEmail,
+        limit,
+        pageToken,
+        readState,
+        categoryName,
+      } = input;
 
       try {
         const emailProvider = await createEmailProvider({
@@ -612,6 +635,7 @@ const outlookSearchInboxTool = ({
         });
         const normalizedInput = normalizeOutlookSearchInput({
           query,
+          fromEmail,
           readState,
           categoryName,
         });
@@ -1632,7 +1656,7 @@ async function runOutlookSearch({
   addSearchQuery(fallbackQuery);
 
   let result: SearchMessagesResult | undefined;
-  let queryUsed = normalizedInput.query;
+  let executedQuery = normalizedInput.query;
   let lastError: unknown;
   const failures: Array<{ query: string; error: unknown }> = [];
   let retryGuidanceAdded = false;
@@ -1644,10 +1668,11 @@ async function runOutlookSearch({
         query: candidateQuery,
         maxResults: limit ?? SEARCH_INBOX_MAX_RESULTS,
         pageToken: pageToken ?? undefined,
+        fromEmail: normalizedInput.fromEmail ?? undefined,
         readState: normalizedInput.readState ?? undefined,
         labelName: normalizedInput.categoryName ?? undefined,
       });
-      queryUsed = candidateQuery;
+      executedQuery = candidateQuery;
       break;
     } catch (error) {
       lastError = error;
@@ -1676,6 +1701,11 @@ async function runOutlookSearch({
     }
   }
 
+  let queryUsed = formatQueryWithFromEmail(
+    executedQuery,
+    normalizedInput.fromEmail,
+  );
+
   if (!result) {
     return { queryUsed, lastError, failures };
   }
@@ -1683,10 +1713,11 @@ async function runOutlookSearch({
   result = await skipEmptyOutlookSearchPages({
     emailProvider,
     searchResult: result,
-    queryUsed,
+    query: executedQuery,
     limit,
     readState: normalizedInput.readState,
     categoryName: normalizedInput.categoryName,
+    fromEmail: normalizedInput.fromEmail,
   });
 
   if (
@@ -1709,17 +1740,19 @@ async function runOutlookSearch({
 async function skipEmptyOutlookSearchPages({
   emailProvider,
   searchResult,
-  queryUsed,
+  query,
   limit,
   readState,
   categoryName,
+  fromEmail,
 }: {
   emailProvider: EmailProvider;
   searchResult: SearchMessagesResult;
-  queryUsed: string;
+  query: string;
   limit?: number;
   readState?: OutlookReadState | null;
   categoryName?: string | null;
+  fromEmail?: string | null;
 }) {
   let result = searchResult;
   let emptyPageSkips = 0;
@@ -1731,9 +1764,10 @@ async function skipEmptyOutlookSearchPages({
   ) {
     emptyPageSkips += 1;
     result = await emailProvider.searchMessages({
-      query: queryUsed,
+      query,
       maxResults: limit ?? SEARCH_INBOX_MAX_RESULTS,
       pageToken: result.nextPageToken,
+      fromEmail: fromEmail ?? undefined,
       readState: readState ?? undefined,
       labelName: categoryName ?? undefined,
     });
@@ -1744,6 +1778,7 @@ async function skipEmptyOutlookSearchPages({
 
 type NormalizedOutlookSearchInput = {
   query: string;
+  fromEmail?: string | null;
   readState?: OutlookReadState | null;
   categoryName?: string | null;
   fallbackQuery?: string | null;
@@ -1751,10 +1786,12 @@ type NormalizedOutlookSearchInput = {
 
 function normalizeOutlookSearchInput({
   query,
+  fromEmail,
   readState,
   categoryName,
 }: {
   query: string;
+  fromEmail?: string | null;
   readState?: OutlookReadState | null;
   categoryName?: string | null;
 }): NormalizedOutlookSearchInput {
@@ -1764,6 +1801,22 @@ function normalizeOutlookSearchInput({
   const queryWithoutState = inferredReadState
     ? stripStandaloneOutlookStateTerms(normalizedQuery).trim()
     : normalizedQuery;
+  const explicitFromEmail = fromEmail?.trim() || null;
+  const queryFromEmail =
+    getStandaloneSenderEmailFromOutlookQuery(queryWithoutState);
+  const effectiveFromEmail = explicitFromEmail ?? queryFromEmail;
+
+  if (effectiveFromEmail) {
+    const queryIsRedundant =
+      !explicitFromEmail ||
+      queryFromEmail?.toLowerCase() === explicitFromEmail.toLowerCase();
+    return {
+      query: queryIsRedundant ? "" : queryWithoutState,
+      fromEmail: effectiveFromEmail,
+      readState: inferredReadState,
+      categoryName,
+    };
+  }
 
   if (categoryName) {
     return {
@@ -1797,6 +1850,24 @@ function normalizeOutlookSearchInput({
     categoryName: scopeCandidate,
     fallbackQuery: normalizedQuery,
   };
+}
+
+function getStandaloneSenderEmailFromOutlookQuery(query: string) {
+  const match = query
+    .trim()
+    .match(
+      /^(?:from\s*:\s*)?["']?([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})["']?$/i,
+    );
+  return match?.[1] ?? null;
+}
+
+function formatQueryWithFromEmail(
+  query: string,
+  fromEmail: string | null | undefined,
+) {
+  if (!fromEmail) return query;
+  if (!query.trim()) return `from:${fromEmail}`;
+  return `from:${fromEmail} ${query}`;
 }
 
 function inferOutlookReadStateFromQuery(

--- a/apps/web/utils/ai/assistant/chat-provider-microsoft.ts
+++ b/apps/web/utils/ai/assistant/chat-provider-microsoft.ts
@@ -22,10 +22,11 @@ export const microsoftChatProviderConfig: AssistantChatProviderConfig = {
   },
   searchSyntaxPolicy: `Provider search syntax:
 - Use Outlook search syntax with keyword search, unread/read, and simple subject: filters.
-- Prefer a plain sender email like \`person@example.com\` over \`from:\` when searching by sender.
+- When the exact sender address is known, pass it in searchInbox.fromEmail instead of query.
+- If only a sender name or brand is known, search first, inspect the returned from values, then retry with searchInbox.fromEmail when you have the exact address.
 - If you use \`from:\` or \`to:\`, keep it as a simple standalone filter instead of combining extra terms after the field value.
 - Keep Outlook queries to one simple clause whenever possible. Do not mix sender, unread/read, date, and subject constraints into one retry.
-- Use searchInbox structured fields for category/folder scope and read state; use query for sender, subject, body text, or date/age filters.
+- Use searchInbox structured fields for sender, category/folder scope, and read state; use query for subject, body text, or date/age filters.
 - Do not use Gmail-specific operators.`,
   inboxTriagePolicy: `Provider inbox defaults:
 - For inbox triage summaries, include the literal token \`unread\` in the query unless the user asks to include read messages. Do not add unread/read to direct cleanup action searches unless the user asks for that read state.

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -706,7 +706,7 @@ export function buildResolvedSystemPrompt({
 - User timezone: ${userTimezone}. Current timestamp: ${currentTimestamp}. Resolve relative dates like today, tomorrow, this afternoon, Monday, or Friday from this timezone before calling calendar or inbox date-range tools.`,
     providerPolicy.searchSyntaxPolicy,
     `Search strategy:
-- If the user names a sender or brand but the actual email address is not known yet, search first, inspect the returned \`from\` values, and then refine with \`from:\` before writing when needed.
+- If the user names a sender or brand but the actual email address is not known yet, search first, inspect the returned \`from\` values, and then refine with the provider's exact sender field before writing when needed.
 - When the sender or domain is known, prefer the provider's sender-focused syntax over a broad bare keyword.`,
     providerPolicy.inboxTriagePolicy,
     `Inbox workflows:

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1146,9 +1146,13 @@ export class GmailProvider implements EmailProvider {
     query: string;
     maxResults?: number;
     pageToken?: string;
+    fromEmail?: string;
   }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
+    const query = options.fromEmail
+      ? [`from:${options.fromEmail}`, options.query].filter(Boolean).join(" ")
+      : options.query;
     const response = await getMessages(this.client, {
-      query: options.query,
+      query,
       maxResults: options.maxResults || 20,
       pageToken: options.pageToken || undefined,
     });

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -167,6 +167,40 @@ describe("OutlookProvider.getSentMessageIds", () => {
   });
 });
 
+describe("OutlookProvider.searchMessages", () => {
+  it("uses an exact OData sender filter when fromEmail is provided", async () => {
+    getFolderIdsMock.mockResolvedValue({
+      inbox: "folder-inbox",
+      archive: "folder-archive",
+      drafts: "folder-drafts",
+      deleteditems: "folder-trash",
+      junkemail: "folder-spam",
+      sentitems: "folder-sent",
+    });
+
+    const client = createMockOutlookClient([
+      createMessage({
+        id: "message-1",
+        conversationId: "thread-1",
+        parentFolderId: "folder-inbox",
+      }),
+    ]);
+    const provider = new OutlookProvider(client);
+
+    const result = await provider.searchMessages({
+      query: "",
+      fromEmail: "sender@example.com",
+      maxResults: 20,
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(client.getRequestLog()).toContainEqual({
+      apiPath: "/me/messages",
+      filter: "from/emailAddress/address eq 'sender@example.com'",
+    });
+  });
+});
+
 describe("OutlookProvider.getThreadsWithQuery", () => {
   it("filters returned threads by explicit labelIds", async () => {
     getFolderIdsMock.mockResolvedValue({

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1132,6 +1132,7 @@ export class OutlookProvider implements EmailProvider {
     query: string;
     maxResults?: number;
     pageToken?: string;
+    fromEmail?: string;
     readState?: "read" | "unread";
     labelName?: string;
   }): Promise<{ messages: ParsedMessage[]; nextPageToken?: string }> {
@@ -1141,6 +1142,7 @@ export class OutlookProvider implements EmailProvider {
         searchQuery: options.query,
         maxResults: options.maxResults || 20,
         pageToken: options.pageToken,
+        fromEmail: options.fromEmail,
         readState: options.readState,
         categoryNames: options.labelName ? [options.labelName] : [],
       },

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -247,6 +247,7 @@ export interface EmailProvider {
     query: string;
     maxResults?: number;
     pageToken?: string;
+    fromEmail?: string;
     readState?: "read" | "unread";
     labelName?: string;
   }): Promise<{

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -447,6 +447,13 @@ function matchesOutlookMetadataFilters(
   return true;
 }
 
+function matchesOutlookSender(message: Message, normalizedFromEmail: string) {
+  return (
+    message.from?.emailAddress?.address?.trim().toLowerCase() ===
+    normalizedFromEmail
+  );
+}
+
 function createOutlookMetadataODataFilters(filters: OutlookMetadataFilters) {
   const odataFilters: string[] = [];
 
@@ -471,12 +478,14 @@ export async function queryBatchMessages(
     maxResults?: number;
     pageToken?: string;
     folderId?: string;
+    fromEmail?: string;
     readState?: "read" | "unread";
     categoryNames?: string[];
   },
   logger: Logger,
 ) {
   const { searchQuery, dateFilters, pageToken, folderId } = options;
+  const normalizedFromEmail = options.fromEmail?.trim().toLowerCase();
 
   const MAX_RESULTS = 20;
 
@@ -513,6 +522,12 @@ export async function queryBatchMessages(
 
     const filteredMessages = response.value.filter((message) => {
       if (folderId && message.parentFolderId !== folderId) return false;
+      if (
+        normalizedFromEmail &&
+        !matchesOutlookSender(message, normalizedFromEmail)
+      ) {
+        return false;
+      }
       return matchesOutlookMetadataFilters(message, metadataSearch.filters);
     });
     const messages = await convertMessages(
@@ -573,6 +588,12 @@ export async function queryBatchMessages(
 
     const filteredMessages = response.value.filter((message) => {
       if (folderId && message.parentFolderId !== folderId) return false;
+      if (
+        normalizedFromEmail &&
+        !matchesOutlookSender(message, normalizedFromEmail)
+      ) {
+        return false;
+      }
       return matchesOutlookMetadataFilters(message, metadataSearch.filters);
     });
     const messages = await convertMessages(
@@ -602,6 +623,12 @@ export async function queryBatchMessages(
 
     if (metadataSearch.odataFilters.length) {
       filters.push(...metadataSearch.odataFilters);
+    }
+
+    if (options.fromEmail) {
+      filters.push(
+        `from/emailAddress/address eq '${escapeODataString(options.fromEmail)}'`,
+      );
     }
 
     // Add date filters if provided


### PR DESCRIPTION
Adds structured exact sender filtering for inbox search so Gmail and Outlook can search by sender address without relying on broad text syntax.

- Adds searchInbox.fromEmail and forwards it through email providers.
- Applies exact Outlook sender filtering through OData and paginated fallback paths.
- Updates provider guidance and targeted tests for sender search behavior.
- Tests: pnpm test utils/ai/assistant/chat-inbox-tools.test.ts utils/email/microsoft.test.ts