### PR TITLE
Fix Gmail draft threading

### DIFF
--- a/apps/web/__tests__/integration/slack-notifications.test.ts
+++ b/apps/web/__tests__/integration/slack-notifications.test.ts
@@ -571,7 +571,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       } = await import("@/utils/messaging/rule-notifications");
 
       const gmailEmail = "slack-draft-send@example.com";
-      const subject = getUniqueSubject("Edited draft");
+      const subject = getUniqueSubject("Edited draft câfé 👀🔍");
       const editedContent = "I reviewed this and sent the update.";
       const gmailHarness = await createGmailTestHarness({
         port: 4112,
@@ -857,7 +857,10 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
           sentMessageId!,
         );
 
-        expect(sentReply.headers.subject).toBe(`Re: ${subject}`);
+        expect(sentReply.threadId).toBe(sourceMessage.threadId);
+        expect(decodeMimeSubject(sentReply.headers.subject)).toBe(
+          `Re: ${subject}`,
+        );
         expect(sentReply.textPlain || sentReply.textHtml || "").toContain(
           editedContent,
         );
@@ -1336,4 +1339,44 @@ function getActionLabels(blocks: unknown[] | undefined) {
 
 function getUniqueSubject(prefix: string) {
   return `${prefix} ${Date.now()} ${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function decodeMimeSubject(subject: string) {
+  const unfolded = subject.replace(/\r?\n[ \t]+/g, " ");
+  const encodedWordPattern = /=\?UTF-8\?([QB])\?([^?]+)\?=/gi;
+  let decoded = "";
+  let cursor = 0;
+  let match = encodedWordPattern.exec(unfolded);
+
+  while (match) {
+    decoded += unfolded.slice(cursor, match.index);
+    decoded += decodeMimeWord(match[1], match[2]);
+    cursor = encodedWordPattern.lastIndex;
+
+    const adjacentEncodedWordSpace = /^\s+(?==\?UTF-8\?[QB]\?)/i.exec(
+      unfolded.slice(cursor),
+    );
+    if (adjacentEncodedWordSpace) {
+      cursor += adjacentEncodedWordSpace[0].length;
+      encodedWordPattern.lastIndex = cursor;
+    }
+
+    match = encodedWordPattern.exec(unfolded);
+  }
+
+  return decoded + unfolded.slice(cursor);
+}
+
+function decodeMimeWord(encoding: string, value: string) {
+  if (encoding.toUpperCase() === "B") {
+    return Buffer.from(value, "base64").toString("utf8");
+  }
+
+  const binary = value
+    .replace(/_/g, " ")
+    .replace(/=([0-9A-F]{2})/gi, (_match, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    );
+
+  return Buffer.from(binary, "binary").toString("utf8");
 }

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -5,7 +5,7 @@ import { GmailLabel } from "@/utils/gmail/label";
 import * as gmailLabelModule from "@/utils/gmail/label";
 import { GmailProvider } from "./google";
 
-const { envMock, gmailMailMock } = vi.hoisted(() => ({
+const { envMock, gmailMailMock, gmailDraftMock } = vi.hoisted(() => ({
   envMock: {
     NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
     EMAIL_ENCRYPT_SECRET: "test-encrypt-secret",
@@ -18,13 +18,23 @@ const { envMock, gmailMailMock } = vi.hoisted(() => ({
     sendEmailWithPlainText: vi.fn(),
     sendEmailWithHtml: vi.fn(),
   },
+  gmailDraftMock: {
+    getDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+    sendDraft: vi.fn(),
+  },
 }));
 
 vi.mock("@/env", () => ({
   env: envMock,
 }));
 
-vi.mock("@/utils/gmail/mail", () => gmailMailMock);
+vi.mock("@/utils/gmail/mail", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/gmail/mail")>();
+  return { ...actual, ...gmailMailMock };
+});
+
+vi.mock("@/utils/gmail/draft", () => gmailDraftMock);
 
 describe("GmailProvider.getLatestMessageInThread", () => {
   afterEach(() => {
@@ -150,6 +160,58 @@ describe("GmailProvider.getSentMessageIds", () => {
   });
 });
 
+describe("GmailProvider.updateDraft", () => {
+  it("keeps Gmail threading metadata and MIME-encodes non-ASCII subjects", async () => {
+    const update = vi.fn().mockResolvedValue({ data: {} });
+    const provider = new GmailProvider({
+      users: { drafts: { update } },
+    } as any);
+    const subject = "Re: ok but you NEED to share your secrets 👀🔍";
+
+    gmailDraftMock.getDraft.mockResolvedValueOnce(
+      createParsedMessage({
+        id: "draft-message-1",
+        internalDate: "1000",
+        threadId: "thread-special",
+        subject,
+        labelIds: [GmailLabel.DRAFT],
+        headers: {
+          to: "sender@example.com",
+          subject,
+          "in-reply-to": "<original@example.com>",
+          references: "<root@example.com> <original@example.com>",
+        },
+      }),
+    );
+
+    await provider.updateDraft("r-123", {
+      subject,
+      messageHtml: "<p>Edited response.</p>",
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      userId: "me",
+      id: "r-123",
+      requestBody: {
+        message: {
+          threadId: "thread-special",
+          raw: expect.any(String),
+        },
+      },
+    });
+
+    const raw = update.mock.calls[0]?.[0]?.requestBody?.message?.raw;
+    const decodedMessage = decodeBase64Url(raw);
+
+    expect(decodedMessage).toContain("Subject: =?UTF-8?");
+    expect(decodedMessage).toContain("In-Reply-To: <original@example.com>");
+    expect(decodedMessage).toContain(
+      "References: <root@example.com> <original@example.com>",
+    );
+    expect(decodedMessage).toContain("Edited response.");
+  });
+});
+
 describe("GmailProvider.getLabels", () => {
   it("returns visible user labels by default", async () => {
     vi.spyOn(gmailLabelModule, "getLabels").mockResolvedValue([
@@ -242,29 +304,40 @@ function createThread(messages: ParsedMessage[]): EmailThread {
 function createParsedMessage({
   id,
   internalDate,
+  threadId = "thread-1",
   labelIds,
+  subject = "Subject",
+  headers,
 }: {
   id: string;
   internalDate: string;
+  threadId?: string;
   labelIds?: string[];
+  subject?: string;
+  headers?: Partial<ParsedMessage["headers"]>;
 }): ParsedMessage {
   return {
     id,
-    threadId: "thread-1",
+    threadId,
     labelIds,
     snippet: "",
     historyId: "history-1",
     inline: [],
     headers: {
-      subject: "Subject",
+      subject,
       from: "sender@example.com",
       to: "recipient@example.com",
       date: "Mon, 01 Jan 2026 00:00:00 +0000",
+      ...headers,
     },
-    subject: "Subject",
+    subject,
     date: "Mon, 01 Jan 2026 00:00:00 +0000",
     internalDate,
     textPlain: "",
     textHtml: "",
   };
+}
+
+function decodeBase64Url(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
 }

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -27,12 +27,15 @@ import type { InboxZeroLabel } from "@/utils/label";
 import type { ThreadsQuery } from "@/utils/threads/validation";
 import { getMessageByRfc822Id } from "@/utils/gmail/message";
 import {
+  createMail,
   draftEmail,
   forwardEmail,
   replyToEmail,
   sendEmailWithPlainText,
   sendEmailWithHtml,
 } from "@/utils/gmail/mail";
+import { convertEmailHtmlToText } from "@/utils/mail";
+import { buildThreadingHeaders } from "@/utils/email/threading";
 import {
   archiveThread,
   labelMessage,
@@ -78,18 +81,6 @@ import { createScopedLogger, type Logger } from "@/utils/logger";
 import { getGmailSignatures } from "@/utils/gmail/signature-settings";
 import { withRateLimitRecording } from "@/utils/email/rate-limit";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
-
-/**
- * Build a raw RFC 2822 message and encode it as base64url for Gmail API
- */
-function buildRawMessageBase64(headers: string[], body: string): string {
-  const rawMessage = `${headers.join("\r\n")}\r\n\r\n${body}`;
-  return Buffer.from(rawMessage)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
 
 export class GmailProvider implements EmailProvider {
   readonly name = "google";
@@ -724,28 +715,32 @@ export class GmailProvider implements EmailProvider {
       replyToMessageId: params.replyToMessageId,
     });
 
-    // Build the raw email message
-    const headers = [
-      `To: ${params.to}`,
-      `Subject: ${params.subject}`,
-      "Content-Type: text/html; charset=utf-8",
-    ];
+    let threadId: string | undefined;
+    let headerMessageId = "";
+    let parentReferences: string | undefined;
 
-    // Add threading headers if replying
     if (params.replyToMessageId) {
       try {
         const originalMessage = await this.getMessage(params.replyToMessageId);
-        const messageIdHeader = originalMessage.headers?.["message-id"];
-        if (messageIdHeader) {
-          headers.push(`In-Reply-To: ${messageIdHeader}`);
-          headers.push(`References: ${messageIdHeader}`);
-        }
+        threadId = originalMessage.threadId;
+        headerMessageId = originalMessage.headers?.["message-id"] || "";
+        parentReferences = originalMessage.headers?.references;
       } catch {
         this.logger.warn("Could not get original message for threading");
       }
     }
 
-    const encodedMessage = buildRawMessageBase64(headers, params.messageHtml);
+    const encodedMessage = await createMail({
+      to: params.to,
+      subject: params.subject,
+      text: convertEmailHtmlToText({ htmlText: params.messageHtml }),
+      html: params.messageHtml,
+      ...buildThreadingHeaders({
+        headerMessageId,
+        references: parentReferences,
+      }),
+      headers: { "X-Mailer": "Inbox Zero Web" },
+    });
 
     const result = await withGmailRetry(() =>
       this.client.users.drafts.create({
@@ -753,7 +748,7 @@ export class GmailProvider implements EmailProvider {
         requestBody: {
           message: {
             raw: encodedMessage,
-            // Threading is handled by In-Reply-To/References headers, not threadId
+            threadId,
           },
         },
       }),
@@ -778,26 +773,21 @@ export class GmailProvider implements EmailProvider {
       throw new Error(`Draft ${draftId} not found`);
     }
 
-    // Build updated message
     const subject = params.subject || currentDraft.subject || "";
     const content = params.messageHtml || currentDraft.textHtml || "";
 
-    // Get the To address from the current draft headers
-    const toAddress = currentDraft.headers?.to || "";
-
-    const headers = [
-      `To: ${toAddress}`,
-      `Subject: ${subject}`,
-      "Content-Type: text/html; charset=utf-8",
-    ];
-
-    // Preserve threading headers for reply drafts
-    const inReplyTo = currentDraft.headers?.["in-reply-to"];
-    const references = currentDraft.headers?.references;
-    if (inReplyTo) headers.push(`In-Reply-To: ${inReplyTo}`);
-    if (references) headers.push(`References: ${references}`);
-
-    const encodedMessage = buildRawMessageBase64(headers, content);
+    const encodedMessage = await createMail({
+      to: currentDraft.headers?.to || "",
+      cc: currentDraft.headers?.cc,
+      bcc: currentDraft.headers?.bcc,
+      replyTo: currentDraft.headers?.["reply-to"],
+      subject,
+      text: convertEmailHtmlToText({ htmlText: content }),
+      html: content,
+      inReplyTo: currentDraft.headers?.["in-reply-to"],
+      references: currentDraft.headers?.references,
+      headers: { "X-Mailer": "Inbox Zero Web" },
+    });
 
     await withGmailRetry(() =>
       this.client.users.drafts.update({
@@ -805,6 +795,7 @@ export class GmailProvider implements EmailProvider {
         id: draftId,
         requestBody: {
           message: {
+            threadId: currentDraft.threadId,
             raw: encodedMessage,
           },
         },

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -59,7 +59,7 @@ const encodeMessage = (message: Buffer) =>
     .replace(/\//g, "_")
     .replace(/=+$/, "");
 
-const createMail = async (options: Mail.Options) => {
+export const createMail = async (options: Mail.Options) => {
   const mailComposer = new MailComposer(options);
   const message = await mailComposer.compile().build();
   return encodeMessage(message);


### PR DESCRIPTION
Fix Gmail draft create and update paths to preserve reply threading while using the shared MIME composer. This keeps edited reply drafts in the existing conversation and handles encoded subjects correctly.

- Reuses the shared Gmail MIME assembly for draft create/update raw messages.
- Preserves thread IDs and reply headers when creating or updating drafts.
- Adds focused unit coverage for encoded draft subjects and updates the notification integration expectation.
- Tests: `pnpm test utils/email/google.test.ts __tests__/integration/slack-notifications.test.ts` (integration spec skipped by env guard).
- Performance impact: no new database calls; Gmail network calls stay limited to the existing draft and reply-thread operations; MIME assembly adds small CPU work outside hot paths.