### PR TITLE
Fix duplicate account linking flow

### DIFF
--- a/apps/web/app/(app)/accounts/page.tsx
+++ b/apps/web/app/(app)/accounts/page.tsx
@@ -304,10 +304,10 @@ function getAccountErrorMessage(
       description: `This account doesn't exist in ${BRAND_NAME} yet. Please select 'No, it's a new account' instead.`,
       toastDescription: `This account doesn't exist in ${BRAND_NAME} yet. Please select 'No, it's a new account' instead.`,
     },
-    account_already_exists_use_merge: {
+    account_already_exists: {
       title: "Account already exists",
-      description: `This account already exists in ${BRAND_NAME}. Please select 'Yes, it's an existing ${BRAND_NAME} account' to merge.`,
-      toastDescription: `This account already exists in ${BRAND_NAME}. Please select 'Yes, it's an existing ${BRAND_NAME} account' to merge.`,
+      description: `This account is already linked to another ${BRAND_NAME} profile. Sign in to that profile, use a different email account, or contact support if you need help.`,
+      toastDescription: `This account is already linked to another ${BRAND_NAME} profile. Sign in to that profile, use a different email account, or contact support if you need help.`,
     },
     already_linked_to_self: {
       title: "Account already linked",

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -94,15 +94,13 @@ describe("handleAccountLinking", () => {
     });
   });
 
-  it("should return merge when creating an account whose email already belongs to another user for the same provider", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        accountId: "existing-account-id",
+  it("should redirect with account_already_exists when creating an account whose email belongs to a different user", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      getMockEmailAccountSelect({
         userId: "different-user-id",
         email: "existing@gmail.com",
-      }),
-      account: { provider: "google" },
-    } as any);
+      }) as any,
+    );
 
     const result = await handleAccountLinking({
       existingAccountId: null,
@@ -110,33 +108,6 @@ describe("handleAccountLinking", () => {
       existingUserId: null,
       targetUserId: "target-user-id",
       provider: "google",
-      providerEmail: "existing@gmail.com",
-      logger,
-    });
-
-    expect(result).toEqual({
-      type: "merge",
-      sourceAccountId: "existing-account-id",
-      sourceUserId: "different-user-id",
-    });
-  });
-
-  it("should redirect when the existing email belongs to another provider", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        accountId: "existing-account-id",
-        userId: "different-user-id",
-        email: "existing@gmail.com",
-      }),
-      account: { provider: "google" },
-    } as any);
-
-    const result = await handleAccountLinking({
-      existingAccountId: null,
-      hasEmailAccount: false,
-      existingUserId: null,
-      targetUserId: "target-user-id",
-      provider: "microsoft",
       providerEmail: "existing@gmail.com",
       logger,
     });

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -94,13 +94,15 @@ describe("handleAccountLinking", () => {
     });
   });
 
-  it("should redirect with error when creating account that already exists for different user", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue(
-      getMockEmailAccountSelect({
+  it("should return merge when creating an account whose email already belongs to another user for the same provider", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
+        accountId: "existing-account-id",
         userId: "different-user-id",
         email: "existing@gmail.com",
-      }) as any,
-    );
+      }),
+      account: { provider: "google" },
+    } as any);
 
     const result = await handleAccountLinking({
       existingAccountId: null,
@@ -112,12 +114,37 @@ describe("handleAccountLinking", () => {
       logger,
     });
 
+    expect(result).toEqual({
+      type: "merge",
+      sourceAccountId: "existing-account-id",
+      sourceUserId: "different-user-id",
+    });
+  });
+
+  it("should redirect when the existing email belongs to another provider", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
+        accountId: "existing-account-id",
+        userId: "different-user-id",
+        email: "existing@gmail.com",
+      }),
+      account: { provider: "google" },
+    } as any);
+
+    const result = await handleAccountLinking({
+      existingAccountId: null,
+      hasEmailAccount: false,
+      existingUserId: null,
+      targetUserId: "target-user-id",
+      provider: "microsoft",
+      providerEmail: "existing@gmail.com",
+      logger,
+    });
+
     expect(result.type).toBe("redirect");
     if (result.type === "redirect") {
       const url = new URL(result.response.headers.get("location") || "");
-      expect(url.searchParams.get("error")).toBe(
-        "account_already_exists_use_merge",
-      );
+      expect(url.searchParams.get("error")).toBe("account_already_exists");
     }
   });
 

--- a/apps/web/utils/oauth/account-linking.ts
+++ b/apps/web/utils/oauth/account-linking.ts
@@ -58,36 +58,12 @@ export async function handleAccountLinking({
   if (!existingAccountId || !hasEmailAccount) {
     const existingEmailAccount = await prisma.emailAccount.findUnique({
       where: { email: providerEmail.trim().toLowerCase() },
-      select: {
-        accountId: true,
-        account: { select: { provider: true } },
-        userId: true,
-      },
+      select: { userId: true },
     });
 
     if (existingEmailAccount && existingEmailAccount.userId !== targetUserId) {
-      if (existingEmailAccount.account.provider !== provider) {
-        logger.warn(
-          "Create failed: account with this email already exists for another provider",
-          {
-            provider,
-            email: providerEmail,
-            existingProvider: existingEmailAccount.account.provider,
-            existingUserId: existingEmailAccount.userId,
-            targetUserId,
-          },
-        );
-
-        return {
-          type: "redirect",
-          response: createAccountLinkingRedirect({
-            query: { error: "account_already_exists" },
-          }),
-        };
-      }
-
       logger.warn(
-        "Account email exists for a different user, merging accounts",
+        "Create failed: account with this email already exists for a different user",
         {
           provider,
           email: providerEmail,
@@ -95,10 +71,12 @@ export async function handleAccountLinking({
           targetUserId,
         },
       );
+
       return {
-        type: "merge",
-        sourceAccountId: existingEmailAccount.accountId,
-        sourceUserId: existingEmailAccount.userId,
+        type: "redirect",
+        response: createAccountLinkingRedirect({
+          query: { error: "account_already_exists" },
+        }),
       };
     }
 

--- a/apps/web/utils/oauth/account-linking.ts
+++ b/apps/web/utils/oauth/account-linking.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { env } from "@/env";
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
+import { createAccountLinkingRedirect } from "@/utils/oauth/account-linking-redirect";
 import { cleanupOrphanedAccount } from "@/utils/user/orphaned-account";
 
 interface AccountLinkingParams {
@@ -28,7 +29,6 @@ export async function handleAccountLinking({
   | { type: "merge"; sourceAccountId: string; sourceUserId: string }
   | { type: "update_tokens"; existingAccountId: string }
 > {
-  const redirectUrl = new URL("/accounts", env.NEXT_PUBLIC_BASE_URL);
   const hasActiveTargetUser = await hasActiveAccountLinkingUser({
     targetUserId,
     logger,
@@ -58,12 +58,36 @@ export async function handleAccountLinking({
   if (!existingAccountId || !hasEmailAccount) {
     const existingEmailAccount = await prisma.emailAccount.findUnique({
       where: { email: providerEmail.trim().toLowerCase() },
-      select: { id: true, userId: true, email: true },
+      select: {
+        accountId: true,
+        account: { select: { provider: true } },
+        userId: true,
+      },
     });
 
     if (existingEmailAccount && existingEmailAccount.userId !== targetUserId) {
+      if (existingEmailAccount.account.provider !== provider) {
+        logger.warn(
+          "Create failed: account with this email already exists for another provider",
+          {
+            provider,
+            email: providerEmail,
+            existingProvider: existingEmailAccount.account.provider,
+            existingUserId: existingEmailAccount.userId,
+            targetUserId,
+          },
+        );
+
+        return {
+          type: "redirect",
+          response: createAccountLinkingRedirect({
+            query: { error: "account_already_exists" },
+          }),
+        };
+      }
+
       logger.warn(
-        "Create failed: account with this email already exists for a different user",
+        "Account email exists for a different user, merging accounts",
         {
           provider,
           email: providerEmail,
@@ -71,10 +95,10 @@ export async function handleAccountLinking({
           targetUserId,
         },
       );
-      redirectUrl.searchParams.set("error", "account_already_exists_use_merge");
       return {
-        type: "redirect",
-        response: NextResponse.redirect(redirectUrl),
+        type: "merge",
+        sourceAccountId: existingEmailAccount.accountId,
+        sourceUserId: existingEmailAccount.userId,
       };
     }
 


### PR DESCRIPTION
Fixes the duplicate account-linking path so same-provider duplicate emails merge instead of showing an incorrect merge-option error. Cross-provider duplicates now show actionable account-exists guidance.

- Merge same-provider duplicate email accounts through the linking flow.
- Keep cross-provider duplicate email attempts on an account-exists redirect with updated UI copy.
- Tests: `pnpm --filter inbox-zero-ai test --run utils/oauth/account-linking.test.ts`.