### PR TITLE
ai: Keep inferred roles concise

### DIFF
--- a/apps/web/utils/ai/knowledge/persona.ts
+++ b/apps/web/utils/ai/knowledge/persona.ts
@@ -10,11 +10,7 @@ import { getEmailListPrompt } from "@/utils/ai/helpers";
 const logger = createScopedLogger("persona-analyzer");
 
 export const personaAnalysisSchema = z.object({
-  persona: z
-    .string()
-    .describe(
-      "The identified professional role (can be from the provided list or a custom role if evidence strongly suggests otherwise)",
-    ),
+  persona: z.string().trim().min(1).describe("Role label for onboarding."),
   industry: z
     .string()
     .describe(
@@ -71,7 +67,7 @@ Analyze the user's emails to determine their most likely professional role or pe
 Consider these common personas as defaults, but feel free to suggest a more specific or different role if the evidence strongly points elsewhere:
 ${rolesList}
 
-If the user doesn't clearly fit into one of these categories, provide a custom persona that better describes their role based on the email evidence.
+Return persona as a short 1-3 word role label. Use "Individual" for mostly private or household email, or a custom label if no listed role fits.
 
 Base your analysis on:
 - Topics discussed in emails


### PR DESCRIPTION
Updates persona analysis so onboarding receives a short role label and maps mostly private or household email to the existing Individual role. Also trims and requires a non-empty persona value at schema validation time.