### PR TITLE
organization: Add member activity status

### DIFF
--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -48,6 +48,7 @@ import { TypographyH3 } from "@/components/Typography";
 import { useOrganizationMembership } from "@/hooks/useOrganizationMembership";
 import { hasOrganizationAdminRole } from "@/utils/organizations/roles";
 import {
+  RECENT_ACTIVITY_HOURS,
   getMemberActivityStatus,
   type MemberActivityStatus,
 } from "./member-activity";
@@ -516,7 +517,7 @@ const ACTIVITY_BADGE: Record<
     tooltip: () => "This member has not allowed org admin analytics.",
   },
   inactive: {
-    label: "No recent activity",
+    label: `No activity in ${RECENT_ACTIVITY_HOURS}h`,
     variant: "secondary",
     tooltip: ({ lastProcessedEmailAt }) =>
       `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`,

--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -400,7 +400,7 @@ function MemberActivityBadge({
   lastProcessedEmailAt?: Date | string | null;
   status: MemberActivityStatus;
 }) {
-  const display = getActivityBadgeDisplay(status);
+  const display = ACTIVITY_BADGE[status];
 
   return (
     <TooltipProvider>
@@ -411,9 +411,7 @@ function MemberActivityBadge({
           </Badge>
         </TooltipTrigger>
         <TooltipContent>
-          <p>
-            {getActivityTooltip(status, disconnectedAt, lastProcessedEmailAt)}
-          </p>
+          <p>{display.tooltip({ disconnectedAt, lastProcessedEmailAt })}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -487,41 +485,48 @@ function getInitials(name: string | null | undefined, email: string) {
   return name ? name.charAt(0).toUpperCase() : email.charAt(0).toUpperCase();
 }
 
-function getActivityBadgeDisplay(status: MemberActivityStatus) {
-  switch (status) {
-    case "active":
-      return { label: "Active", variant: "green" as const };
-    case "disconnected":
-      return { label: "Disconnected", variant: "red" as const };
-    case "hidden":
-      return { label: "Activity hidden", variant: "outline" as const };
-    case "inactive":
-      return { label: "No recent activity", variant: "secondary" as const };
-    case "none":
-      return { label: "No activity yet", variant: "secondary" as const };
+const ACTIVITY_BADGE: Record<
+  MemberActivityStatus,
+  {
+    label: string;
+    variant: "green" | "red" | "outline" | "secondary";
+    tooltip: (dates: {
+      disconnectedAt?: Date | string | null;
+      lastProcessedEmailAt?: Date | string | null;
+    }) => string;
   }
-}
-
-function getActivityTooltip(
-  status: MemberActivityStatus,
-  disconnectedAt?: Date | string | null,
-  lastProcessedEmailAt?: Date | string | null,
-) {
-  switch (status) {
-    case "active":
-      return `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`;
-    case "disconnected":
-      return disconnectedAt
+> = {
+  active: {
+    label: "Active",
+    variant: "green",
+    tooltip: ({ lastProcessedEmailAt }) =>
+      `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`,
+  },
+  disconnected: {
+    label: "Disconnected",
+    variant: "red",
+    tooltip: ({ disconnectedAt }) =>
+      disconnectedAt
         ? `Email account disconnected ${formatRelativeDate(disconnectedAt)}.`
-        : "Email account is disconnected.";
-    case "hidden":
-      return "This member has not allowed org admin analytics.";
-    case "inactive":
-      return `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`;
-    case "none":
-      return "No assistant-processed email found for this account.";
-  }
-}
+        : "Email account is disconnected.",
+  },
+  hidden: {
+    label: "Activity hidden",
+    variant: "outline",
+    tooltip: () => "This member has not allowed org admin analytics.",
+  },
+  inactive: {
+    label: "No recent activity",
+    variant: "secondary",
+    tooltip: ({ lastProcessedEmailAt }) =>
+      `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`,
+  },
+  none: {
+    label: "No activity yet",
+    variant: "secondary",
+    tooltip: () => "No assistant-processed email found for this account.",
+  },
+};
 
 function formatRelativeDate(date: Date | string | null | undefined) {
   if (!date) return "unknown";

--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
+import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { useOrganizationMembers } from "@/hooks/useOrganizationMembers";
 import { LoadingContent } from "@/components/LoadingContent";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -46,6 +47,10 @@ import { useExecutedRulesCount } from "@/hooks/useExecutedRulesCount";
 import { TypographyH3 } from "@/components/Typography";
 import { useOrganizationMembership } from "@/hooks/useOrganizationMembership";
 import { hasOrganizationAdminRole } from "@/utils/organizations/roles";
+import {
+  getMemberActivityStatus,
+  type MemberActivityStatus,
+} from "./member-activity";
 
 type Member = OrganizationMembersResponse["members"][0];
 type PendingInvitation = OrganizationMembersResponse["pendingInvitations"][0];
@@ -53,19 +58,24 @@ type PendingInvitation = OrganizationMembersResponse["pendingInvitations"][0];
 export function Members({ organizationId }: { organizationId: string }) {
   const { data, isLoading, error, mutate } =
     useOrganizationMembers(organizationId);
-  const { data: executedRulesData } = useExecutedRulesCount(organizationId);
   const { data: membership } = useOrganizationMembership();
   const isAdmin = hasOrganizationAdminRole(membership?.role ?? "");
+  const { data: executedRulesData } = useExecutedRulesCount(
+    isAdmin ? organizationId : null,
+  );
   const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
 
   // Create a Map for O(1) lookups instead of O(n) Array.find for each member
-  const executedRulesCountMap = useMemo(() => {
+  const executedRulesStatsMap = useMemo(() => {
     if (!executedRulesData?.memberCounts) return new Map();
 
     return new Map(
       executedRulesData.memberCounts.map((item) => [
         item.emailAccountId,
-        item.executedRulesCount,
+        {
+          executedRulesCount: item.executedRulesCount,
+          lastProcessedEmailAt: item.lastProcessedEmailAt,
+        },
       ]),
     );
   }, [executedRulesData?.memberCounts]);
@@ -155,7 +165,7 @@ export function Members({ organizationId }: { organizationId: string }) {
 
         <div className="space-y-2 mt-4">
           {data?.members.map((member) => {
-            const executedRulesCount = executedRulesCountMap.get(
+            const executedRulesStats = executedRulesStatsMap.get(
               member.emailAccount.id,
             );
 
@@ -165,7 +175,10 @@ export function Members({ organizationId }: { organizationId: string }) {
                 member={member}
                 onRemove={handleRemoveMember}
                 onUpdateRole={handleUpdateRole}
-                executedRulesCount={executedRulesCount}
+                executedRulesCount={executedRulesStats?.executedRulesCount}
+                lastProcessedEmailAt={
+                  executedRulesStats?.lastProcessedEmailAt ?? null
+                }
                 isAdmin={isAdmin}
                 isPending={pendingMemberId === member.id}
               />
@@ -229,6 +242,7 @@ function MemberCard({
   onRemove,
   onUpdateRole,
   executedRulesCount,
+  lastProcessedEmailAt,
   isAdmin,
   isPending,
 }: {
@@ -236,11 +250,17 @@ function MemberCard({
   onRemove: (memberId: string) => void;
   onUpdateRole: (memberId: string, role: "admin" | "member") => void;
   executedRulesCount?: number;
+  lastProcessedEmailAt?: Date | string | null;
   isAdmin: boolean;
   isPending: boolean;
 }) {
   const { emailAccountId } = useAccount();
   const canChangeRole = member.role !== "owner";
+  const activityStatus = getMemberActivityStatus({
+    allowOrgAdminAnalytics: member.allowOrgAdminAnalytics,
+    disconnectedAt: member.emailAccount.disconnectedAt,
+    lastProcessedEmailAt,
+  });
 
   return (
     <CardWrapper
@@ -336,7 +356,7 @@ function MemberCard({
         )
       }
     >
-      <div className="flex items-center space-x-3">
+      <div className="flex flex-wrap items-center gap-2">
         <p className="font-medium">{member.emailAccount.name || "No name"}</p>
         <Badge
           variant={
@@ -346,8 +366,15 @@ function MemberCard({
         >
           {capitalizeRole(member.role)}
         </Badge>
+        {isAdmin && (
+          <MemberActivityBadge
+            status={activityStatus}
+            disconnectedAt={member.emailAccount.disconnectedAt}
+            lastProcessedEmailAt={lastProcessedEmailAt}
+          />
+        )}
       </div>
-      <div className="flex items-center space-x-3 mt-1">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
         <span className="text-xs text-muted-foreground">
           {member.emailAccount.email}
         </span>
@@ -361,6 +388,35 @@ function MemberCard({
         )}
       </div>
     </CardWrapper>
+  );
+}
+
+function MemberActivityBadge({
+  disconnectedAt,
+  lastProcessedEmailAt,
+  status,
+}: {
+  disconnectedAt?: Date | string | null;
+  lastProcessedEmailAt?: Date | string | null;
+  status: MemberActivityStatus;
+}) {
+  const display = getActivityBadgeDisplay(status);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant={display.variant} className="text-xs">
+            {display.label}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            {getActivityTooltip(status, disconnectedAt, lastProcessedEmailAt)}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -429,4 +485,46 @@ function capitalizeRole(role: string) {
 
 function getInitials(name: string | null | undefined, email: string) {
   return name ? name.charAt(0).toUpperCase() : email.charAt(0).toUpperCase();
+}
+
+function getActivityBadgeDisplay(status: MemberActivityStatus) {
+  switch (status) {
+    case "active":
+      return { label: "Active", variant: "green" as const };
+    case "disconnected":
+      return { label: "Disconnected", variant: "red" as const };
+    case "hidden":
+      return { label: "Activity hidden", variant: "outline" as const };
+    case "inactive":
+      return { label: "No recent activity", variant: "secondary" as const };
+    case "none":
+      return { label: "No activity yet", variant: "secondary" as const };
+  }
+}
+
+function getActivityTooltip(
+  status: MemberActivityStatus,
+  disconnectedAt?: Date | string | null,
+  lastProcessedEmailAt?: Date | string | null,
+) {
+  switch (status) {
+    case "active":
+      return `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`;
+    case "disconnected":
+      return disconnectedAt
+        ? `Email account disconnected ${formatRelativeDate(disconnectedAt)}.`
+        : "Email account is disconnected.";
+    case "hidden":
+      return "This member has not allowed org admin analytics.";
+    case "inactive":
+      return `Last processed email ${formatRelativeDate(lastProcessedEmailAt)}.`;
+    case "none":
+      return "No assistant-processed email found for this account.";
+  }
+}
+
+function formatRelativeDate(date: Date | string | null | undefined) {
+  if (!date) return "unknown";
+
+  return formatDistanceToNow(new Date(date), { addSuffix: true });
 }

--- a/apps/web/app/(app)/organization/[organizationId]/member-activity.test.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/member-activity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getMemberActivityStatus } from "./member-activity";
+
+describe("getMemberActivityStatus", () => {
+  const now = new Date("2026-05-29T00:00:00.000Z");
+
+  it("treats disconnected accounts as disconnected before evaluating activity", () => {
+    expect(
+      getMemberActivityStatus({
+        allowOrgAdminAnalytics: true,
+        disconnectedAt: new Date("2026-05-28T00:00:00.000Z"),
+        lastProcessedEmailAt: new Date("2026-05-28T00:00:00.000Z"),
+        now,
+      }),
+    ).toBe("disconnected");
+  });
+
+  it("hides processing activity when org analytics are not allowed", () => {
+    expect(
+      getMemberActivityStatus({
+        allowOrgAdminAnalytics: false,
+        lastProcessedEmailAt: new Date("2026-05-28T00:00:00.000Z"),
+        now,
+      }),
+    ).toBe("hidden");
+  });
+
+  it("marks recently processed accounts as active", () => {
+    expect(
+      getMemberActivityStatus({
+        allowOrgAdminAnalytics: true,
+        lastProcessedEmailAt: new Date("2026-05-01T00:00:00.000Z"),
+        now,
+      }),
+    ).toBe("active");
+  });
+
+  it("marks accounts without recent processing as inactive", () => {
+    expect(
+      getMemberActivityStatus({
+        allowOrgAdminAnalytics: true,
+        lastProcessedEmailAt: new Date("2026-04-01T00:00:00.000Z"),
+        now,
+      }),
+    ).toBe("inactive");
+  });
+
+  it("separates no processing history from stale processing history", () => {
+    expect(
+      getMemberActivityStatus({
+        allowOrgAdminAnalytics: true,
+        lastProcessedEmailAt: null,
+        now,
+      }),
+    ).toBe("none");
+  });
+});

--- a/apps/web/app/(app)/organization/[organizationId]/member-activity.test.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/member-activity.test.ts
@@ -29,7 +29,7 @@ describe("getMemberActivityStatus", () => {
     expect(
       getMemberActivityStatus({
         allowOrgAdminAnalytics: true,
-        lastProcessedEmailAt: new Date("2026-05-01T00:00:00.000Z"),
+        lastProcessedEmailAt: new Date("2026-05-28T00:01:00.000Z"),
         now,
       }),
     ).toBe("active");
@@ -39,7 +39,7 @@ describe("getMemberActivityStatus", () => {
     expect(
       getMemberActivityStatus({
         allowOrgAdminAnalytics: true,
-        lastProcessedEmailAt: new Date("2026-04-01T00:00:00.000Z"),
+        lastProcessedEmailAt: new Date("2026-05-27T23:59:00.000Z"),
         now,
       }),
     ).toBe("inactive");

--- a/apps/web/app/(app)/organization/[organizationId]/member-activity.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/member-activity.ts
@@ -1,4 +1,4 @@
-export const RECENT_ACTIVITY_DAYS = 30;
+export const RECENT_ACTIVITY_HOURS = 24;
 
 export type MemberActivityStatus =
   | "active"
@@ -23,9 +23,8 @@ export function getMemberActivityStatus({
   if (!lastProcessedEmailAt) return "none";
 
   const lastProcessedDate = new Date(lastProcessedEmailAt);
-  const recentActivityThreshold = new Date(now);
-  recentActivityThreshold.setDate(
-    recentActivityThreshold.getDate() - RECENT_ACTIVITY_DAYS,
+  const recentActivityThreshold = new Date(
+    now.getTime() - RECENT_ACTIVITY_HOURS * 60 * 60 * 1000,
   );
 
   return lastProcessedDate >= recentActivityThreshold ? "active" : "inactive";

--- a/apps/web/app/(app)/organization/[organizationId]/member-activity.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/member-activity.ts
@@ -1,0 +1,32 @@
+export const RECENT_ACTIVITY_DAYS = 30;
+
+export type MemberActivityStatus =
+  | "active"
+  | "disconnected"
+  | "hidden"
+  | "inactive"
+  | "none";
+
+export function getMemberActivityStatus({
+  allowOrgAdminAnalytics,
+  disconnectedAt,
+  lastProcessedEmailAt,
+  now = new Date(),
+}: {
+  allowOrgAdminAnalytics: boolean;
+  disconnectedAt?: Date | string | null;
+  lastProcessedEmailAt?: Date | string | null;
+  now?: Date;
+}): MemberActivityStatus {
+  if (disconnectedAt) return "disconnected";
+  if (!allowOrgAdminAnalytics) return "hidden";
+  if (!lastProcessedEmailAt) return "none";
+
+  const lastProcessedDate = new Date(lastProcessedEmailAt);
+  const recentActivityThreshold = new Date(now);
+  recentActivityThreshold.setDate(
+    recentActivityThreshold.getDate() - RECENT_ACTIVITY_DAYS,
+  );
+
+  return lastProcessedDate >= recentActivityThreshold ? "active" : "inactive";
+}

--- a/apps/web/app/api/organizations/[organizationId]/executed-rules-count/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/executed-rules-count/route.ts
@@ -39,11 +39,13 @@ async function getExecutedRulesCount({
       },
     },
     _count: true,
+    _max: { createdAt: true },
   });
 
-  const result = memberCounts.map(({ emailAccountId, _count }) => ({
+  const result = memberCounts.map(({ emailAccountId, _count, _max }) => ({
     emailAccountId,
     executedRulesCount: _count,
+    lastProcessedEmailAt: _max.createdAt,
   }));
 
   return { memberCounts: result };

--- a/apps/web/app/api/organizations/[organizationId]/members/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/members/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
 import { withAuth } from "@/utils/middleware";
 import { fetchAndCheckIsMember } from "@/utils/organizations/access";
+import { hasOrganizationAdminRole } from "@/utils/organizations/roles";
 
 export type OrganizationMembersResponse = Awaited<
   ReturnType<typeof getOrganizationMembers>
@@ -20,17 +21,22 @@ export const GET = withAuth(
       );
     }
 
-    await fetchAndCheckIsMember({ organizationId, userId });
+    const membership = await fetchAndCheckIsMember({ organizationId, userId });
 
-    const result = await getOrganizationMembers({ organizationId });
+    const result = await getOrganizationMembers({
+      organizationId,
+      isAdmin: hasOrganizationAdminRole(membership.role),
+    });
 
     return NextResponse.json(result);
   },
 );
 
 async function getOrganizationMembers({
+  isAdmin,
   organizationId,
 }: {
+  isAdmin: boolean;
   organizationId: string;
 }) {
   const [members, pendingInvitations] = await Promise.all([
@@ -47,6 +53,11 @@ async function getOrganizationMembers({
             name: true,
             email: true,
             image: true,
+            account: {
+              select: {
+                disconnectedAt: true,
+              },
+            },
           },
         },
       },
@@ -77,7 +88,18 @@ async function getOrganizationMembers({
   ]);
 
   return {
-    members,
+    members: members.map((member) => ({
+      ...member,
+      emailAccount: {
+        id: member.emailAccount.id,
+        name: member.emailAccount.name,
+        email: member.emailAccount.email,
+        image: member.emailAccount.image,
+        disconnectedAt: isAdmin
+          ? member.emailAccount.account.disconnectedAt
+          : null,
+      },
+    })),
     pendingInvitations,
   };
 }

--- a/apps/web/hooks/useExecutedRulesCount.ts
+++ b/apps/web/hooks/useExecutedRulesCount.ts
@@ -1,8 +1,10 @@
 import useSWR from "swr";
 import type { GetExecutedRulesCountResponse } from "@/app/api/organizations/[organizationId]/executed-rules-count/route";
 
-export function useExecutedRulesCount(organizationId: string) {
+export function useExecutedRulesCount(organizationId: string | null) {
   return useSWR<GetExecutedRulesCountResponse>(
-    `/api/organizations/${organizationId}/executed-rules-count`,
+    organizationId
+      ? `/api/organizations/${organizationId}/executed-rules-count`
+      : null,
   );
 }


### PR DESCRIPTION
Adds admin-only activity indicators to organization member rows using connection state and the latest assistant-processed email timestamp.

- Includes disconnected, active, stale, empty, and hidden activity states.
- Extends existing organization endpoints with the needed status fields.
- Adds focused tests for the member activity status rules.