### PR TITLE
Fix assistant reply-all recipients

### DIFF
--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -517,12 +517,14 @@ async function confirmPendingReplyEmailAction({
     output.reference?.threadId,
   );
   const from = await getFormattedSenderAddress({ emailAccountId });
-  const replyOptions = from ? { from } : undefined;
   const sentAfter = new Date();
   await emailProvider.replyToEmail(
     message,
     contentOverride || output.pendingAction.content,
-    replyOptions,
+    {
+      ...(from ? { from } : {}),
+      ...(output.pendingAction.replyAll ? { replyAll: true } : {}),
+    },
   );
 
   const messageId = await resolveSentMessageId({

--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -518,12 +518,14 @@ async function confirmPendingReplyEmailAction({
     output.reference?.threadId,
   );
   const from = await getFormattedSenderAddress({ emailAccountId });
-  const replyOptions = from ? { from } : undefined;
   const sentAfter = new Date();
   await emailProvider.replyToEmail(
     message,
     contentOverride || output.pendingAction.content,
-    replyOptions,
+    {
+      ...(from ? { from } : {}),
+      ...(output.pendingAction.replyAll ? { replyAll: true } : {}),
+    },
   );
 
   const messageId = await resolveSentMessageId({

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -320,6 +320,62 @@ describe("confirmAssistantEmailAction", () => {
     });
   });
 
+  it("sends a pending prepared reply all with the account email for recipient exclusion", async () => {
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildPendingReplyPart({ replyAll: true })],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sourceMessage = {
+      id: "source-message-1",
+      threadId: "thread-1",
+      headers: {
+        from: "sender@example.com",
+        to: "owner@example.com, teammate@example.com",
+        cc: "manager@example.com",
+        subject: "Original subject",
+      },
+      subject: "Original subject",
+    };
+    const replyToEmail = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessage: vi.fn().mockResolvedValue(sourceMessage),
+      replyToEmail,
+      getSentMessageIds: vi.fn().mockResolvedValue({
+        messages: [{ id: "reply-message-2", threadId: "thread-1" }],
+      }),
+    } as any);
+
+    await confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "reply_email",
+      } as any,
+    );
+
+    expect(replyToEmail).toHaveBeenCalledWith(sourceMessage, "Thanks!", {
+      from: "Owner <owner@example.com>",
+      replyAll: true,
+    });
+  });
+
   it("sends a pending prepared forward and persists confirmed output", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
@@ -1534,7 +1590,7 @@ function confirmPendingSendEmail() {
   );
 }
 
-function buildPendingReplyPart() {
+function buildPendingReplyPart({ replyAll = false } = {}) {
   return {
     type: "tool-replyEmail",
     toolCallId: "tool-1",
@@ -1547,6 +1603,7 @@ function buildPendingReplyPart() {
       pendingAction: {
         messageId: "source-message-1",
         content: "Thanks!",
+        replyAll,
       },
       reference: {
         messageId: "source-message-1",

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -385,6 +385,62 @@ describe("confirmAssistantEmailAction", () => {
     });
   });
 
+  it("sends a pending prepared reply all with replyAll enabled", async () => {
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildPendingReplyPart({ replyAll: true })],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+
+    const sourceMessage = {
+      id: "source-message-1",
+      threadId: "thread-1",
+      headers: {
+        from: "sender@example.com",
+        to: "owner@example.com, teammate@example.com",
+        cc: "manager@example.com",
+        subject: "Original subject",
+      },
+      subject: "Original subject",
+    };
+    const replyToEmail = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessage: vi.fn().mockResolvedValue(sourceMessage),
+      replyToEmail,
+      getSentMessageIds: vi.fn().mockResolvedValue({
+        messages: [{ id: "reply-message-2", threadId: "thread-1" }],
+      }),
+    } as any);
+
+    await confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "reply_email",
+      } as any,
+    );
+
+    expect(replyToEmail).toHaveBeenCalledWith(sourceMessage, "Thanks!", {
+      from: "Owner <owner@example.com>",
+      replyAll: true,
+    });
+  });
+
   it("sends a pending prepared forward and persists confirmed output", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
@@ -1647,7 +1703,7 @@ function confirmPendingSendEmail() {
   );
 }
 
-function buildPendingReplyPart() {
+function buildPendingReplyPart({ replyAll = false } = {}) {
   return {
     type: "tool-replyEmail",
     toolCallId: "tool-1",
@@ -1661,6 +1717,13 @@ function buildPendingReplyPart() {
       pendingAction: {
         messageId: "source-message-1",
         content: "Thanks!",
+        ...(replyAll
+          ? {
+              replyAll: true,
+              to: "sender@example.com",
+              cc: "teammate@example.com, manager@example.com",
+            }
+          : {}),
       },
       reference: {
         messageId: "source-message-1",

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -53,6 +53,7 @@ export const pendingReplyEmailToolOutputSchema = z.object({
   pendingAction: z.object({
     messageId: z.string().trim().min(1),
     content: z.string().trim().min(1),
+    replyAll: z.boolean().optional(),
   }),
   reference: z
     .object({

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -59,6 +59,9 @@ export const pendingReplyEmailToolOutputSchema = z.object({
   pendingAction: z.object({
     messageId: z.string().trim().min(1),
     content: z.string().trim().min(1),
+    replyAll: z.boolean().optional(),
+    to: z.string().nullish(),
+    cc: z.string().nullish(),
   }),
   reference: z
     .object({

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -183,6 +183,54 @@ describe("chat inbox tools", () => {
     });
   });
 
+  it("preserves reply-all intent in the pending reply action", async () => {
+    const message: ParsedMessage = {
+      id: "message-1",
+      threadId: "thread-1",
+      snippet: "",
+      historyId: "",
+      inline: [],
+      headers: {
+        from: "contact@example.com",
+        to: `${TEST_EMAIL}, teammate@example.com`,
+        cc: "manager@example.com",
+        subject: "Question",
+        date: "2026-02-18T00:00:00.000Z",
+      },
+      subject: "Question",
+      date: "2026-02-18T00:00:00.000Z",
+    };
+
+    const getMessage = vi.fn().mockResolvedValue(message);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessage,
+    } as any);
+
+    const toolInstance = replyEmailTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      messageId: "message-1",
+      content: "Thanks for the update.",
+      replyAll: true,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      actionType: "reply_email",
+      pendingAction: {
+        messageId: "message-1",
+        content: "Thanks for the update.",
+        replyAll: true,
+      },
+    });
+  });
+
   it("prepares forward flow without sending immediately", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       name: "Test User",

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -193,6 +193,60 @@ describe("chat inbox tools", () => {
         threadId: "thread-1",
       },
     });
+    expect(result.pendingAction).not.toHaveProperty("replyAll");
+  });
+
+  it("preserves reply-all recipients in the pending reply action", async () => {
+    const message: ParsedMessage = {
+      id: "message-1",
+      threadId: "thread-1",
+      snippet: "",
+      historyId: "",
+      inline: [],
+      headers: {
+        from: "contact@example.com",
+        to: `${TEST_EMAIL}, teammate@example.com`,
+        cc: "manager@example.com",
+        subject: "Question",
+        date: "2026-02-18T00:00:00.000Z",
+      },
+      subject: "Question",
+      date: "2026-02-18T00:00:00.000Z",
+    };
+
+    const getMessage = vi.fn().mockResolvedValue(message);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessage,
+    } as any);
+
+    const toolInstance = replyEmailTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      messageId: "message-1",
+      content: "Thanks for the update.",
+      replyAll: true,
+    });
+
+    expect(getMessage).toHaveBeenCalledWith("message-1");
+    expect(result).toMatchObject({
+      success: true,
+      actionType: "reply_email",
+      pendingAction: {
+        messageId: "message-1",
+        content: "Thanks for the update.",
+        replyAll: true,
+        to: "contact@example.com",
+      },
+    });
+    expect(result.pendingAction.cc).toContain("manager@example.com");
+    expect(result.pendingAction.cc).toContain("teammate@example.com");
+    expect(result.pendingAction.cc).not.toContain(TEST_EMAIL);
   });
 
   it("prepares forward flow without sending immediately", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -126,6 +126,12 @@ const replyEmailToolInputSchema = z
       .min(1)
       .max(10_000)
       .describe("Reply body content to include in the draft."),
+    replyAll: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set to true only when the user asks to reply all or include all original recipients.",
+      ),
   })
   .strict();
 const forwardEmailToolInputSchema = z
@@ -1411,6 +1417,7 @@ function createPendingReplyEmailOutput(
     pendingAction: {
       messageId: input.messageId,
       content: input.content,
+      replyAll: input.replyAll,
     },
     reference: {
       messageId: message.id,

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -17,6 +17,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
+import { buildReplyAllRecipients, formatCcList } from "@/utils/email/reply-all";
 import { runWithBoundedConcurrency } from "@/utils/async";
 import { findNestedLabelMatches } from "@/utils/label/find-nested-label-matches";
 import { normalizeLabelName } from "@/utils/label/normalize-label-name";
@@ -112,6 +113,12 @@ const replyEmailToolInputSchema = z
       .min(1)
       .max(10_000)
       .describe("Reply body content to include in the draft."),
+    replyAll: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set to true only when the user asks to reply all or include all original recipients.",
+      ),
   })
   .strict();
 const forwardEmailToolInputSchema = z
@@ -1310,6 +1317,7 @@ export const replyEmailTool = ({
           parsedInput.data,
           message,
           emailAccountId,
+          email,
         );
       } catch (error) {
         logger.error("Failed to prepare reply from chat", { error });
@@ -1432,7 +1440,13 @@ function createPendingReplyEmailOutput(
   input: z.infer<typeof replyEmailToolInputSchema>,
   message: ParsedMessage,
   emailAccountId: string,
+  userEmail: string,
 ) {
+  const replyAll = input.replyAll === true;
+  const replyAllRecipients = replyAll
+    ? buildReplyAllRecipients(message.headers, undefined, userEmail)
+    : null;
+
   return {
     success: true,
     emailAccountId,
@@ -1442,6 +1456,13 @@ function createPendingReplyEmailOutput(
     pendingAction: {
       messageId: input.messageId,
       content: input.content,
+      ...(replyAllRecipients
+        ? {
+            replyAll: true,
+            to: replyAllRecipients.to,
+            cc: formatCcList(replyAllRecipients.cc) ?? null,
+          }
+        : {}),
     },
     reference: {
       messageId: message.id,

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -378,6 +378,85 @@ describe("GmailProvider.getLatestMessageInThread", () => {
 
     expect(latest).toBeNull();
   });
+});
+
+describe("GmailProvider.replyToEmail", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    gmailMailMock.replyToEmail.mockReset();
+    gmailSignatureMock.getGmailSignatures.mockResolvedValue([]);
+  });
+
+  it("passes send-as aliases when sending a reply all", async () => {
+    gmailSignatureMock.getGmailSignatures.mockResolvedValue([
+      {
+        email: "user@example.com",
+        signature: "",
+        isDefault: true,
+      },
+      {
+        email: "alias@example.com",
+        signature: "",
+        isDefault: false,
+      },
+    ]);
+    gmailMailMock.replyToEmail.mockResolvedValue({ data: { id: "sent-1" } });
+    const provider = new GmailProvider({} as any);
+    const message = createParsedMessage({
+      id: "message-1",
+      internalDate: "1000",
+    });
+
+    await provider.replyToEmail(message, "Thanks", {
+      from: "User <user@example.com>",
+      replyAll: true,
+    });
+
+    expect(gmailMailMock.replyToEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      message,
+      "Thanks",
+      "User <user@example.com>",
+      expect.objectContaining({
+        replyAll: true,
+        userEmails: ["user@example.com", "alias@example.com"],
+      }),
+    );
+  });
+
+  it("does not fetch send-as aliases for a sender-only reply", async () => {
+    gmailMailMock.replyToEmail.mockResolvedValue({ data: { id: "sent-1" } });
+    const provider = new GmailProvider({} as any);
+    const message = createParsedMessage({
+      id: "message-1",
+      internalDate: "1000",
+    });
+
+    await provider.replyToEmail(message, "Thanks", {
+      from: "User <user@example.com>",
+    });
+
+    expect(gmailSignatureMock.getGmailSignatures).not.toHaveBeenCalled();
+    expect(gmailMailMock.replyToEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      message,
+      "Thanks",
+      "User <user@example.com>",
+      expect.objectContaining({
+        replyAll: undefined,
+        userEmails: undefined,
+      }),
+    );
+  });
+});
+
+describe("GmailProvider.draftEmail", () => {
+  afterEach(() => {
+    envMock.NEXT_PUBLIC_AUTO_DRAFT_DISABLED = false;
+    vi.clearAllMocks();
+    gmailMailMock.draftEmail.mockResolvedValue({ data: { id: "draft-1" } });
+    gmailSignatureMock.getGmailSignatures.mockResolvedValue([]);
+  });
 
   it("no-ops draftEmail when auto-drafting is disabled", async () => {
     envMock.NEXT_PUBLIC_AUTO_DRAFT_DISABLED = true;

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -874,6 +874,7 @@ export class GmailProvider implements EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<void> {
     await replyToEmail(this.client, email, content, options?.from, options);

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -107,7 +107,10 @@ import { createScopedLogger, type Logger } from "@/utils/logger";
 import { getGmailSignatures } from "@/utils/gmail/signature-settings";
 import { withRateLimitRecording } from "@/utils/email/rate-limit";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
-import { extractUniqueEmailAddresses } from "@/utils/email";
+import {
+  extractEmailAddress,
+  extractUniqueEmailAddresses,
+} from "@/utils/email";
 import { requireSentMessageId } from "@/utils/email/sent-message-id";
 import { getGmailMailboxSyncPage } from "@/utils/gmail/mailbox-sync";
 
@@ -1083,14 +1086,26 @@ export class GmailProvider implements EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<{ messageId: string }> {
+    const userEmails =
+      options?.replyAll === true
+        ? await this.getSelfEmailAddresses(
+            extractEmailAddress(options.from || ""),
+          )
+        : undefined;
     const result = await replyToEmail(
       this.client,
       email,
       content,
       options?.from,
-      options,
+      {
+        replyTo: options?.replyTo,
+        attachments: options?.attachments,
+        replyAll: options?.replyAll,
+        userEmails,
+      },
     );
     return { messageId: requireSentMessageId(result.data.id) };
   }

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -685,6 +685,7 @@ export class OutlookProvider implements EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<void> {
     await replyToEmail(this.client, email, content, this.logger, options);

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -795,6 +795,7 @@ export class OutlookProvider implements EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<{ messageId: string }> {
     const result = await replyToEmail(

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -241,6 +241,7 @@ export interface EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<void>;
   searchMessages(options: {

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -320,6 +320,7 @@ export interface EmailProvider {
       replyTo?: string;
       from?: string;
       attachments?: MailAttachment[];
+      replyAll?: boolean;
     },
   ): Promise<{ messageId: string }>;
   searchContacts(query: string): Promise<EmailContact[]>;

--- a/apps/web/utils/gmail/mail.test.ts
+++ b/apps/web/utils/gmail/mail.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vitest";
+import type { gmail_v1 } from "@googleapis/gmail";
+import { describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import { formatEmailDate } from "@/utils/gmail/reply";
 
 import {
   buildReplyMessageText,
   convertTextToHtmlParagraphs,
+  replyToEmail,
 } from "@/utils/gmail/mail";
+
+vi.mock("@/utils/mail", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/mail")>();
+  return {
+    ...actual,
+    ensureEmailSendingEnabled: vi.fn(),
+  };
+});
 
 describe("convertTextToHtmlParagraphs", () => {
   it("preserves paragraph spacing with double newlines", () => {
@@ -80,4 +90,52 @@ describe("convertTextToHtmlParagraphs", () => {
     expect(plainText).toContain("> Original message content");
     expect(plainText).not.toContain("<a href=");
   });
+
+  it("includes original to and cc recipients when sending a reply all", async () => {
+    const send = vi.fn(async () => ({
+      data: { id: "sent-message-1", threadId: "thread-1" },
+    }));
+    const gmail = {
+      users: {
+        messages: {
+          send,
+        },
+      },
+    } as unknown as gmail_v1.Gmail;
+
+    await replyToEmail(
+      gmail,
+      {
+        threadId: "thread-1",
+        headers: {
+          from: "Sender <sender@example.com>",
+          to: "Owner <owner@example.com>, Teammate <teammate@example.com>",
+          cc: "Manager <manager@example.com>",
+          subject: "Project update",
+          date: "Thu, 6 Feb 2025 23:23:47 +0200",
+          "message-id": "<original@example.com>",
+        },
+        textPlain: "Original message content",
+        textHtml: "<div>Original message content</div>",
+      },
+      "Thanks for the update.",
+      "Owner <owner@example.com>",
+      {
+        replyAll: true,
+      },
+    );
+
+    const raw = send.mock.calls[0][0].requestBody.raw;
+    const decoded = decodeRawMessage(raw);
+
+    expect(decoded).toContain("To: Sender <sender@example.com>");
+    expect(decoded).toContain("Cc: manager@example.com, teammate@example.com");
+    expect(decoded).not.toContain("owner@example.com,");
+  });
 });
+
+function decodeRawMessage(raw: string) {
+  return Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64")
+    .toString("utf8")
+    .replace(/\r\n/g, "\n");
+}

--- a/apps/web/utils/gmail/mail.test.ts
+++ b/apps/web/utils/gmail/mail.test.ts
@@ -2,12 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
 import { formatEmailDate } from "@/utils/gmail/reply";
 
+import type { gmail_v1 } from "@googleapis/gmail";
 import {
   buildReplyMessageText,
   createMail,
   convertTextToHtmlParagraphs,
+  replyToEmail,
   stripHtmlTagsForPlainText,
 } from "@/utils/gmail/mail";
+
+vi.mock("@/utils/mail", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/mail")>();
+  return {
+    ...actual,
+    ensureEmailSendingEnabled: vi.fn(),
+  };
+});
 
 describe("createMail", () => {
   it("keeps BCC recipients in raw messages sent through the Gmail API", async () => {
@@ -48,11 +58,6 @@ describe("createMail", () => {
     expect(message).toContain('src="cid:diagram@example"');
   });
 });
-
-vi.mock("@/utils/mail", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/utils/mail")>()),
-  ensureEmailSendingEnabled: vi.fn(),
-}));
 
 describe("convertTextToHtmlParagraphs", () => {
   it("separates paragraphs on blank lines", () => {
@@ -124,6 +129,54 @@ describe("convertTextToHtmlParagraphs", () => {
   });
 });
 
+describe("replyToEmail", () => {
+  it("includes original to and cc recipients when sending a reply all", async () => {
+    const send = vi.fn(async () => ({
+      data: { id: "sent-message-1", threadId: "thread-1" },
+    }));
+    const gmail = {
+      users: {
+        messages: {
+          send,
+        },
+      },
+    } as unknown as gmail_v1.Gmail;
+
+    await replyToEmail(
+      gmail,
+      {
+        threadId: "thread-1",
+        headers: {
+          from: "Sender <sender@example.com>",
+          to: "Owner <owner@example.com>, Teammate <teammate@example.com>",
+          cc: "Manager <manager@example.com>",
+          subject: "Project update",
+          date: "Thu, 6 Feb 2025 23:23:47 +0200",
+          "message-id": "<original@example.com>",
+        },
+        textPlain: "Original message content",
+        textHtml: "<div>Original message content</div>",
+      },
+      "Thanks for the update.",
+      "Owner <owner@example.com>",
+      {
+        replyAll: true,
+        userEmails: ["owner@example.com", "alias@example.com"],
+      },
+    );
+
+    const raw = send.mock.calls[0][0].requestBody.raw;
+    const decoded = decodeRawMessage(raw);
+
+    expect(decoded).toContain("To: Sender <sender@example.com>");
+    expect(decoded).toContain("Cc:");
+    expect(decoded).toContain("manager@example.com");
+    expect(decoded).toContain("teammate@example.com");
+    expect(decoded).not.toContain("Cc: owner@example.com");
+    expect(decoded).not.toContain("alias@example.com");
+  });
+});
+
 describe("stripHtmlTagsForPlainText", () => {
   it("skips HTML comments while preserving surrounding text", () => {
     expect(
@@ -139,3 +192,9 @@ describe("stripHtmlTagsForPlainText", () => {
     );
   });
 });
+
+function decodeRawMessage(raw: string) {
+  return Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64")
+    .toString("utf8")
+    .replace(/\r\n/g, "\n");
+}

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -20,6 +20,7 @@ import {
   formatCcList,
   mergeAndDedupeRecipients,
 } from "@/utils/email/reply-all";
+import { extractEmailAddress } from "@/utils/email";
 import { formatReplySubject } from "@/utils/email/subject";
 import { buildThreadingHeaders } from "@/utils/email/threading";
 import { ensureEmailSendingEnabled } from "@/utils/mail";
@@ -161,7 +162,11 @@ export async function replyToEmail(
   >,
   reply: string,
   from?: string,
-  options?: { replyTo?: string; attachments?: Attachment[] },
+  options?: {
+    replyTo?: string;
+    attachments?: Attachment[];
+    replyAll?: boolean;
+  },
 ) {
   ensureEmailSendingEnabled();
 
@@ -174,10 +179,21 @@ export async function replyToEmail(
     message,
   });
 
-  // Only replying to the original sender
+  const replyAllRecipients = options?.replyAll
+    ? buildReplyAllRecipients(
+        message.headers,
+        undefined,
+        extractEmailAddress(from || ""),
+      )
+    : null;
+
   const raw = await createRawMailMessage({
-    to: message.headers["reply-to"] || message.headers.from,
+    to:
+      replyAllRecipients?.to ||
+      message.headers["reply-to"] ||
+      message.headers.from,
     from,
+    cc: replyAllRecipients ? formatCcList(replyAllRecipients.cc) : undefined,
     replyTo: options?.replyTo,
     subject: formatReplySubject(message.headers.subject),
     messageText,

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -12,6 +12,7 @@ import {
 import type { ParsedMessage } from "@/utils/types";
 import { createReplyContent, formatEmailDate } from "@/utils/gmail/reply";
 import type { EmailForAction } from "@/utils/ai/types";
+import { extractEmailAddress } from "@/utils/email";
 import { createScopedLogger, type Logger } from "@/utils/logger";
 import {
   extractErrorInfo,
@@ -190,6 +191,8 @@ export async function replyToEmail(
   options?: {
     replyTo?: string;
     attachments?: Attachment[];
+    replyAll?: boolean;
+    userEmails?: string | string[];
   },
 ) {
   ensureEmailSendingEnabled();
@@ -203,10 +206,21 @@ export async function replyToEmail(
     message,
   });
 
-  // Only replying to the original sender
+  const replyAllRecipients = options?.replyAll
+    ? buildReplyAllRecipients(
+        message.headers,
+        undefined,
+        options.userEmails ?? extractEmailAddress(from || ""),
+      )
+    : null;
+
   const raw = await createRawMailMessage({
-    to: message.headers["reply-to"] || message.headers.from,
+    to:
+      replyAllRecipients?.to ||
+      message.headers["reply-to"] ||
+      message.headers.from,
     from,
+    cc: replyAllRecipients ? formatCcList(replyAllRecipients.cc) : undefined,
     replyTo: options?.replyTo,
     subject: formatReplySubject(message.headers.subject),
     messageText,

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -708,6 +708,66 @@ describe("replyToEmail", () => {
     );
     expect(sendDraft).toHaveBeenCalledTimes(1);
   });
+
+  it("restores unread status when reply-all send fails", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: false }));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+          from: {
+            emailAddress: {
+              address: "owner@example.com",
+            },
+          },
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => {
+      throw new Error("send failed");
+    });
+    const restoreUnread = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus, patch: restoreUnread };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    let thrown: unknown;
+    try {
+      await replyToEmail(
+        client,
+        {
+          id: "message-1",
+          threadId: "conversation-1",
+          headers: {
+            from: "sender@example.com",
+            to: "owner@example.com",
+            subject: "Original subject",
+            date: "2026-01-01T12:00:00.000Z",
+          },
+          textPlain: "Original body",
+          textHtml: "<p>Original body</p>",
+        } as EmailForAction,
+        "Thanks for the update.",
+        createTestLogger(),
+        { replyAll: true },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(restoreUnread).toHaveBeenCalledWith({ isRead: false });
+  });
 });
 
 describe("draftEmail", () => {

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
 import { createTestLogger } from "@/__tests__/helpers";
 import type { EmailForAction } from "@/utils/ai/types";
-import { draftEmail, forwardEmail, sendEmailWithHtml } from "./mail";
+import {
+  draftEmail,
+  forwardEmail,
+  replyToEmail,
+  sendEmailWithHtml,
+} from "./mail";
 
 vi.mock("@/utils/mail", () => ({
   ensureEmailSendingEnabled: vi.fn(),
@@ -634,6 +639,70 @@ describe("forwardEmail", () => {
         body: expect.objectContaining({
           contentType: "html",
           content: expect.stringContaining("Forwarding this"),
+        }),
+      }),
+    );
+    expect(sendDraft).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("replyToEmail", () => {
+  it("uses createReplyAll when sending a reply all", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: true }));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+          from: {
+            emailAddress: {
+              address: "owner@example.com",
+            },
+          },
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await replyToEmail(
+      client,
+      {
+        id: "message-1",
+        threadId: "conversation-1",
+        headers: {
+          from: "sender@example.com",
+          to: "owner@example.com, teammate@example.com",
+          cc: "manager@example.com",
+          subject: "Original subject",
+          date: "2026-01-01T12:00:00.000Z",
+        },
+        textPlain: "Original body",
+        textHtml: "<p>Original body</p>",
+      } as EmailForAction,
+      "Thanks for the update.",
+      createTestLogger(),
+      { replyAll: true },
+    );
+
+    expect(getOriginalReadStatus).toHaveBeenCalledTimes(1);
+    expect(createReplyAllDraft).toHaveBeenCalledWith({});
+    expect(updateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          contentType: "html",
+          content: expect.stringContaining("Thanks for the update."),
         }),
       }),
     );

--- a/apps/web/utils/outlook/mail.test.ts
+++ b/apps/web/utils/outlook/mail.test.ts
@@ -407,6 +407,172 @@ describe("replyToEmail", () => {
     expect(sendDraft).toHaveBeenCalledTimes(1);
     expect(result.id).toBe("draft-1");
   });
+
+  it("uses createReplyAll when sending a reply all", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: true }));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+          from: {
+            emailAddress: {
+              address: "owner@example.com",
+            },
+          },
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await replyToEmail(
+      client,
+      {
+        id: "message-1",
+        threadId: "conversation-1",
+        headers: {
+          from: "sender@example.com",
+          to: "owner@example.com, teammate@example.com",
+          cc: "manager@example.com",
+          subject: "Original subject",
+          date: "2026-01-01T12:00:00.000Z",
+        },
+        textPlain: "Original body",
+        textHtml: "<p>Original body</p>",
+      } as EmailForAction,
+      "Thanks for the update.",
+      createTestLogger(),
+      { replyAll: true },
+    );
+
+    expect(getOriginalReadStatus).toHaveBeenCalledTimes(1);
+    expect(createReplyAllDraft).toHaveBeenCalledWith({});
+    expect(updateDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          contentType: "html",
+          content: expect.stringContaining("Thanks for the update."),
+        }),
+      }),
+    );
+    expect(sendDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores unread status when reply-all send fails", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: false }));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+          from: {
+            emailAddress: {
+              address: "owner@example.com",
+            },
+          },
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => {
+      throw new Error("send failed");
+    });
+    const restoreUnread = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus, patch: restoreUnread };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await expect(
+      replyToEmail(
+        client,
+        {
+          id: "message-1",
+          threadId: "conversation-1",
+          headers: {
+            from: "sender@example.com",
+            to: "owner@example.com",
+            subject: "Original subject",
+            date: "2026-01-01T12:00:00.000Z",
+          },
+          textPlain: "Original body",
+          textHtml: "<p>Original body</p>",
+        } as EmailForAction,
+        "Thanks for the update.",
+        createTestLogger(),
+        { replyAll: true },
+      ),
+    ).rejects.toThrow("send failed");
+
+    expect(restoreUnread).toHaveBeenCalledWith({ isRead: false });
+  });
+
+  it("restores unread status after a successful reply-all send", async () => {
+    const getOriginalReadStatus = vi.fn(async () => ({ isRead: false }));
+    const restoreUnread = vi.fn(async () => ({}));
+    const createReplyAllDraft = vi.fn(
+      async () =>
+        ({
+          id: "draft-1",
+          conversationId: "conversation-1",
+        }) as Message,
+    );
+    const updateDraft = vi.fn(async () => ({}));
+    const sendDraft = vi.fn(async () => ({}));
+
+    const client = createMockOutlookClient((path) => {
+      if (path === "/me/messages/message-1") {
+        return { get: getOriginalReadStatus, patch: restoreUnread };
+      }
+      if (path === "/me/messages/message-1/createReplyAll") {
+        return { post: createReplyAllDraft };
+      }
+      if (path === "/me/messages/draft-1") return { patch: updateDraft };
+      if (path === "/me/messages/draft-1/send") return { post: sendDraft };
+      throw new Error(`Unexpected API path: ${path}`);
+    });
+
+    await replyToEmail(
+      client,
+      {
+        id: "message-1",
+        threadId: "conversation-1",
+        headers: {
+          from: "sender@example.com",
+          to: "owner@example.com",
+          subject: "Original subject",
+          date: "2026-01-01T12:00:00.000Z",
+        },
+        textPlain: "Original body",
+        textHtml: "<p>Original body</p>",
+      } as EmailForAction,
+      "Thanks for the update.",
+      createTestLogger(),
+      { replyAll: true },
+    );
+
+    expect(sendDraft).toHaveBeenCalledTimes(1);
+    expect(restoreUnread).toHaveBeenCalledWith({ isRead: false });
+  });
 });
 
 describe("forwardEmail", () => {

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -103,7 +103,12 @@ export async function replyToEmail(
   message: EmailForAction,
   reply: string,
   logger: Logger,
-  options?: { replyTo?: string; from?: string; attachments?: Attachment[] },
+  options?: {
+    replyTo?: string;
+    from?: string;
+    attachments?: Attachment[];
+    replyAll?: boolean;
+  },
 ) {
   ensureEmailSendingEnabled();
 
@@ -112,55 +117,69 @@ export async function replyToEmail(
     message,
   });
 
-  // Use createReply to create a properly threaded draft
-  // Microsoft Graph's sendMail doesn't support setting In-Reply-To/References headers
-  // Only createReply/createReplyAll endpoints ensure proper threading
-  const replyDraft: Message = await withOutlookRetry(
-    () =>
-      client.getClient().api(`/me/messages/${message.id}/createReply`).post({}),
-    logger,
-  );
+  const isReplyAll = options?.replyAll === true;
 
-  const fromField = buildGraphFromField(
-    options?.from,
-    replyDraft.from?.emailAddress?.address,
-  );
-
-  // Update the draft with our content
-  await withOutlookRetry(
-    () =>
-      client
-        .getClient()
-        .api(`/me/messages/${replyDraft.id}`)
-        .patch({
-          body: {
-            contentType: "html",
-            content: html,
-          },
-          ...(fromField ? { from: fromField } : {}),
-          ...(options?.replyTo
-            ? {
-                replyTo: [{ emailAddress: { address: options.replyTo } }],
-              }
-            : {}),
-        }),
-    logger,
-  );
-
-  if (options?.attachments?.length) {
-    await addAttachmentsToDraft({
-      client,
-      draftId: replyDraft.id || "",
-      attachments: options.attachments,
+  // Use createReply/createReplyAll because Graph's sendMail doesn't set
+  // In-Reply-To/References headers needed for proper threading.
+  const performReply = async () => {
+    const replyDraft: Message = await withOutlookRetry(
+      () =>
+        client
+          .getClient()
+          .api(
+            `/me/messages/${message.id}/${isReplyAll ? "createReplyAll" : "createReply"}`,
+          )
+          .post({}),
       logger,
-    });
-  }
+    );
 
-  // Send the draft
-  await withOutlookRetry(
-    () => client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
-    logger,
-  );
+    const fromField = buildGraphFromField(
+      options?.from,
+      replyDraft.from?.emailAddress?.address,
+    );
+
+    await withOutlookRetry(
+      () =>
+        client
+          .getClient()
+          .api(`/me/messages/${replyDraft.id}`)
+          .patch({
+            body: {
+              contentType: "html",
+              content: html,
+            },
+            ...(fromField ? { from: fromField } : {}),
+            ...(options?.replyTo
+              ? {
+                  replyTo: [{ emailAddress: { address: options.replyTo } }],
+                }
+              : {}),
+          }),
+      logger,
+    );
+
+    if (options?.attachments?.length) {
+      await addAttachmentsToDraft({
+        client,
+        draftId: replyDraft.id || "",
+        attachments: options.attachments,
+        logger,
+      });
+    }
+
+    await withOutlookRetry(
+      () =>
+        client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
+      logger,
+    );
+
+    return replyDraft;
+  };
+
+  // createReplyAll marks the original as read; preserve unread state.
+  const replyDraft = isReplyAll
+    ? await withPreservedUnreadStatus(client, message.id, logger, performReply)
+    : await performReply();
 
   // Draft ID is no longer valid after /send; Graph doesn't return sent message ID
   return {
@@ -330,75 +349,58 @@ export async function draftEmail(
     },
   }));
 
-  // Get the original message's isRead status before creating the draft
-  // Microsoft Graph's createReplyAll automatically marks the original as read
-  const originalMessage: Message = await withOutlookRetry(
-    () =>
-      client
+  // createReplyAll marks the original as read; preserve unread state.
+  const { replyDraft, updatedDraft } = await withPreservedUnreadStatus(
+    client,
+    originalEmail.id,
+    logger,
+    async () => {
+      const replyDraft: Message = await withOutlookRetry(
+        () =>
+          client
+            .getClient()
+            .api(`/me/messages/${originalEmail.id}/createReplyAll`)
+            .post({}),
+        logger,
+      );
+
+      const updateRequest = client
         .getClient()
-        .api(`/me/messages/${originalEmail.id}`)
-        .select("isRead")
-        .get(),
-    logger,
+        .api(`/me/messages/${replyDraft.id}`);
+
+      // To handle change key error
+      const etag = (replyDraft as { "@odata.etag"?: string })?.["@odata.etag"];
+      if (etag) {
+        updateRequest.header("If-Match", etag);
+      }
+
+      const updatedDraft: Message = await withOutlookRetry(
+        () =>
+          updateRequest.patch({
+            subject: args.subject || originalEmail.headers.subject,
+            body: {
+              contentType: "html",
+              content: html,
+            },
+            toRecipients: [toRecipient],
+            ccRecipients,
+            bccRecipients,
+          }),
+        logger,
+      );
+
+      if (args.attachments?.length) {
+        await addAttachmentsToDraft({
+          client,
+          draftId: replyDraft.id || updatedDraft.id || "",
+          attachments: args.attachments,
+          logger,
+        });
+      }
+
+      return { replyDraft, updatedDraft };
+    },
   );
-  const wasUnread = originalMessage.isRead === false;
-
-  // Use createReplyAll endpoint to create a proper reply draft
-  // This ensures the draft is linked to the original message as a reply all
-  const replyDraft: Message = await withOutlookRetry(
-    () =>
-      client
-        .getClient()
-        .api(`/me/messages/${originalEmail.id}/createReplyAll`)
-        .post({}),
-    logger,
-  );
-
-  // Update the draft with our content
-  const updateRequest = client.getClient().api(`/me/messages/${replyDraft.id}`);
-
-  // To handle change key error
-  const etag = (replyDraft as { "@odata.etag"?: string })?.["@odata.etag"];
-  if (etag) {
-    updateRequest.header("If-Match", etag);
-  }
-
-  const updatedDraft: Message = await withOutlookRetry(
-    () =>
-      updateRequest.patch({
-        subject: args.subject || originalEmail.headers.subject,
-        body: {
-          contentType: "html",
-          content: html,
-        },
-        toRecipients: [toRecipient],
-        ccRecipients,
-        bccRecipients,
-      }),
-    logger,
-  );
-
-  if (args.attachments?.length) {
-    await addAttachmentsToDraft({
-      client,
-      draftId: replyDraft.id || updatedDraft.id || "",
-      attachments: args.attachments,
-      logger,
-    });
-  }
-
-  // Restore the original message's unread status if it was unread before
-  // createReplyAll automatically marks the original message as read
-  if (wasUnread) {
-    await withOutlookRetry(
-      () =>
-        client
-          .getClient()
-          .api(`/me/messages/${originalEmail.id}`)
-          .patch({ isRead: false }),
-      logger,
-    );
-  }
 
   // Use the original replyDraft.id since that's the stable ID
   // The PATCH response might not always include the full object?
@@ -487,6 +489,39 @@ async function sendReplyUsingCreateReply(
     id: "",
     conversationId: replyDraft.conversationId,
   };
+}
+
+async function withPreservedUnreadStatus<T>(
+  client: OutlookClient,
+  messageId: string,
+  logger: Logger,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original: Message = await withOutlookRetry(
+    () =>
+      client
+        .getClient()
+        .api(`/me/messages/${messageId}`)
+        .select("isRead")
+        .get(),
+    logger,
+  );
+  const wasUnread = original.isRead === false;
+
+  const result = await fn();
+
+  if (wasUnread) {
+    await withOutlookRetry(
+      () =>
+        client
+          .getClient()
+          .api(`/me/messages/${messageId}`)
+          .patch({ isRead: false }),
+      logger,
+    );
+  }
+
+  return result;
 }
 
 function buildGraphRecipients(

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -508,20 +508,24 @@ async function withPreservedUnreadStatus<T>(
   );
   const wasUnread = original.isRead === false;
 
-  const result = await fn();
-
-  if (wasUnread) {
-    await withOutlookRetry(
-      () =>
-        client
-          .getClient()
-          .api(`/me/messages/${messageId}`)
-          .patch({ isRead: false }),
-      logger,
-    );
+  try {
+    return await fn();
+  } finally {
+    if (wasUnread) {
+      try {
+        await withOutlookRetry(
+          () =>
+            client
+              .getClient()
+              .api(`/me/messages/${messageId}`)
+              .patch({ isRead: false }),
+          logger,
+        );
+      } catch (restoreError) {
+        logger.error("Failed to restore unread status", { restoreError });
+      }
+    }
   }
-
-  return result;
 }
 
 function buildGraphRecipients(

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -111,6 +111,7 @@ export async function replyToEmail(
     replyTo?: string;
     from?: string;
     attachments?: Attachment[];
+    replyAll?: boolean;
   },
 ) {
   ensureEmailSendingEnabled();
@@ -120,60 +121,99 @@ export async function replyToEmail(
     message,
   });
 
-  // Use createReply to create a properly threaded draft
-  // Microsoft Graph's sendMail doesn't support setting In-Reply-To/References headers
-  // Only createReply/createReplyAll endpoints ensure proper threading
-  const replyDraft: Message = await withMicrosoftGraphWriteRetry(
-    () =>
-      client.getClient().api(`/me/messages/${message.id}/createReply`).post({}),
-    logger,
-  );
+  const isReplyAll = options?.replyAll === true;
+  const performReply = async () => {
+    // Graph's sendMail doesn't set In-Reply-To/References headers needed for threading.
+    const replyDraft: Message = await withMicrosoftGraphWriteRetry(
+      () =>
+        client
+          .getClient()
+          .api(
+            `/me/messages/${message.id}/${isReplyAll ? "createReplyAll" : "createReply"}`,
+          )
+          .post({}),
+      logger,
+    );
 
-  const fromField = buildGraphFromField(
-    options?.from,
-    replyDraft.from?.emailAddress?.address,
-  );
+    const fromField = buildGraphFromField(
+      options?.from,
+      replyDraft.from?.emailAddress?.address,
+    );
 
-  // Update the draft with our content
-  await withMicrosoftGraphWriteRetry(
+    await withMicrosoftGraphWriteRetry(
+      () =>
+        client
+          .getClient()
+          .api(`/me/messages/${replyDraft.id}`)
+          .patch({
+            body: {
+              contentType: "html",
+              content: html,
+            },
+            ...(fromField ? { from: fromField } : {}),
+            ...(options?.replyTo
+              ? {
+                  replyTo: [{ emailAddress: { address: options.replyTo } }],
+                }
+              : {}),
+          }),
+      logger,
+    );
+
+    if (options?.attachments?.length) {
+      await addAttachmentsToDraft({
+        client,
+        draftId: replyDraft.id || "",
+        attachments: options.attachments,
+        logger,
+      });
+    }
+
+    await withMicrosoftGraphWriteRetry(
+      () =>
+        client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
+      logger,
+    );
+
+    return {
+      id: replyDraft.id,
+      conversationId: replyDraft.conversationId,
+    };
+  };
+
+  if (!isReplyAll) {
+    return performReply();
+  }
+
+  const original: Message = await withMicrosoftGraphRetry(
     () =>
       client
         .getClient()
-        .api(`/me/messages/${replyDraft.id}`)
-        .patch({
-          body: {
-            contentType: "html",
-            content: html,
-          },
-          ...(fromField ? { from: fromField } : {}),
-          ...(options?.replyTo
-            ? {
-                replyTo: [{ emailAddress: { address: options.replyTo } }],
-              }
-            : {}),
-        }),
+        .api(`/me/messages/${message.id}`)
+        .select("isRead")
+        .get(),
     logger,
   );
+  const wasUnread = original.isRead === false;
 
-  if (options?.attachments?.length) {
-    await addAttachmentsToDraft({
-      client,
-      draftId: replyDraft.id || "",
-      attachments: options.attachments,
-      logger,
-    });
+  try {
+    return await performReply();
+  } finally {
+    if (wasUnread) {
+      try {
+        await withMicrosoftGraphWriteRetry(
+          () =>
+            client
+              .getClient()
+              .api(`/me/messages/${message.id}`)
+              .patch({ isRead: false }),
+          logger,
+        );
+      } catch (restoreError) {
+        logger.error("Failed to restore unread status", { restoreError });
+      }
+    }
   }
-
-  // Send the draft
-  await withMicrosoftGraphWriteRetry(
-    () => client.getClient().api(`/me/messages/${replyDraft.id}/send`).post({}),
-    logger,
-  );
-
-  return {
-    id: replyDraft.id,
-    conversationId: replyDraft.conversationId,
-  };
 }
 
 export async function forwardEmail(


### PR DESCRIPTION
Preserves assistant reply-all intent through pending reply confirmation so confirmed replies include original recipients when requested. Updates Gmail and Outlook provider handling to send reply-all responses while preserving unread state where Graph mutates it.

- Adds reply-all metadata to the assistant pending reply flow.
- Uses Gmail recipient merging and Outlook createReplyAll for confirmed reply-all sends.
- Adds focused tests for pending reply metadata and Gmail/Outlook reply-all behavior.
- Tests: pnpm --dir apps/web exec vitest run utils/actions/assistant-chat.test.ts utils/ai/assistant/chat-inbox-tools.test.ts utils/gmail/mail.test.ts utils/outlook/mail.test.ts
- Performance: Adds no database work. Reply-all sends use the same send path for Gmail; Outlook reply-all adds a read-state lookup and may restore unread state with one PATCH, limited to reply-all actions and not a hot path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for drafting and sending “Reply all” messages.
  - Preserves original recipients and CC addresses across Gmail and Outlook.
  - Supports configured sender identities when replying all from Gmail.
  - Preserves an email’s unread status after sending a reply-all message.

- **Bug Fixes**
  - Confirmation actions now correctly forward reply-all settings when sending prepared replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->