### PR TITLE
fix(privacy): encrypt id_token at rest; drop email subject from skip log

### DIFF
--- a/apps/web/app/api/outlook/webhook/process-history.ts
+++ b/apps/web/app/api/outlook/webhook/process-history.ts
@@ -104,7 +104,8 @@ export async function processHistoryForUser({
         const isInSentItems = message.labelIds?.includes("SENT") || false;
 
         if (!isInInbox && !isInSentItems) {
-          logger.info("Skipping message not in inbox or sent items", {
+          // trace: carries PII (subject is not redacted at info level)
+          logger.trace("Skipping message not in inbox or sent items", {
             labelIds: message.labelIds,
             from: message.headers.from,
             to: message.headers.to,

--- a/apps/web/utils/prisma-extensions.ts
+++ b/apps/web/utils/prisma-extensions.ts
@@ -13,7 +13,7 @@ import { decryptToken, encryptToken } from "@/utils/encryption";
  * EmailToken.token): random-IV encryption breaks WHERE lookups.
  */
 const ENCRYPTED_FIELDS = {
-  account: ["access_token", "refresh_token"],
+  account: ["access_token", "refresh_token", "id_token"],
   calendarConnection: ["accessToken", "refreshToken"],
   driveConnection: ["accessToken", "refreshToken"],
   messagingChannel: ["accessToken", "refreshToken"],


### PR DESCRIPTION
## Summary

Two small, independent privacy-hardening fixes.

### 1. Encrypt `Account.id_token` at rest
`access_token` and `refresh_token` are transparently encrypted via the Prisma extension, but `id_token` — a Google JWT whose payload carries email / name / sub — was stored in **plaintext**. Add `id_token` to `ENCRYPTED_FIELDS.account`.

- **No migration required:** per the extension's own contract, reads pass existing plaintext values through untouched and the value adopts the versioned ciphertext format on its next write.
- `id_token` is never queried by value (only written on the Google linking callback; the in-memory OAuth `tokens.id_token` is what gets verified), so the random-IV "do not encrypt fields queried by value" constraint holds.

### 2. Don't log email `subject` at info level
The Outlook `"Skipping message not in inbox or sent items"` log ran at `info` and included `message.subject`. `from`/`to` are hashed in production, but `subject` is in none of the redaction sets, so raw subjects were written to logs for every skipped Outlook message. Move the call to `logger.trace()` (per the repo policy of keeping PII at trace).

## Test plan

- `utils/prisma-extensions.test.ts` (generic encryption mechanism) → 15/15 still pass; the change is a declarative field-list addition to that already-tested mechanism.
- The log change is a logging-level edit; no behavioral assertion added (asserting log copy/level is an anti-pattern per the repo's testing guidance).
- Full unit suite green (`pnpm test`): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)