### PR TITLE
fix(rules): anchor static from/to address matching to prevent spoofing

### DIFF
--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -122,6 +122,78 @@ describe("matchesStaticRule", () => {
     expect(matchesStaticRule(rule, message, logger)).toBe(false);
   });
 
+  it("does not match a full-address pattern against a spoofed suffix domain", () => {
+    const rule = getStaticRule({ from: "boss@company.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "boss@company.com.evil.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
+  it("does not match a full-address pattern against a prefixed local part", () => {
+    const rule = getStaticRule({ from: "boss@company.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "xboss@company.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
+  it("does not match a domain pattern against a spoofed suffix domain", () => {
+    const rule = getStaticRule({ from: "@company.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "user@company.com.evil.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
+  it("does not match a wildcard-local pattern against a spoofed suffix domain", () => {
+    const rule = getStaticRule({ from: "*@gmail.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "test@gmail.com.evil.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
+  it("does not match a bare-domain pattern against a lookalike domain", () => {
+    const rule = getStaticRule({ from: "example.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "user@myexample.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
+  it("still matches a bare-domain pattern against an address at that domain", () => {
+    const rule = getStaticRule({ from: "example.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "user@example.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(true);
+  });
+
+  it("still matches a bare-domain pattern against a subdomain of that domain", () => {
+    const rule = getStaticRule({ from: "example.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "user@mail.example.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(true);
+  });
+
+  it("treats the @domain form as an exact domain (no subdomain match)", () => {
+    const rule = getStaticRule({ from: "@example.com" });
+    const message = getMessage({
+      headers: getHeaders({ from: "user@mail.example.com" }),
+    });
+
+    expect(matchesStaticRule(rule, message, logger)).toBe(false);
+  });
+
   it("matches from against the sender address, not the display name", () => {
     const rule = getStaticRule({ from: "@trusted.com" });
     const message = getMessage({

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -915,11 +915,31 @@ function matchesRulePattern(pattern: string, text: string) {
   return createRulePatternRegex(pattern).test(text);
 }
 
-function createRulePatternRegex(pattern: string) {
-  const escapedPattern = pattern.replace(/[.+?^${}()[\]\\]/g, "\\$&");
-  const regexPattern = escapedPattern.replace(/\*/g, ".*");
+// Escape regex metacharacters, then turn the `*` glob into `.*`.
+function globToRegexSource(pattern: string) {
+  return pattern.replace(/[.+?^${}()[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+}
 
-  return new RegExp(regexPattern);
+// Unanchored: intended for subject/body keyword and display-name substring matching.
+function createRulePatternRegex(pattern: string) {
+  return new RegExp(globToRegexSource(pattern));
+}
+
+// Anchored: for from/to address patterns, so a pattern matches a whole address
+// boundary and cannot be satisfied by a spoofed prefix/suffix (e.g. a rule for
+// `boss@company.com` must not match `boss@company.com.evil.com`).
+function createAnchoredAddressRegex(pattern: string) {
+  // `@domain` → any local part, exact domain (no subdomain), e.g. user@domain.
+  if (pattern.startsWith("@")) {
+    return new RegExp(`^.*${globToRegexSource(pattern)}$`);
+  }
+  // `local@domain` → exact address (local part may contain `*` wildcards).
+  if (pattern.includes("@")) {
+    return new RegExp(`^${globToRegexSource(pattern)}$`);
+  }
+  // Bare domain → addresses at that domain or a subdomain (`@domain`/`.domain`),
+  // but not a lookalike domain (e.g. `example.com` must not match myexample.com).
+  return new RegExp(`^.*[@.]${globToRegexSource(pattern)}$`);
 }
 
 function matchesEmailFieldPattern({
@@ -941,7 +961,12 @@ function matchesEmailFieldPattern({
       const regex = createRulePatternRegex(normalizedPattern);
 
       if (isAddressLikeEmailPattern(patternPart)) {
-        if (regex.test(addressText)) return true;
+        // `addressText` may hold several recipients joined as "a@x, b@y"; the
+        // anchored regex must be tested against each address individually.
+        const addressRegex = createAnchoredAddressRegex(normalizedPattern);
+        const addresses = addressText.split(", ").filter(Boolean);
+        if (addresses.some((address) => addressRegex.test(address)))
+          return true;
         continue;
       }
 


### PR DESCRIPTION
## Summary

Static `from`/`to` rule patterns were compiled to an **unanchored** regex and tested with `.test()` (a substring match). This let a trusted-address rule match attacker-controlled lookalikes:

- a rule for `boss@company.com` also matched `boss@company.com.evil.com` (attacker owns `evil.com`) and `xboss@company.com`;
- a bare-domain rule `example.com` matched the lookalike `myexample.com`.

For rules whose action is ARCHIVE / LABEL / REPLY / FORWARD, an attacker could craft a sending address that satisfies a trusted static rule. The suffix variant is the real escalation (the attacker fully controls the appended domain).

## Fix

Add `createAnchoredAddressRegex`, used **only** in the address branch of `matchesEmailFieldPattern`:

| Pattern form | Anchored regex | Matches |
|---|---|---|
| `local@domain` | `^local@domain$` | exact address (`*` wildcard preserved) |
| `@domain` | `^.*@domain$` | any local part, exact domain (no subdomain — preserves current behavior) |
| bare `domain` | `^.*[@.]domain$` | address at that domain or a subdomain, **not** a lookalike domain |

Multi-recipient `to` headers are normalized as `"a@x, b@y"`, so the anchored regex is tested against **each** address individually rather than the joined string.

Subject/body keyword matching and display-name matching keep their intended **unanchored substring** behavior — `createRulePatternRegex` is unchanged; only the shared escape/glob logic was extracted into a `globToRegexSource` helper so both paths stay in sync.

## Behavior change

This narrows live user rules: overly broad existing `from`/`to` rules will match less (which is the point). The `@domain` form remains exact-domain (no implicit subdomain match) to preserve current behavior; bare-domain keeps subdomain matching. These decisions are pinned by explicit tests.

## Test plan (TDD)

Added to `match-rules.test.ts` (written first, watched fail, then green):
- spoofing rejected: full-address suffix/prefix, `@domain` suffix, `*@domain` suffix, bare-domain lookalike;
- preserved: bare-domain at-domain + subdomain; `@domain` treated as exact domain.
- `pnpm test utils/ai/choose-rule/match-rules.test.ts` → 117/117 pass (8 new, no existing test modified).
- Full unit suite green (`pnpm test`): 3817 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)