### PR TITLE
assistant: Restore automation tab content spacing

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/automation/AutomationTabs.tsx
@@ -58,7 +58,7 @@ export function AutomationTabs() {
         />
       </div>
 
-      <div className="mb-10">
+      <div className="mt-2 mb-10">
         {selectedTab === "rules" && <RulesTab />}
         {selectedTab === "settings" && <SettingsTab />}
         {selectedTab === "test" && <Process />}


### PR DESCRIPTION
Adds a small top margin below the AI Assistant automation tab border so the rules actions no longer touch the divider.

- Restores `mt-2` spacing on the automation tab content wrapper
- Keeps the fix scoped to layout spacing only