### PR TITLE
auth: Fix sign-in origin handling

### DIFF
--- a/apps/web/app/(landing)/login/LoginForm.test.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.test.tsx
@@ -121,4 +121,24 @@ describe("LoginForm", () => {
       });
     });
   });
+
+  it("shows a stable message for Safari network failures during Microsoft sign-in", async () => {
+    mockSignInSocial.mockRejectedValue(new Error("Load failed"));
+
+    render(
+      <LoginForm enabledProviders={["microsoft"]} useGoogleOauthEmulator />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign in with microsoft/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith({
+        title: "Error signing in with Microsoft",
+        description:
+          "Could not start sign-in. Please check that this app is opened from its configured public URL, then try again.",
+      });
+    });
+  });
 });

--- a/apps/web/app/(landing)/login/LoginForm.tsx
+++ b/apps/web/app/(landing)/login/LoginForm.tsx
@@ -202,8 +202,22 @@ async function handleSocialSignIn({
 
 function getSocialSignInErrorMessage(error: unknown) {
   if (error instanceof Error && error.message) {
+    if (isNetworkSignInError(error.message)) {
+      return "Could not start sign-in. Please check that this app is opened from its configured public URL, then try again.";
+    }
+
     return error.message;
   }
 
   return "Please try again or contact support.";
+}
+
+function isNetworkSignInError(message: string) {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    normalizedMessage === "load failed" ||
+    normalizedMessage === "failed to fetch" ||
+    normalizedMessage === "networkerror when attempting to fetch resource."
+  );
 }

--- a/apps/web/utils/auth-client.test.ts
+++ b/apps/web/utils/auth-client.test.ts
@@ -1,79 +1,90 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.fn();
-
-vi.mock("@/env", () => ({
-  env: {
-    NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+const mockCreateAuthClient = vi.fn(() => ({
+  getSession: vi.fn(),
+  signIn: {
+    oauth2: vi.fn(),
+    social: vi.fn(),
   },
+  signOut: vi.fn(),
+  signUp: vi.fn(),
+  sso: vi.fn(),
+  useSession: vi.fn(),
 }));
 
 vi.mock("better-auth/react", () => ({
-  createAuthClient: vi.fn(() => ({
-    signIn: {
-      social: vi.fn(),
-      oauth2: vi.fn(),
-    },
-    signOut: vi.fn(),
-    signUp: vi.fn(),
-    useSession: vi.fn(),
-    getSession: vi.fn(),
-    sso: vi.fn(),
-  })),
+  createAuthClient: mockCreateAuthClient,
 }));
 
 vi.mock("@better-auth/sso/client", () => ({
-  ssoClient: vi.fn(() => ({})),
+  ssoClient: vi.fn(() => "sso-client"),
 }));
 
 vi.mock("better-auth/client/plugins", () => ({
-  genericOAuthClient: vi.fn(() => ({})),
-  organizationClient: vi.fn(() => ({})),
+  genericOAuthClient: vi.fn(() => "generic-oauth-client"),
+  organizationClient: vi.fn(() => "organization-client"),
 }));
+
+describe("auth-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("uses same-origin auth requests for the browser client", async () => {
+    await import("./auth-client");
+
+    expect(mockCreateAuthClient).toHaveBeenCalledWith({
+      plugins: ["sso-client", "organization-client"],
+    });
+  });
+});
 
 describe("signInWithOauth2", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
     vi.stubGlobal("fetch", mockFetch);
   });
 
   it("does not attach a fallback error message to successful responses", async () => {
     mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
       json: async () => ({
         url: "https://example.com/oauth",
       }),
+      ok: true,
+      status: 200,
     });
 
     const { signInWithOauth2 } = await import("./auth-client");
 
     const result = await signInWithOauth2({
-      providerId: "google",
       callbackURL: "/welcome",
       errorCallbackURL: "/login/error",
+      providerId: "google",
     });
 
     expect(result).toEqual({
-      url: "https://example.com/oauth",
       error: undefined,
+      url: "https://example.com/oauth",
     });
   });
 
   it("uses the fallback error message only for failed responses", async () => {
     mockFetch.mockResolvedValue({
+      json: async () => ({}),
       ok: false,
       status: 500,
-      json: async () => ({}),
     });
 
     const { signInWithOauth2 } = await import("./auth-client");
 
     await expect(
       signInWithOauth2({
-        providerId: "google",
         callbackURL: "/welcome",
         errorCallbackURL: "/login/error",
+        providerId: "google",
       }),
     ).rejects.toThrow("Request failed with status 500");
   });

--- a/apps/web/utils/auth-client.ts
+++ b/apps/web/utils/auth-client.ts
@@ -1,5 +1,4 @@
 import { createAuthClient } from "better-auth/react";
-import { env } from "@/env";
 import { ssoClient } from "@better-auth/sso/client";
 import {
   genericOAuthClient,
@@ -8,13 +7,11 @@ import {
 
 export const { signIn, signOut, signUp, useSession, getSession, sso } =
   createAuthClient({
-    baseURL: env.NEXT_PUBLIC_BASE_URL,
     plugins: [ssoClient(), organizationClient()],
   });
 
 function createGenericOauthAuthClient() {
   return createAuthClient({
-    baseURL: env.NEXT_PUBLIC_BASE_URL,
     plugins: [genericOAuthClient()],
   });
 }


### PR DESCRIPTION
Use same-origin browser auth requests so sign-in starts reliably when the app is opened from the active deployment URL.

- Remove the fixed public base URL from the browser auth client
- Show stable user-facing copy for browser network failures during social sign-in
- Add focused coverage for auth client configuration and sign-in error handling

Tests: pnpm test utils/auth-client.test.ts app/'(landing)'/login/LoginForm.test.tsx; pnpm --filter inbox-zero-ai exec biome check utils/auth-client.ts utils/auth-client.test.ts app/'(landing)'/login/LoginForm.tsx app/'(landing)'/login/LoginForm.test.tsx