### PR TITLE
Fix entity normalization in similarity scoring

### DIFF
--- a/apps/web/utils/similarity-score.test.ts
+++ b/apps/web/utils/similarity-score.test.ts
@@ -268,6 +268,16 @@ Company
       expect(score).toBe(1.0);
     });
 
+    it("should decode named HTML entities before comparing plain text signatures", () => {
+      const storedContent = "Thanks for the update.\n\n&lt;3 Team";
+      const gmailMessage = createParsedMessage(
+        "Thanks for the update.\n\n<3 Team",
+      );
+
+      const score = realCalculateSimilarity(storedContent, gmailMessage);
+      expect(score).toBe(1.0);
+    });
+
     it.each([
       { emoji: "👋", hex: "&#x1F44B;", name: "waving hand" },
       { emoji: "😀", hex: "&#x1F600;", name: "grinning face" },

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -1,3 +1,4 @@
+import he from "he";
 import * as stringSimilarity from "string-similarity";
 import {
   convertEmailHtmlToText,
@@ -75,7 +76,8 @@ function decodeHtmlEntities(text: string): string {
         return match;
       }
       return String.fromCodePoint(codePoint);
-    });
+    })
+    .replace(/&[a-zA-Z][a-zA-Z0-9]+;/g, (match) => he.decode(match));
 }
 
 /**


### PR DESCRIPTION
Decode named HTML entities before draft similarity comparisons so equivalent text scores consistently.

- Reuses the existing HTML entity decoder for named entities.
- Adds a regression test for equivalent plain text signature content.

Tested with `pnpm test utils/similarity-score.test.ts`.