### PR TITLE
Fix assistant sidebar close control

### DIFF
--- a/apps/web/components/SidebarRight.tsx
+++ b/apps/web/components/SidebarRight.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useEffect } from "react";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Chat } from "@/components/assistant-chat/chat";
 import { cn } from "@/utils";
@@ -11,8 +12,7 @@ export function SidebarRight({
   name: string;
   className?: string;
 }) {
-  const { state, openMobile, isMobile } = useSidebar();
-  const isOpen = isMobile ? openMobile.includes(name) : state.includes(name);
+  const { isOpen, close } = useSidebarPanel(name);
 
   return (
     <div
@@ -24,8 +24,36 @@ export function SidebarRight({
       )}
     >
       <div className="flex h-full w-full flex-col overflow-hidden">
-        <Chat open={isOpen} />
+        <Chat open={isOpen} onClose={close} />
       </div>
     </div>
   );
+}
+
+function useSidebarPanel(name: string) {
+  const { state, openMobile, isMobile, setOpen, setOpenMobile } = useSidebar();
+  const isOpen = isMobile ? openMobile.includes(name) : state.includes(name);
+  const close = useCallback(() => {
+    const removeSidebar = (openSidebars: string[]) =>
+      openSidebars.filter((sidebarName) => sidebarName !== name);
+
+    setOpen(removeSidebar);
+    setOpenMobile(removeSidebar);
+  }, [name, setOpen, setOpenMobile]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [close, isOpen]);
+
+  return { close, isOpen };
 }

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -8,6 +8,7 @@ import {
   PaperclipIcon,
   PlusIcon,
   SquareIcon,
+  XIcon,
 } from "lucide-react";
 import { Messages } from "./messages";
 import { PreviewAttachment } from "./preview-attachment";
@@ -51,7 +52,13 @@ const ACCEPTED_IMAGE_TYPES = [
   "image/gif",
 ];
 
-export function Chat({ open }: { open: boolean }) {
+export function Chat({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose?: () => void;
+}) {
   const analytics = useProductAnalytics("assistant_chat");
   const {
     chat,
@@ -298,7 +305,7 @@ export function Chat({ open }: { open: boolean }) {
         } as React.CSSProperties
       }
     >
-      <ChatTopBar hasMessages={hasMessages} />
+      <ChatTopBar hasMessages={hasMessages} onClose={onClose} />
       {hasMessages ? (
         <ChatMessagesView
           status={status}
@@ -430,18 +437,19 @@ function NewChatView({
   );
 }
 
-function ChatTopBar({ hasMessages }: { hasMessages: boolean }) {
+function ChatTopBar({
+  hasMessages,
+  onClose,
+}: {
+  hasMessages: boolean;
+  onClose?: () => void;
+}) {
   return (
     <div className="relative mx-auto w-full max-w-[calc(var(--chat-max-w)+var(--chat-px)*2)] px-[var(--chat-px)] pt-2">
       <div className="flex items-center justify-end gap-1">
-        {hasMessages ? (
-          <>
-            <NewChatButton />
-            <ChatHistoryDropdown />
-          </>
-        ) : (
-          <ChatHistoryDropdown />
-        )}
+        {hasMessages ? <NewChatButton /> : null}
+        <ChatHistoryDropdown />
+        {onClose ? <CloseChatButton onClose={onClose} /> : null}
       </div>
     </div>
   );
@@ -455,6 +463,22 @@ function NewChatButton() {
       <Button variant="ghost" size="icon" onClick={setNewChat}>
         <PlusIcon className="size-5" />
         <span className="sr-only">New Chat</span>
+      </Button>
+    </Tooltip>
+  );
+}
+
+function CloseChatButton({ onClose }: { onClose: () => void }) {
+  return (
+    <Tooltip content="Close assistant">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onClose}
+        aria-label="Close assistant"
+      >
+        <XIcon className="size-5" aria-hidden="true" />
       </Button>
     </Tooltip>
   );


### PR DESCRIPTION
Fixes the assistant sidebar so it can be dismissed from inside the panel when narrow layouts cover the external AI Chat toggle.

- Adds an optional in-panel close button for sidebar chat instances
- Closes the sidebar with Escape while it is open
- Keeps the full assistant page unchanged

Performance impact: no added network or database calls; only a lightweight keydown listener while the sidebar is open.