### PR TITLE
follow-up: Prevent cleanup loop

### DIFF
--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -325,6 +325,7 @@ describe("clearFollowUpLabel", () => {
       },
       select: {
         id: true,
+        messageId: true,
         followUpDraftId: true,
       },
     });
@@ -520,6 +521,38 @@ describe("clearFollowUpLabel", () => {
       "thread-1",
       "label-123",
     );
+  });
+
+  it("does not clear follow-up state when the webhook is for the tracked message", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      {
+        id: "tracker-1",
+        messageId: "tracked-message-1",
+        followUpDraftId: null,
+      },
+    ]);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      triggerMessageId: "tracked-message-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
+    expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
+    expect(mockProvider.getLabelByName).not.toHaveBeenCalled();
+    expect(mockProvider.removeThreadLabel).not.toHaveBeenCalled();
+    expect(messagingMocks.slackChatUpdate).not.toHaveBeenCalled();
+    expect(messagingMocks.teamsEditMessage).not.toHaveBeenCalled();
+    expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
   });
 
   it("updates delivered follow-up notifications when a reply clears the follow-up", async () => {

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -126,11 +126,13 @@ export async function hasFollowUpLabel({
 export async function clearFollowUpLabel({
   emailAccountId,
   threadId,
+  triggerMessageId,
   provider,
   logger,
 }: {
   emailAccountId: string;
   threadId: string;
+  triggerMessageId?: string;
   provider: EmailProvider;
   logger: Logger;
 }): Promise<void> {
@@ -151,12 +153,24 @@ export async function clearFollowUpLabel({
       },
       select: {
         id: true,
+        messageId: true,
         followUpDraftId: true,
       },
     });
 
     if (activeTrackers.length === 0) {
       logger.info("No active follow-up state to clear", { threadId });
+      return;
+    }
+
+    if (
+      triggerMessageId &&
+      activeTrackers.every((tracker) => tracker.messageId === triggerMessageId)
+    ) {
+      logger.info("Skipping follow-up cleanup for tracked message webhook", {
+        threadId,
+        messageId: triggerMessageId,
+      });
       return;
     }
 

--- a/apps/web/utils/webhook/process-history-item.ts
+++ b/apps/web/utils/webhook/process-history-item.ts
@@ -257,6 +257,7 @@ export async function processHistoryItem(
       await clearFollowUpLabel({
         emailAccountId,
         threadId: actualThreadId,
+        triggerMessageId: parsedMessage.id,
         provider,
         logger,
       });


### PR DESCRIPTION
Prevents follow-up cleanup from running when a webhook is for the same message that already owns active follow-up state.

- Passes the triggering message id into cleanup.
- Skips provider and messaging cleanup for tracked-message webhooks.
- Adds regression coverage for the skip path.