### PR TITLE
Fix rule suggestion approval state

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -199,6 +199,9 @@ describe("AssistantInlineEmailResponse", () => {
         expect.stringContaining("Create this suggested rule: Monitoring"),
       );
     });
+
+    expect(screen.queryByRole("button", { name: /Approve/i })).toBeNull();
+    expect(screen.getByText("Rule created")).toBeTruthy();
   });
 
   it("renders rule suggestions with attributes split across lines", () => {

--- a/apps/web/components/assistant-chat/inline-rule-suggestion-card.tsx
+++ b/apps/web/components/assistant-chat/inline-rule-suggestion-card.tsx
@@ -54,6 +54,7 @@ export function InlineRuleSuggestionCard({
 }: InlineRuleSuggestionCardProps) {
   const { submitTextMessage } = useChat();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRuleCreated, setIsRuleCreated] = useState(false);
   const title = normalizeTagAttribute(name) || "Suggested rule";
   const whenText = normalizeTagAttribute(when);
   const actionText = normalizeTagAttribute(action);
@@ -85,6 +86,7 @@ export function InlineRuleSuggestionCard({
           .filter(Boolean)
           .join("\n"),
       );
+      setIsRuleCreated(true);
     } finally {
       setIsSubmitting(false);
     }
@@ -94,20 +96,27 @@ export function InlineRuleSuggestionCard({
     <RuleSummaryCard
       title={title}
       actions={
-        <Button
-          type="button"
-          size="sm"
-          className="h-8 shrink-0 gap-1.5"
-          disabled={isSubmitting}
-          onClick={handleApproveRule}
-        >
-          {isSubmitting ? (
-            <Loader2Icon className="size-3.5 animate-spin" />
-          ) : (
+        isRuleCreated ? (
+          <Badge color="green" className="shrink-0 gap-1.5">
             <CheckIcon className="size-3.5" />
-          )}
-          Approve
-        </Button>
+            Rule created
+          </Badge>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 shrink-0 gap-1.5"
+            disabled={isSubmitting}
+            onClick={handleApproveRule}
+          >
+            {isSubmitting ? (
+              <Loader2Icon className="size-3.5 animate-spin" />
+            ) : (
+              <CheckIcon className="size-3.5" />
+            )}
+            Approve
+          </Button>
+        )
       }
     >
       {whenText && <RuleSummaryRow label="When">{whenText}</RuleSummaryRow>}


### PR DESCRIPTION
Stops the inline rule suggestion from showing the approval action after a rule has been created. Adds coverage for the completed state.

- Replace the approve button with a created-state badge after submission.
- Extend the assistant inline response test to assert the completed state.
- Test: `pnpm test components/assistant-chat/assistant-inline-email-response.test.tsx`.

Performance impact: Adds one local React state flag only; no additional runtime work beyond render state updates, no database or network calls, and no hot-path risk.