### PR TITLE
Fix Slack draft send completion

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -3,6 +3,7 @@ import prisma from "@/utils/__mocks__/prisma";
 import {
   ActionType,
   AttachmentSourceType,
+  DraftEmailStatus,
   MessagingMessageStatus,
   MessagingProvider,
   MessagingRoutePurpose,
@@ -178,6 +179,106 @@ describe("handleRuleNotificationAction", () => {
     expect(cardText).toContain(
       "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
     );
+  });
+
+  it("closes the Slack edit modal when the draft sends but the message update fails", async () => {
+    const provider = {
+      updateDraft: vi.fn().mockResolvedValue(undefined),
+      sendDraft: vi.fn().mockResolvedValue(undefined),
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Edited draft body",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Edited draft body",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+    mockNotificationContext({
+      id: "action-1",
+      type: ActionType.DRAFT_MESSAGING_CHANNEL,
+      content: "Initial draft body",
+      messagingMessageId: "slack-ts-1",
+      mailboxDraftAction: {
+        id: "draft-action-1",
+        draftId: "draft-1",
+        subject: "Re: Test subject",
+      },
+    });
+    prisma.executedAction.update.mockResolvedValue({} as never);
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 2 } as never);
+
+    const { handleSlackRuleNotificationModalSubmit } = await import(
+      "./rule-notifications"
+    );
+
+    const response = await handleSlackRuleNotificationModalSubmit({
+      event: {
+        privateMetadata: "action-1",
+        values: {
+          draft_content: "Edited draft body",
+        },
+        user: { userId: "user-1" },
+        raw: { team: { id: "team-1" } },
+        relatedMessage: {
+          edit: vi.fn().mockRejectedValue(new Error("Slack update failed")),
+        },
+      } as any,
+      logger,
+    });
+
+    expect(response).toEqual({ action: "close" });
+    expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
+        messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+      },
+    });
+    expect(mockSlackUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        ts: "slack-ts-1",
+        text: expect.stringContaining("Reply sent."),
+      }),
+    );
+    expect(
+      JSON.stringify(mockSlackUpdate.mock.calls[0]?.[0]?.blocks),
+    ).not.toContain("Send reply");
   });
 
   it("sends Telegram draft replies from the notification Send button", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -737,14 +737,13 @@ export async function handleSlackRuleNotificationModalSubmit({
       context: { ...context, content: nextContent },
       logger,
       editMessage: async (card) => {
-        if (event.relatedMessage) {
-          await event.relatedMessage.edit(card);
-          return;
+        if (!event.relatedMessage) {
+          throw new Error(
+            "Slack draft modal submitted without related message",
+          );
         }
 
-        logger.warn("Slack draft modal submitted without related message", {
-          executedActionId: context.id,
-        });
+        await event.relatedMessage.edit(card);
       },
     });
   } catch (error) {
@@ -957,32 +956,147 @@ async function sendDraftReplyFromNotification({
     );
   }
 
-  await prisma.executedAction.update({
-    where: { id: context.id },
-    data: {
-      draftStatus: DraftEmailStatus.LIKELY_SENT,
-      messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
-    },
-  });
-
-  if (mailboxDraftAction?.id) {
-    await prisma.executedAction.update({
-      where: { id: mailboxDraftAction.id },
-      data: {
-        draftStatus: DraftEmailStatus.LIKELY_SENT,
-      },
+  try {
+    await Promise.all([
+      prisma.executedAction.update({
+        where: { id: context.id },
+        data: {
+          draftStatus: DraftEmailStatus.LIKELY_SENT,
+          messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+        },
+      }),
+      ...(mailboxDraftAction?.id
+        ? [
+            prisma.executedAction.update({
+              where: { id: mailboxDraftAction.id },
+              data: { draftStatus: DraftEmailStatus.LIKELY_SENT },
+            }),
+          ]
+        : []),
+    ]);
+  } catch (error) {
+    logger.warn("Failed to mark notification draft reply as sent", {
+      executedActionId: context.id,
+      mailboxDraftActionId: mailboxDraftAction?.id,
+      error,
     });
   }
 
-  await editMessage(
-    buildHandledNotificationCard({
+  await updateSentDraftNotificationMessage({
+    context,
+    logger,
+    editMessage,
+    card: buildHandledNotificationCard({
       content: notificationContent,
       openLink: getNotificationOpenLink(context),
       status: "Reply sent.",
     }),
-  );
+  });
 
   return "sent";
+}
+
+async function updateSentDraftNotificationMessage({
+  context,
+  logger,
+  editMessage,
+  card,
+}: {
+  context: NotificationContext;
+  logger: Logger;
+  editMessage: (card: CardElement) => Promise<void>;
+  card: CardElement;
+}) {
+  try {
+    await editMessage(card);
+    return;
+  } catch (error) {
+    logger.warn("Failed to update sent draft notification message", {
+      executedActionId: context.id,
+      error,
+    });
+  }
+
+  await updateStoredSlackNotificationMessage({
+    context,
+    logger,
+    card,
+  });
+}
+
+async function updateStoredSlackNotificationMessage({
+  context,
+  logger,
+  card,
+}: {
+  context: NotificationContext;
+  logger: Logger;
+  card: CardElement;
+}) {
+  if (
+    !context.messagingMessageId ||
+    !context.messagingChannel ||
+    !isOperationalSlackChannel(context.messagingChannel)
+  ) {
+    return;
+  }
+
+  const route = getMessagingRoute(
+    context.messagingChannel.routes,
+    MessagingRoutePurpose.RULE_NOTIFICATIONS,
+  );
+
+  try {
+    const destinationChannelId = await resolveSlackRouteDestination({
+      accessToken: context.messagingChannel.accessToken,
+      route,
+    });
+
+    if (!destinationChannelId) {
+      logger.warn(
+        "Skipping sent Slack draft notification update with no route",
+        {
+          executedActionId: context.id,
+          messagingChannelId: context.messagingChannelId,
+        },
+      );
+      return;
+    }
+
+    await updateSlackCard({
+      accessToken: context.messagingChannel.accessToken,
+      channel: destinationChannelId,
+      ts: context.messagingMessageId,
+      card,
+    });
+  } catch (error) {
+    logger.warn("Failed to update stored Slack draft notification message", {
+      executedActionId: context.id,
+      messagingMessageId: context.messagingMessageId,
+      error,
+    });
+  }
+}
+
+async function updateSlackCard({
+  accessToken,
+  channel,
+  ts,
+  card,
+}: {
+  accessToken: string;
+  channel: string;
+  ts: string;
+  card: CardElement;
+}) {
+  await createSlackClient(accessToken).chat.update(
+    disableSlackLinkUnfurls({
+      channel,
+      ts,
+      text: cardToFallbackText(card),
+      blocks: cardToBlockKit(card),
+    }),
+  );
 }
 
 export function buildNotificationReplySendBody({
@@ -2148,16 +2262,12 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
           return;
         }
 
-        await createSlackClient(
-          context.messagingChannel.accessToken,
-        ).chat.update(
-          disableSlackLinkUnfurls({
-            channel: destinationChannelId,
-            ts: context.messagingMessageId,
-            text: cardToFallbackText(card),
-            blocks: cardToBlockKit(card),
-          }),
-        );
+        await updateSlackCard({
+          accessToken: context.messagingChannel.accessToken,
+          channel: destinationChannelId,
+          ts: context.messagingMessageId,
+          card,
+        });
         break;
       }
       case MessagingProvider.TEAMS: {


### PR DESCRIPTION
Ensures Slack draft-send submissions finish cleanly after the email draft is sent, even if the immediate modal message edit fails. Adds a fallback update path for the stored Slack notification so the send controls are removed when possible.

- Marks draft notifications as sent after provider send succeeds, without blocking on follow-up status persistence failures.
- Falls back to updating the stored Slack notification when the modal-related message edit fails.
- Reuses Slack card update logic across notification cleanup paths.
- Tests: `pnpm test utils/messaging/rule-notifications.test.ts` (43 passed).

Performance impact: no new hot-path work before sending the draft; after successful sends this may perform one fallback Slack API update only when the primary message edit fails, with no new database reads and the existing sent-status writes preserved.