### PR TITLE
teams: Improve connect discovery and confirmation logging

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -620,6 +620,8 @@ function LinkCodeDialog({
 
   const providerName = dialog.provider === "TEAMS" ? "Teams" : "Telegram";
   const command = `/connect ${dialog.code}`;
+  const openBotLabel =
+    dialog.provider === "TEAMS" ? "Open Teams app" : "Open Telegram bot";
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
@@ -635,11 +637,11 @@ function LinkCodeDialog({
           <div className="text-xs text-muted-foreground">Command</div>
           <CopyInput value={command} />
         </div>
-        {dialog.provider === "TELEGRAM" && dialog.botUrl && (
+        {dialog.botUrl && (
           <div className="pt-1">
             <Button asChild size="sm">
               <a href={dialog.botUrl} target="_blank" rel="noopener noreferrer">
-                Open Telegram bot
+                {openBotLabel}
               </a>
             </Button>
           </div>

--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -40,6 +40,7 @@ const { mockEnv, generateMessagingLinkCodeMock } = vi.hoisted(() => ({
   mockEnv: {
     TEAMS_BOT_APP_ID: "teams-app-id" as string | undefined,
     TEAMS_BOT_APP_PASSWORD: "teams-app-password",
+    TEAMS_BOT_APP_TENANT_ID: undefined as string | undefined,
     TELEGRAM_BOT_TOKEN: "telegram-bot-token" as string | undefined,
   },
   generateMessagingLinkCodeMock: vi.fn(
@@ -65,6 +66,7 @@ describe("createMessagingLinkCodeAction", () => {
 
     mockEnv.TEAMS_BOT_APP_ID = "teams-app-id";
     mockEnv.TEAMS_BOT_APP_PASSWORD = "teams-app-password";
+    mockEnv.TEAMS_BOT_APP_TENANT_ID = undefined;
     mockEnv.TELEGRAM_BOT_TOKEN = "telegram-bot-token";
 
     prisma.emailAccount.findUnique.mockResolvedValue({
@@ -89,7 +91,24 @@ describe("createMessagingLinkCodeAction", () => {
       code: "test-link-code",
       provider: "TEAMS",
       expiresInSeconds: 600,
+      botUrl: "https://teams.microsoft.com/l/app/teams-app-id",
     });
+  });
+
+  it("includes the Teams tenant id in the Teams bot URL when configured", async () => {
+    mockEnv.TEAMS_BOT_APP_TENANT_ID = "tenant-id";
+
+    const result = await createMessagingLinkCodeAction(
+      "email-account-1" as any,
+      {
+        provider: "TEAMS",
+      },
+    );
+
+    expect(result?.serverError).toBeUndefined();
+    expect(result?.data?.botUrl).toBe(
+      "https://teams.microsoft.com/l/app/teams-app-id?tenantId=tenant-id",
+    );
   });
 
   it("returns an error when Teams is not configured", async () => {

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -314,7 +314,7 @@ export const createMessagingLinkCodeAction = actionClient
       provider,
     });
     const botUrl =
-      provider === "TELEGRAM" ? await getTelegramBotUrl() : undefined;
+      provider === "TELEGRAM" ? await getTelegramBotUrl() : getTeamsBotUrl();
 
     return {
       code,
@@ -456,6 +456,20 @@ async function getTelegramBotUrl() {
   } catch {
     return;
   }
+}
+
+function getTeamsBotUrl() {
+  if (!env.TEAMS_BOT_APP_ID) return;
+
+  const url = new URL(
+    `https://teams.microsoft.com/l/app/${env.TEAMS_BOT_APP_ID}`,
+  );
+
+  if (env.TEAMS_BOT_APP_TENANT_ID) {
+    url.searchParams.set("tenantId", env.TEAMS_BOT_APP_TENANT_ID);
+  }
+
+  return url.toString();
 }
 
 async function syncMessagingFeatureRoute({

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -1834,9 +1834,19 @@ async function handleMessagingLinkCommand({
     },
   });
 
-  await thread.post(
-    `Connected successfully. You can now chat with your Inbox Zero assistant in this ${provider} DM.`,
-  );
+  await postMessagingThreadMessage({
+    thread,
+    logger,
+    message: `Connected successfully. You can now chat with your Inbox Zero assistant in this ${provider} DM.`,
+    errorLogMessage: "Failed to send messaging link confirmation",
+    logMeta: {
+      provider,
+      emailAccountId: emailAccount.id,
+      messagingChannelId: messagingChannel.id,
+      teamId: identity.teamId,
+      providerUserId: identity.providerUserId,
+    },
+  });
 
   return true;
 }


### PR DESCRIPTION
Adds a Teams app deep link to the messaging connect dialog and improves observability for connect confirmation delivery.

- Return a Teams app URL from the messaging link-code action using the existing Teams bot app id
- Show an Open Teams app button in the connect dialog alongside the one-time command
- Send connect confirmation messages through the logged posting helper for Axiom visibility

Test: pnpm test utils/actions/messaging-channels.test.ts

Performance impact: Teams link generation is local URL construction with no added network or database calls. The connect confirmation path still sends one Teams message; the only runtime change is catching/logging send failures instead of letting them disappear from product context.