### PR TITLE
reply: Handle inline image markers in drafts

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -1217,6 +1217,76 @@ Dana`,
       );
 
       test(
+        "does not claim inline screenshots are unavailable",
+        async () => {
+          const messages = [
+            {
+              ...getEmail({
+                from: "Jordan Blake <jordan@customer.example>",
+                to: emailAccount.email,
+                subject: "Setup error",
+                content: `Hi,
+
+I tried again but I get this error message:
+
+[image: setup error screenshot]
+
+What should I do next?
+
+Thanks,
+Jordan`,
+              }),
+              date: new Date("2026-05-04T10:15:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent: null,
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+          });
+
+          const testName = "inline screenshot placeholder";
+          const judgeResult = await judgeEvalOutput({
+            input: formatThreadForJudge(messages),
+            output: result.reply,
+            expected:
+              "A natural support-style reply that treats the inline screenshot as present in the email and does not claim the image, screenshot, or attachment is missing, inaccessible, invisible, or unreadable. It may ask for the exact error text or a relevant detail if needed.",
+            criterion: {
+              name: "Inline image treated as present",
+              description:
+                "The draft should not tell the sender that the image cannot be seen, read, opened, accessed, or found. The sender included the screenshot; only the drafting model lacks visual details. The reply should proceed naturally from the surrounding text and optional image label.",
+            },
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected: "no claim that inline screenshot is unavailable",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should treat the inline screenshot as present.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
         "mentions selected attachment when attachment context is provided",
         async () => {
           const messages = [

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 16;
+export const DRAFT_PIPELINE_VERSION = 17;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -37,6 +37,7 @@ Never use placeholders for the user's name. You do not need to sign off with the
 Do not invent information.
 Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
 When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
+Inline image markers such as [image] or [image: ...] mean a real image exists in the email. Do not say it is missing or unreadable; respond from the available text and image label.
 Treat email dates as message metadata, not calendar context.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.


### PR DESCRIPTION
Updates draft reply guidance so inline image markers are treated as present email content instead of unavailable model input.

- Adds semantic eval coverage for inline image placeholders.
- Bumps the draft pipeline version for attribution.