### PR TITLE
Fix follow-up cleanup state handling

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -197,9 +197,10 @@ export async function processAccountFollowUps({
     return;
   }
 
+  const providerName = emailAccount.account.provider;
   const provider = await createEmailProvider({
     emailAccountId,
-    provider: emailAccount.account.provider,
+    provider: providerName,
     logger,
   });
 
@@ -208,12 +209,17 @@ export async function processAccountFollowUps({
     provider.getLabels({ includeHidden: true }),
     getFollowUpNotificationChannels(emailAccountId),
   ]);
+
+  logger.info("Loaded follow-up reminder prerequisites", {
+    providerName,
+    providerLabelCount: providerLabels.length,
+    notificationChannelCount: notificationChannels.length,
+  });
+
   const followUpLabel = await getOrCreateFollowUpLabel(
     provider,
     providerLabels,
   );
-
-  const providerName = emailAccount.account.provider;
 
   await processFollowUpsForType({
     systemType: SystemType.AWAITING_REPLY,
@@ -351,6 +357,16 @@ async function processFollowUpsForType({
     emailAccountId: emailAccount.id,
     threadIds,
   });
+  const processedLedgerStats =
+    summarizeProcessedFollowUpLedger(processedLedger);
+
+  logger.info("Loaded processed follow-up ledger", {
+    systemType,
+    candidateThreadCount: threadIds.length,
+    ledgerThreadCount: processedLedgerStats.threadCount,
+    ledgerMessageIdCount: processedLedgerStats.messageIdCount,
+    ledgerSentAtCount: processedLedgerStats.sentAtCount,
+  });
 
   let processedCount = 0;
   let skippedAlreadyProcessedCount = 0;
@@ -386,18 +402,37 @@ async function processFollowUpsForType({
         continue;
       }
 
-      if (
-        hasFollowUpBeenProcessed({
-          processedLedger,
-          threadId: thread.id,
-          messageId: lastMessage.id,
-          sentAt: messageDate,
-        })
-      ) {
+      const ledgerEntry = processedLedger.get(thread.id);
+      const processedReason = getFollowUpProcessedReason({
+        processedLedger,
+        threadId: thread.id,
+        messageId: lastMessage.id,
+        sentAt: messageDate,
+      });
+
+      if (processedReason) {
         skippedAlreadyProcessedCount++;
         skippedAlreadyProcessedThreadIds.add(thread.id);
+        threadLogger.info("Skipping already-processed follow-up candidate", {
+          systemType,
+          messageId: lastMessage.id,
+          sentAt: messageDate.toISOString(),
+          processedReason,
+          ledgerMessageIdCount: ledgerEntry?.messageIds.size ?? 0,
+          ledgerSentAtCount: ledgerEntry?.sentAtTimes.size ?? 0,
+        });
         continue;
       }
+
+      threadLogger.info("Follow-up candidate missing from processed ledger", {
+        systemType,
+        messageId: lastMessage.id,
+        sentAt: messageDate.toISOString(),
+        trackerType,
+        ledgerThreadKnown: Boolean(ledgerEntry),
+        ledgerMessageIdCount: ledgerEntry?.messageIds.size ?? 0,
+        ledgerSentAtCount: ledgerEntry?.sentAtTimes.size ?? 0,
+      });
 
       await applyFollowUpLabel({
         provider,
@@ -418,6 +453,7 @@ async function processFollowUpsForType({
       });
 
       let tracker: { id: string; followUpNotifications: unknown };
+      let trackerWritePath: string;
       if (existingTracker) {
         try {
           tracker = await prisma.threadTracker.update({
@@ -428,6 +464,7 @@ async function processFollowUpsForType({
               followUpAppliedAt: now,
             },
           });
+          trackerWritePath = "updated-existing";
         } catch (error) {
           if (isDuplicateError(error)) {
             tracker = await prisma.threadTracker.update({
@@ -445,6 +482,7 @@ async function processFollowUpsForType({
                 followUpAppliedAt: now,
               },
             });
+            trackerWritePath = "updated-duplicate";
           } else {
             throw error;
           }
@@ -461,6 +499,7 @@ async function processFollowUpsForType({
               followUpAppliedAt: now,
             },
           });
+          trackerWritePath = "created";
         } catch (error) {
           if (isDuplicateError(error)) {
             tracker = await prisma.threadTracker.update({
@@ -478,11 +517,20 @@ async function processFollowUpsForType({
                 followUpAppliedAt: now,
               },
             });
+            trackerWritePath = "created-duplicate-updated";
           } else {
             throw error;
           }
         }
       }
+
+      threadLogger.info("Stored follow-up tracker state", {
+        trackerId: tracker.id,
+        messageId: lastMessage.id,
+        sentAt: messageDate.toISOString(),
+        trackerType,
+        trackerWritePath,
+      });
 
       let draftCreated = false;
       if (generateDraft) {
@@ -558,6 +606,14 @@ async function processFollowUpsForType({
               },
             });
           }
+          threadLogger.info(
+            "Follow-up notification delivery attempt finished",
+            {
+              trackerId: tracker.id,
+              configuredChannelCount: notificationChannels.length,
+              deliveryCount: notificationDeliveries.length,
+            },
+          );
         } catch (notifyError) {
           threadLogger.error(
             "Follow-up notification failed, label still applied",
@@ -649,11 +705,29 @@ async function getProcessedFollowUpLedger({
   return processedLedger;
 }
 
+function summarizeProcessedFollowUpLedger(ledger: ProcessedFollowUpLedger) {
+  let messageIdCount = 0;
+  let sentAtCount = 0;
+
+  for (const processed of ledger.values()) {
+    messageIdCount += processed.messageIds.size;
+    sentAtCount += processed.sentAtTimes.size;
+  }
+
+  return {
+    threadCount: ledger.size,
+    messageIdCount,
+    sentAtCount,
+  };
+}
+
+type FollowUpProcessedReason = "message-id" | "sent-at";
+
 // sentAt is checked because Outlook can return a different provider message ID
 // for the same sent message across runs, including after Mark done. The ledger
 // only includes rows that already have follow-up history, so ordinary Reply Zero
 // trackers still receive their first follow-up.
-function hasFollowUpBeenProcessed({
+function getFollowUpProcessedReason({
   processedLedger,
   threadId,
   messageId,
@@ -663,14 +737,13 @@ function hasFollowUpBeenProcessed({
   threadId: string;
   messageId: string;
   sentAt: Date;
-}): boolean {
+}): FollowUpProcessedReason | null {
   const processed = processedLedger.get(threadId);
-  if (!processed) return false;
+  if (!processed) return null;
 
-  return (
-    processed.messageIds.has(messageId) ||
-    processed.sentAtTimes.has(sentAt.getTime())
-  );
+  if (processed.messageIds.has(messageId)) return "message-id";
+  if (processed.sentAtTimes.has(sentAt.getTime())) return "sent-at";
+  return null;
 }
 
 async function processLoadedFollowUpReminderAccount({

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -328,6 +328,7 @@ describe("clearFollowUpLabel", () => {
         messageId: true,
         followUpAppliedAt: true,
         followUpDraftId: true,
+        followUpNotifications: true,
         resolved: true,
       },
     });

--- a/apps/web/utils/follow-up/labels.test.ts
+++ b/apps/web/utils/follow-up/labels.test.ts
@@ -326,7 +326,9 @@ describe("clearFollowUpLabel", () => {
       select: {
         id: true,
         messageId: true,
+        followUpAppliedAt: true,
         followUpDraftId: true,
+        resolved: true,
       },
     });
     expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
@@ -338,7 +340,7 @@ describe("clearFollowUpLabel", () => {
     expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
   });
 
-  it("removes label and clears followUpAppliedAt even without drafts", async () => {
+  it("removes label and resolves active follow-up without clearing followUpAppliedAt", async () => {
     const mockProvider = createMockEmailProvider({
       getLabelByName: vi
         .fn()
@@ -346,7 +348,13 @@ describe("clearFollowUpLabel", () => {
     });
 
     prisma.threadTracker.findMany.mockResolvedValue([
-      { id: "tracker-1", followUpDraftId: null },
+      {
+        id: "tracker-1",
+        messageId: "message-1",
+        followUpAppliedAt: new Date("2026-05-20T10:00:00.000Z"),
+        followUpDraftId: null,
+        resolved: false,
+      },
     ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
 
@@ -357,18 +365,19 @@ describe("clearFollowUpLabel", () => {
       logger,
     });
 
-    // Should clear followUpAppliedAt
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
-        emailAccountId: "account-1",
-        threadId: "thread-1",
-        resolved: false,
-        followUpAppliedAt: { not: null },
+        id: { in: ["tracker-1"] },
       },
       data: {
-        followUpAppliedAt: null,
+        resolved: true,
       },
     });
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ followUpAppliedAt: null }),
+      }),
+    );
     expect(mockProvider.deleteDraft).not.toHaveBeenCalled();
     // Always removes label
     expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
@@ -386,7 +395,13 @@ describe("clearFollowUpLabel", () => {
     });
 
     prisma.threadTracker.findMany.mockResolvedValue([
-      { id: "tracker-1", followUpDraftId: "draft-abc" },
+      {
+        id: "tracker-1",
+        messageId: "message-1",
+        followUpAppliedAt: new Date("2026-05-20T10:00:00.000Z"),
+        followUpDraftId: "draft-abc",
+        resolved: false,
+      },
     ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
 
@@ -422,7 +437,13 @@ describe("clearFollowUpLabel", () => {
     });
 
     prisma.threadTracker.findMany.mockResolvedValue([
-      { id: "tracker-1", followUpDraftId: "draft-abc" },
+      {
+        id: "tracker-1",
+        messageId: "message-1",
+        followUpAppliedAt: new Date("2026-05-20T10:00:00.000Z"),
+        followUpDraftId: "draft-abc",
+        resolved: false,
+      },
     ]);
     prisma.threadTracker.updateMany.mockResolvedValue({ count: 1 });
 
@@ -441,18 +462,19 @@ describe("clearFollowUpLabel", () => {
         data: { followUpDraftId: null },
       }),
     );
-    // Still clears followUpAppliedAt and removes label
     expect(prisma.threadTracker.updateMany).toHaveBeenCalledWith({
       where: {
-        emailAccountId: "account-1",
-        threadId: "thread-1",
-        resolved: false,
-        followUpAppliedAt: { not: null },
+        id: { in: ["tracker-1"] },
       },
       data: {
-        followUpAppliedAt: null,
+        resolved: true,
       },
     });
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ followUpAppliedAt: null }),
+      }),
+    );
     expect(mockProvider.removeThreadLabel).toHaveBeenCalledWith(
       "thread-1",
       "label-123",
@@ -534,7 +556,9 @@ describe("clearFollowUpLabel", () => {
       {
         id: "tracker-1",
         messageId: "tracked-message-1",
+        followUpAppliedAt: new Date("2026-05-20T10:00:00.000Z"),
         followUpDraftId: null,
+        resolved: false,
       },
     ]);
 
@@ -553,6 +577,44 @@ describe("clearFollowUpLabel", () => {
     expect(messagingMocks.slackChatUpdate).not.toHaveBeenCalled();
     expect(messagingMocks.teamsEditMessage).not.toHaveBeenCalled();
     expect(messagingMocks.telegramEditMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not clear follow-up state for a tracked-message webhook when the thread has older trackers", async () => {
+    const mockProvider = createMockEmailProvider({
+      getLabelByName: vi
+        .fn()
+        .mockResolvedValue({ id: "label-123", name: "Follow-up" }),
+    });
+
+    prisma.threadTracker.findMany.mockResolvedValue([
+      {
+        id: "tracker-1",
+        messageId: "tracked-message-1",
+        followUpAppliedAt: new Date("2026-05-20T10:00:00.000Z"),
+        followUpDraftId: null,
+        resolved: false,
+      },
+      {
+        id: "tracker-2",
+        messageId: "older-message-1",
+        followUpAppliedAt: new Date("2026-05-19T10:00:00.000Z"),
+        followUpDraftId: null,
+        resolved: true,
+      },
+    ]);
+
+    await clearFollowUpLabel({
+      emailAccountId: "account-1",
+      threadId: "thread-1",
+      triggerMessageId: "tracked-message-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(prisma.threadTracker.updateMany).not.toHaveBeenCalled();
+    expect(prisma.messagingChannel.findMany).not.toHaveBeenCalled();
+    expect(mockProvider.getLabelByName).not.toHaveBeenCalled();
+    expect(mockProvider.removeThreadLabel).not.toHaveBeenCalled();
   });
 
   it("updates delivered follow-up notifications when a reply clears the follow-up", async () => {
@@ -709,9 +771,7 @@ describe("clearFollowUpLabel", () => {
           followUpNotifications: notifications,
         },
       ]);
-    prisma.threadTracker.updateMany
-      .mockResolvedValueOnce({ count: 1 })
-      .mockResolvedValueOnce({ count: 0 });
+    prisma.threadTracker.updateMany.mockResolvedValueOnce({ count: 0 });
 
     await clearFollowUpLabel({
       emailAccountId: "account-1",
@@ -911,7 +971,6 @@ describe("clearFollowUpLabel", () => {
         },
       ]);
     prisma.threadTracker.updateMany
-      .mockResolvedValueOnce({ count: 1 })
       .mockResolvedValueOnce({ count: 1 })
       .mockResolvedValueOnce({ count: 0 })
       .mockResolvedValueOnce({ count: 1 });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -156,6 +156,7 @@ export async function clearFollowUpLabel({
         messageId: true,
         followUpAppliedAt: true,
         followUpDraftId: true,
+        followUpNotifications: true,
         resolved: true,
       },
     });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -154,7 +154,9 @@ export async function clearFollowUpLabel({
       select: {
         id: true,
         messageId: true,
+        followUpAppliedAt: true,
         followUpDraftId: true,
+        resolved: true,
       },
     });
 
@@ -165,7 +167,10 @@ export async function clearFollowUpLabel({
 
     if (
       triggerMessageId &&
-      activeTrackers.every((tracker) => tracker.messageId === triggerMessageId)
+      activeTrackers.some(
+        (tracker) =>
+          tracker.messageId === triggerMessageId && tracker.followUpAppliedAt,
+      )
     ) {
       logger.info("Skipping follow-up cleanup for tracked message webhook", {
         threadId,
@@ -213,22 +218,24 @@ export async function clearFollowUpLabel({
       );
     }
 
-    // Clear followUpAppliedAt only on unresolved trackers (preserve resolved history)
-    await withPrismaRetry(
-      () =>
-        prisma.threadTracker.updateMany({
-          where: {
-            emailAccountId,
-            threadId,
-            resolved: false,
-            followUpAppliedAt: { not: null },
-          },
-          data: {
-            followUpAppliedAt: null,
-          },
-        }),
-      { logger },
-    );
+    const activeFollowUpTrackerIds = activeTrackers
+      .filter((tracker) => !tracker.resolved && tracker.followUpAppliedAt)
+      .map((tracker) => tracker.id);
+
+    if (activeFollowUpTrackerIds.length > 0) {
+      await withPrismaRetry(
+        () =>
+          prisma.threadTracker.updateMany({
+            where: {
+              id: { in: activeFollowUpTrackerIds },
+            },
+            data: {
+              resolved: true,
+            },
+          }),
+        { logger },
+      );
+    }
 
     // Always remove the label regardless of tracker state
     await removeFollowUpLabel({ provider, threadId, logger });

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -165,13 +165,31 @@ export async function clearFollowUpLabel({
       return;
     }
 
-    if (
+    const triggerMatchesFollowUpTracker = Boolean(
       triggerMessageId &&
-      activeTrackers.some(
-        (tracker) =>
-          tracker.messageId === triggerMessageId && tracker.followUpAppliedAt,
-      )
-    ) {
+        activeTrackers.some(
+          (tracker) =>
+            tracker.messageId === triggerMessageId && tracker.followUpAppliedAt,
+        ),
+    );
+
+    logger.info("Loaded follow-up cleanup state", {
+      threadId,
+      triggerMessageId,
+      trackerCount: activeTrackers.length,
+      unresolvedFollowUpTrackerCount: activeTrackers.filter(
+        (tracker) => !tracker.resolved && tracker.followUpAppliedAt,
+      ).length,
+      draftTrackerCount: activeTrackers.filter(
+        (tracker) => tracker.followUpDraftId,
+      ).length,
+      notificationTrackerCount: activeTrackers.filter(
+        (tracker) => tracker.followUpNotifications,
+      ).length,
+      triggerMatchesFollowUpTracker,
+    });
+
+    if (triggerMatchesFollowUpTracker) {
       logger.info("Skipping follow-up cleanup for tracked message webhook", {
         threadId,
         messageId: triggerMessageId,
@@ -223,6 +241,11 @@ export async function clearFollowUpLabel({
       .map((tracker) => tracker.id);
 
     if (activeFollowUpTrackerIds.length > 0) {
+      logger.info("Resolving follow-up trackers while preserving ledger", {
+        threadId,
+        trackerCount: activeFollowUpTrackerIds.length,
+      });
+
       await withPrismaRetry(
         () =>
           prisma.threadTracker.updateMany({
@@ -248,6 +271,7 @@ export async function clearFollowUpLabel({
     logger.info("Cleared follow-up label and cleaned up trackers", {
       threadId,
       draftsDeleted: deletedDraftTrackerIds.length,
+      resolvedFollowUpTrackers: activeFollowUpTrackerIds.length,
     });
   } catch (error) {
     logger.error("Failed to clear follow-up label", { threadId, error });


### PR DESCRIPTION
Fix follow-up cleanup to preserve reminder ledger state after cleanup and skip cleanup for tracked-message webhooks.

- Resolve active follow-up trackers instead of clearing the applied timestamp.
- Add diagnostic logging around ledger hits/misses, tracker writes, notification delivery attempts, and cleanup state.
- Add regression coverage for preserving follow-up history and webhook cleanup skips.

Tests: pnpm test utils/follow-up/labels.test.ts; pnpm test app/api/follow-up-reminders/process.test.ts; pnpm lint.