### PR TITLE
perf: Instrument account redirect timing

### DIFF
--- a/apps/web/utils/account.test.ts
+++ b/apps/web/utils/account.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   auth: vi.fn(),
   cookies: vi.fn(),
   findFirst: vi.fn(),
+  loggerInfo: vi.fn(),
+  flushLoggerSafely: vi.fn(),
+  after: vi.fn(),
   redirect: vi.fn((url: string) => {
     throw new Error(`redirect:${url}`);
   }),
@@ -19,6 +22,20 @@ vi.mock("next/headers", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: (url: string) => mocks.redirect(url),
+}));
+
+vi.mock("next/server", () => ({
+  after: (callback: () => void | Promise<void>) => mocks.after(callback),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  createScopedLogger: () => ({
+    info: (...args: unknown[]) => mocks.loggerInfo(...args),
+  }),
+}));
+
+vi.mock("@/utils/logger-flush", () => ({
+  flushLoggerSafely: (...args: unknown[]) => mocks.flushLoggerSafely(...args),
 }));
 
 vi.mock("@/utils/prisma", () => ({
@@ -48,7 +65,26 @@ describe("redirectToEmailAccountPath", () => {
 
     expect(mocks.findFirst).toHaveBeenCalledWith({
       where: { userId: "user_123" },
+      select: { id: true },
+      orderBy: { createdAt: "asc" },
     });
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      "Resolved account redirect",
+      expect.objectContaining({
+        path: "/setup",
+        outcome: "connect-mailbox",
+        usedLastEmailAccountCookie: false,
+        usedFallbackAccountLookup: true,
+        foundEmailAccount: false,
+        durationMs: expect.any(Number),
+        stepDurationsMs: expect.objectContaining({
+          auth: expect.any(Number),
+          "last-email-account-cookie": expect.any(Number),
+          "fallback-email-account-lookup": expect.any(Number),
+        }),
+      }),
+    );
+    expect(mocks.after).toHaveBeenCalledOnce();
     expect(mocks.redirect).toHaveBeenCalledWith(
       "/connect-mailbox?next=%2Fsetup",
     );
@@ -68,6 +104,42 @@ describe("redirectToEmailAccountPath", () => {
 
     expect(mocks.redirect).toHaveBeenCalledWith(
       "/connect-mailbox?next=%2Fsetup%3Fsource%3Dcheckout%26step%3Done%26step%3Dtwo",
+    );
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      "Resolved account redirect",
+      expect.objectContaining({
+        searchParamKeys: ["source", "step"],
+      }),
+    );
+  });
+
+  it("uses the last email account cookie without querying for an account", async () => {
+    mocks.cookies.mockResolvedValue({
+      get: () => ({
+        value: JSON.stringify({
+          userId: "user_123",
+          emailAccountId: "account_123",
+        }),
+      }),
+    });
+
+    await expect(redirectToEmailAccountPath("/setup")).rejects.toThrow(
+      "redirect:/account_123/setup",
+    );
+
+    expect(mocks.findFirst).not.toHaveBeenCalled();
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      "Resolved account redirect",
+      expect.objectContaining({
+        path: "/setup",
+        outcome: "account-path",
+        usedLastEmailAccountCookie: true,
+        usedFallbackAccountLookup: false,
+        foundEmailAccount: true,
+        stepDurationsMs: expect.not.objectContaining({
+          "fallback-email-account-lookup": expect.any(Number),
+        }),
+      }),
     );
   });
 });

--- a/apps/web/utils/account.test.ts
+++ b/apps/web/utils/account.test.ts
@@ -4,9 +4,14 @@ const mocks = vi.hoisted(() => ({
   auth: vi.fn(),
   cookies: vi.fn(),
   findFirst: vi.fn(),
-  loggerInfo: vi.fn(),
   flushLoggerSafely: vi.fn(),
   after: vi.fn(),
+  env: {
+    NODE_ENV: "test",
+    AXIOM_TOKEN: undefined,
+    NEXT_PUBLIC_LOG_SCOPES: undefined,
+    ENABLE_DEBUG_LOGS: false,
+  },
   redirect: vi.fn((url: string) => {
     throw new Error(`redirect:${url}`);
   }),
@@ -28,10 +33,8 @@ vi.mock("next/server", () => ({
   after: (callback: () => void | Promise<void>) => mocks.after(callback),
 }));
 
-vi.mock("@/utils/logger", () => ({
-  createScopedLogger: () => ({
-    info: (...args: unknown[]) => mocks.loggerInfo(...args),
-  }),
+vi.mock("@/env", () => ({
+  env: mocks.env,
 }));
 
 vi.mock("@/utils/logger-flush", () => ({
@@ -50,8 +53,11 @@ vi.mock("@/utils/prisma", () => ({
 import { redirectToEmailAccountPath } from "./account";
 
 describe("redirectToEmailAccountPath", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     mocks.auth.mockResolvedValue({ user: { id: "user_123" } });
     mocks.cookies.mockResolvedValue({ get: () => undefined });
   });
@@ -66,10 +72,9 @@ describe("redirectToEmailAccountPath", () => {
     expect(mocks.findFirst).toHaveBeenCalledWith({
       where: { userId: "user_123" },
       select: { id: true },
-      orderBy: { createdAt: "asc" },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     });
-    expect(mocks.loggerInfo).toHaveBeenCalledWith(
-      "Resolved account redirect",
+    expect(getAccountRedirectLog(consoleLogSpy)).toEqual(
       expect.objectContaining({
         path: "/setup",
         outcome: "connect-mailbox",
@@ -105,8 +110,7 @@ describe("redirectToEmailAccountPath", () => {
     expect(mocks.redirect).toHaveBeenCalledWith(
       "/connect-mailbox?next=%2Fsetup%3Fsource%3Dcheckout%26step%3Done%26step%3Dtwo",
     );
-    expect(mocks.loggerInfo).toHaveBeenCalledWith(
-      "Resolved account redirect",
+    expect(getAccountRedirectLog(consoleLogSpy)).toEqual(
       expect.objectContaining({
         searchParamKeys: ["source", "step"],
       }),
@@ -128,8 +132,7 @@ describe("redirectToEmailAccountPath", () => {
     );
 
     expect(mocks.findFirst).not.toHaveBeenCalled();
-    expect(mocks.loggerInfo).toHaveBeenCalledWith(
-      "Resolved account redirect",
+    expect(getAccountRedirectLog(consoleLogSpy)).toEqual(
       expect.objectContaining({
         path: "/setup",
         outcome: "account-path",
@@ -143,3 +146,23 @@ describe("redirectToEmailAccountPath", () => {
     );
   });
 });
+
+function getAccountRedirectLog(consoleLogSpy: ReturnType<typeof vi.spyOn>) {
+  const logCall = [...consoleLogSpy.mock.calls]
+    .reverse()
+    .find(
+      ([message]) =>
+        typeof message === "string" &&
+        message.includes("[account-redirect]: Resolved account redirect"),
+    );
+
+  expect(logCall).toBeDefined();
+
+  const message = logCall?.[0];
+  expect(typeof message).toBe("string");
+
+  const jsonStart = (message as string).indexOf("{");
+  expect(jsonStart).toBeGreaterThanOrEqual(0);
+
+  return JSON.parse((message as string).slice(jsonStart));
+}

--- a/apps/web/utils/account.ts
+++ b/apps/web/utils/account.ts
@@ -38,7 +38,7 @@ export async function redirectToEmailAccountPath(
 
   let emailAccountId = lastEmailAccountId;
 
-  // If no last account or it doesn't exist, fall back to first account
+  // If no last account is available, fall back to the first account.
   if (!emailAccountId) {
     const emailAccount = await measureRedirectStep(
       timing,
@@ -97,7 +97,7 @@ type RedirectTiming = {
   path: string;
   searchParamKeys: string[];
   startedAt: number;
-  steps: Record<string, number>;
+  stepDurationsMs: Record<string, number>;
 };
 
 function createRedirectTiming(
@@ -108,7 +108,7 @@ function createRedirectTiming(
     path,
     searchParamKeys: Object.keys(searchParams ?? {}).sort(),
     startedAt: Date.now(),
-    steps: {},
+    stepDurationsMs: {},
   };
 }
 
@@ -121,7 +121,7 @@ async function measureRedirectStep<T>(
   try {
     return await operation();
   } finally {
-    timing.steps[step] = Date.now() - startedAt;
+    timing.stepDurationsMs[step] = Date.now() - startedAt;
   }
 }
 
@@ -139,7 +139,7 @@ function logRedirectTiming(
     path: timing.path,
     searchParamKeys: timing.searchParamKeys,
     durationMs,
-    stepDurationsMs: timing.steps,
+    stepDurationsMs: timing.stepDurationsMs,
     ...metadata,
   });
 

--- a/apps/web/utils/account.ts
+++ b/apps/web/utils/account.ts
@@ -47,7 +47,7 @@ export async function redirectToEmailAccountPath(
         prisma.emailAccount.findFirst({
           where: { userId },
           select: { id: true },
-          orderBy: { createdAt: "asc" },
+          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
         }),
     );
     emailAccountId = emailAccount?.id ?? null;

--- a/apps/web/utils/account.ts
+++ b/apps/web/utils/account.ts
@@ -1,36 +1,65 @@
 import { cookies } from "next/headers";
 import { auth } from "@/utils/auth";
 import { redirect } from "next/navigation";
+import { after } from "next/server";
 import prisma from "@/utils/prisma";
 import {
   LAST_EMAIL_ACCOUNT_COOKIE,
   parseLastEmailAccountCookieValue,
 } from "@/utils/cookies";
 import { buildLoginRedirectUrl, buildRedirectUrl } from "@/utils/redirect";
+import { createScopedLogger } from "@/utils/logger";
+import { flushLoggerSafely } from "@/utils/logger-flush";
+
+const logger = createScopedLogger("account-redirect");
 
 export async function redirectToEmailAccountPath(
   path: `/${string}`,
   searchParams?: Record<string, string | string[] | undefined>,
 ) {
-  const session = await auth();
+  const timing = createRedirectTiming(path, searchParams);
+  const session = await measureRedirectStep(timing, "auth", () => auth());
   const userId = session?.user.id;
   if (!userId) {
+    logRedirectTiming(timing, {
+      outcome: "login",
+      usedLastEmailAccountCookie: false,
+      usedFallbackAccountLookup: false,
+      foundEmailAccount: false,
+    });
     redirect(buildLoginRedirectUrl(buildRedirectUrl(path, searchParams)));
   }
 
-  const lastEmailAccountId = await getLastEmailAccountFromCookie(userId);
+  const lastEmailAccountId = await measureRedirectStep(
+    timing,
+    "last-email-account-cookie",
+    () => getLastEmailAccountFromCookie(userId),
+  );
 
   let emailAccountId = lastEmailAccountId;
 
   // If no last account or it doesn't exist, fall back to first account
   if (!emailAccountId) {
-    const emailAccount = await prisma.emailAccount.findFirst({
-      where: { userId },
-    });
+    const emailAccount = await measureRedirectStep(
+      timing,
+      "fallback-email-account-lookup",
+      () =>
+        prisma.emailAccount.findFirst({
+          where: { userId },
+          select: { id: true },
+          orderBy: { createdAt: "asc" },
+        }),
+    );
     emailAccountId = emailAccount?.id ?? null;
   }
 
   if (!emailAccountId) {
+    logRedirectTiming(timing, {
+      outcome: "connect-mailbox",
+      usedLastEmailAccountCookie: !!lastEmailAccountId,
+      usedFallbackAccountLookup: !lastEmailAccountId,
+      foundEmailAccount: false,
+    });
     redirect(
       buildRedirectUrl("/connect-mailbox", {
         next: buildRedirectUrl(path, searchParams),
@@ -43,6 +72,12 @@ export async function redirectToEmailAccountPath(
     searchParams,
   );
 
+  logRedirectTiming(timing, {
+    outcome: "account-path",
+    usedLastEmailAccountCookie: !!lastEmailAccountId,
+    usedFallbackAccountLookup: !lastEmailAccountId,
+    foundEmailAccount: true,
+  });
   redirect(redirectUrl);
 }
 
@@ -56,4 +91,63 @@ async function getLastEmailAccountFromCookie(
   } catch {
     return null;
   }
+}
+
+type RedirectTiming = {
+  path: string;
+  searchParamKeys: string[];
+  startedAt: number;
+  steps: Record<string, number>;
+};
+
+function createRedirectTiming(
+  path: `/${string}`,
+  searchParams?: Record<string, string | string[] | undefined>,
+): RedirectTiming {
+  return {
+    path,
+    searchParamKeys: Object.keys(searchParams ?? {}).sort(),
+    startedAt: Date.now(),
+    steps: {},
+  };
+}
+
+async function measureRedirectStep<T>(
+  timing: RedirectTiming,
+  step: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    return await operation();
+  } finally {
+    timing.steps[step] = Date.now() - startedAt;
+  }
+}
+
+function logRedirectTiming(
+  timing: RedirectTiming,
+  metadata: {
+    outcome: "account-path" | "connect-mailbox" | "login";
+    usedLastEmailAccountCookie: boolean;
+    usedFallbackAccountLookup: boolean;
+    foundEmailAccount: boolean;
+  },
+) {
+  const durationMs = Date.now() - timing.startedAt;
+  logger.info("Resolved account redirect", {
+    path: timing.path,
+    searchParamKeys: timing.searchParamKeys,
+    durationMs,
+    stepDurationsMs: timing.steps,
+    ...metadata,
+  });
+
+  after(async () => {
+    await flushLoggerSafely(logger, {
+      path: timing.path,
+      durationMs,
+      outcome: metadata.outcome,
+    });
+  });
 }


### PR DESCRIPTION
Adds timing visibility for account-scoped redirects and trims the fallback account lookup.

- Logs per-step redirect timings for auth, last-account cookie resolution, and fallback account lookup
- Flushes redirect logs after the response so logging does not add redirect latency
- Selects only the account id in the fallback query and orders account fallback deterministically
- Extends redirect tests for logging, fallback query shape, and cookie-based account redirects

Validation:
- pnpm test utils/account.test.ts
- pnpm check

Performance impact: adds one structured log event per account redirect resolution, with flushing scheduled via after(); no new database calls. The fallback database call now fetches only id and uses deterministic ordering.