### PR TITLE
Fix draft channel rule selection

### DIFF
--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -25,6 +25,7 @@ import { findMatchingRules } from "@/utils/ai/choose-rule/match-rules";
 import { getActionItemsWithAiArgs } from "@/utils/ai/choose-rule/choose-args";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { determineConversationStatus } from "@/utils/reply-tracker/handle-conversation-status";
+import { isDraftReplyActionType } from "@/utils/actions/draft-reply";
 
 const logger = createTestLogger();
 
@@ -550,6 +551,100 @@ describe("runRules draft attribution persistence", () => {
     ]);
   });
 
+  it("keeps a configured draft messaging channel when another matched rule has no channel", async () => {
+    const emailOnlyRule = createRule("email-only-rule", null, [
+      getAction({
+        id: "email-draft-action",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "email-only-rule",
+      }),
+    ]);
+    const channelRule = createRule("channel-rule", null, [
+      getAction({
+        id: "channel-draft-action",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "channel-rule",
+      }),
+      getAction({
+        id: "channel-delivery-action",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: null,
+        messagingChannelId: "channel-1",
+        ruleId: "channel-rule",
+      }),
+    ]);
+
+    mockMatchingRules([
+      {
+        rule: emailOnlyRule,
+        matchReasons: [{ type: ConditionType.STATIC }],
+      },
+      {
+        rule: channelRule,
+        matchReasons: [{ type: ConditionType.STATIC }],
+      },
+    ]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockImplementation(
+      async ({ selectedRule }) =>
+        selectedRule.actions.map((action) => ({
+          ...action,
+          content: isDraftReplyActionType(action.type)
+            ? "Generated draft content"
+            : action.content,
+        })),
+    );
+
+    const createdActionsByRule = new Map<string | null, ActionType[]>();
+    const createdMessagingChannelsByRule = new Map<
+      string | null,
+      Array<string | null | undefined>
+    >();
+    (prisma.executedRule.create as any).mockImplementation(
+      async (args: any) => {
+        const actionItems = args.data.actionItems?.createMany?.data || [];
+        const ruleId = args.data.rule?.connect?.id ?? null;
+        createdActionsByRule.set(
+          ruleId,
+          actionItems.map((action: any) => action.type),
+        );
+        createdMessagingChannelsByRule.set(
+          ruleId,
+          actionItems.map((action: any) => action.messagingChannelId),
+        );
+
+        return {
+          id: `exec-${createdActionsByRule.size}`,
+          status: ExecutedRuleStatus.APPLYING,
+          ruleId,
+          threadId,
+          messageId: "message-1",
+          actionItems: actionItems.map((action: any, index: number) => ({
+            ...action,
+            id: action.id || `action-${createdActionsByRule.size}-${index}`,
+            executedRuleId: `exec-${createdActionsByRule.size}`,
+          })),
+        };
+      },
+    );
+
+    await runRulesWithDefaults({
+      rules: [emailOnlyRule, channelRule],
+    });
+
+    expect(createdActionsByRule.get("email-only-rule")).toEqual([
+      ActionType.DRAFT_EMAIL,
+      ActionType.DRAFT_MESSAGING_CHANNEL,
+    ]);
+    expect(createdMessagingChannelsByRule.get("email-only-rule")).toEqual([
+      null,
+      "channel-1",
+    ]);
+    expect(createdActionsByRule.get("channel-rule")).toEqual([]);
+  });
+
   it("returns the final status after immediate actions execute", async () => {
     const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
       getAction({
@@ -1031,6 +1126,49 @@ describe("limitDraftEmailActions", () => {
 
     expect(result[0].rule.actions).toHaveLength(1);
     expect(result[0].rule.actions[0].id).toBe("draft-guest");
+    expect(result[1].rule.actions).toEqual([]);
+  });
+
+  it("moves configured draft messaging delivery to the selected draft rule", () => {
+    const emailOnlyRule = createRule("email-only-rule", null, [
+      getAction({
+        id: "email-draft-action",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "email-only-rule",
+      }),
+    ]);
+    const channelRule = createRule("channel-rule", null, [
+      getAction({
+        id: "channel-draft-action",
+        type: ActionType.DRAFT_EMAIL,
+        content: null,
+        ruleId: "channel-rule",
+      }),
+      getAction({
+        id: "channel-delivery-action",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        content: null,
+        messagingChannelId: "channel-1",
+        ruleId: "channel-rule",
+      }),
+    ]);
+
+    const result = limitDraftEmailActions(
+      [{ rule: emailOnlyRule }, { rule: channelRule }],
+      logger,
+    );
+
+    expect(result[0].rule.actions.map((action) => action.type)).toEqual([
+      ActionType.DRAFT_EMAIL,
+      ActionType.DRAFT_MESSAGING_CHANNEL,
+    ]);
+    expect(result[0].rule.actions[1]).toEqual(
+      expect.objectContaining({
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+      }),
+    );
     expect(result[1].rule.actions).toEqual([]);
   });
 });

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -53,6 +53,7 @@ import {
 import {
   isDraftReplyActionType,
   isMessagingChannelActionType,
+  isMessagingDraftActionType,
 } from "@/utils/actions/draft-reply";
 
 const MODULE = "ai/choose-rule";
@@ -847,11 +848,10 @@ function isConversationRule(ruleId: string): boolean {
 /**
  * Limits drafting to a single rule selection.
  * If there are multiple rules with draft reply actions, we prefer the first static
- * drafting rule (fixed content) over a fully dynamic drafting rule. Once a rule is
- * selected, all of its draft reply actions are preserved so the generated draft can
- * fan out to multiple destinations.
- * If there are no draft reply actions, we return the matches as is.
- * If only one rule contains draft reply actions, we return the matches as is.
+ * drafting rule (fixed content) over a fully dynamic drafting rule. Configured
+ * messaging destinations from the other matched draft rules are moved onto the
+ * selected draft rule so the single generated draft can still fan out to every
+ * matched channel.
  */
 export function limitDraftEmailActions<
   T extends { rule: RuleWithActions; matchReasons?: MatchReason[] },
@@ -860,7 +860,7 @@ export function limitDraftEmailActions<
     match.rule.actions
       .filter((action) => isDraftReplyActionType(action.type))
       .map((action) => ({
-        ruleId: match.rule.id,
+        match,
         action,
         hasFixedContent: Boolean(action.content?.trim()),
       })),
@@ -876,16 +876,34 @@ export function limitDraftEmailActions<
     draftCandidates.find((candidate) => candidate.hasFixedContent) ||
     draftCandidates[0];
 
-  const selectedDraftRuleId = preferredCandidate.ruleId;
+  const selectedMatch = preferredCandidate.match;
+  const selectedDraftRuleId = selectedMatch.rule.id;
+  const selectedDraftAction = preferredCandidate.action;
 
   logger.info("Limiting draft actions to a single rule selection", {
     module: MODULE,
     selectedDraftRuleId,
   });
 
+  const copiedMessagingActions = collectMessagingChannelsFromOtherRules({
+    matches,
+    selectedMatch,
+    selectedDraftAction,
+  });
+
   return matches.map((match) => {
     if (match.rule.id === selectedDraftRuleId) {
-      return match;
+      if (!copiedMessagingActions.length) {
+        return match;
+      }
+
+      return {
+        ...match,
+        rule: {
+          ...match.rule,
+          actions: [...match.rule.actions, ...copiedMessagingActions],
+        },
+      };
     }
 
     const hasExtraDrafts = match.rule.actions.some((action) =>
@@ -906,4 +924,52 @@ export function limitDraftEmailActions<
       },
     };
   });
+}
+
+function collectMessagingChannelsFromOtherRules<
+  T extends { rule: RuleWithActions },
+>({
+  matches,
+  selectedMatch,
+  selectedDraftAction,
+}: {
+  matches: T[];
+  selectedMatch: T;
+  selectedDraftAction: RuleWithActions["actions"][number];
+}) {
+  const seenChannelIds = new Set(
+    selectedMatch.rule.actions
+      .filter((action) => isMessagingDraftActionType(action.type))
+      .map((action) => action.messagingChannelId?.trim())
+      .filter((channelId): channelId is string => Boolean(channelId)),
+  );
+
+  const actions: RuleWithActions["actions"] = [];
+
+  for (const match of matches) {
+    if (match === selectedMatch) continue;
+
+    for (const action of match.rule.actions) {
+      if (!isMessagingDraftActionType(action.type)) continue;
+
+      const messagingChannelId = action.messagingChannelId?.trim();
+      if (!messagingChannelId || seenChannelIds.has(messagingChannelId)) {
+        continue;
+      }
+
+      seenChannelIds.add(messagingChannelId);
+      actions.push({
+        ...action,
+        subject: selectedDraftAction.subject,
+        content: selectedDraftAction.content,
+        to: selectedDraftAction.to,
+        cc: selectedDraftAction.cc,
+        bcc: selectedDraftAction.bcc,
+        delayInMinutes: selectedDraftAction.delayInMinutes,
+        staticAttachments: selectedDraftAction.staticAttachments,
+      });
+    }
+  }
+
+  return actions;
 }


### PR DESCRIPTION
Preserve draft messaging channel delivery when multiple matched draft rules collapse to one generated draft. This keeps a single draft selection while carrying configured channel destinations onto the selected rule.

- Copies unique draft messaging channel actions from non-selected draft rules onto the selected draft rule.
- Keeps copied channel actions aligned with the selected draft content and metadata.
- Tests: `pnpm test utils/ai/choose-rule/run-rules.test.ts`

Performance impact: adds a small in-memory pass over matched rule actions during rule selection. No new database or network calls; hot-path risk is low because work is bounded by the existing matched rules/actions set.