### PR TITLE
automation: Improve tab responsiveness

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -17,10 +17,10 @@ import { Button } from "@/components/ui/button";
 import { toastError } from "@/components/Toast";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { MessagesResponse } from "@/app/api/messages/route";
 import { EmailMessageCell } from "@/components/EmailMessageCell";
 import { runRulesAction } from "@/utils/actions/ai-rule";
-import type { RulesResponse } from "@/app/api/user/rules/route";
 import { Table, TableBody, TableRow, TableCell } from "@/components/ui/table";
 import { Card } from "@/components/ui/card";
 import type { RunRulesResult } from "@/utils/ai/choose-rule/run-rules";
@@ -40,6 +40,7 @@ import {
   getSelectionMetadataTraceDetails,
   summarizeSelectionMetadata,
 } from "@/utils/ai/choose-rule/selection-metadata-summary";
+import { useRules } from "@/hooks/useRules";
 
 type Message = MessagesResponse["messages"][number];
 
@@ -101,7 +102,7 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
     });
   }, [data]);
 
-  const { data: rules } = useSWR<RulesResponse>("/api/user/rules");
+  const { data: rules } = useRules();
   const { emailAccountId, userEmail } = useAccount();
 
   // Fetch existing executed rules for current messages
@@ -315,7 +316,11 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
         </div>
       )}
 
-      <LoadingContent loading={isLoading} error={error}>
+      <LoadingContent
+        loading={isLoading}
+        error={error}
+        loadingComponent={<ProcessRulesLoading />}
+      >
         {messages.length === 0 ? (
           <MutedText className="p-4 text-center">No emails found</MutedText>
         ) : (
@@ -357,6 +362,31 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
         )}
       </LoadingContent>
     </div>
+  );
+}
+
+function ProcessRulesLoading() {
+  return (
+    <Card>
+      <Table>
+        <TableBody>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <TableRow key={index} className="hover:bg-transparent">
+              <TableCell>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-4 w-full max-w-xl" />
+                    <Skeleton className="h-3 w-full max-w-md" />
+                  </div>
+                  <Skeleton className="h-9 w-16 shrink-0" />
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
   );
 }
 

--- a/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryState } from "nuqs";
+import { useSWRConfig } from "swr";
+import { TabSelect } from "@/components/TabSelect";
+import { History } from "@/app/(app)/[emailAccountId]/assistant/History";
+import { Process } from "@/app/(app)/[emailAccountId]/assistant/Process";
+import { SettingsTab } from "@/app/(app)/[emailAccountId]/assistant/settings/SettingsTab";
+import { RulesTab } from "@/app/(app)/[emailAccountId]/assistant/RulesTabNew";
+
+const automationTabs = ["rules", "test", "history", "settings"] as const;
+type AutomationTab = (typeof automationTabs)[number];
+
+const defaultTab: AutomationTab = "rules";
+
+const tabOptions = [
+  {
+    id: "rules",
+    label: "Rules",
+  },
+  {
+    id: "test",
+    label: "Test",
+  },
+  {
+    id: "history",
+    label: "History",
+  },
+  {
+    id: "settings",
+    label: "Settings",
+  },
+] satisfies { id: AutomationTab; label: string }[];
+
+export function AutomationTabs() {
+  const [tab, setTab] = useQueryState("tab", {
+    defaultValue: defaultTab,
+    history: "push",
+  });
+  const urlTab = isAutomationTab(tab) ? tab : defaultTab;
+  const [selectedTab, setSelectedTab] = useState<AutomationTab>(urlTab);
+  usePrefetchTestTab(selectedTab);
+
+  useEffect(() => {
+    setSelectedTab(urlTab);
+  }, [urlTab]);
+
+  const onSelect = useCallback(
+    (value: AutomationTab) => {
+      setSelectedTab(value);
+      setTab(value === defaultTab ? null : value);
+    },
+    [setTab],
+  );
+
+  return (
+    <>
+      <div className="border-b border-neutral-200 pt-2">
+        <TabSelect
+          options={tabOptions}
+          selected={selectedTab}
+          onSelect={onSelect}
+        />
+      </div>
+
+      <div className="mb-10">
+        {selectedTab === "rules" && <RulesTab />}
+        {selectedTab === "settings" && <SettingsTab />}
+        {selectedTab === "test" && <Process />}
+        {selectedTab === "history" && <History />}
+      </div>
+    </>
+  );
+}
+
+function usePrefetchTestTab(selectedTab: AutomationTab) {
+  const { fetcher, mutate } = useSWRConfig();
+  const hasPrefetchedRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      hasPrefetchedRef.current ||
+      selectedTab === "test" ||
+      typeof fetcher !== "function"
+    ) {
+      return;
+    }
+    hasPrefetchedRef.current = true;
+
+    const prefetch = () => {
+      fetcher("/api/messages")
+        .then((data) => mutate("/api/messages", data, { revalidate: false }))
+        .catch(() => undefined);
+    };
+
+    if ("requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(prefetch, { timeout: 1500 });
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = window.setTimeout(prefetch, 500);
+    return () => window.clearTimeout(timeoutId);
+  }, [fetcher, mutate, selectedTab]);
+}
+
+function isAutomationTab(value: string): value is AutomationTab {
+  return automationTabs.includes(value as AutomationTab);
+}

--- a/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useQueryState } from "nuqs";
 import { useSWRConfig } from "swr";
 import { TabSelect } from "@/components/TabSelect";
@@ -38,17 +38,11 @@ export function AutomationTabs() {
     defaultValue: defaultTab,
     history: "push",
   });
-  const urlTab = isAutomationTab(tab) ? tab : defaultTab;
-  const [selectedTab, setSelectedTab] = useState<AutomationTab>(urlTab);
+  const selectedTab = isAutomationTab(tab) ? tab : defaultTab;
   usePrefetchTestTab(selectedTab);
-
-  useEffect(() => {
-    setSelectedTab(urlTab);
-  }, [urlTab]);
 
   const onSelect = useCallback(
     (value: AutomationTab) => {
-      setSelectedTab(value);
       setTab(value === defaultTab ? null : value);
     },
     [setTab],

--- a/apps/web/app/(app)/[emailAccountId]/automation/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/page.tsx
@@ -3,16 +3,10 @@ import { SparklesIcon } from "lucide-react";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import prisma from "@/utils/prisma";
-import { History } from "@/app/(app)/[emailAccountId]/assistant/History";
-import { Tabs, TabsContent } from "@/components/ui/tabs";
-import { Process } from "@/app/(app)/[emailAccountId]/assistant/Process";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
 import { EmailProvider } from "@/providers/EmailProvider";
 import { ASSISTANT_ONBOARDING_COOKIE } from "@/utils/cookies";
 import { checkUserOwnsEmailAccount } from "@/utils/email-account";
-import { SettingsTab } from "@/app/(app)/[emailAccountId]/assistant/settings/SettingsTab";
-import { TabSelect } from "@/components/TabSelect";
-import { RulesTab } from "@/app/(app)/[emailAccountId]/assistant/RulesTabNew";
 import { AIChatButton } from "@/app/(app)/[emailAccountId]/assistant/AIChatButton";
 import { AllRulesDisabledBanner } from "@/app/(app)/[emailAccountId]/assistant/AllRulesDisabledBanner";
 import { PageWrapper } from "@/components/PageWrapper";
@@ -22,41 +16,16 @@ import {
   STEP_KEYS,
   getOnboardingStepHref,
 } from "@/app/(app)/[emailAccountId]/onboarding/onboardingFlow";
+import { AutomationTabs } from "@/app/(app)/[emailAccountId]/automation/AutomationTabs";
 
 export const maxDuration = 300; // Applies to the actions
 
-const tabOptions = (emailAccountId: string) => [
-  {
-    id: "rules",
-    label: "Rules",
-    href: `/${emailAccountId}/automation?tab=rules`,
-  },
-  {
-    id: "test",
-    label: "Test",
-    href: `/${emailAccountId}/automation?tab=test`,
-  },
-  {
-    id: "history",
-    label: "History",
-    href: `/${emailAccountId}/automation?tab=history`,
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    href: `/${emailAccountId}/automation?tab=settings`,
-  },
-];
-
 export default async function AutomationPage({
   params,
-  searchParams,
 }: {
   params: Promise<{ emailAccountId: string }>;
-  searchParams: Promise<{ tab: string }>;
 }) {
   const { emailAccountId } = await params;
-  const { tab } = await searchParams;
   await checkUserOwnsEmailAccount({ emailAccountId });
 
   // onboarding redirect
@@ -101,13 +70,6 @@ export default async function AutomationPage({
 
           <AllRulesDisabledBanner />
 
-          <div className="border-b border-neutral-200 pt-2">
-            <TabSelect
-              options={tabOptions(emailAccountId)}
-              selected={tab ?? "rules"}
-            />
-          </div>
-
           <DismissibleVideoCard
             className="my-4"
             icon={<SparklesIcon className="h-5 w-5" />}
@@ -121,20 +83,7 @@ export default async function AutomationPage({
             }}
           />
 
-          <Tabs defaultValue="rules">
-            <TabsContent value="rules" className="mb-10">
-              <RulesTab />
-            </TabsContent>
-            <TabsContent value="settings" className="mb-10">
-              <SettingsTab />
-            </TabsContent>
-            <TabsContent value="test" className="mb-10">
-              <Process />
-            </TabsContent>
-            <TabsContent value="history" className="mb-10">
-              <History />
-            </TabsContent>
-          </Tabs>
+          <AutomationTabs />
         </PageWrapper>
       </Suspense>
     </EmailProvider>

--- a/apps/web/components/TabSelect.tsx
+++ b/apps/web/components/TabSelect.tsx
@@ -62,23 +62,19 @@ export function TabSelect<T extends string>({
       <LayoutGroup id={layoutGroupId}>
         {options.map(({ id, label, href, target }) => {
           const isSelected = id === selected;
-          const As = href ? Link : "div";
-          return (
-            <As
-              key={id}
-              className="relative"
-              href={href ?? "#"}
-              target={target ?? undefined}
-            >
+          const content = (
+            <>
               <button
                 type="button"
                 onClick={() => {
-                  analytics.captureAction("tab_selected", {
-                    tab: id,
-                    tab_label: label,
-                    has_href: Boolean(href),
-                  });
                   if (onSelect && !href) onSelect(id);
+                  setTimeout(() => {
+                    analytics.captureAction("tab_selected", {
+                      tab: id,
+                      tab_label: label,
+                      has_href: Boolean(href),
+                    });
+                  }, 0);
                 }}
                 className={cn(
                   tabSelectButtonVariants({ variant }),
@@ -103,7 +99,26 @@ export function TabSelect<T extends string>({
                   <div className="h-0.5 rounded-t-full bg-current" />
                 </motion.div>
               )}
-            </As>
+            </>
+          );
+
+          if (href) {
+            return (
+              <Link
+                key={id}
+                className="relative"
+                href={href}
+                target={target ?? undefined}
+              >
+                {content}
+              </Link>
+            );
+          }
+
+          return (
+            <div key={id} className="relative">
+              {content}
+            </div>
           );
         })}
       </LayoutGroup>


### PR DESCRIPTION
Improves automation tab switching so the active tab updates before URL sync or data loading.

- Moves automation tab selection to a client wrapper with deferred analytics and URL sync.
- Warms the test tab message request on idle and shows a skeleton while data loads.
- Reuses the shared rules hook so rules data can come from the existing SWR cache.

Performance impact: adds one idle browser prefetch for the messages endpoint on the automation page; no new database writes or hot-path processing.