### PR TITLE
Fix follow-up notification completion

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -48,9 +48,6 @@ vi.mock("@/utils/follow-up/generate-draft", () => ({
 
 vi.mock("@/utils/follow-up/send-follow-up-notification", () => ({
   getFollowUpNotificationChannels: vi.fn().mockResolvedValue([]),
-  parseFollowUpNotificationDeliveries: vi.fn((value: unknown) =>
-    Array.isArray(value) ? value : [],
-  ),
   sendFollowUpNotification: vi.fn().mockResolvedValue([]),
 }));
 

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -8,10 +8,10 @@ import {
 import { generateFollowUpDraft } from "@/utils/follow-up/generate-draft";
 import {
   getFollowUpNotificationChannels,
-  parseFollowUpNotificationDeliveries,
   sendFollowUpNotification,
   type FollowUpNotificationChannel,
 } from "@/utils/follow-up/send-follow-up-notification";
+import { parseFollowUpNotificationDeliveries } from "@/utils/follow-up/notification-deliveries";
 import { ThreadTrackerType, SystemType } from "@/generated/prisma/enums";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -38,16 +38,12 @@ function makeEvent(
   const post = vi.fn().mockResolvedValue(undefined);
   const editMessage = vi.fn().mockResolvedValue(undefined);
   const value = "value" in overrides ? overrides.value : "tracker-1";
+  const raw = buildRaw(overrides);
   const event = {
     actionId: overrides.actionId ?? FOLLOW_UP_MARK_DONE_ACTION_ID,
     value,
     user: { userId: overrides.userId ?? "U_USER" },
-    raw:
-      "raw" in overrides
-        ? overrides.raw
-        : overrides.teamId === null
-          ? {}
-          : { team: { id: overrides.teamId ?? "T_TEAM" } },
+    raw,
     threadId: overrides.threadId ?? "slack:C_CHANNEL:1700000000.000100",
     messageId: "1700000000.000100",
     adapter: { name: overrides.adapterName ?? "slack", editMessage } as any,
@@ -56,6 +52,14 @@ function makeEvent(
     openModal: vi.fn(),
   };
   return { event: event as any, postEphemeral, post, editMessage };
+}
+
+function buildRaw(
+  overrides: Partial<{ raw: unknown; teamId: string | null }>,
+): unknown {
+  if ("raw" in overrides) return overrides.raw;
+  if (overrides.teamId === null) return {};
+  return { team: { id: overrides.teamId ?? "T_TEAM" } };
 }
 
 describe("handleFollowUpReminderAction", () => {

--- a/apps/web/utils/follow-up/follow-up-actions.test.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.test.ts
@@ -8,7 +8,18 @@ import {
   handleFollowUpReminderAction,
 } from "./follow-up-actions";
 
+const { slackChatUpdate } = vi.hoisted(() => ({
+  slackChatUpdate: vi
+    .fn()
+    .mockResolvedValue({ ok: true, ts: "1700000000.000100" }),
+}));
+
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/messaging/providers/slack/client", () => ({
+  createSlackClient: vi.fn(() => ({
+    chat: { update: slackChatUpdate },
+  })),
+}));
 
 const logger = createTestLogger();
 
@@ -98,6 +109,56 @@ describe("handleFollowUpReminderAction", () => {
     expect(threadId).toBe("slack:C_CHANNEL:1700000000.000100");
     expect(messageId).toBe("1700000000.000100");
     expect(JSON.stringify(card)).toMatch(/done/i);
+  });
+
+  it("replaces the stored Slack notification before clearing its reference", async () => {
+    const notification = {
+      messagingChannelId: "channel-1",
+      provider: MessagingProvider.SLACK,
+      providerThreadId: "C_CHANNEL",
+      providerMessageId: "1700000000.000100",
+    };
+
+    prisma.threadTracker.findUnique.mockResolvedValue({
+      id: "tracker-1",
+      resolved: false,
+      emailAccountId: "account-1",
+      followUpNotifications: [notification],
+    } as any);
+    prisma.messagingChannel.findFirst.mockResolvedValue({
+      id: "channel-1",
+    } as any);
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      {
+        id: "channel-1",
+        provider: MessagingProvider.SLACK,
+        accessToken: "xoxb-token",
+      },
+    ] as any);
+    prisma.threadTracker.update.mockResolvedValue({} as any);
+
+    const { event, editMessage } = makeEvent();
+    await handleFollowUpReminderAction({ event, logger });
+
+    expect(prisma.threadTracker.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "tracker-1" },
+      data: { resolved: true },
+    });
+    expect(slackChatUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C_CHANNEL",
+        ts: "1700000000.000100",
+        text: expect.stringMatching(/done/i),
+        blocks: expect.any(Array),
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    );
+    expect(editMessage).not.toHaveBeenCalled();
+    expect(prisma.threadTracker.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "tracker-1" },
+      data: { followUpNotifications: Prisma.JsonNull },
+    });
   });
 
   it("scopes the channel auth lookup to the tracker's email account, slack, the slack team and the clicker", async () => {

--- a/apps/web/utils/follow-up/follow-up-actions.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.ts
@@ -1,11 +1,15 @@
 import { Card, CardText, type ActionEvent } from "chat";
+import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import { MessagingProvider } from "@/generated/prisma/enums";
 import { Prisma } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
+import { parseFollowUpNotificationDeliveries } from "@/utils/follow-up/notification-deliveries";
 import {
   getSlackTeamId,
   getTelegramChatId,
 } from "@/utils/messaging/action-event-identifiers";
+import { createSlackClient } from "@/utils/messaging/providers/slack/client";
+import { disableSlackLinkUnfurls } from "@/utils/messaging/providers/slack/send";
 import prisma from "@/utils/prisma";
 
 export const FOLLOW_UP_MARK_DONE_ACTION_ID = "follow_up_mark_done";
@@ -28,7 +32,12 @@ export async function handleFollowUpReminderAction({
 
   const tracker = await prisma.threadTracker.findUnique({
     where: { id: trackerId },
-    select: { id: true, resolved: true, emailAccountId: true },
+    select: {
+      id: true,
+      resolved: true,
+      emailAccountId: true,
+      followUpNotifications: true,
+    },
   });
 
   if (!tracker) {
@@ -61,18 +70,33 @@ export async function handleFollowUpReminderAction({
 
   await prisma.threadTracker.update({
     where: { id: trackerId },
-    data: {
-      resolved: true,
-      followUpNotifications: Prisma.JsonNull,
-    },
+    data: getInitialResolvedUpdateData(tracker.followUpNotifications),
   });
 
   const feedback = tracker.resolved
     ? "This follow-up is already done."
     : "Marked done. We won't follow up on this thread again.";
 
+  const storedNotificationResult = await replaceStoredResolvedCards({
+    emailAccountId: tracker.emailAccountId,
+    notifications: tracker.followUpNotifications,
+    logger,
+  });
+  const fallbackResult =
+    storedNotificationResult !== "replaced"
+      ? await replaceWithResolvedCard(event, logger)
+      : false;
+
+  const shouldClearNotificationReferences =
+    storedNotificationResult === "replaced" ||
+    (storedNotificationResult === "failed" && fallbackResult);
+
   await Promise.all([
-    replaceWithResolvedCard(event, logger),
+    shouldClearNotificationReferences &&
+      prisma.threadTracker.update({
+        where: { id: trackerId },
+        data: { followUpNotifications: Prisma.JsonNull },
+      }),
     postFeedback(event, logger, feedback),
   ]);
 }
@@ -80,24 +104,107 @@ export async function handleFollowUpReminderAction({
 async function replaceWithResolvedCard(
   event: ActionEvent,
   logger: Logger,
-): Promise<void> {
-  if (!event.threadId || !event.messageId) return;
+): Promise<boolean> {
+  if (!event.threadId || !event.messageId) return false;
 
   try {
     await event.adapter.editMessage(
       event.threadId,
       event.messageId,
-      Card({
-        title: "✅ Follow-up marked done",
-        children: [CardText("We won't follow up on this thread again.")],
-      }),
+      buildResolvedCard(),
     );
+    return true;
   } catch (error) {
     logger.warn("Failed to update follow-up notification after Mark done", {
       actionId: event.actionId,
       error,
     });
+    return false;
   }
+}
+
+function getInitialResolvedUpdateData(followUpNotifications: unknown) {
+  const notifications = parseFollowUpNotificationDeliveries(
+    followUpNotifications,
+  );
+
+  return notifications.length === 0
+    ? { resolved: true, followUpNotifications: Prisma.JsonNull }
+    : { resolved: true };
+}
+
+async function replaceStoredResolvedCards({
+  emailAccountId,
+  notifications,
+  logger,
+}: {
+  emailAccountId: string;
+  notifications: unknown;
+  logger: Logger;
+}): Promise<"none" | "replaced" | "failed"> {
+  const parsedNotifications =
+    parseFollowUpNotificationDeliveries(notifications);
+  if (parsedNotifications.length === 0) return "none";
+
+  const messagingChannelIds = [
+    ...new Set(
+      parsedNotifications.map(
+        (notification) => notification.messagingChannelId,
+      ),
+    ),
+  ];
+  const channels = await prisma.messagingChannel.findMany({
+    where: {
+      emailAccountId,
+      id: { in: messagingChannelIds },
+      isConnected: true,
+    },
+    select: {
+      id: true,
+      accessToken: true,
+    },
+  });
+  const channelsById = new Map(
+    channels.map((channel) => [channel.id, channel]),
+  );
+  const card = buildResolvedCard();
+
+  const results = await Promise.all(
+    parsedNotifications.map(async (notification) => {
+      const channel = channelsById.get(notification.messagingChannelId);
+      if (!channel) return true;
+
+      if (notification.provider !== MessagingProvider.SLACK) return false;
+      if (!channel.accessToken) return true;
+
+      try {
+        await createSlackClient(channel.accessToken).chat.update(
+          disableSlackLinkUnfurls({
+            channel: notification.providerThreadId,
+            ts: notification.providerMessageId,
+            text: cardToFallbackText(card),
+            blocks: cardToBlockKit(card),
+          }),
+        );
+        return true;
+      } catch (error) {
+        logger.warn("Failed to update stored Slack follow-up notification", {
+          messagingChannelId: notification.messagingChannelId,
+          error,
+        });
+        return false;
+      }
+    }),
+  );
+
+  return results.every(Boolean) ? "replaced" : "failed";
+}
+
+function buildResolvedCard() {
+  return Card({
+    title: "✅ Follow-up marked done",
+    children: [CardText("We won't follow up on this thread again.")],
+  });
 }
 
 async function postFeedback(

--- a/apps/web/utils/follow-up/follow-up-actions.ts
+++ b/apps/web/utils/follow-up/follow-up-actions.ts
@@ -1,9 +1,12 @@
-import { Card, CardText, type ActionEvent } from "chat";
+import { Card, CardText, type ActionEvent, type CardElement } from "chat";
 import { cardToBlockKit, cardToFallbackText } from "@chat-adapter/slack";
 import { MessagingProvider } from "@/generated/prisma/enums";
 import { Prisma } from "@/generated/prisma/client";
 import type { Logger } from "@/utils/logger";
-import { parseFollowUpNotificationDeliveries } from "@/utils/follow-up/notification-deliveries";
+import {
+  parseFollowUpNotificationDeliveries,
+  type FollowUpNotificationDelivery,
+} from "@/utils/follow-up/notification-deliveries";
 import {
   getSlackTeamId,
   getTelegramChatId,
@@ -68,51 +71,59 @@ export async function handleFollowUpReminderAction({
     return;
   }
 
+  const storedNotifications = parseFollowUpNotificationDeliveries(
+    tracker.followUpNotifications,
+  );
+  const card = buildResolvedCard();
+
+  // Mark resolved up front so the action is idempotent if subsequent steps fail.
   await prisma.threadTracker.update({
     where: { id: trackerId },
-    data: getInitialResolvedUpdateData(tracker.followUpNotifications),
+    data:
+      storedNotifications.length === 0
+        ? { resolved: true, followUpNotifications: Prisma.JsonNull }
+        : { resolved: true },
   });
+
+  const allStoredReplaced =
+    storedNotifications.length > 0 &&
+    (await replaceStoredResolvedCards({
+      emailAccountId: tracker.emailAccountId,
+      notifications: storedNotifications,
+      card,
+      logger,
+    }));
+
+  const fallbackHandled =
+    !allStoredReplaced && (await replaceWithResolvedCard(event, card, logger));
+
+  const shouldClearNotificationReferences =
+    storedNotifications.length > 0 && (allStoredReplaced || fallbackHandled);
 
   const feedback = tracker.resolved
     ? "This follow-up is already done."
     : "Marked done. We won't follow up on this thread again.";
 
-  const storedNotificationResult = await replaceStoredResolvedCards({
-    emailAccountId: tracker.emailAccountId,
-    notifications: tracker.followUpNotifications,
-    logger,
-  });
-  const fallbackResult =
-    storedNotificationResult !== "replaced"
-      ? await replaceWithResolvedCard(event, logger)
-      : false;
-
-  const shouldClearNotificationReferences =
-    storedNotificationResult === "replaced" ||
-    (storedNotificationResult === "failed" && fallbackResult);
-
   await Promise.all([
-    shouldClearNotificationReferences &&
-      prisma.threadTracker.update({
-        where: { id: trackerId },
-        data: { followUpNotifications: Prisma.JsonNull },
-      }),
+    shouldClearNotificationReferences
+      ? prisma.threadTracker.update({
+          where: { id: trackerId },
+          data: { followUpNotifications: Prisma.JsonNull },
+        })
+      : null,
     postFeedback(event, logger, feedback),
   ]);
 }
 
 async function replaceWithResolvedCard(
   event: ActionEvent,
+  card: CardElement,
   logger: Logger,
 ): Promise<boolean> {
   if (!event.threadId || !event.messageId) return false;
 
   try {
-    await event.adapter.editMessage(
-      event.threadId,
-      event.messageId,
-      buildResolvedCard(),
-    );
+    await event.adapter.editMessage(event.threadId, event.messageId, card);
     return true;
   } catch (error) {
     logger.warn("Failed to update follow-up notification after Mark done", {
@@ -123,34 +134,20 @@ async function replaceWithResolvedCard(
   }
 }
 
-function getInitialResolvedUpdateData(followUpNotifications: unknown) {
-  const notifications = parseFollowUpNotificationDeliveries(
-    followUpNotifications,
-  );
-
-  return notifications.length === 0
-    ? { resolved: true, followUpNotifications: Prisma.JsonNull }
-    : { resolved: true };
-}
-
 async function replaceStoredResolvedCards({
   emailAccountId,
   notifications,
+  card,
   logger,
 }: {
   emailAccountId: string;
-  notifications: unknown;
+  notifications: FollowUpNotificationDelivery[];
+  card: CardElement;
   logger: Logger;
-}): Promise<"none" | "replaced" | "failed"> {
-  const parsedNotifications =
-    parseFollowUpNotificationDeliveries(notifications);
-  if (parsedNotifications.length === 0) return "none";
-
+}): Promise<boolean> {
   const messagingChannelIds = [
     ...new Set(
-      parsedNotifications.map(
-        (notification) => notification.messagingChannelId,
-      ),
+      notifications.map((notification) => notification.messagingChannelId),
     ),
   ];
   const channels = await prisma.messagingChannel.findMany({
@@ -167,10 +164,11 @@ async function replaceStoredResolvedCards({
   const channelsById = new Map(
     channels.map((channel) => [channel.id, channel]),
   );
-  const card = buildResolvedCard();
+  const text = cardToFallbackText(card);
+  const blocks = cardToBlockKit(card);
 
   const results = await Promise.all(
-    parsedNotifications.map(async (notification) => {
+    notifications.map(async (notification) => {
       const channel = channelsById.get(notification.messagingChannelId);
       if (!channel) return true;
 
@@ -182,8 +180,8 @@ async function replaceStoredResolvedCards({
           disableSlackLinkUnfurls({
             channel: notification.providerThreadId,
             ts: notification.providerMessageId,
-            text: cardToFallbackText(card),
-            blocks: cardToBlockKit(card),
+            text,
+            blocks,
           }),
         );
         return true;
@@ -197,7 +195,7 @@ async function replaceStoredResolvedCards({
     }),
   );
 
-  return results.every(Boolean) ? "replaced" : "failed";
+  return results.every(Boolean);
 }
 
 function buildResolvedCard() {

--- a/apps/web/utils/follow-up/labels.ts
+++ b/apps/web/utils/follow-up/labels.ts
@@ -15,7 +15,7 @@ import { getMessagingAdapterRegistry } from "@/utils/messaging/chat-sdk/adapters
 import {
   parseFollowUpNotificationDeliveries,
   type FollowUpNotificationDelivery,
-} from "./send-follow-up-notification";
+} from "./notification-deliveries";
 
 export async function getOrCreateFollowUpLabel(
   provider: EmailProvider,

--- a/apps/web/utils/follow-up/notification-deliveries.ts
+++ b/apps/web/utils/follow-up/notification-deliveries.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { MessagingProvider } from "@/generated/prisma/enums";
+
+export const followUpNotificationDeliverySchema = z.object({
+  messagingChannelId: z.string(),
+  provider: z.nativeEnum(MessagingProvider),
+  providerThreadId: z.string(),
+  providerMessageId: z.string(),
+});
+
+export type FollowUpNotificationDelivery = z.infer<
+  typeof followUpNotificationDeliverySchema
+>;
+
+export const followUpNotificationDeliveriesSchema =
+  followUpNotificationDeliverySchema.array();
+
+export function parseFollowUpNotificationDeliveries(
+  value: unknown,
+): FollowUpNotificationDelivery[] {
+  const parsed = followUpNotificationDeliveriesSchema.safeParse(value);
+  return parsed.success ? parsed.data : [];
+}

--- a/apps/web/utils/follow-up/send-follow-up-notification.test.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.test.ts
@@ -7,10 +7,10 @@ import {
 } from "@/generated/prisma/enums";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
-  parseFollowUpNotificationDeliveries,
   sendFollowUpNotification,
   type FollowUpNotificationChannel,
 } from "./send-follow-up-notification";
+import { parseFollowUpNotificationDeliveries } from "./notification-deliveries";
 import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "./follow-up-actions";
 import {
   resolveSlackRouteDestination,

--- a/apps/web/utils/follow-up/send-follow-up-notification.ts
+++ b/apps/web/utils/follow-up/send-follow-up-notification.ts
@@ -6,7 +6,6 @@ import {
   LinkButton,
   type CardChild,
 } from "chat";
-import { z } from "zod";
 import {
   MessagingProvider,
   MessagingRoutePurpose,
@@ -33,6 +32,7 @@ import {
   truncateSnippet,
 } from "@/utils/follow-up/copy";
 import { FOLLOW_UP_MARK_DONE_ACTION_ID } from "@/utils/follow-up/follow-up-actions";
+import type { FollowUpNotificationDelivery } from "@/utils/follow-up/notification-deliveries";
 
 const TELEGRAM_SNIPPET_MAX_CHARS = 3000;
 
@@ -61,27 +61,6 @@ type FollowUpNotificationContent = {
   threadLinkLabel?: string;
   trackerId: string;
 };
-
-export const followUpNotificationDeliverySchema = z.object({
-  messagingChannelId: z.string(),
-  provider: z.nativeEnum(MessagingProvider),
-  providerThreadId: z.string(),
-  providerMessageId: z.string(),
-});
-
-export type FollowUpNotificationDelivery = z.infer<
-  typeof followUpNotificationDeliverySchema
->;
-
-export const followUpNotificationDeliveriesSchema =
-  followUpNotificationDeliverySchema.array();
-
-export function parseFollowUpNotificationDeliveries(
-  value: unknown,
-): FollowUpNotificationDelivery[] {
-  const parsed = followUpNotificationDeliveriesSchema.safeParse(value);
-  return parsed.success ? parsed.data : [];
-}
 
 export async function getFollowUpNotificationChannels(
   emailAccountId: string,


### PR DESCRIPTION
Updates follow-up completion so stored notification messages are replaced before their references are cleared. This keeps the completion state visible in messaging channels while preserving the resolved tracker state used by later follow-up runs.

- Update stored Slack notification cards on completion
- Move notification delivery parsing into a shared helper
- Add regression coverage for the stored notification path

Tests: pnpm test utils/follow-up/follow-up-actions.test.ts; pnpm test utils/follow-up/send-follow-up-notification.test.ts; pnpm test utils/follow-up/labels.test.ts; pnpm test app/api/follow-up-reminders/process.test.ts; pnpm check