### PR TITLE
follow-up: Avoid rescanning completed candidates

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -149,6 +149,20 @@ function createMockProvider(
     ...overrides,
   } as any;
 
+  if (!provider.getThreadsWithQuery) {
+    provider.getThreadsWithQuery = vi.fn(
+      async ({
+        query,
+        maxResults,
+      }: Parameters<EmailProvider["getThreadsWithQuery"]>[0]) => ({
+        threads: await provider.getThreadsWithLabel({
+          labelId: query?.labelId || "",
+          maxResults,
+        }),
+      }),
+    );
+  }
+
   if (!provider.getLatestMessageFromThreadSnapshot) {
     provider.getLatestMessageFromThreadSnapshot = vi.fn(
       async (thread: { id: string }) =>
@@ -860,6 +874,26 @@ describe("processAccountFollowUps - dedup logic", () => {
       }),
     );
     expect(generateFollowUpDraft).not.toHaveBeenCalled();
+  });
+
+  it("excludes already follow-up-labeled threads from candidate scans", async () => {
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi.fn().mockResolvedValue([]),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(provider.getThreadsWithQuery).toHaveBeenCalledWith({
+      query: {
+        labelId: "awaiting-label",
+        excludeLabelNames: ["Follow-up"],
+      },
+      maxResults: 50,
+    });
   });
 
   it("uses the recipient as the notification counterparty for awaiting follow-ups", async () => {

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -47,6 +47,7 @@ import {
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 import { env } from "@/env";
+import { FOLLOW_UP_LABEL } from "@/utils/label";
 
 const FOLLOW_UP_ELIGIBILITY_WINDOW_MINUTES = 15;
 const FOLLOW_UP_THREAD_SCAN_LIMIT = 50;
@@ -337,8 +338,11 @@ async function processFollowUpsForType({
     labelId = found.id;
   }
 
-  const threads = await provider.getThreadsWithLabel({
-    labelId,
+  const { threads } = await provider.getThreadsWithQuery({
+    query: {
+      labelId,
+      excludeLabelNames: [FOLLOW_UP_LABEL],
+    },
     maxResults: FOLLOW_UP_THREAD_SCAN_LIMIT,
   });
 


### PR DESCRIPTION
Updates follow-up candidate scans to use the existing thread query API with the follow-up label excluded, so completed candidates do not remain in the hourly source-label scan.

- Excludes already-followed-up threads from follow-up candidate scans
- Adds regression coverage for follow-up candidate filtering

Validation:
- pnpm test app/api/follow-up-reminders/process.test.ts
- pnpm test utils/email/google.test.ts utils/email/microsoft.test.ts
- pnpm lint
- pnpm --filter inbox-zero-ai build:ci