### PR TITLE
eval: Add result history and caching

### DIFF
--- a/.claude/skills/testing/eval.md
+++ b/.claude/skills/testing/eval.md
@@ -24,7 +24,7 @@ const isAiTest = process.env.RUN_AI_TESTS === "true";
 const TIMEOUT = 15_000;
 
 describe.runIf(isAiTest)("Eval: Your Feature", () => {
-  const evalReporter = createEvalReporter();
+  const evalReporter = createEvalReporter({ evalName: "your-feature" });
 
   describeEvalMatrix("feature", (model, emailAccount) => {
     test("case description", async () => {
@@ -90,13 +90,56 @@ EVAL_MODELS=gemini-2.5-flash,gpt-5.4-mini pnpm test-ai eval/your-feature
 
 # Save report to file
 EVAL_REPORT_PATH=eval-results/report.md EVAL_MODELS=all pnpm test-ai eval/your-feature
+
+# Reuse unchanged eval/model results from the local result cache
+EVAL_RESULT_CACHE=readwrite pnpm test-ai eval/your-feature
 ```
+
+## Result History and Cache
+
+Eval runs with `RUN_AI_TESTS=true` write JSON history to `.context/eval-results/<eval-name>/` by default. Set `EVAL_HISTORY_DIR=off` to disable this, or set `EVAL_HISTORY_DIR=path/to/dir` to choose a different location.
+
+Use `evalReporter.recordCached()` for eval cases where an unchanged scenario/model pair can reuse the previous result instead of calling the model and judge again:
+
+```typescript
+const record = await evalReporter.recordCached(
+  {
+    testName: "case",
+    model: model.label,
+    cacheKeyParts: [{ model, scenario }],
+  },
+  async () => {
+    const result = await yourFunction({ emailAccount, scenario });
+    const pass = result === expected;
+
+    return {
+      testName: "case",
+      model: model.label,
+      pass,
+      expected,
+      actual: String(result),
+    };
+  },
+);
+
+expect(record.pass).toBe(true);
+```
+
+Cache modes:
+
+- `EVAL_RESULT_CACHE=readwrite` — read cached records when present, run and write misses
+- `EVAL_RESULT_CACHE=readonly` — require cached records and fail on misses
+- `EVAL_RESULT_CACHE=refresh` — ignore cached records, run live, and overwrite
+- unset / other values — no result cache
+
+Cache records are stored in `.context/eval-result-cache/` by default. The cache key includes the eval name, test name, reported model, `cacheKeyParts`, and a conservative git fingerprint, so prompt/code changes miss the cache.
 
 ## Eval Utilities
 
 - `describeEvalMatrix(name, fn)` — runs tests across all models in `EVAL_MODELS`
 - `createEvalReporter()` — creates a reporter instance for recording pass/fail
 - `evalReporter.record(result)` — records pass/fail for the comparison report
+- `evalReporter.recordCached(options, fn)` — records a cached eval result when available, otherwise runs `fn`
 - `evalReporter.printReport()` — outputs console report + optionally writes files
 - `judgeBinary({ input, output, criterion })` — binary LLM-as-judge evaluation
 - `judgeMultiple({ input, output, criteria })` — evaluates multiple criteria
@@ -106,6 +149,9 @@ EVAL_REPORT_PATH=eval-results/report.md EVAL_MODELS=all pnpm test-ai eval/your-f
 
 - `EVAL_MODELS` — not set: single run with env model; `all`: all models; comma-separated: specific models
 - `EVAL_REPORT_PATH` — save markdown + JSON report to file
+- `EVAL_HISTORY_DIR` — save per-run JSON history; defaults to `.context/eval-results` for AI evals; set `off` to disable
+- `EVAL_RESULT_CACHE` — opt into scenario-level result caching: `readwrite`, `readonly`, or `refresh`
+- `EVAL_RESULT_CACHE_DIR` — cache directory; defaults to `.context/eval-result-cache`
 
 ## Anti-overfitting
 

--- a/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
@@ -32,7 +32,9 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 240_000;
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-memory-safety",
+});
 const logger = createScopedLogger("eval-assistant-chat-memory-safety");
 const selectedScenarios =
   getEvalModels().length > 1
@@ -164,23 +166,42 @@ describe.runIf(shouldRunEval)("Eval: assistant chat memory safety", () => {
       test(
         scenario.title,
         async () => {
-          configureScenarioMocks(scenario);
+          const record = await evalReporter.recordCached(
+            {
+              testName: scenario.reportName,
+              model: model.label,
+              cacheKeyParts: [
+                {
+                  model,
+                  scenario,
+                  latestMemorySafetyEmailFixture,
+                  latestMemorySafetyAttachmentFixture,
+                },
+              ],
+            },
+            async () => {
+              configureScenarioMocks(scenario);
 
-          const result = await runAssistantChat({
-            emailAccount,
-            messages: scenario.messages,
-          });
+              const result = await runAssistantChat({
+                emailAccount,
+                messages: scenario.messages,
+              });
 
-          const evaluation = await evaluateScenario(result, scenario);
+              const evaluation = await evaluateScenario(result, scenario);
 
-          evalReporter.record({
-            testName: scenario.reportName,
-            model: model.label,
-            pass: evaluation.pass,
-            actual: evaluation.actual,
-          });
+              return {
+                testName: scenario.reportName,
+                model: model.label,
+                pass: evaluation.pass,
+                actual: evaluation.actual,
+              };
+            },
+          );
 
-          expect(evaluation.pass).toBe(true);
+          expect(
+            record.pass,
+            `Scenario should pass.\n\nActual:\n${record.actual}`,
+          ).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/reply-guidance-grounding.test.ts
+++ b/apps/web/__tests__/eval/reply-guidance-grounding.test.ts
@@ -22,7 +22,9 @@ const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 90_000;
 
 describe.runIf(shouldRunEval)("reply guidance grounding eval", () => {
-  const evalReporter = createEvalReporter();
+  const evalReporter = createEvalReporter({
+    evalName: "reply-guidance-grounding",
+  });
 
   describeEvalMatrix(
     "stale guidance vs current facts",
@@ -46,42 +48,49 @@ Can you check why it is still firing?`,
               threadId: "current-thread",
             },
           ];
-          const provider = getProviderWithHistoricalAccountRequest();
 
-          const result = await aiCollectReplyContext({
-            currentThread,
-            emailAccount,
-            emailProvider: provider,
-          });
-
-          const output = JSON.stringify(result ?? {}, null, 2);
-          const judgeResult = await judgeEvalOutput({
-            input: JSON.stringify({ currentThread }, null, 2),
-            output,
-            expected:
-              "Collector output should not recommend asking for the affected account when the current thread already contains it, and should not treat a prior unresolved request for that same detail as useful drafting guidance.",
-            criterion: {
-              name: "No stale missing-info guidance",
-              description:
-                "The collector may return genuinely useful historical resolution details, but it must not pass along historical context whose only value is asking the sender for information that is already present in the current thread.",
+          const testName = "collector ignores stale missing-info guidance";
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, currentThread }],
             },
-          });
+            async () => {
+              const provider = getProviderWithHistoricalAccountRequest();
 
-          evalReporter.record({
-            testName: "collector ignores stale missing-info guidance",
-            model: model.label,
-            pass: judgeResult.pass,
-            expected: "no stale request for already-provided details",
-            actual: formatSemanticJudgeActual(output, judgeResult),
-          });
+              const result = await aiCollectReplyContext({
+                currentThread,
+                emailAccount,
+                emailProvider: provider,
+              });
+
+              const output = JSON.stringify(result ?? {}, null, 2);
+              const judgeResult = await judgeEvalOutput({
+                input: JSON.stringify({ currentThread }, null, 2),
+                output,
+                expected:
+                  "Collector output should not recommend asking for the affected account when the current thread already contains it, and should not treat a prior unresolved request for that same detail as useful drafting guidance.",
+                criterion: {
+                  name: "No stale missing-info guidance",
+                  description:
+                    "The collector may return genuinely useful historical resolution details, but it must not pass along historical context whose only value is asking the sender for information that is already present in the current thread.",
+                },
+              });
+
+              return {
+                testName,
+                model: model.label,
+                pass: judgeResult.pass,
+                expected: "no stale request for already-provided details",
+                actual: formatSemanticJudgeActual(output, judgeResult),
+              };
+            },
+          );
 
           expect(
-            judgeResult.pass,
-            `Collector should not forward stale missing-info guidance.\n\nOutput:\n${output}\n\nJudge: ${JSON.stringify(
-              judgeResult,
-              null,
-              2,
-            )}`,
+            record.pass,
+            `Collector should not forward stale missing-info guidance.\n\nActual:\n${record.actual}`,
           ).toBe(true);
         },
         TIMEOUT,
@@ -107,59 +116,67 @@ Can you check why it is still firing?`,
             },
           ];
 
-          const result = await aiDraftReplyWithConfidence({
-            messages,
-            emailAccount,
-            knowledgeBaseContent: null,
-            emailHistorySummary: null,
-            emailHistoryContext: {
-              notes:
-                "In a prior unresolved thread, support asked the sender to provide the affected account before investigating.",
-              relevantEmails: [
-                "Support reply in a prior thread: Could you share the affected account identifier so we can look into it?",
-              ],
-            },
-            calendarAvailability: null,
-            writingStyle: null,
-            mcpContext: null,
-            meetingContext: null,
-          });
+          const helperContext = {
+            notes:
+              "In a prior unresolved thread, support asked the sender to provide the affected account before investigating.",
+            relevantEmails: [
+              "Support reply in a prior thread: Could you share the affected account identifier so we can look into it?",
+            ],
+          };
 
-          const judgeResult = await judgeEvalOutput({
-            input: JSON.stringify(
-              {
-                currentThread: messages,
-                helperContext:
-                  "A helper says prior support asked for the affected account identifier.",
-              },
-              null,
-              2,
-            ),
-            output: result.reply,
-            expected:
-              "A concise support reply that acknowledges the issue and says the user is checking or investigating, without asking the sender to provide the affected account because the current thread already includes it.",
-            criterion: {
-              name: "Current thread facts override helper guidance",
-              description:
-                "The draft must use the current email thread as the primary source of truth. It must not ask for details that are already provided in the latest email just because helper or historical context suggested asking for them.",
+          const testName = "drafter ignores stale missing-info guidance";
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages, helperContext }],
             },
-          });
+            async () => {
+              const result = await aiDraftReplyWithConfidence({
+                messages,
+                emailAccount,
+                knowledgeBaseContent: null,
+                emailHistorySummary: null,
+                emailHistoryContext: helperContext,
+                calendarAvailability: null,
+                writingStyle: null,
+                mcpContext: null,
+                meetingContext: null,
+              });
 
-          evalReporter.record({
-            testName: "drafter ignores stale missing-info guidance",
-            model: model.label,
-            pass: judgeResult.pass,
-            expected: "does not ask for already-provided account details",
-            actual: formatSemanticJudgeActual(result.reply, judgeResult),
-          });
+              const judgeResult = await judgeEvalOutput({
+                input: JSON.stringify(
+                  {
+                    currentThread: messages,
+                    helperContext:
+                      "A helper says prior support asked for the affected account identifier.",
+                  },
+                  null,
+                  2,
+                ),
+                output: result.reply,
+                expected:
+                  "A concise support reply that acknowledges the issue and says the user is checking or investigating, without asking the sender to provide the affected account because the current thread already includes it.",
+                criterion: {
+                  name: "Current thread facts override helper guidance",
+                  description:
+                    "The draft must use the current email thread as the primary source of truth. It must not ask for details that are already provided in the latest email just because helper or historical context suggested asking for them.",
+                },
+              });
+
+              return {
+                testName,
+                model: model.label,
+                pass: judgeResult.pass,
+                expected: "does not ask for already-provided account details",
+                actual: formatSemanticJudgeActual(result.reply, judgeResult),
+              };
+            },
+          );
 
           expect(
-            judgeResult.pass,
-            `Draft should not ask for already-provided details.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
-              judgeResult,
-              null,
-              2,
-            )}`,
+            record.pass,
+            `Draft should not ask for already-provided details.\n\nActual:\n${record.actual}`,
           ).toBe(true);
         },
         TIMEOUT,

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -164,10 +164,11 @@ describe("eval reporter", () => {
   });
 
   it("reuses cached eval records in readwrite mode", async () => {
-    const { packageDir } = createTempWorkspace();
+    const { workspaceRoot, packageDir } = createTempWorkspace();
     process.chdir(packageDir);
     process.env.EVAL_RESULT_CACHE = "readwrite";
     process.env.EVAL_RESULT_CACHE_DIR = ".context/cache";
+    process.env.EVAL_REPORT_PATH = ".context/evals/report.md";
 
     const firstRun = vi.fn().mockResolvedValue({
       testName: "example case",
@@ -176,6 +177,7 @@ describe("eval reporter", () => {
       actual: "live result",
     });
     const secondRun = vi.fn();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const firstReporter = createEvalReporter({ evalName: "example eval" });
     const firstRecord = await firstReporter.recordCached(
@@ -196,6 +198,7 @@ describe("eval reporter", () => {
       },
       secondRun,
     );
+    secondReporter.printReport();
 
     expect(firstRun).toHaveBeenCalledTimes(1);
     expect(secondRun).not.toHaveBeenCalled();
@@ -207,6 +210,14 @@ describe("eval reporter", () => {
       actual: "live result",
       cached: true,
     });
+    expect(consoleLog.mock.calls.at(-1)?.[0]).toContain("Cached records: 1/1");
+
+    const markdown = fs.readFileSync(
+      path.join(workspaceRoot, ".context", "evals", "report.md"),
+      "utf8",
+    );
+    expect(markdown).toContain("## Eval Cache");
+    expect(markdown).toContain("Cached records: 1/1");
   });
 });
 

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -16,6 +16,10 @@ vi.mock("@/utils/redis/usage", () => ({
 describe("eval reporter", () => {
   const originalCwd = process.cwd();
   const originalEvalReportPath = process.env.EVAL_REPORT_PATH;
+  const originalEvalHistoryDir = process.env.EVAL_HISTORY_DIR;
+  const originalEvalResultCache = process.env.EVAL_RESULT_CACHE;
+  const originalEvalResultCacheDir = process.env.EVAL_RESULT_CACHE_DIR;
+  const originalRunAiTests = process.env.RUN_AI_TESTS;
 
   afterEach(() => {
     process.chdir(originalCwd);
@@ -24,6 +28,30 @@ describe("eval reporter", () => {
       delete process.env.EVAL_REPORT_PATH;
     } else {
       process.env.EVAL_REPORT_PATH = originalEvalReportPath;
+    }
+
+    if (originalEvalHistoryDir === undefined) {
+      delete process.env.EVAL_HISTORY_DIR;
+    } else {
+      process.env.EVAL_HISTORY_DIR = originalEvalHistoryDir;
+    }
+
+    if (originalEvalResultCache === undefined) {
+      delete process.env.EVAL_RESULT_CACHE;
+    } else {
+      process.env.EVAL_RESULT_CACHE = originalEvalResultCache;
+    }
+
+    if (originalEvalResultCacheDir === undefined) {
+      delete process.env.EVAL_RESULT_CACHE_DIR;
+    } else {
+      process.env.EVAL_RESULT_CACHE_DIR = originalEvalResultCacheDir;
+    }
+
+    if (originalRunAiTests === undefined) {
+      delete process.env.RUN_AI_TESTS;
+    } else {
+      process.env.RUN_AI_TESTS = originalRunAiTests;
     }
 
     vi.restoreAllMocks();
@@ -93,6 +121,92 @@ describe("eval reporter", () => {
     expect(markdown).toContain("## Eval Cost");
     expect(markdown).toContain("Provider-reported total: $0.000200");
     expect(markdown).toContain("openrouter:deepseek/deepseek-v4-flash");
+  });
+
+  it("writes eval history when AI tests are enabled", () => {
+    const { workspaceRoot, packageDir } = createTempWorkspace();
+    process.chdir(packageDir);
+    process.env.RUN_AI_TESTS = "true";
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const reporter = createEvalReporter({ evalName: "example eval" });
+    reporter.record({
+      testName: "example case",
+      model: "Gemini 3 Flash",
+      pass: true,
+    });
+
+    reporter.printReport();
+
+    const historyDir = path.join(
+      workspaceRoot,
+      ".context",
+      "eval-results",
+      "example-eval",
+    );
+    const historyFiles = fs.readdirSync(historyDir);
+    expect(historyFiles).toHaveLength(1);
+
+    const history = JSON.parse(
+      fs.readFileSync(path.join(historyDir, historyFiles[0]!), "utf8"),
+    );
+    expect(history).toMatchObject({
+      schemaVersion: 1,
+      evalName: "example eval",
+      records: [
+        {
+          testName: "example case",
+          model: "Gemini 3 Flash",
+          pass: true,
+        },
+      ],
+    });
+  });
+
+  it("reuses cached eval records in readwrite mode", async () => {
+    const { packageDir } = createTempWorkspace();
+    process.chdir(packageDir);
+    process.env.EVAL_RESULT_CACHE = "readwrite";
+    process.env.EVAL_RESULT_CACHE_DIR = ".context/cache";
+
+    const firstRun = vi.fn().mockResolvedValue({
+      testName: "example case",
+      model: "Gemini 3 Flash",
+      pass: true,
+      actual: "live result",
+    });
+    const secondRun = vi.fn();
+
+    const firstReporter = createEvalReporter({ evalName: "example eval" });
+    const firstRecord = await firstReporter.recordCached(
+      {
+        testName: "example case",
+        model: "Gemini 3 Flash",
+        cacheKeyParts: [{ input: "hello" }],
+      },
+      firstRun,
+    );
+
+    const secondReporter = createEvalReporter({ evalName: "example eval" });
+    const secondRecord = await secondReporter.recordCached(
+      {
+        testName: "example case",
+        model: "Gemini 3 Flash",
+        cacheKeyParts: [{ input: "hello" }],
+      },
+      secondRun,
+    );
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(firstRecord).toMatchObject({
+      actual: "live result",
+      cached: false,
+    });
+    expect(secondRecord).toMatchObject({
+      actual: "live result",
+      cached: true,
+    });
   });
 });
 

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -1,16 +1,39 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
 import type { JudgeResult } from "@/__tests__/eval/judge";
 import { subscribeToAiUsage, type AiUsageEvent } from "@/utils/usage";
 
 export interface EvalRecord {
   actual?: string;
+  cached?: boolean;
+  cacheKey?: string;
   criteria?: JudgeResult[];
   durationMs?: number;
   expected?: string;
   model: string;
   pass: boolean;
   testName: string;
+}
+
+export interface EvalReporterOptions {
+  evalName?: string;
+}
+
+export interface CachedEvalOptions {
+  cacheKeyParts?: unknown[];
+  cacheVersion?: string;
+  evalName?: string;
+  model: string;
+  testName: string;
+}
+
+interface CachedEvalFile {
+  cacheKey: string;
+  createdAt: string;
+  record: EvalRecord;
+  schemaVersion: 1;
 }
 
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -22,9 +45,11 @@ const numberFormatter = new Intl.NumberFormat("en-US");
 class EvalReporter {
   private readonly records: EvalRecord[] = [];
   private readonly usageEvents: AiUsageEvent[] = [];
+  private readonly evalName: string | undefined;
   private unsubscribeFromUsage: (() => void) | undefined;
 
-  constructor() {
+  constructor(options: EvalReporterOptions = {}) {
+    this.evalName = options.evalName;
     this.unsubscribeFromUsage = subscribeToAiUsage((event) => {
       this.usageEvents.push(event);
     });
@@ -32,6 +57,55 @@ class EvalReporter {
 
   record(result: EvalRecord): void {
     this.records.push(result);
+  }
+
+  async recordCached(
+    options: CachedEvalOptions,
+    run: () => Promise<EvalRecord>,
+  ): Promise<EvalRecord> {
+    const cacheMode = getEvalResultCacheMode();
+    const cacheKey = buildEvalCacheKey({
+      cacheKeyParts: options.cacheKeyParts ?? [],
+      cacheVersion: options.cacheVersion,
+      evalName: options.evalName ?? this.evalName,
+      model: options.model,
+      testName: options.testName,
+    });
+    const cachePath = getEvalResultCachePath(cacheKey);
+
+    if (cacheMode !== "off" && cacheMode !== "refresh") {
+      const cachedRecord = readCachedEvalRecord(cachePath);
+      if (cachedRecord) {
+        const record = {
+          ...cachedRecord,
+          cached: true,
+          cacheKey,
+        };
+        this.record(record);
+        return record;
+      }
+
+      if (cacheMode === "readonly") {
+        throw new Error(
+          `Eval result cache miss for ${options.testName} (${options.model})`,
+        );
+      }
+    }
+
+    const record = {
+      ...(await run()),
+      cacheKey,
+      cached: false,
+      model: options.model,
+      testName: options.testName,
+    };
+    this.record(record);
+
+    if (cacheMode === "readwrite" || cacheMode === "refresh") {
+      writeCachedEvalRecord(cachePath, cacheKey, record);
+    }
+
+    return record;
   }
 
   printReport(): void {
@@ -48,6 +122,8 @@ class EvalReporter {
       if (process.env.EVAL_REPORT_PATH) {
         this.writeReport(resolveEvalReportPath(process.env.EVAL_REPORT_PATH));
       }
+
+      this.writeHistoryReport();
     } finally {
       this.unsubscribeFromUsage?.();
       this.unsubscribeFromUsage = undefined;
@@ -63,6 +139,33 @@ class EvalReporter {
       ? filePath.replace(/\.md$/, ".json")
       : `${filePath}.json`;
     fs.writeFileSync(jsonPath, JSON.stringify(this.records, null, 2));
+  }
+
+  private writeHistoryReport(): void {
+    const historyDir = getEvalHistoryDir();
+    if (!historyDir) return;
+
+    const evalName = slugify(this.evalName ?? "eval-run");
+    const outDir = path.join(historyDir, evalName);
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const createdAt = new Date().toISOString();
+    const fileName = `${createdAt.replace(/[:.]/g, "-")}--${process.pid}.json`;
+    fs.writeFileSync(
+      path.join(outDir, fileName),
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          evalName: this.evalName ?? null,
+          createdAt,
+          cacheMode: getEvalResultCacheMode(),
+          records: this.records,
+          usage: summarizeUsageEvents(this.usageEvents),
+        },
+        null,
+        2,
+      )}\n`,
+    );
   }
 
   private generateConsoleReport(): string {
@@ -116,9 +219,10 @@ class EvalReporter {
         (r) => r.testName === testName && r.model === model,
       );
       const status = record?.pass ? green("PASS") : red("FAIL");
+      const cacheDetail = record?.cached ? dim(" (cached)") : "";
       const detail =
         !record?.pass && record?.actual ? dim(` (got: ${record.actual})`) : "";
-      lines.push(`  ${status}  ${testName}${detail}`);
+      lines.push(`  ${status}  ${testName}${cacheDetail}${detail}`);
     }
 
     const passed = this.records.filter(
@@ -147,10 +251,11 @@ class EvalReporter {
         const record = this.records.find(
           (r) => r.testName === testName && r.model === model,
         );
-        if (record?.pass) return pad(green("PASS"), colWidth + 9);
+        const cached = record?.cached ? " (cached)" : "";
+        if (record?.pass) return pad(green(`PASS${cached}`), colWidth + 9);
         const actual = record?.actual
-          ? red(`FAIL (${record.actual})`)
-          : red("FAIL");
+          ? red(`FAIL${cached} (${record.actual})`)
+          : red(`FAIL${cached}`);
         return pad(actual, colWidth + 9);
       });
       return `  ${displayName.padEnd(40)} ${cells.join("  ")}`;
@@ -239,7 +344,7 @@ class EvalReporter {
       const record = this.records.find(
         (r) => r.testName === testName && r.model === model,
       );
-      const result = record?.pass ? "PASS" : "FAIL";
+      const result = `${record?.pass ? "PASS" : "FAIL"}${record?.cached ? " (cached)" : ""}`;
       const actual = record?.actual ?? "-";
       lines.push(`| ${testName} | ${result} | ${actual} |`);
     }
@@ -260,8 +365,11 @@ class EvalReporter {
         const record = this.records.find(
           (r) => r.testName === testName && r.model === model,
         );
-        if (record?.pass) return "PASS";
-        return record?.actual ? `FAIL (${record.actual})` : "FAIL";
+        const cached = record?.cached ? " (cached)" : "";
+        if (record?.pass) return `PASS${cached}`;
+        return record?.actual
+          ? `FAIL${cached} (${record.actual})`
+          : `FAIL${cached}`;
       });
       return `| ${testName} | ${cells.join(" | ")} |`;
     });
@@ -284,8 +392,10 @@ class EvalReporter {
   }
 }
 
-export function createEvalReporter(): EvalReporter {
-  return new EvalReporter();
+export function createEvalReporter(
+  options: EvalReporterOptions = {},
+): EvalReporter {
+  return new EvalReporter(options);
 }
 
 type UsageSummary = {
@@ -417,6 +527,153 @@ function resolveEvalReportPath(filePath: string): string {
   if (path.isAbsolute(filePath)) return filePath;
 
   return path.join(findWorkspaceRoot(process.cwd()), filePath);
+}
+
+type EvalResultCacheMode = "off" | "readonly" | "readwrite" | "refresh";
+
+function getEvalResultCacheMode(): EvalResultCacheMode {
+  const value = process.env.EVAL_RESULT_CACHE;
+  if (value === "readonly" || value === "readwrite" || value === "refresh") {
+    return value;
+  }
+  return "off";
+}
+
+function getEvalHistoryDir(): string | null {
+  if (process.env.EVAL_HISTORY_DIR === "off") return null;
+  if (process.env.EVAL_HISTORY_DIR) {
+    return resolveEvalReportPath(process.env.EVAL_HISTORY_DIR);
+  }
+  if (process.env.RUN_AI_TESTS === "true") {
+    return resolveEvalReportPath(".context/eval-results");
+  }
+  return null;
+}
+
+function getEvalResultCachePath(cacheKey: string): string {
+  const cacheDir = resolveEvalReportPath(
+    process.env.EVAL_RESULT_CACHE_DIR ?? ".context/eval-result-cache",
+  );
+  return path.join(cacheDir, `${cacheKey}.json`);
+}
+
+function readCachedEvalRecord(filePath: string): EvalRecord | null {
+  try {
+    const file = JSON.parse(
+      fs.readFileSync(filePath, "utf8"),
+    ) as Partial<CachedEvalFile>;
+    if (file.schemaVersion !== 1 || !file.record) return null;
+    return file.record;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function writeCachedEvalRecord(
+  filePath: string,
+  cacheKey: string,
+  record: EvalRecord,
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    tempPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        cacheKey,
+        createdAt: new Date().toISOString(),
+        record,
+      } satisfies CachedEvalFile,
+      null,
+      2,
+    )}\n`,
+  );
+  fs.renameSync(tempPath, filePath);
+}
+
+function buildEvalCacheKey({
+  cacheKeyParts,
+  cacheVersion,
+  evalName,
+  model,
+  testName,
+}: {
+  cacheKeyParts: unknown[];
+  cacheVersion?: string;
+  evalName?: string;
+  model: string;
+  testName: string;
+}): string {
+  return hashJson({
+    schemaVersion: 1,
+    cacheVersion: cacheVersion ?? "1",
+    evalName: evalName ?? null,
+    testName,
+    model,
+    cacheKeyParts,
+    git: getGitFingerprint(),
+  });
+}
+
+function getGitFingerprint(): { diffHash: string | null; head: string | null } {
+  const repoRoot = findWorkspaceRoot(process.cwd());
+  return {
+    head: readGitOutput(repoRoot, ["rev-parse", "HEAD"]),
+    diffHash: hashString(readGitOutput(repoRoot, ["diff", "--no-ext-diff"])),
+  };
+}
+
+function readGitOutput(cwd: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function hashJson(value: unknown): string {
+  return hashString(stableStringify(value));
+}
+
+function hashString(value: string | null): string | null {
+  if (value == null) return null;
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  return `{${Object.entries(value)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+    .join(",")}}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
 }
 
 function findWorkspaceRoot(startDir: string): string {

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -114,6 +114,7 @@ class EvalReporter {
 
       const reportParts = [
         this.generateConsoleReport(),
+        this.generateCacheConsoleReport(),
         this.generateCostConsoleReport(),
       ].filter((part): part is string => Boolean(part));
 
@@ -211,6 +212,18 @@ class EvalReporter {
     return lines.join("\n");
   }
 
+  private generateCacheConsoleReport(): string | null {
+    const cached = this.records.filter((record) => record.cached).length;
+    if (cached === 0) return null;
+
+    const total = this.records.length;
+    return [
+      bold("Eval Cache"),
+      "",
+      `  Cached records: ${cached}/${total}`,
+    ].join("\n");
+  }
+
   private generateSingleModelConsole(model: string, tests: string[]): string {
     const lines = [bold(`Eval Results: ${model}`), ""];
 
@@ -290,10 +303,25 @@ class EvalReporter {
       models.length <= 1
         ? this.generateSingleModelMarkdown(models[0] ?? "Default", tests)
         : this.generateComparisonMarkdown(models, tests);
+    const cacheMarkdown = this.generateCacheMarkdown();
     const costMarkdown = this.generateCostMarkdown();
-    if (!costMarkdown) return resultMarkdown;
+    const extraMarkdown = [cacheMarkdown, costMarkdown].filter(
+      (part): part is string => Boolean(part),
+    );
+    if (extraMarkdown.length === 0) return resultMarkdown;
 
-    return `${resultMarkdown}\n\n${costMarkdown}`;
+    return `${resultMarkdown}\n\n${extraMarkdown.join("\n\n")}`;
+  }
+
+  private generateCacheMarkdown(): string | null {
+    const cached = this.records.filter((record) => record.cached).length;
+    if (cached === 0) return null;
+
+    return [
+      "## Eval Cache",
+      "",
+      `Cached records: ${cached}/${this.records.length}`,
+    ].join("\n");
   }
 
   private generateCostMarkdown(): string | null {


### PR DESCRIPTION
Adds eval reporter support for persistent run history and opt-in cached result reuse.

- Adds cache-aware reporting, local history output, and cache summary output.
- Migrates selected eval suites to cached result recording.
- Documents cache and history environment variables.

Tests: `pnpm test __tests__/eval/reporter.test.ts`; `pnpm test __tests__/eval/reply-guidance-grounding.test.ts`; `pnpm test __tests__/eval/assistant-chat-memory-safety.test.ts`; `pnpm --filter inbox-zero-ai exec biome check ...`