### PR TITLE
setup: Gate calendar setup step

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/setup/SetupContent.tsx
@@ -261,6 +261,7 @@ function Checklist({
   isBulkUnsubscribeConfigured,
   isAiAssistantConfigured,
   isCalendarConnected,
+  showCalendarStep,
   isTabsExtensionCompleted,
   teamInvite,
   onSetupProgressChanged,
@@ -272,6 +273,7 @@ function Checklist({
   isBulkUnsubscribeConfigured: boolean;
   isAiAssistantConfigured: boolean;
   isCalendarConnected: boolean;
+  showCalendarStep: boolean;
   isTabsExtensionCompleted: boolean;
   teamInvite: {
     completed: boolean;
@@ -367,18 +369,20 @@ function Checklist({
         markDonePending={pendingStep === "bulkUnsubscribe"}
       />
 
-      <StepItem
-        href={prefixPath(emailAccountId, "/calendars")}
-        icon={<CalendarIcon size={18} />}
-        title="Connect your calendar"
-        timeEstimate="2 minutes"
-        completed={isCalendarConnected}
-        actionText="Connect"
-        onMarkDone={() => handleMarkStepDone("calendarConnected")}
-        showMarkDone
-        markDoneDisabled={isDismissingStep}
-        markDonePending={pendingStep === "calendarConnected"}
-      />
+      {showCalendarStep && (
+        <StepItem
+          href={prefixPath(emailAccountId, "/calendars")}
+          icon={<CalendarIcon size={18} />}
+          title="Connect your calendar"
+          timeEstimate="2 minutes"
+          completed={isCalendarConnected}
+          actionText="Connect"
+          onMarkDone={() => handleMarkStepDone("calendarConnected")}
+          showMarkDone
+          markDoneDisabled={isDismissingStep}
+          markDonePending={pendingStep === "calendarConnected"}
+        />
+      )}
 
       {teamInvite && (
         <StepItem
@@ -452,6 +456,7 @@ export function SetupContent() {
           isAiAssistantConfigured={data.steps.aiAssistant}
           isBulkUnsubscribeConfigured={data.steps.bulkUnsubscribe}
           isCalendarConnected={data.steps.calendarConnected}
+          showCalendarStep={data.showCalendarStep}
           isTabsExtensionCompleted={data.tabsExtensionCompleted}
           completedCount={data.completed}
           totalSteps={data.total}
@@ -471,6 +476,7 @@ function SetupPageContent({
   isBulkUnsubscribeConfigured,
   isAiAssistantConfigured,
   isCalendarConnected,
+  showCalendarStep,
   isTabsExtensionCompleted,
   completedCount,
   totalSteps,
@@ -484,6 +490,7 @@ function SetupPageContent({
   isBulkUnsubscribeConfigured: boolean;
   isAiAssistantConfigured: boolean;
   isCalendarConnected: boolean;
+  showCalendarStep: boolean;
   isTabsExtensionCompleted: boolean;
   completedCount: number;
   totalSteps: number;
@@ -517,6 +524,7 @@ function SetupPageContent({
           isBulkUnsubscribeConfigured={isBulkUnsubscribeConfigured}
           isAiAssistantConfigured={isAiAssistantConfigured}
           isCalendarConnected={isCalendarConnected}
+          showCalendarStep={showCalendarStep}
           isTabsExtensionCompleted={isTabsExtensionCompleted}
           completedCount={completedCount}
           totalSteps={totalSteps}

--- a/apps/web/app/api/user/setup-progress/route.test.ts
+++ b/apps/web/app/api/user/setup-progress/route.test.ts
@@ -1,0 +1,120 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+const { mockEnv, mockLogger } = vi.hoisted(() => ({
+  mockEnv: {
+    meetingBriefsEnabled: false,
+    bookingLinksEnabled: false,
+  },
+  mockLogger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    get NEXT_PUBLIC_MEETING_BRIEFS_ENABLED() {
+      return mockEnv.meetingBriefsEnabled;
+    },
+    get NEXT_PUBLIC_BOOKING_LINKS_ENABLED() {
+      return mockEnv.bookingLinksEnabled;
+    },
+  },
+}));
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (_name: string, handler: (request: any) => Promise<Response>) =>
+    (request: NextRequest) =>
+      handler(
+        Object.assign(request, {
+          auth: { emailAccountId: "email-account-1", userId: "user-1" },
+          logger: mockLogger,
+        }),
+      ),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/user/setup-progress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.meetingBriefsEnabled = false;
+    mockEnv.bookingLinksEnabled = false;
+  });
+
+  it("omits the calendar setup step when calendar features are disabled", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      createEmailAccount({ calendarConnections: [{ id: "connection-1" }] }),
+    );
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      steps: {
+        aiAssistant: false,
+        bulkUnsubscribe: false,
+        calendarConnected: true,
+      },
+      completed: 0,
+      total: 2,
+      isComplete: false,
+      showCalendarStep: false,
+    });
+  });
+
+  it("includes the calendar setup step when a calendar feature is enabled", async () => {
+    mockEnv.meetingBriefsEnabled = true;
+    prisma.emailAccount.findUnique.mockResolvedValue(
+      createEmailAccount({ calendarConnections: [] }),
+    );
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      steps: {
+        aiAssistant: false,
+        bulkUnsubscribe: false,
+        calendarConnected: false,
+      },
+      completed: 0,
+      total: 3,
+      isComplete: false,
+      showCalendarStep: true,
+    });
+  });
+});
+
+function createEmailAccount({
+  calendarConnections,
+}: {
+  calendarConnections: { id: string }[];
+}) {
+  return {
+    rules: [],
+    newsletters: [],
+    calendarConnections,
+    user: { dismissedHints: [] },
+    members: [
+      {
+        role: "member",
+        organizationId: "organization-1",
+        organization: {
+          _count: {
+            members: 1,
+            invitations: 0,
+          },
+        },
+      },
+    ],
+  };
+}
+
+function createRequest() {
+  return new NextRequest("http://localhost/api/user/setup-progress");
+}

--- a/apps/web/app/api/user/setup-progress/route.ts
+++ b/apps/web/app/api/user/setup-progress/route.ts
@@ -85,9 +85,10 @@ async function getSetupProgress({
   const tabsExtensionCompleted = emailAccount.user.dismissedHints.includes(
     `setup:tabsExtension:${emailAccountId}`,
   );
-  const showCalendarStep =
+  const showCalendarStep = Boolean(
     env.NEXT_PUBLIC_MEETING_BRIEFS_ENABLED ||
-    env.NEXT_PUBLIC_BOOKING_LINKS_ENABLED;
+      env.NEXT_PUBLIC_BOOKING_LINKS_ENABLED,
+  );
 
   const teamInviteCompleted =
     hasTeamMembers || hasPendingInvitations || teamInviteDismissed;

--- a/apps/web/app/api/user/setup-progress/route.ts
+++ b/apps/web/app/api/user/setup-progress/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/utils/prisma";
 import { SafeError } from "@/utils/error";
 import { withEmailAccount } from "@/utils/middleware";
+import { env } from "@/env";
 
 export type GetSetupProgressResponse = Awaited<
   ReturnType<typeof getSetupProgress>
@@ -84,6 +85,9 @@ async function getSetupProgress({
   const tabsExtensionCompleted = emailAccount.user.dismissedHints.includes(
     `setup:tabsExtension:${emailAccountId}`,
   );
+  const showCalendarStep =
+    env.NEXT_PUBLIC_MEETING_BRIEFS_ENABLED ||
+    env.NEXT_PUBLIC_BOOKING_LINKS_ENABLED;
 
   const teamInviteCompleted =
     hasTeamMembers || hasPendingInvitations || teamInviteDismissed;
@@ -94,12 +98,17 @@ async function getSetupProgress({
     aiAssistant: emailAccount.rules.length > 0 || aiAssistantDismissed,
     bulkUnsubscribe:
       emailAccount.newsletters.length > 0 || bulkUnsubscribeDismissed,
-    calendarConnected:
-      emailAccount.calendarConnections.length > 0 || calendarConnectedDismissed,
+    calendarConnected: showCalendarStep
+      ? emailAccount.calendarConnections.length > 0 ||
+        calendarConnectedDismissed
+      : true,
   };
 
-  const baseCompleted = Object.values(steps).filter(Boolean).length;
-  const baseTotal = Object.keys(steps).length;
+  const baseCompleted =
+    Number(steps.aiAssistant) +
+    Number(steps.bulkUnsubscribe) +
+    (showCalendarStep ? Number(steps.calendarConnected) : 0);
+  const baseTotal = 2 + (showCalendarStep ? 1 : 0);
 
   const completed = showTeamInviteStep
     ? baseCompleted + (teamInviteCompleted ? 1 : 0)
@@ -111,6 +120,7 @@ async function getSetupProgress({
     completed,
     total,
     isComplete: completed === total,
+    showCalendarStep,
     tabsExtensionCompleted,
     teamInvite: showTeamInviteStep
       ? {

--- a/apps/web/app/api/user/setup-progress/route.ts
+++ b/apps/web/app/api/user/setup-progress/route.ts
@@ -104,11 +104,13 @@ async function getSetupProgress({
       : true,
   };
 
-  const baseCompleted =
-    Number(steps.aiAssistant) +
-    Number(steps.bulkUnsubscribe) +
-    (showCalendarStep ? Number(steps.calendarConnected) : 0);
-  const baseTotal = 2 + (showCalendarStep ? 1 : 0);
+  const visibleSetupSteps = [
+    steps.aiAssistant,
+    steps.bulkUnsubscribe,
+    ...(showCalendarStep ? [steps.calendarConnected] : []),
+  ];
+  const baseCompleted = visibleSetupSteps.filter(Boolean).length;
+  const baseTotal = visibleSetupSteps.length;
 
   const completed = showTeamInviteStep
     ? baseCompleted + (teamInviteCompleted ? 1 : 0)


### PR DESCRIPTION
Shows the calendar setup step only when calendar-backed features are enabled.

- Adds setup-progress metadata for whether the calendar step should be shown.
- Keeps setup totals aligned when the calendar step is unavailable.
- Adds route coverage for enabled and disabled calendar-feature cases.

Tests: `pnpm test 'app/api/user/setup-progress/route.test.ts'` and `pnpm check` on touched files.