### PR TITLE
Format rule suggestions in messaging

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -131,6 +131,24 @@ describe("normalizeMessagingAssistantText", () => {
       "Suggested rule:\n**Road Trip Plans**\nWhen: emails discussing road trips\nThen: move to Travels and notify Telegram",
     );
   });
+
+  it("formats differently-cased rule suggestion tags", () => {
+    expect(
+      normalizeMessagingAssistantText({
+        text: '<Rule-Suggestion name="Monitoring" when="alerts" archive="true" />',
+      }),
+    ).toBe("Suggested rule:\n**Monitoring**\nWhen: alerts\nThen: Archive");
+  });
+
+  it("treats shorthand boolean rule suggestion attributes as enabled", () => {
+    expect(
+      normalizeMessagingAssistantText({
+        text: '<rule-suggestion name="Updates" when="low-priority updates" archive draft markread />',
+      }),
+    ).toBe(
+      "Suggested rule:\n**Updates**\nWhen: low-priority updates\nThen: Archive, Draft Reply, Mark Read",
+    );
+  });
 });
 
 describe("normalizeMessagingUserText", () => {

--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -84,6 +84,53 @@ describe("normalizeMessagingAssistantText", () => {
       "I prepared that reply for you. This draft is pending confirmation.";
     expect(normalizeMessagingAssistantText({ text: input })).toBe(input);
   });
+
+  it("formats inline rule suggestions as readable messaging text", () => {
+    const output = normalizeMessagingAssistantText({
+      text: [
+        "Here are a few suggestions.",
+        "",
+        "<rule-suggestions>",
+        "<rule-suggestion",
+        'name="Monitoring"',
+        'when="mention alerts from monitoring tools"',
+        'label="Monitoring"',
+        'archive="true" />',
+        "<rule-suggestion",
+        'name="Digest Updates"',
+        'when="summary emails from Inbox Zero"',
+        'label="Notification"',
+        "archive={false}",
+        "/>",
+        "</rule-suggestions>",
+        "",
+        "Want me to create either one?",
+      ].join("\n"),
+    });
+
+    expect(output).toContain("Here are a few suggestions.");
+    expect(output).toContain("Suggested rules:");
+    expect(output).toContain("**Monitoring**");
+    expect(output).toContain("When: mention alerts from monitoring tools");
+    expect(output).toContain("Then: Label as 'Monitoring', Archive");
+    expect(output).toContain("**Digest Updates**");
+    expect(output).toContain("When: summary emails from Inbox Zero");
+    expect(output).toContain("Then: Label as 'Notification'");
+    expect(output).toContain("Want me to create either one?");
+    expect(output).not.toContain("<rule-suggestion");
+    expect(output).not.toContain("</rule-suggestions>");
+    expect(output).not.toContain("Then: Label as 'Notification', Archive");
+  });
+
+  it("formats standalone free-form rule suggestions", () => {
+    expect(
+      normalizeMessagingAssistantText({
+        text: '<rule-suggestion name="Road Trip Plans" when="emails discussing road trips" do="move to Travels and notify Telegram" />',
+      }),
+    ).toBe(
+      "Suggested rule:\n**Road Trip Plans**\nWhen: emails discussing road trips\nThen: move to Travels and notify Telegram",
+    );
+  });
 });
 
 describe("normalizeMessagingUserText", () => {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -2880,7 +2880,7 @@ const ruleSuggestionPattern =
   /<rule-suggestions\b[^>]*>[\s\S]*?<\/rule-suggestions>|<rule-suggestion\b[^>]*?\/\s*>|<rule-suggestion\b[^>]*>[\s\S]*?<\/rule-suggestion>/gi;
 
 function formatRuleSuggestionMarkupForMessaging(text: string) {
-  if (!text.includes("<rule-suggestion")) return text;
+  if (!/<rule-suggestion/i.test(text)) return text;
 
   return text
     .replace(ruleSuggestionPattern, (markup) => {
@@ -2964,7 +2964,7 @@ function renderRuleSuggestionForMessaging(suggestion: ParsedRuleSuggestion) {
     .join("\n");
 }
 
-// Tolerates JSX-style booleans the model occasionally emits, e.g. `archive={true}`.
+// Tolerates shorthand and JSX-style booleans the model occasionally emits.
 function normalizeBooleanAttribute(value: string | undefined) {
   return (
     value
@@ -2976,7 +2976,7 @@ function normalizeBooleanAttribute(value: string | undefined) {
 
 function isTrueAttribute(value: string | undefined) {
   const v = normalizeBooleanAttribute(value);
-  return v === "true" || v === "yes";
+  return value !== undefined && (v === "" || v === "true" || v === "yes");
 }
 
 function isFalseAttribute(value: string | undefined) {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -25,13 +25,16 @@ import {
   type ReactionEvent,
   type Thread,
 } from "chat";
+import { load } from "cheerio";
 import { env } from "@/env";
 import type { Prisma } from "@/generated/prisma/client";
 import {
+  ActionType,
   MessagingProvider,
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
+import { getActionDisplay } from "@/utils/action-display";
 import { confirmAssistantEmailActionForAccount } from "@/utils/actions/assistant-chat-confirmation";
 import type { AssistantPendingEmailActionType } from "@/utils/actions/assistant-chat.validation";
 import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
@@ -2662,6 +2665,7 @@ export function stripLeadingSlackMention(text: string): string {
 export function normalizeMessagingAssistantText({ text }: { text: string }) {
   let normalized = text;
 
+  normalized = formatRuleSuggestionMarkupForMessaging(normalized);
   normalized = normalized.replace(
     /(?:you can|please)\s+click [^.]*button[^.]*\./gi,
     "This draft is pending confirmation.",
@@ -2863,4 +2867,119 @@ function prependAccountIndicator({
 }) {
   if (!hasMultipleAccounts) return text;
   return `[${email}]\n${text}`;
+}
+
+type ParsedRuleSuggestion = {
+  title: string;
+  when: string;
+  actions: string;
+  summary: string;
+};
+
+const ruleSuggestionPattern =
+  /<rule-suggestions\b[^>]*>[\s\S]*?<\/rule-suggestions>|<rule-suggestion\b[^>]*?\/\s*>|<rule-suggestion\b[^>]*>[\s\S]*?<\/rule-suggestion>/gi;
+
+function formatRuleSuggestionMarkupForMessaging(text: string) {
+  if (!text.includes("<rule-suggestion")) return text;
+
+  return text
+    .replace(ruleSuggestionPattern, (markup) => {
+      const suggestions = parseRuleSuggestionsMarkup(markup);
+      return suggestions.length
+        ? renderRuleSuggestionsForMessaging(suggestions)
+        : markup;
+    })
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+function parseRuleSuggestionsMarkup(markup: string): ParsedRuleSuggestion[] {
+  const $ = load(markup, null, false);
+
+  return $("rule-suggestion")
+    .toArray()
+    .map((element) => {
+      const attrs = element.attribs ?? {};
+      const structuredActions = buildStructuredRuleActions(attrs).map(
+        (action) => getActionDisplay(action, "", []),
+      );
+      const freeFormAction = attrs.do?.trim() ?? "";
+
+      return {
+        title: attrs.name?.trim() || "Suggested rule",
+        when: attrs.when?.trim() ?? "",
+        actions: [...structuredActions, freeFormAction]
+          .filter(Boolean)
+          .join(", "),
+        summary: $(element).text().trim(),
+      };
+    });
+}
+
+function buildStructuredRuleActions(attrs: Record<string, string>) {
+  const actions: Array<{
+    type: ActionType;
+    label?: string;
+    notificationDestination?: string;
+  }> = [];
+  const label = attrs.label?.trim();
+  if (label) actions.push({ type: ActionType.LABEL, label });
+  if (isTrueAttribute(attrs.archive))
+    actions.push({ type: ActionType.ARCHIVE });
+  if (isTrueAttribute(attrs.draft)) {
+    actions.push({ type: ActionType.DRAFT_EMAIL });
+  }
+  const notify = attrs.notify?.trim();
+  if (notify && !isFalseAttribute(notify)) {
+    actions.push({
+      type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+      notificationDestination: isTrueAttribute(notify) ? undefined : notify,
+    });
+  }
+  if (isTrueAttribute(attrs.markread)) {
+    actions.push({ type: ActionType.MARK_READ });
+  }
+  return actions;
+}
+
+function renderRuleSuggestionsForMessaging(
+  suggestions: ParsedRuleSuggestion[],
+) {
+  const heading =
+    suggestions.length === 1 ? "Suggested rule:" : "Suggested rules:";
+
+  return [
+    heading,
+    suggestions.map(renderRuleSuggestionForMessaging).join("\n\n"),
+  ].join("\n");
+}
+
+function renderRuleSuggestionForMessaging(suggestion: ParsedRuleSuggestion) {
+  return [
+    `**${suggestion.title}**`,
+    suggestion.when ? `When: ${suggestion.when}` : null,
+    suggestion.actions ? `Then: ${suggestion.actions}` : null,
+    suggestion.summary ? `Context: ${suggestion.summary}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+// Tolerates JSX-style booleans the model occasionally emits, e.g. `archive={true}`.
+function normalizeBooleanAttribute(value: string | undefined) {
+  return (
+    value
+      ?.trim()
+      .replace(/^\{(.+)\}$/, "$1")
+      .toLowerCase() ?? ""
+  );
+}
+
+function isTrueAttribute(value: string | undefined) {
+  const v = normalizeBooleanAttribute(value);
+  return v === "true" || v === "yes";
+}
+
+function isFalseAttribute(value: string | undefined) {
+  const v = normalizeBooleanAttribute(value);
+  return v === "false" || v === "no";
 }


### PR DESCRIPTION
Formats rule suggestion markup into readable chat text before messages are sent to messaging channels. This prevents raw XML-style suggestions from appearing in channel responses while preserving existing confirmation text normalization.

- Converts rule suggestion markup into human-readable suggested-rule sections.
- Supports structured label, archive, notification, and free-form actions.
- Adds focused coverage for inline and standalone rule suggestion formatting.
- Test: `pnpm test utils/messaging/chat-sdk/bot.test.ts`.
- Performance: Adds a cheap substring guard before parsing; parsing runs only for assistant messages containing rule suggestion tags, with no database or network calls and low hot-path risk.