### PR TITLE
chore: update dependency override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@xmldom/xmldom': 0.8.13
-  axios: 1.15.2
+  axios: 1.16.1
   fast-xml-parser: 5.8.0
   js-yaml: 3.14.2
   jws: 4.0.1
@@ -6806,8 +6806,8 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -14961,6 +14961,7 @@ snapshots:
       qs: 6.15.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@microsoft/teams.apps@2.0.10':
     dependencies:
@@ -14968,7 +14969,7 @@ snapshots:
       '@microsoft/teams.api': 2.0.10
       '@microsoft/teams.common': 2.0.10
       '@microsoft/teams.graph': 2.0.10
-      axios: 1.15.2
+      axios: 1.16.1
       cors: 2.8.6
       express: 5.2.1
       jsonwebtoken: 9.0.3
@@ -14982,9 +14983,10 @@ snapshots:
 
   '@microsoft/teams.common@2.0.10':
     dependencies:
-      axios: 1.15.2
+      axios: 1.16.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@microsoft/teams.graph-endpoints@2.0.10': {}
 
@@ -14994,6 +14996,7 @@ snapshots:
       qs: 6.15.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)':
     dependencies:
@@ -17684,6 +17687,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
   '@slack/types@2.21.1': {}
@@ -17694,7 +17698,7 @@ snapshots:
       '@slack/types': 2.21.1
       '@types/node': 24.10.1
       '@types/retry': 0.12.0
-      axios: 1.15.2
+      axios: 1.16.1
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -17704,6 +17708,7 @@ snapshots:
       retry: 0.13.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   '@smithy/eventstream-codec@4.2.14':
     dependencies:
@@ -18795,13 +18800,15 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  axios@1.15.2:
+  axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ overrides:
   "@types/react": "19.2.14"
   "@types/react-dom": "19.2.3"
   "@xmldom/xmldom": "0.8.13"
-  axios: "1.15.2"
+  axios: "1.16.1"
   fast-xml-parser: "5.8.0"
   js-yaml: "3.14.2"
   jws: "4.0.1"


### PR DESCRIPTION
Updates a pinned transitive dependency override to a patched version and refreshes the lockfile.

- Keeps the dependency resolution to a single patched version
- Regenerates lockfile metadata for affected transitive consumers

Validation: pnpm lint; pnpm test