### PR TITLE
login: Adjust provider order

### DIFF
--- a/apps/web/app/(landing)/login/LoginForm.test.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.test.tsx
@@ -64,6 +64,23 @@ describe("LoginForm", () => {
     cleanup();
   });
 
+  it("places Apple after Google and Microsoft when all OAuth options are shown", () => {
+    render(
+      <LoginForm
+        enabledProviders={["google", "microsoft", "apple", "sso"]}
+        useGoogleOauthEmulator
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual([
+      "Sign in with Google",
+      "Sign in with Microsoft",
+      "Sign in with Apple",
+    ]);
+  });
+
   it("starts Apple sign-in when the Apple option is shown", async () => {
     mockSignInSocial.mockResolvedValue(undefined);
 

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -81,27 +81,6 @@ export function LoginForm({
 
   return (
     <div className="flex flex-col justify-center gap-2 px-4 sm:px-16">
-      {showAppleLogin ? (
-        <Button
-          size="2xl"
-          loading={loadingApple}
-          onClick={() =>
-            handleSocialSignIn({
-              provider: "apple",
-              providerName: "Apple",
-              callbackURL: appleCallbackURL,
-              errorCallbackURL,
-              setLoading: setLoadingApple,
-            })
-          }
-        >
-          <span className="flex items-center justify-center">
-            <AppleLogo className="size-6" aria-hidden="true" />
-            <span className="ml-2">Sign in with Apple</span>
-          </span>
-        </Button>
-      ) : null}
-
       {showGoogleLogin ? (
         <Button size="2xl" loading={loadingGoogle} onClick={handleGoogleSignIn}>
           <span className="flex items-center justify-center">
@@ -132,6 +111,28 @@ export function LoginForm({
               unoptimized
             />
             <span className="ml-2">Sign in with Microsoft</span>
+          </span>
+        </Button>
+      ) : null}
+
+      {showAppleLogin ? (
+        <Button
+          size="2xl"
+          color="white"
+          loading={loadingApple}
+          onClick={() =>
+            handleSocialSignIn({
+              provider: "apple",
+              providerName: "Apple",
+              callbackURL: appleCallbackURL,
+              errorCallbackURL,
+              setLoading: setLoadingApple,
+            })
+          }
+        >
+          <span className="flex items-center justify-center">
+            <AppleLogo className="size-6" aria-hidden="true" />
+            <span className="ml-2">Sign in with Apple</span>
           </span>
         </Button>
       ) : null}


### PR DESCRIPTION
Updates the login form so the Apple OAuth option appears after the primary provider options and uses a secondary visual style.

- Moves Apple after Google and Microsoft in the OAuth button list
- Adds a focused regression test for OAuth provider order

Performance impact: UI-only change with no added runtime work beyond existing rendering, no new database or network calls, and no hot-path risk.