### PR TITLE
Simplify onboarding step visibility logic

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingContent.tsx
@@ -64,9 +64,7 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
   const stepMap: Record<string, (() => React.ReactNode) | undefined> = {
     [STEP_KEYS.CHAT]: () => <StepChat onNext={onNext} />,
     [STEP_KEYS.EMAILS_SORTED]: () => <StepEmailsSorted onNext={onNext} />,
-    [STEP_KEYS.DRAFT_REPLIES]: env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED
-      ? undefined
-      : () => <StepDraftReplies onNext={onNext} />,
+    [STEP_KEYS.DRAFT_REPLIES]: () => <StepDraftReplies onNext={onNext} />,
     [STEP_KEYS.BULK_UNSUBSCRIBE]: () => <StepBulkUnsubscribe onNext={onNext} />,
     [STEP_KEYS.WHO]: () => (
       <StepWho
@@ -84,15 +82,13 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
         onNext={onNext}
       />
     ),
-    [STEP_KEYS.DRAFT]: env.NEXT_PUBLIC_AUTO_DRAFT_DISABLED
-      ? undefined
-      : () => (
-          <StepDraft
-            provider={provider}
-            emailAccountId={emailAccountId}
-            onNext={onNext}
-          />
-        ),
+    [STEP_KEYS.DRAFT]: () => (
+      <StepDraft
+        provider={provider}
+        emailAccountId={emailAccountId}
+        onNext={onNext}
+      />
+    ),
     [STEP_KEYS.CUSTOM_RULES]: () => (
       <StepCustomRules provider={provider} onNext={onNext} />
     ),
@@ -299,17 +295,8 @@ export function OnboardingContent({ step }: OnboardingContentProps) {
 
   const renderStep = steps[currentStepIndex] || steps[0];
 
-  // Show loading if provider is needed but not loaded yet
-  if (isLoading && !provider) {
-    return null;
-  }
-
-  // Wait for membership data to load before determining steps
-  if (isMembershipLoading) {
-    return null;
-  }
-
-  if (isRulesLoading) {
+  // Wait for the inputs that determine which steps are visible before rendering.
+  if ((isLoading && !provider) || isMembershipLoading || isRulesLoading) {
     return null;
   }
 

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/onboardingFlow.ts
@@ -39,6 +39,13 @@ const legacyNumericOnboardingStepOrder: readonly (StepKey | "welcome")[] = [
   ...onboardingStepOrder,
 ];
 
+// Sales/marketing survey steps that are irrelevant for self-hosted deployments.
+const salesSurveyStepKeys: readonly StepKey[] = [
+  STEP_KEYS.WHO,
+  STEP_KEYS.COMPANY_SIZE,
+  STEP_KEYS.HOW_YOU_HEARD,
+];
+
 export function getVisibleOnboardingStepKeys({
   canInviteTeam,
   autoDraftDisabled,
@@ -60,12 +67,7 @@ export function getVisibleOnboardingStepKeys({
       return false;
     }
 
-    if (
-      isSelfHosted &&
-      (stepKey === STEP_KEYS.WHO ||
-        stepKey === STEP_KEYS.COMPANY_SIZE ||
-        stepKey === STEP_KEYS.HOW_YOU_HEARD)
-    ) {
+    if (isSelfHosted && salesSurveyStepKeys.includes(stepKey)) {
       return false;
     }
 


### PR DESCRIPTION
Follow-up cleanup on the onboarding flow after the self-hosted step changes merged in #2759.

## Changes
- **Consolidate loading guards**: collapse the three consecutive `return null` blocks in `OnboardingContent` into a single early return.
- **Name the survey step group**: replace the inline three-way `stepKey ===` OR with a `salesSurveyStepKeys` constant + `.includes()`, naming the domain concept.
- **Remove redundant draft gating**: drop the env-based `undefined` branches in `stepMap` for the draft steps, since `getVisibleOnboardingStepKeys` already excludes those keys when drafting is disabled. All draft suppression now funnels through one mechanism.

No behavior change. Existing `onboardingFlow` tests pass (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)