### PR TITLE
Fix CLI environment generation

### DIFF
--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -200,7 +200,10 @@ const parsedEnv = createEnv({
     QSTASH_TOKEN: z.string().optional(),
     QSTASH_CURRENT_SIGNING_KEY: z.string().optional(),
     QSTASH_NEXT_SIGNING_KEY: z.string().optional(),
-    QUEUE_BACKEND: z.enum(["bullmq", "internal", "qstash"]).optional(),
+    QUEUE_BACKEND: z.preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.enum(["bullmq", "internal", "qstash"]).optional(),
+    ),
 
     GOOGLE_PUBSUB_TOPIC_NAME: z.string().min(1),
     GOOGLE_PUBSUB_VERIFICATION_TOKEN: z.string().optional(),

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -596,6 +596,7 @@ async function runSetupQuick(options: { name?: string }) {
     DATABASE_URL: `postgresql://postgres:${dbPassword}@db:5432/inboxzero`,
     UPSTASH_REDIS_TOKEN: redisToken,
     UPSTASH_REDIS_URL: "http://serverless-redis-http:80",
+    QUEUE_BACKEND: "internal",
     INTERNAL_API_URL: "http://web:3000",
     // Secrets
     AUTH_SECRET: generateSecret(32),
@@ -1108,6 +1109,7 @@ Full guide: https://docs.getinboxzero.com/self-hosting/microsoft-oauth`,
     env.REDIS_HTTP_PORT = redisHttpPort;
     env.WEB_PORT = webPort;
     env.UPSTASH_REDIS_TOKEN = redisToken;
+    env.QUEUE_BACKEND = "internal";
 
     if (runWebInDocker) {
       // Web app runs in Docker: use container hostnames

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -368,6 +368,8 @@ LLM_API_KEY=
 # Redis
 # =============================================================================
 UPSTASH_REDIS_TOKEN=
+REDIS_URL= # used for subscriptions and BullMQ worker
+QUEUE_BACKEND= # bullmq | qstash | internal
 `;
 
     const fullEnv: EnvConfig = {
@@ -379,6 +381,7 @@ UPSTASH_REDIS_TOKEN=
         "postgresql://postgres:supersecretpassword123@db:5432/inboxzero",
       UPSTASH_REDIS_URL: "http://serverless-redis-http:80",
       UPSTASH_REDIS_TOKEN: "redis-token-abc123",
+      QUEUE_BACKEND: "internal",
       // App
       NEXT_PUBLIC_BASE_URL: "https://mail.example.com",
       NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: "true",
@@ -467,6 +470,8 @@ LLM_API_KEY=sk-ant-api-key-value
 # Redis
 # =============================================================================
 UPSTASH_REDIS_TOKEN=redis-token-abc123
+REDIS_URL= # used for subscriptions and BullMQ worker
+QUEUE_BACKEND=internal
 `;
 
     expect(result).toBe(expectedOutput);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -72,12 +72,16 @@ export function generateEnvFile(config: {
     setValue("DIRECT_URL", wrapInQuotes(env.DIRECT_URL));
     setValue("UPSTASH_REDIS_URL", wrapInQuotes(env.UPSTASH_REDIS_URL));
     setValue("UPSTASH_REDIS_TOKEN", env.UPSTASH_REDIS_TOKEN);
+    setValue("REDIS_URL", wrapInQuotes(env.REDIS_URL));
+    setValue("QUEUE_BACKEND", env.QUEUE_BACKEND);
   } else {
     // External infra - set placeholders
     setValue("DATABASE_URL", wrapInQuotes(env.DATABASE_URL));
     setValue("DIRECT_URL", wrapInQuotes(env.DIRECT_URL));
     setValue("UPSTASH_REDIS_URL", wrapInQuotes(env.UPSTASH_REDIS_URL));
     setValue("UPSTASH_REDIS_TOKEN", env.UPSTASH_REDIS_TOKEN);
+    setValue("REDIS_URL", wrapInQuotes(env.REDIS_URL));
+    setValue("QUEUE_BACKEND", env.QUEUE_BACKEND);
   }
 
   // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Updates CLI-generated environment files to include a valid queue backend for default Docker setup.

Adds focused generator coverage so blank queue backend template values are replaced with a valid default, and treats blank optional queue backend values as unset for existing configurations.

Tests: pnpm --filter @inbox-zero/cli test -- src/utils.test.ts; pnpm exec biome check apps/web/env.ts packages/cli/src/main.ts packages/cli/src/utils.ts packages/cli/src/utils.test.ts packages/cli/vitest.config.ts