### PR TITLE
booking: Improve public link metadata

### DIFF
--- a/apps/web/app/book/[slug]/metadata.test.ts
+++ b/apps/web/app/book/[slug]/metadata.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildBookingLinkDescription,
+  buildBookingLinkPageMetadata,
+  buildBookingLinkTitle,
+} from "./metadata";
+
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: "https://app.example.com",
+    NEXT_PUBLIC_BRAND_NAME: "Inbox Zero",
+  },
+}));
+
+describe("booking link metadata", () => {
+  it("builds Cal-style social metadata for a public booking link", () => {
+    const metadata = buildBookingLinkPageMetadata({
+      slug: "intro-call",
+      title: "Intro call",
+      description: "Talk through fit.",
+      durationMinutes: 30,
+      hostName: "Host User",
+    });
+
+    expect(metadata).toEqual({
+      title: "Intro call | Host User",
+      description: "Talk through fit.",
+      alternates: {
+        canonical: "https://app.example.com/book/intro-call",
+      },
+      robots: {
+        index: false,
+        follow: false,
+      },
+      openGraph: {
+        title: "Intro call | Host User",
+        description: "Talk through fit.",
+        url: "https://app.example.com/book/intro-call",
+        siteName: "Inbox Zero",
+        type: "website",
+        images: [
+          {
+            url: "https://app.example.com/book/intro-call/opengraph-image",
+            width: 1200,
+            height: 630,
+            alt: "Intro call | Host User",
+          },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "Intro call | Host User",
+        description: "Talk through fit.",
+        images: ["https://app.example.com/book/intro-call/twitter-image"],
+      },
+    });
+  });
+
+  it("falls back to a booking description when the link has no description", () => {
+    const bookingLink = {
+      slug: "intro call",
+      title: "Intro call",
+      description: null,
+      durationMinutes: 45,
+      hostName: "Host User",
+    };
+
+    expect(buildBookingLinkTitle(bookingLink)).toBe("Intro call | Host User");
+    expect(buildBookingLinkDescription(bookingLink)).toBe(
+      "Book a 45 min meeting with Host User.",
+    );
+
+    expect(buildBookingLinkPageMetadata(bookingLink).openGraph).toMatchObject({
+      url: "https://app.example.com/book/intro%20call",
+      images: [
+        {
+          url: "https://app.example.com/book/intro%20call/opengraph-image",
+        },
+      ],
+    });
+  });
+
+  it("uses the brand when the host name is unavailable", () => {
+    const bookingLink = {
+      slug: "intro-call",
+      title: "Intro call",
+      description: " ",
+      durationMinutes: 30,
+      hostName: null,
+    };
+
+    expect(buildBookingLinkTitle(bookingLink)).toBe("Intro call | Inbox Zero");
+    expect(buildBookingLinkDescription(bookingLink)).toBe(
+      "Book a 30 min meeting.",
+    );
+  });
+});

--- a/apps/web/app/book/[slug]/metadata.ts
+++ b/apps/web/app/book/[slug]/metadata.ts
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { BRAND_NAME, toAbsoluteUrl } from "@/utils/branding";
+
+type BookingLinkMetadata = {
+  slug: string;
+  title: string;
+  description: string | null;
+  durationMinutes: number;
+  hostName: string | null;
+};
+
+export function buildBookingLinkPageMetadata(
+  bookingLink: BookingLinkMetadata,
+): Metadata {
+  const title = buildBookingLinkTitle(bookingLink);
+  const description = buildBookingLinkDescription(bookingLink);
+  const canonicalUrl = getBookingLinkUrl(bookingLink.slug);
+  const imageUrl = getBookingLinkImageUrl(bookingLink.slug);
+  const twitterImageUrl = getBookingLinkTwitterImageUrl(bookingLink.slug);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalUrl,
+      siteName: BRAND_NAME,
+      type: "website",
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [twitterImageUrl],
+    },
+  };
+}
+
+export function buildBookingLinkTitle(bookingLink: BookingLinkMetadata) {
+  const title = bookingLink.title.trim() || "Meeting";
+  const hostName = bookingLink.hostName?.trim();
+
+  return `${title} | ${hostName || BRAND_NAME}`;
+}
+
+export function buildBookingLinkDescription(bookingLink: BookingLinkMetadata) {
+  const description = bookingLink.description?.trim();
+  if (description) return description;
+
+  const hostName = bookingLink.hostName?.trim();
+  if (hostName) {
+    return `Book a ${bookingLink.durationMinutes} min meeting with ${hostName}.`;
+  }
+
+  return `Book a ${bookingLink.durationMinutes} min meeting.`;
+}
+
+function getBookingLinkUrl(slug: string) {
+  return toAbsoluteUrl(`/book/${encodeURIComponent(slug)}`);
+}
+
+function getBookingLinkImageUrl(slug: string) {
+  return toAbsoluteUrl(`/book/${encodeURIComponent(slug)}/opengraph-image`);
+}
+
+function getBookingLinkTwitterImageUrl(slug: string) {
+  return toAbsoluteUrl(`/book/${encodeURIComponent(slug)}/twitter-image`);
+}

--- a/apps/web/app/book/[slug]/opengraph-image.test.tsx
+++ b/apps/web/app/book/[slug]/opengraph-image.test.tsx
@@ -1,0 +1,114 @@
+import { headers } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEnforcePublicAvailabilityRateLimit,
+  mockGetPublicBookingLinkMetadata,
+  mockHeaders,
+  mockImageResponse,
+  MockImageResponse,
+} = vi.hoisted(() => {
+  const mockImageResponse = vi.fn();
+
+  return {
+    mockEnforcePublicAvailabilityRateLimit: vi.fn(),
+    mockGetPublicBookingLinkMetadata: vi.fn(),
+    mockHeaders: vi.fn(),
+    mockImageResponse,
+    MockImageResponse: class extends Response {
+      constructor(element: unknown, init?: ResponseInit) {
+        mockImageResponse(element, init);
+        super("image", {
+          headers: init?.headers,
+          status: init?.status,
+          statusText: init?.statusText,
+        });
+      }
+    },
+  };
+});
+
+vi.mock("next/headers", () => ({
+  headers: mockHeaders,
+}));
+
+vi.mock("next/og", () => ({
+  ImageResponse: MockImageResponse,
+}));
+
+vi.mock("@/utils/booking/public-rate-limit", () => ({
+  enforcePublicAvailabilityRateLimit: mockEnforcePublicAvailabilityRateLimit,
+}));
+
+vi.mock("@/utils/booking/public", () => ({
+  getPublicBookingLinkMetadata: mockGetPublicBookingLinkMetadata,
+}));
+
+import { SafeError } from "@/utils/error";
+import Image from "./opengraph-image";
+
+describe("booking link Open Graph image", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHeaders.mockResolvedValue(
+      new Headers({ "x-forwarded-for": "198.51.100.1, 203.0.113.9" }),
+    );
+    mockEnforcePublicAvailabilityRateLimit.mockResolvedValue(undefined);
+    mockGetPublicBookingLinkMetadata.mockResolvedValue({
+      slug: "intro-call",
+      title: "Intro call",
+      description: "Talk through fit.",
+      durationMinutes: 30,
+      locationType: "CUSTOM",
+      locationValue: null,
+      hostName: "Host User",
+    });
+  });
+
+  it("rate limits before loading booking metadata and caches successful images", async () => {
+    const response = await Image({
+      params: Promise.resolve({ slug: "intro-call" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("image");
+    expect(headers).toHaveBeenCalled();
+    expect(mockEnforcePublicAvailabilityRateLimit).toHaveBeenCalledWith({
+      slug: "intro-call",
+      clientIp: "203.0.113.9",
+      logger: expect.any(Object),
+    });
+    expect(mockGetPublicBookingLinkMetadata).toHaveBeenCalledWith("intro-call");
+    expect(mockImageResponse).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        width: 1200,
+        height: 630,
+        headers: {
+          "Cache-Control":
+            "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      }),
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+    );
+  });
+
+  it("does not load booking metadata when rate limited", async () => {
+    mockEnforcePublicAvailabilityRateLimit.mockRejectedValue(
+      new SafeError("Too many availability checks.", 429),
+    );
+
+    const response = await Image({
+      params: Promise.resolve({ slug: "intro-call" }),
+    });
+
+    expect(response.status).toBe(429);
+    await expect(response.text()).resolves.toBe(
+      "Too many availability checks.",
+    );
+    expect(mockGetPublicBookingLinkMetadata).not.toHaveBeenCalled();
+    expect(mockImageResponse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/book/[slug]/opengraph-image.tsx
+++ b/apps/web/app/book/[slug]/opengraph-image.tsx
@@ -1,0 +1,150 @@
+import { headers } from "next/headers";
+import { ImageResponse } from "next/og";
+import { BRAND_NAME } from "@/utils/branding";
+import { getPublicBookingLinkMetadata } from "@/utils/booking/public";
+import { enforcePublicAvailabilityRateLimit } from "@/utils/booking/public-rate-limit";
+import { SafeError } from "@/utils/error";
+import { createScopedLogger } from "@/utils/logger";
+import { getClientIp } from "@/utils/rate-limit";
+import { buildBookingLinkDescription, buildBookingLinkTitle } from "./metadata";
+
+const logger = createScopedLogger("public/booking-link-og-image");
+
+export const alt = "Booking link";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const requestHeaders = await headers();
+
+  try {
+    await enforcePublicAvailabilityRateLimit({
+      slug,
+      clientIp: getClientIp(requestHeaders),
+      logger,
+    });
+  } catch (error) {
+    if (error instanceof SafeError && error.statusCode === 429) {
+      return new Response(error.safeMessage, { status: 429 });
+    }
+    throw error;
+  }
+
+  const bookingLink = await getBookingLinkOrNull(slug);
+  const title = bookingLink
+    ? buildBookingLinkTitle(bookingLink)
+    : `Meeting | ${BRAND_NAME}`;
+  const description = bookingLink
+    ? buildBookingLinkDescription(bookingLink)
+    : `Book a meeting with ${BRAND_NAME}.`;
+  const duration = bookingLink ? `${bookingLink.durationMinutes} min` : null;
+  const hostName = bookingLink?.hostName?.trim() || BRAND_NAME;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#f8fafc",
+        color: "#111827",
+        padding: 72,
+        fontFamily: "Arial, Helvetica, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 30,
+          color: "#334155",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <div
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: 16,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "#111827",
+              color: "#ffffff",
+              fontSize: 32,
+              fontWeight: 700,
+            }}
+          >
+            {hostName.charAt(0).toUpperCase()}
+          </div>
+          <div>{hostName}</div>
+        </div>
+        {duration ? <div>{duration}</div> : null}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
+        <div
+          style={{
+            fontSize: 80,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: 0,
+            maxWidth: 960,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 34,
+            lineHeight: 1.35,
+            color: "#475569",
+            maxWidth: 900,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          fontSize: 28,
+          color: "#64748b",
+        }}
+      >
+        <div>Booking link</div>
+        <div>{BRAND_NAME}</div>
+      </div>
+    </div>,
+    {
+      ...size,
+      headers: {
+        "Cache-Control":
+          "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
+  );
+}
+
+async function getBookingLinkOrNull(slug: string) {
+  return getPublicBookingLinkMetadata(slug).catch((error: unknown) => {
+    if (error instanceof SafeError && error.statusCode === 404) return null;
+    throw error;
+  });
+}

--- a/apps/web/app/book/[slug]/page.tsx
+++ b/apps/web/app/book/[slug]/page.tsx
@@ -1,33 +1,52 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicBookingLinkMetadata } from "@/utils/booking/public";
 import { SafeError } from "@/utils/error";
 import { BookingPageClient } from "./BookingPageClient";
+import { buildBookingLinkPageMetadata } from "./metadata";
 
-export const metadata: Metadata = {
-  robots: {
-    index: false,
-    follow: false,
-  },
+const getCachedPublicBookingLinkMetadata = cache(getPublicBookingLinkMetadata);
+
+type BookingLinkPageProps = {
+  params: Promise<{ slug: string }>;
 };
+
+export async function generateMetadata({
+  params,
+}: BookingLinkPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const bookingLink = await getBookingLinkOrNull(slug);
+
+  if (!bookingLink) {
+    return {
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  return buildBookingLinkPageMetadata(bookingLink);
+}
 
 export default async function BookingLinkPage({
   params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+}: BookingLinkPageProps) {
   const { slug } = await params;
-  const bookingLink = await getPublicBookingLinkMetadata(slug).catch(
-    (error: unknown) => {
-      // Only swallow the explicit "not found" path; any other failure
-      // (DB outage, provider error, etc.) should surface so it isn't masked
-      // as a missing booking link.
-      if (error instanceof SafeError && error.statusCode === 404) return null;
-      throw error;
-    },
-  );
+  const bookingLink = await getBookingLinkOrNull(slug);
 
   if (!bookingLink) notFound();
 
   return <BookingPageClient bookingLink={bookingLink} />;
+}
+
+async function getBookingLinkOrNull(slug: string) {
+  return getCachedPublicBookingLinkMetadata(slug).catch((error: unknown) => {
+    // Only swallow the explicit "not found" path; any other failure
+    // (DB outage, provider error, etc.) should surface so it isn't masked
+    // as a missing booking link.
+    if (error instanceof SafeError && error.statusCode === 404) return null;
+    throw error;
+  });
 }

--- a/apps/web/app/book/[slug]/twitter-image.tsx
+++ b/apps/web/app/book/[slug]/twitter-image.tsx
@@ -1,0 +1,12 @@
+import Image from "./opengraph-image";
+
+export const alt = "Booking link";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default Image;


### PR DESCRIPTION
Improve public booking link previews with route-specific metadata and a generated social image. This keeps indexing disabled while making shared links more descriptive.

- Add dynamic title, description, canonical, Open Graph, and Twitter metadata for public booking links
- Add a generated social preview image endpoint for booking links
- Cover metadata formatting with focused tests

Performance impact: adds one cached metadata lookup during booking page metadata generation and one database lookup when a crawler requests the generated preview image; normal booking interactions are unchanged.