### PR TITLE
email: Fix auth cleanup for watch setup

### DIFF
--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
+import { createEmailProvider } from "@/utils/email/provider";
+import { captureException } from "@/utils/error";
+import { ensureEmailAccountsWatched } from "./watch-manager";
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
+  cleanupInvalidTokens: vi.fn(),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("@/utils/log-error-with-dedupe", () => ({
+  logErrorWithDedupe: vi.fn(),
+}));
+
+vi.mock("@/utils/premium", () => ({
+  getPremiumUserFilter: vi.fn(() => ({})),
+  getUserTier: vi.fn(() => "PRO"),
+  hasAiAccess: vi.fn(() => true),
+  premiumEntitlementSelect: {},
+}));
+
+const logger = createTestLogger();
+
+describe("ensureEmailAccountsWatched", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cleans up invalid tokens when watch setup reports a detailed invalid_grant error", async () => {
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      {
+        id: "email-account-id",
+        email: "account@example.com",
+        watchEmailsExpirationDate: new Date(Date.now() + 3_600_000),
+        watchEmailsSubscriptionId: null,
+        account: {
+          provider: "google",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_at: Date.now() + 3_600_000,
+          disconnectedAt: null,
+        },
+        user: {
+          id: "user-id",
+          aiApiKey: null,
+          premium: null,
+        },
+      },
+    ] as any);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      name: "google",
+      watchEmails: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("invalid_grant: token has been expired or revoked"),
+        ),
+    } as any);
+
+    const results = await ensureEmailAccountsWatched({
+      userIds: null,
+      logger,
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledTimes(1);
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "email-account-id",
+        reason: "invalid_grant",
+      }),
+    );
+    expect(captureException).not.toHaveBeenCalled();
+    expect(results).toEqual([
+      {
+        emailAccountId: "email-account-id",
+        status: "error",
+        message: "Failed to set up watch for this account.",
+        errorDetails: "invalid_grant: token has been expired or revoked",
+      },
+    ]);
+  });
+});

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -251,10 +251,10 @@ async function watchEmails({
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    // Minimal centralized handling of permanent auth failures (exact checks only)
-    const isInsufficientPermissions =
-      errorMessage === "Request had insufficient authentication scopes.";
-    const isInvalidGrant = errorMessage === "invalid_grant";
+    const isInsufficientPermissions = errorMessage.includes(
+      "Request had insufficient authentication scopes.",
+    );
+    const isInvalidGrant = errorMessage.includes("invalid_grant");
 
     if (isInsufficientPermissions || isInvalidGrant) {
       logger.warn("Auth failure while watching inbox - cleaning up tokens", {

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { people } from "@googleapis/people";
 import { auth } from "@googleapis/gmail";
 import { saveTokens } from "@/utils/auth/save-tokens";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { createTestLogger } from "@/__tests__/helpers";
 import {
   getContactsClient,
@@ -17,6 +18,10 @@ import { gmail } from "@googleapis/gmail";
 
 vi.mock("@/utils/auth/save-tokens", () => ({
   saveTokens: vi.fn(),
+}));
+
+vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
+  cleanupInvalidTokens: vi.fn(),
 }));
 
 vi.mock("@/utils/google/oauth", () => ({
@@ -154,5 +159,29 @@ describe("gmail oauth client configuration", () => {
         }),
       }),
     );
+  });
+
+  it("cleans up invalid Gmail tokens when refresh reports invalid_grant", async () => {
+    refreshAccessToken.mockRejectedValue(
+      new Error("invalid_grant: token has been expired or revoked"),
+    );
+
+    await expect(
+      getGmailClientWithRefresh({
+        accessToken: "stale-access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() - 1000,
+        emailAccountId: "email-account-id",
+        logger,
+      }),
+    ).rejects.toThrow("invalid_grant");
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledTimes(1);
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-id",
+      reason: "invalid_grant",
+      logger,
+    });
+    expect(saveTokens).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -184,4 +184,27 @@ describe("gmail oauth client configuration", () => {
     });
     expect(saveTokens).not.toHaveBeenCalled();
   });
+
+  it("preserves the original refresh error when invalid token cleanup fails", async () => {
+    const refreshError = new Error(
+      "invalid_grant: token has been expired or revoked",
+    );
+    refreshAccessToken.mockRejectedValue(refreshError);
+    vi.mocked(cleanupInvalidTokens).mockRejectedValue(
+      new Error("cleanup failed"),
+    );
+
+    await expect(
+      getGmailClientWithRefresh({
+        accessToken: "stale-access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() - 1000,
+        emailAccountId: "email-account-id",
+        logger,
+      }),
+    ).rejects.toBe(refreshError);
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledTimes(1);
+    expect(saveTokens).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -1,6 +1,7 @@
 import { auth, gmail, type gmail_v1 } from "@googleapis/gmail";
 import { people } from "@googleapis/people";
 import { saveTokens } from "@/utils/auth/save-tokens";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import type { Logger } from "@/utils/logger";
 import { SCOPES } from "@/utils/gmail/scopes";
 import { SafeError } from "@/utils/error";
@@ -102,6 +103,12 @@ export const getGmailClientWithRefresh = async ({
         error: error.message,
         // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
         errorDescription: (error as any).response?.data?.error_description,
+      });
+
+      await cleanupInvalidTokens({
+        emailAccountId,
+        reason: "invalid_grant",
+        logger,
       });
     }
 

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -105,11 +105,21 @@ export const getGmailClientWithRefresh = async ({
         errorDescription: (error as any).response?.data?.error_description,
       });
 
-      await cleanupInvalidTokens({
-        emailAccountId,
-        reason: "invalid_grant",
-        logger,
-      });
+      try {
+        await cleanupInvalidTokens({
+          emailAccountId,
+          reason: "invalid_grant",
+          logger,
+        });
+      } catch (cleanupError) {
+        logger.error(
+          "Failed to clean up invalid tokens after refresh failure",
+          {
+            emailAccountId,
+            cleanupError,
+          },
+        );
+      }
     }
 
     throw error;


### PR DESCRIPTION
Ensures permanent email auth failures clean up tokens during Gmail refresh and watch setup.

- Run invalid-token cleanup when Gmail refresh reports a permanent auth failure.
- Treat detailed auth failure messages as cleanup candidates in watch setup.
- Add regression tests for refresh and watch setup cleanup paths.

Tests:
- `pnpm test utils/gmail/client.test.ts utils/email/watch-manager.test.ts`
- `pnpm --filter inbox-zero-ai lint`

Performance impact: adds cleanup work only on permanent auth failure paths; no new work on successful watch setup or token refresh.
