### PR TITLE
automation: Fix Test tab prefetch cache key and simplify hook

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -54,7 +54,7 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
   );
 
   const { data, isLoading, isValidating, error, setSize, mutate, size } =
-    useInfiniteMessages(searchQuery);
+    useInfiniteMessages({ searchQuery });
 
   const onLoadMore = async () => {
     const nextSize = size + 1;

--- a/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
@@ -7,18 +7,10 @@ import { History } from "@/app/(app)/[emailAccountId]/assistant/History";
 import { Process } from "@/app/(app)/[emailAccountId]/assistant/Process";
 import { SettingsTab } from "@/app/(app)/[emailAccountId]/assistant/settings/SettingsTab";
 import { RulesTab } from "@/app/(app)/[emailAccountId]/assistant/RulesTabNew";
-import { useMessages } from "@/hooks/useMessages";
+import { useInfiniteMessages } from "@/hooks/useMessages";
 
 const automationTabs = ["rules", "test", "history", "settings"] as const;
 type AutomationTab = (typeof automationTabs)[number];
-type IdleWindow = Window &
-  typeof globalThis & {
-    requestIdleCallback?: (
-      callback: IdleRequestCallback,
-      options?: IdleRequestOptions,
-    ) => number;
-    cancelIdleCallback?: (handle: number) => void;
-  };
 
 const defaultTab: AutomationTab = "rules";
 
@@ -78,22 +70,20 @@ export function AutomationTabs() {
 
 function usePrefetchTestTabMessages(selectedTab: AutomationTab) {
   const [shouldPrefetch, setShouldPrefetch] = useState(false);
-  useMessages({ enabled: shouldPrefetch });
+  useInfiniteMessages({ enabled: shouldPrefetch });
 
   useEffect(() => {
     if (shouldPrefetch || selectedTab === "test") return;
 
-    const idleWindow = window as IdleWindow;
-    if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
-      const idleId = idleWindow.requestIdleCallback(
-        () => setShouldPrefetch(true),
-        { timeout: 1500 },
-      );
-      return () => idleWindow.cancelIdleCallback?.(idleId);
+    if (typeof window.requestIdleCallback === "function") {
+      const idleId = window.requestIdleCallback(() => setShouldPrefetch(true), {
+        timeout: 1500,
+      });
+      return () => window.cancelIdleCallback(idleId);
     }
 
-    const timeoutId = globalThis.setTimeout(() => setShouldPrefetch(true), 500);
-    return () => globalThis.clearTimeout(timeoutId);
+    const timeoutId = window.setTimeout(() => setShouldPrefetch(true), 500);
+    return () => window.clearTimeout(timeoutId);
   }, [selectedTab, shouldPrefetch]);
 }
 

--- a/apps/web/hooks/useMessages.ts
+++ b/apps/web/hooks/useMessages.ts
@@ -1,28 +1,18 @@
-import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 import type { MessagesResponse } from "@/app/api/messages/route";
 
-type MessagesOptions = {
+type UseInfiniteMessagesOptions = {
   enabled?: boolean;
   searchQuery?: string | null;
 };
 
-type MessagesPageOptions = MessagesOptions & {
-  pageToken?: string | null;
-};
-
-export function useMessages({
+export function useInfiniteMessages({
   enabled = true,
   searchQuery,
-}: MessagesOptions = {}) {
-  return useSWR<MessagesResponse>(
-    enabled ? getMessagesUrl({ searchQuery }) : null,
-  );
-}
-
-export function useInfiniteMessages(searchQuery?: string | null) {
+}: UseInfiniteMessagesOptions = {}) {
   return useSWRInfinite<MessagesResponse>(
     (index, previousPageData) => {
+      if (!enabled) return null;
       if (index === 0) return getMessagesUrl({ searchQuery });
 
       const pageToken = previousPageData?.nextPageToken;
@@ -36,7 +26,13 @@ export function useInfiniteMessages(searchQuery?: string | null) {
   );
 }
 
-function getMessagesUrl({ searchQuery, pageToken }: MessagesPageOptions = {}) {
+function getMessagesUrl({
+  searchQuery,
+  pageToken,
+}: {
+  searchQuery?: string | null;
+  pageToken?: string | null;
+} = {}) {
   const params = new URLSearchParams();
   if (searchQuery) params.set("q", searchQuery);
   if (pageToken) params.set("pageToken", pageToken);


### PR DESCRIPTION
## Summary
- The Test-tab prefetch warmed the `useSWR` cache for `/api/messages`, but `ProcessRules` consumes `useSWRInfinite`, which uses a different cache key namespace, so the prefetch never populated the cache it was intended for.
- Switch the prefetch to `useInfiniteMessages` (with an `enabled` flag) so the cache keys actually match.
- Drop the unused `useMessages` export, remove the unnecessary `IdleWindow` type cast (`requestIdleCallback`/`cancelIdleCallback` are already typed via the project's `dom` lib), and use `window.*` consistently.

## Test plan
- [ ] Load Rules tab; confirm a single `/api/messages` request fires after idle.
- [ ] Switch to Test tab; confirm no second `/api/messages` request (cache hit).
- [ ] Load Test tab directly; confirm normal fetch and pagination still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)