### PR TITLE
Fix rule suggestion rendering

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -201,6 +201,44 @@ describe("AssistantInlineEmailResponse", () => {
     });
   });
 
+  it("renders rule suggestions with attributes split across lines", () => {
+    render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        [
+          "\n<rule-suggestions>\n",
+          "<rule-suggestion\n",
+          'name="ProfitWell Updates"\n',
+          'when="emails from product@profitwell.com regarding goal updates"\n',
+          'archive="true"\n',
+          'label="Notification" />\n',
+          "<rule-suggestion\n",
+          'name="Sentry Alerts"\n',
+          'when="emails from noreply@sentry.io regarding infrastructure or load balancer changes"\n',
+          'archive="true"\n',
+          'label="Notification" />\n',
+          "</rule-suggestions>\n",
+        ].join(""),
+      ),
+    );
+
+    expect(screen.getByText("ProfitWell Updates")).toBeTruthy();
+    expect(screen.getByText("Sentry Alerts")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "emails from product@profitwell.com regarding goal updates",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "emails from noreply@sentry.io regarding infrastructure or load balancer changes",
+      ),
+    ).toBeTruthy();
+    expect(screen.getAllByText("Label as 'Notification'")).toHaveLength(2);
+    expect(screen.getAllByText("Archive")).toHaveLength(2);
+  });
+
   it("renders free-form rule suggestion actions as plain text", () => {
     render(
       createElement(

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -41,22 +41,43 @@ const components = {
 const literalTagContent = ["email", "email-detail", "rule-suggestion"];
 
 export const AssistantInlineEmailResponse = memo(
-  ({ className, ...props }: AssistantInlineEmailResponseProps) =>
-    createElement(Streamdown, {
-      className: cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-        "[&_[data-streamdown='heading-1']]:!mt-8",
-        "[&_[data-streamdown='heading-2']]:!mt-8",
-        "[&_[data-streamdown='heading-3']]:!mt-7",
-        "[&_a]:!text-inherit [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80",
-        className,
-      ),
-      allowedTags,
-      components,
-      literalTagContent,
-      normalizeHtmlIndentation: true,
-      ...props,
-    }),
+  ({ className, children, ...props }: AssistantInlineEmailResponseProps) =>
+    createElement(
+      Streamdown,
+      {
+        className: cn(
+          "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          "[&_[data-streamdown='heading-1']]:!mt-8",
+          "[&_[data-streamdown='heading-2']]:!mt-8",
+          "[&_[data-streamdown='heading-3']]:!mt-7",
+          "[&_a]:!text-inherit [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80",
+          className,
+        ),
+        allowedTags,
+        components,
+        literalTagContent,
+        normalizeHtmlIndentation: true,
+        ...props,
+      },
+      normalizeSelfClosingAllowedTags(children),
+    ),
 );
 
 AssistantInlineEmailResponse.displayName = "AssistantInlineEmailResponse";
+
+const selfClosingAllowedTagPattern = new RegExp(
+  `<(${Object.keys(allowedTags).join("|")})(\\s(?:[^"'<>]|"[^"]*"|'[^']*')*)?\\s*/>`,
+  "gi",
+);
+
+function normalizeSelfClosingAllowedTags(
+  children: AssistantInlineEmailResponseProps["children"],
+) {
+  if (typeof children !== "string" || !children.includes("/>")) return children;
+
+  return children.replace(
+    selfClosingAllowedTagPattern,
+    (_match, tagName: string, attributes = "") =>
+      `<${tagName}${attributes}></${tagName}>`,
+  );
+}


### PR DESCRIPTION
Fix assistant chat rendering so self-closing supported inline tags are normalized before Streamdown parses responses. This prevents rule suggestions with multi-line attributes from appearing as raw markup.

- Normalizes self-closing allowed assistant tags into explicit open/close pairs before rendering.
- Adds regression coverage for multi-line rule suggestion attributes.
- Test: `pnpm test components/assistant-chat/assistant-inline-email-response.test.tsx`

Performance impact: Adds a small string check and replacement only for string chat responses containing self-closing markup; no database or network calls; low hot-path risk.