### PR TITLE
drafts: Preserve link context in replies

### DIFF
--- a/apps/web/utils/actions/generate-reply.ts
+++ b/apps/web/utils/actions/generate-reply.ts
@@ -35,11 +35,17 @@ export const generateNudgeReplyAction = actionClient
       const messages = inputMessages.map((msg) => ({
         ...msg,
         date: new Date(msg.date),
-        content: emailToContentForAI({
-          textPlain: msg.textPlain,
-          textHtml: msg.textHtml,
-          snippet: "",
-        }),
+        content: emailToContentForAI(
+          {
+            textPlain: msg.textPlain,
+            textHtml: msg.textHtml,
+            snippet: "",
+          },
+          {
+            includeLinkUrls: true,
+            includeImageAltText: true,
+          },
+        ),
       }));
 
       const { text, attribution } = await aiGenerateNudge({

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 14;
+export const DRAFT_PIPELINE_VERSION = 15;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/reply-context-collector.ts
+++ b/apps/web/utils/ai/reply/reply-context-collector.ts
@@ -256,7 +256,13 @@ export async function searchReplyContextEmails({
     "id",
   )
     .slice(0, MAX_EXPANDED_EMAILS_PER_QUERY)
-    .map((message) => getEmailForLLM(message, { maxLength: 2000 }));
+    .map((message) =>
+      getEmailForLLM(message, {
+        maxLength: 2000,
+        includeLinkUrls: true,
+        includeImageAltText: true,
+      }),
+    );
 }
 
 async function getHistoricalThreadMessages({

--- a/apps/web/utils/follow-up/generate-draft.ts
+++ b/apps/web/utils/follow-up/generate-draft.ts
@@ -81,6 +81,8 @@ export async function generateFollowUpDraft({
         maxLength: index === threadMessages.length - 1 ? 2000 : 500,
         extractReply: true,
         removeForwarded: false,
+        includeLinkUrls: true,
+        includeImageAltText: true,
       }),
     }));
 

--- a/apps/web/utils/get-email-from-message.test.ts
+++ b/apps/web/utils/get-email-from-message.test.ts
@@ -75,15 +75,15 @@ describe("getEmailForLLM", () => {
     expect(result.content).not.toContain("https://tracker.example.com");
   });
 
-  it("skips images without alt text when image alt text is requested", () => {
+  it("uses a placeholder for images without alt text when image alt text is requested", () => {
     const msg = makeParsedMessage({
       textHtml:
         '<p>See below.</p><img src="https://tracker.example.com/pixel.png" />',
     });
     const result = getEmailForLLM(msg, { includeImageAltText: true });
 
-    expect(result.content).toBe("See below.");
-    expect(result.content).not.toContain("[image");
+    expect(result.content).toContain("See below.");
+    expect(result.content).toContain("[image]");
     expect(result.content).not.toContain("https://tracker.example.com");
   });
 

--- a/apps/web/utils/get-email-from-message.test.ts
+++ b/apps/web/utils/get-email-from-message.test.ts
@@ -75,6 +75,18 @@ describe("getEmailForLLM", () => {
     expect(result.content).not.toContain("https://tracker.example.com");
   });
 
+  it("skips images without alt text when image alt text is requested", () => {
+    const msg = makeParsedMessage({
+      textHtml:
+        '<p>See below.</p><img src="https://tracker.example.com/pixel.png" />',
+    });
+    const result = getEmailForLLM(msg, { includeImageAltText: true });
+
+    expect(result.content).toBe("See below.");
+    expect(result.content).not.toContain("[image");
+    expect(result.content).not.toContain("https://tracker.example.com");
+  });
+
   it("strips display:none elements from HTML content", () => {
     const msg = makeParsedMessage({
       textHtml:

--- a/apps/web/utils/get-email-from-message.test.ts
+++ b/apps/web/utils/get-email-from-message.test.ts
@@ -53,6 +53,28 @@ describe("getEmailForLLM", () => {
     expect(result.content).not.toContain("hidden comment");
   });
 
+  it("preserves URLs from descriptive HTML links when requested", () => {
+    const msg = makeParsedMessage({
+      textHtml:
+        '<p>Can you add your billing info <a href="https://example.com/billing">here</a>?</p>',
+    });
+    const result = getEmailForLLM(msg, { includeLinkUrls: true });
+
+    expect(result.content).toContain("billing info here");
+    expect(result.content).toContain("https://example.com/billing");
+  });
+
+  it("preserves image alt text without image source URLs when requested", () => {
+    const msg = makeParsedMessage({
+      textHtml:
+        '<p>See below.</p><img src="https://tracker.example.com/pixel.png" alt="Billing form screenshot" />',
+    });
+    const result = getEmailForLLM(msg, { includeImageAltText: true });
+
+    expect(result.content).toContain("[image: Billing form screenshot]");
+    expect(result.content).not.toContain("https://tracker.example.com");
+  });
+
   it("strips display:none elements from HTML content", () => {
     const msg = makeParsedMessage({
       textHtml:

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -186,7 +186,7 @@ describe("emailToContent", () => {
       expect(result).not.toContain("https://tracker.example.com");
     });
 
-    it("skips images without useful alt text when image alt text is requested", () => {
+    it("uses a placeholder for images without useful alt text when requested", () => {
       const result = emailToContent(
         {
           textHtml:
@@ -197,8 +197,8 @@ describe("emailToContent", () => {
         { includeImageAltText: true },
       );
 
-      expect(result).toBe("See below.");
-      expect(result).not.toContain("[image");
+      expect(result).toContain("See below.");
+      expect(result).toContain("[image]");
       expect(result).not.toContain("https://tracker.example.com");
     });
   });

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -142,6 +142,66 @@ describe("emailToContent", () => {
       expect(result).not.toContain("\n\n\n\n");
     });
   });
+
+  describe("HTML link and image context", () => {
+    it("removes link URLs by default", () => {
+      const result = emailToContent({
+        textHtml:
+          '<p>Add your billing info <a href="https://example.com/billing">here</a>.</p>',
+        textPlain: "",
+        snippet: "",
+      });
+
+      expect(result).toContain("billing info here");
+      expect(result).not.toContain("https://example.com/billing");
+    });
+
+    it("preserves link URLs when requested", () => {
+      const result = emailToContent(
+        {
+          textHtml:
+            '<p>Add your billing info <a href="https://example.com/billing">here</a>.</p>',
+          textPlain: "",
+          snippet: "",
+        },
+        { includeLinkUrls: true },
+      );
+
+      expect(result).toContain("billing info here");
+      expect(result).toContain("https://example.com/billing");
+    });
+
+    it("preserves image alt text without exposing image sources when requested", () => {
+      const result = emailToContent(
+        {
+          textHtml:
+            '<p>See below.</p><img src="https://tracker.example.com/pixel.png" alt="Billing form screenshot" />',
+          textPlain: "",
+          snippet: "",
+        },
+        { includeImageAltText: true },
+      );
+
+      expect(result).toContain("[image: Billing form screenshot]");
+      expect(result).not.toContain("https://tracker.example.com");
+    });
+
+    it("skips images without useful alt text when image alt text is requested", () => {
+      const result = emailToContent(
+        {
+          textHtml:
+            '<p>See below.</p><img src="https://tracker.example.com/pixel.png" alt="image" />',
+          textPlain: "",
+          snippet: "",
+        },
+        { includeImageAltText: true },
+      );
+
+      expect(result).toBe("See below.");
+      expect(result).not.toContain("[image");
+      expect(result).not.toContain("https://tracker.example.com");
+    });
+  });
 });
 
 describe("convertEmailHtmlToText", () => {

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import EmailReplyParser from "email-reply-parser";
-import { convert } from "html-to-text";
+import { convert, type FormatCallback } from "html-to-text";
 import type { ParsedMessage } from "@/utils/types";
 import { removeExcessiveWhitespace, truncate } from "@/utils/string";
 import { env } from "@/env";
@@ -12,22 +12,58 @@ export function parseReply(plainText: string) {
   return result;
 }
 
+const IMAGE_ALT_MAX_LENGTH = 160;
+const LOW_VALUE_IMAGE_ALT_TEXT_PATTERN =
+  /^(?:avatar|decorative|graphic|icon|image|img|logo|photo|picture|pixel|spacer|tracking pixel)$/i;
+
 // important to do before processing html emails
 // this will cut down an email from 100,000 characters to 1,000 characters in some cases
-function htmlToText(html: string, removeLinks = true, removeImages = true) {
+function htmlToText(
+  html: string,
+  {
+    includeLinkUrls = false,
+    includeImageAltText = false,
+  }: Pick<
+    EmailToContentOptions,
+    "includeLinkUrls" | "includeImageAltText"
+  > = {},
+) {
   const text = convert(html, {
     wordwrap: 130,
-    // this removes links and images.
-    // might want to change this in the future if we're searching for links like Unsubscribe
+    formatters: includeImageAltText
+      ? { imageAltText: formatImageAltText }
+      : undefined,
     selectors: [
-      ...(removeLinks
-        ? [{ selector: "a", options: { ignoreHref: true } }]
-        : []),
-      ...(removeImages ? [{ selector: "img", format: "skip" }] : []),
+      {
+        selector: "a",
+        options: includeLinkUrls
+          ? { hideLinkHrefIfSameAsText: true }
+          : { ignoreHref: true },
+      },
+      includeImageAltText
+        ? { selector: "img", format: "imageAltText" }
+        : { selector: "img", format: "skip" },
     ],
   });
 
   return text;
+}
+
+const formatImageAltText: FormatCallback = (elem, _walk, builder) => {
+  const altText = normalizeImageAltText(elem.attribs?.alt);
+  if (!altText) return;
+
+  builder.addInline(`[image: ${altText}]`, { noWordTransform: true });
+};
+
+function normalizeImageAltText(value: unknown) {
+  if (typeof value !== "string") return "";
+
+  const altText = removeExcessiveWhitespace(value).trim();
+  if (!altText) return "";
+  if (LOW_VALUE_IMAGE_ALT_TEXT_PATTERN.test(altText)) return "";
+
+  return truncate(altText, IMAGE_ALT_MAX_LENGTH);
 }
 
 export function getEmailClient(messageId: string) {
@@ -69,6 +105,8 @@ export type EmailToContentOptions = {
   maxLength?: number;
   extractReply?: boolean;
   removeForwarded?: boolean;
+  includeLinkUrls?: boolean;
+  includeImageAltText?: boolean;
 };
 
 export function emailToContent(
@@ -77,12 +115,17 @@ export function emailToContent(
     maxLength = 2000,
     extractReply = false,
     removeForwarded = false,
+    includeLinkUrls = false,
+    includeImageAltText = false,
   }: EmailToContentOptions = {},
 ): string {
   let content = "";
 
   if (email.textHtml) {
-    content = htmlToText(email.textHtml);
+    content = htmlToText(email.textHtml, {
+      includeLinkUrls,
+      includeImageAltText,
+    });
   } else if (email.textPlain) {
     content = email.textPlain;
   } else if (email.snippet) {

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -30,9 +30,7 @@ function htmlToText(
 ) {
   const text = convert(html, {
     wordwrap: 130,
-    formatters: includeImageAltText
-      ? { imageAltText: formatImageAltText }
-      : undefined,
+    formatters: { imageAltText: formatImageAltText },
     selectors: [
       {
         selector: "a",
@@ -40,9 +38,10 @@ function htmlToText(
           ? { hideLinkHrefIfSameAsText: true }
           : { ignoreHref: true },
       },
-      includeImageAltText
-        ? { selector: "img", format: "imageAltText" }
-        : { selector: "img", format: "skip" },
+      {
+        selector: "img",
+        format: includeImageAltText ? "imageAltText" : "skip",
+      },
     ],
   });
 

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -13,7 +13,8 @@ export function parseReply(plainText: string) {
 }
 
 const IMAGE_ALT_MAX_LENGTH = 160;
-const LOW_VALUE_IMAGE_ALT_TEXT_PATTERN =
+const IMAGE_PLACEHOLDER = "[image]";
+const GENERIC_IMAGE_ALT_TEXT_PATTERN =
   /^(?:avatar|decorative|graphic|icon|image|img|logo|photo|picture|pixel|spacer|tracking pixel)$/i;
 
 // important to do before processing html emails
@@ -49,20 +50,19 @@ function htmlToText(
 }
 
 const formatImageAltText: FormatCallback = (elem, _walk, builder) => {
-  const altText = normalizeImageAltText(elem.attribs?.alt);
-  if (!altText) return;
-
-  builder.addInline(`[image: ${altText}]`, { noWordTransform: true });
+  builder.addInline(getImageText(elem.attribs?.alt), {
+    noWordTransform: true,
+  });
 };
 
-function normalizeImageAltText(value: unknown) {
-  if (typeof value !== "string") return "";
+function getImageText(value: unknown) {
+  if (typeof value !== "string") return IMAGE_PLACEHOLDER;
 
   const altText = removeExcessiveWhitespace(value).trim();
-  if (!altText) return "";
-  if (LOW_VALUE_IMAGE_ALT_TEXT_PATTERN.test(altText)) return "";
+  if (!altText) return IMAGE_PLACEHOLDER;
+  if (GENERIC_IMAGE_ALT_TEXT_PATTERN.test(altText)) return IMAGE_PLACEHOLDER;
 
-  return truncate(altText, IMAGE_ALT_MAX_LENGTH);
+  return `[image: ${truncate(altText, IMAGE_ALT_MAX_LENGTH)}]`;
 }
 
 export function getEmailClient(messageId: string) {

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -254,6 +254,38 @@ describe("fetchMessagesAndGenerateDraft - AI content escaping", () => {
     );
   });
 
+  it("preserves link URLs and image alt text in draft prompt messages", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "I will fill that out.",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+      attribution: null,
+    });
+    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue(
+      createMockEmailAccountSettings(),
+    );
+
+    await fetchMessagesAndGenerateDraft(
+      createMockEmailAccount(),
+      "thread-1",
+      createMockClient(),
+      {
+        ...createMockMessage(),
+        textPlain: "Can you add your billing info here?",
+        textHtml:
+          '<p>Can you add your billing info <a href="https://example.com/billing">here</a>?</p><p><img src="https://tracker.example.com/pixel.png" alt="Billing form screenshot" /></p>',
+      },
+      logger,
+    );
+
+    const [draftArgs] = vi.mocked(aiDraftReplyWithConfidence).mock.calls[0]!;
+    const [message] = draftArgs.messages;
+
+    expect(message.content).toContain("billing info here");
+    expect(message.content).toContain("https://example.com/billing");
+    expect(message.content).toContain("[image: Billing form screenshot]");
+    expect(message.content).not.toContain("https://tracker.example.com");
+  });
+
   it("escapes zero-size font attacks in AI content", async () => {
     const maliciousAiOutput =
       'Normal text<span style="font-size:0">hidden instructions</span>';

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -220,6 +220,8 @@ async function generateDraftContent(
       maxLength: index === threadMessages.length - 1 ? 2000 : 500,
       extractReply: true,
       removeForwarded: false,
+      includeLinkUrls: true,
+      includeImageAltText: true,
     }),
   }));
 
@@ -243,6 +245,8 @@ async function generateDraftContent(
         maxLength: 1000,
         extractReply: true,
         removeForwarded: false,
+        includeLinkUrls: true,
+        includeImageAltText: true,
       }),
     );
   const senderEmail = extractEmailAddress(lastMessage.headers.from);


### PR DESCRIPTION
Updates draft email context parsing so reply generation can see relevant link URLs and useful image alt text while keeping default email conversion compact. Adds focused coverage for link and image handling in draft-related paths.

- Preserve link destinations for draft, nudge, follow-up, and reply-context inputs
- Include useful image alt text without exposing image source URLs
- Keep default conversion behavior unchanged for other callers
- Bump draft pipeline attribution version