### PR TITLE
logging: Adjust batch retry severity

### DIFF
--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -70,7 +70,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           return;
         }
 
-        logger.error("Error fetching batch item, adding to retry queue", {
+        logger.warn("Error fetching batch item, adding to retry queue", {
           id: ids[i],
           code,
           errorMessage,


### PR DESCRIPTION
Adjusts retryable provider batch item failures to log as warnings instead of errors.\n\n- Keeps terminal batch failures on error-level logging.\n- Adds focused test coverage for retryable batch fetch logging.\n\nValidation: pnpm test utils/gmail/thread.test.ts; pnpm exec biome check apps/web/utils/gmail/batch-with-retry.ts apps/web/utils/gmail/thread.test.ts