### PR TITLE
Simplify follow-up notification update return paths

### DIFF
--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -389,7 +389,7 @@ async function replaceFollowUpNotification({
             blocks: cardToBlockKit(card),
           }),
         );
-        return true;
+        break;
       }
       case MessagingProvider.TEAMS: {
         const teamsAdapter = getMessagingAdapterRegistry().typedAdapters.teams;
@@ -400,7 +400,7 @@ async function replaceFollowUpNotification({
           notification.providerMessageId,
           REPLY_RECEIVED_TEXT,
         );
-        return true;
+        break;
       }
       case MessagingProvider.TELEGRAM: {
         const telegramAdapter =
@@ -412,7 +412,7 @@ async function replaceFollowUpNotification({
           notification.providerMessageId,
           REPLY_RECEIVED_TEXT,
         );
-        return true;
+        break;
       }
     }
     return true;


### PR DESCRIPTION
## Summary
- Replace redundant per-case `return true` statements in `replaceFollowUpNotification` with `break`, leaving a single success return after the switch.
- No behavior change.

## Test plan
- [x] `pnpm test utils/follow-up/labels.test.ts` (22 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)