### PR TITLE
automation: Fix tab prefetch build

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useState, useRef, useMemo } from "react";
 import useSWR from "swr";
-import useSWRInfinite from "swr/infinite";
 import { parseAsBoolean, useQueryState } from "nuqs";
 import PQueue from "p-queue";
 import {
@@ -41,6 +40,7 @@ import {
   summarizeSelectionMetadata,
 } from "@/utils/ai/choose-rule/selection-metadata-summary";
 import { useRules } from "@/hooks/useRules";
+import { useInfiniteMessages } from "@/hooks/useMessages";
 
 type Message = MessagesResponse["messages"][number];
 
@@ -54,32 +54,7 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
   );
 
   const { data, isLoading, isValidating, error, setSize, mutate, size } =
-    useSWRInfinite<MessagesResponse>(
-      (index, previousPageData) => {
-        // Always return the URL for the first page
-        if (index === 0) {
-          const params = new URLSearchParams();
-          if (searchQuery) params.set("q", searchQuery);
-          const paramsString = params.toString();
-
-          return `/api/messages${paramsString ? `?${paramsString}` : ""}`;
-        }
-
-        // For subsequent pages, check if we have a next page token
-        const pageToken = previousPageData?.nextPageToken;
-        if (!pageToken) return null;
-
-        const params = new URLSearchParams();
-        if (searchQuery) params.set("q", searchQuery);
-        params.set("pageToken", pageToken);
-        const paramsString = params.toString();
-
-        return `/api/messages${paramsString ? `?${paramsString}` : ""}`;
-      },
-      {
-        revalidateFirstPage: false,
-      },
-    );
+    useInfiniteMessages(searchQuery);
 
   const onLoadMore = async () => {
     const nextSize = size + 1;

--- a/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQueryState } from "nuqs";
-import { useSWRConfig } from "swr";
 import { TabSelect } from "@/components/TabSelect";
 import { History } from "@/app/(app)/[emailAccountId]/assistant/History";
 import { Process } from "@/app/(app)/[emailAccountId]/assistant/Process";
 import { SettingsTab } from "@/app/(app)/[emailAccountId]/assistant/settings/SettingsTab";
 import { RulesTab } from "@/app/(app)/[emailAccountId]/assistant/RulesTabNew";
+import { useMessages } from "@/hooks/useMessages";
 
 const automationTabs = ["rules", "test", "history", "settings"] as const;
 type AutomationTab = (typeof automationTabs)[number];
+type IdleWindow = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
 
 const defaultTab: AutomationTab = "rules";
 
@@ -39,7 +47,7 @@ export function AutomationTabs() {
     history: "push",
   });
   const selectedTab = isAutomationTab(tab) ? tab : defaultTab;
-  usePrefetchTestTab(selectedTab);
+  usePrefetchTestTabMessages(selectedTab);
 
   const onSelect = useCallback(
     (value: AutomationTab) => {
@@ -68,34 +76,25 @@ export function AutomationTabs() {
   );
 }
 
-function usePrefetchTestTab(selectedTab: AutomationTab) {
-  const { fetcher, mutate } = useSWRConfig();
-  const hasPrefetchedRef = useRef(false);
+function usePrefetchTestTabMessages(selectedTab: AutomationTab) {
+  const [shouldPrefetch, setShouldPrefetch] = useState(false);
+  useMessages({ enabled: shouldPrefetch });
 
   useEffect(() => {
-    if (
-      hasPrefetchedRef.current ||
-      selectedTab === "test" ||
-      typeof fetcher !== "function"
-    ) {
-      return;
-    }
-    hasPrefetchedRef.current = true;
+    if (shouldPrefetch || selectedTab === "test") return;
 
-    const prefetch = () => {
-      fetcher("/api/messages")
-        .then((data) => mutate("/api/messages", data, { revalidate: false }))
-        .catch(() => undefined);
-    };
-
-    if ("requestIdleCallback" in window) {
-      const idleId = window.requestIdleCallback(prefetch, { timeout: 1500 });
-      return () => window.cancelIdleCallback(idleId);
+    const idleWindow = window as IdleWindow;
+    if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
+      const idleId = idleWindow.requestIdleCallback(
+        () => setShouldPrefetch(true),
+        { timeout: 1500 },
+      );
+      return () => idleWindow.cancelIdleCallback?.(idleId);
     }
 
-    const timeoutId = window.setTimeout(prefetch, 500);
-    return () => window.clearTimeout(timeoutId);
-  }, [fetcher, mutate, selectedTab]);
+    const timeoutId = globalThis.setTimeout(() => setShouldPrefetch(true), 500);
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [selectedTab, shouldPrefetch]);
 }
 
 function isAutomationTab(value: string): value is AutomationTab {

--- a/apps/web/hooks/useMessages.ts
+++ b/apps/web/hooks/useMessages.ts
@@ -1,0 +1,46 @@
+import useSWR from "swr";
+import useSWRInfinite from "swr/infinite";
+import type { MessagesResponse } from "@/app/api/messages/route";
+
+type MessagesOptions = {
+  enabled?: boolean;
+  searchQuery?: string | null;
+};
+
+type MessagesPageOptions = MessagesOptions & {
+  pageToken?: string | null;
+};
+
+export function useMessages({
+  enabled = true,
+  searchQuery,
+}: MessagesOptions = {}) {
+  return useSWR<MessagesResponse>(
+    enabled ? getMessagesUrl({ searchQuery }) : null,
+  );
+}
+
+export function useInfiniteMessages(searchQuery?: string | null) {
+  return useSWRInfinite<MessagesResponse>(
+    (index, previousPageData) => {
+      if (index === 0) return getMessagesUrl({ searchQuery });
+
+      const pageToken = previousPageData?.nextPageToken;
+      if (!pageToken) return null;
+
+      return getMessagesUrl({ searchQuery, pageToken });
+    },
+    {
+      revalidateFirstPage: false,
+    },
+  );
+}
+
+function getMessagesUrl({ searchQuery, pageToken }: MessagesPageOptions = {}) {
+  const params = new URLSearchParams();
+  if (searchQuery) params.set("q", searchQuery);
+  if (pageToken) params.set("pageToken", pageToken);
+
+  const paramsString = params.toString();
+  return `/api/messages${paramsString ? `?${paramsString}` : ""}`;
+}


### PR DESCRIPTION
Fixes the automation tab prefetch implementation so it uses shared SWR message hooks instead of calling the untyped global SWR fetcher.

- Adds shared message hooks for first-page and paginated message loading.
- Reuses the paginated hook in the test tab.
- Keeps idle test-tab prefetching through the shared hook path.

Performance impact: preserves the single idle browser prefetch for the messages endpoint and does not add database writes or hot-path work.