### PR TITLE
fix(gmail): handle per-thread batch errors in getThreadsBatch

### DIFF
--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1210,6 +1210,7 @@ export class GmailProvider implements EmailProvider {
     const threads = await getThreadsBatch(
       threadIds,
       getAccessTokenFromClient(this.client),
+      this.logger,
     );
 
     return threads
@@ -1464,6 +1465,7 @@ export class GmailProvider implements EmailProvider {
       const threads = await getThreadsBatch(
         threadIds,
         getAccessTokenFromClient(this.client),
+        this.logger,
       );
 
       const emailThreads: EmailThread[] = threads
@@ -1508,6 +1510,7 @@ export class GmailProvider implements EmailProvider {
       this.getAccessToken(),
       sender,
       limit,
+      this.logger,
     );
   }
 

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -1,0 +1,150 @@
+import chunk from "lodash/chunk";
+import { type BatchError, isBatchError, isDefined } from "@/utils/types";
+import { getBatch } from "@/utils/gmail/batch";
+import { isRetryableError } from "@/utils/gmail/retry";
+import { sleep } from "@/utils/sleep";
+import type { Logger } from "@/utils/logger";
+
+const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
+
+// Fetches a Gmail batch and handles per-item errors: throws on 401, retries
+// retryable items (re-fetching only the missing ids, in smaller chunks when
+// rate-limited), and drops non-retryable items with a warning. Without this,
+// per-item batch errors are returned as-is and silently treated as
+// valid-but-empty results, so threads/messages disappear under partial failure.
+export async function getBatchWithRetry<TRaw, TParsed>({
+  ids,
+  endpoint,
+  accessToken,
+  parse,
+  logger,
+  retryCount = 0,
+}: {
+  ids: string[];
+  endpoint: string; // e.g. /gmail/v1/users/me/messages
+  accessToken: string;
+  parse: (item: TRaw) => TParsed;
+  logger: Logger;
+  retryCount?: number;
+}): Promise<TParsed[]> {
+  if (!accessToken) throw new Error("No access token");
+
+  if (retryCount > 3) {
+    logger.error("Too many batch retries", { ids, retryCount });
+    return [];
+  }
+
+  const batch: (TRaw | BatchError)[] = await getBatch(
+    ids,
+    endpoint,
+    accessToken,
+  );
+
+  if (batch.some((item) => isBatchError(item) && item.error.code === 401)) {
+    logger.error("Error fetching batch", { firstBatchItem: batch?.[0] });
+    throw new Error("Invalid access token");
+  }
+
+  const missingIds = new Set<string>();
+  let shouldRetryInSmallerBatches = false;
+
+  const parsed = batch
+    .map((item, i) => {
+      if (isBatchError(item)) {
+        const { code, message: errorMessage, errors } = item.error;
+        const reason = errors?.[0]?.reason;
+
+        const { retryable, isRateLimit } = isRetryableError({
+          status: code,
+          reason,
+          errorMessage,
+        });
+
+        if (!retryable) {
+          logger.warn("Skipping batch item due to non-retryable error", {
+            id: ids[i],
+            code,
+            reason,
+            errorMessage,
+          });
+          return;
+        }
+
+        logger.error("Error fetching batch item, adding to retry queue", {
+          id: ids[i],
+          code,
+          errorMessage,
+          reason,
+        });
+        if (isRateLimit) shouldRetryInSmallerBatches = true;
+        missingIds.add(ids[i]);
+        return;
+      }
+
+      return parse(item);
+    })
+    .filter(isDefined);
+
+  if (missingIds.size > 0) {
+    const remainingIds = Array.from(missingIds);
+    logger.info("Missing batch items", {
+      missingIds: remainingIds,
+      retryMode: shouldRetryInSmallerBatches ? "chunked" : "batch",
+    });
+    const nextRetryCount = retryCount + 1;
+    await sleep(1000 * nextRetryCount);
+    const refetched = shouldRetryInSmallerBatches
+      ? await getBatchWithRetryInChunks({
+          ids: remainingIds,
+          endpoint,
+          accessToken,
+          parse,
+          retryCount: nextRetryCount,
+          logger,
+        })
+      : await getBatchWithRetry({
+          ids: remainingIds,
+          endpoint,
+          accessToken,
+          parse,
+          retryCount: nextRetryCount,
+          logger,
+        });
+    return [...parsed, ...refetched];
+  }
+
+  return parsed;
+}
+
+async function getBatchWithRetryInChunks<TRaw, TParsed>({
+  ids,
+  endpoint,
+  accessToken,
+  parse,
+  retryCount,
+  logger,
+}: {
+  ids: string[];
+  endpoint: string;
+  accessToken: string;
+  parse: (item: TRaw) => TParsed;
+  retryCount: number;
+  logger: Logger;
+}): Promise<TParsed[]> {
+  const chunked = chunk(ids, RATE_LIMIT_RETRY_BATCH_SIZE);
+  const results: TParsed[] = [];
+
+  for (const idsChunk of chunked) {
+    const chunkResults = await getBatchWithRetry<TRaw, TParsed>({
+      ids: idsChunk,
+      endpoint,
+      accessToken,
+      parse,
+      retryCount,
+      logger,
+    });
+    results.push(...chunkResults);
+  }
+
+  return results;
+}

--- a/apps/web/utils/gmail/message.ts
+++ b/apps/web/utils/gmail/message.ts
@@ -1,24 +1,18 @@
 import type { gmail_v1 } from "@googleapis/gmail";
-import chunk from "lodash/chunk";
 import {
-  type BatchError,
   type MessageWithPayload,
   type ParsedMessage,
   type ThreadWithPayloadMessages,
-  isBatchError,
   isDefined,
 } from "@/utils/types";
-import { getBatch } from "@/utils/gmail/batch";
+import { getBatchWithRetry } from "@/utils/gmail/batch-with-retry";
 import { getSearchTermForSender } from "@/utils/email";
-import { sleep } from "@/utils/sleep";
 import { getAccessTokenFromClient } from "@/utils/gmail/client";
 import { GmailLabel } from "@/utils/gmail/label";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import parse from "gmail-api-parse-message";
-import { isRetryableError, withGmailRetry } from "@/utils/gmail/retry";
+import { withGmailRetry } from "@/utils/gmail/retry";
 import type { Logger } from "@/utils/logger";
-
-const RATE_LIMIT_RETRY_BATCH_SIZE = 10;
 
 export function parseMessage(
   message: MessageWithPayload,
@@ -122,93 +116,16 @@ export async function getMessagesBatch({
   retryCount?: number;
   logger: Logger;
 }): Promise<ParsedMessage[]> {
-  if (!accessToken) throw new Error("No access token");
-
-  if (retryCount > 3) {
-    logger.error("Too many retries", { messageIds, retryCount });
-    return [];
-  }
   if (messageIds.length > 100) throw new Error("Too many messages. Max 100");
 
-  const batch: (MessageWithPayload | BatchError)[] = await getBatch(
-    messageIds,
-    "/gmail/v1/users/me/messages",
+  return getBatchWithRetry<MessageWithPayload, ParsedMessage>({
+    ids: messageIds,
+    endpoint: "/gmail/v1/users/me/messages",
     accessToken,
-  );
-
-  const missingMessageIds = new Set<string>();
-  let shouldRetryInSmallerBatches = false;
-
-  if (batch.some((m) => isBatchError(m) && m.error.code === 401)) {
-    logger.error("Error fetching messages", {
-      firstBatchItem: batch?.[0],
-    });
-    throw new Error("Invalid access token");
-  }
-
-  const messages = batch
-    .map((message, i) => {
-      if (isBatchError(message)) {
-        const { code, message: errorMessage, errors } = message.error;
-        const reason = errors?.[0]?.reason;
-
-        const { retryable, isRateLimit } = isRetryableError({
-          status: code,
-          reason,
-          errorMessage,
-        });
-
-        if (!retryable) {
-          logger.warn("Skipping message due to non-retryable error", {
-            messageId: messageIds[i],
-            code,
-            reason,
-            errorMessage,
-          });
-          return;
-        }
-
-        logger.error("Error fetching message, adding to retry queue", {
-          messageId: messageIds[i],
-          code,
-          errorMessage,
-          reason,
-        });
-        if (isRateLimit) shouldRetryInSmallerBatches = true;
-        missingMessageIds.add(messageIds[i]);
-        return;
-      }
-
-      return parseMessage(message as MessageWithPayload);
-    })
-    .filter(isDefined);
-
-  // if we errored, then try to refetch the missing messages
-  if (missingMessageIds.size > 0) {
-    const missingIds = Array.from(missingMessageIds);
-    logger.info("Missing messages", {
-      missingMessageIds: missingIds,
-      retryMode: shouldRetryInSmallerBatches ? "chunked" : "batch",
-    });
-    const nextRetryCount = retryCount + 1;
-    await sleep(1000 * nextRetryCount);
-    const missingMessages = shouldRetryInSmallerBatches
-      ? await getMessagesBatchInRetryChunks({
-          messageIds: missingIds,
-          accessToken,
-          retryCount: nextRetryCount,
-          logger,
-        })
-      : await getMessagesBatch({
-          messageIds: missingIds,
-          accessToken,
-          retryCount: nextRetryCount,
-          logger,
-        });
-    return [...messages, ...missingMessages];
-  }
-
-  return messages;
+    parse: (message) => parseMessage(message),
+    retryCount,
+    logger,
+  });
 }
 
 async function findPreviousEmailsWithSender(
@@ -379,31 +296,4 @@ export async function getSentMessages(
     logger,
   });
   return messages.messages;
-}
-
-async function getMessagesBatchInRetryChunks({
-  messageIds,
-  accessToken,
-  retryCount,
-  logger,
-}: {
-  messageIds: string[];
-  accessToken: string;
-  retryCount: number;
-  logger: Logger;
-}) {
-  const chunkedMessages = chunk(messageIds, RATE_LIMIT_RETRY_BATCH_SIZE);
-  const messages: ParsedMessage[] = [];
-
-  for (const messageIdsChunk of chunkedMessages) {
-    const chunkMessages = await getMessagesBatch({
-      messageIds: messageIdsChunk,
-      accessToken,
-      retryCount,
-      logger,
-    });
-    messages.push(...chunkMessages);
-  }
-
-  return messages;
 }

--- a/apps/web/utils/gmail/thread.test.ts
+++ b/apps/web/utils/gmail/thread.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getThreadsBatch } from "./thread";
+import { getBatch } from "@/utils/gmail/batch";
+import { createTestLogger } from "@/__tests__/helpers";
+
+vi.mock("@/utils/gmail/batch");
+vi.mock("@/utils/sleep", () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("getThreadsBatch", () => {
+  const logger = createTestLogger();
+  const accessToken = "token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refetches threads that failed with a retryable error", async () => {
+    vi.mocked(getBatch)
+      .mockResolvedValueOnce([
+        {
+          error: {
+            code: 429,
+            message: "Rate limit exceeded",
+            errors: [{ reason: "rateLimitExceeded" }],
+            status: "RESOURCE_EXHAUSTED",
+          },
+        },
+      ])
+      .mockResolvedValueOnce([{ id: "t1", snippet: "hi", messages: [] }]);
+
+    const result = await getThreadsBatch(["t1"], accessToken, logger);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("t1");
+    expect(getBatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips threads with a non-retryable error instead of returning them as valid", async () => {
+    vi.mocked(getBatch).mockResolvedValueOnce([
+      { id: "t1", snippet: "ok", messages: [] },
+      {
+        error: {
+          code: 404,
+          message: "Not Found",
+          errors: [{ reason: "notFound" }],
+          status: "NOT_FOUND",
+        },
+      },
+    ]);
+
+    const result = await getThreadsBatch(["t1", "t2"], accessToken, logger);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("t1");
+    expect(getBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on a 401 batch error", async () => {
+    vi.mocked(getBatch).mockResolvedValueOnce([
+      {
+        error: {
+          code: 401,
+          message: "Invalid Credentials",
+          errors: [{ reason: "authError" }],
+          status: "UNAUTHENTICATED",
+        },
+      },
+    ]);
+
+    await expect(getThreadsBatch(["t1"], accessToken, logger)).rejects.toThrow(
+      "Invalid access token",
+    );
+  });
+});

--- a/apps/web/utils/gmail/thread.ts
+++ b/apps/web/utils/gmail/thread.ts
@@ -1,5 +1,5 @@
 import type { gmail_v1 } from "@googleapis/gmail";
-import { getBatch } from "@/utils/gmail/batch";
+import { getBatchWithRetry } from "@/utils/gmail/batch-with-retry";
 import {
   isDefined,
   type ThreadWithPayloadMessages,
@@ -91,14 +91,20 @@ export async function getThreadsWithNextPageToken({
 export async function getThreadsBatch(
   threadIds: string[],
   accessToken: string,
+  logger: Logger,
 ): Promise<ThreadWithPayloadMessages[]> {
-  const batch = await getBatch(
-    threadIds,
-    "/gmail/v1/users/me/threads",
-    accessToken,
-  );
+  if (!threadIds.length) return [];
 
-  return batch;
+  return getBatchWithRetry<
+    ThreadWithPayloadMessages,
+    ThreadWithPayloadMessages
+  >({
+    ids: threadIds,
+    endpoint: "/gmail/v1/users/me/threads",
+    accessToken,
+    parse: (thread) => thread,
+    logger,
+  });
 }
 
 async function getThreadsFromSender(
@@ -131,6 +137,7 @@ export async function getThreadsFromSenderWithSubject(
   accessToken: string,
   sender: string,
   limit: number,
+  logger: Logger,
 ): Promise<
   Array<{
     id: string;
@@ -140,7 +147,11 @@ export async function getThreadsFromSenderWithSubject(
 > {
   const threads = await getThreadsFromSender(gmail, sender, limit);
   const threadIds = threads.map((t) => t.id).filter(isDefined);
-  const threadsWithSubject = await getThreadsBatch(threadIds, accessToken);
+  const threadsWithSubject = await getThreadsBatch(
+    threadIds,
+    accessToken,
+    logger,
+  );
   return threadsWithSubject
     .map((t) =>
       t.id

--- a/apps/web/utils/types.ts
+++ b/apps/web/utils/types.ts
@@ -29,10 +29,8 @@ export type BatchError = {
   };
 };
 
-export function isBatchError(
-  message: MessageWithPayload | BatchError,
-): message is BatchError {
-  return (message as BatchError).error !== undefined;
+export function isBatchError<T>(item: T | BatchError): item is BatchError {
+  return (item as BatchError).error !== undefined;
 }
 
 export type MessageWithPayload = {


### PR DESCRIPTION
## Summary

`getThreadsBatch` returned the **raw** Gmail batch result, which can contain per-item `BatchError` objects (one per failed sub-request). Consumers filter on `thread.id`, so a thread that failed (404 / 429 / 5xx) was silently **dropped** — or returned with no messages — with **no retry and no log**. Under partial rate-limiting, threads simply vanished from listings and automation.

`getMessagesBatch` already handled this case correctly (401 → throw, retryable classification, chunked re-fetch of missing ids). `getThreadsBatch` had none of it.

## Fix

Extract the batch error-handling/retry logic out of `getMessagesBatch` into a shared generic helper `getBatchWithRetry` (`utils/gmail/batch-with-retry.ts`), used by **both** `getMessagesBatch` and `getThreadsBatch`:

- throw on any `401`;
- per item, classify retryable vs fatal (`isRetryableError`); drop non-retryable items with a warning;
- re-fetch only the missing ids, in smaller chunks when rate-limited, with a retry cap.

Notes:
- `getThreadsBatch` now takes a `logger` (both call sites in `google.ts` pass `this.logger`).
- `isBatchError` generalized to `<T>(item: T | BatchError)`.
- The helper lives in its **own module** (not `batch.ts`) on purpose: the existing test strategy mocks the low-level `getBatch`, and a same-module call could not be intercepted. Keeping `getBatchWithRetry` in a separate module preserves cross-module mockability, so **`message.test.ts` is unchanged** and remains the regression net for the extracted logic.

## Test plan (TDD)

- New `utils/gmail/thread.test.ts` (written first, watched fail, then green): retryable error → missing thread refetched and present; non-retryable error → skipped (not returned as a valid empty thread); `401` → throws.
- `utils/gmail/message.test.ts` unchanged → 6/6 still pass (proves the extraction is behavior-preserving).
- Full unit suite green (`pnpm test`): 3813 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)