### PR TITLE
Limit rule notifications list height in Channels

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -433,7 +433,7 @@ function ConnectedChannelSection({
           )}
         </Item>
         <ItemSeparator />
-        <div className="max-h-80 overflow-y-auto">
+        <div className="max-h-[8.5rem] overflow-y-auto">
           {rules.length > 0 ? (
             rules.map((rule) => (
               <RuleToggle


### PR DESCRIPTION
## Summary
- Cap the rule notifications list in the Channels page at ~3.5 visible rows so the section no longer dominates the page; additional rules scroll within the container.

## Test plan
- [ ] Open the Channels page with a connected Slack channel and many enabled rules; confirm the list shows ~3.5 rows and scrolls.
- [ ] Confirm pages with few rules render without unnecessary empty space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)