### PR TITLE
Fix follow-up reminder deduplication

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -21,6 +21,7 @@ import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import type { WebClient } from "@slack/web-api";
 import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
+import { Prisma } from "@/generated/prisma/client";
 import {
   ActionType,
   DraftEmailStatus,
@@ -439,7 +440,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       // Tracker flipped to resolved.
       expect(prisma.threadTracker.update).toHaveBeenCalledWith({
         where: { id: trackerId },
-        data: { resolved: true },
+        data: {
+          resolved: true,
+          followUpNotifications: Prisma.JsonNull,
+        },
       });
 
       expect(editMessage).toHaveBeenCalledTimes(1);

--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -475,7 +475,91 @@ describe("processAccountFollowUps - dedup logic", () => {
     expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
   });
 
-  it("does not use sentAt to skip resolved trackers with a different message", async () => {
+  it("does not notify again when a marked-done Outlook follow-up gets a different provider ID for the same sent message", async () => {
+    const sentAt = "2026-01-01T12:00:00.000Z";
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-outlook-marked-done", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi
+        .fn()
+        .mockResolvedValue(
+          mockAwaitingMessage("msg-outlook-marked-done-2", sentAt),
+        ),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
+      { id: "channel-outlook-marked-done" } as any,
+    ]);
+
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([
+      {
+        threadId: "thread-outlook-marked-done",
+        messageId: "msg-outlook-marked-done-1",
+        resolved: true,
+        sentAt: new Date(sentAt),
+        followUpAppliedAt: new Date("2026-01-02T12:00:00.000Z"),
+      } as any,
+    ]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(applyFollowUpLabel).not.toHaveBeenCalled();
+    expect(sendFollowUpNotification).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.create).not.toHaveBeenCalled();
+  });
+
+  it("processes the first follow-up when a tracker has no follow-up history yet", async () => {
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-first-follow-up", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi
+        .fn()
+        .mockResolvedValue(
+          mockAwaitingMessage("msg-first-follow-up", OLD_DATE),
+        ),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+
+    vi.mocked(prisma.threadTracker.findMany).mockImplementation((args: any) => {
+      if (args?.where?.OR) return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          threadId: "thread-first-follow-up",
+          messageId: "msg-first-follow-up",
+          sentAt: new Date(Number(OLD_DATE)),
+        } as any,
+      ]);
+    });
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
+      id: "tracker-first-follow-up",
+    } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(applyFollowUpLabel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-first-follow-up",
+        messageId: "msg-first-follow-up",
+      }),
+    );
+    expect(generateFollowUpDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses sentAt to skip resolved Outlook trackers with a different provider ID", async () => {
     const sentAt = "2026-01-01T12:00:00.000Z";
     const provider = createMockProvider({
       getThreadsWithLabel: vi
@@ -495,6 +579,7 @@ describe("processAccountFollowUps - dedup logic", () => {
         messageId: "msg-resolved-old",
         resolved: true,
         sentAt: new Date(sentAt),
+        followUpAppliedAt: new Date("2026-01-02T12:00:00.000Z"),
       } as any,
     ]);
     vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
@@ -507,14 +592,9 @@ describe("processAccountFollowUps - dedup logic", () => {
       logger,
     });
 
-    expect(applyFollowUpLabel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadId: "thread-resolved-repeat",
-        messageId: "msg-resolved-new",
-      }),
-    );
-    expect(prisma.threadTracker.create).toHaveBeenCalledTimes(1);
-    expect(generateFollowUpDraft).toHaveBeenCalledTimes(1);
+    expect(applyFollowUpLabel).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.create).not.toHaveBeenCalled();
+    expect(generateFollowUpDraft).not.toHaveBeenCalled();
   });
 
   it("does not create a second draft when duplicate outbound processing resolved the tracker", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -629,7 +629,7 @@ async function getProcessedFollowUpLedger({
         { followUpDraftId: { not: null } },
       ],
     },
-    select: { threadId: true, messageId: true, resolved: true, sentAt: true },
+    select: { threadId: true, messageId: true, sentAt: true },
   });
 
   const processedLedger: ProcessedFollowUpLedger = new Map();
@@ -640,7 +640,7 @@ async function getProcessedFollowUpLedger({
       sentAtTimes: new Set<number>(),
     };
     processed.messageIds.add(tracker.messageId);
-    if (!tracker.resolved && tracker.sentAt) {
+    if (tracker.sentAt) {
       processed.sentAtTimes.add(tracker.sentAt.getTime());
     }
     processedLedger.set(tracker.threadId, processed);
@@ -649,8 +649,10 @@ async function getProcessedFollowUpLedger({
   return processedLedger;
 }
 
-// sentAt is checked for unresolved trackers because Outlook can return a
-// different provider message ID for the same sent message across runs.
+// sentAt is checked because Outlook can return a different provider message ID
+// for the same sent message across runs, including after Mark done. The ledger
+// only includes rows that already have follow-up history, so ordinary Reply Zero
+// trackers still receive their first follow-up.
 function hasFollowUpBeenProcessed({
   processedLedger,
   threadId,

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { MessagingProvider } from "@/generated/prisma/enums";
+import { Prisma } from "@/generated/prisma/client";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
   FOLLOW_UP_MARK_DONE_ACTION_ID,
@@ -62,7 +63,10 @@ describe("handleFollowUpReminderAction", () => {
 
     expect(prisma.threadTracker.update).toHaveBeenCalledWith({
       where: { id: "tracker-1" },
-      data: { resolved: true },
+      data: {
+        resolved: true,
+        followUpNotifications: Prisma.JsonNull,
+      },
     });
     expect(postEphemeral).toHaveBeenCalled();
     const text = postEphemeral.mock.calls[0]?.[1];
@@ -141,7 +145,7 @@ describe("handleFollowUpReminderAction", () => {
     expect(postEphemeral).toHaveBeenCalled();
   });
 
-  it("no-ops when the tracker is already resolved", async () => {
+  it("clears stored notification references when the tracker is already resolved", async () => {
     prisma.threadTracker.findUnique.mockResolvedValue({
       id: "tracker-1",
       resolved: true,
@@ -154,7 +158,13 @@ describe("handleFollowUpReminderAction", () => {
     const { event, postEphemeral } = makeEvent();
     await handleFollowUpReminderAction({ event, logger });
 
-    expect(prisma.threadTracker.update).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.update).toHaveBeenCalledWith({
+      where: { id: "tracker-1" },
+      data: {
+        resolved: true,
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
     expect(postEphemeral).toHaveBeenCalled();
   });
 

--- a/apps/web/utils/follow-up/follow-up-actions.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.ts
@@ -1,5 +1,6 @@
 import { Card, CardText, type ActionEvent } from "chat";
 import { MessagingProvider } from "@/generated/prisma/enums";
+import { Prisma } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 
@@ -54,12 +55,13 @@ export async function handleFollowUpReminderAction({
     return;
   }
 
-  if (!tracker.resolved) {
-    await prisma.threadTracker.update({
-      where: { id: trackerId },
-      data: { resolved: true },
-    });
-  }
+  await prisma.threadTracker.update({
+    where: { id: trackerId },
+    data: {
+      resolved: true,
+      followUpNotifications: Prisma.JsonNull,
+    },
+  });
 
   const feedback = tracker.resolved
     ? "This follow-up is already done."


### PR DESCRIPTION
Fixes follow-up reminder deduplication so previously tracked labeled messages are skipped even after cleanup changes tracker state.\n\n- Loads existing trackers for currently labeled threads when building the processed ledger.\n- Keeps provider message ID and sent timestamp checks to prevent repeat processing across provider ID churn.\n- Adds regression coverage for cleanup-cleared tracker state and provider ID changes.