### PR TITLE
Fix messaging draft send state

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -257,6 +257,7 @@ describe("handleRuleNotificationAction", () => {
 
     expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
     expect(provider.sendEmailWithHtml).not.toHaveBeenCalled();
+    expect(prisma.executedAction.update).toHaveBeenCalledTimes(1);
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -181,6 +181,92 @@ describe("handleRuleNotificationAction", () => {
     );
   });
 
+  it("sends the existing Gmail draft when the Slack action owns the draft id", async () => {
+    const provider = {
+      sendDraft: vi
+        .fn()
+        .mockResolvedValue({ messageId: "sent-1", threadId: "thread-1" }),
+      sendEmailWithHtml: vi.fn().mockResolvedValue(undefined),
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Thanks for the note.",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Thanks for the note.",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+
+    mockNotificationContext({
+      id: "action-1",
+      type: ActionType.DRAFT_EMAIL,
+      content: "Thanks for the note.",
+      draftId: "draft-1",
+      subject: "Re: Test subject",
+    });
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = createSlackActionEvent({
+      actionId: "rule_draft_send",
+      value: "action-1",
+      editMessage,
+    });
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger,
+    });
+
+    expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(provider.sendEmailWithHtml).not.toHaveBeenCalled();
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
+        messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+      },
+    });
+    expect(editMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("closes the Slack edit modal when the draft sends but the message update fails", async () => {
     const provider = {
       updateDraft: vi.fn().mockResolvedValue(undefined),
@@ -2334,6 +2420,8 @@ function getNotificationContext({
   accountProvider = "google",
   messagingMessageId = null,
   messagingMessageStatus = null,
+  draftId = null,
+  subject = null,
   mailboxDraftAction = null,
   staticAttachments = null,
   selectedAttachments = null,
@@ -2341,6 +2429,8 @@ function getNotificationContext({
   id: string;
   type: ActionType;
   content: string | null;
+  draftId?: string | null;
+  subject?: string | null;
   messagingChannel?: {
     id: string;
     emailAccountId?: string;
@@ -2393,11 +2483,11 @@ function getNotificationContext({
     id,
     type,
     content,
-    subject: null,
+    subject,
     to: null,
     cc: null,
     bcc: null,
-    draftId: null,
+    draftId,
     staticAttachments,
     selectedAttachments,
     messagingChannelId: "channel-1",

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -969,7 +969,7 @@ async function sendDraftReplyFromNotification({
           messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
         },
       }),
-      ...(mailboxDraftAction?.id
+      ...(mailboxDraftAction?.id && mailboxDraftAction.id !== context.id
         ? [
             prisma.executedAction.update({
               where: { id: mailboxDraftAction.id },
@@ -1540,6 +1540,14 @@ async function getNotificationContext(executedActionId: string) {
 }
 
 function getMailboxDraftActionForMessagingDraft(context: NotificationContext) {
+  if (context.draftId) {
+    return {
+      id: context.id,
+      draftId: context.draftId,
+      subject: context.subject,
+    };
+  }
+
   return context.executedRule.actionItems?.[0] ?? null;
 }
 


### PR DESCRIPTION
Fixes the messaging notification send flow so an action that already owns a mailbox draft sends that existing draft and keeps the action state consistent.

- Uses the current notification action as the mailbox draft source when it already has a draft id.
- Avoids updating the same executed action twice after a draft send.
- Tests: `pnpm test utils/messaging/rule-notifications.test.ts`