### PR TITLE
Fix AI draft cleanup retries

### DIFF
--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -59,6 +59,21 @@ describe("cleanupAIDraftsForAccount", () => {
       expect.objectContaining({
         where: expect.objectContaining({
           executedRule: { emailAccountId: "email-account-1" },
+          OR: [
+            {
+              draftStatus: {
+                in: [
+                  DraftEmailStatus.PENDING,
+                  DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+                ],
+              },
+            },
+            { draftStatus: null },
+            {
+              draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+              wasDraftSent: false,
+            },
+          ],
           createdAt: { lt: expectedCutoffDate },
         }),
       }),
@@ -169,6 +184,77 @@ describe("cleanupAIDraftsForAccount", () => {
       cleanupDays: 14,
     });
   });
+
+  it("retries legacy cleanup records that still have provider drafts", async () => {
+    mocks.prisma.executedAction.findMany.mockResolvedValue([
+      {
+        id: "action-legacy-cleaned",
+        draftId: "draft-legacy-cleaned",
+        content: "Legacy generated reply.",
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+        wasDraftSent: false,
+      },
+    ]);
+    mocks.provider.getDraft.mockResolvedValue({
+      textPlain: "Legacy generated reply.",
+      textHtml: null,
+    });
+
+    const result = await cleanupAIDraftsForAccount({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+      cleanupDays: 14,
+    });
+
+    expect(mocks.provider.deleteDraft).toHaveBeenCalledWith(
+      "draft-legacy-cleaned",
+    );
+    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-legacy-cleaned" },
+      data: {
+        wasDraftSent: null,
+      },
+    });
+    expect(result).toMatchObject({
+      total: 1,
+      deleted: 1,
+      cleanupDays: 14,
+    });
+  });
+
+  it("marks legacy cleanup records as checked when the provider draft is gone", async () => {
+    mocks.prisma.executedAction.findMany.mockResolvedValue([
+      {
+        id: "action-legacy-missing",
+        draftId: "draft-legacy-missing",
+        content: "Legacy generated reply.",
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+        wasDraftSent: false,
+      },
+    ]);
+    mocks.provider.getDraft.mockResolvedValue(null);
+
+    const result = await cleanupAIDraftsForAccount({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+      cleanupDays: 14,
+    });
+
+    expect(mocks.provider.deleteDraft).not.toHaveBeenCalled();
+    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-legacy-missing" },
+      data: {
+        wasDraftSent: null,
+      },
+    });
+    expect(result).toMatchObject({
+      total: 1,
+      alreadyGone: 1,
+      cleanupDays: 14,
+    });
+  });
 });
 
 describe("cleanupConfiguredAIDrafts", () => {
@@ -199,12 +285,21 @@ describe("cleanupConfiguredAIDrafts", () => {
               some: {
                 type: ActionType.DRAFT_EMAIL,
                 draftId: { not: null },
-                draftStatus: {
-                  in: [
-                    DraftEmailStatus.PENDING,
-                    DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
-                  ],
-                },
+                OR: [
+                  {
+                    draftStatus: {
+                      in: [
+                        DraftEmailStatus.PENDING,
+                        DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+                      ],
+                    },
+                  },
+                  { draftStatus: null },
+                  {
+                    draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+                    wasDraftSent: false,
+                  },
+                ],
               },
             },
           },

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -24,15 +24,14 @@ export async function cleanupAIDraftsForAccount({
       executedRule: { emailAccountId },
       type: ActionType.DRAFT_EMAIL,
       draftId: { not: null },
-      draftStatus: {
-        in: [DraftEmailStatus.PENDING, DraftEmailStatus.REPLIED_WITHOUT_DRAFT],
-      },
+      ...getDraftCleanupCandidateWhere(),
       createdAt: { lt: cutoffDate },
     },
     select: {
       id: true,
       draftId: true,
       draftStatus: true,
+      wasDraftSent: true,
       content: true,
     },
     orderBy: { createdAt: "asc" },
@@ -69,6 +68,7 @@ export async function cleanupAIDraftsForAccount({
       if (!draftDetails?.textPlain && !draftDetails?.textHtml) {
         const statusData = getDraftCleanupStatusData({
           draftStatus: action.draftStatus,
+          wasDraftSent: action.wasDraftSent,
           status: DraftEmailStatus.MISSING_FROM_PROVIDER,
         });
         if (statusData) {
@@ -97,6 +97,7 @@ export async function cleanupAIDraftsForAccount({
       await provider.deleteDraft(action.draftId);
       const statusData = getDraftCleanupStatusData({
         draftStatus: action.draftStatus,
+        wasDraftSent: action.wasDraftSent,
         status: DraftEmailStatus.CLEANED_UP_UNUSED,
       });
       if (statusData) {
@@ -149,12 +150,7 @@ export async function cleanupConfiguredAIDrafts({
             some: {
               type: ActionType.DRAFT_EMAIL,
               draftId: { not: null },
-              draftStatus: {
-                in: [
-                  DraftEmailStatus.PENDING,
-                  DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
-                ],
-              },
+              ...getDraftCleanupCandidateWhere(),
             },
           },
         },
@@ -222,17 +218,53 @@ export async function getConfiguredDraftCleanupDays(emailAccountId: string) {
 
 function getDraftCleanupStatusData({
   draftStatus,
+  wasDraftSent,
   status,
 }: {
   draftStatus?: DraftEmailStatus | null;
+  wasDraftSent?: boolean | null;
   status: DraftEmailStatus;
-}): { draftStatus: DraftEmailStatus } | null {
-  if (
-    draftStatus &&
-    draftStatus !== DraftEmailStatus.PENDING &&
-    draftStatus !== DraftEmailStatus.REPLIED_WITHOUT_DRAFT
-  ) {
-    return null;
+}): { draftStatus?: DraftEmailStatus; wasDraftSent?: null } | null {
+  const data: { draftStatus?: DraftEmailStatus; wasDraftSent?: null } = {};
+
+  if (canTransitionDraftStatus(draftStatus) && draftStatus !== status) {
+    data.draftStatus = status;
   }
-  return { draftStatus: status };
+  if (wasDraftSent === false) {
+    data.wasDraftSent = null;
+  }
+
+  return Object.keys(data).length > 0 ? data : null;
+}
+
+function canTransitionDraftStatus(
+  current: DraftEmailStatus | null | undefined,
+) {
+  return (
+    !current ||
+    current === DraftEmailStatus.PENDING ||
+    current === DraftEmailStatus.REPLIED_WITHOUT_DRAFT
+  );
+}
+
+function getDraftCleanupCandidateWhere() {
+  return {
+    OR: [
+      {
+        draftStatus: {
+          in: [
+            DraftEmailStatus.PENDING,
+            DraftEmailStatus.REPLIED_WITHOUT_DRAFT,
+          ],
+        },
+      },
+      { draftStatus: null },
+      // Legacy rows with wasDraftSent=false were migrated to CLEANED_UP_UNUSED,
+      // even when the provider draft still needed a retry.
+      {
+        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
+        wasDraftSent: false,
+      },
+    ],
+  };
 }


### PR DESCRIPTION
Fixes AI draft cleanup so older candidate rows are retried when provider drafts still need cleanup, while marking checked legacy rows to avoid repeated retries. This keeps cleanup behavior focused on unedited tracked AI drafts.

- Includes null-status and legacy cleanup candidates in draft cleanup queries
- Preserves existing draft status unless it is eligible to transition
- Adds focused tests for retrying and marking legacy cleanup records

Tests:
- pnpm test utils/ai/draft-cleanup.test.ts

Performance impact: Adds one boolean field to the existing draft cleanup select and broadens the existing cleanup query predicate. Runtime work remains bounded by the existing cleanup flow; no new database writes beyond status flag updates already made during cleanup, no new network calls outside existing provider draft checks/deletes, and low hot-path risk because this runs in cleanup/manual draft deletion paths rather than request-critical rendering.