### PR TITLE
fix(usage): guarantee weekly-cost TTL; don't mask partial usage failures

### DIFF
--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -34,6 +34,42 @@ describe("redis usage tracking", () => {
     vi.mocked(redis.expire).mockResolvedValue(1);
   });
 
+  describe("saveUsage", () => {
+    const usage = {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    } as never;
+
+    it("does not set the weekly cost TTL when the weekly increment fails", async () => {
+      vi.mocked(redis.hincrbyfloat).mockRejectedValue(new Error("redis down"));
+
+      await saveUsage({
+        userId: "user-1",
+        emailAccountId: "acc-1",
+        usage,
+        cost: 1,
+        now: NOW,
+      });
+
+      expect(redis.expire).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when a usage write rejects", async () => {
+      vi.mocked(redis.hincrby).mockRejectedValue(new Error("redis down"));
+
+      await expect(
+        saveUsage({
+          userId: "user-1",
+          emailAccountId: "acc-1",
+          usage,
+          cost: 1,
+          now: NOW,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   it("reads usage by email account ID", async () => {
     vi.mocked(redis.hgetall).mockResolvedValue({ openaiCalls: 3 });
 

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -199,19 +199,34 @@ export async function saveUsage(options: {
   ];
   const weeklyCostKey = userId ? getWeeklyUsageCostKey(userId, now) : null;
 
-  await Promise.all([
-    ...usageKeys.flatMap((key) =>
-      getUsageIncrementOperations(key, usage, cost),
-    ),
-    cost && weeklyCostKey
-      ? redis.hincrbyfloat(weeklyCostKey, "cost", cost)
-      : null,
-    cost && weeklyCostKey
-      ? redis.expire(weeklyCostKey, WEEKLY_USAGE_COST_TTL_SECONDS)
-      : null,
-  ]).catch((error) => {
-    logger.error("Error saving usage", { error: error.message, cost, usage });
-  });
+  const operations = usageKeys
+    .flatMap((key) => getUsageIncrementOperations(key, usage, cost))
+    .filter(Boolean);
+
+  // Best-effort: a failed increment must not break the AI call. Use allSettled
+  // so one rejection doesn't mask the others, and surface how many failed.
+  const results = await Promise.allSettled(operations);
+  const failedCount = results.filter((r) => r.status === "rejected").length;
+  if (failedCount > 0) {
+    logger.error("Error saving usage increments", {
+      failedCount,
+      totalCount: results.length,
+      cost,
+      usage,
+    });
+  }
+
+  // Increment the weekly cost, then set its TTL — sequenced so the key exists
+  // before expire runs (a concurrent expire can no-op on the first write of the
+  // week, leaving the key without a TTL).
+  if (cost && weeklyCostKey) {
+    try {
+      await redis.hincrbyfloat(weeklyCostKey, "cost", cost);
+      await redis.expire(weeklyCostKey, WEEKLY_USAGE_COST_TTL_SECONDS);
+    } catch (error) {
+      logger.error("Error saving weekly usage cost", { error, cost });
+    }
+  }
 }
 
 export async function getWeeklyUsageCost({


### PR DESCRIPTION
## Summary

`saveUsage` fired the per-account/user increments, the weekly-cost increment, and the weekly-cost `expire` together in one `Promise.all` with a single `.catch`. Two issues:

1. **Weekly-cost TTL race.** `redis.expire(weeklyCostKey, …)` ran concurrently with the `redis.hincrbyfloat(weeklyCostKey, …)` that *creates* the key. On the first write of the week the `expire` can land first and no-op, leaving the key **without a TTL** until some later write happens to set it.
2. **Masked partial failures.** A single rejection short-circuits `Promise.all` and is swallowed by one generic log, hiding which/how many writes actually failed.

## Fix

- **Sequence** the weekly increment then its `expire`, so the key exists before `expire` runs.
- Use **`Promise.allSettled`** for the per-key increments so one failure doesn't mask the others, and log the failed count.

Still **best-effort by design** — a usage write failure must not break the AI call. The weekly cost gates only the *trial* AI limit, where slight under-counting on a Redis blip is preferable to blocking legitimate usage (so this intentionally does **not** switch to fail-closed).

## Test plan (TDD)

- `utils/redis/usage.test.ts` — new `saveUsage` tests (the TTL test written first, watched fail, then green):
  - does **not** call `expire` when the weekly increment rejects (proves the sequencing — previously `expire` was fired regardless);
  - does not throw when a usage write rejects (fail-open contract guard).
- Existing usage tests (incl. "stores usage under both email account and user keys") still pass → 20/20.
- Full unit suite green (`pnpm test`): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)