### PR TITLE
assistant: Add inbox label removal action

### DIFF
--- a/apps/web/components/assistant-chat/message-part.tsx
+++ b/apps/web/components/assistant-chat/message-part.tsx
@@ -778,6 +778,7 @@ function getManageInboxInputForDisplay(
 function normalizeManageInboxActionForDisplay(action: unknown) {
   if (typeof action !== "string") return;
   if (action === "categorize_threads") return "label_threads";
+  if (action === "remove_category_threads") return "remove_label_threads";
   return isManageInboxAction(action) ? action : undefined;
 }
 

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -1879,6 +1879,7 @@ function CollapsibleDiffContent({
 function parseManageInboxAction(
   action: string | undefined,
 ): ManageInboxAction | undefined {
+  if (action === "remove_category_threads") return "remove_label_threads";
   return isManageInboxAction(action) ? action : undefined;
 }
 
@@ -1912,6 +1913,9 @@ export function getManageInboxActionLabel({
   }
   if (action === "label_threads") {
     return inProgress ? "Labeling emails" : "Labeled emails";
+  }
+  if (action === "remove_label_threads") {
+    return inProgress ? "Removing labels" : "Removed labels";
   }
   if (action === "mark_read_threads") {
     if (inProgress) {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -492,6 +492,121 @@ describe("chat inbox tools", () => {
     expect(labelMessage).not.toHaveBeenCalled();
   });
 
+  it("resolves an exact labelName before removing labels from threads", async () => {
+    const getLabelByName = vi.fn().mockResolvedValue({
+      id: "Label_123",
+      name: "Finance",
+      type: "user",
+    });
+    const removeThreadLabel = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getLabelByName,
+      removeThreadLabel,
+    } as any);
+
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      action: "remove_label_threads",
+      labelName: "Finance",
+      threadIds: ["thread-1", "thread-2"],
+    });
+
+    expect(getLabelByName).toHaveBeenCalledWith("Finance");
+    expect(getLabelByName).toHaveBeenCalledTimes(1);
+    expect(removeThreadLabel).toHaveBeenNthCalledWith(
+      1,
+      "thread-1",
+      "Label_123",
+    );
+    expect(removeThreadLabel).toHaveBeenNthCalledWith(
+      2,
+      "thread-2",
+      "Label_123",
+    );
+    expect(result).toMatchObject({
+      action: "remove_label_threads",
+      success: true,
+      failedCount: 0,
+      successCount: 2,
+      requestedCount: 2,
+      labelId: "Label_123",
+      labelName: "Finance",
+    });
+  });
+
+  it("returns a transparent error when removing a label that does not exist", async () => {
+    const getLabelByName = vi.fn().mockResolvedValue(null);
+    const removeThreadLabel = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getLabelByName,
+      removeThreadLabel,
+    } as any);
+
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      action: "remove_label_threads",
+      labelName: "Finance",
+      threadIds: ["thread-1"],
+    });
+
+    expect(result).toEqual({
+      error: 'Label "Finance" does not exist, so no label was removed.',
+      toolErrorVisibility: "hidden",
+    });
+    expect(getLabelByName).toHaveBeenCalledWith("Finance");
+    expect(removeThreadLabel).not.toHaveBeenCalled();
+  });
+
+  it("removes Outlook categories using category wording in the tool contract", async () => {
+    const getLabelByName = vi.fn().mockResolvedValue({
+      id: "category-123",
+      name: "Finance",
+      type: "user",
+    });
+    const removeThreadLabel = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getLabelByName,
+      removeThreadLabel,
+    } as any);
+
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      action: "remove_category_threads",
+      categoryName: "Finance",
+      threadIds: ["thread-1"],
+    });
+
+    expect(getLabelByName).toHaveBeenCalledWith("Finance");
+    expect(removeThreadLabel).toHaveBeenCalledWith("thread-1", "category-123");
+    expect(result).toMatchObject({
+      action: "remove_category_threads",
+      success: true,
+      categoryId: "category-123",
+      categoryName: "Finance",
+    });
+  });
+
   it("marks a thread labeling action as failed when any message label call fails", async () => {
     const getThreadMessages = vi.fn().mockResolvedValue([
       { id: "thread-1-message-1", threadId: "thread-1" },

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -860,6 +860,7 @@ const microsoftManageInboxActions = [
   "archive_threads",
   "trash_threads",
   "categorize_threads",
+  "remove_category_threads",
   "mark_read_threads",
   "bulk_archive_senders",
   "unsubscribe_senders",
@@ -869,12 +870,12 @@ const outlookManageInboxInputSchema = z.object({
   action: z
     .enum(microsoftManageInboxActions)
     .describe(
-      "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. categorize_threads: apply a category (requires categoryName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide after the user confirms that broad scope (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
+      "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. categorize_threads: apply a category (requires categoryName). remove_category_threads: remove an existing category (requires categoryName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide after the user confirms that broad scope (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
     ),
   threadIds: threadIdsSchema
     .nullish()
     .describe(
-      "Required for archive_threads, trash_threads, categorize_threads, and mark_read_threads. Use IDs from searchInbox results or thread IDs the user already provided.",
+      "Required for archive_threads, trash_threads, categorize_threads, remove_category_threads, and mark_read_threads. Use IDs from searchInbox results or thread IDs the user already provided.",
     ),
   category: z
     .string()
@@ -887,7 +888,9 @@ const outlookManageInboxInputSchema = z.object({
     .trim()
     .min(1)
     .nullish()
-    .describe("Exact Outlook category name to apply to the selected threads."),
+    .describe(
+      "Exact Outlook category name to apply to or remove from the selected threads.",
+    ),
   read: z
     .boolean()
     .nullish()
@@ -903,12 +906,12 @@ const gmailManageInboxInputSchema = z.object({
   action: z
     .enum(manageInboxActions)
     .describe(
-      "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: apply a label (requires labelName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide after the user confirms that broad scope (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
+      "archive_threads: archive by ID (default unless user says delete/trash). trash_threads: move to trash. label_threads: apply a label (requires labelName). remove_label_threads: remove an existing label (requires labelName). mark_read_threads: mark read/unread. bulk_archive_senders: archive ALL emails from senders server-wide after the user confirms that broad scope (never for trash/delete). unsubscribe_senders: unsubscribe and archive from senders (only for explicit unsubscribe requests).",
     ),
   threadIds: threadIdsSchema
     .nullish()
     .describe(
-      "Required for archive_threads, trash_threads, label_threads, and mark_read_threads. Use IDs from searchInbox results or thread IDs the user already provided.",
+      "Required for archive_threads, trash_threads, label_threads, remove_label_threads, and mark_read_threads. Use IDs from searchInbox results or thread IDs the user already provided.",
     ),
   label: z
     .string()
@@ -921,7 +924,9 @@ const gmailManageInboxInputSchema = z.object({
     .trim()
     .min(1)
     .nullish()
-    .describe("Exact Gmail label name to apply to the selected threads."),
+    .describe(
+      "Exact Gmail label name to apply to or remove from the selected threads.",
+    ),
   read: z
     .boolean()
     .nullish()
@@ -937,7 +942,7 @@ type ManageInboxTaxonomyConfig = {
   threadIdsRequiredError: string;
   labelNameRequiredError: string;
   labelResolutionFallbackError: string;
-  missingLabelError: (name: string) => string;
+  missingLabelError: (name: string, action: ManageInboxAction) => string;
   resultKeys: {
     id: "categoryId" | "labelId";
     name: "categoryName" | "labelName";
@@ -951,12 +956,14 @@ const outlookManageInboxTool = (options: InboxToolOptions) =>
     normalizeInput: normalizeOutlookManageInboxInput,
     taxonomy: {
       threadIdsRequiredError:
-        "threadIds is required when action is archive_threads, categorize_threads, or mark_read_threads",
+        "threadIds is required when action is archive_threads, categorize_threads, remove_category_threads, or mark_read_threads",
       labelNameRequiredError:
-        "categoryName is required when action is categorize_threads",
+        "categoryName is required when action is categorize_threads or remove_category_threads",
       labelResolutionFallbackError: "Failed to resolve category",
-      missingLabelError: (name) =>
-        `Category "${name}" does not exist. Use createOrGetCategory first if you want to create it.`,
+      missingLabelError: (name, action) =>
+        action === "remove_label_threads"
+          ? `Category "${name}" does not exist, so no category was removed.`
+          : `Category "${name}" does not exist. Use createOrGetCategory first if you want to create it.`,
       resultKeys: {
         id: "categoryId",
         name: "categoryName",
@@ -971,12 +978,14 @@ const gmailManageInboxTool = (options: InboxToolOptions) =>
     normalizeInput: normalizeGmailManageInboxInput,
     taxonomy: {
       threadIdsRequiredError:
-        "threadIds is required when action is archive_threads, label_threads, or mark_read_threads",
+        "threadIds is required when action is archive_threads, label_threads, remove_label_threads, or mark_read_threads",
       labelNameRequiredError:
-        "labelName is required when action is label_threads",
+        "labelName is required when action is label_threads or remove_label_threads",
       labelResolutionFallbackError: "Failed to resolve label",
-      missingLabelError: (name) =>
-        `Label "${name}" does not exist. Use createOrGetLabel first if you want to create it.`,
+      missingLabelError: (name, action) =>
+        action === "remove_label_threads"
+          ? `Label "${name}" does not exist, so no label was removed.`
+          : `Label "${name}" does not exist. Use createOrGetLabel first if you want to create it.`,
       resultKeys: {
         id: "labelId",
         name: "labelName",
@@ -1044,7 +1053,7 @@ const buildManageInboxTool = ({
         };
       }
 
-      if (action === "label_threads" && !labelName) {
+      if (isThreadLabelAction(action) && !labelName) {
         return {
           error: taxonomy.labelNameRequiredError,
         };
@@ -1134,11 +1143,12 @@ const buildManageInboxTool = ({
           ReturnType<typeof resolveThreadLabel>
         > | null = null;
 
-        if (action === "label_threads") {
+        if (isThreadLabelAction(action)) {
           try {
             resolvedThreadLabel = await resolveThreadLabel({
               emailProvider,
               labelName: labelName!,
+              action,
               missingLabelError: taxonomy.missingLabelError,
             });
           } catch (error) {
@@ -1174,6 +1184,11 @@ const buildManageInboxTool = ({
                 labelId: resolvedThreadLabel!.labelId,
                 labelName: resolvedThreadLabel!.labelName,
               });
+            } else if (action === "remove_label_threads") {
+              await emailProvider.removeThreadLabel(
+                threadId,
+                resolvedThreadLabel!.labelId,
+              );
             } else {
               await emailProvider.markReadThread(
                 threadId,
@@ -1949,16 +1964,18 @@ async function applyLabelToThread({
 async function resolveThreadLabel({
   emailProvider,
   labelName,
+  action,
   missingLabelError,
 }: {
   emailProvider: EmailProvider;
   labelName: string;
-  missingLabelError: (name: string) => string;
+  action: ManageInboxAction;
+  missingLabelError: (name: string, action: ManageInboxAction) => string;
 }) {
   const existingLabel = await emailProvider.getLabelByName(labelName);
 
   if (!existingLabel) {
-    throw new Error(missingLabelError(labelName));
+    throw new Error(missingLabelError(labelName, action));
   }
 
   return {
@@ -2380,7 +2397,9 @@ function normalizeOutlookManageInboxInput(
   const action: ManageInboxAction =
     originalAction === "categorize_threads"
       ? "label_threads"
-      : (originalAction as ManageInboxAction);
+      : originalAction === "remove_category_threads"
+        ? "remove_label_threads"
+        : (originalAction as ManageInboxAction);
 
   return {
     action,
@@ -2391,6 +2410,12 @@ function normalizeOutlookManageInboxInput(
     read: parsed.read as boolean | null | undefined,
     fromEmails: parsed.fromEmails as string[] | null | undefined,
   };
+}
+
+function isThreadLabelAction(
+  action: ManageInboxAction | undefined,
+): action is "label_threads" | "remove_label_threads" {
+  return action === "label_threads" || action === "remove_label_threads";
 }
 
 const LABEL_MESSAGE_CONCURRENCY = 1;

--- a/apps/web/utils/ai/assistant/manage-inbox-actions.test.ts
+++ b/apps/web/utils/ai/assistant/manage-inbox-actions.test.ts
@@ -10,6 +10,7 @@ describe("manageInbox action helpers", () => {
     expect(isManageInboxAction("archive_threads")).toBe(true);
     expect(isManageInboxAction("trash_threads")).toBe(true);
     expect(isManageInboxAction("label_threads")).toBe(true);
+    expect(isManageInboxAction("remove_label_threads")).toBe(true);
     expect(isManageInboxAction("unknown_action")).toBe(false);
     expect(isManageInboxAction(undefined)).toBe(false);
   });
@@ -18,6 +19,7 @@ describe("manageInbox action helpers", () => {
     expect(requiresThreadIds("archive_threads")).toBe(true);
     expect(requiresThreadIds("trash_threads")).toBe(true);
     expect(requiresThreadIds("label_threads")).toBe(true);
+    expect(requiresThreadIds("remove_label_threads")).toBe(true);
     expect(requiresThreadIds("mark_read_threads")).toBe(true);
     expect(requiresThreadIds("bulk_archive_senders")).toBe(false);
   });

--- a/apps/web/utils/ai/assistant/manage-inbox-actions.ts
+++ b/apps/web/utils/ai/assistant/manage-inbox-actions.ts
@@ -2,6 +2,7 @@ export const manageInboxActions = [
   "archive_threads",
   "trash_threads",
   "label_threads",
+  "remove_label_threads",
   "mark_read_threads",
   "bulk_archive_senders",
   "unsubscribe_senders",
@@ -13,6 +14,7 @@ const threadIdManageInboxActions = [
   "archive_threads",
   "trash_threads",
   "label_threads",
+  "remove_label_threads",
   "mark_read_threads",
 ] as const satisfies readonly ManageInboxAction[];
 


### PR DESCRIPTION
Adds thread-level label/category removal support to the assistant inbox management tool.\n\nUpdates user-facing tool status and missing-label errors so unsuccessful removals are explicit.\n\nAdds focused unit coverage for label removal, category removal, and action helper handling.