### PR TITLE
Fix draft notification sync

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -79,6 +79,7 @@ describe("handleRuleNotificationAction", () => {
     mockTelegramOpenDm.mockResolvedValue("telegram-thread-1");
     mockTelegramPostMessage.mockResolvedValue({ id: "telegram-message-1" });
     mockTelegramEditMessage.mockResolvedValue({ id: "telegram-message-1" });
+    prisma.executedAction.findMany.mockResolvedValue([] as never);
   });
 
   it("keeps the draft preview visible after sending from Slack", async () => {
@@ -266,6 +267,151 @@ describe("handleRuleNotificationAction", () => {
       },
     });
     expect(editMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses sibling draft notifications when a draft is sent from Slack", async () => {
+    const provider = {
+      sendDraft: vi
+        .fn()
+        .mockResolvedValue({ messageId: "sent-1", threadId: "thread-1" }),
+      getDraft: vi.fn().mockResolvedValue({
+        id: "draft-1",
+        threadId: "thread-1",
+        textPlain: "Thanks for the note.",
+        subject: "Re: Test subject",
+        date: new Date().toISOString(),
+        snippet: "Thanks for the note.",
+        historyId: "1",
+        internalDate: "1",
+        headers: {
+          from: "user@example.com",
+          to: "sender@example.com",
+          subject: "Re: Test subject",
+          date: "Mon, 1 Jan 2024 12:00:00 +0000",
+        },
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+      getMessage: vi.fn().mockResolvedValue({
+        id: "message-1",
+        threadId: "thread-1",
+        textPlain: "Original message body",
+        textHtml: "<p>Original message body</p>",
+        subject: "Test subject",
+        date: new Date().toISOString(),
+        snippet: "Original message body",
+        historyId: "2",
+        internalDate: "2",
+        headers: {
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Test subject",
+          date: "Mon, 1 Jan 2024 11:00:00 +0000",
+          "message-id": "<message-1@example.com>",
+        },
+        attachments: [],
+        labelIds: [],
+        inline: [],
+      } satisfies ParsedMessage),
+    };
+
+    mockCreateEmailProvider.mockResolvedValue(provider);
+
+    const slackContext = getNotificationContext({
+      id: "slack-action-1",
+      type: ActionType.DRAFT_MESSAGING_CHANNEL,
+      content: "Thanks for the note.",
+      messagingMessageId: "slack-ts-1",
+      messagingMessageStatus: MessagingMessageStatus.SENT,
+      mailboxDraftAction: {
+        id: "draft-action-1",
+        draftId: "draft-1",
+        subject: "Re: Test subject",
+      },
+    });
+    const telegramContext = getNotificationContext({
+      id: "telegram-action-1",
+      type: ActionType.DRAFT_MESSAGING_CHANNEL,
+      content: "Thanks for the note.",
+      messagingMessageId: "telegram-message-1",
+      messagingMessageStatus: MessagingMessageStatus.SENT,
+      messagingChannel: {
+        id: "telegram-channel-1",
+        provider: MessagingProvider.TELEGRAM,
+        isConnected: true,
+        teamId: "telegram-chat-1",
+        providerUserId: "telegram-user-1",
+        accessToken: null,
+        channelId: null,
+        routes: [
+          {
+            purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+            targetId: "telegram-chat-1",
+            targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+          },
+        ],
+      },
+      mailboxDraftAction: {
+        id: "draft-action-1",
+        draftId: "draft-1",
+        subject: "Re: Test subject",
+      },
+    });
+
+    prisma.executedAction.findUnique.mockImplementation(async ({ where }) => {
+      if (where?.id === "slack-action-1") return slackContext as never;
+      if (where?.id === "telegram-action-1") return telegramContext as never;
+      return null as never;
+    });
+    prisma.executedAction.findMany.mockResolvedValue([
+      { id: "telegram-action-1" },
+    ] as never);
+    prisma.executedAction.update.mockResolvedValue({} as never);
+    prisma.executedAction.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const event = createSlackActionEvent({
+      actionId: "rule_draft_send",
+      value: "slack-action-1",
+      editMessage,
+    });
+
+    const { handleRuleNotificationAction } = await import(
+      "./rule-notifications"
+    );
+
+    await handleRuleNotificationAction({
+      event,
+      logger,
+    });
+
+    expect(provider.sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    expect(prisma.executedAction.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "telegram-action-1",
+        OR: [
+          { messagingMessageStatus: null },
+          {
+            messagingMessageStatus: {
+              in: [
+                MessagingMessageStatus.SENT,
+                MessagingMessageStatus.DRAFT_EDITED,
+              ],
+            },
+          },
+        ],
+      },
+      data: {
+        messagingMessageStatus: MessagingMessageStatus.DRAFT_SENT,
+      },
+    });
+    expect(mockTelegramOpenDm).toHaveBeenCalledWith("telegram-chat-1");
+    expect(mockTelegramEditMessage).toHaveBeenCalledWith(
+      "telegram-thread-1",
+      "telegram-message-1",
+      "Draft already sent. No action needed.",
+    );
   });
 
   it("closes the Slack edit modal when the draft sends but the message update fails", async () => {

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -95,6 +95,8 @@ const RULE_NOTIFY_TRASH_ACTION_ID = "rule_notify_trash";
 const RULE_NOTIFY_MARK_SPAM_ACTION_ID = "rule_notify_mark_spam";
 export const SLACK_DRAFT_EDIT_MODAL_ID = "rule_draft_edit_modal";
 const SLACK_DRAFT_EDIT_FIELD_ID = "draft_content";
+const WEB_REPLY_HANDLED_TEXT = "Already replied on the web.";
+const DRAFT_ALREADY_SENT_TEXT = "Draft already sent. No action needed.";
 
 export const RULE_NOTIFICATION_ACTION_IDS = [
   RULE_DRAFT_SEND_ACTION_ID,
@@ -202,36 +204,100 @@ export async function replaceMessagingDraftNotificationsWithHandledOnWebState({
   executedRuleId: string;
   logger: Logger;
 }) {
-  const notificationActions = await prisma.executedAction.findMany({
-    where: {
-      executedRuleId,
-      type: ActionType.DRAFT_MESSAGING_CHANNEL,
-      messagingMessageId: { not: null },
-      messagingChannel: {
-        isConnected: true,
-      },
-    },
-    select: {
-      id: true,
-    },
+  await replaceMessagingDraftNotificationsWithTerminalState({
+    executedRuleId,
+    logger,
+    terminalStatus: MessagingMessageStatus.EXPIRED,
+    terminalMessage: WEB_REPLY_HANDLED_TEXT,
   });
+}
 
-  const results = await Promise.allSettled(
-    notificationActions.map(({ id }) =>
-      replaceMessagingDraftNotificationWithHandledOnWebState({
-        executedActionId: id,
-        logger,
-      }),
-    ),
-  );
+export async function replaceMessagingDraftNotificationsWithDraftSentState({
+  executedRuleId,
+  logger,
+  excludeExecutedActionId,
+}: {
+  executedRuleId: string;
+  logger: Logger;
+  excludeExecutedActionId?: string;
+}) {
+  await replaceMessagingDraftNotificationsWithTerminalState({
+    executedRuleId,
+    logger,
+    excludeExecutedActionId,
+    terminalStatus: MessagingMessageStatus.DRAFT_SENT,
+    terminalMessage: DRAFT_ALREADY_SENT_TEXT,
+  });
+}
 
-  for (const result of results) {
-    if (result.status === "rejected") {
-      logger.warn("Failed to collapse one messaging draft notification", {
+async function replaceMessagingDraftNotificationsWithTerminalState({
+  executedRuleId,
+  logger,
+  excludeExecutedActionId,
+  terminalStatus,
+  terminalMessage,
+}: {
+  executedRuleId: string;
+  logger: Logger;
+  excludeExecutedActionId?: string;
+  terminalStatus: MessagingMessageStatus;
+  terminalMessage: string;
+}) {
+  try {
+    const notificationActions = await prisma.executedAction.findMany({
+      where: {
+        id: excludeExecutedActionId
+          ? { not: excludeExecutedActionId }
+          : undefined,
         executedRuleId,
-        error: result.reason,
-      });
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingMessageId: { not: null },
+        messagingChannel: {
+          isConnected: true,
+        },
+        OR: [
+          { messagingMessageStatus: null },
+          {
+            messagingMessageStatus: {
+              in: [
+                MessagingMessageStatus.SENT,
+                MessagingMessageStatus.DRAFT_EDITED,
+              ],
+            },
+          },
+        ],
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const results = await Promise.allSettled(
+      notificationActions.map(({ id }) =>
+        replaceMessagingDraftNotificationWithTerminalState({
+          executedActionId: id,
+          logger,
+          terminalStatus,
+          terminalMessage,
+        }),
+      ),
+    );
+
+    for (const result of results) {
+      if (result.status === "rejected") {
+        logger.warn("Failed to collapse one messaging draft notification", {
+          executedRuleId,
+          terminalStatus,
+          error: result.reason,
+        });
+      }
     }
+  } catch (error) {
+    logger.warn("Failed to collapse messaging draft notifications", {
+      executedRuleId,
+      terminalStatus,
+      error,
+    });
   }
 }
 
@@ -995,6 +1061,12 @@ async function sendDraftReplyFromNotification({
       openLink: getNotificationOpenLink(context),
       status: "Reply sent.",
     }),
+  });
+
+  await replaceMessagingDraftNotificationsWithDraftSentState({
+    executedRuleId: context.executedRule.id,
+    logger,
+    excludeExecutedActionId: context.id,
   });
 
   return "sent";
@@ -2185,22 +2257,20 @@ async function postSlackCard({
   }
 }
 
-async function replaceMessagingDraftNotificationWithHandledOnWebState({
+async function replaceMessagingDraftNotificationWithTerminalState({
   executedActionId,
   logger,
+  terminalStatus,
+  terminalMessage,
 }: {
   executedActionId: string;
   logger: Logger;
+  terminalStatus: MessagingMessageStatus;
+  terminalMessage: string;
 }) {
-  const context = await getNotificationContext(executedActionId);
-
-  if (!context?.messagingMessageId) {
-    return;
-  }
-
   const updated = await prisma.executedAction.updateMany({
     where: {
-      id: context.id,
+      id: executedActionId,
       OR: [
         { messagingMessageStatus: null },
         {
@@ -2214,11 +2284,17 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
       ],
     },
     data: {
-      messagingMessageStatus: MessagingMessageStatus.EXPIRED,
+      messagingMessageStatus: terminalStatus,
     },
   });
 
   if (updated.count === 0) {
+    return;
+  }
+
+  const context = await getNotificationContext(executedActionId);
+
+  if (!context?.messagingMessageId) {
     return;
   }
 
@@ -2253,7 +2329,7 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
 
   const card = buildTerminalCard({
     title: "Draft reply",
-    message: "Already replied on the web.",
+    message: terminalMessage,
   });
 
   try {
@@ -2316,7 +2392,7 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
         await teamsAdapter.editMessage(
           threadId,
           context.messagingMessageId,
-          "Already replied on the web.",
+          terminalMessage,
         );
         break;
       }
@@ -2350,7 +2426,7 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
         await telegramAdapter.editMessage(
           threadId,
           context.messagingMessageId,
-          "Already replied on the web.",
+          terminalMessage,
         );
         break;
       }
@@ -2359,10 +2435,11 @@ async function replaceMessagingDraftNotificationWithHandledOnWebState({
     }
   } catch (error) {
     logger.warn(
-      "Failed to collapse messaging draft notification after web reply",
+      "Failed to collapse messaging draft notification after terminal state",
       {
         executedActionId: context.id,
         provider: context.messagingChannel.provider,
+        terminalStatus,
         error,
       },
     );

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -21,6 +21,9 @@ vi.mock("@/utils/ai/reply/reply-memory", () => ({
   syncReplyMemoriesFromDraftSendLogs: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/utils/messaging/rule-notifications", () => ({
+  replaceMessagingDraftNotificationsWithDraftSentState: vi
+    .fn()
+    .mockResolvedValue(undefined),
   replaceMessagingDraftNotificationsWithHandledOnWebState: vi
     .fn()
     .mockResolvedValue(undefined),
@@ -33,7 +36,10 @@ import {
   saveDraftSendLogReplyMemory,
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
-import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
+import {
+  replaceMessagingDraftNotificationsWithDraftSentState,
+  replaceMessagingDraftNotificationsWithHandledOnWebState,
+} from "@/utils/messaging/rule-notifications";
 
 const logger = createTestLogger();
 
@@ -91,11 +97,14 @@ describe("trackSentDraftStatus", () => {
       }),
     );
     expect(
-      replaceMessagingDraftNotificationsWithHandledOnWebState,
+      replaceMessagingDraftNotificationsWithDraftSentState,
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,
     });
+    expect(
+      replaceMessagingDraftNotificationsWithHandledOnWebState,
+    ).not.toHaveBeenCalled();
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {
@@ -233,6 +242,12 @@ describe("trackSentDraftStatus", () => {
         draftStatus: DraftEmailStatus.LIKELY_SENT,
       },
     });
+    expect(
+      replaceMessagingDraftNotificationsWithDraftSentState,
+    ).toHaveBeenCalledWith({
+      executedRuleId: "executed-rule-1",
+      logger,
+    });
   });
 
   it("treats sent messages to someone else as ignored drafts and skips learning", async () => {
@@ -353,11 +368,14 @@ describe("trackSentDraftStatus", () => {
       }),
     });
     expect(
-      replaceMessagingDraftNotificationsWithHandledOnWebState,
+      replaceMessagingDraftNotificationsWithDraftSentState,
     ).toHaveBeenCalledWith({
       executedRuleId: "executed-rule-1",
       logger,
     });
+    expect(
+      replaceMessagingDraftNotificationsWithHandledOnWebState,
+    ).not.toHaveBeenCalled();
     expect(prisma.executedAction.update).toHaveBeenCalledWith({
       where: { id: "action-1" },
       data: {

--- a/apps/web/utils/reply-tracker/draft-tracking.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.ts
@@ -13,7 +13,10 @@ import {
   syncReplyMemoriesFromDraftSendLogs,
 } from "@/utils/ai/reply/reply-memory";
 import { stripProviderSignatureFromParsedMessage } from "@/utils/email/signature-normalization";
-import { replaceMessagingDraftNotificationsWithHandledOnWebState } from "@/utils/messaging/rule-notifications";
+import {
+  replaceMessagingDraftNotificationsWithDraftSentState,
+  replaceMessagingDraftNotificationsWithHandledOnWebState,
+} from "@/utils/messaging/rule-notifications";
 import { emailToContentForAI } from "@/utils/ai/content-sanitizer";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { messageRepliesToSourceSender } from "@/utils/email";
@@ -230,7 +233,10 @@ export async function trackSentDraftStatus({
     );
   }
 
-  await replaceMessagingDraftNotificationsWithHandledOnWebState({
+  const replaceMessagingDraftNotifications = wasLikelyDraftSent
+    ? replaceMessagingDraftNotificationsWithDraftSentState
+    : replaceMessagingDraftNotificationsWithHandledOnWebState;
+  await replaceMessagingDraftNotifications({
     executedRuleId: executedAction.executedRuleId,
     logger,
   });


### PR DESCRIPTION
Updates draft notification cleanup so sibling messaging notifications move to a sent terminal state when a draft is sent, while web replies continue to expire stale notifications. The shared terminal-state path keeps cleanup scoped to actionable draft notification records.

- Collapse sibling messaging draft notifications to `DRAFT_SENT` after draft-send flows complete.
- Preserve web-reply cleanup as `EXPIRED` through the same guarded terminal-state handler.
- Tests: `pnpm test utils/messaging/rule-notifications.test.ts utils/reply-tracker/draft-tracking.test.ts`

Performance impact: Adds bounded database lookups/updates and existing messaging edit calls only when draft notification cleanup runs; no schema changes, background runtime work, or new hot-path database/network calls outside draft send and sent-draft tracking flows.