### PR TITLE
fix(sentry): scrub PII/secrets before sending events

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { env } from "@/env";
+import { beforeSend, beforeSendTransaction } from "@/utils/sentry-scrub";
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN,
@@ -13,6 +14,10 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Redact PII/secrets before sending to Sentry (third party).
+  beforeSend,
+  beforeSendTransaction,
 
   replaysOnErrorSampleRate: 1.0,
 

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-process-env */
 import * as Sentry from "@sentry/nextjs";
+import { beforeSend, beforeSendTransaction } from "@/utils/sentry-scrub";
 
 export function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
@@ -10,6 +11,9 @@ export function register() {
       tracesSampleRate: 1,
       // Setting this option to true will print useful information to the console while you're setting up Sentry.
       debug: false,
+      // Redact PII/secrets before sending to Sentry (third party).
+      beforeSend,
+      beforeSendTransaction,
       // uncomment the line below to enable Spotlight (https://spotlightjs.com)
       // spotlight: process.env.NODE_ENV === 'development',
     });
@@ -23,6 +27,9 @@ export function register() {
       tracesSampleRate: 1,
       // Setting this option to true will print useful information to the console while you're setting up Sentry.
       debug: false,
+      // Redact PII/secrets before sending to Sentry (third party).
+      beforeSend,
+      beforeSendTransaction,
     });
   }
 }

--- a/apps/web/utils/logger.ts
+++ b/apps/web/utils/logger.ts
@@ -5,6 +5,7 @@ import { serializeError } from "serialize-error";
 import { env } from "@/env";
 import {
   CONTENT_FIELD_NAMES,
+  normalizeRedactionFieldName,
   REDACTED_FIELD_NAMES,
   SENSITIVE_FIELD_NAMES,
 } from "@/utils/redact-fields";
@@ -12,6 +13,13 @@ import {
 export type Logger = ReturnType<typeof createScopedLogger>;
 
 type LogLevel = "info" | "error" | "warn" | "trace";
+
+const NORMALIZED_REDACTED_FIELD_NAMES =
+  normalizeFieldNames(REDACTED_FIELD_NAMES);
+const NORMALIZED_CONTENT_FIELD_NAMES = normalizeFieldNames(CONTENT_FIELD_NAMES);
+const NORMALIZED_SENSITIVE_FIELD_NAMES = normalizeFieldNames(
+  SENSITIVE_FIELD_NAMES,
+);
 
 const colors = {
   info: "\x1b[0m", // white
@@ -219,13 +227,15 @@ function hashSensitiveFields<T>(obj: T, depth = 0): T {
   if (isPlainObject(obj)) {
     const processed: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
+      const normalizedKey = normalizeRedactionFieldName(key);
+
       // Always redact tokens - never log them
-      if (REDACTED_FIELD_NAMES.has(key)) {
+      if (NORMALIZED_REDACTED_FIELD_NAMES.has(normalizedKey)) {
         processed[key] = !!value;
       }
       // Redact content fields in production (unless debug logs enabled)
       else if (
-        CONTENT_FIELD_NAMES.has(key) &&
+        NORMALIZED_CONTENT_FIELD_NAMES.has(normalizedKey) &&
         env.NODE_ENV === "production" &&
         !env.ENABLE_DEBUG_LOGS
       ) {
@@ -233,7 +243,7 @@ function hashSensitiveFields<T>(obj: T, depth = 0): T {
       }
       // Hash emails in production only (server-side only)
       else if (
-        SENSITIVE_FIELD_NAMES.has(key) &&
+        NORMALIZED_SENSITIVE_FIELD_NAMES.has(normalizedKey) &&
         typeof value === "string" &&
         env.NODE_ENV === "production" &&
         typeof window === "undefined" // Server-side check
@@ -261,4 +271,8 @@ function isPlainObject(obj: unknown): obj is Record<string, unknown> {
   if (typeof obj !== "object" || obj === null) return false;
   const proto = Object.getPrototypeOf(obj);
   return proto === Object.prototype || proto === null;
+}
+
+function normalizeFieldNames(fieldNames: Set<string>) {
+  return new Set([...fieldNames].map(normalizeRedactionFieldName));
 }

--- a/apps/web/utils/logger.ts
+++ b/apps/web/utils/logger.ts
@@ -3,6 +3,11 @@ import get from "lodash/get";
 import { log } from "next-axiom";
 import { serializeError } from "serialize-error";
 import { env } from "@/env";
+import {
+  CONTENT_FIELD_NAMES,
+  REDACTED_FIELD_NAMES,
+  SENSITIVE_FIELD_NAMES,
+} from "@/utils/redact-fields";
 
 export type Logger = ReturnType<typeof createScopedLogger>;
 
@@ -188,27 +193,6 @@ function getSimpleErrorMessage(error: unknown): string | undefined {
 
   return;
 }
-
-// Field names that contain PII and should be hashed in production
-const SENSITIVE_FIELD_NAMES = new Set(["from", "sender", "to", "replyTo"]);
-
-// Field names that should NEVER be logged - replaced with boolean
-const REDACTED_FIELD_NAMES = new Set([
-  "accessToken",
-  "access_token",
-  "refreshToken",
-  "refresh_token",
-  "idToken",
-  "id_token",
-  "headers",
-  "authorization",
-  "requestBodyValues",
-  "systemInstruction",
-  "contents",
-]);
-
-// Fields containing email/message content - redacted in production unless debug logs enabled
-const CONTENT_FIELD_NAMES = new Set(["text", "body", "content"]);
 
 /**
  * Recursively processes an object to protect sensitive data:

--- a/apps/web/utils/redact-fields.ts
+++ b/apps/web/utils/redact-fields.ts
@@ -1,0 +1,29 @@
+// Field-name sets shared by the logger (hashes/redacts in logs) and the Sentry
+// scrubber (redacts before sending to a third party). Pure string Sets only —
+// no env, no crypto — so this is safe in client and edge bundles.
+
+// PII identifiers (correspondent addresses). Hashed in logs, redacted for Sentry.
+export const SENSITIVE_FIELD_NAMES = new Set([
+  "from",
+  "sender",
+  "to",
+  "replyTo",
+]);
+
+// Secrets that must never leave the process.
+export const REDACTED_FIELD_NAMES = new Set([
+  "accessToken",
+  "access_token",
+  "refreshToken",
+  "refresh_token",
+  "idToken",
+  "id_token",
+  "headers",
+  "authorization",
+  "requestBodyValues",
+  "systemInstruction",
+  "contents",
+]);
+
+// Email/message content.
+export const CONTENT_FIELD_NAMES = new Set(["text", "body", "content"]);

--- a/apps/web/utils/redact-fields.ts
+++ b/apps/web/utils/redact-fields.ts
@@ -26,4 +26,17 @@ export const REDACTED_FIELD_NAMES = new Set([
 ]);
 
 // Email/message content.
-export const CONTENT_FIELD_NAMES = new Set(["text", "body", "content"]);
+export const CONTENT_FIELD_NAMES = new Set([
+  "text",
+  "body",
+  "content",
+  "subject",
+  "textPlain",
+  "textHtml",
+  "snippet",
+  "decodedSnippet",
+]);
+
+export function normalizeRedactionFieldName(fieldName: string) {
+  return fieldName.toLowerCase().replace(/[\s_-]/g, "");
+}

--- a/apps/web/utils/sentry-scrub.test.ts
+++ b/apps/web/utils/sentry-scrub.test.ts
@@ -27,6 +27,61 @@ describe("scrubSentryEvent", () => {
     expect(result.extra.nested.body).toBe("[redacted]");
   });
 
+  it("redacts field names with variant casing and separators recursively", () => {
+    const event = {
+      extra: {
+        Authorization: "Bearer secret",
+        nested: {
+          "access-token": "secret",
+          reply_to: "sender@other.com",
+          "text plain": "private email body",
+          messages: [{ "Decoded-Snippet": "private preview" }],
+        },
+      },
+    };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+
+    expect(result.extra.Authorization).toBe("[redacted]");
+    expect(result.extra.nested["access-token"]).toBe("[redacted]");
+    expect(result.extra.nested.reply_to).toBe("[redacted]");
+    expect(result.extra.nested["text plain"]).toBe("[redacted]");
+    expect(result.extra.nested.messages[0]["Decoded-Snippet"]).toBe(
+      "[redacted]",
+    );
+  });
+
+  it("redacts actual email content fields in rich extra objects", () => {
+    const event = {
+      extra: {
+        thread: {
+          messages: [
+            {
+              subject: "Private invoice details",
+              textPlain: "Plain private body",
+              textHtml: "<p>HTML private body</p>",
+              snippet: "Private preview",
+              decodedSnippet: "Decoded private preview",
+              metadata: { id: "message-1" },
+            },
+          ],
+        },
+      },
+      user: { email: "me@own.com", id: "user-1" },
+    };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+    const message = result.extra.thread.messages[0];
+
+    expect(message.subject).toBe("[redacted]");
+    expect(message.textPlain).toBe("[redacted]");
+    expect(message.textHtml).toBe("[redacted]");
+    expect(message.snippet).toBe("[redacted]");
+    expect(message.decodedSnippet).toBe("[redacted]");
+    expect(message.metadata.id).toBe("message-1");
+    expect(result.user.email).toBe("me@own.com");
+  });
+
   it("redacts sensitive request data and headers", () => {
     const event = {
       request: {

--- a/apps/web/utils/sentry-scrub.test.ts
+++ b/apps/web/utils/sentry-scrub.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { scrubSentryEvent } from "./sentry-scrub";
+
+describe("scrubSentryEvent", () => {
+  it("redacts correspondent address fields in extra, preserving non-sensitive keys", () => {
+    const event = {
+      extra: { from: "sender@other.com", to: "rcpt@other.com", scope: "reply" },
+    };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+
+    expect(result.extra.from).toBe("[redacted]");
+    expect(result.extra.to).toBe("[redacted]");
+    expect(result.extra.scope).toBe("reply");
+  });
+
+  it("redacts tokens and content fields recursively", () => {
+    const event = {
+      extra: {
+        nested: { access_token: "secret", body: "private email body" },
+      },
+    };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+
+    expect(result.extra.nested.access_token).toBe("[redacted]");
+    expect(result.extra.nested.body).toBe("[redacted]");
+  });
+
+  it("redacts sensitive request data and headers", () => {
+    const event = {
+      request: {
+        data: { from: "sender@other.com" },
+        headers: { authorization: "Bearer secret" },
+      },
+    };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+
+    expect(result.request.data.from).toBe("[redacted]");
+    expect(result.request.headers.authorization).toBe("[redacted]");
+  });
+
+  it("preserves the authenticated user's own email on event.user", () => {
+    const event = { user: { email: "me@own.com", id: "user-1" } };
+
+    const result = scrubSentryEvent(event as never) as typeof event;
+
+    expect(result.user.email).toBe("me@own.com");
+  });
+});

--- a/apps/web/utils/sentry-scrub.ts
+++ b/apps/web/utils/sentry-scrub.ts
@@ -1,0 +1,64 @@
+import type { Event } from "@sentry/nextjs";
+import {
+  CONTENT_FIELD_NAMES,
+  REDACTED_FIELD_NAMES,
+  SENSITIVE_FIELD_NAMES,
+} from "@/utils/redact-fields";
+
+const REDACTED = "[redacted]";
+const MAX_DEPTH = 10;
+
+const REDACT_KEYS = new Set<string>([
+  ...REDACTED_FIELD_NAMES,
+  ...CONTENT_FIELD_NAMES,
+  ...SENSITIVE_FIELD_NAMES,
+]);
+
+// Sentry is a third party. Before sending an event, redact PII/secrets from the
+// fields where captureException context and request data land. We redact (not
+// hash) so this stays client- and edge-safe (no node:crypto). event.user.email
+// is intentionally left alone: it is the authenticated user's own email, which
+// the logging policy allows.
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  if (event.extra) event.extra = redactPii(event.extra);
+  if (event.contexts) event.contexts = redactPii(event.contexts);
+  if (event.request) {
+    const { data, headers, cookies } = event.request;
+    if (data) event.request.data = redactPii(data);
+    if (headers) event.request.headers = redactPii(headers);
+    if (cookies) event.request.cookies = redactPii(cookies);
+  }
+  return event;
+}
+
+// Wired into Sentry.init as beforeSend / beforeSendTransaction across all
+// runtimes. scrubSentryEvent is generic over the event type, so it instantiates
+// to ErrorEvent / TransactionEvent at each call site (both share the scrubbed
+// fields). Aliased rather than re-typed to avoid importing TransactionEvent,
+// which @sentry/nextjs does not re-export.
+export const beforeSend = scrubSentryEvent;
+export const beforeSendTransaction = scrubSentryEvent;
+
+function redactPii<T>(value: T, depth = 0): T {
+  if (depth > MAX_DEPTH || value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactPii(item, depth + 1)) as T;
+  }
+
+  if (!isPlainObject(value)) return value;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    result[key] = REDACT_KEYS.has(key)
+      ? REDACTED
+      : redactPii(nested, depth + 1);
+  }
+  return result as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/apps/web/utils/sentry-scrub.ts
+++ b/apps/web/utils/sentry-scrub.ts
@@ -1,6 +1,7 @@
 import type { Event } from "@sentry/nextjs";
 import {
   CONTENT_FIELD_NAMES,
+  normalizeRedactionFieldName,
   REDACTED_FIELD_NAMES,
   SENSITIVE_FIELD_NAMES,
 } from "@/utils/redact-fields";
@@ -8,11 +9,13 @@ import {
 const REDACTED = "[redacted]";
 const MAX_DEPTH = 10;
 
-const REDACT_KEYS = new Set<string>([
-  ...REDACTED_FIELD_NAMES,
-  ...CONTENT_FIELD_NAMES,
-  ...SENSITIVE_FIELD_NAMES,
-]);
+const REDACT_KEYS = new Set<string>(
+  [
+    ...REDACTED_FIELD_NAMES,
+    ...CONTENT_FIELD_NAMES,
+    ...SENSITIVE_FIELD_NAMES,
+  ].map(normalizeRedactionFieldName),
+);
 
 // Sentry is a third party. Before sending an event, redact PII/secrets from the
 // fields where captureException context and request data land. We redact (not
@@ -50,7 +53,7 @@ function redactPii<T>(value: T, depth = 0): T {
 
   const result: Record<string, unknown> = {};
   for (const [key, nested] of Object.entries(value)) {
-    result[key] = REDACT_KEYS.has(key)
+    result[key] = REDACT_KEYS.has(normalizeRedactionFieldName(key))
       ? REDACTED
       : redactPii(nested, depth + 1);
   }


### PR DESCRIPTION
## Summary

Neither the server/edge (`instrumentation.ts`) nor the client (`instrumentation-client.ts`) `Sentry.init` defined a `beforeSend`. So `captureException` context (`extra`), request data, and `contexts` were forwarded to Sentry — a third party — **unscrubbed**. Any correspondent address (`from`/`to`/`sender`/`replyTo`), email `body`/`content`, or token placed in those fields could egress.

The codebase already has a redaction layer for **logs** (`hashSensitiveFields` in `logger.ts`), but it only runs inside the logger — never on the Sentry path.

## Fix

Add a pure scrubber `utils/sentry-scrub.ts`, wired as `beforeSend` **and** `beforeSendTransaction` into **all three** init sites (nodejs, edge, client). It recursively redacts fields in `extra`, `contexts`, and `request` (`data`/`headers`/`cookies`) using the **same field-name sets as the logger**, which are extracted into a shared, dependency-free module `utils/redact-fields.ts` so the two stay in sync.

- **Redaction, not hashing** → client- and edge-safe (no `node:crypto`).
- `event.user.email` is left intact — it is the authenticated user's own email, which the logging policy allows.

## Scope (verified)

- The *"email content via `APICallError` body"* vector is **not reachable** with the current Sentry config: `requestBodyValues` (the prompt) is a separate property, and `extraErrorDataIntegration` is **not** a default integration in `@sentry/nextjs` v10, so `APICallError` properties are not serialized into the event.
- **Residual (out of scope):** a provider error message that echoes `responseBody` into the exception message string (`event.exception.values[].value`) — would need structural message handling.
- `tracesSampleRate` left unchanged (affects volume, not per-event PII).

## Test plan (TDD)

- New `utils/sentry-scrub.test.ts` (written first, watched fail, then green): correspondent address fields in `extra` redacted; tokens/content redacted recursively; request `data`/`headers` redacted; `event.user.email` preserved.
- `utils/logger.test.ts` unchanged → 12/12 still pass (the field-set extraction is behavior-preserving).
- Full unit suite green (`pnpm test`): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)