### PR TITLE
docker: gate all cron loops behind curl install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     image: alpine:latest
     command: >
       sh -c "
-        apk add --no-cache curl &&
+        apk add --no-cache curl && {
         (
           while true; do
             echo \"[cron] Processing scheduled actions...\"
@@ -153,6 +153,7 @@ services:
           done
         ) &
         wait
+        }
       "
     env_file:
       - path: ./apps/web/.env


### PR DESCRIPTION
The `cron` service runs `apk add --no-cache curl && (loop1) & (loop2) & ... & wait`. Shell precedence binds `&&` only to the first backgrounded unit, so only the `scheduled-actions` loop waits for curl. The other five — `automation-jobs`, `follow-up-reminders`, `digest`, `meeting-briefs`, and `watch` renewal — start immediately and race the apk install.

On a fast network apk finishes in ~1s and the race is invisible. After a slow boot (power outage, network not yet up) the ungated loops spin failing with `curl: not found` until apk completes. Watch renewal sleeps 21600s between attempts, so a missed first attempt leaves Gmail push subscriptions un-renewed for up to 6h — new mail stops being processed until the next cycle.

## Fix

Wrap all loops in a brace group gated behind apk so none start until curl is installed. If apk fails, the group is skipped, `sh -c` exits non-zero, and the existing `restart: always` retries — no silent curl-less loops.

Validated with `sh -n` (brace-group syntax) and `docker compose config` (YAML + rendered command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
