### PR TITLE
Fix draft messaging channel toggles

### DIFF
--- a/apps/web/utils/actions/messaging-channels.test.ts
+++ b/apps/web/utils/actions/messaging-channels.test.ts
@@ -458,7 +458,7 @@ describe("toggleRuleChannelAction", () => {
     });
   });
 
-  it("falls back to NOTIFY when the client requests DRAFT but the rule has no DRAFT_EMAIL action", async () => {
+  it("falls back to NOTIFY when the client requests DRAFT but the rule has no draft action", async () => {
     prisma.rule.findUnique.mockResolvedValue({
       emailAccountId: "email-account-1",
       actions: [],
@@ -532,6 +532,64 @@ describe("toggleRuleChannelAction", () => {
         type: "DRAFT_MESSAGING_CHANNEL",
         ruleId: "rule-1",
         messagingChannelId: "channel-1",
+      },
+    });
+  });
+
+  it("creates DRAFT_MESSAGING_CHANNEL when the rule already drafts to another chat channel", async () => {
+    prisma.rule.findUnique.mockResolvedValue({
+      emailAccountId: "email-account-1",
+      actions: [{ id: "slack-draft-action-1" }],
+    } as any);
+    prisma.messagingChannel.findUnique.mockResolvedValue({
+      emailAccountId: "email-account-1",
+      provider: "TELEGRAM",
+      isConnected: true,
+      accessToken: null,
+      providerUserId: "telegram-user-1",
+      routes: [
+        {
+          purpose: MessagingRoutePurpose.RULE_NOTIFICATIONS,
+          targetType: MessagingRouteTargetType.DIRECT_MESSAGE,
+          targetId: "telegram-chat-1",
+        },
+      ],
+    } as any);
+
+    const result = await toggleRuleChannelAction("email-account-1" as any, {
+      ruleId: "rule-1",
+      messagingChannelId: "telegram-channel-1",
+      enabled: true,
+      actionType: "DRAFT_MESSAGING_CHANNEL",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.rule.findUnique).toHaveBeenCalledWith({
+      where: {
+        id_emailAccountId: {
+          id: "rule-1",
+          emailAccountId: "email-account-1",
+        },
+      },
+      select: {
+        actions: {
+          where: {
+            type: {
+              in: ["DRAFT_EMAIL", "DRAFT_MESSAGING_CHANNEL"],
+            },
+          },
+          select: { id: true },
+          take: 1,
+        },
+      },
+    });
+    expect(prisma.action.create).toHaveBeenCalledWith({
+      data: {
+        emailAccountId: "email-account-1",
+        messagingChannelEmailAccountId: "email-account-1",
+        type: "DRAFT_MESSAGING_CHANNEL",
+        ruleId: "rule-1",
+        messagingChannelId: "telegram-channel-1",
       },
     });
   });

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -21,7 +21,10 @@ import {
   type MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
 import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code";
-import { MESSAGING_CHANNEL_ACTION_TYPES } from "@/utils/actions/draft-reply";
+import {
+  DRAFT_REPLY_ACTION_TYPES,
+  MESSAGING_CHANNEL_ACTION_TYPES,
+} from "@/utils/actions/draft-reply";
 import { env } from "@/env";
 import {
   getMessagingChannelReconnectMessage,
@@ -348,7 +351,7 @@ export const toggleRuleChannelAction = actionClient
           },
           select: {
             actions: {
-              where: { type: ActionType.DRAFT_EMAIL },
+              where: { type: { in: DRAFT_REPLY_ACTION_TYPES } },
               select: { id: true },
               take: 1,
             },
@@ -386,10 +389,10 @@ export const toggleRuleChannelAction = actionClient
 
       let actionType: ActionType =
         requestedType ?? ActionType.NOTIFY_MESSAGING_CHANNEL;
-      const hasDraftEmailAction = (rule.actions?.length ?? 0) > 0;
+      const hasDraftReplyAction = (rule.actions?.length ?? 0) > 0;
       if (
         actionType === ActionType.DRAFT_MESSAGING_CHANNEL &&
-        !hasDraftEmailAction
+        !hasDraftReplyAction
       ) {
         actionType = ActionType.NOTIFY_MESSAGING_CHANNEL;
       }

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -351,7 +351,7 @@ export const toggleRuleChannelAction = actionClient
           },
           select: {
             actions: {
-              where: { type: { in: DRAFT_REPLY_ACTION_TYPES } },
+              where: { type: { in: [...DRAFT_REPLY_ACTION_TYPES] } },
               select: { id: true },
               take: 1,
             },


### PR DESCRIPTION
Draft notification toggles now recognize existing draft replies sent through supported draft action types. This keeps rules that already draft to a chat channel from falling back to notify-only when enabling another messaging channel.

- Checks both email draft and draft messaging actions before enabling draft messaging channel actions.
- Adds regression coverage for rules that already draft to another chat channel.
- Tests: `pnpm test utils/actions/messaging-channels.test.ts`.
- Performance impact: reuses the existing rule action lookup with a small action-type filter; no extra network calls and low hot-path risk.
