### PR TITLE
messaging: Fix notification formatting

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -330,8 +330,8 @@ describe("buildPendingEmailConfirmationCard", () => {
       .map((child) => child.content);
 
     expect(textChildren[0]).toContain("first\\_last@outlook.com");
-    expect(textChildren[0]).toContain("Plan \\[draft]");
-    expect(textChildren[1]).toContain("foo\\_bar \\*soon\\* \\[ok]");
+    expect(textChildren[0]).toContain("Plan \\[draft\\]");
+    expect(textChildren[1]).toContain("foo\\_bar \\*soon\\* \\[ok\\]");
   });
 
   it("leaves non-Telegram pending email card text unchanged", () => {

--- a/apps/web/utils/messaging/providers/telegram/format.test.ts
+++ b/apps/web/utils/messaging/providers/telegram/format.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramText } from "./format";
+import { escapeTelegramMarkdown, markdownToTelegramText } from "./format";
+
+describe("escapeTelegramMarkdown", () => {
+  it("escapes link-shaped text and URLs for Telegram", () => {
+    const input =
+      "Review [portal](https://example.com/a_(b)?x=1.2) and foo_bar *soon*!";
+
+    expect(escapeTelegramMarkdown(input)).toBe(
+      "Review \\[portal\\]\\(https://example.com/a\\_\\(b\\)?x=1.2\\) and foo\\_bar \\*soon\\*!",
+    );
+  });
+});
 
 describe("markdownToTelegramText", () => {
   it("normalizes escaped markdown from assistant output", () => {

--- a/apps/web/utils/messaging/providers/telegram/format.ts
+++ b/apps/web/utils/messaging/providers/telegram/format.ts
@@ -1,5 +1,5 @@
 export function escapeTelegramMarkdown(text: string): string {
-  return text.replace(/([\\_*`[])/g, "\\$1");
+  return text.replace(/([\\_*`[\]()])/g, "\\$1");
 }
 
 export function markdownToTelegramText(text: string): string {

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -2090,7 +2090,7 @@ describe("sendMessagingRuleNotification", () => {
     expect(cardText).not.toContain("*They wrote:*");
     expect(cardText).not.toContain("Sender_Name");
     expect(cardText).toContain("Sender\\_Name");
-    expect(cardText).toContain("\\[billing]");
+    expect(cardText).toContain("\\[billing\\]");
     expect(cardText).toContain("5 \\* 6");
     expect(cardText).toContain(String.raw`C:\\labels\\account\_name`);
   });


### PR DESCRIPTION
Fixes a formatting edge case that could cause messaging notifications to be rejected by a provider.

- Escape additional markdown control characters in messaging notification text
- Add regression coverage for link-shaped notification content

Performance impact: negligible string escaping work only; no added database queries or network calls.