### PR TITLE
marketing: Add mobile app page

### DIFF
--- a/apps/web/app/(landing)/home/Footer.tsx
+++ b/apps/web/app/(landing)/home/Footer.tsx
@@ -12,6 +12,7 @@ export const footerNavigation = {
       target: "_blank",
     },
     { name: "AI Email Assistant", href: "/ai-automation" },
+    { name: "Mobile App", href: "/mobile-app" },
     { name: "AI Chat for Slack & Telegram", href: "/ai-assistant-chat" },
     { name: "Slack AI Assistant", href: "/slack-integration" },
     { name: "Telegram AI Assistant", href: "/telegram-integration" },


### PR DESCRIPTION
## Summary
- Adds a brief `/mobile-app` landing page introducing the iOS chat app, linked from the Product column in the footer
- Surfaces the support email as a visible mailto link on `/support` (the button alone doesn't always trigger a mail client)

The "Download on the App Store" CTA points at `/app`, which already redirects to the App Store URL, so the canonical link stays in one place.

Submodule branch: [`inbox-zero/marketing@mobile-app-page`](https://github.com/inbox-zero/marketing/tree/mobile-app-page) — needs to land before this can merge.

## Test plan
- [ ] Visit `/mobile-app` and verify the hero, phone mockup, feature grid, and final CTA render
- [ ] Click "Download on the App Store" → redirects to App Store
- [ ] Visit `/support` and verify the email is shown as text and the mailto link works
- [ ] Footer "Mobile App" link navigates to `/mobile-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)