### PR TITLE
Improve email send error details

### DIFF
--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -7,7 +7,7 @@ import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-ad
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { sleep } from "@/utils/sleep";
-import { convertNewlinesToBr, escapeHtml } from "@/utils/string";
+import { convertNewlinesToBr, escapeHtml, truncate } from "@/utils/string";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import {
   type AssistantEmailConfirmationResult,
@@ -139,7 +139,7 @@ export async function confirmAssistantEmailActionForAccount({
       error,
       actionType,
     });
-    throw new SafeError(getAssistantEmailActionErrorMessage(actionType));
+    throw new SafeError(getAssistantEmailActionErrorMessage(actionType, error));
   }
 
   try {
@@ -1133,8 +1133,79 @@ async function resolveSentMessageId({
 
 function getAssistantEmailActionErrorMessage(
   actionType: AssistantPendingEmailActionType,
+  error?: unknown,
 ) {
-  return ASSISTANT_EMAIL_ACTION_METADATA[actionType].errorMessage;
+  const fallback = ASSISTANT_EMAIL_ACTION_METADATA[actionType].errorMessage;
+  const providerErrorMessage = getProviderErrorMessage(error);
+
+  return providerErrorMessage
+    ? `${fallback}: ${providerErrorMessage}`
+    : fallback;
+}
+
+function getProviderErrorMessage(error: unknown): string | null {
+  if (!isRecord(error)) return null;
+
+  const raw = extractRawProviderErrorMessage(error);
+  return raw ? sanitizeProviderErrorMessage(raw) : null;
+}
+
+function extractRawProviderErrorMessage(
+  error: Record<string, unknown>,
+): string | null {
+  const bodyMessage = getProviderErrorBodyMessage(error.body);
+  if (bodyMessage) return bodyMessage;
+
+  const nestedError = error.error;
+  if (isRecord(nestedError) && typeof nestedError.message === "string") {
+    return nestedError.message;
+  }
+
+  const hasMetadata = Boolean(
+    error.status ||
+      error.statusCode ||
+      error.code ||
+      error.body ||
+      error.response ||
+      error.data,
+  );
+  if (
+    hasMetadata &&
+    typeof error.message === "string" &&
+    error.message.trim()
+  ) {
+    return error.message;
+  }
+
+  return null;
+}
+
+function getProviderErrorBodyMessage(body: unknown): string | null {
+  if (typeof body !== "string" || !body.trim()) return null;
+
+  try {
+    const parsed = JSON.parse(body);
+    if (!isRecord(parsed)) return null;
+
+    const error = parsed.error;
+    if (isRecord(error) && typeof error.message === "string") {
+      return error.message;
+    }
+
+    if (typeof parsed.message === "string") return parsed.message;
+  } catch {}
+
+  return body;
+}
+
+function sanitizeProviderErrorMessage(message: string) {
+  const sanitized = message
+    .replace(/[\w.%+-]+@[\w.-]+\.[A-Z]{2,}/gi, "[email]")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!sanitized) return null;
+  return truncate(sanitized, 237);
 }
 
 function getAssistantToolTypeForAction(

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -1039,43 +1039,9 @@ describe("confirmAssistantEmailAction", () => {
   });
 
   it("clears processing state when provider send fails", async () => {
-    (prisma.emailAccount.findUnique as any)
-      .mockResolvedValueOnce({
-        email: "owner@example.com",
-        account: { userId: "u1", provider: "google" },
-      })
-      .mockResolvedValueOnce({
-        name: "Owner",
-        email: "owner@example.com",
-      });
+    mockPendingSendFailure(new Error("send failed"), "google");
 
-    prisma.chatMessage.findFirst
-      .mockResolvedValueOnce({
-        id: "chat-message-1",
-        chatId: "chat-1",
-        updatedAt: new Date("2026-02-23T00:00:00.000Z"),
-        parts: [buildPendingSendPart()],
-      } as any)
-      .mockResolvedValueOnce({
-        id: "chat-message-1",
-        parts: [buildProcessingSendPart()],
-      } as any);
-
-    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
-
-    vi.mocked(createEmailProvider).mockResolvedValue({
-      sendEmailWithHtml: vi.fn().mockRejectedValue(new Error("send failed")),
-    } as any);
-
-    const result = await confirmAssistantEmailAction(
-      "ea_1" as any,
-      {
-        chatId: "chat-1",
-        chatMessageId: "chat-message-1",
-        toolCallId: "tool-1",
-        actionType: "send_email",
-      } as any,
-    );
+    const result = await confirmPendingSendEmail();
 
     expect(result?.serverError).toBe("Failed to send email");
     expect(prisma.chatMessage.updateMany).toHaveBeenCalledTimes(2);
@@ -1083,6 +1049,42 @@ describe("confirmAssistantEmailAction", () => {
       prisma.chatMessage.updateMany.mock.calls[1][0] as any
     ).data.parts as any[];
     expect(revertedParts[0].output.confirmationState).toBe("pending");
+  });
+
+  it("shows a sanitized provider reason when an email send is rejected", async () => {
+    const providerError = Object.assign(new Error("Graph request failed"), {
+      statusCode: 403,
+      code: "ErrorSendAsDenied",
+      body: JSON.stringify({
+        error: {
+          code: "ErrorSendAsDenied",
+          message:
+            "The user does not have permission to send as owner@example.com.",
+        },
+      }),
+    });
+    mockPendingSendFailure(providerError);
+
+    const result = await confirmPendingSendEmail();
+
+    expect(result?.serverError).toBe(
+      "Failed to send email: The user does not have permission to send as [email].",
+    );
+  });
+
+  it("shows a sanitized plain-text provider reason when an email send is rejected", async () => {
+    const providerError = Object.assign(new Error("Graph request failed"), {
+      statusCode: 403,
+      code: "ErrorSendRejected",
+      body: "Mailbox disabled for owner@example.com.\nTry again later.",
+    });
+    mockPendingSendFailure(providerError);
+
+    const result = await confirmPendingSendEmail();
+
+    expect(result?.serverError).toBe(
+      "Failed to send email: Mailbox disabled for [email]. Try again later.",
+    );
   });
 
   it("merges confirmation into the latest message state before persisting", async () => {
@@ -1488,6 +1490,48 @@ function buildProcessingSendPart({
       confirmationProcessingAt: processingAt,
     },
   };
+}
+
+function mockPendingSendFailure(error: unknown, provider = "microsoft") {
+  (prisma.emailAccount.findUnique as any)
+    .mockResolvedValueOnce({
+      email: "owner@example.com",
+      account: { userId: "u1", provider },
+    })
+    .mockResolvedValueOnce({
+      name: "Owner",
+      email: "owner@example.com",
+    });
+
+  prisma.chatMessage.findFirst
+    .mockResolvedValueOnce({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildPendingSendPart()],
+    } as any)
+    .mockResolvedValueOnce({
+      id: "chat-message-1",
+      parts: [buildProcessingSendPart()],
+    } as any);
+
+  prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+  vi.mocked(createEmailProvider).mockResolvedValue({
+    sendEmailWithHtml: vi.fn().mockRejectedValue(error),
+  } as any);
+}
+
+function confirmPendingSendEmail() {
+  return confirmAssistantEmailAction(
+    "ea_1" as any,
+    {
+      chatId: "chat-1",
+      chatMessageId: "chat-message-1",
+      toolCallId: "tool-1",
+      actionType: "send_email",
+    } as any,
+  );
 }
 
 function buildPendingReplyPart() {


### PR DESCRIPTION
Surfaces sanitized provider rejection details when assistant email confirmations fail, instead of returning only a generic send failure. Adds focused coverage for preserving user-visible context while redacting email addresses from provider messages.

Validation:
- pnpm --filter inbox-zero-ai test utils/actions/assistant-chat.test.ts -- --run
- pnpm exec ultracite check apps/web/utils/actions/assistant-chat-confirmation.ts apps/web/utils/actions/assistant-chat.test.ts