### PR TITLE
login: Subtle secondary provider option

### DIFF
--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { type SVGProps, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/Button";
 import { Button as UIButton } from "@/components/ui/button";
 import { signIn, signInWithOauth2 } from "@/utils/auth-client";
@@ -116,9 +116,10 @@ export function LoginForm({
       ) : null}
 
       {showAppleLogin ? (
-        <Button
-          size="2xl"
-          color="white"
+        <UIButton
+          variant="ghost"
+          size="lg"
+          className="w-full hover:scale-105 transition-transform"
           loading={loadingApple}
           onClick={() =>
             handleSocialSignIn({
@@ -130,11 +131,8 @@ export function LoginForm({
             })
           }
         >
-          <span className="flex items-center justify-center">
-            <AppleLogo className="size-6" aria-hidden="true" />
-            <span className="ml-2">Sign in with Apple</span>
-          </span>
-        </Button>
+          Sign in with Apple
+        </UIButton>
       ) : null}
 
       {showSsoLogin ? (
@@ -208,12 +206,4 @@ function getSocialSignInErrorMessage(error: unknown) {
   }
 
   return "Please try again or contact support.";
-}
-
-function AppleLogo(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
-      <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.091zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.56-1.701z" />
-    </svg>
-  );
 }


### PR DESCRIPTION
Updates the login form so the secondary OAuth option uses the same subtle visual treatment as the SSO option.

- Uses a ghost-style button for the secondary provider option
- Removes the extra provider icon from that lower-priority option

Performance impact: UI-only change with no added runtime work beyond existing rendering, no new database or network calls, and no hot-path risk.