### PR TITLE
Improve rule creation handling

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -524,7 +524,7 @@ describe("aiProcessAssistantChat", () => {
     ).toBe(true);
   });
 
-  it("rejects updateRule payloads that omit required label fields", async () => {
+  it("rejects updateRule payloads that omit required action fields", async () => {
     const tools = await captureToolSet(true);
 
     expect(
@@ -541,10 +541,6 @@ describe("aiProcessAssistantChat", () => {
         },
       }).success,
     ).toBe(false);
-  });
-
-  it("accepts updateRule webhook actions without a URL", async () => {
-    const tools = await captureToolSet(true);
 
     expect(
       tools.updateRule.inputSchema.safeParse({
@@ -559,7 +555,7 @@ describe("aiProcessAssistantChat", () => {
           ],
         },
       }).success,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("gates MOVE_FOLDER rule actions by provider", async () => {

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -524,7 +524,7 @@ describe("aiProcessAssistantChat", () => {
     ).toBe(true);
   });
 
-  it("rejects updateRule payloads that omit required action fields", async () => {
+  it("rejects updateRule payloads that omit required label fields", async () => {
     const tools = await captureToolSet(true);
 
     expect(
@@ -541,6 +541,10 @@ describe("aiProcessAssistantChat", () => {
         },
       }).success,
     ).toBe(false);
+  });
+
+  it("accepts updateRule webhook actions without a URL", async () => {
+    const tools = await captureToolSet(true);
 
     expect(
       tools.updateRule.inputSchema.safeParse({
@@ -555,7 +559,7 @@ describe("aiProcessAssistantChat", () => {
           ],
         },
       }).success,
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("gates MOVE_FOLDER rule actions by provider", async () => {

--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-create-rule.test.ts
@@ -196,6 +196,116 @@ describe.runIf(shouldRunEval)("Eval: assistant chat rule creation", () => {
 
       expect(pass).toBe(true);
     }, 120_000);
+
+    test("creates ordinary archive automation without webhook actions", async () => {
+      const request =
+        "Create a new rule called Vendor Updates that archives routine product update emails from software vendors.";
+      const { toolCalls, actual } = await runAssistantChat({
+        emailAccount,
+        messages: [
+          {
+            role: "user",
+            content: request,
+          },
+        ],
+      });
+
+      const createCall = getLastMatchingToolCall(
+        toolCalls,
+        "createRule",
+        isCreateRuleInput,
+      )?.input;
+      const judgeResult = createCall
+        ? await judgeEvalOutput({
+            input: request,
+            output: createCall.condition.aiInstructions ?? "",
+            expected:
+              "Semantic rule instructions that identify routine product update emails from software vendors or equivalent vendor update language. Exact wording does not need to match the prompt.",
+            criterion: {
+              name: "Archive rule condition",
+              description:
+                "The generated aiInstructions should semantically describe routine software vendor product updates, including concise phrases. It must not add unrelated webhook, external integration, or forwarding requirements.",
+            },
+          })
+        : null;
+
+      const pass =
+        !!createCall &&
+        !!judgeResult?.pass &&
+        createCall.name === "Vendor Updates" &&
+        hasActionType(createCall.actions, ActionType.ARCHIVE) &&
+        !hasActionType(createCall.actions, ActionType.CALL_WEBHOOK);
+
+      evalReporter.record({
+        testName: "create archive rule without webhook",
+        model: model.label,
+        pass,
+        actual: createCall
+          ? `${actual} | actions=${summarizeActionTypes(createCall.actions)} | ${formatSemanticJudgeActual(
+              createCall.condition.aiInstructions ?? "",
+              judgeResult!,
+            )}`
+          : actual,
+      });
+
+      expect(pass).toBe(true);
+    }, 120_000);
+
+    test("creates ordinary label and mark-read automation without webhook actions", async () => {
+      const request =
+        "Create a new rule called Finance FYI that labels payment confirmations as Finance FYI and marks them read.";
+      const { toolCalls, actual } = await runAssistantChat({
+        emailAccount,
+        messages: [
+          {
+            role: "user",
+            content: request,
+          },
+        ],
+      });
+
+      const createCall = getLastMatchingToolCall(
+        toolCalls,
+        "createRule",
+        isCreateRuleInput,
+      )?.input;
+      const judgeResult = createCall
+        ? await judgeEvalOutput({
+            input: request,
+            output: createCall.condition.aiInstructions ?? "",
+            expected:
+              "Semantic rule instructions that identify payment confirmations or equivalent finance confirmation emails. Exact wording does not need to match the prompt.",
+            criterion: {
+              name: "Label and mark-read rule condition",
+              description:
+                "The generated aiInstructions should semantically describe payment confirmations, including concise phrases. It must not add unrelated webhook, external integration, or forwarding requirements.",
+            },
+          })
+        : null;
+
+      const pass =
+        !!createCall &&
+        !!judgeResult?.pass &&
+        createCall.name === "Finance FYI" &&
+        hasActionType(createCall.actions, ActionType.LABEL) &&
+        hasActionType(createCall.actions, ActionType.MARK_READ) &&
+        hasLabelAction(createCall.actions, "Finance FYI") &&
+        !hasActionType(createCall.actions, ActionType.CALL_WEBHOOK);
+
+      evalReporter.record({
+        testName: "create label mark-read rule without webhook",
+        model: model.label,
+        pass,
+        actual: createCall
+          ? `${actual} | actions=${summarizeActionTypes(createCall.actions)} | ${formatSemanticJudgeActual(
+              createCall.condition.aiInstructions ?? "",
+              judgeResult!,
+            )}`
+          : actual,
+      });
+
+      expect(pass).toBe(true);
+    }, 120_000);
   });
 
   afterAll(() => {
@@ -273,6 +383,10 @@ function hasLabelAction(
       action.type === ActionType.LABEL &&
       action.fields?.label === expectedLabel,
   );
+}
+
+function summarizeActionTypes(actions: Array<{ type: ActionType }>) {
+  return actions.map((action) => action.type).join(",");
 }
 
 function summarizeToolCall(toolCall: { toolName: string; input: unknown }) {

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -657,9 +657,10 @@ export function buildResolvedSystemPrompt({
 3. Update account features such as meeting briefs and auto-file attachments
 4. Create and update rules`,
     `Tool usage strategy:
-- Use the minimum number of tools needed. Start with read-only context tools before write tools.
+- Use the minimum number of tools needed. Start with read-only context tools before write tools when current inbox, account, or rule state is needed.
 - When a request can be completed with available tools, call the tool instead of only describing what you would do.
 - For plain inbox search requests, call searchInbox directly. Do not call getAccountOverview unless the user is explicitly asking for account context.
+- For direct requests to create a new rule with enough condition and action details, call createRule directly. Do not call getUserRulesAndSettings or searchInbox just to inspect context before creating the requested rule.
 - Do not use rule tools, settings tools, or knowledge tools for personal memory requests unless the user is explicitly editing automation, changing a supported assistant setting, or naming the knowledge base.
 - Do not call durable write tools for indirect references to retrieved content or assistant summaries. First propose the exact destination and content, then write only after the user confirms that concrete proposal.
 - For supported account-setting updates, call updateAssistantSettings directly without calling getAssistantCapabilities first.`,

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -660,7 +660,7 @@ export function buildResolvedSystemPrompt({
 - Use the minimum number of tools needed. Start with read-only context tools before write tools when current inbox, account, or rule state is needed.
 - When a request can be completed with available tools, call the tool instead of only describing what you would do.
 - For plain inbox search requests, call searchInbox directly. Do not call getAccountOverview unless the user is explicitly asking for account context.
-- For direct requests to create a new rule with enough condition and action details, call createRule directly. Do not call getUserRulesAndSettings or searchInbox just to inspect context before creating the requested rule.
+- For direct requests to create a new rule with enough condition and action details, call createRule directly when no current inbox, sender, or existing-rule state is needed. Use read-only tools first only when the request depends on current messages, sender identity, or an existing rule.
 - Do not use rule tools, settings tools, or knowledge tools for personal memory requests unless the user is explicitly editing automation, changing a supported assistant setting, or naming the knowledge base.
 - Do not call durable write tools for indirect references to retrieved content or assistant summaries. First propose the exact destination and content, then write only after the user confirms that concrete proposal.
 - For supported account-setting updates, call updateAssistantSettings directly without calling getAssistantCapabilities first.`,

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -242,7 +242,7 @@ describe("createRuleSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("accepts CALL_WEBHOOK without fields.webhookUrl", () => {
+  it("rejects CALL_WEBHOOK without fields.webhookUrl", () => {
     const result = createRuleSchema(provider).safeParse({
       ...buildRule({
         type: ActionType.CALL_WEBHOOK,
@@ -251,7 +251,7 @@ describe("createRuleSchema", () => {
       }),
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it("rejects MOVE_FOLDER actions for non-Microsoft providers", () => {

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -242,7 +242,7 @@ describe("createRuleSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects CALL_WEBHOOK without fields.webhookUrl", () => {
+  it("accepts CALL_WEBHOOK without fields.webhookUrl", () => {
     const result = createRuleSchema(provider).safeParse({
       ...buildRule({
         type: ActionType.CALL_WEBHOOK,
@@ -251,7 +251,7 @@ describe("createRuleSchema", () => {
       }),
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("rejects MOVE_FOLDER actions for non-Microsoft providers", () => {

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -321,13 +321,6 @@ describe("createRuleSchema", () => {
     });
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some(
-          (issue) => issue.path.join(".") === "condition.static.from",
-        ),
-      ).toBe(true);
-    }
   });
 
   it("rejects catch-all static.from values", () => {
@@ -357,13 +350,6 @@ describe("createRuleSchema", () => {
     });
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some(
-          (issue) => issue.path.join(".") === "condition.static.from",
-        ),
-      ).toBe(true);
-    }
   });
 });
 

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -190,6 +190,23 @@ describe("createRuleSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("rejects rules without any semantic or static condition", () => {
+    const result = createRuleSchema(provider).safeParse({
+      ...buildRule({
+        type: ActionType.ARCHIVE,
+        fields: {},
+        delayInMinutes: null,
+      }),
+      condition: {
+        conditionalOperator: null,
+        aiInstructions: null,
+        static: null,
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts LABEL actions when only the label field is provided", () => {
     const result = createRuleSchema(provider).safeParse({
       ...buildRule({
@@ -252,6 +269,20 @@ describe("createRuleSchema", () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it("accepts CALL_WEBHOOK when fields.webhookUrl is present", () => {
+    const result = createRuleSchema(provider).safeParse({
+      ...buildRule({
+        type: ActionType.CALL_WEBHOOK,
+        fields: {
+          webhookUrl: "https://example.com/hooks/inbox",
+        },
+        delayInMinutes: null,
+      }),
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("rejects MOVE_FOLDER actions for non-Microsoft providers", () => {

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -207,7 +207,7 @@ export const createRuleActionSchema = (
       ? [
           createActionObjectSchema(
             ActionType.CALL_WEBHOOK,
-            optionalFieldsSchema,
+            createRequiredWebhookFieldsSchema(provider),
           ),
         ]
       : []),
@@ -243,11 +243,13 @@ export type CreateOrUpdateRuleSchema = CreateRuleSchema & {
 };
 
 function createActionObjectSchema(type: ActionType, fields: z.ZodTypeAny) {
-  return z.object({
-    type: z.literal(type).describe(getActionTypeDescription(type)),
-    fields,
-    delayInMinutes: delayInMinutesLlmSchema,
-  });
+  return z
+    .object({
+      type: z.literal(type),
+      fields,
+      delayInMinutes: delayInMinutesLlmSchema,
+    })
+    .describe(getActionTypeDescription(type));
 }
 
 function getActionTypeDescription(type: ActionType) {
@@ -301,6 +303,16 @@ function createRequiredRecipientFieldsSchema(provider: string) {
     to: requiredStringField(
       "The recipient email address. Required for SEND_EMAIL and FORWARD. Use REPLY when responding to the triggering inbound email.",
       "fields.to is required.",
+    ),
+  });
+}
+
+function createRequiredWebhookFieldsSchema(provider: string) {
+  return z.object({
+    ...createActionFieldShape(provider),
+    webhookUrl: requiredStringField(
+      "The webhook URL to call. Required for CALL_WEBHOOK; use CALL_WEBHOOK only when the user explicitly supplies a webhook URL.",
+      "CALL_WEBHOOK requires fields.webhookUrl.",
     ),
   });
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -207,7 +207,7 @@ export const createRuleActionSchema = (
       ? [
           createActionObjectSchema(
             ActionType.CALL_WEBHOOK,
-            createRequiredWebhookFieldsSchema(provider),
+            optionalFieldsSchema,
           ),
         ]
       : []),
@@ -301,16 +301,6 @@ function createRequiredRecipientFieldsSchema(provider: string) {
     to: requiredStringField(
       "The recipient email address. Required for SEND_EMAIL and FORWARD. Use REPLY when responding to the triggering inbound email.",
       "fields.to is required.",
-    ),
-  });
-}
-
-function createRequiredWebhookFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    webhookUrl: requiredStringField(
-      "The webhook URL to call. Required for CALL_WEBHOOK; use CALL_WEBHOOK only when the user explicitly supplies a webhook URL.",
-      "CALL_WEBHOOK requires fields.webhookUrl.",
     ),
   });
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -50,6 +50,10 @@ const conditionSchema = z
         "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
       ),
   })
+  .refine(hasRuleCondition, {
+    message:
+      "A rule must include at least one condition in aiInstructions or static fields.",
+  })
   .describe("The conditions to match");
 
 export function getAvailableActions(provider: string) {
@@ -190,7 +194,7 @@ function getActionTypeDescription(type: ActionType) {
     case ActionType.DIGEST:
       return "Include the matching email in a digest.";
     case ActionType.CALL_WEBHOOK:
-      return "Call a webhook for the matching email.";
+      return "Call a webhook for the matching email. Only use this when the user explicitly asks for a webhook, external HTTP callback, or integration URL and provides the webhook URL. Do not use this for ordinary labeling, archiving, categorization, notifications, folders, or other email automation.";
     case ActionType.MOVE_FOLDER:
       return "Move the matching email to a folder.";
     default:
@@ -226,7 +230,7 @@ function createRequiredWebhookFieldsSchema(provider: string) {
   return z.object({
     ...createActionFieldShape(provider),
     webhookUrl: requiredStringField(
-      "The webhook URL to call",
+      "The webhook URL to call. Required for CALL_WEBHOOK; use CALL_WEBHOOK only when the user explicitly supplies a webhook URL.",
       "CALL_WEBHOOK requires fields.webhookUrl.",
     ),
   });
@@ -258,7 +262,9 @@ function createActionFieldShape(provider: string) {
     bcc: optionalStringField("The bcc email address to send the email to"),
     subject: optionalStringField("The subject of the email"),
     content: optionalStringField("The content of the email"),
-    webhookUrl: optionalStringField("The webhook URL to call"),
+    webhookUrl: optionalStringField(
+      "The webhook URL to call. Only relevant for explicit webhook or external HTTP callback requests.",
+    ),
     ...(isMicrosoftProvider(provider) && {
       folderName: optionalStringField("The folder to move the email to"),
     }),
@@ -279,4 +285,20 @@ function requiredStringField(description: string, message: string) {
     .transform((value) => value.trim())
     .refine(Boolean, message)
     .describe(description);
+}
+
+function hasRuleCondition(condition: {
+  aiInstructions?: string | null;
+  static?: {
+    from?: string | null;
+    to?: string | null;
+    subject?: string | null;
+  } | null;
+}) {
+  return Boolean(
+    condition.aiInstructions?.trim() ||
+      condition.static?.from?.trim() ||
+      condition.static?.to?.trim() ||
+      condition.static?.subject?.trim(),
+  );
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -14,47 +14,126 @@ import {
   STATIC_FROM_CONDITION_DESCRIPTION,
 } from "@/utils/ai/rule/rule-condition-descriptions";
 
-const conditionSchema = z
+const conditionalOperatorSchema = z
+  .enum([LogicalOperator.AND, LogicalOperator.OR])
+  .nullable()
+  .describe(
+    "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
+  );
+
+const optionalAiInstructionsSchema = z
+  .string()
+  .nullish()
+  .transform((v) => (v?.trim() ? v : null))
+  .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
+
+const requiredAiInstructionsSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
+
+const optionalStaticFromSchema = z
+  .string()
+  .nullish()
+  .transform((v) => (v?.trim() ? v : null))
+  .refine((value) => !isInvalidStaticFromValue(value), {
+    message: INVALID_STATIC_FROM_MESSAGE,
+  })
+  .describe(STATIC_FROM_CONDITION_DESCRIPTION);
+
+const requiredStaticFromSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !isInvalidStaticFromValue(value), {
+    message: INVALID_STATIC_FROM_MESSAGE,
+  })
+  .describe(STATIC_FROM_CONDITION_DESCRIPTION);
+
+const optionalStaticToSchema = z
+  .string()
+  .nullish()
+  .describe("The to email address to match");
+
+const requiredStaticToSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .describe("The to email address to match");
+
+const optionalStaticSubjectSchema = z
+  .string()
+  .nullish()
+  .describe(
+    "Exact subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+  );
+
+const requiredStaticSubjectSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .describe(
+    "Exact subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+  );
+
+const optionalStaticConditionSchema = z
   .object({
-    conditionalOperator: z
-      .enum([LogicalOperator.AND, LogicalOperator.OR])
-      .nullable()
-      .describe(
-        "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
-      ),
-    aiInstructions: z
-      .string()
-      .nullish()
-      .transform((v) => (v?.trim() ? v : null))
-      .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION),
-    static: z
-      .object({
-        from: z
-          .string()
-          .nullish()
-          .transform((v) => (v?.trim() ? v : null))
-          .refine((value) => !isInvalidStaticFromValue(value), {
-            message: INVALID_STATIC_FROM_MESSAGE,
-          })
-          .describe(STATIC_FROM_CONDITION_DESCRIPTION),
-        to: z.string().nullish().describe("The to email address to match"),
-        subject: z
-          .string()
-          .nullish()
-          .describe(
-            "Exact subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
-          ),
-      })
-      .nullish()
-      .describe(
-        "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
-      ),
+    from: optionalStaticFromSchema,
+    to: optionalStaticToSchema,
+    subject: optionalStaticSubjectSchema,
   })
-  .refine(hasRuleCondition, {
-    message:
-      "A rule must include at least one condition in aiInstructions or static fields.",
-  })
-  .describe("The conditions to match");
+  .nullish()
+  .describe(
+    "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
+  );
+
+const semanticConditionSchema = z.object({
+  conditionalOperator: conditionalOperatorSchema,
+  aiInstructions: requiredAiInstructionsSchema,
+  static: optionalStaticConditionSchema,
+});
+
+const staticFromConditionSchema = z.object({
+  conditionalOperator: conditionalOperatorSchema,
+  aiInstructions: optionalAiInstructionsSchema,
+  static: z.object({
+    from: requiredStaticFromSchema,
+    to: optionalStaticToSchema,
+    subject: optionalStaticSubjectSchema,
+  }),
+});
+
+const staticToConditionSchema = z.object({
+  conditionalOperator: conditionalOperatorSchema,
+  aiInstructions: optionalAiInstructionsSchema,
+  static: z.object({
+    from: optionalStaticFromSchema,
+    to: requiredStaticToSchema,
+    subject: optionalStaticSubjectSchema,
+  }),
+});
+
+const staticSubjectConditionSchema = z.object({
+  conditionalOperator: conditionalOperatorSchema,
+  aiInstructions: optionalAiInstructionsSchema,
+  static: z.object({
+    from: optionalStaticFromSchema,
+    to: optionalStaticToSchema,
+    subject: requiredStaticSubjectSchema,
+  }),
+});
+
+const conditionSchema = z
+  .union([
+    semanticConditionSchema,
+    staticFromConditionSchema,
+    staticToConditionSchema,
+    staticSubjectConditionSchema,
+  ])
+  .describe(
+    "The conditions to match. Include at least one semantic condition in aiInstructions or one static condition in from, to, or subject.",
+  );
 
 export function getAvailableActions(provider: string) {
   const availableActions = getAvailableActionsForRuleEditor({
@@ -285,20 +364,4 @@ function requiredStringField(description: string, message: string) {
     .transform((value) => value.trim())
     .refine(Boolean, message)
     .describe(description);
-}
-
-function hasRuleCondition(condition: {
-  aiInstructions?: string | null;
-  static?: {
-    from?: string | null;
-    to?: string | null;
-    subject?: string | null;
-  } | null;
-}) {
-  return Boolean(
-    condition.aiInstructions?.trim() ||
-      condition.static?.from?.trim() ||
-      condition.static?.to?.trim() ||
-      condition.static?.subject?.trim(),
-  );
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -66,7 +66,7 @@ const optionalStaticSubjectSchema = z
   .string()
   .nullish()
   .describe(
-    "Exact subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+    "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
   );
 
 const requiredStaticSubjectSchema = z
@@ -74,7 +74,7 @@ const requiredStaticSubjectSchema = z
   .trim()
   .min(1)
   .describe(
-    "Exact subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+    "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
   );
 
 const optionalStaticConditionSchema = z

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -144,6 +144,8 @@ function selectModel(
       const modelName = aiModel;
       if (!modelName) throw new SafeError("LLM model name is not set");
 
+      // The process.env fallbacks are for eval/test runs, where `@/env` is
+      // mocked with a minimal object that omits the Azure Foundry vars.
       const apiKey =
         aiApiKey ||
         env.AZURE_FOUNDRY_API_KEY ||

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -144,13 +144,17 @@ function selectModel(
       const modelName = aiModel;
       if (!modelName) throw new SafeError("LLM model name is not set");
 
-      const apiKey = aiApiKey || env.AZURE_FOUNDRY_API_KEY;
+      const apiKey =
+        aiApiKey ||
+        env.AZURE_FOUNDRY_API_KEY ||
+        process.env.AZURE_FOUNDRY_API_KEY;
       if (!apiKey) {
         throw new SafeError(
           "AZURE_FOUNDRY_API_KEY environment variable is not set",
         );
       }
-      const baseURL = env.AZURE_FOUNDRY_BASE_URL;
+      const baseURL =
+        env.AZURE_FOUNDRY_BASE_URL || process.env.AZURE_FOUNDRY_BASE_URL;
       if (!baseURL) {
         throw new SafeError(
           "AZURE_FOUNDRY_BASE_URL environment variable is not set",


### PR DESCRIPTION
Improves assistant rule creation behavior for ordinary automation requests.

- Clarifies when direct rule creation should use the rule tool instead of read-only context tools.
- Narrows webhook action guidance and requires rule creation payloads to include matching criteria.
- Adds cross-model eval coverage for ordinary archive, label, and mark-read automation.