### PR TITLE
docker: Simplify public env placeholder replacement

### DIFF
--- a/apps/web/app/(landing)/login/page.tsx
+++ b/apps/web/app/(landing)/login/page.tsx
@@ -34,11 +34,6 @@ export default async function AuthenticationPage(props: {
   const session = await auth();
   const nextPath = normalizeInternalPath(searchParams?.next);
   const isSelfHosted = env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS;
-  const selfHostedLoginFooterText =
-    env.NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT ===
-    "NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT_PLACEHOLDER"
-      ? undefined
-      : env.NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT;
 
   if (session?.user && !searchParams?.error) {
     redirect(nextPath ?? WELCOME_PATH);
@@ -88,7 +83,9 @@ export default async function AuthenticationPage(props: {
 
         <LoginFooter
           isSelfHosted={isSelfHosted}
-          selfHostedLoginFooterText={selfHostedLoginFooterText}
+          selfHostedLoginFooterText={
+            env.NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT || undefined
+          }
         />
       </div>
     </div>

--- a/docker/scripts/replace-next-public-placeholders.sh
+++ b/docker/scripts/replace-next-public-placeholders.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Next.js inlines NEXT_PUBLIC_ values at build time. Docker images build with
+# placeholder values, then this script swaps those placeholders for runtime envs.
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BUILD_OUTPUT_PATHS="apps/web/.next/ apps/web/public/"
+NEXT_PUBLIC_PLACEHOLDER_PATTERN='http://NEXT_PUBLIC_[A-Z0-9_]+_PLACEHOLDER|NEXT_PUBLIC_[A-Z0-9_]+_PLACEHOLDER'
+
+egrep -r -h -o "$NEXT_PUBLIC_PLACEHOLDER_PATTERN" $BUILD_OUTPUT_PATHS 2>/dev/null |
+    sort -u |
+while IFS= read -r PLACEHOLDER; do
+    ENV_NAME=${PLACEHOLDER#http://}
+    ENV_NAME=${ENV_NAME%_PLACEHOLDER}
+    VALUE=$(printenv "$ENV_NAME" 2>/dev/null || true)
+    "$SCRIPT_DIR/replace-placeholder.sh" "$PLACEHOLDER" "$VALUE"
+done

--- a/docker/scripts/replace-placeholder.sh
+++ b/docker/scripts/replace-placeholder.sh
@@ -1,23 +1,27 @@
 #!/bin/sh
 
-FROM=$1
-TO=$2
+PLACEHOLDER=$1
+VALUE=${2-}
 
-if [ -z "$FROM" ] || [ -z "$TO" ]; then
+if [ -z "$PLACEHOLDER" ] || [ "$#" -lt 2 ]; then
     echo "Usage: $0 <PLACEHOLDER> <VALUE>"
     exit 1
 fi
 
-if [ "${FROM}" = "${TO}" ]; then
-    echo "Nothing to replace, the value is already set to ${TO}."
+if [ "${PLACEHOLDER}" = "${VALUE}" ]; then
+    echo "Nothing to replace, the value is already set to ${VALUE}."
     exit 0
 fi
 
-echo "Replacing all statically built instances of $FROM with $TO."
+if [ -z "$VALUE" ]; then
+    echo "Replacing all statically built instances of $PLACEHOLDER with an empty value."
+else
+    echo "Replacing all statically built instances of $PLACEHOLDER with $VALUE."
+fi
 
-ESCAPED_TO=$(printf '%s' "$TO" | sed -e 's/[\\&|]/\\&/g')
+ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/[\\&|]/\\&/g')
 
 # We use || true to prevent the script from exiting if no files are found (egrep returns 1)
-for file in $(egrep -r -l "${FROM}" apps/web/.next/ apps/web/public/ || true); do
-    sed -i -e "s|$FROM|$ESCAPED_TO|g" "$file"
+for file in $(egrep -r -l "${PLACEHOLDER}" apps/web/.next/ apps/web/public/ || true); do
+    sed -i -e "s|$PLACEHOLDER|$ESCAPED_VALUE|g" "$file"
 done

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -8,47 +8,7 @@ echo "🚀 Starting Inbox Zero..."
 
 . /app/docker/scripts/configure-rds-ca.sh
 
-# Define the variables to replace
-# Add more NEXT_PUBLIC_ variables here as needed
-if [ -n "$NEXT_PUBLIC_BASE_URL" ]; then
-    /app/docker/scripts/replace-placeholder.sh "http://NEXT_PUBLIC_BASE_URL_PLACEHOLDER" "$NEXT_PUBLIC_BASE_URL"
-fi
-
-if [ -n "$NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS_PLACEHOLDER" "$NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS"
-fi
-
-if [ -n "$NEXT_PUBLIC_EMAIL_SEND_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_EMAIL_SEND_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_EMAIL_SEND_ENABLED"
-fi
-
-if [ -n "$NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT_PLACEHOLDER" "$NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT"
-fi
-
-if [ -n "$NEXT_PUBLIC_CLEANER_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_CLEANER_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_CLEANER_ENABLED"
-fi
-
-# Always replace — the placeholder is a non-empty string that would be coerced
-# to true by booleanString, incorrectly disabling drafting by default
-/app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_AUTO_DRAFT_DISABLED_PLACEHOLDER" "${NEXT_PUBLIC_AUTO_DRAFT_DISABLED:-false}"
-
-if [ -n "$NEXT_PUBLIC_MEETING_BRIEFS_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_MEETING_BRIEFS_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_MEETING_BRIEFS_ENABLED"
-fi
-
-if [ -n "$NEXT_PUBLIC_INTEGRATIONS_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_INTEGRATIONS_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_INTEGRATIONS_ENABLED"
-fi
-
-if [ -n "$NEXT_PUBLIC_DIGEST_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_DIGEST_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_DIGEST_ENABLED"
-fi
-
-if [ -n "$NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED" ]; then
-    /app/docker/scripts/replace-placeholder.sh "NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED_PLACEHOLDER" "$NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED"
-fi
+/app/docker/scripts/replace-next-public-placeholders.sh
 
 if [ "${SKIP_DB_MIGRATIONS:-false}" = "true" ]; then
     echo "Skipping database migrations during web startup."


### PR DESCRIPTION
Updates Docker startup to replace public Next.js env placeholders generically at runtime, clearing unset placeholders to empty values instead of leaving placeholder text in the bundle.

- Adds a helper that discovers built NEXT_PUBLIC placeholders and replaces them from runtime env
- Allows empty placeholder replacements and removes the manual replacement list from startup
- Simplifies login footer env usage now that placeholders are cleared before server start