### PR TITLE
assistant: Refine automation tab spacing

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/Process.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Process.tsx
@@ -11,7 +11,7 @@ export function Process() {
 
   return (
     <>
-      <div className="flex items-center justify-between py-4">
+      <div className="flex items-center justify-between pb-4">
         <div className="flex flex-col space-y-1.5">
           <CardDescription>
             {isApplyMode


### PR DESCRIPTION
Keeps the AI Assistant content wrapper spacing simple and removes the Test tab's duplicate top padding so it does not get extra room below the tab divider.

- Leaves the shared automation tab content wrapper as `mt-2 mb-10`
- Changes the Test tab header from `py-4` to `pb-4` so only the duplicate top padding is removed