### PR TITLE
booking: Stabilize calendar layout

### DIFF
--- a/apps/web/app/book/[slug]/BookingPageClient.tsx
+++ b/apps/web/app/book/[slug]/BookingPageClient.tsx
@@ -392,7 +392,9 @@ export function BookingShell({
       <div
         className={cn(
           "w-full min-w-0 overflow-hidden rounded-xl border bg-background shadow-lg sm:rounded-2xl",
-          size === "compact" ? "max-w-3xl" : "max-w-5xl",
+          size === "compact"
+            ? "max-w-3xl"
+            : "max-w-5xl md:flex md:h-[48rem] md:max-h-[calc(100dvh-5rem)] md:flex-col",
         )}
       >
         {children}

--- a/apps/web/app/book/[slug]/BookingSidebar.tsx
+++ b/apps/web/app/book/[slug]/BookingSidebar.tsx
@@ -61,7 +61,7 @@ export function BookingSidebar({
   const hostName = bookingLink.hostName || bookingLink.title;
   const initial = (hostName || "?").trim().charAt(0).toUpperCase();
   return (
-    <div className="flex min-h-0 flex-col gap-4 p-4 sm:p-6 md:p-7">
+    <div className="flex min-h-0 flex-col gap-4 overflow-y-auto p-4 sm:p-6 md:p-7">
       {backButton}
       <div className="flex size-12 items-center justify-center rounded-full bg-blue-50 text-lg font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300">
         {initial}

--- a/apps/web/app/book/[slug]/PickTimeStep.tsx
+++ b/apps/web/app/book/[slug]/PickTimeStep.tsx
@@ -46,9 +46,9 @@ export function PickTimeStep({
     detectDefaultHourFormat(),
   );
   return (
-    <div className="grid min-w-0 grid-cols-1 overflow-hidden md:grid-cols-[260px_minmax(0,1fr)_240px]">
+    <div className="grid min-w-0 grid-cols-1 overflow-hidden md:min-h-0 md:flex-1 md:grid-cols-[260px_minmax(0,1fr)_240px]">
       {sidebar}
-      <div className="min-w-0 border-t p-4 sm:p-6 md:border-l md:border-t-0 md:p-7">
+      <div className="min-w-0 border-t p-4 sm:p-6 md:min-h-0 md:overflow-y-auto md:border-l md:border-t-0 md:p-7">
         <BookingCalendar
           visibleMonth={visibleMonth}
           onMonthChange={onMonthChange}
@@ -58,8 +58,8 @@ export function PickTimeStep({
           timezone={timezone}
         />
       </div>
-      <div className="min-w-0 border-t bg-muted/30 p-4 sm:p-6 md:max-h-none md:border-l md:border-t-0 md:p-7">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+      <div className="flex min-w-0 flex-col border-t bg-muted/30 p-4 sm:p-6 md:min-h-0 md:border-l md:border-t-0 md:p-7">
+        <div className="mb-3 flex shrink-0 flex-wrap items-center justify-between gap-2">
           <div className="min-w-0 text-sm font-semibold text-foreground">
             {selectedDateKey
               ? formatSelectedDateHeading(selectedDateKey)
@@ -76,7 +76,7 @@ export function PickTimeStep({
             No slots available on this day.
           </p>
         ) : (
-          <div className="flex max-h-[min(50vh,22rem)] flex-col gap-1.5 overflow-y-auto pr-1 md:max-h-none">
+          <div className="flex max-h-[min(50vh,22rem)] flex-col gap-1.5 overflow-y-auto pr-1 md:min-h-0 md:flex-1 md:max-h-none">
             {slotsForDay.map((slot) => (
               <button
                 key={slot.startTime}


### PR DESCRIPTION
Keeps the booking calendar shell at a stable desktop height while allowing side content and time slots to scroll internally. Mobile keeps the existing natural page flow with capped slot scrolling.

- Adds desktop height constraints to the wide booking shell
- Makes booking sidebar and slot list scroll within their available space

Validation: pnpm lint