### PR TITLE
eval: Cache more assistant eval results

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
@@ -274,8 +274,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat attachments", () => {
               );
 
               return {
-                testName: scenario.reportName,
-                model: model.label,
                 pass: evaluation.pass,
                 actual: evaluation.actual,
               };

--- a/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
@@ -26,7 +26,9 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 120_000;
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-attachments",
+});
 const logger = createScopedLogger("eval-assistant-chat-attachments");
 
 const scenarios: EvalScenario[] = [
@@ -237,32 +239,50 @@ describe.runIf(shouldRunEval)("Eval: assistant chat attachments", () => {
       test(
         scenario.title,
         async () => {
-          if (scenario.searchMessages) {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: scenario.searchMessages,
-              nextPageToken: undefined,
-            });
-          }
+          const messages = [
+            { role: "user" as const, content: scenario.prompt },
+          ];
+          const record = await evalReporter.recordCached(
+            {
+              testName: scenario.reportName,
+              model: model.label,
+              cacheKeyParts: [
+                {
+                  model,
+                  scenario,
+                  messages,
+                },
+              ],
+            },
+            async () => {
+              if (scenario.searchMessages) {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: scenario.searchMessages,
+                  nextPageToken: undefined,
+                });
+              }
 
-          const result = await runAssistantChat({
-            emailAccount,
-            messages: [{ role: "user", content: scenario.prompt }],
-          });
+              const result = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
 
-          const evaluation = await evaluateScenario(
-            result,
-            scenario.prompt,
-            scenario.expectation,
+              const evaluation = await evaluateScenario(
+                result,
+                scenario.prompt,
+                scenario.expectation,
+              );
+
+              return {
+                testName: scenario.reportName,
+                model: model.label,
+                pass: evaluation.pass,
+                actual: evaluation.actual,
+              };
+            },
           );
 
-          evalReporter.record({
-            testName: scenario.reportName,
-            model: model.label,
-            pass: evaluation.pass,
-            actual: evaluation.actual,
-          });
-
-          expect(evaluation.pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
@@ -13,6 +13,7 @@ import {
   captureAssistantChatToolCalls,
   getFirstMatchingToolCall,
   getLastMatchingToolCall,
+  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -249,7 +250,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat attachments", () => {
               cacheKeyParts: [
                 {
                   model,
-                  scenario,
+                  scenario: getScenarioCacheKey(scenario),
                   messages,
                 },
               ],
@@ -348,6 +349,13 @@ type EvalScenario = {
   searchMessages?: ReturnType<typeof getMockMessage>[];
   expectation: ScenarioExpectation;
 };
+
+function getScenarioCacheKey(scenario: EvalScenario) {
+  return {
+    ...scenario,
+    searchMessages: getStableMessageCacheKey(scenario.searchMessages),
+  };
+}
 
 function isSearchInboxInput(input: unknown): input is SearchInboxInput {
   return (

--- a/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
@@ -26,7 +26,9 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-email-actions",
+});
 const logger = createScopedLogger("eval-assistant-chat-email-actions");
 const scenarios: EvalScenario[] = [
   {
@@ -230,32 +232,44 @@ describe.runIf(shouldRunEval)("Eval: assistant chat email actions", () => {
       test(
         scenario.title,
         async () => {
-          if (scenario.searchMessages) {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: scenario.searchMessages,
-              nextPageToken: undefined,
-            });
-          }
+          const messages = [
+            { role: "user" as const, content: scenario.prompt },
+          ];
+          const record = await evalReporter.recordCached(
+            {
+              testName: scenario.reportName,
+              model: model.label,
+              cacheKeyParts: [{ model, scenario, messages }],
+            },
+            async () => {
+              if (scenario.searchMessages) {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: scenario.searchMessages,
+                  nextPageToken: undefined,
+                });
+              }
 
-          const result = await runAssistantChat({
-            emailAccount,
-            messages: [{ role: "user", content: scenario.prompt }],
-          });
+              const result = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
 
-          const evaluation = await evaluateScenario(
-            result,
-            scenario.prompt,
-            scenario.expectation,
+              const evaluation = await evaluateScenario(
+                result,
+                scenario.prompt,
+                scenario.expectation,
+              );
+
+              return {
+                testName: scenario.reportName,
+                model: model.label,
+                pass: evaluation.pass,
+                actual: evaluation.actual,
+              };
+            },
           );
 
-          evalReporter.record({
-            testName: scenario.reportName,
-            model: model.label,
-            pass: evaluation.pass,
-            actual: evaluation.actual,
-          });
-
-          expect(evaluation.pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
@@ -13,6 +13,7 @@ import {
   captureAssistantChatTrace,
   getFirstMatchingToolCall,
   getLastMatchingToolCall,
+  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -239,7 +240,9 @@ describe.runIf(shouldRunEval)("Eval: assistant chat email actions", () => {
             {
               testName: scenario.reportName,
               model: model.label,
-              cacheKeyParts: [{ model, scenario, messages }],
+              cacheKeyParts: [
+                { model, scenario: getScenarioCacheKey(scenario), messages },
+              ],
             },
             async () => {
               if (scenario.searchMessages) {
@@ -359,6 +362,13 @@ type EvalScenario = {
   searchMessages?: ReturnType<typeof getMockMessage>[];
   expectation: ScenarioExpectation;
 };
+
+function getScenarioCacheKey(scenario: EvalScenario) {
+  return {
+    ...scenario,
+    searchMessages: getStableMessageCacheKey(scenario.searchMessages),
+  };
+}
 
 function isSearchInboxInput(input: unknown): input is SearchInboxInput {
   return (

--- a/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
@@ -261,8 +261,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat email actions", () => {
               );
 
               return {
-                testName: scenario.reportName,
-                model: model.label,
                 pass: evaluation.pass,
                 actual: evaluation.actual,
               };

--- a/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
@@ -252,6 +252,39 @@ export function getLastRuleConditionUpdate(toolCalls: RecordedToolCall[]) {
   return null;
 }
 
+export function getStableMessageCacheKey(
+  messages:
+    | Array<{
+        attachments?: unknown;
+        headers?: {
+          from?: unknown;
+          subject?: unknown;
+          to?: unknown;
+        };
+        id?: unknown;
+        labelIds?: unknown;
+        snippet?: unknown;
+        subject?: unknown;
+        textHtml?: unknown;
+        textPlain?: unknown;
+        threadId?: unknown;
+      }>
+    | undefined,
+) {
+  return messages?.map((message) => ({
+    id: message.id,
+    threadId: message.threadId,
+    from: message.headers?.from,
+    to: message.headers?.to,
+    subject: message.headers?.subject ?? message.subject,
+    snippet: message.snippet,
+    textPlain: message.textPlain,
+    textHtml: message.textHtml,
+    labelIds: message.labelIds,
+    attachments: message.attachments,
+  }));
+}
+
 export type UpdateRuleConditionsInput = {
   ruleName: string;
   condition: {

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
@@ -23,7 +23,9 @@ import {
 // pnpm test-ai eval/assistant-chat-inbox-workflows
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-inbox-workflows
 
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-inbox-workflows-search",
+});
 
 describe.runIf(shouldRunEval)(
   "Eval: assistant chat inbox workflows search",
@@ -36,74 +38,88 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "uses inbox search for direct email lookup requests [$label]",
           async ({ provider, label }) => {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: [
-                getMockMessage({
-                  id: "msg-search-1",
-                  threadId: "thread-search-1",
-                  from: "support@smtprelay.example",
-                  subject: "SMTP relay API setup guide",
-                  snippet:
-                    "Here are the connection details for your API client.",
-                  labelIds: ["UNREAD"],
-                }),
-                getMockMessage({
-                  id: "msg-search-2",
-                  threadId: "thread-search-2",
-                  from: "billing@smtprelay.example",
-                  subject: "Receipt for your SMTP relay subscription",
-                  snippet: "Your monthly invoice is attached.",
-                  labelIds: [],
-                }),
-              ],
-              nextPageToken: undefined,
-            });
+            const testName = `direct email lookup uses search (${label})`;
+            const userPrompt =
+              "Find me an email related to setting up the SMTP relay API.";
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-search-1",
+                threadId: "thread-search-1",
+                from: "support@smtprelay.example",
+                subject: "SMTP relay API setup guide",
+                snippet: "Here are the connection details for your API client.",
+                labelIds: ["UNREAD"],
+              }),
+              getMockMessage({
+                id: "msg-search-2",
+                threadId: "thread-search-2",
+                from: "billing@smtprelay.example",
+                subject: "Receipt for your SMTP relay subscription",
+                snippet: "Your monthly invoice is attached.",
+                labelIds: [],
+              }),
+            ];
+            const messages = [
+              {
+                role: "user" as const,
+                content: userPrompt,
+              },
+            ];
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              messages: [
-                {
-                  role: "user",
-                  content:
-                    "Find me an email related to setting up the SMTP relay API.",
-                },
-              ],
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  { model, provider, label, userPrompt, searchMessages },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
 
-            const searchCall = getFirstSearchInboxCall(toolCalls);
-            const searchJudge = searchCall
-              ? await judgeSearchInboxQuery({
-                  prompt:
-                    "Find me an email related to setting up the SMTP relay API.",
-                  query: searchCall.query,
-                  expected:
-                    "A search query focused on the SMTP relay API setup email.",
-                })
-              : null;
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  messages,
+                });
 
-            const pass =
-              !!searchCall &&
-              !!searchJudge?.pass &&
-              hasSearchBeforeFirstWrite(toolCalls) &&
-              hasNoWriteToolCalls(toolCalls);
+                const searchCall = getFirstSearchInboxCall(toolCalls);
+                const searchJudge = searchCall
+                  ? await judgeSearchInboxQuery({
+                      prompt: userPrompt,
+                      query: searchCall.query,
+                      expected:
+                        "A search query focused on the SMTP relay API setup email.",
+                    })
+                  : null;
 
-            evalReporter.record({
-              testName: `direct email lookup uses search (${label})`,
-              model: model.label,
-              pass,
-              actual:
-                searchCall && searchJudge
-                  ? `${actual} | ${formatSemanticJudgeActual(
-                      searchCall.query,
-                      searchJudge,
-                    )}`
-                  : actual,
-            });
+                const pass =
+                  !!searchCall &&
+                  !!searchJudge?.pass &&
+                  hasSearchBeforeFirstWrite(toolCalls) &&
+                  hasNoWriteToolCalls(toolCalls);
 
-            expect(pass).toBe(true);
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual:
+                    searchCall && searchJudge
+                      ? `${actual} | ${formatSemanticJudgeActual(
+                          searchCall.query,
+                          searchJudge,
+                        )}`
+                      : actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );
@@ -111,72 +127,87 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "reads the full email after search when the user asks what a message says [$label]",
           async ({ provider, label }) => {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: [
-                getMockMessage({
-                  id: "msg-read-1",
-                  threadId: "thread-read-1",
-                  from: "ops@partner.example",
-                  subject: "Question on the revised plan",
-                  snippet: "Can you confirm the revised timeline?",
-                  labelIds: ["UNREAD"],
-                }),
-              ],
-              nextPageToken: undefined,
-            });
+            const testName = `search then read full email (${label})`;
+            const userPrompt =
+              "What does the email about the revised plan say? I need the full contents.";
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-read-1",
+                threadId: "thread-read-1",
+                from: "ops@partner.example",
+                subject: "Question on the revised plan",
+                snippet: "Can you confirm the revised timeline?",
+                labelIds: ["UNREAD"],
+              }),
+            ];
+            const messages = [
+              {
+                role: "user" as const,
+                content: userPrompt,
+              },
+            ];
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              messages: [
-                {
-                  role: "user",
-                  content:
-                    "What does the email about the revised plan say? I need the full contents.",
-                },
-              ],
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  { model, provider, label, userPrompt, searchMessages },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
 
-            const searchCall = getFirstSearchInboxCall(toolCalls);
-            const searchJudge = searchCall
-              ? await judgeSearchInboxQuery({
-                  prompt:
-                    "What does the email about the revised plan say? I need the full contents.",
-                  query: searchCall.query,
-                  expected:
-                    "A search query focused on the email about the revised plan.",
-                })
-              : null;
-            const readCall = getLastMatchingToolCall(
-              toolCalls,
-              "readEmail",
-              isReadEmailInput,
-            )?.input;
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  messages,
+                });
 
-            const pass =
-              !!searchCall &&
-              !!readCall &&
-              !!searchJudge?.pass &&
-              hasSearchBeforeTool(toolCalls, "readEmail") &&
-              readCall.messageId === "msg-read-1" &&
-              hasNoWriteToolCalls(toolCalls);
+                const searchCall = getFirstSearchInboxCall(toolCalls);
+                const searchJudge = searchCall
+                  ? await judgeSearchInboxQuery({
+                      prompt: userPrompt,
+                      query: searchCall.query,
+                      expected:
+                        "A search query focused on the email about the revised plan.",
+                    })
+                  : null;
+                const readCall = getLastMatchingToolCall(
+                  toolCalls,
+                  "readEmail",
+                  isReadEmailInput,
+                )?.input;
 
-            evalReporter.record({
-              testName: `search then read full email (${label})`,
-              model: model.label,
-              pass,
-              actual:
-                searchCall && searchJudge
-                  ? `${actual} | ${formatSemanticJudgeActual(
-                      searchCall.query,
-                      searchJudge,
-                    )}`
-                  : actual,
-            });
+                const pass =
+                  !!searchCall &&
+                  !!readCall &&
+                  !!searchJudge?.pass &&
+                  hasSearchBeforeTool(toolCalls, "readEmail") &&
+                  readCall.messageId === "msg-read-1" &&
+                  hasNoWriteToolCalls(toolCalls);
 
-            expect(pass).toBe(true);
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual:
+                    searchCall && searchJudge
+                      ? `${actual} | ${formatSemanticJudgeActual(
+                          searchCall.query,
+                          searchJudge,
+                        )}`
+                      : actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
@@ -3,6 +3,7 @@ import { describeEvalMatrix } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { formatSemanticJudgeActual } from "@/__tests__/eval/semantic-judge";
 import { getMockMessage } from "@/__tests__/helpers";
+import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -71,7 +72,13 @@ describe.runIf(shouldRunEval)(
                 testName,
                 model: model.label,
                 cacheKeyParts: [
-                  { model, provider, label, userPrompt, searchMessages },
+                  {
+                    model,
+                    provider,
+                    label,
+                    userPrompt,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
+                  },
                 ],
               },
               async () => {
@@ -150,7 +157,13 @@ describe.runIf(shouldRunEval)(
                 testName,
                 model: model.label,
                 cacheKeyParts: [
-                  { model, provider, label, userPrompt, searchMessages },
+                  {
+                    model,
+                    provider,
+                    label,
+                    userPrompt,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
+                  },
                 ],
               },
               async () => {

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
@@ -105,8 +105,6 @@ describe.runIf(shouldRunEval)(
                   hasNoWriteToolCalls(toolCalls);
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual:
                     searchCall && searchJudge
@@ -193,8 +191,6 @@ describe.runIf(shouldRunEval)(
                   hasNoWriteToolCalls(toolCalls);
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual:
                     searchCall && searchJudge

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -20,7 +20,9 @@ import {
 // pnpm test-ai eval/assistant-chat-inbox-workflows
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-inbox-workflows
 
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-inbox-workflows-triage",
+});
 
 describe.runIf(shouldRunEval)(
   "Eval: assistant chat inbox workflows triage",
@@ -33,58 +35,86 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "handles inbox update requests with read-only triage search first [$label]",
           async ({ provider, label, unreadSignal }) => {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: [
-                getMockMessage({
-                  id: "msg-triage-1",
-                  threadId: "thread-triage-1",
-                  from: "founder@client.example",
-                  subject: "Need approval today",
-                  snippet: "Can you confirm the rollout before 3pm?",
-                  labelIds: ["UNREAD", "Label_To Reply"],
-                }),
-                getMockMessage({
-                  id: "msg-triage-2",
-                  threadId: "thread-triage-2",
-                  from: "updates@vendor.example",
-                  subject: "Weekly platform digest",
-                  snippet: "Here is this week's product update.",
-                  labelIds: ["UNREAD"],
-                }),
-              ],
-              nextPageToken: undefined,
-            });
+            const testName = `inbox update uses triage search first (${label})`;
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-triage-1",
+                threadId: "thread-triage-1",
+                from: "founder@client.example",
+                subject: "Need approval today",
+                snippet: "Can you confirm the rollout before 3pm?",
+                labelIds: ["UNREAD", "Label_To Reply"],
+              }),
+              getMockMessage({
+                id: "msg-triage-2",
+                threadId: "thread-triage-2",
+                from: "updates@vendor.example",
+                subject: "Weekly platform digest",
+                snippet: "Here is this week's product update.",
+                labelIds: ["UNREAD"],
+              }),
+            ];
+            const inboxStats = { total: 240, unread: 18 };
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Help me handle my inbox today.",
+              },
+            ];
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              inboxStats: { total: 240, unread: 18 },
-              messages: [
-                {
-                  role: "user",
-                  content: "Help me handle my inbox today.",
-                },
-              ],
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  {
+                    model,
+                    provider,
+                    label,
+                    unreadSignal,
+                    searchMessages,
+                    inboxStats,
+                    messages,
+                  },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
 
-            const searchCall = getFirstSearchInboxCall(toolCalls);
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  inboxStats,
+                  messages,
+                });
 
-            const pass =
-              !!searchCall &&
-              hasSearchBeforeFirstWrite(toolCalls) &&
-              hasUnreadTriageSignal(searchCall.query, provider, unreadSignal) &&
-              hasNoWriteToolCalls(toolCalls);
+                const searchCall = getFirstSearchInboxCall(toolCalls);
 
-            evalReporter.record({
-              testName: `inbox update uses triage search first (${label})`,
-              model: model.label,
-              pass,
-              actual,
-            });
+                const pass =
+                  !!searchCall &&
+                  hasSearchBeforeFirstWrite(toolCalls) &&
+                  hasUnreadTriageSignal(
+                    searchCall.query,
+                    provider,
+                    unreadSignal,
+                  ) &&
+                  hasNoWriteToolCalls(toolCalls);
 
-            expect(pass).toBe(true);
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );
@@ -92,57 +122,72 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "uses read-only inbox search for reply triage requests [$label]",
           async ({ provider, label }) => {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: [
-                getMockMessage({
-                  id: "msg-reply-1",
-                  threadId: "thread-reply-1",
-                  from: "ops@partner.example",
-                  subject: "Question on the revised plan",
-                  snippet: "Can you send your answer today?",
-                  labelIds: ["UNREAD", "Label_To Reply"],
-                }),
-                getMockMessage({
-                  id: "msg-reply-2",
-                  threadId: "thread-reply-2",
-                  from: "digest@briefings.example",
-                  subject: "Morning roundup",
-                  snippet: "Here are the top stories for today.",
-                  labelIds: ["UNREAD"],
-                }),
-              ],
-              nextPageToken: undefined,
-            });
+            const testName = `reply triage stays read-only (${label})`;
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-reply-1",
+                threadId: "thread-reply-1",
+                from: "ops@partner.example",
+                subject: "Question on the revised plan",
+                snippet: "Can you send your answer today?",
+                labelIds: ["UNREAD", "Label_To Reply"],
+              }),
+              getMockMessage({
+                id: "msg-reply-2",
+                threadId: "thread-reply-2",
+                from: "digest@briefings.example",
+                subject: "Morning roundup",
+                snippet: "Here are the top stories for today.",
+                labelIds: ["UNREAD"],
+              }),
+            ];
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Do I need to reply to any mail?",
+              },
+            ];
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              messages: [
-                {
-                  role: "user",
-                  content: "Do I need to reply to any mail?",
-                },
-              ],
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  { model, provider, label, searchMessages, messages },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
 
-            const searchCall = getFirstSearchInboxCall(toolCalls);
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  messages,
+                });
 
-            const pass =
-              !!searchCall &&
-              hasSearchBeforeFirstWrite(toolCalls) &&
-              hasReplyTriageFocus(searchCall.query, provider) &&
-              hasNoWriteToolCalls(toolCalls);
+                const searchCall = getFirstSearchInboxCall(toolCalls);
 
-            evalReporter.record({
-              testName: `reply triage stays read-only (${label})`,
-              model: model.label,
-              pass,
-              actual,
-            });
+                const pass =
+                  !!searchCall &&
+                  hasSearchBeforeFirstWrite(toolCalls) &&
+                  hasReplyTriageFocus(searchCall.query, provider) &&
+                  hasNoWriteToolCalls(toolCalls);
 
-            expect(pass).toBe(true);
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -106,8 +106,6 @@ describe.runIf(shouldRunEval)(
                   hasNoWriteToolCalls(toolCalls);
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual,
                 };
@@ -179,8 +177,6 @@ describe.runIf(shouldRunEval)(
                   hasNoWriteToolCalls(toolCalls);
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual,
                 };

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "vitest";
 import { describeEvalMatrix } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
+import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -72,7 +73,7 @@ describe.runIf(shouldRunEval)(
                     provider,
                     label,
                     unreadSignal,
-                    searchMessages,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
                     inboxStats,
                     messages,
                   },
@@ -151,7 +152,13 @@ describe.runIf(shouldRunEval)(
                 testName,
                 model: model.label,
                 cacheKeyParts: [
-                  { model, provider, label, searchMessages, messages },
+                  {
+                    model,
+                    provider,
+                    label,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
+                    messages,
+                  },
                 ],
               },
               async () => {

--- a/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
@@ -20,7 +20,9 @@ import { createScopedLogger } from "@/utils/logger";
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-label-management",
+});
 const logger = createScopedLogger("eval-assistant-chat-label-management");
 
 const {
@@ -134,38 +136,52 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "lists labels without attempting creation",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content: "What labels do I already have?",
-              },
-            ],
-          });
+          const testName = "list labels";
+          const messages = [
+            {
+              role: "user" as const,
+              content: "What labels do I already have?",
+            },
+          ];
 
-          const listLabelsCall = getLastMatchingToolCall(
-            toolCalls,
-            "listLabels",
-            isListLabelsInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const listLabelsCall = getLastMatchingToolCall(
+                toolCalls,
+                "listLabels",
+                isListLabelsInput,
+              );
+              const pass =
+                !!listLabelsCall &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "createOrGetLabel" &&
+                    isCreateOrGetLabelInput(toolCall.input),
+                ) &&
+                !toolCalls.some(
+                  (toolCall) => toolCall.toolName === "manageInbox",
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const pass =
-            !!listLabelsCall &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "createOrGetLabel" &&
-                isCreateOrGetLabelInput(toolCall.input),
-            ) &&
-            !toolCalls.some((toolCall) => toolCall.toolName === "manageInbox");
 
-          evalReporter.record({
-            testName: "list labels",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -173,51 +189,63 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "creates or reuses a label before labeling explicit threads",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content:
-                  "Create a Finance label if I do not already have it, then label thread-1 and thread-2 with it.",
-              },
-            ],
-          });
+          const testName = "create or get then label threads";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                "Create a Finance label if I do not already have it, then label thread-1 and thread-2 with it.",
+            },
+          ];
 
-          const createOrGetMatch = getLastMatchingToolCall(
-            toolCalls,
-            "createOrGetLabel",
-            isCreateOrGetLabelInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const createOrGetMatch = getLastMatchingToolCall(
+                toolCalls,
+                "createOrGetLabel",
+                isCreateOrGetLabelInput,
+              );
+              const labelThreadsMatch = getLastMatchingToolCall(
+                toolCalls,
+                "manageInbox",
+                isManageInboxLabelThreadsInput,
+              );
+              const createOrGetCall = createOrGetMatch?.input ?? null;
+              const labelThreadsCall = labelThreadsMatch?.input ?? null;
+              const createOrGetIndex = createOrGetMatch?.index ?? -1;
+              const labelThreadsIndex = labelThreadsMatch?.index ?? -1;
+              const pass =
+                !!createOrGetCall &&
+                !!labelThreadsCall &&
+                createOrGetCall.name === "Finance" &&
+                labelThreadsCall.threadIds.length === 2 &&
+                labelThreadsCall.threadIds.includes("thread-1") &&
+                labelThreadsCall.threadIds.includes("thread-2") &&
+                labelThreadsCall.labelName === "Finance" &&
+                labelThreadsCall.action === "label_threads" &&
+                createOrGetIndex >= 0 &&
+                labelThreadsIndex > createOrGetIndex;
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const labelThreadsMatch = getLastMatchingToolCall(
-            toolCalls,
-            "manageInbox",
-            isManageInboxLabelThreadsInput,
-          );
-          const createOrGetCall = createOrGetMatch?.input ?? null;
-          const labelThreadsCall = labelThreadsMatch?.input ?? null;
-          const createOrGetIndex = createOrGetMatch?.index ?? -1;
-          const labelThreadsIndex = labelThreadsMatch?.index ?? -1;
-          const pass =
-            !!createOrGetCall &&
-            !!labelThreadsCall &&
-            createOrGetCall.name === "Finance" &&
-            labelThreadsCall.threadIds.length === 2 &&
-            labelThreadsCall.threadIds.includes("thread-1") &&
-            labelThreadsCall.threadIds.includes("thread-2") &&
-            labelThreadsCall.labelName === "Finance" &&
-            labelThreadsCall.action === "label_threads" &&
-            createOrGetIndex >= 0 &&
-            labelThreadsIndex > createOrGetIndex;
 
-          evalReporter.record({
-            testName: "create or get then label threads",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -225,36 +253,50 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "creates a label without running inbox actions when the user only asks for the label",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content:
-                  "Create a label named Finance, but do not apply it to any emails yet.",
-              },
-            ],
-          });
+          const testName = "create label only";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                "Create a label named Finance, but do not apply it to any emails yet.",
+            },
+          ];
 
-          const createOrGetMatch = getLastMatchingToolCall(
-            toolCalls,
-            "createOrGetLabel",
-            isCreateOrGetLabelInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const createOrGetMatch = getLastMatchingToolCall(
+                toolCalls,
+                "createOrGetLabel",
+                isCreateOrGetLabelInput,
+              );
+              const createOrGetCall = createOrGetMatch?.input ?? null;
+              const pass =
+                !!createOrGetCall &&
+                createOrGetCall.name === "Finance" &&
+                !toolCalls.some(
+                  (toolCall) => toolCall.toolName === "manageInbox",
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const createOrGetCall = createOrGetMatch?.input ?? null;
-          const pass =
-            !!createOrGetCall &&
-            createOrGetCall.name === "Finance" &&
-            !toolCalls.some((toolCall) => toolCall.toolName === "manageInbox");
 
-          evalReporter.record({
-            testName: "create label only",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -262,42 +304,54 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "applies an existing label to a single explicit thread",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content:
-                  "Use my existing Travel label on thread-1. Do not create a new label.",
-              },
-            ],
-          });
+          const testName = "apply existing label to one thread";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                "Use my existing Travel label on thread-1. Do not create a new label.",
+            },
+          ];
 
-          const labelThreadsMatch = getLastMatchingToolCall(
-            toolCalls,
-            "manageInbox",
-            isManageInboxLabelThreadsInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const labelThreadsMatch = getLastMatchingToolCall(
+                toolCalls,
+                "manageInbox",
+                isManageInboxLabelThreadsInput,
+              );
+              const labelThreadsCall = labelThreadsMatch?.input ?? null;
+              const pass =
+                !!labelThreadsCall &&
+                labelThreadsCall.threadIds.length === 1 &&
+                labelThreadsCall.threadIds[0] === "thread-1" &&
+                labelThreadsCall.labelName === "Travel" &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "createOrGetLabel" &&
+                    isCreateOrGetLabelInput(toolCall.input),
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const labelThreadsCall = labelThreadsMatch?.input ?? null;
-          const pass =
-            !!labelThreadsCall &&
-            labelThreadsCall.threadIds.length === 1 &&
-            labelThreadsCall.threadIds[0] === "thread-1" &&
-            labelThreadsCall.labelName === "Travel" &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "createOrGetLabel" &&
-                isCreateOrGetLabelInput(toolCall.input),
-            );
 
-          evalReporter.record({
-            testName: "apply existing label to one thread",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -305,43 +359,55 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "applies an existing label to multiple explicit threads",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content:
-                  "Label thread-1 and thread-2 with my Travel label. It already exists.",
-              },
-            ],
-          });
+          const testName = "apply existing label to multiple threads";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                "Label thread-1 and thread-2 with my Travel label. It already exists.",
+            },
+          ];
 
-          const labelThreadsMatch = getLastMatchingToolCall(
-            toolCalls,
-            "manageInbox",
-            isManageInboxLabelThreadsInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const labelThreadsMatch = getLastMatchingToolCall(
+                toolCalls,
+                "manageInbox",
+                isManageInboxLabelThreadsInput,
+              );
+              const labelThreadsCall = labelThreadsMatch?.input ?? null;
+              const pass =
+                !!labelThreadsCall &&
+                labelThreadsCall.threadIds.length === 2 &&
+                labelThreadsCall.threadIds.includes("thread-1") &&
+                labelThreadsCall.threadIds.includes("thread-2") &&
+                labelThreadsCall.labelName === "Travel" &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "createOrGetLabel" &&
+                    isCreateOrGetLabelInput(toolCall.input),
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const labelThreadsCall = labelThreadsMatch?.input ?? null;
-          const pass =
-            !!labelThreadsCall &&
-            labelThreadsCall.threadIds.length === 2 &&
-            labelThreadsCall.threadIds.includes("thread-1") &&
-            labelThreadsCall.threadIds.includes("thread-2") &&
-            labelThreadsCall.labelName === "Travel" &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "createOrGetLabel" &&
-                isCreateOrGetLabelInput(toolCall.input),
-            );
 
-          evalReporter.record({
-            testName: "apply existing label to multiple threads",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -349,49 +415,61 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       test(
         "keeps spaced label names separate from the label_threads action",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount,
-            messages: [
-              {
-                role: "user",
-                content:
-                  'Apply my existing "04 ARCHIVES" label to thread-1 and thread-2.',
-              },
-            ],
-          });
+          const testName = "apply spaced existing label to explicit threads";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                'Apply my existing "04 ARCHIVES" label to thread-1 and thread-2.',
+            },
+          ];
 
-          const labelThreadsMatch = getLastMatchingToolCall(
-            toolCalls,
-            "manageInbox",
-            isManageInboxLabelThreadsInput,
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const labelThreadsMatch = getLastMatchingToolCall(
+                toolCalls,
+                "manageInbox",
+                isManageInboxLabelThreadsInput,
+              );
+              const labelThreadsCall = labelThreadsMatch?.input ?? null;
+              const pass =
+                !!labelThreadsCall &&
+                labelThreadsCall.action === "label_threads" &&
+                labelThreadsCall.labelName === "04 ARCHIVES" &&
+                labelThreadsCall.threadIds.length === 2 &&
+                labelThreadsCall.threadIds.includes("thread-1") &&
+                labelThreadsCall.threadIds.includes("thread-2") &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "createOrGetLabel" &&
+                    isCreateOrGetLabelInput(toolCall.input),
+                ) &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "listLabels" &&
+                    isListLabelsInput(toolCall.input),
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual,
+              };
+            },
           );
-          const labelThreadsCall = labelThreadsMatch?.input ?? null;
-          const pass =
-            !!labelThreadsCall &&
-            labelThreadsCall.action === "label_threads" &&
-            labelThreadsCall.labelName === "04 ARCHIVES" &&
-            labelThreadsCall.threadIds.length === 2 &&
-            labelThreadsCall.threadIds.includes("thread-1") &&
-            labelThreadsCall.threadIds.includes("thread-2") &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "createOrGetLabel" &&
-                isCreateOrGetLabelInput(toolCall.input),
-            ) &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "listLabels" &&
-                isListLabelsInput(toolCall.input),
-            );
 
-          evalReporter.record({
-            testName: "apply spaced existing label to explicit threads",
-            model: model.label,
-            pass,
-            actual,
-          });
-
-          expect(pass).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
@@ -173,8 +173,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };
@@ -237,8 +235,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 labelThreadsIndex > createOrGetIndex;
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };
@@ -288,8 +284,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };
@@ -343,8 +337,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };
@@ -399,8 +391,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };
@@ -461,8 +451,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual,
               };

--- a/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-memory-safety.test.ts
@@ -190,8 +190,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat memory safety", () => {
               const evaluation = await evaluateScenario(result, scenario);
 
               return {
-                testName: scenario.reportName,
-                model: model.label,
                 pass: evaluation.pass,
                 actual: evaluation.actual,
               };

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
+import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
 import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 import {
   cloneEmailAccountForProvider,
@@ -65,7 +66,12 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
               testName,
               model: model.label,
               cacheKeyParts: [
-                { model, provider: "microsoft", searchMessages, messages },
+                {
+                  model,
+                  provider: "microsoft",
+                  searchMessages: getStableMessageCacheKey(searchMessages),
+                  messages,
+                },
               ],
             },
             async () => {

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -105,8 +105,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual: `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
                   movedThreadIds,
@@ -159,8 +157,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual: `${actual} | folderName=${folderCall?.name ?? "none"}`,
               };
@@ -214,8 +210,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
                 );
 
               return {
-                testName,
-                model: model.label,
                 pass,
                 actual: `${actual} | output=${outputText}`,
               };

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -21,7 +21,9 @@ import {
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-outlook-folders.test.ts
 
 const shouldRunEval = shouldRunEvalTests();
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-outlook-folders",
+});
 
 describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
   setupInboxWorkflowEval();
@@ -32,75 +34,88 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
       test(
         "moves searched messages to an Outlook folder",
         async () => {
-          mockSearchMessages.mockResolvedValueOnce({
-            messages: [
-              getMockMessage({
-                id: "msg-folder-move-1",
-                threadId: "thread-folder-move-1",
-                from: "updates@vendor.example",
-                subject: "Release update",
-                snippet: "A release note for review.",
-                labelIds: ["INBOX"],
-              }),
-              getMockMessage({
-                id: "msg-folder-move-2",
-                threadId: "thread-folder-move-2",
-                from: "updates@vendor.example",
-                subject: "Maintenance update",
-                snippet: "A maintenance notice for review.",
-                labelIds: ["INBOX"],
-              }),
-            ],
-            nextPageToken: undefined,
-          });
+          const testName = "outlook folder move uses folder tool after search";
+          const searchMessages = [
+            getMockMessage({
+              id: "msg-folder-move-1",
+              threadId: "thread-folder-move-1",
+              from: "updates@vendor.example",
+              subject: "Release update",
+              snippet: "A release note for review.",
+              labelIds: ["INBOX"],
+            }),
+            getMockMessage({
+              id: "msg-folder-move-2",
+              threadId: "thread-folder-move-2",
+              from: "updates@vendor.example",
+              subject: "Maintenance update",
+              snippet: "A maintenance notice for review.",
+              labelIds: ["INBOX"],
+            }),
+          ];
+          const messages = [
+            {
+              role: "user" as const,
+              content: `Move the two vendor update emails to my Operations${FOLDER_SEPARATOR}Reports Outlook folder.`,
+            },
+          ];
 
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount: cloneEmailAccountForProvider(
-              emailAccount,
-              "microsoft",
-            ),
-            messages: [
-              {
-                role: "user",
-                content: `Move the two vendor update emails to my Operations${FOLDER_SEPARATOR}Reports Outlook folder.`,
-              },
-            ],
-          });
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [
+                { model, provider: "microsoft", searchMessages, messages },
+              ],
+            },
+            async () => {
+              mockSearchMessages.mockResolvedValueOnce({
+                messages: searchMessages,
+                nextPageToken: undefined,
+              });
 
-          const moveCall = getLastMatchingToolCall(
-            toolCalls,
-            "moveThreadsToFolder",
-            isMoveThreadsToFolderInput,
-          )?.input;
-          const movedThreadIds = new Set(moveCall?.threadIds ?? []);
-          const movedToNestedFolder = mockMoveThreadToFolder.mock.calls.every(
-            ([, , folderId]) => folderId === "folder-operations-reports",
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount: cloneEmailAccountForProvider(
+                  emailAccount,
+                  "microsoft",
+                ),
+                messages,
+              });
+
+              const moveCall = getLastMatchingToolCall(
+                toolCalls,
+                "moveThreadsToFolder",
+                isMoveThreadsToFolderInput,
+              )?.input;
+              const movedThreadIds = new Set(moveCall?.threadIds ?? []);
+              const movedToNestedFolder =
+                mockMoveThreadToFolder.mock.calls.every(
+                  ([, , folderId]) => folderId === "folder-operations-reports",
+                );
+              const pass =
+                !!moveCall &&
+                hasSearchBeforeTool(toolCalls, "moveThreadsToFolder") &&
+                movedThreadIds.has("thread-folder-move-1") &&
+                movedThreadIds.has("thread-folder-move-2") &&
+                normalizeFolderName(moveCall.folderName).includes("reports") &&
+                mockMoveThreadToFolder.mock.calls.length === 2 &&
+                movedToNestedFolder &&
+                !toolCalls.some(
+                  (toolCall) => toolCall.toolName === "manageInbox",
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual: `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
+                  movedThreadIds,
+                ).join(",")}`,
+              };
+            },
           );
-          const pass =
-            !!moveCall &&
-            hasSearchBeforeTool(toolCalls, "moveThreadsToFolder") &&
-            movedThreadIds.has("thread-folder-move-1") &&
-            movedThreadIds.has("thread-folder-move-2") &&
-            normalizeFolderName(moveCall.folderName).includes("reports") &&
-            mockMoveThreadToFolder.mock.calls.length === 2 &&
-            movedToNestedFolder &&
-            !toolCalls.some((toolCall) => toolCall.toolName === "manageInbox");
 
-          evalReporter.record({
-            testName: "outlook folder move uses folder tool after search",
-            model: model.label,
-            pass,
-            actual: `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
-              movedThreadIds,
-            ).join(",")}`,
-          });
-
-          expect(
-            pass,
-            `${actual} | folderName=${moveCall?.folderName ?? "none"} | moved=${Array.from(
-              movedThreadIds,
-            ).join(",")}`,
-          ).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -108,42 +123,51 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
       test(
         "creates or reuses an Outlook folder when explicitly asked",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount: cloneEmailAccountForProvider(
-              emailAccount,
-              "microsoft",
-            ),
-            messages: [
-              {
-                role: "user",
-                content:
-                  "Make sure I have an Outlook folder called Vendor Updates.",
-              },
-            ],
-          });
+          const testName = "outlook explicit folder create uses folder tool";
+          const messages = [
+            {
+              role: "user" as const,
+              content:
+                "Make sure I have an Outlook folder called Vendor Updates.",
+            },
+          ];
 
-          const folderCall = getLastMatchingToolCall(
-            toolCalls,
-            "createOrGetFolder",
-            isCreateOrGetFolderInput,
-          )?.input;
-          const pass =
-            normalizeFolderName(folderCall?.name) === "vendor updates" &&
-            !toolCalls.some(
-              (toolCall) => toolCall.toolName === "createOrGetCategory",
-            );
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, provider: "microsoft", messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount: cloneEmailAccountForProvider(
+                  emailAccount,
+                  "microsoft",
+                ),
+                messages,
+              });
 
-          evalReporter.record({
-            testName: "outlook explicit folder create uses folder tool",
-            model: model.label,
-            pass,
-            actual: `${actual} | folderName=${folderCall?.name ?? "none"}`,
-          });
+              const folderCall = getLastMatchingToolCall(
+                toolCalls,
+                "createOrGetFolder",
+                isCreateOrGetFolderInput,
+              )?.input;
+              const pass =
+                normalizeFolderName(folderCall?.name) === "vendor updates" &&
+                !toolCalls.some(
+                  (toolCall) => toolCall.toolName === "createOrGetCategory",
+                );
 
-          expect(
-            pass,
-            `${actual} | folderName=${folderCall?.name ?? "none"}`,
-          ).toBe(true);
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual: `${actual} | folderName=${folderCall?.name ?? "none"}`,
+              };
+            },
+          );
+
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );
@@ -151,42 +175,54 @@ describe.runIf(shouldRunEval)("Eval: assistant chat Outlook folders", () => {
       test(
         "lists Outlook folders without exposing internal folder ids",
         async () => {
-          const { toolCalls, actual } = await runAssistantChat({
-            emailAccount: cloneEmailAccountForProvider(
-              emailAccount,
-              "microsoft",
-            ),
-            messages: [
-              {
-                role: "user",
-                content: "Show me my Outlook folders.",
-              },
-            ],
-          });
+          const testName = "outlook folder listing hides internal ids";
+          const messages = [
+            {
+              role: "user" as const,
+              content: "Show me my Outlook folders.",
+            },
+          ];
 
-          const listCall = toolCalls.find(
-            (toolCall) => toolCall.toolName === "listFolders",
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, provider: "microsoft", messages }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount: cloneEmailAccountForProvider(
+                  emailAccount,
+                  "microsoft",
+                ),
+                messages,
+              });
+
+              const listCall = toolCalls.find(
+                (toolCall) => toolCall.toolName === "listFolders",
+              );
+              const outputText = JSON.stringify(listCall?.output ?? {});
+              const pass =
+                !!listCall &&
+                outputText.includes(`Operations${FOLDER_SEPARATOR}Reports`) &&
+                !outputText.includes("folder-operations") &&
+                !outputText.includes("folder-vendor-updates") &&
+                !toolCalls.some(
+                  (toolCall) =>
+                    toolCall.toolName === "listCategories" ||
+                    toolCall.toolName === "createOrGetCategory",
+                );
+
+              return {
+                testName,
+                model: model.label,
+                pass,
+                actual: `${actual} | output=${outputText}`,
+              };
+            },
           );
-          const outputText = JSON.stringify(listCall?.output ?? {});
-          const pass =
-            !!listCall &&
-            outputText.includes(`Operations${FOLDER_SEPARATOR}Reports`) &&
-            !outputText.includes("folder-operations") &&
-            !outputText.includes("folder-vendor-updates") &&
-            !toolCalls.some(
-              (toolCall) =>
-                toolCall.toolName === "listCategories" ||
-                toolCall.toolName === "createOrGetCategory",
-            );
 
-          evalReporter.record({
-            testName: "outlook folder listing hides internal ids",
-            model: model.label,
-            pass,
-            actual: `${actual} | output=${outputText}`,
-          });
-
-          expect(pass, `${actual} | output=${outputText}`).toBe(true);
+          expect(record.pass, record.actual).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
@@ -148,8 +148,6 @@ describe.runIf(shouldRunEval)(
                   !usesSenderCategoryExecutionPath(toolCalls);
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual,
                 };
@@ -221,8 +219,6 @@ describe.runIf(shouldRunEval)(
                   !hasToolCall(toolCalls, "getSenderCategorizationStatus");
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual,
                 };
@@ -316,8 +312,6 @@ describe.runIf(shouldRunEval)(
                         firstSearchCall > lastStatusCall)));
 
                 return {
-                  testName,
-                  model: model.label,
                   pass,
                   actual,
                 };

--- a/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
@@ -18,7 +18,9 @@ import {
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts
 
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-sender-category-cleanup",
+});
 
 const hoisted = vi.hoisted(() => ({
   mockGetCategoryOverview: vi.fn(),
@@ -74,64 +76,87 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "generic cleanup stays search-led instead of entering sender categorization [$label]",
           async ({ provider, label }) => {
-            mockSearchMessages.mockResolvedValueOnce({
-              messages: [
-                getMockMessage({
-                  id: "msg-cleanup-1",
-                  threadId: "thread-cleanup-1",
-                  from: "founder@client.example",
-                  subject: "Need approval today",
-                  snippet: "Can you confirm the revised rollout before 3pm?",
-                  labelIds: ["UNREAD"],
-                }),
-                getMockMessage({
-                  id: "msg-cleanup-2",
-                  threadId: "thread-cleanup-2",
-                  from: "updates@vendor.example",
-                  subject: "Weekly product digest",
-                  snippet: "Here is the latest vendor platform update.",
-                  labelIds: [],
-                }),
-                getMockMessage({
-                  id: "msg-cleanup-3",
-                  threadId: "thread-cleanup-3",
-                  from: "receipts@bank.example",
-                  subject: "Your monthly receipt",
-                  snippet: "Receipt for your March statement.",
-                  labelIds: [],
-                }),
-              ],
-              nextPageToken: undefined,
-            });
+            const testName = `generic cleanup stays search-led (${label})`;
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-cleanup-1",
+                threadId: "thread-cleanup-1",
+                from: "founder@client.example",
+                subject: "Need approval today",
+                snippet: "Can you confirm the revised rollout before 3pm?",
+                labelIds: ["UNREAD"],
+              }),
+              getMockMessage({
+                id: "msg-cleanup-2",
+                threadId: "thread-cleanup-2",
+                from: "updates@vendor.example",
+                subject: "Weekly product digest",
+                snippet: "Here is the latest vendor platform update.",
+                labelIds: [],
+              }),
+              getMockMessage({
+                id: "msg-cleanup-3",
+                threadId: "thread-cleanup-3",
+                from: "receipts@bank.example",
+                subject: "Your monthly receipt",
+                snippet: "Receipt for your March statement.",
+                labelIds: [],
+              }),
+            ];
+            const inboxStats = { total: 188, unread: 9 };
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Clean up my inbox.",
+              },
+            ];
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              inboxStats: { total: 188, unread: 9 },
-              messages: [
-                {
-                  role: "user",
-                  content: "Clean up my inbox.",
-                },
-              ],
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  {
+                    model,
+                    provider,
+                    label,
+                    searchMessages,
+                    inboxStats,
+                    messages,
+                  },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
 
-            const searchCall = getFirstSearchInboxCall(toolCalls);
-            const pass =
-              !!searchCall &&
-              hasSearchBeforeFirstWrite(toolCalls) &&
-              !usesSenderCategoryExecutionPath(toolCalls);
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  inboxStats,
+                  messages,
+                });
 
-            evalReporter.record({
-              testName: `generic cleanup stays search-led (${label})`,
-              model: model.label,
-              pass,
-              actual,
-            });
+                const searchCall = getFirstSearchInboxCall(toolCalls);
+                const pass =
+                  !!searchCall &&
+                  hasSearchBeforeFirstWrite(toolCalls) &&
+                  !usesSenderCategoryExecutionPath(toolCalls);
 
-            expect(pass).toBe(true);
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );
@@ -139,49 +164,72 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "explicit category cleanup uses category tools when coverage is ready [$label]",
           async ({ provider, label }) => {
-            hoisted.mockGetCategoryOverview.mockResolvedValueOnce(
-              buildReadyCategoryOverview(),
+            const testName = `ready category cleanup uses category tools (${label})`;
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Archive the Newsletters category.",
+              },
+            ];
+            const readyCategoryOverview = buildReadyCategoryOverview();
+            const archiveCategoryResult = buildArchiveCategoryResult();
+
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  {
+                    model,
+                    provider,
+                    label,
+                    messages,
+                    readyCategoryOverview,
+                    archiveCategoryResult,
+                  },
+                ],
+              },
+              async () => {
+                hoisted.mockGetCategoryOverview.mockResolvedValueOnce(
+                  readyCategoryOverview,
+                );
+                hoisted.mockArchiveCategory.mockResolvedValueOnce(
+                  archiveCategoryResult,
+                );
+
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  messages,
+                });
+
+                const overviewCall = getFirstToolCallIndex(
+                  toolCalls,
+                  "getSenderCategoryOverview",
+                );
+                const manageCall =
+                  getFirstMatchingManageSenderCategoryCall(toolCalls);
+                const pass =
+                  overviewCall >= 0 &&
+                  !!manageCall &&
+                  overviewCall < manageCall.index &&
+                  referencesNewslettersCategory(manageCall.input) &&
+                  !hasToolCall(toolCalls, "searchInbox") &&
+                  !hasToolCall(toolCalls, "startSenderCategorization") &&
+                  !hasToolCall(toolCalls, "getSenderCategorizationStatus");
+
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual,
+                };
+              },
             );
-            hoisted.mockArchiveCategory.mockResolvedValueOnce(
-              buildArchiveCategoryResult(),
-            );
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              messages: [
-                {
-                  role: "user",
-                  content: "Archive the Newsletters category.",
-                },
-              ],
-            });
-
-            const overviewCall = getFirstToolCallIndex(
-              toolCalls,
-              "getSenderCategoryOverview",
-            );
-            const manageCall =
-              getFirstMatchingManageSenderCategoryCall(toolCalls);
-            const pass =
-              overviewCall >= 0 &&
-              !!manageCall &&
-              overviewCall < manageCall.index &&
-              referencesNewslettersCategory(manageCall.input) &&
-              !hasToolCall(toolCalls, "searchInbox") &&
-              !hasToolCall(toolCalls, "startSenderCategorization") &&
-              !hasToolCall(toolCalls, "getSenderCategorizationStatus");
-
-            evalReporter.record({
-              testName: `ready category cleanup uses category tools (${label})`,
-              model: model.label,
-              pass,
-              actual,
-            });
-
-            expect(pass).toBe(true);
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );
@@ -189,64 +237,94 @@ describe.runIf(shouldRunEval)(
         test.each(inboxWorkflowProviders)(
           "missing category coverage starts categorization before any search fallback [$label]",
           async ({ provider, label }) => {
-            hoisted.mockGetCategoryOverview.mockResolvedValue(
-              buildUnreadyCategoryOverview(),
-            );
-            hoisted.mockStartBulkCategorization.mockResolvedValueOnce(
-              buildStartCategorizationResult(),
-            );
-            hoisted.mockGetCategorizationProgress.mockResolvedValue(
-              buildRunningCategorizationProgress(),
+            const testName = `missing coverage starts categorization before fallback (${label})`;
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Archive the Newsletters category.",
+              },
+            ];
+            const unreadyCategoryOverview = buildUnreadyCategoryOverview();
+            const startCategorizationResult = buildStartCategorizationResult();
+            const runningCategorizationProgress =
+              buildRunningCategorizationProgress();
+
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  {
+                    model,
+                    provider,
+                    label,
+                    messages,
+                    unreadyCategoryOverview,
+                    startCategorizationResult,
+                    runningCategorizationProgress,
+                  },
+                ],
+              },
+              async () => {
+                hoisted.mockGetCategoryOverview.mockResolvedValue(
+                  unreadyCategoryOverview,
+                );
+                hoisted.mockStartBulkCategorization.mockResolvedValueOnce(
+                  startCategorizationResult,
+                );
+                hoisted.mockGetCategorizationProgress.mockResolvedValue(
+                  runningCategorizationProgress,
+                );
+
+                const { toolCalls, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  messages,
+                });
+
+                const overviewCall = getFirstToolCallIndex(
+                  toolCalls,
+                  "getSenderCategoryOverview",
+                );
+                const startCall = getFirstToolCallIndex(
+                  toolCalls,
+                  "startSenderCategorization",
+                );
+                const statusCalls =
+                  getSenderCategorizationStatusCalls(toolCalls);
+                const firstSearchCall = getFirstToolCallIndex(
+                  toolCalls,
+                  "searchInbox",
+                );
+                const lastStatusCall = getLastToolCallIndex(
+                  toolCalls,
+                  "getSenderCategorizationStatus",
+                );
+                const pass =
+                  overviewCall >= 0 &&
+                  startCall > overviewCall &&
+                  !hasToolCall(toolCalls, "manageSenderCategory") &&
+                  statusCalls.length <= 3 &&
+                  statusCalls.every(
+                    (toolCall) => toolCall.input.waitMs <= 1500,
+                  ) &&
+                  (firstSearchCall < 0 ||
+                    (firstSearchCall > startCall &&
+                      (lastStatusCall < 0 ||
+                        firstSearchCall > lastStatusCall)));
+
+                return {
+                  testName,
+                  model: model.label,
+                  pass,
+                  actual,
+                };
+              },
             );
 
-            const { toolCalls, actual } = await runAssistantChat({
-              emailAccount: cloneEmailAccountForProvider(
-                emailAccount,
-                provider,
-              ),
-              messages: [
-                {
-                  role: "user",
-                  content: "Archive the Newsletters category.",
-                },
-              ],
-            });
-
-            const overviewCall = getFirstToolCallIndex(
-              toolCalls,
-              "getSenderCategoryOverview",
-            );
-            const startCall = getFirstToolCallIndex(
-              toolCalls,
-              "startSenderCategorization",
-            );
-            const statusCalls = getSenderCategorizationStatusCalls(toolCalls);
-            const firstSearchCall = getFirstToolCallIndex(
-              toolCalls,
-              "searchInbox",
-            );
-            const lastStatusCall = getLastToolCallIndex(
-              toolCalls,
-              "getSenderCategorizationStatus",
-            );
-            const pass =
-              overviewCall >= 0 &&
-              startCall > overviewCall &&
-              !hasToolCall(toolCalls, "manageSenderCategory") &&
-              statusCalls.length <= 3 &&
-              statusCalls.every((toolCall) => toolCall.input.waitMs <= 1500) &&
-              (firstSearchCall < 0 ||
-                (firstSearchCall > startCall &&
-                  (lastStatusCall < 0 || firstSearchCall > lastStatusCall)));
-
-            evalReporter.record({
-              testName: `missing coverage starts categorization before fallback (${label})`,
-              model: model.label,
-              pass,
-              actual,
-            });
-
-            expect(pass).toBe(true);
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );

--- a/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
@@ -2,7 +2,10 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { describeEvalMatrix } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
-import type { RecordedToolCall } from "@/__tests__/eval/assistant-chat-eval-utils";
+import {
+  getStableMessageCacheKey,
+  type RecordedToolCall,
+} from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -120,7 +123,7 @@ describe.runIf(shouldRunEval)(
                     model,
                     provider,
                     label,
-                    searchMessages,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
                     inboxStats,
                     messages,
                   },

--- a/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   captureAssistantChatToolCalls,
   getLastMatchingToolCall,
+  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
@@ -275,7 +276,9 @@ describe.runIf(shouldRunEval)("Eval: assistant chat trash/delete", () => {
               {
                 testName: scenario.reportName,
                 model: model.label,
-                cacheKeyParts: [{ model, scenario, messages }],
+                cacheKeyParts: [
+                  { model, scenario: getScenarioCacheKey(scenario), messages },
+                ],
               },
               async () => {
                 if (scenario.searchMessages) {
@@ -365,6 +368,14 @@ type EvalScenario = {
   searchMessages?: ReturnType<typeof getMockMessage>[];
   expectation: ScenarioExpectation;
 };
+
+function getScenarioCacheKey(scenario: EvalScenario) {
+  return {
+    ...scenario,
+    prefillSearch: getStableMessageCacheKey(scenario.prefillSearch),
+    searchMessages: getStableMessageCacheKey(scenario.searchMessages),
+  };
+}
 
 function isManageInboxInput(input: unknown): input is ManageInboxInput {
   return (

--- a/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
@@ -25,7 +25,9 @@ import type { getEmailAccount } from "@/__tests__/helpers";
 
 const shouldRunEval = shouldRunEvalTests();
 const TIMEOUT = 60_000;
-const evalReporter = createEvalReporter();
+const evalReporter = createEvalReporter({
+  evalName: "assistant-chat-trash-delete",
+});
 const logger = createScopedLogger("eval-assistant-chat-trash-delete");
 
 const spamMessages = [
@@ -255,13 +257,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat trash/delete", () => {
         test(
           scenario.title,
           async () => {
-            if (scenario.searchMessages) {
-              mockSearchMessages.mockResolvedValueOnce({
-                messages: scenario.searchMessages,
-                nextPageToken: undefined,
-              });
-            }
-
             const messages: ModelMessage[] = [];
 
             if (scenario.prefillSearch) {
@@ -276,25 +271,41 @@ describe.runIf(shouldRunEval)("Eval: assistant chat trash/delete", () => {
 
             messages.push({ role: "user", content: scenario.prompt });
 
-            const result = await runAssistantChat({
-              emailAccount,
-              messages,
-            });
+            const record = await evalReporter.recordCached(
+              {
+                testName: scenario.reportName,
+                model: model.label,
+                cacheKeyParts: [{ model, scenario, messages }],
+              },
+              async () => {
+                if (scenario.searchMessages) {
+                  mockSearchMessages.mockResolvedValueOnce({
+                    messages: scenario.searchMessages,
+                    nextPageToken: undefined,
+                  });
+                }
 
-            const evaluation = await evaluateScenario(
-              result,
-              scenario.prompt,
-              scenario.expectation,
+                const result = await runAssistantChat({
+                  emailAccount,
+                  messages,
+                });
+
+                const evaluation = await evaluateScenario(
+                  result,
+                  scenario.prompt,
+                  scenario.expectation,
+                );
+
+                return {
+                  testName: scenario.reportName,
+                  model: model.label,
+                  pass: evaluation.pass,
+                  actual: evaluation.actual,
+                };
+              },
             );
 
-            evalReporter.record({
-              testName: scenario.reportName,
-              model: model.label,
-              pass: evaluation.pass,
-              actual: evaluation.actual,
-            });
-
-            expect(evaluation.pass).toBe(true);
+            expect(record.pass, record.actual).toBe(true);
           },
           TIMEOUT,
         );

--- a/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
@@ -297,8 +297,6 @@ describe.runIf(shouldRunEval)("Eval: assistant chat trash/delete", () => {
                 );
 
                 return {
-                  testName: scenario.reportName,
-                  model: model.label,
                   pass: evaluation.pass,
                   actual: evaluation.actual,
                 };

--- a/apps/web/__tests__/eval/reply-guidance-grounding.test.ts
+++ b/apps/web/__tests__/eval/reply-guidance-grounding.test.ts
@@ -79,8 +79,6 @@ Can you check why it is still firing?`,
               });
 
               return {
-                testName,
-                model: model.label,
                 pass: judgeResult.pass,
                 expected: "no stale request for already-provided details",
                 actual: formatSemanticJudgeActual(output, judgeResult),
@@ -165,8 +163,6 @@ Can you check why it is still firing?`,
               });
 
               return {
-                testName,
-                model: model.label,
                 pass: judgeResult.pass,
                 expected: "does not ask for already-provided account details",
                 actual: formatSemanticJudgeActual(result.reply, judgeResult),

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -36,6 +36,10 @@ interface CachedEvalFile {
   schemaVersion: 1;
 }
 
+// `recordCached` always sets `model` and `testName` from its options, so the
+// callback only returns the parts that vary per run.
+type EvalRunResult = Omit<EvalRecord, "model" | "testName">;
+
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -61,7 +65,7 @@ class EvalReporter {
 
   async recordCached(
     options: CachedEvalOptions,
-    run: () => Promise<EvalRecord>,
+    run: () => Promise<EvalRunResult>,
   ): Promise<EvalRecord> {
     const cacheMode = getEvalResultCacheMode();
     const cacheKey = buildEvalCacheKey({


### PR DESCRIPTION
Adds cached result recording to additional assistant eval suites.

- Migrates inbox workflow triage and search evals to use cached result records.
- Migrates Outlook folder evals to use cached result records.
- Keeps cache keys tied to model, provider, prompts, and mocked fixture inputs.

Tests: `pnpm test __tests__/eval/assistant-chat-inbox-workflows-triage.test.ts`; `pnpm test __tests__/eval/assistant-chat-inbox-workflows-search.test.ts`; `pnpm test __tests__/eval/assistant-chat-outlook-folders.test.ts`; `pnpm --filter inbox-zero-ai exec biome check ...`