### PR TITLE
Fix follow-up notification snippets

### DIFF
--- a/apps/web/app/api/follow-up-reminders/process.test.ts
+++ b/apps/web/app/api/follow-up-reminders/process.test.ts
@@ -863,6 +863,8 @@ describe("processAccountFollowUps - dedup logic", () => {
   });
 
   it("uses the recipient as the notification counterparty for awaiting follow-ups", async () => {
+    const notificationBody =
+      "The provider preview stops here but the email keeps going with enough detail to make the follow-up notification clearly incomplete if we only send the preview.";
     const provider = createMockProvider({
       getThreadsWithLabel: vi
         .fn()
@@ -871,6 +873,8 @@ describe("processAccountFollowUps - dedup logic", () => {
         ]),
       getLatestMessageInThread: vi.fn().mockResolvedValue({
         ...mockAwaitingMessage("msg-awaiting-notify", OLD_DATE),
+        snippet: "The provider preview stops here",
+        textPlain: notificationBody,
         subject: "Pricing follow-up",
         headers: {
           from: "user@example.com",
@@ -901,6 +905,7 @@ describe("processAccountFollowUps - dedup logic", () => {
         counterpartyName: "Alex Partner",
         counterpartyEmail: "alex@partner.com",
         trackerType: ThreadTrackerType.AWAITING,
+        snippet: notificationBody,
         threadLinkLabel: "Open in Outlook",
       }),
     );

--- a/apps/web/app/api/follow-up-reminders/process.ts
+++ b/apps/web/app/api/follow-up-reminders/process.ts
@@ -35,6 +35,7 @@ import {
   hasElapsedBusinessDays,
   internalDateToDate,
 } from "@/utils/date";
+import { emailToContent } from "@/utils/mail";
 import {
   extractEmailAddress,
   extractNameFromEmail,
@@ -46,6 +47,7 @@ import {
 } from "@/utils/email/provider-types";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
+import type { ParsedMessage } from "@/utils/types";
 import { env } from "@/env";
 
 const FOLLOW_UP_ELIGIBILITY_WINDOW_MINUTES = 15;
@@ -581,7 +583,7 @@ async function processFollowUpsForType({
               end: now,
               timezone: emailAccount.timezone,
             }),
-            snippet: lastMessage.snippet || undefined,
+            snippet: getFollowUpNotificationSnippet(lastMessage),
             threadLink:
               getEmailUrlForOptionalMessage({
                 messageId: lastMessage.id,
@@ -829,6 +831,14 @@ function resolveFollowUpCounterparty({
   const email = extractEmailAddress(header || "") || header || "";
   const name = extractNameFromEmail(header || "") || email || "someone";
   return { name, email };
+}
+
+function getFollowUpNotificationSnippet(
+  message: Pick<ParsedMessage, "snippet" | "textHtml" | "textPlain">,
+) {
+  return (
+    emailToContent(message, { maxLength: 0, extractReply: true }) || undefined
+  );
 }
 
 function getThreadLinkLabel(provider: string) {


### PR DESCRIPTION
Updates follow-up notifications to derive snippets from parsed message content so long messages are not limited to provider previews.

- Uses existing message content parsing for follow-up notification snippets.
- Adds coverage for notification payloads when provider previews are incomplete.
- Tests: `pnpm test app/api/follow-up-reminders/process.test.ts`
- Performance: Adds no database or network calls; runtime work is limited to existing email content parsing during follow-up reminder processing, with low hot-path risk.