### PR TITLE
Fix messaging channel fallback labels

### DIFF
--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -175,6 +175,47 @@ describe("GET /api/user/messaging-channels", () => {
     expect(body.availableProviders).toEqual(["SLACK"]);
   });
 
+  it("labels saved Slack channel routes as unavailable when the bot can no longer access the target", async () => {
+    const channels = [
+      {
+        id: "channel-1",
+        provider: "SLACK",
+        teamName: "Workspace",
+        teamId: "team-1",
+        providerUserId: "U123",
+        accessToken: "xoxb-token",
+        isConnected: true,
+        routes: [
+          {
+            purpose: "RULE_NOTIFICATIONS",
+            targetType: "CHANNEL",
+            targetId: "C_REMOVED",
+          },
+        ],
+        actions: [],
+      },
+    ] satisfies MessagingChannelRecord[];
+    prisma.messagingChannel.findMany.mockResolvedValue(channels);
+    vi.mocked(createSlackClient).mockReturnValue({} as never);
+    vi.mocked(listChannels).mockResolvedValue([
+      {
+        id: "C234",
+        name: "finance-alerts",
+        isPrivate: true,
+      },
+    ]);
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(body.channels[0].destinations.ruleNotifications).toEqual({
+      enabled: true,
+      targetId: "C_REMOVED",
+      targetLabel: "Channel unavailable",
+      isDm: false,
+    });
+  });
+
   it("reuses a workspace target lookup for channels with the same Slack token", async () => {
     const channels = [
       {

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -125,13 +125,10 @@ async function getSlackTargetNames(
     providerUserId: string | null;
   }>,
 ) {
-  const targetNamesByChannelId = Object.fromEntries(
-    channels.map((channel) => [channel.id, {} as Record<string, string>]),
-  );
+  const targetNamesByChannelId: Record<string, Record<string, string>> = {};
 
-  const slackChannels = channels.filter(isOperationalSlackChannel);
   const channelIdsByToken = new Map<string, string[]>();
-  for (const channel of slackChannels) {
+  for (const channel of channels.filter(isOperationalSlackChannel)) {
     const accessToken = channel.accessToken;
     if (!accessToken) continue;
     const channelIds = channelIdsByToken.get(accessToken) ?? [];
@@ -152,7 +149,7 @@ async function getSlackTargetNames(
             targetNamesByChannelId[channelId] = targetNames;
           }
         } catch {
-          // Empty objects were already initialized; nothing to do.
+          // Leave channelId unset so callers fall back to the raw target id.
         }
       },
     ),

--- a/apps/web/utils/messaging/routes.ts
+++ b/apps/web/utils/messaging/routes.ts
@@ -118,7 +118,9 @@ export function formatRouteTargetLabelWithNames(
 ) {
   if (!route) return null;
   if (isDirectMessageRoute(route)) return "Direct message";
-  return targetNamesById?.[route.targetId] ?? formatRouteTargetLabel(route);
+  if (targetNamesById)
+    return targetNamesById[route.targetId] ?? "Channel unavailable";
+  return formatRouteTargetLabel(route);
 }
 
 export function getMessagingRouteSummary(


### PR DESCRIPTION
Updates messaging channel route labels so inaccessible saved Slack channel targets show a clear unavailable state instead of exposing raw target IDs. Also adds a regression test covering the missing-target lookup path.

- Use fetched Slack target-name maps to distinguish unavailable channel targets from untouched fallback formatting.
- Avoid pre-initializing empty lookup maps so callers can detect failed or missing lookups.
- Tests: `pnpm test app/api/user/messaging-channels/route.test.ts`; `git diff --check`.

Performance impact: no additional runtime work beyond the existing Slack channel lookup path; no new database or network calls; low hot-path risk because this only changes fallback label formatting for messaging channel route responses.