### PR TITLE
auth: Add Microsoft admin consent flow

### DIFF
--- a/apps/web/app/(app)/accounts/page.tsx
+++ b/apps/web/app/(app)/accounts/page.tsx
@@ -390,6 +390,11 @@ function buildMicrosoftPermissionHelp(summary: string) {
         Ask your Microsoft 365 admin to approve {BRAND_NAME} for the Microsoft
         Graph permissions below, then try again.
       </p>
+      <Button asChild size="sm">
+        <Link href="/login/microsoft-admin-consent">
+          Open Microsoft admin approval
+        </Link>
+      </Button>
       <div>
         <p className="font-medium">Email and inbox connection</p>
         <PermissionList scopes={MICROSOFT_EMAIL_SCOPES} />

--- a/apps/web/app/(landing)/login/microsoft-admin-consent/page.tsx
+++ b/apps/web/app/(landing)/login/microsoft-admin-consent/page.tsx
@@ -1,0 +1,152 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { CheckCircle2Icon } from "lucide-react";
+import { AlertBasic } from "@/components/Alert";
+import { Button } from "@/components/ui/button";
+import { Logo } from "@/components/Logo";
+import { getEnabledLoginProviders } from "@/utils/oauth/login-providers";
+import { BRAND_NAME, SUPPORT_EMAIL, getBrandTitle } from "@/utils/branding";
+
+export const metadata: Metadata = {
+  title: getBrandTitle("Microsoft admin consent"),
+  description: `Approve ${BRAND_NAME} for your Microsoft 365 organization.`,
+  alternates: { canonical: "/login/microsoft-admin-consent" },
+};
+
+export default async function MicrosoftAdminConsentPage(props: {
+  searchParams?: Promise<Record<string, string>>;
+}) {
+  const searchParams = await props.searchParams;
+  const hasMicrosoftLogin = getEnabledLoginProviders().has("microsoft");
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto grid min-h-screen w-full max-w-6xl gap-14 px-6 py-12 md:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] md:items-center lg:px-8">
+        <section className="max-w-xl">
+          <Logo className="mb-12 h-auto w-56 text-primary" />
+          <h1 className="font-title text-4xl font-semibold tracking-normal text-foreground sm:text-5xl">
+            Approve {BRAND_NAME} for your organization
+          </h1>
+          <p className="mt-6 text-lg leading-8 text-muted-foreground">
+            Grant tenant-wide Microsoft admin consent so users in your
+            organization can connect their own Outlook mailboxes without each
+            approval being blocked by IT.
+          </p>
+
+          <AdminConsentStatus
+            status={searchParams?.status}
+            error={searchParams?.error}
+          />
+
+          <div className="mt-12 space-y-6">
+            {hasMicrosoftLogin ? (
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="w-full py-6"
+              >
+                <a
+                  href="/api/outlook/admin-consent"
+                  className="flex items-center justify-center"
+                >
+                  <Image
+                    src="/images/microsoft.svg"
+                    alt="Microsoft"
+                    width={24}
+                    height={24}
+                    unoptimized
+                  />
+                  <span className="ml-3">
+                    Grant Admin Consent with Microsoft
+                  </span>
+                </a>
+              </Button>
+            ) : (
+              <AlertBasic
+                variant="destructive"
+                title="Microsoft login is not configured"
+                description={`Set up Microsoft OAuth before granting admin consent. Contact ${SUPPORT_EMAIL} if you need help.`}
+              />
+            )}
+
+            <p className="text-center text-sm text-muted-foreground">
+              <Link
+                href="/login"
+                className="font-medium text-foreground hover:underline"
+              >
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-8">
+          {ADMIN_CONSENT_POINTS.map((point) => (
+            <div key={point.title} className="flex gap-4">
+              <CheckCircle2Icon className="mt-1 size-7 shrink-0 text-green-500" />
+              <div>
+                <h2 className="text-base font-semibold uppercase tracking-normal text-foreground">
+                  {point.title}
+                </h2>
+                <p className="mt-1 text-base leading-7 text-muted-foreground">
+                  {point.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+const ADMIN_CONSENT_POINTS = [
+  {
+    title: "Microsoft 365 integration",
+    description: "Works with your existing Microsoft Entra organization.",
+  },
+  {
+    title: "Tenant-wide approval",
+    description: "Approves the Microsoft permissions once for eligible users.",
+  },
+  {
+    title: "User-level connection",
+    description: "Each user still signs in and connects their own mailbox.",
+  },
+  {
+    title: "Admin control",
+    description: "Manage access later from Microsoft Entra Enterprise Apps.",
+  },
+] as const;
+
+function AdminConsentStatus({
+  status,
+  error,
+}: {
+  status?: string;
+  error?: string;
+}) {
+  if (status === "success") {
+    return (
+      <AlertBasic
+        className="mt-8"
+        variant="success"
+        title="Admin consent granted"
+        description="Users in your organization can now sign in with Microsoft and connect their own Outlook mailbox."
+      />
+    );
+  }
+
+  if (!error) return null;
+
+  return (
+    <AlertBasic
+      className="mt-8"
+      variant="destructive"
+      title="Admin consent was not completed"
+      description="Try again with a Microsoft 365 admin account that is allowed to grant tenant-wide consent."
+    />
+  );
+}

--- a/apps/web/app/api/outlook/admin-consent/callback/route.ts
+++ b/apps/web/app/api/outlook/admin-consent/callback/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import {
+  MICROSOFT_ADMIN_CONSENT_PAGE_PATH,
+  MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME,
+  type MicrosoftAdminConsentState,
+} from "@/utils/microsoft/admin-consent";
+import { env } from "@/env";
+import { withError } from "@/utils/middleware";
+import { validateSignedOAuthState } from "@/utils/oauth/state";
+import { buildRedirectUrl } from "@/utils/redirect";
+
+export const GET = withError(
+  "outlook/admin-consent/callback",
+  async (request) => {
+    const searchParams = request.nextUrl.searchParams;
+    const stateValidation =
+      validateSignedOAuthState<MicrosoftAdminConsentState>({
+        receivedState: searchParams.get("state"),
+        storedState: request.cookies.get(
+          MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME,
+        )?.value,
+      });
+
+    if (!stateValidation.success) {
+      request.logger.warn("Invalid state during Microsoft admin consent");
+      return createAdminConsentRedirect({
+        error: "invalid_state",
+      });
+    }
+
+    if (stateValidation.state.type !== "microsoft-admin-consent") {
+      request.logger.warn("Unexpected Microsoft admin consent state type");
+      return createAdminConsentRedirect({
+        error: "invalid_state",
+      });
+    }
+
+    const oauthError = searchParams.get("error");
+    if (oauthError) {
+      request.logger.warn("Microsoft admin consent returned an error", {
+        oauthError,
+      });
+      return createAdminConsentRedirect({
+        error: "oauth_error",
+      });
+    }
+
+    if (searchParams.get("admin_consent")?.toLowerCase() !== "true") {
+      request.logger.warn("Microsoft admin consent was not granted");
+      return createAdminConsentRedirect({
+        error: "not_granted",
+      });
+    }
+
+    return createAdminConsentRedirect({ status: "success" });
+  },
+);
+
+function createAdminConsentRedirect(
+  query: { status: "success" } | { error: string },
+) {
+  const response = NextResponse.redirect(
+    new URL(
+      buildRedirectUrl(MICROSOFT_ADMIN_CONSENT_PAGE_PATH, query),
+      env.NEXT_PUBLIC_BASE_URL,
+    ),
+  );
+  response.cookies.delete(MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME);
+
+  return response;
+}

--- a/apps/web/app/api/outlook/admin-consent/route.ts
+++ b/apps/web/app/api/outlook/admin-consent/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import {
+  MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME,
+  getMicrosoftAdminConsentUrl,
+  type MicrosoftAdminConsentState,
+} from "@/utils/microsoft/admin-consent";
+import { withError } from "@/utils/middleware";
+import {
+  generateSignedOAuthState,
+  oauthStateCookieOptions,
+} from "@/utils/oauth/state";
+
+export const GET = withError("outlook/admin-consent", async () => {
+  const state = generateSignedOAuthState<MicrosoftAdminConsentState>({
+    type: "microsoft-admin-consent",
+  });
+
+  const response = NextResponse.redirect(getMicrosoftAdminConsentUrl(state));
+  response.cookies.set(
+    MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME,
+    state,
+    oauthStateCookieOptions,
+  );
+
+  return response;
+});

--- a/apps/web/utils/microsoft/admin-consent.test.ts
+++ b/apps/web/utils/microsoft/admin-consent.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Microsoft admin consent helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/env");
+  });
+
+  it("uses organizations for admin consent when login uses common", async () => {
+    const adminConsent = await importAdminConsentModule({
+      MICROSOFT_TENANT_ID: "common",
+    });
+
+    expect(adminConsent.getMicrosoftAdminConsentTenant()).toBe("organizations");
+  });
+
+  it("uses a configured tenant for self-hosted admin consent", async () => {
+    const adminConsent = await importAdminConsentModule({
+      MICROSOFT_TENANT_ID: "contoso.onmicrosoft.com",
+    });
+
+    expect(adminConsent.getMicrosoftAdminConsentTenant()).toBe(
+      "contoso.onmicrosoft.com",
+    );
+  });
+
+  it("builds the Microsoft admin consent URL", async () => {
+    const adminConsent = await importAdminConsentModule({
+      MICROSOFT_CLIENT_ID: "client-id",
+      MICROSOFT_TENANT_ID: "common",
+      NEXT_PUBLIC_BASE_URL: "https://app.example.com",
+    });
+
+    const url = new URL(
+      adminConsent.getMicrosoftAdminConsentUrl("signed-state"),
+    );
+
+    expect(url.origin).toBe("https://login.microsoftonline.com");
+    expect(url.pathname).toBe("/organizations/v2.0/adminconsent");
+    expect(url.searchParams.get("client_id")).toBe("client-id");
+    expect(url.searchParams.get("scope")).toBe(
+      "https://graph.microsoft.com/.default",
+    );
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://app.example.com/api/outlook/admin-consent/callback",
+    );
+    expect(url.searchParams.get("state")).toBe("signed-state");
+  });
+});
+
+async function importAdminConsentModule(
+  envOverrides?: Partial<{
+    MICROSOFT_CLIENT_ID: string | undefined;
+    MICROSOFT_TENANT_ID: string | undefined;
+    NEXT_PUBLIC_BASE_URL: string;
+  }>,
+) {
+  vi.doMock("@/env", () => ({
+    env: {
+      MICROSOFT_CLIENT_ID: "client-id",
+      MICROSOFT_TENANT_ID: "common",
+      NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+      ...envOverrides,
+    },
+  }));
+
+  return import("./admin-consent");
+}

--- a/apps/web/utils/microsoft/admin-consent.ts
+++ b/apps/web/utils/microsoft/admin-consent.ts
@@ -1,0 +1,49 @@
+import { env } from "@/env";
+
+const MICROSOFT_LOGIN_BASE_URL = "https://login.microsoftonline.com";
+const MICROSOFT_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.com/.default";
+const DEFAULT_ADMIN_CONSENT_TENANT = "organizations";
+
+export const MICROSOFT_ADMIN_CONSENT_STATE_COOKIE_NAME =
+  "microsoft_admin_consent_state";
+export const MICROSOFT_ADMIN_CONSENT_CALLBACK_PATH =
+  "/api/outlook/admin-consent/callback";
+export const MICROSOFT_ADMIN_CONSENT_PAGE_PATH =
+  "/login/microsoft-admin-consent";
+
+export type MicrosoftAdminConsentState = {
+  type: "microsoft-admin-consent";
+};
+
+export function getMicrosoftAdminConsentUrl(state: string) {
+  const clientId = env.MICROSOFT_CLIENT_ID?.trim();
+  if (!clientId) {
+    throw new Error("Microsoft login not enabled - missing client ID");
+  }
+
+  const url = new URL(
+    `${MICROSOFT_LOGIN_BASE_URL}/${getMicrosoftAdminConsentTenant()}/v2.0/adminconsent`,
+  );
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("scope", MICROSOFT_GRAPH_DEFAULT_SCOPE);
+  url.searchParams.set("redirect_uri", getMicrosoftAdminConsentRedirectUri());
+  url.searchParams.set("state", state);
+
+  return url.toString();
+}
+
+export function getMicrosoftAdminConsentTenant() {
+  const tenantId = env.MICROSOFT_TENANT_ID?.trim();
+  if (tenantId && tenantId.toLowerCase() !== "common") {
+    return encodeURIComponent(tenantId);
+  }
+
+  return DEFAULT_ADMIN_CONSENT_TENANT;
+}
+
+export function getMicrosoftAdminConsentRedirectUri() {
+  return new URL(
+    MICROSOFT_ADMIN_CONSENT_CALLBACK_PATH,
+    env.NEXT_PUBLIC_BASE_URL,
+  ).toString();
+}


### PR DESCRIPTION
Adds a Microsoft admin consent flow for organizations that require tenant-level app approval.

- Adds an admin approval page and callback flow with signed state validation.
- Uses tenant-specific admin consent for configured tenants, otherwise falls back to Microsoft organizations.
- Adds a targeted link from the existing Microsoft permission help surface.
- Covers admin consent URL behavior with focused unit tests.