### PR TITLE
Fix draft signature ordering

### DIFF
--- a/apps/web/utils/follow-up/generate-draft.test.ts
+++ b/apps/web/utils/follow-up/generate-draft.test.ts
@@ -124,6 +124,7 @@ describe("generateFollowUpDraft", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     envMock.NEXT_PUBLIC_AUTO_DRAFT_DISABLED = false;
+    envMock.NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE = true;
     vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue({
       includeReferralSignature: false,
       signature: null,
@@ -268,6 +269,52 @@ describe("generateFollowUpDraft", () => {
       userMessage2,
       expect.objectContaining({
         to: "bob@external.com",
+      }),
+      "user@example.com",
+      undefined,
+    );
+  });
+
+  it("places the referral signature after the configured user signature", async () => {
+    envMock.NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE = false;
+    vi.mocked(aiDraftFollowUp).mockResolvedValue("What do you think about it?");
+    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue({
+      includeReferralSignature: true,
+      signature: "Cheers!<br>Barbara",
+    } as any);
+
+    const userMessage = createMockMessage({
+      id: "user-msg",
+      headers: {
+        from: "user@example.com",
+        to: "bob@external.com",
+        subject: "Initial Question",
+        date: "2024-01-01T00:00:00Z",
+      },
+    });
+
+    const mockProvider = createMockProvider({
+      getThread: vi.fn().mockResolvedValue({
+        id: "thread-1",
+        messages: [userMessage],
+        snippet: "Test",
+      }),
+    });
+
+    await generateFollowUpDraft({
+      emailAccount: createMockEmailAccount(),
+      threadId: "thread-1",
+      messageId: "user-msg",
+      trackerId: "tracker-1",
+      provider: mockProvider,
+      logger,
+    });
+
+    expect(mockProvider.draftEmail).toHaveBeenCalledWith(
+      userMessage,
+      expect.objectContaining({
+        content:
+          'What do you think about it?\n\nCheers!<br>Barbara\n\nDrafted by <a href="https://getinboxzero.com/?ref=TEST123">Inbox Zero</a>.',
       }),
       "user@example.com",
       undefined,

--- a/apps/web/utils/follow-up/generate-draft.ts
+++ b/apps/web/utils/follow-up/generate-draft.ts
@@ -112,6 +112,10 @@ export async function generateFollowUpDraft({
       },
     });
 
+    if (emailAccountWithSignatures?.signature) {
+      draftContent = `${draftContent}\n\n${emailAccountWithSignatures.signature}`;
+    }
+
     if (
       !env.NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE &&
       emailAccountWithSignatures?.includeReferralSignature
@@ -122,10 +126,6 @@ export async function generateFollowUpDraft({
       const referralLink = generateReferralLink(referralSignature.code);
       const htmlSignature = renderReferralSignatureHtml(referralLink);
       draftContent = `${draftContent}\n\n${htmlSignature}`;
-    }
-
-    if (emailAccountWithSignatures?.signature) {
-      draftContent = `${draftContent}\n\n${emailAccountWithSignatures.signature}`;
     }
 
     const { draftId } = await provider.draftEmail(

--- a/apps/web/utils/reply-tracker/generate-draft.test.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.test.ts
@@ -409,6 +409,31 @@ describe("fetchMessagesAndGenerateDraft - AI content escaping", () => {
     );
   });
 
+  it("places the referral signature after the configured user signature", async () => {
+    vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
+      reply: "What do you think about it?",
+      confidence: DraftReplyConfidence.HIGH_CONFIDENCE,
+    });
+    vi.mocked(prisma.emailAccount.findUnique).mockResolvedValue(
+      createMockEmailAccountSettings({
+        includeReferralSignature: true,
+        signature: "Cheers!<br>Barbara",
+      }),
+    );
+
+    const result = await fetchMessagesAndGenerateDraft(
+      createMockEmailAccount(),
+      "thread-1",
+      createMockClient(),
+      createMockMessage(),
+      logger,
+    );
+
+    expect(result).toBe(
+      'What do you think about it?\n\nCheers!<br>Barbara\n\nDrafted by <a href="https://getinboxzero.com/?ref=TEST123">Inbox Zero</a>.',
+    );
+  });
+
   it("converts AI link markup into provider-ready draft content for the reply-tracker flow", async () => {
     vi.mocked(aiDraftReplyWithConfidence).mockResolvedValue({
       reply:

--- a/apps/web/utils/reply-tracker/generate-draft.ts
+++ b/apps/web/utils/reply-tracker/generate-draft.ts
@@ -119,6 +119,10 @@ export async function fetchMessagesAndGenerateDraftWithConfidenceThreshold(
       emailAccountWithSignatures?.allowHiddenAiDraftLinks ?? false,
   });
 
+  if (emailAccountWithSignatures?.signature) {
+    finalResult = `${finalResult}\n\n${emailAccountWithSignatures.signature}`;
+  }
+
   if (
     !env.NEXT_PUBLIC_DISABLE_REFERRAL_SIGNATURE &&
     emailAccountWithSignatures?.includeReferralSignature
@@ -129,10 +133,6 @@ export async function fetchMessagesAndGenerateDraftWithConfidenceThreshold(
     const referralLink = generateReferralLink(referralSignature.code);
     const htmlSignature = renderReferralSignatureHtml(referralLink);
     finalResult = `${finalResult}\n\n${htmlSignature}`;
-  }
-
-  if (emailAccountWithSignatures?.signature) {
-    finalResult = `${finalResult}\n\n${emailAccountWithSignatures.signature}`;
   }
 
   return {


### PR DESCRIPTION
Moves the referral signature after configured user signatures in generated drafts so attribution appears at the bottom. Covers both follow-up and reply-tracker draft generation flows.

- Append configured user signatures before referral attribution in follow-up drafts.
- Apply the same ordering in reply-tracker generated drafts.
- Tests: `pnpm test utils/follow-up/generate-draft.test.ts utils/reply-tracker/generate-draft.test.ts`.
