### PR TITLE
email: Handle provider error spikes

### DIFF
--- a/apps/web/app/api/google/webhook/process-history.ts
+++ b/apps/web/app/api/google/webhook/process-history.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { getGmailClientWithRefresh } from "@/utils/gmail/client";
 import { GmailLabel } from "@/utils/gmail/label";
-import { captureException } from "@/utils/error";
+import { captureException, isInvalidGrantError } from "@/utils/error";
 import {
   HistoryEventType,
   type ProcessHistoryOptions,
@@ -195,7 +195,7 @@ export async function processHistoryForUser(
       },
     );
   } catch (error) {
-    if (error instanceof Error && error.message === "invalid_grant") {
+    if (isInvalidGrantError(error)) {
       logger.warn("Invalid grant", { email });
       return NextResponse.json({ ok: true });
     }

--- a/apps/web/app/api/outlook/watch/all/route.ts
+++ b/apps/web/app/api/outlook/watch/all/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
 import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
 import { withError } from "@/utils/middleware";
-import { captureException } from "@/utils/error";
+import { captureException, isInvalidGrantError } from "@/utils/error";
 import {
   getPremiumUserFilter,
   getUserTier,
@@ -119,13 +119,12 @@ async function watchAllEmails(logger: Logger) {
       });
     } catch (error) {
       if (error instanceof Error) {
-        const warn = [
-          "invalid_grant",
-          "Mail service not enabled",
-          "Insufficient Permission",
-        ];
+        const warn = ["Mail service not enabled", "Insufficient Permission"];
 
-        if (warn.some((w) => error.message.includes(w))) {
+        if (
+          isInvalidGrantError(error) ||
+          warn.some((w) => error.message.includes(w))
+        ) {
           logger.warn("Not watching emails for user", {
             email: emailAccount.email,
             error,

--- a/apps/web/app/api/outlook/webhook/process-history.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.ts
@@ -1,6 +1,10 @@
 import { after, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { captureException, checkCommonErrors } from "@/utils/error";
+import {
+  captureException,
+  checkCommonErrors,
+  isInvalidGrantError,
+} from "@/utils/error";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { OutlookResourceData } from "@/app/api/outlook/webhook/types";
 import { processHistoryItem } from "@/utils/webhook/process-history-item";
@@ -184,7 +188,7 @@ export async function processHistoryForUser({
       },
     );
   } catch (error) {
-    if (error instanceof Error && error.message.includes("invalid_grant")) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Invalid grant");
       return NextResponse.json({ ok: true });
     }

--- a/apps/web/utils/calendar/client.ts
+++ b/apps/web/utils/calendar/client.ts
@@ -2,7 +2,7 @@ import { auth, calendar, type calendar_v3 } from "@googleapis/calendar";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
 import { CALENDAR_SCOPES as GOOGLE_CALENDAR_SCOPES } from "@/utils/gmail/scopes";
-import { SafeError } from "@/utils/error";
+import { isInvalidGrantError, SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import {
   getGoogleApiRootUrl,
@@ -105,13 +105,10 @@ export const getCalendarClientWithRefresh = async ({
 
     return cal;
   } catch (error) {
-    const isInvalidGrantError =
-      error instanceof Error && error.message.includes("invalid_grant");
-
-    if (isInvalidGrantError) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Error refreshing Calendar access token", {
         emailAccountId,
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
         errorDescription: (
           error as Error & {
             response?: { data?: { error_description?: string } };

--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -18,6 +18,8 @@ vi.mock("@/utils/email/provider", () => ({
 
 vi.mock("@/utils/error", () => ({
   captureException: vi.fn(),
+  isInvalidGrantError: (error: unknown) =>
+    error instanceof Error && error.message.includes("invalid_grant"),
 }));
 
 vi.mock("@/utils/log-error-with-dedupe", () => ({

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -7,7 +7,7 @@ import {
 } from "@/utils/premium";
 import type { Logger } from "@/utils/logger";
 import { createEmailProvider } from "@/utils/email/provider";
-import { captureException } from "@/utils/error";
+import { captureException, isInvalidGrantError } from "@/utils/error";
 import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import type { EmailProvider } from "@/utils/email/types";
 import { createManagedOutlookSubscription } from "@/utils/outlook/subscription-manager";
@@ -97,13 +97,15 @@ async function watchEmailAccounts(
     } catch (error) {
       if (error instanceof Error) {
         const warn = [
-          "invalid_grant",
           "Mail service not enabled",
           "Insufficient Permission",
           "AADSTS7000215", // Raw Azure AD error for invalid client secret (old tokens after secret rotation)
         ];
 
-        if (warn.some((w) => error.message.includes(w))) {
+        if (
+          isInvalidGrantError(error) ||
+          warn.some((w) => error.message.includes(w))
+        ) {
           logger.warn("Not watching emails for user", {
             email: emailAccount.email,
             error,
@@ -254,7 +256,7 @@ async function watchEmails({
     const isInsufficientPermissions = errorMessage.includes(
       "Request had insufficient authentication scopes.",
     );
-    const isInvalidGrant = errorMessage.includes("invalid_grant");
+    const isInvalidGrant = isInvalidGrantError(error);
 
     if (isInsufficientPermissions || isInvalidGrant) {
       logger.warn("Auth failure while watching inbox - cleaning up tokens", {
@@ -289,7 +291,7 @@ export async function unwatchEmails({
 
     await provider.unwatchEmails(subscriptionId || undefined);
   } catch (error) {
-    if (error instanceof Error && error.message.includes("invalid_grant")) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Error unwatching emails, invalid grant");
     } else {
       logger.error("Error unwatching emails", { error });

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -158,6 +158,15 @@ export class SafeError extends Error {
   }
 }
 
+const INVALID_GRANT_ERROR_MARKERS = ["invalid_grant", "AADSTS50173"] as const;
+
+export function isInvalidGrantError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  if (!message) return false;
+
+  return INVALID_GRANT_ERROR_MARKERS.some((marker) => message.includes(marker));
+}
+
 export function isGmailInsufficientPermissionsError(error: unknown): boolean {
   // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
   return (error as any)?.errors?.[0]?.reason === "insufficientPermissions";

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -4,7 +4,7 @@ import { saveTokens } from "@/utils/auth/save-tokens";
 import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import type { Logger } from "@/utils/logger";
 import { SCOPES } from "@/utils/gmail/scopes";
-import { SafeError } from "@/utils/error";
+import { isInvalidGrantError, SafeError } from "@/utils/error";
 import { env } from "@/env";
 import {
   getGoogleGmailApiRootUrl,
@@ -94,13 +94,10 @@ export const getGmailClientWithRefresh = async ({
 
     return g;
   } catch (error) {
-    const isInvalidGrantError =
-      error instanceof Error && error.message.includes("invalid_grant");
-
-    if (isInvalidGrantError) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Error refreshing Gmail access token", {
         emailAccountId,
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
         // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
         errorDescription: (error as any).response?.data?.error_description,
       });

--- a/apps/web/utils/outlook/batch.test.ts
+++ b/apps/web/utils/outlook/batch.test.ts
@@ -77,6 +77,52 @@ describe("moveMessagesForSenders", () => {
       ownerEmail: "owner@example.com",
     });
   });
+
+  it("moves Outlook messages in small batches to avoid mailbox concurrency throttling", async () => {
+    const messages = Array.from({ length: 9 }, (_, index) => ({
+      id: `message-${index + 1}`,
+      conversationId: `thread-${index + 1}`,
+    }));
+    const batchPost = vi.fn(
+      async (body: {
+        requests: Array<{ id: string; url: string; method: string }>;
+      }) => ({
+        responses: body.requests.map((request) => ({
+          id: request.id,
+          status: 201,
+          body: {},
+        })),
+      }),
+    );
+    const client = createMockOutlookClient({
+      listMessages: async () => ({
+        value: messages,
+      }),
+      batchPost,
+    });
+
+    const movedCount = await moveMessagesForSenders({
+      client,
+      senders: ["sender@example.com"],
+      destinationId: "deleteditems",
+      action: "trash",
+      ownerEmail: "owner@example.com",
+      emailAccountId: "account-1",
+      logger: createTestLogger(),
+    });
+
+    expect(movedCount).toBe(9);
+    expect(batchPost).toHaveBeenCalledTimes(3);
+    expect(batchPost.mock.calls.map(([body]) => body.requests.length)).toEqual([
+      4, 4, 1,
+    ]);
+    expect(mockUpdateEmailMessagesForSender).toHaveBeenCalledWith({
+      sender: "sender@example.com",
+      messageIds: messages.map((message) => message.id),
+      emailAccountId: "account-1",
+      action: "trash",
+    });
+  });
 });
 
 function createMockOutlookClient({

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -8,6 +8,7 @@ import {
 } from "@/utils/email/bulk-action-tracking";
 
 const GRAPH_JSON_BATCH_LIMIT = 20; // Microsoft Graph JSON batching limit
+const GRAPH_MOVE_BATCH_LIMIT = 4;
 
 type GraphBatchRequestItem<TBody = unknown> = {
   id: string;
@@ -36,12 +37,14 @@ type MoveMessagesBatchResult = {
 async function batch<TRequestBody = unknown, TResponseBody = unknown>({
   client,
   requests,
+  chunkSize,
   onFailure,
   context,
   logger,
 }: {
   client: OutlookClient;
   requests: GraphBatchRequestItem<TRequestBody>[];
+  chunkSize?: number;
   onFailure?: (params: {
     request?: GraphBatchRequestItem<TRequestBody>;
     response: GraphBatchResponseItem<TResponseBody>;
@@ -53,13 +56,13 @@ async function batch<TRequestBody = unknown, TResponseBody = unknown>({
 
   const graphClient = client.getClient();
   const aggregatedResponses: GraphBatchResponseItem<TResponseBody>[] = [];
+  const effectiveChunkSize = Math.min(
+    chunkSize ?? GRAPH_JSON_BATCH_LIMIT,
+    GRAPH_JSON_BATCH_LIMIT,
+  );
 
-  for (
-    let start = 0;
-    start < requests.length;
-    start += GRAPH_JSON_BATCH_LIMIT
-  ) {
-    const chunk = requests.slice(start, start + GRAPH_JSON_BATCH_LIMIT);
+  for (let start = 0; start < requests.length; start += effectiveChunkSize) {
+    const chunk = requests.slice(start, start + effectiveChunkSize);
 
     try {
       const response = (await graphClient
@@ -133,6 +136,7 @@ async function moveMessagesInBatches({
   const responses = await batch({
     client,
     requests,
+    chunkSize: GRAPH_MOVE_BATCH_LIMIT,
     context: {
       action,
       destinationId,

--- a/apps/web/utils/outlook/calendar-client.ts
+++ b/apps/web/utils/outlook/calendar-client.ts
@@ -6,7 +6,7 @@ import {
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import { CALENDAR_SCOPES } from "@/utils/outlook/scopes";
-import { SafeError } from "@/utils/error";
+import { isInvalidGrantError, SafeError } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { saveCalendarTokens } from "@/utils/calendar/save-calendar-tokens";
 import {
@@ -122,13 +122,10 @@ export const getCalendarClientWithRefresh = async ({
       ...getMicrosoftGraphClientOptions(tokens.access_token),
     });
   } catch (error) {
-    const isInvalidGrantError =
-      error instanceof Error && error.message.includes("invalid_grant");
-
-    if (isInvalidGrantError) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Error refreshing Calendar access token", {
         emailAccountId,
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
 

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -10,7 +10,7 @@ import {
   requestMicrosoftToken,
 } from "@/utils/microsoft/oauth";
 import { SCOPES } from "@/utils/outlook/scopes";
-import { SafeError } from "@/utils/error";
+import { isInvalidGrantError, SafeError } from "@/utils/error";
 
 // Add buffer time to prevent token expiry during long-running operations
 const TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
@@ -169,27 +169,25 @@ export const getOutlookClientWithRefresh = async ({
       // AADSTS70008 = Refresh token expired due to inactivity
       // AADSTS70011 = Invalid scope
       // AADSTS700082 = Refresh token expired
-      // AADSTS50173 = Invalid grant (refresh token revoked)
       // AADSTS65001 = User hasn't consented to permissions
       // AADSTS500011 = Resource principal not found (scope issue)
       // AADSTS54005 = Authorization code already redeemed
       // AADSTS50076 = MFA required (Conditional Access policy)
       // AADSTS50079 = MFA registration required
       // AADSTS50158 = External security challenge not satisfied
-      // invalid_grant = General token refresh failure
+      // Invalid grants are handled by isInvalidGrantError.
       const requiresReauth =
+        isInvalidGrantError(errorMessage) ||
         errorMessage.includes("AADSTS70000") ||
         errorMessage.includes("AADSTS70008") ||
         errorMessage.includes("AADSTS70011") ||
         errorMessage.includes("AADSTS700082") ||
-        errorMessage.includes("AADSTS50173") ||
         errorMessage.includes("AADSTS65001") ||
         errorMessage.includes("AADSTS500011") ||
         errorMessage.includes("AADSTS54005") ||
         errorMessage.includes("AADSTS50076") ||
         errorMessage.includes("AADSTS50079") ||
-        errorMessage.includes("AADSTS50158") ||
-        errorMessage.includes("invalid_grant");
+        errorMessage.includes("AADSTS50158");
 
       if (requiresReauth) {
         logger.warn(
@@ -228,12 +226,7 @@ export const getOutlookClientWithRefresh = async ({
 
     return createOutlookClient(tokens.access_token, logger);
   } catch (error) {
-    const isInvalidGrantError =
-      error instanceof Error &&
-      (error.message.includes("invalid_grant") ||
-        error.message.includes("AADSTS50173"));
-
-    if (isInvalidGrantError) {
+    if (isInvalidGrantError(error)) {
       logger.warn("Error refreshing Outlook access token", { error });
     }
 

--- a/apps/web/utils/webhook/error-handler.test.ts
+++ b/apps/web/utils/webhook/error-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handleWebhookError } from "@/utils/webhook/error-handler";
 import { trackError } from "@/utils/posthog";
 import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/posthog", () => ({
@@ -9,6 +10,9 @@ vi.mock("@/utils/posthog", () => ({
 }));
 vi.mock("@/utils/email/rate-limit", () => ({
   recordRateLimitFromApiError: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
+  cleanupInvalidTokens: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("handleWebhookError", () => {
@@ -27,8 +31,23 @@ describe("handleWebhookError", () => {
   const mockRecordRateLimitFromApiError = vi.mocked(
     recordRateLimitFromApiError,
   );
+  const mockCleanupInvalidTokens = vi.mocked(cleanupInvalidTokens);
 
   describe("Gmail errors", () => {
+    it("cleans up invalid grants without reporting an unhandled webhook error", async () => {
+      const error = new Error("invalid_grant");
+
+      await handleWebhookError(error, baseOptions);
+
+      expect(mockCleanupInvalidTokens).toHaveBeenCalledWith({
+        emailAccountId: "acc-123",
+        reason: "invalid_grant",
+        logger,
+      });
+      expect(trackError).not.toHaveBeenCalled();
+      expect(mockRecordRateLimitFromApiError).not.toHaveBeenCalled();
+    });
+
     it("tracks Gmail rate limit errors", async () => {
       const error = Object.assign(new Error("Rate limit exceeded"), {
         errors: [

--- a/apps/web/utils/webhook/error-handler.ts
+++ b/apps/web/utils/webhook/error-handler.ts
@@ -1,7 +1,8 @@
-import { checkCommonErrors } from "@/utils/error";
+import { checkCommonErrors, isInvalidGrantError } from "@/utils/error";
 import { trackError } from "@/utils/posthog";
 import type { Logger } from "@/utils/logger";
 import { recordRateLimitFromApiError } from "@/utils/email/rate-limit";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 
 /**
  * Handles errors from async webhook processing in the same way as withError middleware
@@ -17,6 +18,20 @@ export async function handleWebhookError(
   },
 ) {
   const { email, emailAccountId, url, logger } = options;
+
+  if (isInvalidGrantError(error)) {
+    logger.warn("Invalid grant while processing webhook", { emailAccountId });
+
+    if (emailAccountId !== "unknown") {
+      await cleanupInvalidTokens({
+        emailAccountId,
+        reason: "invalid_grant",
+        logger,
+      });
+    }
+
+    return;
+  }
 
   const apiError = checkCommonErrors(error, url, logger);
   if (apiError) {


### PR DESCRIPTION
Adds shared provider auth error detection and applies it across webhook, watch, and refresh handling paths. Reduces noisy unhandled error logging for permanent auth failures and lowers Outlook bulk move batch size to reduce provider throttling. Includes focused regression coverage for webhook cleanup and Outlook move batching.\n\nTests: pnpm check on touched files; pnpm test utils/gmail/client.test.ts utils/email/watch-manager.test.ts utils/webhook/error-handler.test.ts utils/outlook/batch.test.ts\n\nPerformance impact: adds cleanup work only when permanent auth failures occur and reduces Outlook bulk move concurrency, trading some bulk action throughput for fewer provider throttle failures.