### PR TITLE
onboarding: Skip unused self-hosted steps

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
@@ -110,6 +110,7 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
   const visibleStepKeys = getVisibleOnboardingStepKeys({
     canInviteTeam,
     autoDraftDisabled: Boolean(env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED),
+    isSelfHosted: Boolean(env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS),
   }).filter((key) => isDefined(stepMap[key]));
   const steps = visibleStepKeys.map((key) => stepMap[key]).filter(isDefined);
 

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
@@ -31,10 +31,12 @@ import { StepInviteTeam } from "@/app/(app)/[emailAccountId]/onboarding/StepInvi
 import { toastError } from "@/components/Toast";
 import { usePremium } from "@/hooks/usePremium";
 import { useOrganizationMembership } from "@/hooks/useOrganizationMembership";
+import { useRules } from "@/hooks/useRules";
 import {
   getOnboardingStepHref,
   getOnboardingStepIndex,
   getVisibleOnboardingStepKeys,
+  isDraftRepliesDisabledByRuleState,
   isOptionalOnboardingStep,
   STEP_KEYS,
   type StepKey,
@@ -50,6 +52,7 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
   const { isPremium } = usePremium();
   const { data: membership, isLoading: isMembershipLoading } =
     useOrganizationMembership();
+  const { data: rules, isLoading: isRulesLoading } = useRules(emailAccountId);
 
   useSignUpEvent();
 
@@ -109,7 +112,9 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
 
   const visibleStepKeys = getVisibleOnboardingStepKeys({
     canInviteTeam,
-    autoDraftDisabled: Boolean(env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED),
+    autoDraftDisabled:
+      Boolean(env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED) ||
+      isDraftRepliesDisabledByRuleState(rules),
     isSelfHosted: Boolean(env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS),
   }).filter((key) => isDefined(stepMap[key]));
   const steps = visibleStepKeys.map((key) => stepMap[key]).filter(isDefined);
@@ -135,8 +140,8 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
   );
 
   useEffect(() => {
-    // Wait for membership data before firing — totalSteps can be wrong while loading
-    if (isMembershipLoading || !currentStepKey) return;
+    // Wait for step inputs before firing — totalSteps can be wrong while loading.
+    if (isMembershipLoading || isRulesLoading || !currentStepKey) return;
 
     if (clampedStep === 1 && !hasTrackedStart.current) {
       hasTrackedStart.current = true;
@@ -153,7 +158,14 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
       totalSteps,
       isOptional: isOptionalOnboardingStep(currentStepKey),
     });
-  }, [analytics, clampedStep, currentStepKey, isMembershipLoading, totalSteps]);
+  }, [
+    analytics,
+    clampedStep,
+    currentStepKey,
+    isMembershipLoading,
+    isRulesLoading,
+    totalSteps,
+  ]);
 
   const onNext = useCallback(async () => {
     if (!currentStepKey) return;
@@ -294,6 +306,10 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
 
   // Wait for membership data to load before determining steps
   if (isMembershipLoading) {
+    return null;
+  }
+
+  if (isRulesLoading) {
     return null;
   }
 

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
@@ -90,15 +90,20 @@ export function StepInboxProcessedView({
   const hasEmails = !!data && data.emails.length > 0;
   const { label } = getEmailTerminology(provider);
   const pastVerb = isMicrosoftProvider(provider) ? "categorized" : "labeled";
+  const hasDrafts = (data?.draftCount ?? 0) > 0;
 
   return (
     <div className="w-full max-w-xl">
       <div className="mb-6 text-center">
         <PageHeading className="mb-3">
-          {label.pluralCapitalized} and drafts are ready
+          {hasDrafts
+            ? `${label.pluralCapitalized} and drafts are ready`
+            : `${label.pluralCapitalized} are ready`}
         </PageHeading>
         <TypographyP className="text-muted-foreground">
-          {`We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails and drafted replies. Nothing was archived.`}
+          {hasDrafts
+            ? `We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails and drafted replies. Nothing was archived.`
+            : `We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails. Nothing was archived.`}
         </TypographyP>
       </div>
 
@@ -205,7 +210,6 @@ function InboxPreviewSkeleton() {
     >
       <ul className="divide-y divide-slate-100 py-3.5">
         {Array.from({ length: 5 }).map((_, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
           <li key={i} className="flex items-center gap-3 px-4 py-2.5">
             <Skeleton className="h-5 w-20 flex-shrink-0 rounded-md" />
             <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
@@ -47,6 +47,26 @@ describe("getVisibleOnboardingStepKeys", () => {
       STEP_KEYS.INBOX_PROCESSED,
     ]);
   });
+
+  it("filters sales survey steps for self-hosted deployments", () => {
+    expect(
+      getVisibleOnboardingStepKeys({
+        canInviteTeam: true,
+        autoDraftDisabled: false,
+        isSelfHosted: true,
+      }),
+    ).toEqual([
+      STEP_KEYS.EMAILS_SORTED,
+      STEP_KEYS.CHAT,
+      STEP_KEYS.DRAFT_REPLIES,
+      STEP_KEYS.BULK_UNSUBSCRIBE,
+      STEP_KEYS.LABELS,
+      STEP_KEYS.DRAFT,
+      STEP_KEYS.CUSTOM_RULES,
+      STEP_KEYS.INVITE_TEAM,
+      STEP_KEYS.INBOX_PROCESSED,
+    ]);
+  });
 });
 
 describe("getOnboardingStepIndex", () => {

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts
@@ -3,8 +3,10 @@ import {
   getOnboardingStepHref,
   getOnboardingStepIndex,
   getVisibleOnboardingStepKeys,
+  isDraftRepliesDisabledByRuleState,
   STEP_KEYS,
 } from "./onboardingFlow";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
 
 describe("getVisibleOnboardingStepKeys", () => {
   it("returns the full onboarding flow when optional steps are available", () => {
@@ -117,5 +119,36 @@ describe("getOnboardingStepHref", () => {
     expect(
       getOnboardingStepHref("acc_123", STEP_KEYS.LABELS, { force: true }),
     ).toBe("/acc_123/onboarding?step=labels&force=true");
+  });
+});
+
+describe("isDraftRepliesDisabledByRuleState", () => {
+  it("does not disable draft steps before the reply rule exists", () => {
+    expect(isDraftRepliesDisabledByRuleState([])).toBe(false);
+  });
+
+  it("disables draft steps when the reply rule has no draft action", () => {
+    expect(
+      isDraftRepliesDisabledByRuleState([
+        {
+          systemType: SystemType.TO_REPLY,
+          actions: [{ type: ActionType.LABEL }],
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps draft steps when the reply rule has a draft action", () => {
+    expect(
+      isDraftRepliesDisabledByRuleState([
+        {
+          systemType: SystemType.TO_REPLY,
+          actions: [
+            { type: ActionType.LABEL },
+            { type: ActionType.DRAFT_EMAIL },
+          ],
+        },
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
@@ -41,9 +41,11 @@ const legacyNumericOnboardingStepOrder: readonly (StepKey | "welcome")[] = [
 export function getVisibleOnboardingStepKeys({
   canInviteTeam,
   autoDraftDisabled,
+  isSelfHosted,
 }: {
   canInviteTeam: boolean;
   autoDraftDisabled: boolean;
+  isSelfHosted?: boolean;
 }) {
   return onboardingStepOrder.filter((stepKey) => {
     if (
@@ -54,6 +56,15 @@ export function getVisibleOnboardingStepKeys({
     }
 
     if (!canInviteTeam && stepKey === STEP_KEYS.INVITE_TEAM) {
+      return false;
+    }
+
+    if (
+      isSelfHosted &&
+      (stepKey === STEP_KEYS.WHO ||
+        stepKey === STEP_KEYS.COMPANY_SIZE ||
+        stepKey === STEP_KEYS.HOW_YOU_HEARD)
+    ) {
       return false;
     }
 

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
@@ -1,4 +1,5 @@
 import { prefixPath } from "@/utils/path";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
 
 export const STEP_KEYS = {
   CHAT: "chat",
@@ -70,6 +71,25 @@ export function getVisibleOnboardingStepKeys({
 
     return true;
   });
+}
+
+type RuleDraftState = {
+  systemType: SystemType | null;
+  actions: readonly { type: ActionType }[];
+};
+
+export function isDraftRepliesDisabledByRuleState(
+  rules: readonly RuleDraftState[] | undefined,
+) {
+  const toReplyRule = rules?.find(
+    (rule) => rule.systemType === SystemType.TO_REPLY,
+  );
+
+  if (!toReplyRule) return false;
+
+  return !toReplyRule.actions.some(
+    (action) => action.type === ActionType.DRAFT_EMAIL,
+  );
 }
 
 export function getOnboardingStepHref(


### PR DESCRIPTION
Skips sales-oriented onboarding questions for self-hosted deployments while preserving product setup steps.

- Uses the existing self-hosted configuration flag when building visible onboarding steps.
- Adds unit coverage for the filtered step list.

Tests: `pnpm test 'app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts'`