### PR TITLE
chore: gitignore local agent/scanning scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ qa/browser-flows/results/*
 
 # eval reports
 eval-results/
+
+.agent-worktrees/
+.context/
+.deepsec/


### PR DESCRIPTION
Ignores three machine-local scratch directories that were showing up as untracked and could be accidentally committed (`git add -A` would stage them):

- `.agent-worktrees/` — git worktrees created by agent tooling
- `.context/` — local eval run logs
- `.deepsec/` — local security-scanning workspace

All three are transient, per-developer, and regenerable — nothing here belongs in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)