### PR TITLE
llm: Fix role selection follow-ups

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -58,4 +58,4 @@ Open http://localhost:3000
 
 - PostgreSQL + Redis (local containers)
 - Auth secrets (auto-generated)
-- LLM config placeholders (`DEFAULT_LLMS`, `ECONOMY_LLMS`, `CHAT_LLMS`)
+- LLM config placeholders (`DEFAULT_LLMS`, `ECONOMY_LLMS`, `CHAT_LLMS`, `NANO_LLMS`, `DRAFT_LLMS`)

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -75,6 +75,8 @@ QSTASH_NEXT_SIGNING_KEY=""
 DEFAULT_LLMS=openai:gpt-5.4-mini
 ECONOMY_LLMS=openai:gpt-5.4-nano
 CHAT_LLMS=openai:gpt-5.4-mini
+NANO_LLMS=openai:gpt-5.4-nano
+DRAFT_LLMS=openai:gpt-5.4-mini
 LLM_API_KEY=
 
 # Dev settings
@@ -97,6 +99,8 @@ echo "  - GOOGLE_CLIENT_SECRET"
 echo "  - DEFAULT_LLMS"
 echo "  - ECONOMY_LLMS"
 echo "  - CHAT_LLMS"
+echo "  - NANO_LLMS"
+echo "  - DRAFT_LLMS"
 echo "  - LLM_API_KEY"
 echo ""
 echo "Then run: pnpm dev"

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/env", () => ({
   },
 }));
 vi.mock("@/utils/llms/model", () => ({
-  getConfiguredRolePrimaryModelEntry: vi.fn(() => ({
+  getResolvedDeploymentRolePrimaryModelEntry: vi.fn(() => ({
     provider: "openai",
     modelName: "gpt-5.4-mini",
   })),
@@ -45,9 +45,14 @@ vi.doUnmock("@/utils/date");
 
 import { buildPrompt } from "./generate-briefing";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
+import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockReturnValue({
+    provider: "openai",
+    modelName: "gpt-5.4-mini",
+  });
 });
 
 describe("buildPrompt timezone handling", () => {
@@ -185,5 +190,48 @@ describe("buildPrompt timezone handling", () => {
       2. Use search tools to find their professional background
       3. Once you have all information, call finalizeBriefing with the complete briefing"
     `);
+  });
+
+  it("uses the meeting web search role to decide web search availability", () => {
+    vi.mocked(getResolvedDeploymentRolePrimaryModelEntry).mockImplementation(
+      (modelType) => {
+        if (modelType === "economy") {
+          return {
+            provider: "anthropic",
+            modelName: "claude-haiku-4-5-20251001",
+          };
+        }
+
+        return {
+          provider: "openai",
+          modelName: "gpt-5.4-mini",
+        };
+      },
+    );
+
+    const briefingData: MeetingBriefingData = {
+      event: {
+        id: "upcoming",
+        title: "Intro Meeting",
+        startTime: new Date("2024-12-31T21:00:00Z"),
+        endTime: new Date("2024-12-31T22:00:00Z"),
+        attendees: [
+          { email: "user@company.com" },
+          { email: "newcontact@other.com", name: "New Person" },
+        ],
+      },
+      externalGuests: [{ email: "newcontact@other.com", name: "New Person" }],
+      internalTeamMembers: [],
+      emailThreads: [],
+      pastMeetings: [],
+    };
+
+    const prompt = buildPrompt(briefingData, mockEmailAccount);
+
+    expect(getResolvedDeploymentRolePrimaryModelEntry).toHaveBeenCalledWith(
+      "economy",
+    );
+    expect(prompt).toContain("Available search tools: perplexitySearch");
+    expect(prompt).not.toContain("webSearch");
   });
 });

--- a/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
+++ b/apps/web/utils/ai/meeting-briefs/generate-briefing.ts
@@ -5,8 +5,12 @@ import { openai } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 import { env } from "@/env";
 import { createGenerateText } from "@/utils/llms";
-import { getConfiguredRolePrimaryModelEntry } from "@/utils/llms/model";
-import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
+import { getResolvedDeploymentRolePrimaryModelEntry } from "@/utils/llms/model";
+import {
+  getModelForUseCase,
+  LLM_USE_CASE_MODEL_TYPES,
+  LlmUseCase,
+} from "@/utils/llms/use-cases";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import { getUserInfoPrompt } from "@/utils/ai/helpers";
 import type { CalendarEvent } from "@/utils/calendar/event-types";
@@ -294,10 +298,9 @@ type WebSearchConfig = {
 };
 
 function getWebSearchConfig(): WebSearchConfig | null {
-  const defaultProvider =
-    getConfiguredRolePrimaryModelEntry("default")?.provider;
+  const webSearchProvider = getMeetingWebSearchProvider();
 
-  switch (defaultProvider) {
+  switch (webSearchProvider) {
     case Provider.OPEN_AI:
       return {
         providerName: "OpenAI",
@@ -415,13 +418,7 @@ export function buildPrompt(
   // List available search tools for the prompt
   const availableTools: string[] = [];
   if (env.PERPLEXITY_API_KEY) availableTools.push("perplexitySearch");
-  const defaultProvider =
-    getConfiguredRolePrimaryModelEntry("default")?.provider;
-  if (
-    defaultProvider === Provider.OPEN_AI ||
-    defaultProvider === Provider.GOOGLE ||
-    defaultProvider === Provider.OPENROUTER
-  ) {
+  if (getWebSearchConfig()) {
     availableTools.push("webSearch");
   }
 
@@ -450,6 +447,12 @@ For each guest listed above:
 3. Once you have all information, call finalizeBriefing with the complete briefing`;
 
   return prompt;
+}
+
+function getMeetingWebSearchProvider(): string | undefined {
+  return getResolvedDeploymentRolePrimaryModelEntry(
+    LLM_USE_CASE_MODEL_TYPES[LlmUseCase.MeetingWebSearch],
+  )?.provider;
 }
 
 type GuestContextForPrompt = {

--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getModel } from "./model";
+import {
+  getConfiguredRolePrimaryModelEntry,
+  getModel,
+  getResolvedDeploymentRolePrimaryModelEntry,
+} from "./model";
 import { Provider } from "./config";
 import { env } from "@/env";
 import type { UserAIFields } from "./types";
@@ -809,6 +813,28 @@ describe("Models", () => {
       expect(result.provider).toBe(Provider.OPEN_AI);
       expect(result.modelName).toBe("gpt-5.4-mini");
       expect(result.fallbackModels).toEqual([]);
+    });
+
+    it("should return the first credentialed primary model entry", () => {
+      vi.mocked(env).DEFAULT_LLMS =
+        "bedrock:global.anthropic.claude-sonnet-4-6,openai:gpt-5.4-mini";
+      vi.mocked(env).BEDROCK_ACCESS_KEY = "";
+      vi.mocked(env).BEDROCK_SECRET_KEY = "";
+
+      expect(getConfiguredRolePrimaryModelEntry("default")).toEqual({
+        provider: Provider.OPEN_AI,
+        modelName: "gpt-5.4-mini",
+      });
+    });
+
+    it("should return the resolved deployment role primary entry with role fallbacks", () => {
+      setDefaultLlms(Provider.OPEN_AI, "gpt-5.4-mini");
+      vi.mocked(env).ECONOMY_LLMS = undefined;
+
+      expect(getResolvedDeploymentRolePrimaryModelEntry("economy")).toEqual({
+        provider: Provider.OPEN_AI,
+        modelName: "gpt-5.4-mini",
+      });
     });
 
     it("should omit duplicate LLMS entries from fallbacks", () => {

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -416,10 +416,27 @@ export function getConfiguredRolePrimaryModel(
 export function getConfiguredRolePrimaryModelEntry(
   modelType: ModelType,
 ): { provider: string; modelName: string } | null {
-  const entry = getFirstSupportedModelListEntry(modelType);
-  if (!entry?.modelName) return null;
+  const resolvedModel = getConfiguredRolePrimaryModel(modelType);
+  if (!resolvedModel) return null;
 
-  return { provider: entry.provider, modelName: entry.modelName };
+  return {
+    provider: resolvedModel.provider,
+    modelName: resolvedModel.modelName,
+  };
+}
+
+export function getResolvedDeploymentRolePrimaryModelEntry(
+  modelType: ModelType,
+): { provider: string; modelName: string } | null {
+  try {
+    const { primaryModel } = selectDeploymentModelByType(modelType);
+    return {
+      provider: primaryModel.provider,
+      modelName: primaryModel.modelName,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function getFirstSupportedModelListEntry(


### PR DESCRIPTION
Fixes follow-up issues in role-based LLM configuration by making configured primary-model entry lookup credential-aware and aligning meeting web-search tool selection with the resolved web-search role. Adds nano and draft LLM list defaults to devcontainer setup output for consistency. Tests: focused LLM resolver and meeting-brief tests, Biome checks, shell syntax check, and git diff check.