### PR TITLE
Add periodic inbox reconcile cron for offline self-hosting.

### DIFF
--- a/apps/web/app/api/cron/reconcile-inbox/route.test.ts
+++ b/apps/web/app/api/cron/reconcile-inbox/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { envMock, captureExceptionMock, reconcileMock } = vi.hoisted(() => ({
+  envMock: {
+    CRON_SECRET: "cron-secret",
+  },
+  captureExceptionMock: vi.fn(),
+  reconcileMock: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/utils/email/reconcile-inbox", () => ({
+  reconcileAllEmailInboxes: (...args: unknown[]) => reconcileMock(...args),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
+
+import { GET, POST } from "./route";
+
+describe("reconcile inbox cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.CRON_SECRET = "cron-secret";
+    reconcileMock.mockResolvedValue({
+      accountCount: 1,
+      results: [],
+    });
+  });
+
+  it("rejects GET requests without the cron bearer token", async () => {
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/reconcile-inbox"),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(reconcileMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs inbox reconcile for GET requests with the cron bearer token", async () => {
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/reconcile-inbox", {
+        headers: { authorization: "Bearer cron-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accountCount: 1,
+      results: [],
+    });
+    expect(reconcileMock).toHaveBeenCalledWith({
+      logger: expect.anything(),
+    });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("runs inbox reconcile for POST requests with the cron secret in the body", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/cron/reconcile-inbox", {
+        method: "POST",
+        body: JSON.stringify({ CRON_SECRET: "cron-secret" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      accountCount: 1,
+      results: [],
+    });
+    expect(reconcileMock).toHaveBeenCalledWith({
+      logger: expect.anything(),
+    });
+  });
+});

--- a/apps/web/app/api/cron/reconcile-inbox/route.test.ts
+++ b/apps/web/app/api/cron/reconcile-inbox/route.test.ts
@@ -69,6 +69,20 @@ describe("reconcile inbox cron route", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it("rejects POST requests without the cron secret in the body", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/cron/reconcile-inbox", {
+        method: "POST",
+        body: JSON.stringify({ CRON_SECRET: "wrong-secret" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(reconcileMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
   it("runs inbox reconcile for POST requests with the cron secret in the body", async () => {
     const response = await POST(
       new Request("http://localhost:3000/api/cron/reconcile-inbox", {

--- a/apps/web/app/api/cron/reconcile-inbox/route.ts
+++ b/apps/web/app/api/cron/reconcile-inbox/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
+import { captureException } from "@/utils/error";
+import { reconcileAllEmailInboxes } from "@/utils/email/reconcile-inbox";
+import { type RequestWithLogger, withError } from "@/utils/middleware";
+
+export const maxDuration = 800;
+
+export const GET = withError("cron/reconcile-inbox", async (request) => {
+  if (!hasCronSecret(request)) {
+    captureException(
+      new Error("Unauthorized request: api/cron/reconcile-inbox"),
+    );
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return runInboxReconcile(request);
+});
+
+export const POST = withError("cron/reconcile-inbox", async (request) => {
+  if (!(await hasPostCronSecret(request))) {
+    captureException(
+      new Error("Unauthorized cron request: api/cron/reconcile-inbox"),
+    );
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return runInboxReconcile(request);
+});
+
+async function runInboxReconcile(request: RequestWithLogger) {
+  const result = await reconcileAllEmailInboxes({
+    logger: request.logger,
+  });
+
+  return NextResponse.json(result);
+}

--- a/apps/web/app/api/outlook/webhook/process-lifecycle.ts
+++ b/apps/web/app/api/outlook/webhook/process-lifecycle.ts
@@ -1,13 +1,12 @@
 import { createManagedOutlookSubscription } from "@/utils/outlook/subscription-manager";
-import { backfillRecentOutlookMessages } from "@/utils/outlook/backfill-recent-messages";
+import {
+  backfillRecentOutlookMessages,
+  getOutlookReconcileStartDate,
+  OUTLOOK_RECONCILE_MAX_MESSAGES,
+} from "@/utils/outlook/backfill-recent-messages";
 import type { Logger } from "@/utils/logger";
-import prisma from "@/utils/prisma";
 import { getWebhookEmailAccount } from "@/utils/webhook/validate-webhook-account";
 import type { OutlookWebhookNotification } from "@/app/api/outlook/webhook/types";
-
-const OUTLOOK_LIFECYCLE_RECONCILE_FALLBACK_MS = 3 * 24 * 60 * 60 * 1000;
-const OUTLOOK_LIFECYCLE_RECONCILE_BUFFER_MS = 60 * 60 * 1000;
-const OUTLOOK_LIFECYCLE_RECONCILE_MAX_MESSAGES = 100;
 
 export async function processOutlookLifecycleNotification({
   notification,
@@ -49,8 +48,8 @@ export async function processOutlookLifecycleNotification({
         emailAddress: emailAccount.email,
         subscriptionId:
           emailAccount.watchEmailsSubscriptionId || notification.subscriptionId,
-        after: await getLifecycleReconcileStartDate(emailAccount.id),
-        maxMessages: OUTLOOK_LIFECYCLE_RECONCILE_MAX_MESSAGES,
+        after: await getOutlookReconcileStartDate(emailAccount.id),
+        maxMessages: OUTLOOK_RECONCILE_MAX_MESSAGES,
         logger: log,
       });
       return;
@@ -67,8 +66,8 @@ export async function processOutlookLifecycleNotification({
         emailAccountId: emailAccount.id,
         emailAddress: emailAccount.email,
         subscriptionId: refreshed?.subscriptionId,
-        after: await getLifecycleReconcileStartDate(emailAccount.id),
-        maxMessages: OUTLOOK_LIFECYCLE_RECONCILE_MAX_MESSAGES,
+        after: await getOutlookReconcileStartDate(emailAccount.id),
+        maxMessages: OUTLOOK_RECONCILE_MAX_MESSAGES,
         logger: log,
       });
       return;
@@ -89,24 +88,4 @@ export async function processOutlookLifecycleNotification({
     default:
       log.warn("Unhandled Outlook lifecycle event");
   }
-}
-
-async function getLifecycleReconcileStartDate(emailAccountId: string) {
-  const latestMessage = await prisma.emailMessage.findFirst({
-    where: { emailAccountId },
-    orderBy: { date: "desc" },
-    select: { date: true },
-  });
-
-  const fallbackStart = new Date(
-    Date.now() - OUTLOOK_LIFECYCLE_RECONCILE_FALLBACK_MS,
-  );
-  if (!latestMessage?.date) return fallbackStart;
-
-  return new Date(
-    Math.max(
-      latestMessage.date.getTime() - OUTLOOK_LIFECYCLE_RECONCILE_BUFFER_MS,
-      fallbackStart.getTime(),
-    ),
-  );
 }

--- a/apps/web/utils/email/reconcile-inbox.test.ts
+++ b/apps/web/utils/email/reconcile-inbox.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import { reconcileAllEmailInboxes } from "@/utils/email/reconcile-inbox";
+import { processHistoryForUser as processGoogleHistoryForUser } from "@/app/api/google/webhook/process-history";
+import { getGmailClientWithRefresh } from "@/utils/gmail/client";
+import { getGmailCurrentHistoryId } from "@/utils/gmail/profile";
+import {
+  backfillRecentOutlookMessages,
+  getOutlookReconcileStartDate,
+} from "@/utils/outlook/backfill-recent-messages";
+import { getEmailProviderRateLimitState } from "@/utils/email/rate-limit";
+import prisma from "@/utils/prisma";
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    emailAccount: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/app/api/google/webhook/process-history", () => ({
+  processHistoryForUser: vi.fn(),
+}));
+
+vi.mock("@/utils/gmail/client", () => ({
+  getGmailClientWithRefresh: vi.fn(),
+}));
+
+vi.mock("@/utils/gmail/profile", () => ({
+  getGmailCurrentHistoryId: vi.fn(),
+}));
+
+vi.mock("@/utils/outlook/backfill-recent-messages", () => ({
+  backfillRecentOutlookMessages: vi.fn(),
+  getOutlookReconcileStartDate: vi.fn(),
+  OUTLOOK_RECONCILE_MAX_MESSAGES: 100,
+}));
+
+vi.mock("@/utils/email/rate-limit", () => ({
+  getEmailProviderRateLimitState: vi.fn(),
+}));
+
+vi.mock("@/utils/premium", () => ({
+  getPremiumUserFilter: vi.fn(() => ({})),
+  getUserTier: vi.fn(() => "PRO"),
+  hasAiAccess: vi.fn(() => true),
+  premiumEntitlementSelect: {},
+}));
+
+describe("reconcileAllEmailInboxes", () => {
+  const logger = createTestLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getEmailProviderRateLimitState).mockResolvedValue(null);
+    vi.mocked(getGmailClientWithRefresh).mockResolvedValue({} as any);
+  });
+
+  it("skips Gmail accounts that are already synced", async () => {
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      {
+        id: "gmail-account",
+        email: "user@gmail.com",
+        lastSyncedHistoryId: "2000",
+        watchEmailsSubscriptionId: null,
+        account: {
+          provider: "google",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_at: Date.now() + 60_000,
+        },
+        user: {
+          aiApiKey: "ai-key",
+          premium: null,
+        },
+      },
+    ] as any);
+    vi.mocked(getGmailCurrentHistoryId).mockResolvedValue(2000);
+
+    const result = await reconcileAllEmailInboxes({ logger });
+
+    expect(result.accountCount).toBe(1);
+    expect(result.results).toEqual([
+      {
+        emailAccountId: "gmail-account",
+        email: "user@gmail.com",
+        provider: "google",
+        status: "skipped",
+        reason: "already_synced",
+        currentHistoryId: 2000,
+        lastSyncedHistoryId: "2000",
+      },
+    ]);
+    expect(processGoogleHistoryForUser).not.toHaveBeenCalled();
+  });
+
+  it("reconciles Gmail accounts when history is behind", async () => {
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      {
+        id: "gmail-account",
+        email: "user@gmail.com",
+        lastSyncedHistoryId: "1000",
+        watchEmailsSubscriptionId: null,
+        account: {
+          provider: "google",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_at: Date.now() + 60_000,
+        },
+        user: {
+          aiApiKey: "ai-key",
+          premium: null,
+        },
+      },
+    ] as any);
+    vi.mocked(getGmailCurrentHistoryId).mockResolvedValue(2500);
+
+    const result = await reconcileAllEmailInboxes({ logger });
+
+    expect(processGoogleHistoryForUser).toHaveBeenCalledWith(
+      {
+        emailAddress: "user@gmail.com",
+        historyId: 2500,
+      },
+      {},
+      expect.anything(),
+    );
+    expect(result.results).toEqual([
+      {
+        emailAccountId: "gmail-account",
+        email: "user@gmail.com",
+        provider: "google",
+        status: "success",
+        currentHistoryId: 2500,
+        lastSyncedHistoryId: "1000",
+      },
+    ]);
+  });
+
+  it("reconciles Outlook accounts via recent message backfill", async () => {
+    const after = new Date("2026-04-15T00:00:00.000Z");
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      {
+        id: "outlook-account",
+        email: "user@outlook.com",
+        lastSyncedHistoryId: null,
+        watchEmailsSubscriptionId: "subscription-id",
+        account: {
+          provider: "microsoft",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_at: Date.now() + 60_000,
+        },
+        user: {
+          aiApiKey: "ai-key",
+          premium: null,
+        },
+      },
+    ] as any);
+    vi.mocked(getOutlookReconcileStartDate).mockResolvedValue(after);
+    vi.mocked(backfillRecentOutlookMessages).mockResolvedValue({
+      processedCount: 2,
+      candidateCount: 3,
+    });
+
+    const result = await reconcileAllEmailInboxes({ logger });
+
+    expect(getOutlookReconcileStartDate).toHaveBeenCalledWith(
+      "outlook-account",
+    );
+    expect(backfillRecentOutlookMessages).toHaveBeenCalledWith({
+      emailAccountId: "outlook-account",
+      emailAddress: "user@outlook.com",
+      subscriptionId: "subscription-id",
+      after,
+      maxMessages: 100,
+      logger: expect.anything(),
+    });
+    expect(result.results).toEqual([
+      {
+        emailAccountId: "outlook-account",
+        email: "user@outlook.com",
+        provider: "microsoft",
+        status: "success",
+        processedCount: 2,
+        candidateCount: 3,
+      },
+    ]);
+  });
+});

--- a/apps/web/utils/email/reconcile-inbox.ts
+++ b/apps/web/utils/email/reconcile-inbox.ts
@@ -1,0 +1,286 @@
+import "server-only";
+
+import { processHistoryForUser as processGoogleHistoryForUser } from "@/app/api/google/webhook/process-history";
+import { getGmailClientWithRefresh } from "@/utils/gmail/client";
+import { getGmailCurrentHistoryId } from "@/utils/gmail/profile";
+import {
+  backfillRecentOutlookMessages,
+  getOutlookReconcileStartDate,
+  OUTLOOK_RECONCILE_MAX_MESSAGES,
+} from "@/utils/outlook/backfill-recent-messages";
+import { getEmailProviderRateLimitState } from "@/utils/email/rate-limit";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
+import {
+  getPremiumUserFilter,
+  getUserTier,
+  hasAiAccess,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
+import { isInvalidGrantError } from "@/utils/error";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+export type ReconcileEmailAccountResult =
+  | {
+      emailAccountId: string;
+      email: string;
+      provider: string;
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      emailAccountId: string;
+      email: string;
+      provider: string;
+      status: "success";
+      processedCount?: number;
+      candidateCount?: number;
+      currentHistoryId?: number;
+      lastSyncedHistoryId?: string | null;
+    }
+  | {
+      emailAccountId: string;
+      email: string;
+      provider: string;
+      status: "error";
+      message: string;
+    };
+
+export async function reconcileAllEmailInboxes({ logger }: { logger: Logger }) {
+  const emailAccounts = await getEmailAccountsToReconcile();
+  logger.info("Reconciling email inboxes", { count: emailAccounts.length });
+
+  const results: ReconcileEmailAccountResult[] = [];
+
+  for (const emailAccount of emailAccounts) {
+    const accountLogger = logger.with({
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider: emailAccount.account.provider,
+    });
+
+    try {
+      const result = await reconcileEmailAccount(emailAccount, accountLogger);
+      if (result) results.push(result);
+    } catch (error) {
+      if (isInvalidGrantError(error)) {
+        accountLogger.warn("Skipping inbox reconcile due to invalid grant", {
+          error,
+        });
+        results.push({
+          emailAccountId: emailAccount.id,
+          email: emailAccount.email,
+          provider: emailAccount.account.provider,
+          status: "skipped",
+          reason: "invalid_grant",
+        });
+        continue;
+      }
+
+      accountLogger.error("Failed to reconcile inbox", { error });
+      results.push({
+        emailAccountId: emailAccount.id,
+        email: emailAccount.email,
+        provider: emailAccount.account.provider,
+        status: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    accountCount: emailAccounts.length,
+    results,
+  };
+}
+
+async function reconcileEmailAccount(
+  emailAccount: Awaited<ReturnType<typeof getEmailAccountsToReconcile>>[number],
+  logger: Logger,
+): Promise<ReconcileEmailAccountResult | null> {
+  const { account, user } = emailAccount;
+  const provider = account.provider;
+
+  const userHasAiAccess = hasAiAccess(
+    getUserTier(user.premium),
+    !!user.aiApiKey,
+  );
+
+  if (!userHasAiAccess) {
+    return {
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider,
+      status: "skipped",
+      reason: "no_ai_access",
+    };
+  }
+
+  if (!account.access_token || !account.refresh_token) {
+    return {
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider,
+      status: "skipped",
+      reason: "missing_tokens",
+    };
+  }
+
+  if (isGoogleProvider(provider)) {
+    return reconcileGmailInbox(emailAccount, logger);
+  }
+
+  if (isMicrosoftProvider(provider)) {
+    return reconcileOutlookInbox(emailAccount, logger);
+  }
+
+  return {
+    emailAccountId: emailAccount.id,
+    email: emailAccount.email,
+    provider,
+    status: "skipped",
+    reason: "unsupported_provider",
+  };
+}
+
+async function reconcileGmailInbox(
+  emailAccount: Awaited<ReturnType<typeof getEmailAccountsToReconcile>>[number],
+  logger: Logger,
+): Promise<ReconcileEmailAccountResult> {
+  const activeRateLimit = await getEmailProviderRateLimitState({
+    emailAccountId: emailAccount.id,
+    logger,
+  }).catch((error) => {
+    logger.warn("Failed to read provider rate-limit state for reconcile", {
+      error: error instanceof Error ? error.message : error,
+    });
+    return null;
+  });
+
+  if (activeRateLimit?.provider === "google") {
+    return {
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider: emailAccount.account.provider,
+      status: "skipped",
+      reason: "rate_limited",
+    };
+  }
+
+  const gmail = await getGmailClientWithRefresh({
+    accessToken: emailAccount.account.access_token,
+    refreshToken: emailAccount.account.refresh_token,
+    expiresAt: emailAccount.account.expires_at,
+    emailAccountId: emailAccount.id,
+    logger,
+  });
+
+  const currentHistoryId = await getGmailCurrentHistoryId(gmail, logger);
+  if (currentHistoryId == null) {
+    return {
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider: emailAccount.account.provider,
+      status: "skipped",
+      reason: "missing_history_id",
+    };
+  }
+
+  const lastSyncedHistoryId = Number.parseInt(
+    emailAccount.lastSyncedHistoryId || "0",
+    10,
+  );
+
+  if (currentHistoryId <= lastSyncedHistoryId) {
+    return {
+      emailAccountId: emailAccount.id,
+      email: emailAccount.email,
+      provider: emailAccount.account.provider,
+      status: "skipped",
+      reason: "already_synced",
+      currentHistoryId,
+      lastSyncedHistoryId: emailAccount.lastSyncedHistoryId,
+    };
+  }
+
+  logger.info("Reconciling Gmail inbox from history", {
+    currentHistoryId,
+    lastSyncedHistoryId: emailAccount.lastSyncedHistoryId,
+  });
+
+  await processGoogleHistoryForUser(
+    {
+      emailAddress: emailAccount.email,
+      historyId: currentHistoryId,
+    },
+    {},
+    logger,
+  );
+
+  return {
+    emailAccountId: emailAccount.id,
+    email: emailAccount.email,
+    provider: emailAccount.account.provider,
+    status: "success",
+    currentHistoryId,
+    lastSyncedHistoryId: emailAccount.lastSyncedHistoryId,
+  };
+}
+
+async function reconcileOutlookInbox(
+  emailAccount: Awaited<ReturnType<typeof getEmailAccountsToReconcile>>[number],
+  logger: Logger,
+): Promise<ReconcileEmailAccountResult> {
+  const after = await getOutlookReconcileStartDate(emailAccount.id);
+  const result = await backfillRecentOutlookMessages({
+    emailAccountId: emailAccount.id,
+    emailAddress: emailAccount.email,
+    subscriptionId: emailAccount.watchEmailsSubscriptionId || undefined,
+    after,
+    maxMessages: OUTLOOK_RECONCILE_MAX_MESSAGES,
+    logger,
+  });
+
+  return {
+    emailAccountId: emailAccount.id,
+    email: emailAccount.email,
+    provider: emailAccount.account.provider,
+    status: "success",
+    processedCount: result.processedCount,
+    candidateCount: result.candidateCount,
+  };
+}
+
+async function getEmailAccountsToReconcile() {
+  return prisma.emailAccount.findMany({
+    where: {
+      ...getPremiumUserFilter(),
+      account: { disconnectedAt: null },
+    },
+    select: {
+      id: true,
+      email: true,
+      lastSyncedHistoryId: true,
+      watchEmailsSubscriptionId: true,
+      account: {
+        select: {
+          provider: true,
+          access_token: true,
+          refresh_token: true,
+          expires_at: true,
+        },
+      },
+      user: {
+        select: {
+          aiApiKey: true,
+          premium: {
+            select: premiumEntitlementSelect,
+          },
+        },
+      },
+    },
+  });
+}

--- a/apps/web/utils/gmail/profile.ts
+++ b/apps/web/utils/gmail/profile.ts
@@ -1,0 +1,20 @@
+import type { gmail_v1 } from "@googleapis/gmail";
+import { withGmailRetry } from "@/utils/gmail/retry";
+import type { Logger } from "@/utils/logger";
+
+export async function getGmailCurrentHistoryId(
+  gmail: gmail_v1.Gmail,
+  logger?: Logger,
+): Promise<number | null> {
+  const response = await withGmailRetry(
+    () => gmail.users.getProfile({ userId: "me" }),
+    5,
+    { logger },
+  );
+
+  const historyId = response.data.historyId;
+  if (!historyId) return null;
+
+  const parsed = Number.parseInt(historyId, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}

--- a/apps/web/utils/outlook/backfill-recent-messages.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.ts
@@ -6,6 +6,27 @@ import prisma from "@/utils/prisma";
 import type { ParsedMessage } from "@/utils/types";
 
 const OUTLOOK_RECONCILE_PAGE_SIZE = 50;
+export const OUTLOOK_RECONCILE_FALLBACK_MS = 3 * 24 * 60 * 60 * 1000;
+export const OUTLOOK_RECONCILE_BUFFER_MS = 60 * 60 * 1000;
+export const OUTLOOK_RECONCILE_MAX_MESSAGES = 100;
+
+export async function getOutlookReconcileStartDate(emailAccountId: string) {
+  const latestMessage = await prisma.emailMessage.findFirst({
+    where: { emailAccountId },
+    orderBy: { date: "desc" },
+    select: { date: true },
+  });
+
+  const fallbackStart = new Date(Date.now() - OUTLOOK_RECONCILE_FALLBACK_MS);
+  if (!latestMessage?.date) return fallbackStart;
+
+  return new Date(
+    Math.max(
+      latestMessage.date.getTime() - OUTLOOK_RECONCILE_BUFFER_MS,
+      fallbackStart.getTime(),
+    ),
+  );
+}
 
 export async function backfillRecentOutlookMessages({
   emailAccountId,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -91,6 +91,10 @@
     {
       "path": "/api/cron/draft-cleanup",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/reconcile-inbox",
+      "schedule": "*/15 * * * *"
     }
   ]
 }

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -248,6 +248,9 @@ cron:
     watch-renewal:
       schedule: "0 */6 * * *"
       path: /api/watch/all
+    reconcile-inbox:
+      schedule: "*/15 * * * *"
+      path: /api/cron/reconcile-inbox
   resources:
     requests:
       cpu: 25m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,13 @@ services:
             sleep 21600
           done
         ) &
+        (
+          while true; do
+            echo \"[cron] Reconciling email inboxes...\"
+            curl -s -X GET 'http://web:3000/api/cron/reconcile-inbox' -H \"Authorization: Bearer $${CRON_SECRET}\" || echo \"[cron] Warning: reconcile-inbox request failed\"
+            sleep 900
+          done
+        ) &
         wait
         }
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
         (
           while true; do
             echo \"[cron] Reconciling email inboxes...\"
-            curl -s -X GET 'http://web:3000/api/cron/reconcile-inbox' -H \"Authorization: Bearer $${CRON_SECRET}\" || echo \"[cron] Warning: reconcile-inbox request failed\"
+            curl -fs -X GET 'http://web:3000/api/cron/reconcile-inbox' -H \"Authorization: Bearer $${CRON_SECRET}\" || echo \"[cron] Warning: reconcile-inbox request failed\"
             sleep 900
           done
         ) &

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -134,6 +134,7 @@ The Docker Compose setup includes a `cron` container that handles scheduled task
 | **Scheduled actions** | Every minute | `/api/cron/scheduled-actions` | `* * * * *` | Executes delayed/scheduled actions when QStash is not configured |
 | **Reasoning retention** | Daily | `/api/cron/reasoning-retention` | `0 3 * * *` | Redacts only stale AI reasoning fields when `REASONING_RETENTION_DAYS` is set |
 | **Email watch renewal** | Every 6 hours | `/api/watch/all` | `0 */6 * * *` | Renews Gmail/Outlook push notification subscriptions |
+| **Inbox reconcile** | Every 15 minutes | `/api/cron/reconcile-inbox` | `*/15 * * * *` | Polls for missed email when push notifications were unavailable |
 | **Meeting briefs** | Every 15 minutes | `/api/meeting-briefs` | `*/15 * * * *` | Sends pre-meeting briefings to users with the feature enabled |
 | **Follow-up reminders** | Every hour | `/api/follow-up-reminders` | `0 * * * *` | Processes follow-up reminder notifications |
 
@@ -148,6 +149,9 @@ The Docker Compose setup includes a `cron` container that handles scheduled task
 
 # Email watch renewal - every 6 hours
 0 */6 * * * curl -s -X GET "https://yourdomain.com/api/watch/all" -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Inbox reconcile - every 15 minutes (catches email missed while offline)
+*/15 * * * * curl -s -X GET "https://yourdomain.com/api/cron/reconcile-inbox" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Meeting briefs - every 15 minutes (optional, only if using meeting briefs feature)
 */15 * * * * curl -s -X GET "https://yourdomain.com/api/meeting-briefs" -H "Authorization: Bearer YOUR_CRON_SECRET"


### PR DESCRIPTION
Fixes #2504

## Summary
Self-hosted deployments can miss push notifications when the server is offline. This adds a periodic inbox reconcile cron that catches up after downtime:

- **Gmail:** compares profile `historyId` to `lastSyncedHistoryId`, then runs existing history processing
- **Outlook:** reuses `backfillRecentOutlookMessages` (same path as lifecycle `missed` events)
- Wired into Vercel, Docker Compose, and Helm cron schedules (every 15 minutes)

## Test plan
- [x] Unit tests for reconcile logic and cron route auth
- [ ] Manual: stop server, receive email, restart, verify reconcile cron processes it