### PR TITLE
Fix Slack draft notification actions

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -1005,15 +1005,20 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
         ts: rootMessageId!,
       });
 
-      const texts =
-        replies.messages?.map((message) => message.text || "") || [];
-      expect(texts.some((text) => text.includes(firstSubject))).toBe(true);
-      expect(texts.some((text) => text.includes(secondSubject))).toBe(true);
       expect(replies.messages).toHaveLength(2);
+      const firstMessage = replies.messages?.find((message) =>
+        message.text?.includes(firstSubject),
+      );
+      const secondMessage = replies.messages?.find((message) =>
+        message.text?.includes(secondSubject),
+      );
+      expect(firstMessage?.ts).toBeTruthy();
+      expect(secondMessage?.ts).toBeTruthy();
+      expect(secondMessage?.ts).not.toBe(rootMessageId);
       expect(prisma.executedAction.update).toHaveBeenLastCalledWith({
         where: { id: "thread-action-2" },
         data: {
-          messagingMessageId: rootMessageId,
+          messagingMessageId: secondMessage?.ts,
           messagingMessageSentAt: expect.any(Date),
           messagingMessageStatus: "SENT",
         },

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -381,7 +381,7 @@ async function sendSlackRuleNotificationWithContext({
     await prisma.executedAction.update({
       where: { id: context.id },
       data: {
-        messagingMessageId: rootMessageId ?? responseTs ?? null,
+        messagingMessageId: responseTs ?? rootMessageId ?? null,
         messagingMessageSentAt: new Date(),
         messagingMessageStatus: MessagingMessageStatus.SENT,
       },


### PR DESCRIPTION
Stores each threaded Slack notification's own message timestamp so later action-button updates target the correct reply. Adds integration coverage for threaded notification timestamps after a draft notification.

- Persist Slack reply timestamps before falling back to the root message timestamp.
- Update Slack notification integration coverage for per-reply message IDs.
- Tests: `pnpm --filter inbox-zero-ai test-integration -- slack-notifications.test.ts`