### PR TITLE
assistant chat: Decode email preview entities

### DIFF
--- a/apps/web/components/assistant-chat/tools.test.ts
+++ b/apps/web/components/assistant-chat/tools.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { htmlToText } from "./tools";
+
+describe("htmlToText", () => {
+  it("decodes HTML entities so email previews render real characters", () => {
+    const html =
+      "<p>Ol&aacute;, Bah,</p><p>Espero que esteja tudo bem com voc&ecirc;.</p><p>Abra&ccedil;os,<br>Bert</p>";
+
+    expect(htmlToText(html)).toBe(
+      "Olá, Bah,\n Espero que esteja tudo bem com você.\n Abraços,\nBert",
+    );
+  });
+
+  it("collapses non-breaking spaces (decoded from &nbsp;) into regular spaces", () => {
+    expect(htmlToText("<p>hello&nbsp;&nbsp;world</p>")).toBe("hello world");
+  });
+
+  it("decodes &amp; via he.decode rather than the previous manual replace", () => {
+    expect(htmlToText("Tom &amp; Jerry")).toBe("Tom & Jerry");
+  });
+});

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -69,6 +69,7 @@ import { getActionColor } from "@/components/PlanBadge";
 import type { ActionType } from "@/generated/prisma/enums";
 import { formatShortDate } from "@/utils/date";
 import { trimToNonEmptyString } from "@/utils/string";
+import { decodeHtmlEntities } from "@/utils/gmail/decode";
 import { getEmailSearchUrl, getEmailUrlForOptionalMessage } from "@/utils/url";
 import {
   isManageInboxAction,
@@ -595,7 +596,7 @@ function EmailActionResult({
   const recipient =
     to || (actionType === "reply_email" ? referenceFrom : undefined);
   const referenceSubject = getPendingString(reference, "subject");
-  const displaySubject = subject || referenceSubject;
+  const displaySubject = decodeHtmlEntities(subject || referenceSubject);
   const body = getActionBodyText({ actionType, pendingAction });
   const [editedBody, setEditedBody] = useState(body || "");
 
@@ -2065,7 +2066,7 @@ function getActionBodyText({
     return htmlToText(messageHtml);
   }
 
-  return getPendingString(pendingAction, "content");
+  return decodeHtmlEntities(getPendingString(pendingAction, "content"));
 }
 
 function getEmailActionLabel(actionType: PendingEmailActionType) {
@@ -2105,14 +2106,15 @@ function getExternalMessageUrl({
   });
 }
 
-function htmlToText(html: string) {
-  return html
+export function htmlToText(html: string) {
+  const strippedText = html
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/p>/gi, "\n")
     .replace(/<[^>]*>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/[<>]/g, "")
+    .replace(/[<>]/g, "");
+
+  return decodeHtmlEntities(strippedText)
+    .replace(/\u00a0/g, " ")
     .replace(/ {2,}/g, " ")
     .replace(/\s+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")


### PR DESCRIPTION
Decode HTML entities when rendering assistant email action previews so subjects and bodies display user-facing characters correctly. This also normalizes decoded non-breaking spaces during HTML-to-text conversion.

- Decode pending email subjects and body content before rendering previews.
- Reuse the shared entity decoder in HTML-to-text conversion.
- Add focused Vitest coverage for entity decoding and whitespace normalization.
- Test: `pnpm test components/assistant-chat/tools.test.ts`

Performance impact: adds one lightweight decode pass while rendering email previews. No database or network calls are added, and hot-path risk is low because the change is scoped to assistant preview rendering.
