### PR TITLE
messaging: Fix notification failure handling

### DIFF
--- a/apps/web/utils/ai/actions.test.ts
+++ b/apps/web/utils/ai/actions.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ActionType, AttachmentSourceType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  AttachmentSourceType,
+  MessagingMessageStatus,
+} from "@/generated/prisma/enums";
 import { createMockEmailProvider } from "@/utils/__mocks__/email-provider";
 import { runActionFunction } from "@/utils/ai/actions";
 import {
@@ -76,6 +80,7 @@ describe("runActionFunction", () => {
       delivered: true,
       kind: "interactive",
     });
+    vi.mocked(sendMessagingRuleNotification).mockResolvedValue(true);
     vi.mocked(handlePreviousDraftDeletion).mockResolvedValue({
       shouldCreateDraft: true,
     });
@@ -216,7 +221,7 @@ describe("runActionFunction", () => {
   it("sends chat drafts through the messaging notification path", async () => {
     const client = createMockEmailProvider();
 
-    await runActionFunction({
+    const result = await runActionFunction({
       client,
       email,
       action: {
@@ -240,6 +245,7 @@ describe("runActionFunction", () => {
       email,
       logger: expect.anything(),
     });
+    expect(result).toEqual({ success: true });
     expect(client.draftEmail).not.toHaveBeenCalled();
   });
 
@@ -329,36 +335,45 @@ describe("runActionFunction", () => {
     expect(client.draftEmail).toHaveBeenCalled();
   });
 
-  it("throws when chat draft delivery cannot be completed", async () => {
+  it("marks chat draft actions failed when delivery cannot be completed", async () => {
     const client = createMockEmailProvider();
     vi.mocked(sendMessagingRuleNotification).mockResolvedValueOnce(false);
 
-    await expect(
-      runActionFunction({
-        client,
-        email,
-        action: {
-          id: "action-1",
-          type: ActionType.DRAFT_MESSAGING_CHANNEL,
-          messagingChannelId: "channel-1",
-          content: "Draft in chat",
-        },
-        emailAccount,
-        executedRule: {
-          id: "executed-rule-1",
-          threadId: "thread-1",
-          emailAccountId: "account-1",
-          ruleId: "rule-1",
-        } as any,
-        logger,
-      }),
-    ).rejects.toThrow("Failed to deliver DRAFT_MESSAGING_CHANNEL notification");
+    const result = await runActionFunction({
+      client,
+      email,
+      action: {
+        id: "action-1",
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "channel-1",
+        content: "Draft in chat",
+      },
+      emailAccount,
+      executedRule: {
+        id: "executed-rule-1",
+        threadId: "thread-1",
+        emailAccountId: "account-1",
+        ruleId: "rule-1",
+      } as any,
+      logger,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      errorCode: "MESSAGING_DELIVERY_FAILED",
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.FAILED,
+      },
+    });
   });
 
   it("sends NOTIFY_MESSAGING_CHANNEL actions through the messaging notification path", async () => {
     const client = createMockEmailProvider();
 
-    await runActionFunction({
+    const result = await runActionFunction({
       client,
       email,
       action: {
@@ -381,6 +396,7 @@ describe("runActionFunction", () => {
       email,
       logger: expect.anything(),
     });
+    expect(result).toEqual({ success: true });
   });
 
   it("stars the matched message for STAR actions", async () => {
@@ -406,28 +422,37 @@ describe("runActionFunction", () => {
     expect(client.starMessage).toHaveBeenCalledWith("message-1");
   });
 
-  it("throws when notify messaging actions are missing a channel id", async () => {
+  it("marks notify messaging actions failed when missing a channel id", async () => {
     const client = createMockEmailProvider();
 
-    await expect(
-      runActionFunction({
-        client,
-        email,
-        action: {
-          id: "action-1",
-          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
-          messagingChannelId: null,
-        },
-        emailAccount,
-        executedRule: {
-          id: "executed-rule-1",
-          threadId: "thread-1",
-          emailAccountId: "account-1",
-          ruleId: "rule-1",
-        } as any,
-        logger,
-      }),
-    ).rejects.toThrow("Missing messaging channel for NOTIFY_MESSAGING_CHANNEL");
+    const result = await runActionFunction({
+      client,
+      email,
+      action: {
+        id: "action-1",
+        type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+        messagingChannelId: null,
+      },
+      emailAccount,
+      executedRule: {
+        id: "executed-rule-1",
+        threadId: "thread-1",
+        emailAccountId: "account-1",
+        ruleId: "rule-1",
+      } as any,
+      logger,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      errorCode: "MISSING_MESSAGING_CHANNEL",
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.FAILED,
+      },
+    });
   });
 
   it("passes static attachments into replies", async () => {

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -40,8 +40,8 @@ type ActionFunction<T extends Partial<Omit<ActionItem, "type">>> = (options: {
 }) => Promise<unknown>;
 
 type MessagingNotificationActionType =
-  | ActionType.DRAFT_MESSAGING_CHANNEL
-  | ActionType.NOTIFY_MESSAGING_CHANNEL;
+  | typeof ActionType.DRAFT_MESSAGING_CHANNEL
+  | typeof ActionType.NOTIFY_MESSAGING_CHANNEL;
 
 export const runActionFunction = async (options: {
   client: EmailProvider;

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -39,6 +39,10 @@ type ActionFunction<T extends Partial<Omit<ActionItem, "type">>> = (options: {
   logger: Logger;
 }) => Promise<unknown>;
 
+type MessagingNotificationActionType =
+  | ActionType.DRAFT_MESSAGING_CHANNEL
+  | ActionType.NOTIFY_MESSAGING_CHANNEL;
+
 export const runActionFunction = async (options: {
   client: EmailProvider;
   email: EmailForAction;
@@ -267,63 +271,25 @@ const draft: ActionFunction<{
 
 const draft_messaging_channel: ActionFunction<{
   messagingChannelId?: string | null;
-}> = async ({ email, args, logger }) => {
-  if (!args.id) {
-    throw new Error("Missing action id for DRAFT_MESSAGING_CHANNEL");
-  }
-
-  if (!args.messagingChannelId) {
-    await failMessagingAction({
-      actionId: args.id,
-      logger,
-      reason: "Missing messaging channel for DRAFT_MESSAGING_CHANNEL",
-    });
-  }
-
-  const delivered = await sendMessagingRuleNotification({
-    executedActionId: args.id,
+}> = async ({ email, args, logger }) =>
+  runMessagingNotificationAction({
+    actionId: args.id,
+    actionType: ActionType.DRAFT_MESSAGING_CHANNEL,
+    messagingChannelId: args.messagingChannelId,
     email,
     logger,
   });
-
-  if (delivered) return;
-
-  await failMessagingAction({
-    actionId: args.id,
-    logger,
-    reason: "Failed to deliver DRAFT_MESSAGING_CHANNEL notification",
-  });
-};
 
 const notify_messaging_channel: ActionFunction<{
   messagingChannelId?: string | null;
-}> = async ({ email, args, logger }) => {
-  if (!args.id) {
-    throw new Error("Missing action id for NOTIFY_MESSAGING_CHANNEL");
-  }
-
-  if (!args.messagingChannelId) {
-    await failMessagingAction({
-      actionId: args.id,
-      logger,
-      reason: "Missing messaging channel for NOTIFY_MESSAGING_CHANNEL",
-    });
-  }
-
-  const delivered = await sendMessagingRuleNotification({
-    executedActionId: args.id,
+}> = async ({ email, args, logger }) =>
+  runMessagingNotificationAction({
+    actionId: args.id,
+    actionType: ActionType.NOTIFY_MESSAGING_CHANNEL,
+    messagingChannelId: args.messagingChannelId,
     email,
     logger,
   });
-
-  if (delivered) return;
-
-  await failMessagingAction({
-    actionId: args.id,
-    logger,
-    reason: "Failed to deliver NOTIFY_MESSAGING_CHANNEL notification",
-  });
-};
 
 const reply: ActionFunction<{
   content?: string | null;
@@ -662,7 +628,7 @@ async function lazyUpdateActionFolderId({
   }
 }
 
-async function failMessagingAction({
+async function markMessagingActionFailed({
   actionId,
   logger,
   reason,
@@ -670,7 +636,7 @@ async function failMessagingAction({
   actionId: string;
   logger: Logger;
   reason: string;
-}): Promise<never> {
+}) {
   try {
     await prisma.executedAction.update({
       where: { id: actionId },
@@ -684,8 +650,49 @@ async function failMessagingAction({
       error,
     });
   }
+  logger.warn(reason, { actionId });
+}
 
-  throw new Error(reason);
+async function runMessagingNotificationAction({
+  actionId,
+  actionType,
+  messagingChannelId,
+  email,
+  logger,
+}: {
+  actionId?: string | null;
+  actionType: MessagingNotificationActionType;
+  messagingChannelId?: string | null;
+  email: EmailForAction;
+  logger: Logger;
+}) {
+  if (!actionId) {
+    throw new Error(`Missing action id for ${actionType}`);
+  }
+
+  if (!messagingChannelId) {
+    await markMessagingActionFailed({
+      actionId,
+      logger,
+      reason: `Missing messaging channel for ${actionType}`,
+    });
+    return { success: false, errorCode: "MISSING_MESSAGING_CHANNEL" };
+  }
+
+  const delivered = await sendMessagingRuleNotification({
+    executedActionId: actionId,
+    email,
+    logger,
+  });
+
+  if (delivered) return { success: true };
+
+  await markMessagingActionFailed({
+    actionId,
+    logger,
+    reason: `Failed to deliver ${actionType} notification`,
+  });
+  return { success: false, errorCode: "MESSAGING_DELIVERY_FAILED" };
 }
 
 function isLegacyMessagingDraft({

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -150,6 +150,63 @@ describe("executeAct", () => {
     });
   });
 
+  it("continues later messaging notifications after one delivery failure", async () => {
+    mockRunActionFunction
+      .mockResolvedValueOnce({
+        success: false,
+        errorCode: "MESSAGING_DELIVERY_FAILED",
+      })
+      .mockResolvedValueOnce({ success: true });
+
+    const executedRule = {
+      ...baseExecutedRule,
+      actionItems: [
+        {
+          id: "telegram-action",
+          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+          messagingChannelId: "telegram-channel",
+        },
+        {
+          id: "slack-action",
+          type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+          messagingChannelId: "slack-channel",
+        },
+      ],
+    } as any;
+
+    const result = await executeAct({
+      client: mockClient,
+      executedRule,
+      message,
+      emailAccount,
+      logger,
+    });
+
+    expect(result).toBe(ExecutedRuleStatus.ERROR);
+    expect(mockRunActionFunction).toHaveBeenCalledTimes(2);
+    expect(mockRunActionFunction).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: expect.objectContaining({ id: "telegram-action" }),
+      }),
+    );
+    expect(mockRunActionFunction).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: expect.objectContaining({ id: "slack-action" }),
+      }),
+    );
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
+    expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
+      where: { id: "executed-rule-1" },
+      data: {
+        status: ExecutedRuleStatus.ERROR,
+        reason:
+          "Rule matched\nAction failures: NOTIFY_MESSAGING_CHANNEL:MESSAGING_DELIVERY_FAILED",
+      },
+    });
+  });
+
   it("marks executed rule as APPLIED when actions succeed", async () => {
     mockRunActionFunction.mockResolvedValueOnce({ success: true });
 

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -21,6 +21,12 @@ type ActionFailure = {
   errorCode: string;
 };
 
+const ACTION_FAILURE_TYPES = new Set<ActionType>([
+  ActionType.DRAFT_MESSAGING_CHANNEL,
+  ActionType.NOTIFY_MESSAGING_CHANNEL,
+  ActionType.NOTIFY_SENDER,
+]);
+
 export async function executeAct({
   client,
   executedRule,
@@ -156,7 +162,7 @@ function getActionFailure(
   actionType: ActionType,
   actionResult: unknown,
 ): ActionFailure | null {
-  if (actionType !== ActionType.NOTIFY_SENDER) return null;
+  if (!ACTION_FAILURE_TYPES.has(actionType)) return null;
 
   if (
     !actionResult ||
@@ -168,17 +174,21 @@ function getActionFailure(
 
   if (actionResult.success !== false) return null;
 
-  if (!("errorCode" in actionResult)) {
-    return { type: actionType, errorCode: "UNKNOWN_NOTIFY_FAILURE" };
-  }
+  const errorCode =
+    "errorCode" in actionResult && typeof actionResult.errorCode === "string"
+      ? actionResult.errorCode
+      : getUnknownActionFailureCode(actionType);
 
   return {
     type: actionType,
-    errorCode:
-      typeof actionResult.errorCode === "string"
-        ? actionResult.errorCode
-        : "UNKNOWN_NOTIFY_FAILURE",
+    errorCode,
   };
+}
+
+function getUnknownActionFailureCode(actionType: ActionType) {
+  return actionType === ActionType.NOTIFY_SENDER
+    ? "UNKNOWN_NOTIFY_FAILURE"
+    : "UNKNOWN_MESSAGING_FAILURE";
 }
 
 function buildFailureReason(

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -1503,6 +1503,65 @@ describe("sendMessagingRuleNotification", () => {
     });
   });
 
+  it("delivers Telegram notifications through the linked channel DM when route data is missing", async () => {
+    mockNotificationContext({
+      id: "action-1",
+      type: ActionType.NOTIFY_MESSAGING_CHANNEL,
+      content: null,
+      messagingChannel: {
+        id: "channel-1",
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: true,
+        teamId: "telegram-chat-1",
+        providerUserId: "telegram-user-1",
+        accessToken: null,
+        channelId: null,
+        routes: [],
+      },
+    });
+    mockSendAutomationMessage.mockResolvedValueOnce({
+      channelId: "telegram-chat-1",
+      messageId: "telegram-message-1",
+    });
+    prisma.executedAction.update.mockResolvedValue({} as never);
+
+    const { sendMessagingRuleNotification } = await import(
+      "./rule-notifications"
+    );
+
+    const delivered = await sendMessagingRuleNotification({
+      executedActionId: "action-1",
+      email: {
+        headers: {
+          from: "sender@example.com",
+          subject: "Test subject",
+        },
+        snippet: "Preview text",
+      },
+      logger,
+    });
+
+    expect(delivered).toBe(true);
+    expect(mockSendAutomationMessage).toHaveBeenCalledWith({
+      channel: expect.objectContaining({
+        provider: MessagingProvider.TELEGRAM,
+        teamId: "telegram-chat-1",
+        providerUserId: "telegram-user-1",
+      }),
+      route: null,
+      text: expect.stringContaining("From: sender@example.com"),
+      logger: expect.anything(),
+    });
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        messagingMessageId: "telegram-message-1",
+        messagingMessageSentAt: expect.any(Date),
+        messagingMessageStatus: MessagingMessageStatus.SENT,
+      },
+    });
+  });
+
   it("sends plain draft previews through the linked messaging fallback", async () => {
     mockNotificationContext({
       id: "action-1",

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -426,7 +426,10 @@ async function sendLinkedRuleNotification({
     MessagingRoutePurpose.RULE_NOTIFICATIONS,
   );
 
-  if (!route) {
+  if (
+    !route &&
+    !hasLinkedMessagingDirectMessageDestination(context.messagingChannel)
+  ) {
     logger.warn(
       "Skipping messaging notification with no linked channel route",
       {
@@ -485,6 +488,21 @@ async function sendLinkedRuleNotification({
       error,
     });
     return { delivered: false, kind: "none" };
+  }
+}
+
+function hasLinkedMessagingDirectMessageDestination(channel: {
+  provider: MessagingProvider;
+  providerUserId?: string | null;
+  teamId?: string | null;
+}) {
+  switch (channel.provider) {
+    case MessagingProvider.TEAMS:
+      return Boolean(channel.providerUserId);
+    case MessagingProvider.TELEGRAM:
+      return Boolean(channel.teamId || channel.providerUserId);
+    default:
+      return false;
   }
 }
 


### PR DESCRIPTION
Handles recoverable messaging notification failures without aborting remaining rule actions.

- Records failed messaging deliveries as action failures and lets later actions continue.
- Supports linked direct-message delivery through stored destinations when route data is absent.
- Adds regression coverage for failure continuation and destination fallback.

Tests:
- pnpm test utils/messaging/rule-notifications.test.ts utils/ai/actions.test.ts utils/ai/choose-rule/execute.test.ts
- pnpm check (completed with one existing unrelated warning)
- git diff --check