### PR TITLE
Fix account deletion transaction lock

### DIFF
--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -71,6 +71,7 @@ describe("deleteEmailAccountAction", () => {
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
     expect(prisma.$queryRaw).toHaveBeenCalledWith(
       expect.arrayContaining([
+        expect.stringContaining("SELECT true AS locked"),
         expect.stringContaining("pg_advisory_xact_lock"),
       ]),
       "user-1",

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -196,7 +196,10 @@ async function runDeleteEmailAccountTransaction(
   try {
     await prisma.$transaction([
       prisma.$queryRaw`
-        SELECT pg_advisory_xact_lock(539114481, hashtext(${userId}))
+        SELECT true AS locked
+        FROM (
+          SELECT pg_advisory_xact_lock(539114481, hashtext(${userId}))
+        ) lock
       `,
       ...operations,
     ]);


### PR DESCRIPTION
Fixes a server-action transaction failure by making the advisory lock query return a Prisma-readable value while preserving the lock behavior.

- Keeps the account deletion transaction protected by the same advisory lock.
- Adds a regression assertion for the lock query shape.

Tested with `pnpm test utils/actions/user.test.ts`.