### PR TITLE
Fix follow-up notification cleanup race

### DIFF
--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -611,6 +611,7 @@ describe("clearFollowUpLabel", () => {
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
         id: { in: ["tracker-1"] },
+        followUpNotifications: { not: Prisma.AnyNull },
       },
       data: {
         followUpNotifications: Prisma.JsonNull,
@@ -632,5 +633,53 @@ describe("clearFollowUpLabel", () => {
       "telegram-message-1",
       expect.stringMatching(/follow-up/i),
     );
+  });
+
+  it("does not update follow-up notifications when cleanup was already claimed", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
+      .mockResolvedValueOnce([
+        {
+          id: "tracker-1",
+          followUpNotifications: [
+            {
+              messagingChannelId: "channel-1",
+              provider: MessagingProvider.SLACK,
+              providerThreadId: "C123",
+              providerMessageId: "1700000000.000100",
+            },
+          ],
+        },
+      ]);
+    prisma.threadTracker.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+        followUpNotifications: { not: Prisma.AnyNull },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
+    expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
+    expect(messagingMocks.slackChatUpdate).not.toHaveBeenCalled();
+    expect(messagingMocks.teamsEditMessage).not.toHaveBeenCalled();
+    expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -528,32 +528,33 @@ describe("clearFollowUpLabel", () => {
         .fn()
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
+    const notifications = [
+      {
+        messagingChannelId: "channel-1",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C123",
+        providerMessageId: "1700000000.000100",
+      },
+      {
+        messagingChannelId: "channel-2",
+        provider: MessagingProvider.TEAMS,
+        providerThreadId: "teams-thread-1",
+        providerMessageId: "teams-message-1",
+      },
+      {
+        messagingChannelId: "channel-3",
+        provider: MessagingProvider.TELEGRAM,
+        providerThreadId: "telegram-thread-1",
+        providerMessageId: "telegram-message-1",
+      },
+    ];
 
     prisma.threadTracker.findMany
       .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
       .mockResolvedValueOnce([
         {
           id: "tracker-1",
-          followUpNotifications: [
-            {
-              messagingChannelId: "channel-1",
-              provider: MessagingProvider.SLACK,
-              providerThreadId: "C123",
-              providerMessageId: "1700000000.000100",
-            },
-            {
-              messagingChannelId: "channel-2",
-              provider: MessagingProvider.TEAMS,
-              providerThreadId: "teams-thread-1",
-              providerMessageId: "teams-message-1",
-            },
-            {
-              messagingChannelId: "channel-3",
-              provider: MessagingProvider.TELEGRAM,
-              providerThreadId: "telegram-thread-1",
-              providerMessageId: "telegram-message-1",
-            },
-          ],
+          followUpNotifications: notifications,
         },
       ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
@@ -610,8 +611,25 @@ describe("clearFollowUpLabel", () => {
     });
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
+        id: "tracker-1",
+        followUpNotifications: { equals: notifications },
+      },
+      data: {
+        followUpNotifications: expect.objectContaining({
+          type: "reply-received-cleanup-claim",
+          claimId: expect.any(String),
+          claimedAt: expect.any(String),
+          notifications,
+        }),
+      },
+    });
+    expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
+      where: {
         id: { in: ["tracker-1"] },
-        followUpNotifications: { not: Prisma.AnyNull },
+        followUpNotifications: {
+          path: ["claimId"],
+          equals: expect.any(String),
+        },
       },
       data: {
         followUpNotifications: Prisma.JsonNull,
@@ -641,20 +659,21 @@ describe("clearFollowUpLabel", () => {
         .fn()
         .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
     });
+    const notifications = [
+      {
+        messagingChannelId: "channel-1",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C123",
+        providerMessageId: "1700000000.000100",
+      },
+    ];
 
     prisma.threadTracker.findMany
       .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
       .mockResolvedValueOnce([
         {
           id: "tracker-1",
-          followUpNotifications: [
-            {
-              messagingChannelId: "channel-1",
-              provider: MessagingProvider.SLACK,
-              providerThreadId: "C123",
-              providerMessageId: "1700000000.000100",
-            },
-          ],
+          followUpNotifications: notifications,
         },
       ]);
     prisma.threadTracker.updateMany
@@ -670,16 +689,149 @@ describe("clearFollowUpLabel", () => {
 
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
-        id: { in: ["tracker-1"] },
-        followUpNotifications: { not: Prisma.AnyNull },
+        id: "tracker-1",
+        followUpNotifications: { equals: notifications },
       },
       data: {
-        followUpNotifications: Prisma.JsonNull,
+        followUpNotifications: expect.objectContaining({
+          type: "reply-received-cleanup-claim",
+          notifications,
+        }),
       },
     });
     expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
     expect(messagingMocks.slackChatUpdate).not.toHaveBeenCalled();
     expect(messagingMocks.teamsEditMessage).not.toHaveBeenCalled();
     expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps claimed follow-up notifications for retry when a messaging update fails", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+    const notifications = [
+      {
+        messagingChannelId: "channel-1",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C123",
+        providerMessageId: "1700000000.000100",
+      },
+    ];
+
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
+      .mockResolvedValueOnce([
+        {
+          id: "tracker-1",
+          followUpNotifications: notifications,
+        },
+      ]);
+    prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+      },
+    ]);
+    messagingMocks.slackChatUpdate.mockRejectedValueOnce(
+      new Error("Slack timeout"),
+    );
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(messagingMocks.slackChatUpdate).toHaveBeenCalledTimes(1);
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalledWith({
+      where: {
+        id: { in: ["tracker-1"] },
+        followUpNotifications: {
+          path: ["claimId"],
+          equals: expect.any(String),
+        },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
+  });
+
+  it("only updates notifications from trackers this worker claimed", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+    const claimedNotifications = [
+      {
+        messagingChannelId: "channel-1",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C123",
+        providerMessageId: "1700000000.000100",
+      },
+    ];
+    const unclaimedNotifications = [
+      {
+        messagingChannelId: "channel-2",
+        provider: MessagingProvider.SLACK,
+        providerThreadId: "C456",
+        providerMessageId: "1700000000.000200",
+      },
+    ];
+
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([{ id: "tracker-1", followUpDraftId: null }])
+      .mockResolvedValueOnce([
+        {
+          id: "tracker-1",
+          followUpNotifications: claimedNotifications,
+        },
+        {
+          id: "tracker-2",
+          followUpNotifications: unclaimedNotifications,
+        },
+      ]);
+    prisma.threadTracker.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        isConnected: true,
+        accessToken: "xoxb-token",
+      },
+    ]);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.messagingChannel.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ["channel-1"] },
+        }),
+      }),
+    );
+    expect(messagingMocks.slackChatUpdate).toHaveBeenCalledTimes(1);
+    expect(messagingMocks.slackChatUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        ts: "1700000000.000100",
+      }),
+    );
   });
 });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Card, CardText, type CardElement } from "chat";
 import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import prisma from "@/utils/prisma";
@@ -262,29 +263,51 @@ async function replaceFollowUpNotificationsWithReplyReceivedState({
       },
     });
 
-    const notifications = trackers.flatMap((tracker) =>
-      parseFollowUpNotificationDeliveries(tracker.followUpNotifications),
-    );
-    if (notifications.length === 0) return;
+    const claimId = randomUUID();
+    const claimedAt = new Date();
+    const claimedTrackers: {
+      id: string;
+      notifications: FollowUpNotificationDelivery[];
+    }[] = [];
 
-    const trackerIds = trackers.map((tracker) => tracker.id);
-    const claimed = await prisma.threadTracker.updateMany({
-      where: {
-        id: { in: trackerIds },
-        followUpNotifications: { not: Prisma.AnyNull },
-      },
-      data: {
-        followUpNotifications: Prisma.JsonNull,
-      },
-    });
+    for (const tracker of trackers) {
+      const notifications = getClaimableFollowUpNotifications(
+        tracker.followUpNotifications,
+        claimedAt,
+      );
+      if (notifications.length === 0) continue;
 
-    if (claimed.count === 0) {
+      const claimed = await prisma.threadTracker.updateMany({
+        where: {
+          id: tracker.id,
+          followUpNotifications: {
+            equals: tracker.followUpNotifications as Prisma.InputJsonValue,
+          },
+        },
+        data: {
+          followUpNotifications: buildFollowUpNotificationCleanupClaim({
+            claimId,
+            claimedAt,
+            notifications,
+          }),
+        },
+      });
+
+      if (claimed.count === 1) {
+        claimedTrackers.push({ id: tracker.id, notifications });
+      }
+    }
+
+    if (claimedTrackers.length === 0) {
       logger.info("Follow-up notification cleanup already claimed", {
         threadId,
       });
       return;
     }
 
+    const notifications = claimedTrackers.flatMap(
+      (tracker) => tracker.notifications,
+    );
     const messagingChannelIds = [
       ...new Set(
         notifications.map((notification) => notification.messagingChannelId),
@@ -307,7 +330,7 @@ async function replaceFollowUpNotificationsWithReplyReceivedState({
     );
 
     const card = buildReplyReceivedFollowUpCard();
-    await Promise.all(
+    const results = await Promise.all(
       notifications.map((notification) =>
         replaceFollowUpNotification({
           notification,
@@ -317,6 +340,21 @@ async function replaceFollowUpNotificationsWithReplyReceivedState({
         }),
       ),
     );
+
+    if (!results.every(Boolean)) return;
+
+    await prisma.threadTracker.updateMany({
+      where: {
+        id: { in: claimedTrackers.map((tracker) => tracker.id) },
+        followUpNotifications: {
+          path: ["claimId"],
+          equals: claimId,
+        },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
   } catch (error) {
     logger.warn("Failed to update follow-up notifications after reply", {
       threadId,
@@ -335,13 +373,13 @@ async function replaceFollowUpNotification({
   channel: FollowUpNotificationChannelForCleanup | undefined;
   card: CardElement;
   logger: Logger;
-}) {
-  if (!channel) return;
+}): Promise<boolean> {
+  if (!channel) return true;
 
   try {
     switch (notification.provider) {
       case MessagingProvider.SLACK: {
-        if (!channel.accessToken) return;
+        if (!channel.accessToken) return true;
 
         await createSlackClient(channel.accessToken).chat.update(
           disableSlackLinkUnfurls({
@@ -351,45 +389,93 @@ async function replaceFollowUpNotification({
             blocks: cardToBlockKit(card),
           }),
         );
-        return;
+        return true;
       }
       case MessagingProvider.TEAMS: {
         const teamsAdapter = getMessagingAdapterRegistry().typedAdapters.teams;
-        if (!teamsAdapter) return;
+        if (!teamsAdapter) return true;
 
         await teamsAdapter.editMessage(
           notification.providerThreadId,
           notification.providerMessageId,
           REPLY_RECEIVED_TEXT,
         );
-        return;
+        return true;
       }
       case MessagingProvider.TELEGRAM: {
         const telegramAdapter =
           getMessagingAdapterRegistry().typedAdapters.telegram;
-        if (!telegramAdapter) return;
+        if (!telegramAdapter) return true;
 
         await telegramAdapter.editMessage(
           notification.providerThreadId,
           notification.providerMessageId,
           REPLY_RECEIVED_TEXT,
         );
-        return;
+        return true;
       }
     }
+    return true;
   } catch (error) {
     logger.warn("Failed to update follow-up notification after reply", {
       provider: notification.provider,
       error,
     });
+    return false;
   }
 }
 
 const REPLY_RECEIVED_TEXT = "Reply received. Follow-up no longer needed.";
+const FOLLOW_UP_NOTIFICATION_CLEANUP_CLAIM_TYPE =
+  "reply-received-cleanup-claim";
+const FOLLOW_UP_NOTIFICATION_CLEANUP_CLAIM_TTL_MS = 5 * 60 * 1000;
 
 function buildReplyReceivedFollowUpCard() {
   return Card({
     title: "Reply received",
     children: [CardText("Follow-up no longer needed.")],
   });
+}
+
+function buildFollowUpNotificationCleanupClaim({
+  claimId,
+  claimedAt,
+  notifications,
+}: {
+  claimId: string;
+  claimedAt: Date;
+  notifications: FollowUpNotificationDelivery[];
+}): Prisma.InputJsonObject {
+  return {
+    type: FOLLOW_UP_NOTIFICATION_CLEANUP_CLAIM_TYPE,
+    claimId,
+    claimedAt: claimedAt.toISOString(),
+    notifications,
+  };
+}
+
+function getClaimableFollowUpNotifications(
+  value: unknown,
+  now: Date,
+): FollowUpNotificationDelivery[] {
+  const notifications = parseFollowUpNotificationDeliveries(value);
+  if (notifications.length > 0) return notifications;
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+
+  const claim = value as {
+    type?: unknown;
+    claimedAt?: unknown;
+    notifications?: unknown;
+  };
+  if (claim.type !== FOLLOW_UP_NOTIFICATION_CLEANUP_CLAIM_TYPE) return [];
+  if (typeof claim.claimedAt !== "string") return [];
+
+  const claimedAt = new Date(claim.claimedAt).getTime();
+  if (!Number.isFinite(claimedAt)) return [];
+  if (now.getTime() - claimedAt < FOLLOW_UP_NOTIFICATION_CLEANUP_CLAIM_TTL_MS) {
+    return [];
+  }
+
+  return parseFollowUpNotificationDeliveries(claim.notifications);
 }

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -267,6 +267,24 @@ async function replaceFollowUpNotificationsWithReplyReceivedState({
     );
     if (notifications.length === 0) return;
 
+    const trackerIds = trackers.map((tracker) => tracker.id);
+    const claimed = await prisma.threadTracker.updateMany({
+      where: {
+        id: { in: trackerIds },
+        followUpNotifications: { not: Prisma.AnyNull },
+      },
+      data: {
+        followUpNotifications: Prisma.JsonNull,
+      },
+    });
+
+    if (claimed.count === 0) {
+      logger.info("Follow-up notification cleanup already claimed", {
+        threadId,
+      });
+      return;
+    }
+
     const messagingChannelIds = [
       ...new Set(
         notifications.map((notification) => notification.messagingChannelId),
@@ -299,15 +317,6 @@ async function replaceFollowUpNotificationsWithReplyReceivedState({
         }),
       ),
     );
-
-    await prisma.threadTracker.updateMany({
-      where: {
-        id: { in: trackers.map((tracker) => tracker.id) },
-      },
-      data: {
-        followUpNotifications: Prisma.JsonNull,
-      },
-    });
   } catch (error) {
     logger.warn("Failed to update follow-up notifications after reply", {
       threadId,


### PR DESCRIPTION
Prevent duplicate follow-up notification cleanup from editing the same messaging notification multiple times.\n\n- Claim notification cleanup in the database before editing messaging notifications.\n- Skip messaging updates when another worker has already claimed cleanup.\n\nTests: pnpm test utils/follow-up/labels.test.ts; pnpm test utils/webhook/process-history-item.test.ts utils/reply-tracker/handle-outbound.test.ts; pnpm --filter inbox-zero-ai exec biome check utils/follow-up/labels.ts utils/follow-up/labels.test.ts