### PR TITLE
fix: complete ExecutedRule lifecycle when scheduled actions fail

### DIFF
--- a/apps/web/app/api/cron/scheduled-actions/route.ts
+++ b/apps/web/app/api/cron/scheduled-actions/route.ts
@@ -5,7 +5,10 @@ import { captureException } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { ScheduledActionStatus } from "@/generated/prisma/enums";
 import { createEmailProvider } from "@/utils/email/provider";
-import { executeScheduledAction } from "@/utils/scheduled-actions/executor";
+import {
+  checkAndCompleteExecutedRule,
+  executeScheduledAction,
+} from "@/utils/scheduled-actions/executor";
 import { markQStashActionAsExecuting } from "@/utils/scheduled-actions/scheduler";
 import { env } from "@/env";
 import type { Logger } from "@/utils/logger";
@@ -93,6 +96,10 @@ async function processScheduledActions(logger: Logger) {
           where: { id: scheduledAction.id },
           data: { status: ScheduledActionStatus.FAILED },
         });
+        await checkAndCompleteExecutedRule(
+          scheduledAction.executedRuleId,
+          actionLogger,
+        );
         failed += 1;
         continue;
       }
@@ -128,6 +135,10 @@ async function processScheduledActions(logger: Logger) {
         where: { id: scheduledAction.id },
         data: { status: ScheduledActionStatus.FAILED },
       });
+      await checkAndCompleteExecutedRule(
+        scheduledAction.executedRuleId,
+        actionLogger,
+      );
       failed += 1;
     }
   }

--- a/apps/web/app/api/scheduled-actions/execute/route.ts
+++ b/apps/web/app/api/scheduled-actions/execute/route.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { withError } from "@/utils/middleware";
 import { markQStashActionAsExecuting } from "@/utils/scheduled-actions/scheduler";
-import { executeScheduledAction } from "@/utils/scheduled-actions/executor";
+import {
+  checkAndCompleteExecutedRule,
+  executeScheduledAction,
+} from "@/utils/scheduled-actions/executor";
 import prisma from "@/utils/prisma";
 import { ScheduledActionStatus } from "@/generated/prisma/enums";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -17,6 +20,8 @@ export const POST = withError(
   "scheduled-actions/execute",
   withQstashOrInternal(async (request) => {
     const logger = request.logger;
+    let executingAction: { id: string; executedRuleId: string } | null = null;
+
     try {
       logger.info("QStash request received", {
         url: request.url,
@@ -87,11 +92,23 @@ export const POST = withError(
         });
         return new Response("Action already being processed", { status: 200 });
       }
+      executingAction = {
+        id: scheduledAction.id,
+        executedRuleId: scheduledAction.executedRuleId,
+      };
 
       if (!scheduledAction.emailAccount?.account?.provider) {
         logger.error("Email account or provider missing", {
           scheduledActionId: scheduledAction.id,
         });
+        await prisma.scheduledAction.update({
+          where: { id: scheduledAction.id },
+          data: { status: ScheduledActionStatus.FAILED },
+        });
+        await checkAndCompleteExecutedRule(
+          scheduledAction.executedRuleId,
+          logger,
+        );
         return new Response("Email account or provider missing", {
           status: 500,
         });
@@ -123,6 +140,16 @@ export const POST = withError(
       }
     } catch (error) {
       logger.error("QStash scheduled action execution failed", { error });
+      if (executingAction) {
+        await prisma.scheduledAction.update({
+          where: { id: executingAction.id },
+          data: { status: ScheduledActionStatus.FAILED },
+        });
+        await checkAndCompleteExecutedRule(
+          executingAction.executedRuleId,
+          logger,
+        );
+      }
       return new Response("Internal server error", { status: 500 });
     }
   }),

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ActionType, ScheduledActionStatus } from "@/generated/prisma/enums";
-import { executeScheduledAction } from "./executor";
-import prisma from "@/utils/__mocks__/prisma";
+import {
+  ActionType,
+  ExecutedRuleStatus,
+  ScheduledActionStatus,
+} from "@/generated/prisma/enums";
+import { runActionFunction } from "@/utils/ai/actions";
+import { createEmailProvider } from "@/utils/email/provider";
+import { getEmailAccountWithAiAndTokens } from "@/utils/user/get";
 import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { executeScheduledAction } from "./executor";
 
 const logger = createTestLogger();
+const failedScheduledActionReason = "One or more scheduled actions failed";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/user/get", () => ({
@@ -36,110 +44,23 @@ vi.mock("@/utils/email/provider", () => ({
 describe("executor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEmailAccountWithAiAndTokens).mockResolvedValue(
+      mockEmailAccount as any,
+    );
+    vi.mocked(runActionFunction).mockResolvedValue(undefined);
   });
 
   describe("executeScheduledAction", () => {
-    const mockScheduledAction = {
-      id: "scheduled-action-123",
-      executedRuleId: "rule-123",
-      actionType: ActionType.ARCHIVE,
-      messageId: "msg-123",
-      threadId: "thread-123",
-      emailAccountId: "account-123",
-      scheduledFor: new Date("2024-01-01T12:00:00Z"),
-      status: ScheduledActionStatus.PENDING,
-      label: null,
-      subject: null,
-      content: null,
-      to: null,
-      cc: null,
-      bcc: null,
-      url: null,
-      staticAttachments: null,
-      selectedAttachments: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      executedAt: null,
-      executedActionId: null,
-    } as any;
-
     it("should successfully execute action and mark as completed", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.COMPLETED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-123",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "PENDING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      prisma.scheduledAction.count.mockResolvedValue(0);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLIED",
-        automated: true,
-        reason: null,
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
-      );
-
-      (runActionFunction as any).mockResolvedValue(undefined);
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
+      mockScheduledActionUpdate(ScheduledActionStatus.COMPLETED);
+      mockExecutedActionCreate();
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 0 });
+      mockExecutedRuleUpdate(ExecutedRuleStatus.APPLIED);
 
       const result = await executeScheduledAction(
         mockScheduledAction,
-        mockEmailProvider,
+        await getMockEmailProvider(),
         logger,
       );
 
@@ -152,105 +73,40 @@ describe("executor", () => {
           executedActionId: "executed-action-123",
         },
       });
+      expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
     });
 
     it("forwards selectedAttachments into the executed action", async () => {
+      const selectedAttachments = [
+        {
+          fileId: "drive-file-1",
+          name: "proposal.pdf",
+          mimeType: "application/pdf",
+        },
+      ];
       const scheduledActionWithAttachments = {
         ...mockScheduledAction,
         actionType: ActionType.REPLY,
         content: "Reply with attachment",
-        selectedAttachments: [
-          {
-            fileId: "drive-file-1",
-            name: "proposal.pdf",
-            mimeType: "application/pdf",
-          },
-        ],
+        selectedAttachments,
       };
 
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...scheduledActionWithAttachments,
-        status: ScheduledActionStatus.COMPLETED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-123",
-        type: ActionType.REPLY,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: "Reply with attachment",
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-        selectedAttachments: [
-          {
-            fileId: "drive-file-1",
-            name: "proposal.pdf",
-            mimeType: "application/pdf",
-          },
-        ],
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "PENDING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      prisma.scheduledAction.count.mockResolvedValue(0);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLIED",
-        automated: true,
-        reason: null,
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
+      mockScheduledActionUpdate(
+        ScheduledActionStatus.COMPLETED,
+        scheduledActionWithAttachments,
       );
-
-      (runActionFunction as any).mockResolvedValue(undefined);
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
+      mockExecutedActionCreate({
+        type: ActionType.REPLY,
+        content: "Reply with attachment",
+        selectedAttachments,
       });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 0 });
+      mockExecutedRuleUpdate(ExecutedRuleStatus.APPLIED);
 
       await executeScheduledAction(
         scheduledActionWithAttachments,
-        mockEmailProvider,
+        await getMockEmailProvider(),
         logger,
       );
 
@@ -258,241 +114,55 @@ describe("executor", () => {
         data: expect.objectContaining({
           type: ActionType.REPLY,
           content: "Reply with attachment",
-          selectedAttachments: [
-            {
-              fileId: "drive-file-1",
-              name: "proposal.pdf",
-              mimeType: "application/pdf",
-            },
-          ],
+          selectedAttachments,
         }),
       });
     });
 
+    it("should complete the ExecutedRule when the email no longer exists", async () => {
+      const emailProvider = await getMockEmailProvider();
+      (emailProvider.getMessage as any).mockResolvedValueOnce(null);
+      mockScheduledActionUpdate(ScheduledActionStatus.COMPLETED);
+      mockCompletionCounts({ pendingActions: 0, failedActions: 0 });
+      mockExecutedRuleUpdate(ExecutedRuleStatus.APPLIED);
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        emailProvider,
+        logger,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        reason: "Email no longer exists",
+      });
+      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
+        where: { id: "scheduled-action-123" },
+        data: {
+          status: ScheduledActionStatus.COMPLETED,
+          executedAt: expect.any(Date),
+          executedActionId: undefined,
+        },
+      });
+      expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
+    });
+
     it("should handle execution errors and mark as failed", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.FAILED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-123",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "PENDING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      // pending=0, failed=1 → completion check runs and sets ERROR
-      prisma.scheduledAction.count
-        .mockResolvedValueOnce(0)
-        .mockResolvedValueOnce(1);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "ERROR",
-        automated: true,
-        reason: "One or more scheduled actions failed",
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
+      mockScheduledActionUpdate(ScheduledActionStatus.FAILED);
+      mockExecutedActionCreate();
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 1 });
+      mockExecutedRuleUpdate(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
       );
-
-      (runActionFunction as any).mockRejectedValue(
+      vi.mocked(runActionFunction).mockRejectedValue(
         new Error("Execution failed"),
       );
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
 
       const result = await executeScheduledAction(
         mockScheduledAction,
-        mockEmailProvider,
-        logger,
-      );
-
-      expect(result.success).toBe(false);
-      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
-        where: { id: "scheduled-action-123" },
-        data: {
-          status: ScheduledActionStatus.FAILED,
-        },
-      });
-    });
-
-    it("should handle account not found errors", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.EXECUTING,
-      } as any);
-      // pending=0, failed=1 → completion check sets ERROR
-      prisma.scheduledAction.count
-        .mockResolvedValueOnce(0)
-        .mockResolvedValueOnce(1);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "ERROR",
-        automated: true,
-        reason: "One or more scheduled actions failed",
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
-      );
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue(null);
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
-
-      await executeScheduledAction(
-        mockScheduledAction,
-        mockEmailProvider,
-        logger,
-      );
-
-      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
-        where: { id: "scheduled-action-123" },
-        data: {
-          status: ScheduledActionStatus.FAILED,
-        },
-      });
-    });
-    // @ana A001, A002, A003, A009, A010
-    it("should transition ExecutedRule to ERROR when last action fails", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.FAILED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-123",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLYING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      // pending=0, failed=1 → should set ERROR
-      prisma.scheduledAction.count
-        .mockResolvedValueOnce(0)
-        .mockResolvedValueOnce(1);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "ERROR",
-        automated: true,
-        reason: "One or more scheduled actions failed",
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
-      );
-
-      (runActionFunction as any).mockRejectedValue(
-        new Error("Execution failed"),
-      );
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
-
-      const result = await executeScheduledAction(
-        mockScheduledAction,
-        mockEmailProvider,
+        await getMockEmailProvider(),
         logger,
       );
 
@@ -501,267 +171,70 @@ describe("executor", () => {
         where: { id: "scheduled-action-123" },
         data: { status: ScheduledActionStatus.FAILED },
       });
-      expect(prisma.scheduledAction.count).toHaveBeenCalled();
-      expect(prisma.executedRule.update).toHaveBeenCalledWith({
-        where: { id: "rule-123" },
-        data: {
-          status: "ERROR",
-          reason: "One or more scheduled actions failed",
-        },
-      });
+      expectExecutedRuleStatus(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
     });
 
-    // @ana A004, A005
+    it("should handle account not found errors", async () => {
+      mockScheduledActionUpdate(ScheduledActionStatus.FAILED);
+      mockCompletionCounts({ pendingActions: 0, failedActions: 1 });
+      mockExecutedRuleUpdate(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
+      vi.mocked(getEmailAccountWithAiAndTokens).mockResolvedValue(null);
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        await getMockEmailProvider(),
+        logger,
+      );
+
+      expect(result.success).toBe(false);
+      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
+        where: { id: "scheduled-action-123" },
+        data: { status: ScheduledActionStatus.FAILED },
+      });
+      expectExecutedRuleStatus(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
+    });
+
     it("should transition ExecutedRule to ERROR when some actions fail and others succeed", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.COMPLETED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-456",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLYING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      // pending=0, failed=2 (siblings failed earlier) → should set ERROR
-      prisma.scheduledAction.count
-        .mockResolvedValueOnce(0)
-        .mockResolvedValueOnce(2);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "ERROR",
-        automated: true,
-        reason: "One or more scheduled actions failed",
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
+      mockScheduledActionUpdate(ScheduledActionStatus.COMPLETED);
+      mockExecutedActionCreate({ id: "executed-action-456" });
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 2 });
+      mockExecutedRuleUpdate(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
       );
-
-      (runActionFunction as any).mockResolvedValue(undefined);
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
 
       const result = await executeScheduledAction(
         mockScheduledAction,
-        mockEmailProvider,
+        await getMockEmailProvider(),
         logger,
       );
 
       expect(result.success).toBe(true);
-      expect(prisma.executedRule.update).toHaveBeenCalledWith({
-        where: { id: "rule-123" },
-        data: {
-          status: "ERROR",
-          reason: "One or more scheduled actions failed",
-        },
-      });
+      expectExecutedRuleStatus(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
     });
 
-    // @ana A006, A007
-    it("should transition ExecutedRule to APPLIED when all actions succeed", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.COMPLETED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-789",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLYING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      // pending=0, failed=0 → should set APPLIED
-      prisma.scheduledAction.count
-        .mockResolvedValueOnce(0)
-        .mockResolvedValueOnce(0);
-      prisma.executedRule.update.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLIED",
-        automated: true,
-        reason: null,
-        ruleId: null,
-        matchMetadata: null,
-      });
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
-      );
-
-      (runActionFunction as any).mockResolvedValue(undefined);
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
-
-      const result = await executeScheduledAction(
-        mockScheduledAction,
-        mockEmailProvider,
-        logger,
-      );
-
-      expect(result.success).toBe(true);
-      expect(prisma.executedRule.update).toHaveBeenCalledWith({
-        where: { id: "rule-123" },
-        data: { status: "APPLIED" },
-      });
-    });
-
-    // @ana A008
     it("should not update ExecutedRule status when actions are still pending", async () => {
-      prisma.scheduledAction.update.mockResolvedValue({
-        ...mockScheduledAction,
-        status: ScheduledActionStatus.COMPLETED,
-      } as any);
-      prisma.executedAction.create.mockResolvedValue({
-        id: "executed-action-101",
-        type: ActionType.ARCHIVE,
-        label: null,
-        labelId: null,
-        folderName: null,
-        folderId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        executedRuleId: "rule-123",
-        subject: null,
-        content: null,
-        to: null,
-        cc: null,
-        bcc: null,
-        url: null,
-        draftId: null,
-        draftStatus: null,
-      });
-      prisma.executedRule.findUnique.mockResolvedValue({
-        id: "rule-123",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        messageId: "msg-123",
-        threadId: "thread-123",
-        emailAccountId: "account-123",
-        status: "APPLYING",
-        automated: true,
-        reason: null,
-        ruleId: null,
-      } as any);
-      // pending=2 → should NOT update ExecutedRule
-      prisma.scheduledAction.count.mockResolvedValueOnce(2);
-
-      const { runActionFunction } = await import("@/utils/ai/actions");
-      const { getEmailAccountWithAiAndTokens } = await import(
-        "@/utils/user/get"
-      );
-
-      (runActionFunction as any).mockResolvedValue(undefined);
-      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
-        id: "account-123",
-        userId: "user-123",
-        email: "test@example.com",
-        tokens: {
-          access_token: "token",
-          refresh_token: "refresh",
-          expires_at: Date.now() + 3_600_000,
-        },
-      });
-
-      const { createEmailProvider } = await import("@/utils/email/provider");
-      const mockEmailProvider = await createEmailProvider({
-        emailAccountId: "account-123",
-        provider: "google",
-      });
+      mockScheduledActionUpdate(ScheduledActionStatus.COMPLETED);
+      mockExecutedActionCreate({ id: "executed-action-101" });
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 2 });
 
       const result = await executeScheduledAction(
         mockScheduledAction,
-        mockEmailProvider,
+        await getMockEmailProvider(),
         logger,
       );
 
@@ -770,3 +243,132 @@ describe("executor", () => {
     });
   });
 });
+
+const mockEmailAccount = {
+  id: "account-123",
+  userId: "user-123",
+  email: "test@example.com",
+  tokens: {
+    access_token: "token",
+    refresh_token: "refresh",
+    expires_at: Date.now() + 3_600_000,
+  },
+};
+
+const mockScheduledAction = {
+  id: "scheduled-action-123",
+  executedRuleId: "rule-123",
+  actionType: ActionType.ARCHIVE,
+  messageId: "msg-123",
+  threadId: "thread-123",
+  emailAccountId: "account-123",
+  scheduledFor: new Date("2024-01-01T12:00:00Z"),
+  status: ScheduledActionStatus.PENDING,
+  label: null,
+  subject: null,
+  content: null,
+  to: null,
+  cc: null,
+  bcc: null,
+  url: null,
+  staticAttachments: null,
+  selectedAttachments: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  executedAt: null,
+  executedActionId: null,
+} as any;
+
+async function getMockEmailProvider() {
+  return createEmailProvider({
+    emailAccountId: "account-123",
+    provider: "google",
+  });
+}
+
+function mockScheduledActionUpdate(
+  status: ScheduledActionStatus,
+  scheduledAction = mockScheduledAction,
+) {
+  prisma.scheduledAction.update.mockResolvedValue({
+    ...scheduledAction,
+    status,
+  } as any);
+}
+
+function mockExecutedActionCreate(overrides = {}) {
+  prisma.executedAction.create.mockResolvedValue({
+    id: "executed-action-123",
+    type: ActionType.ARCHIVE,
+    label: null,
+    labelId: null,
+    folderName: null,
+    folderId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    executedRuleId: "rule-123",
+    subject: null,
+    content: null,
+    to: null,
+    cc: null,
+    bcc: null,
+    url: null,
+    draftId: null,
+    draftStatus: null,
+    ...overrides,
+  });
+}
+
+function mockExecutedRuleFind() {
+  prisma.executedRule.findUnique.mockResolvedValue({
+    id: "rule-123",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    messageId: "msg-123",
+    threadId: "thread-123",
+    emailAccountId: "account-123",
+    status: ExecutedRuleStatus.APPLYING,
+    automated: true,
+    reason: null,
+    ruleId: null,
+  } as any);
+}
+
+function mockCompletionCounts({
+  pendingActions,
+  failedActions = 0,
+}: {
+  pendingActions: number;
+  failedActions?: number;
+}) {
+  prisma.scheduledAction.count.mockResolvedValueOnce(pendingActions);
+  if (pendingActions === 0) {
+    prisma.scheduledAction.count.mockResolvedValueOnce(failedActions);
+  }
+}
+
+function mockExecutedRuleUpdate(
+  status: ExecutedRuleStatus,
+  reason: string | null = null,
+) {
+  prisma.executedRule.update.mockResolvedValue({
+    id: "rule-123",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    messageId: "msg-123",
+    threadId: "thread-123",
+    emailAccountId: "account-123",
+    status,
+    automated: true,
+    reason,
+    ruleId: null,
+    matchMetadata: null,
+  });
+}
+
+function expectExecutedRuleStatus(status: ExecutedRuleStatus, reason?: string) {
+  expect(prisma.executedRule.update).toHaveBeenCalledWith({
+    where: { id: "rule-123" },
+    data: reason ? { status, reason } : { status },
+  });
+}

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -305,6 +305,23 @@ describe("executor", () => {
         reason: null,
         ruleId: null,
       } as any);
+      // pending=0, failed=1 → completion check runs and sets ERROR
+      prisma.scheduledAction.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+      prisma.executedRule.update.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "ERROR",
+        automated: true,
+        reason: "One or more scheduled actions failed",
+        ruleId: null,
+        matchMetadata: null,
+      });
 
       const { runActionFunction } = await import("@/utils/ai/actions");
       const { getEmailAccountWithAiAndTokens } = await import(
@@ -351,6 +368,23 @@ describe("executor", () => {
         ...mockScheduledAction,
         status: ScheduledActionStatus.EXECUTING,
       } as any);
+      // pending=0, failed=1 → completion check sets ERROR
+      prisma.scheduledAction.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+      prisma.executedRule.update.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "ERROR",
+        automated: true,
+        reason: "One or more scheduled actions failed",
+        ruleId: null,
+        matchMetadata: null,
+      });
 
       const { getEmailAccountWithAiAndTokens } = await import(
         "@/utils/user/get"
@@ -375,6 +409,364 @@ describe("executor", () => {
           status: ScheduledActionStatus.FAILED,
         },
       });
+    });
+    // @ana A001, A002, A003, A009, A010
+    it("should transition ExecutedRule to ERROR when last action fails", async () => {
+      prisma.scheduledAction.update.mockResolvedValue({
+        ...mockScheduledAction,
+        status: ScheduledActionStatus.FAILED,
+      } as any);
+      prisma.executedAction.create.mockResolvedValue({
+        id: "executed-action-123",
+        type: ActionType.ARCHIVE,
+        label: null,
+        labelId: null,
+        folderName: null,
+        folderId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        executedRuleId: "rule-123",
+        subject: null,
+        content: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        url: null,
+        draftId: null,
+        draftStatus: null,
+      });
+      prisma.executedRule.findUnique.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "APPLYING",
+        automated: true,
+        reason: null,
+        ruleId: null,
+      } as any);
+      // pending=0, failed=1 → should set ERROR
+      prisma.scheduledAction.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(1);
+      prisma.executedRule.update.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "ERROR",
+        automated: true,
+        reason: "One or more scheduled actions failed",
+        ruleId: null,
+        matchMetadata: null,
+      });
+
+      const { runActionFunction } = await import("@/utils/ai/actions");
+      const { getEmailAccountWithAiAndTokens } = await import(
+        "@/utils/user/get"
+      );
+
+      (runActionFunction as any).mockRejectedValue(
+        new Error("Execution failed"),
+      );
+      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
+        id: "account-123",
+        userId: "user-123",
+        email: "test@example.com",
+        tokens: {
+          access_token: "token",
+          refresh_token: "refresh",
+          expires_at: Date.now() + 3_600_000,
+        },
+      });
+
+      const { createEmailProvider } = await import("@/utils/email/provider");
+      const mockEmailProvider = await createEmailProvider({
+        emailAccountId: "account-123",
+        provider: "google",
+      });
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        mockEmailProvider,
+        logger,
+      );
+
+      expect(result.success).toBe(false);
+      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
+        where: { id: "scheduled-action-123" },
+        data: { status: ScheduledActionStatus.FAILED },
+      });
+      expect(prisma.scheduledAction.count).toHaveBeenCalled();
+      expect(prisma.executedRule.update).toHaveBeenCalledWith({
+        where: { id: "rule-123" },
+        data: {
+          status: "ERROR",
+          reason: "One or more scheduled actions failed",
+        },
+      });
+    });
+
+    // @ana A004, A005
+    it("should transition ExecutedRule to ERROR when some actions fail and others succeed", async () => {
+      prisma.scheduledAction.update.mockResolvedValue({
+        ...mockScheduledAction,
+        status: ScheduledActionStatus.COMPLETED,
+      } as any);
+      prisma.executedAction.create.mockResolvedValue({
+        id: "executed-action-456",
+        type: ActionType.ARCHIVE,
+        label: null,
+        labelId: null,
+        folderName: null,
+        folderId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        executedRuleId: "rule-123",
+        subject: null,
+        content: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        url: null,
+        draftId: null,
+        draftStatus: null,
+      });
+      prisma.executedRule.findUnique.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "APPLYING",
+        automated: true,
+        reason: null,
+        ruleId: null,
+      } as any);
+      // pending=0, failed=2 (siblings failed earlier) → should set ERROR
+      prisma.scheduledAction.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(2);
+      prisma.executedRule.update.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "ERROR",
+        automated: true,
+        reason: "One or more scheduled actions failed",
+        ruleId: null,
+        matchMetadata: null,
+      });
+
+      const { runActionFunction } = await import("@/utils/ai/actions");
+      const { getEmailAccountWithAiAndTokens } = await import(
+        "@/utils/user/get"
+      );
+
+      (runActionFunction as any).mockResolvedValue(undefined);
+      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
+        id: "account-123",
+        userId: "user-123",
+        email: "test@example.com",
+        tokens: {
+          access_token: "token",
+          refresh_token: "refresh",
+          expires_at: Date.now() + 3_600_000,
+        },
+      });
+
+      const { createEmailProvider } = await import("@/utils/email/provider");
+      const mockEmailProvider = await createEmailProvider({
+        emailAccountId: "account-123",
+        provider: "google",
+      });
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        mockEmailProvider,
+        logger,
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.executedRule.update).toHaveBeenCalledWith({
+        where: { id: "rule-123" },
+        data: {
+          status: "ERROR",
+          reason: "One or more scheduled actions failed",
+        },
+      });
+    });
+
+    // @ana A006, A007
+    it("should transition ExecutedRule to APPLIED when all actions succeed", async () => {
+      prisma.scheduledAction.update.mockResolvedValue({
+        ...mockScheduledAction,
+        status: ScheduledActionStatus.COMPLETED,
+      } as any);
+      prisma.executedAction.create.mockResolvedValue({
+        id: "executed-action-789",
+        type: ActionType.ARCHIVE,
+        label: null,
+        labelId: null,
+        folderName: null,
+        folderId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        executedRuleId: "rule-123",
+        subject: null,
+        content: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        url: null,
+        draftId: null,
+        draftStatus: null,
+      });
+      prisma.executedRule.findUnique.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "APPLYING",
+        automated: true,
+        reason: null,
+        ruleId: null,
+      } as any);
+      // pending=0, failed=0 → should set APPLIED
+      prisma.scheduledAction.count
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0);
+      prisma.executedRule.update.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "APPLIED",
+        automated: true,
+        reason: null,
+        ruleId: null,
+        matchMetadata: null,
+      });
+
+      const { runActionFunction } = await import("@/utils/ai/actions");
+      const { getEmailAccountWithAiAndTokens } = await import(
+        "@/utils/user/get"
+      );
+
+      (runActionFunction as any).mockResolvedValue(undefined);
+      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
+        id: "account-123",
+        userId: "user-123",
+        email: "test@example.com",
+        tokens: {
+          access_token: "token",
+          refresh_token: "refresh",
+          expires_at: Date.now() + 3_600_000,
+        },
+      });
+
+      const { createEmailProvider } = await import("@/utils/email/provider");
+      const mockEmailProvider = await createEmailProvider({
+        emailAccountId: "account-123",
+        provider: "google",
+      });
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        mockEmailProvider,
+        logger,
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.executedRule.update).toHaveBeenCalledWith({
+        where: { id: "rule-123" },
+        data: { status: "APPLIED" },
+      });
+    });
+
+    // @ana A008
+    it("should not update ExecutedRule status when actions are still pending", async () => {
+      prisma.scheduledAction.update.mockResolvedValue({
+        ...mockScheduledAction,
+        status: ScheduledActionStatus.COMPLETED,
+      } as any);
+      prisma.executedAction.create.mockResolvedValue({
+        id: "executed-action-101",
+        type: ActionType.ARCHIVE,
+        label: null,
+        labelId: null,
+        folderName: null,
+        folderId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        executedRuleId: "rule-123",
+        subject: null,
+        content: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        url: null,
+        draftId: null,
+        draftStatus: null,
+      });
+      prisma.executedRule.findUnique.mockResolvedValue({
+        id: "rule-123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        messageId: "msg-123",
+        threadId: "thread-123",
+        emailAccountId: "account-123",
+        status: "APPLYING",
+        automated: true,
+        reason: null,
+        ruleId: null,
+      } as any);
+      // pending=2 → should NOT update ExecutedRule
+      prisma.scheduledAction.count.mockResolvedValueOnce(2);
+
+      const { runActionFunction } = await import("@/utils/ai/actions");
+      const { getEmailAccountWithAiAndTokens } = await import(
+        "@/utils/user/get"
+      );
+
+      (runActionFunction as any).mockResolvedValue(undefined);
+      (getEmailAccountWithAiAndTokens as any).mockResolvedValue({
+        id: "account-123",
+        userId: "user-123",
+        email: "test@example.com",
+        tokens: {
+          access_token: "token",
+          refresh_token: "refresh",
+          expires_at: Date.now() + 3_600_000,
+        },
+      });
+
+      const { createEmailProvider } = await import("@/utils/email/provider");
+      const mockEmailProvider = await createEmailProvider({
+        emailAccountId: "account-123",
+        provider: "google",
+      });
+
+      const result = await executeScheduledAction(
+        mockScheduledAction,
+        mockEmailProvider,
+        logger,
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.executedRule.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -49,6 +49,7 @@ export async function executeScheduledAction(
         log,
         "Email no longer exists",
       );
+      await checkAndCompleteExecutedRule(scheduledAction.executedRuleId, log);
       return { success: true, reason: "Email no longer exists" };
     }
 
@@ -276,7 +277,7 @@ async function markActionFailed(
  * Check if all scheduled actions for an ExecutedRule are complete
  * and update the ExecutedRule status accordingly
  */
-async function checkAndCompleteExecutedRule(
+export async function checkAndCompleteExecutedRule(
   executedRuleId: string,
   log: Logger,
 ) {

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -95,6 +95,7 @@ export async function executeScheduledAction(
     });
 
     await markActionFailed(scheduledAction.id, error, log);
+    await checkAndCompleteExecutedRule(scheduledAction.executedRuleId, log);
     return { success: false, error };
   }
 }
@@ -289,13 +290,35 @@ async function checkAndCompleteExecutedRule(
   });
 
   if (pendingActions === 0) {
-    await prisma.executedRule.update({
-      where: { id: executedRuleId },
-      data: { status: ExecutedRuleStatus.APPLIED },
+    const failedActions = await prisma.scheduledAction.count({
+      where: {
+        executedRuleId,
+        status: ScheduledActionStatus.FAILED,
+      },
     });
 
-    log.info("Completed ExecutedRule - all scheduled actions finished", {
-      executedRuleId,
-    });
+    if (failedActions > 0) {
+      await prisma.executedRule.update({
+        where: { id: executedRuleId },
+        data: {
+          status: ExecutedRuleStatus.ERROR,
+          reason: "One or more scheduled actions failed",
+        },
+      });
+
+      log.info("ExecutedRule errored - some scheduled actions failed", {
+        executedRuleId,
+        failedActions,
+      });
+    } else {
+      await prisma.executedRule.update({
+        where: { id: executedRuleId },
+        data: { status: ExecutedRuleStatus.APPLIED },
+      });
+
+      log.info("Completed ExecutedRule - all scheduled actions finished", {
+        executedRuleId,
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix two related bugs in the scheduled action completion lifecycle where failed actions leave `ExecutedRule` stuck at `APPLYING` or incorrectly marked as `APPLIED`.

## The Problem

When a scheduled action succeeds, `checkAndCompleteExecutedRule` runs and transitions the rule to `APPLIED`. But when a scheduled action **fails**, the completion check never runs — the rule stays `APPLYING` forever.

Additionally, `checkAndCompleteExecutedRule` only checks for `PENDING`/`EXECUTING` actions. It doesn't check for `FAILED` siblings — so if one action fails and another succeeds, the rule gets marked `APPLIED` even though an action failed.

**Scenario A** — single action fails → `ExecutedRule` stuck at `APPLYING` forever  
**Scenario B** — mixed results → `ExecutedRule` incorrectly marked `APPLIED`

## The Fix

1. Call `checkAndCompleteExecutedRule` after `markActionFailed` (1 line — mirrors the success path at line 83)
2. Count `FAILED` actions in the completion check. If any exist, set `ExecutedRuleStatus.ERROR` with reason. If none, set `APPLIED` as before.

This mirrors how the immediate-action path in `execute.ts` already handles `ERROR` transitions. The `ExecutedRuleStatus.ERROR` enum value and `reason` field already exist in the schema.

## Testing

4 new test cases covering the full state matrix:

- Single action fails → rule transitions to `ERROR` ✓
- Mixed success/failure → rule transitions to `ERROR` ✓
- All succeed → rule transitions to `APPLIED` (unchanged) ✓
- Actions still pending → no transition ✓

All 3,789 tests pass (+4 new). No regressions.

---

Found while analyzing the codebase with [Anatomia](https://anatomia.dev). [Full analysis →](https://github.com/rpatricksmith/inbox-zero/tree/feature/fix-scheduled-action-completion/.ana/plans/active/fix-scheduled-action-completion)