### PR TITLE
Fix redundant follow-up cleanup

### DIFF
--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -294,9 +294,6 @@ describe("hasFollowUpLabel", () => {
 describe("clearFollowUpLabel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prisma.threadTracker.findFirst.mockResolvedValue({
-      id: "tracker-active",
-    } as any);
     prisma.messagingChannel.findMany.mockResolvedValue([]);
   });
 
@@ -307,7 +304,7 @@ describe("clearFollowUpLabel", () => {
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
 
-    prisma.threadTracker.findFirst.mockResolvedValue(null);
+    prisma.threadTracker.findMany.mockResolvedValue([]);
 
     await clearFollowUpLabel({
       emailAccountId: "account-1",
@@ -316,7 +313,7 @@ describe("clearFollowUpLabel", () => {
       logger,
     });
 
-    expect(prisma.threadTracker.findFirst).toHaveBeenCalledWith({
+    expect(prisma.threadTracker.findMany).toHaveBeenCalledWith({
       where: {
         emailAccountId: "account-1",
         threadId: "thread-1",
@@ -326,9 +323,11 @@ describe("clearFollowUpLabel", () => {
           { followUpNotifications: { not: Prisma.AnyNull } },
         ],
       },
-      select: { id: true },
+      select: {
+        id: true,
+        followUpDraftId: true,
+      },
     });
-    expect(prisma.threadTracker.findMany).not.toHaveBeenCalled();
     expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
     expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
     expect(mockProvider.getLabelByName).not.toHaveBeenCalled();
@@ -345,7 +344,9 @@ describe("clearFollowUpLabel", () => {
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
 
-    prisma.threadTracker.findMany.mockResolvedValue([]);
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: null },
+    ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
 
     await clearFollowUpLabel({
@@ -355,18 +356,6 @@ describe("clearFollowUpLabel", () => {
       logger,
     });
 
-    // Should query for trackers with drafts (no resolved filter)
-    expect(prisma.threadTracker.findMany).toHaveBeenCalledWith({
-      where: {
-        emailAccountId: "account-1",
-        threadId: "thread-1",
-        followUpDraftId: { not: null },
-      },
-      select: {
-        id: true,
-        followUpDraftId: true,
-      },
-    });
     // Should clear followUpAppliedAt
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
@@ -513,8 +502,10 @@ describe("clearFollowUpLabel", () => {
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
 
-    // No drafts found (trackers may be resolved, but we don't filter on resolved)
-    prisma.threadTracker.findMany.mockResolvedValue([]);
+    // Active tracker with no draft (e.g. resolved tracker with appliedAt still set)
+    prisma.threadTracker.findMany.mockResolvedValue([
+      { id: "tracker-1", followUpDraftId: null },
+    ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 0 });
 
     await clearFollowUpLabel({
@@ -539,7 +530,7 @@ describe("clearFollowUpLabel", () => {
     });
 
     prisma.threadTracker.findMany
-      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
       .mockResolvedValueOnce([
         {
           id: "tracker-1",

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -294,7 +294,48 @@ describe("hasFollowUpLabel", () => {
 describe("clearFollowUpLabel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.threadTracker.findFirst.mockResolvedValue({
+      id: "tracker-active",
+    } as any);
     prisma.messagingChannel.findMany.mockResolvedValue([]);
+  });
+
+  it("does not touch provider labels or notifications without active follow-up state", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+
+    prisma.threadTracker.findFirst.mockResolvedValue(null);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-1",
+        threadId: "thread-1",
+        OR: [
+          { followUpAppliedAt: { not: null } },
+          { followUpDraftId: { not: null } },
+          { followUpNotifications: { not: Prisma.AnyNull } },
+        ],
+      },
+      select: { id: true },
+    });
+    expect(prisma.threadTracker.findMany).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
+    expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
+    expect(mockProvider.getLabelByName).not.toHaveBeenCalled();
+    expect(mockProvider.removeThreadLabel).not.toHaveBeenCalled();
+    expect(messagingMocks.slackChatUpdate).not.toHaveBeenCalled();
+    expect(messagingMocks.teamsEditMessage).not.toHaveBeenCalled();
+    expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
   });
 
   it("removes label and clears followUpAppliedAt even without drafts", async () => {

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -136,6 +136,24 @@ export async function clearFollowUpLabel({
   if (!threadId) return;
 
   try {
+    const activeFollowUpTracker = await prisma.threadTracker.findFirst({
+      where: {
+        emailAccountId,
+        threadId,
+        OR: [
+          { followUpAppliedAt: { not: null } },
+          { followUpDraftId: { not: null } },
+          { followUpNotifications: { not: Prisma.AnyNull } },
+        ],
+      },
+      select: { id: true },
+    });
+
+    if (!activeFollowUpTracker) {
+      logger.info("No active follow-up state to clear", { threadId });
+      return;
+    }
+
     // No resolved filter: trackers may already be resolved by handleOutboundReply
     // before this function runs, but we still need to delete their drafts.
     const trackersWithDrafts = await prisma.threadTracker.findMany({

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -136,7 +136,9 @@ export async function clearFollowUpLabel({
   if (!threadId) return;
 
   try {
-    const activeFollowUpTracker = await prisma.threadTracker.findFirst({
+    // No resolved filter: trackers may already be resolved by handleOutboundReply
+    // before this function runs, but we still need to delete their drafts.
+    const activeTrackers = await prisma.threadTracker.findMany({
       where: {
         emailAccountId,
         threadId,
@@ -146,27 +148,20 @@ export async function clearFollowUpLabel({
           { followUpNotifications: { not: Prisma.AnyNull } },
         ],
       },
-      select: { id: true },
-    });
-
-    if (!activeFollowUpTracker) {
-      logger.info("No active follow-up state to clear", { threadId });
-      return;
-    }
-
-    // No resolved filter: trackers may already be resolved by handleOutboundReply
-    // before this function runs, but we still need to delete their drafts.
-    const trackersWithDrafts = await prisma.threadTracker.findMany({
-      where: {
-        emailAccountId,
-        threadId,
-        followUpDraftId: { not: null },
-      },
       select: {
         id: true,
         followUpDraftId: true,
       },
     });
+
+    if (activeTrackers.length === 0) {
+      logger.info("No active follow-up state to clear", { threadId });
+      return;
+    }
+
+    const trackersWithDrafts = activeTrackers.filter(
+      (tracker) => tracker.followUpDraftId !== null,
+    );
 
     const deletedDraftTrackerIds: string[] = [];
 


### PR DESCRIPTION
Avoid redundant follow-up cleanup when no active follow-up state exists.\n\n- Skip provider and messaging notification cleanup for no-op follow-up state.\n- Add regression coverage for the no-op path.\n\nTests: pnpm test utils/follow-up/labels.test.ts; pnpm test utils/webhook/process-history-item.test.ts utils/reply-tracker/handle-outbound.test.ts; pnpm --filter inbox-zero-ai exec biome check utils/follow-up/labels.ts utils/follow-up/labels.test.ts