### PR TITLE
Fix assistant reply draft reuse

### DIFF
--- a/apps/web/utils/actions/assistant-chat-confirmation.ts
+++ b/apps/web/utils/actions/assistant-chat-confirmation.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { Prisma } from "@/generated/prisma/client";
+import { DraftEmailStatus } from "@/generated/prisma/enums";
 import { SafeError } from "@/utils/error";
 import { createEmailProvider } from "@/utils/email/provider";
 import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
@@ -121,6 +122,7 @@ export async function confirmAssistantEmailActionForAccount({
       emailProvider,
       emailAccountId,
       contentOverride,
+      logger,
     });
   } catch (error) {
     await clearPendingPartProcessing({
@@ -413,11 +415,13 @@ async function executeAssistantEmailAction({
   emailProvider,
   emailAccountId,
   contentOverride,
+  logger,
 }: {
   output: AssistantPendingEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   emailAccountId: string;
   contentOverride?: string;
+  logger: Logger;
 }): Promise<AssistantEmailConfirmationResult> {
   const confirmedAt = new Date().toISOString();
 
@@ -437,6 +441,7 @@ async function executeAssistantEmailAction({
         emailAccountId,
         confirmedAt,
         contentOverride,
+        logger,
       });
     case "forward_email":
       return confirmPendingForwardEmailAction({
@@ -467,7 +472,7 @@ async function confirmPendingSendEmailAction({
     (await getFormattedSenderAddress({ emailAccountId }));
 
   const messageHtml = contentOverride
-    ? convertNewlinesToBr(escapeHtml(contentOverride))
+    ? toMessageHtml(contentOverride)
     : output.pendingAction.messageHtml;
   const sentAfter = new Date();
 
@@ -502,13 +507,26 @@ async function confirmPendingReplyEmailAction({
   emailAccountId,
   confirmedAt,
   contentOverride,
+  logger,
 }: {
   output: PendingReplyEmailToolOutput;
   emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
   emailAccountId: string;
   confirmedAt: string;
   contentOverride?: string;
+  logger: Logger;
 }) {
+  if (output.pendingAction.existingDraftId) {
+    return confirmExistingDraftReplyAction({
+      output,
+      existingDraftId: output.pendingAction.existingDraftId,
+      emailProvider,
+      confirmedAt,
+      contentOverride,
+      logger,
+    });
+  }
+
   const sourceMessage = await emailProvider.getMessage(
     output.pendingAction.messageId,
   );
@@ -539,6 +557,72 @@ async function confirmPendingReplyEmailAction({
     subject: message.subject || message.headers.subject || null,
     confirmedAt,
   };
+}
+
+async function confirmExistingDraftReplyAction({
+  output,
+  existingDraftId,
+  emailProvider,
+  confirmedAt,
+  contentOverride,
+  logger,
+}: {
+  output: PendingReplyEmailToolOutput;
+  existingDraftId: string;
+  emailProvider: Awaited<ReturnType<typeof createEmailProvider>>;
+  confirmedAt: string;
+  contentOverride?: string;
+  logger: Logger;
+}) {
+  if (contentOverride) {
+    await emailProvider.updateDraft(existingDraftId, {
+      messageHtml: toMessageHtml(contentOverride),
+    });
+  }
+
+  const result = await emailProvider.sendDraft(existingDraftId);
+
+  await markExistingRuleGeneratedDraftLikelySent({
+    actionId: output.pendingAction.existingDraftActionId,
+    contentOverride,
+    logger,
+  });
+
+  return {
+    actionType: output.actionType,
+    messageId: result.messageId || null,
+    threadId: result.threadId || output.reference?.threadId || null,
+    to: output.reference?.from || null,
+    subject: output.reference?.subject || null,
+    confirmedAt,
+  };
+}
+
+async function markExistingRuleGeneratedDraftLikelySent({
+  actionId,
+  contentOverride,
+  logger,
+}: {
+  actionId?: string;
+  contentOverride?: string;
+  logger: Logger;
+}) {
+  if (!actionId) return;
+
+  try {
+    await prisma.executedAction.update({
+      where: { id: actionId },
+      data: {
+        draftStatus: DraftEmailStatus.LIKELY_SENT,
+        ...(contentOverride ? { content: contentOverride } : {}),
+      },
+    });
+  } catch (error) {
+    logger.warn("Failed to mark reused assistant draft as sent", {
+      error,
+      executedActionId: actionId,
+    });
+  }
 }
 
 async function confirmPendingForwardEmailAction({
@@ -1874,9 +1958,13 @@ function getPendingActionContentPatch(
   contentOverride: string,
 ): Record<string, string> {
   if (actionType === "send_email") {
-    return { messageHtml: convertNewlinesToBr(escapeHtml(contentOverride)) };
+    return { messageHtml: toMessageHtml(contentOverride) };
   }
   return { content: contentOverride };
+}
+
+function toMessageHtml(content: string) {
+  return convertNewlinesToBr(escapeHtml(content));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/utils/actions/assistant-chat.test.ts
+++ b/apps/web/utils/actions/assistant-chat.test.ts
@@ -320,6 +320,63 @@ describe("confirmAssistantEmailAction", () => {
     });
   });
 
+  it("sends the existing rule-generated draft when confirming a reused reply draft", async () => {
+    (prisma.emailAccount.findUnique as any)
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+        account: { userId: "u1", provider: "google" },
+      })
+      .mockResolvedValueOnce({
+        name: "Owner",
+        email: "owner@example.com",
+      });
+
+    prisma.chatMessage.findFirst.mockResolvedValue({
+      id: "chat-message-1",
+      chatId: "chat-1",
+      updatedAt: new Date("2026-02-23T00:00:00.000Z"),
+      parts: [buildPendingReplyPartWithExistingDraft()],
+    } as any);
+
+    prisma.chatMessage.updateMany.mockResolvedValue({ count: 1 } as any);
+    prisma.executedAction.update.mockResolvedValue({} as any);
+
+    const replyToEmail = vi.fn().mockResolvedValue(undefined);
+    const sendDraft = vi.fn().mockResolvedValue({
+      messageId: "sent-draft-message-1",
+      threadId: "thread-1",
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      replyToEmail,
+      sendDraft,
+    } as any);
+
+    const result = await confirmAssistantEmailAction(
+      "ea_1" as any,
+      {
+        chatId: "chat-1",
+        chatMessageId: "chat-message-1",
+        toolCallId: "tool-1",
+        actionType: "reply_email",
+      } as any,
+    );
+
+    expect(sendDraft).toHaveBeenCalledWith("draft-1");
+    expect(replyToEmail).not.toHaveBeenCalled();
+    expect(prisma.executedAction.update).toHaveBeenCalledWith({
+      where: { id: "executed-action-1" },
+      data: { draftStatus: "LIKELY_SENT" },
+    });
+    expect(result?.data?.confirmationState).toBe("confirmed");
+    expect(result?.data?.confirmationResult).toMatchObject({
+      actionType: "reply_email",
+      messageId: "sent-draft-message-1",
+      threadId: "thread-1",
+      to: "sender@example.com",
+      subject: "Original subject",
+    });
+  });
+
   it("sends a pending prepared forward and persists confirmed output", async () => {
     (prisma.emailAccount.findUnique as any)
       .mockResolvedValueOnce({
@@ -1553,6 +1610,23 @@ function buildPendingReplyPart() {
         threadId: "thread-1",
         from: "sender@example.com",
         subject: "Original subject",
+      },
+    },
+  };
+}
+
+function buildPendingReplyPartWithExistingDraft() {
+  const pendingReplyPart = buildPendingReplyPart();
+
+  return {
+    ...pendingReplyPart,
+    output: {
+      ...pendingReplyPart.output,
+      pendingAction: {
+        ...pendingReplyPart.output.pendingAction,
+        content: "Existing rule draft.",
+        existingDraftId: "draft-1",
+        existingDraftActionId: "executed-action-1",
       },
     },
   };

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -53,6 +53,8 @@ export const pendingReplyEmailToolOutputSchema = z.object({
   pendingAction: z.object({
     messageId: z.string().trim().min(1),
     content: z.string().trim().min(1),
+    existingDraftId: z.string().trim().min(1).optional(),
+    existingDraftActionId: z.string().trim().min(1).optional(),
   }),
   reference: z
     .object({

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -183,6 +183,79 @@ describe("chat inbox tools", () => {
     });
   });
 
+  it("reuses an existing rule-generated draft for the same reply message", async () => {
+    const message: ParsedMessage = {
+      id: "message-1",
+      threadId: "thread-1",
+      snippet: "",
+      historyId: "",
+      inline: [],
+      headers: {
+        from: "contact@example.com",
+        to: TEST_EMAIL,
+        subject: "Question",
+        date: "2026-02-18T00:00:00.000Z",
+      },
+      subject: "Question",
+      date: "2026-02-18T00:00:00.000Z",
+    };
+    const existingDraft: ParsedMessage = {
+      id: "draft-message-1",
+      threadId: "thread-1",
+      snippet: "",
+      historyId: "",
+      inline: [],
+      headers: {
+        from: TEST_EMAIL,
+        to: "contact@example.com",
+        subject: "Re: Question",
+        date: "2026-02-18T00:01:00.000Z",
+      },
+      subject: "Re: Question",
+      date: "2026-02-18T00:01:00.000Z",
+      textPlain: "Existing rule draft.",
+    };
+    const getMessage = vi.fn().mockResolvedValue(message);
+    const getDraft = vi.fn().mockResolvedValue(existingDraft);
+    const replyToEmail = vi.fn().mockResolvedValue(undefined);
+
+    prisma.executedAction.findFirst.mockResolvedValue({
+      id: "executed-action-1",
+      draftId: "draft-1",
+      content: "Original generated draft.",
+    } as any);
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessage,
+      getDraft,
+      replyToEmail,
+    } as any);
+
+    const toolInstance = replyEmailTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      messageId: "message-1",
+      content: "New chat-generated draft.",
+    });
+
+    expect(getDraft).toHaveBeenCalledWith("draft-1");
+    expect(replyToEmail).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      actionType: "reply_email",
+      pendingAction: {
+        messageId: "message-1",
+        content: "Existing rule draft.",
+        existingDraftId: "draft-1",
+        existingDraftActionId: "executed-action-1",
+      },
+    });
+  });
+
   it("prepares forward flow without sending immediately", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       name: "Test User",

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -10,11 +10,19 @@ import {
   splitRecipientList,
 } from "@/utils/email";
 import { getRuleLabel } from "@/utils/rule/consts";
-import { SystemType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  DraftEmailStatus,
+  SystemType,
+} from "@/generated/prisma/enums";
 import type { EmailProvider } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
+import {
+  extractDraftPlainText,
+  stripQuotedContent,
+} from "@/utils/ai/choose-rule/draft-management";
 import { runWithBoundedConcurrency } from "@/utils/async";
 import { resolveLabelNameAndId } from "@/utils/label/resolve-label";
 import {
@@ -1298,11 +1306,21 @@ export const replyEmailTool = ({
           provider,
           logger,
         });
-        const message = await emailProvider.getMessage(
-          parsedInput.data.messageId,
-        );
+        const [message, existingDraft] = await Promise.all([
+          emailProvider.getMessage(parsedInput.data.messageId),
+          getExistingRuleGeneratedReplyDraft({
+            emailAccountId,
+            messageId: parsedInput.data.messageId,
+            emailProvider,
+            logger,
+          }),
+        ]);
 
-        return createPendingReplyEmailOutput(parsedInput.data, message);
+        return createPendingReplyEmailOutput(
+          parsedInput.data,
+          message,
+          existingDraft,
+        );
       } catch (error) {
         logger.error("Failed to prepare reply from chat", { error });
         return { error: "Failed to prepare reply" };
@@ -1391,6 +1409,11 @@ async function listLabelNames({
 }
 
 type PendingEmailActionType = "send_email" | "reply_email" | "forward_email";
+type ExistingRuleGeneratedReplyDraft = {
+  actionId: string;
+  draftId: string;
+  content: string;
+};
 
 function createPendingSendEmailOutput(
   input: z.infer<typeof sendEmailToolInputSchema>,
@@ -1417,6 +1440,7 @@ function createPendingSendEmailOutput(
 function createPendingReplyEmailOutput(
   input: z.infer<typeof replyEmailToolInputSchema>,
   message: ParsedMessage,
+  existingDraft?: ExistingRuleGeneratedReplyDraft | null,
 ) {
   return {
     success: true,
@@ -1425,7 +1449,13 @@ function createPendingReplyEmailOutput(
     confirmationState: "pending" as const,
     pendingAction: {
       messageId: input.messageId,
-      content: input.content,
+      content: existingDraft?.content ?? input.content,
+      ...(existingDraft
+        ? {
+            existingDraftId: existingDraft.draftId,
+            existingDraftActionId: existingDraft.actionId,
+          }
+        : {}),
     },
     reference: {
       messageId: message.id,
@@ -1434,6 +1464,63 @@ function createPendingReplyEmailOutput(
       subject: message.subject || message.headers.subject,
     },
   };
+}
+
+async function getExistingRuleGeneratedReplyDraft({
+  emailAccountId,
+  messageId,
+  emailProvider,
+  logger,
+}: {
+  emailAccountId: string;
+  messageId: string;
+  emailProvider: EmailProvider;
+  logger: Logger;
+}): Promise<ExistingRuleGeneratedReplyDraft | null> {
+  const existingDraftAction = await prisma.executedAction.findFirst({
+    where: {
+      executedRule: {
+        emailAccountId,
+        messageId,
+      },
+      type: ActionType.DRAFT_EMAIL,
+      draftId: { not: null },
+      draftSendLog: null,
+      OR: [{ draftStatus: null }, { draftStatus: DraftEmailStatus.PENDING }],
+    },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      draftId: true,
+      content: true,
+    },
+  });
+
+  if (!existingDraftAction?.draftId) return null;
+
+  try {
+    const draft = await emailProvider.getDraft(existingDraftAction.draftId);
+    if (!draft) return null;
+
+    const content =
+      stripQuotedContent(extractDraftPlainText(draft)).trim() ||
+      existingDraftAction.content?.trim();
+
+    if (!content) return null;
+
+    return {
+      actionId: existingDraftAction.id,
+      draftId: existingDraftAction.draftId,
+      content,
+    };
+  } catch (error) {
+    logger.warn("Failed to load existing rule-generated draft for chat reply", {
+      error,
+      draftId: existingDraftAction.draftId,
+      executedActionId: existingDraftAction.id,
+    });
+    return null;
+  }
 }
 
 function createPendingForwardEmailOutput(


### PR DESCRIPTION
Fixes assistant chat reply confirmation so an existing rule-generated draft for the source message is reused instead of creating a separate reply. The confirmation flow now sends the existing draft and marks its action as likely sent.

- Reuses pending rule-generated reply drafts when preparing assistant chat replies.
- Carries reused draft metadata through validation and confirmation.
- Adds focused coverage for draft reuse during reply preparation and confirmation.
- Tests: `pnpm test utils/actions/assistant-chat.test.ts utils/ai/assistant/chat-inbox-tools.test.ts`
- Performance: adds one database lookup and, when a reusable draft exists, one provider draft fetch during reply preparation; confirmation may update/send the existing draft and mark its action status. Scope is limited to assistant reply preparation/confirmation, with low hot-path risk.
