### PR TITLE
Improve booking link OG image and link previews

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/BookingLinksSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/BookingLinksSection.tsx
@@ -81,9 +81,7 @@ function InboxZeroBookingLinkPanel() {
   const timezone =
     data?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
   const defaultName = emailAccount?.name?.trim() || null;
-  const defaultTitle = defaultName
-    ? `${defaultName}'s booking link`
-    : "Booking link";
+  const defaultTitle = "Booking link";
   const defaultSlug = getBookingLinkSlugSuggestion(defaultName);
 
   const { executeAsync: createLink, isExecuting: isCreating } = useAction(

--- a/apps/web/app/book/[slug]/metadata.test.ts
+++ b/apps/web/app/book/[slug]/metadata.test.ts
@@ -56,7 +56,7 @@ describe("booking link metadata", () => {
     });
   });
 
-  it("falls back to a booking description when the link has no description", () => {
+  it("falls back to a short booking description when the link has no description", () => {
     const bookingLink = {
       slug: "intro call",
       title: "Intro call",
@@ -66,9 +66,7 @@ describe("booking link metadata", () => {
     };
 
     expect(buildBookingLinkTitle(bookingLink)).toBe("Intro call | Host User");
-    expect(buildBookingLinkDescription(bookingLink)).toBe(
-      "Book a 45 min meeting with Host User.",
-    );
+    expect(buildBookingLinkDescription(bookingLink)).toBe("45 min meeting");
 
     expect(buildBookingLinkPageMetadata(bookingLink).openGraph).toMatchObject({
       url: "https://app.example.com/book/intro%20call",
@@ -90,8 +88,6 @@ describe("booking link metadata", () => {
     };
 
     expect(buildBookingLinkTitle(bookingLink)).toBe("Intro call | Inbox Zero");
-    expect(buildBookingLinkDescription(bookingLink)).toBe(
-      "Book a 30 min meeting.",
-    );
+    expect(buildBookingLinkDescription(bookingLink)).toBe("30 min meeting");
   });
 });

--- a/apps/web/app/book/[slug]/metadata.ts
+++ b/apps/web/app/book/[slug]/metadata.ts
@@ -63,12 +63,7 @@ export function buildBookingLinkDescription(bookingLink: BookingLinkMetadata) {
   const description = bookingLink.description?.trim();
   if (description) return description;
 
-  const hostName = bookingLink.hostName?.trim();
-  if (hostName) {
-    return `Book a ${bookingLink.durationMinutes} min meeting with ${hostName}.`;
-  }
-
-  return `Book a ${bookingLink.durationMinutes} min meeting.`;
+  return `${bookingLink.durationMinutes} min meeting`;
 }
 
 function getBookingLinkUrl(slug: string) {

--- a/apps/web/app/book/[slug]/opengraph-image.tsx
+++ b/apps/web/app/book/[slug]/opengraph-image.tsx
@@ -6,7 +6,6 @@ import { enforcePublicAvailabilityRateLimit } from "@/utils/booking/public-rate-
 import { SafeError } from "@/utils/error";
 import { createScopedLogger } from "@/utils/logger";
 import { getClientIp } from "@/utils/rate-limit";
-import { buildBookingLinkDescription, buildBookingLinkTitle } from "./metadata";
 
 const logger = createScopedLogger("public/booking-link-og-image");
 
@@ -18,6 +17,9 @@ export const size = {
 };
 
 export const contentType = "image/png";
+
+const BRAND_BLUE = "#2563eb";
+const BRAND_BLUE_DARK = "#1d4ed8";
 
 export default async function Image({
   params,
@@ -41,14 +43,10 @@ export default async function Image({
   }
 
   const bookingLink = await getBookingLinkOrNull(slug);
-  const title = bookingLink
-    ? buildBookingLinkTitle(bookingLink)
-    : `Meeting | ${BRAND_NAME}`;
-  const description = bookingLink
-    ? buildBookingLinkDescription(bookingLink)
-    : `Book a meeting with ${BRAND_NAME}.`;
-  const duration = bookingLink ? `${bookingLink.durationMinutes} min` : null;
   const hostName = bookingLink?.hostName?.trim() || BRAND_NAME;
+  const duration = bookingLink?.durationMinutes ?? null;
+  const meetingType = duration ? `${duration} Min Meeting` : "Meeting";
+  const headline = bookingLink ? `Meet ${hostName}` : `Meet with ${BRAND_NAME}`;
 
   return new ImageResponse(
     <div
@@ -58,78 +56,139 @@ export default async function Image({
         display: "flex",
         flexDirection: "column",
         justifyContent: "space-between",
-        background: "#f8fafc",
-        color: "#111827",
-        padding: 72,
+        background:
+          "linear-gradient(135deg, #f8fafc 0%, #eef2ff 60%, #e0e7ff 100%)",
+        color: "#0f172a",
+        padding: 80,
         fontFamily: "Arial, Helvetica, sans-serif",
+        position: "relative",
       }}
     >
       <div
         style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          width: 520,
+          height: 520,
+          borderRadius: 9999,
+          background: `radial-gradient(circle, ${BRAND_BLUE}22 0%, transparent 70%)`,
+          transform: "translate(30%, -30%)",
+        }}
+      />
+
+      <div
+        style={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
-          fontSize: 30,
-          color: "#334155",
+          gap: 24,
+          zIndex: 1,
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+          }}
+        >
           <div
             style={{
               width: 64,
               height: 64,
               borderRadius: 16,
+              background: `linear-gradient(135deg, ${BRAND_BLUE} 0%, ${BRAND_BLUE_DARK} 100%)`,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              background: "#111827",
-              color: "#ffffff",
-              fontSize: 32,
-              fontWeight: 700,
+              boxShadow: "0 8px 24px rgba(37, 99, 235, 0.25)",
             }}
           >
-            {hostName.charAt(0).toUpperCase()}
+            <svg
+              width="36"
+              height="36"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="white"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="5" width="18" height="14" rx="2" />
+              <path d="m3 7 9 6 9-6" />
+            </svg>
           </div>
-          <div>{hostName}</div>
+          <div
+            style={{
+              fontSize: 36,
+              fontWeight: 700,
+              color: "#0f172a",
+              letterSpacing: -0.5,
+            }}
+          >
+            {BRAND_NAME}
+          </div>
         </div>
-        {duration ? <div>{duration}</div> : null}
-      </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 30 }}>
         <div
           style={{
-            fontSize: 80,
-            lineHeight: 1.05,
-            fontWeight: 700,
-            letterSpacing: 0,
-            maxWidth: 960,
+            fontSize: 36,
+            color: "#cbd5e1",
+            fontWeight: 300,
+            margin: "0 8px",
           }}
         >
-          {title}
+          /
         </div>
+
         <div
           style={{
-            fontSize: 34,
-            lineHeight: 1.35,
-            color: "#475569",
-            maxWidth: 900,
+            width: 64,
+            height: 64,
+            borderRadius: 9999,
+            background: "#0f172a",
+            color: "#ffffff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 28,
+            fontWeight: 700,
           }}
         >
-          {description}
+          {hostName.charAt(0).toUpperCase()}
         </div>
       </div>
 
       <div
         style={{
           display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          fontSize: 28,
-          color: "#64748b",
+          flexDirection: "column",
+          gap: 16,
+          zIndex: 1,
         }}
       >
-        <div>Booking link</div>
-        <div>{BRAND_NAME}</div>
+        <div
+          style={{
+            fontSize: 88,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: -2,
+            color: "#0f172a",
+            maxWidth: 1000,
+          }}
+        >
+          {headline}
+        </div>
+        <div
+          style={{
+            fontSize: 44,
+            lineHeight: 1.2,
+            color: "#475569",
+            fontWeight: 500,
+          }}
+        >
+          {meetingType}
+        </div>
       </div>
     </div>,
     {


### PR DESCRIPTION
## Summary
- Redesigns the booking link Open Graph image in a cleaner, branded layout (brand mark, host avatar, single "Meet {host}" headline + meeting type) so the host name no longer appears repeatedly in social/email previews.
- Drops the redundant `| {hostName}` repetition by removing the host name from the default link title and shortening the fallback description to `"{n} min meeting"`.

## Test plan
- [x] `pnpm test metadata opengraph-image CreateBookingLinkDialog`
- [ ] Visually verify the rendered OG image for an existing booking link