### PR TITLE
Add organization-managed rules with team targeting

### DIFF
--- a/apps/web/__tests__/helpers.ts
+++ b/apps/web/__tests__/helpers.ts
@@ -306,6 +306,7 @@ export function getRule(
     categoryFilterType: null,
     conditionalOperator: LogicalOperator.AND,
     systemType: null,
+    organizationRuleId: null,
     promptText: null,
   };
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -118,6 +118,7 @@ export function Rules({
         conditionalOperator: LogicalOperator.OR,
         groupId: null,
         systemType,
+        organizationRuleId: null,
         to: null,
         from: null,
         subject: null,
@@ -164,6 +165,7 @@ export function Rules({
               <TableBody>
                 {rules.map((rule) => {
                   const isPlaceholder = rule.id.startsWith("placeholder-");
+                  const isOrganizationManaged = !!rule.organizationRuleId;
 
                   return (
                     <TableRow
@@ -186,6 +188,7 @@ export function Rules({
                         <Switch
                           size="sm"
                           checked={rule.enabled}
+                          disabled={isOrganizationManaged}
                           onCheckedChange={async (enabled) => {
                             const isSystemRule = !!rule.systemType;
 
@@ -223,7 +226,12 @@ export function Rules({
                         />
                       </TableCell>
                       <TableCell className="font-medium p-2 sm:p-4">
-                        {rule.name}
+                        <div className="flex items-center gap-2">
+                          {rule.name}
+                          {isOrganizationManaged && (
+                            <Badge color="purple">Managed by org</Badge>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell className="hidden sm:table-cell p-2 sm:p-4">
                         <TruncatedTooltipText
@@ -257,28 +265,35 @@ export function Rules({
                               align="end"
                               onClick={(e) => e.stopPropagation()}
                             >
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  ruleDialog.onOpen({
-                                    ruleId: rule.id,
-                                    editMode: true,
-                                  });
-                                }}
-                              >
-                                <PenIcon className="mr-2 size-4" />
-                                Edit manually
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  setInput(
-                                    `I'd like to edit the "${rule.name}" rule:\n`,
-                                  );
-                                  setOpen((arr) => [...arr, "chat-sidebar"]);
-                                }}
-                              >
-                                <SparklesIcon className="mr-2 size-4" />
-                                Edit via AI
-                              </DropdownMenuItem>
+                              {!isOrganizationManaged && (
+                                <>
+                                  <DropdownMenuItem
+                                    onClick={() => {
+                                      ruleDialog.onOpen({
+                                        ruleId: rule.id,
+                                        editMode: true,
+                                      });
+                                    }}
+                                  >
+                                    <PenIcon className="mr-2 size-4" />
+                                    Edit manually
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={() => {
+                                      setInput(
+                                        `I'd like to edit the "${rule.name}" rule:\n`,
+                                      );
+                                      setOpen((arr) => [
+                                        ...arr,
+                                        "chat-sidebar",
+                                      ]);
+                                    }}
+                                  >
+                                    <SparklesIcon className="mr-2 size-4" />
+                                    Edit via AI
+                                  </DropdownMenuItem>
+                                </>
+                              )}
                               <DropdownMenuItem
                                 onClick={() => {
                                   ruleDialog.onOpen({
@@ -300,7 +315,7 @@ export function Rules({
                                   History
                                 </Link>
                               </DropdownMenuItem>
-                              {!rule.systemType && (
+                              {!rule.systemType && !isOrganizationManaged && (
                                 <>
                                   <DropdownMenuSeparator />
 

--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -33,6 +33,7 @@ import {
   BarChart3,
   BarChartIcon,
   ShieldIcon,
+  UsersIcon,
   XIcon,
 } from "lucide-react";
 import { InviteMemberModal } from "@/components/InviteMemberModal";
@@ -41,6 +42,8 @@ import {
   removeMemberAction,
   updateMemberRoleAction,
 } from "@/utils/actions/organization";
+import { updateMemberTeamAction } from "@/utils/actions/organization-rule";
+import { useOrganizationTeams } from "@/hooks/useOrganizationTeams";
 import { toastSuccess, toastError } from "@/components/Toast";
 import type { OrganizationMembersResponse } from "@/app/api/organizations/[organizationId]/members/route";
 import { useExecutedRulesCount } from "@/hooks/useExecutedRulesCount";
@@ -62,6 +65,9 @@ export function Members({ organizationId }: { organizationId: string }) {
   const { data: membership } = useOrganizationMembership();
   const isAdmin = hasOrganizationAdminRole(membership?.role ?? "");
   const { data: executedRulesData } = useExecutedRulesCount(
+    isAdmin ? organizationId : null,
+  );
+  const { data: teamsData } = useOrganizationTeams(
     isAdmin ? organizationId : null,
   );
   const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
@@ -151,6 +157,18 @@ export function Members({ organizationId }: { organizationId: string }) {
     [handleAction],
   );
 
+  const handleUpdateTeam = useCallback(
+    (memberId: string, teamId: string | null) =>
+      handleAction(
+        memberId,
+        () => updateMemberTeamAction({ memberId, teamId }),
+        "Error updating team",
+        "Team updated. Organization rules were re-synced.",
+        "Failed to update team",
+      ),
+    [handleAction],
+  );
+
   return (
     <LoadingContent loading={isLoading} error={error}>
       <div>
@@ -176,6 +194,8 @@ export function Members({ organizationId }: { organizationId: string }) {
                 member={member}
                 onRemove={handleRemoveMember}
                 onUpdateRole={handleUpdateRole}
+                onUpdateTeam={handleUpdateTeam}
+                teams={teamsData?.teams ?? []}
                 executedRulesCount={executedRulesStats?.executedRulesCount}
                 lastProcessedEmailAt={
                   executedRulesStats?.lastProcessedEmailAt ?? null
@@ -242,6 +262,8 @@ function MemberCard({
   member,
   onRemove,
   onUpdateRole,
+  onUpdateTeam,
+  teams,
   executedRulesCount,
   lastProcessedEmailAt,
   isAdmin,
@@ -250,6 +272,8 @@ function MemberCard({
   member: Member;
   onRemove: (memberId: string) => void;
   onUpdateRole: (memberId: string, role: "admin" | "member") => void;
+  onUpdateTeam: (memberId: string, teamId: string | null) => void;
+  teams: { id: string; name: string }[];
   executedRulesCount?: number;
   lastProcessedEmailAt?: Date | string | null;
   isAdmin: boolean;
@@ -344,6 +368,37 @@ function MemberCard({
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
               )}
+              {teams.length > 0 && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger disabled={isPending}>
+                    <UsersIcon className="mr-2 size-4" />
+                    Team
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuRadioGroup
+                      value={member.team?.id ?? "none"}
+                      onValueChange={(value) => {
+                        const teamId = value === "none" ? null : value;
+                        if (teamId === (member.team?.id ?? null)) return;
+                        onUpdateTeam(member.id, teamId);
+                      }}
+                    >
+                      <DropdownMenuRadioItem value="none" disabled={isPending}>
+                        No team
+                      </DropdownMenuRadioItem>
+                      {teams.map((team) => (
+                        <DropdownMenuRadioItem
+                          key={team.id}
+                          value={team.id}
+                          disabled={isPending}
+                        >
+                          {team.name}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => onRemove(member.id)}
@@ -367,6 +422,11 @@ function MemberCard({
         >
           {capitalizeRole(member.role)}
         </Badge>
+        {member.team && (
+          <Badge variant="outline" className="text-xs">
+            {member.team.name}
+          </Badge>
+        )}
         {isAdmin && (
           <MemberActivityBadge
             status={activityStatus}

--- a/apps/web/app/(app)/organization/[organizationId]/OrganizationTabs.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/OrganizationTabs.tsx
@@ -32,6 +32,11 @@ export function OrganizationTabs({ organizationId }: OrganizationTabsProps) {
     ...(isAdmin
       ? [
           {
+            id: "rules",
+            label: "Rules",
+            href: `/organization/${organizationId}/rules`,
+          },
+          {
             id: "stats",
             label: "Analytics",
             href: `/organization/${organizationId}/stats`,
@@ -41,7 +46,11 @@ export function OrganizationTabs({ organizationId }: OrganizationTabsProps) {
   ];
 
   // Determine selected tab based on pathname
-  const selected = pathname.includes("/stats") ? "stats" : "members";
+  const selected = pathname.includes("/rules")
+    ? "rules"
+    : pathname.includes("/stats")
+      ? "stats"
+      : "members";
 
   return (
     <div>

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrganizationRuleDialog.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrganizationRuleDialog.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import { useFieldArray, useForm } from "react-hook-form";
+import { PlusIcon, XIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/Input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { toastSuccess, toastError } from "@/components/Toast";
+import { ActionType } from "@/generated/prisma/enums";
+import {
+  createOrganizationRuleAction,
+  updateOrganizationRuleAction,
+} from "@/utils/actions/organization-rule";
+import type { OrganizationRulesResponse } from "@/app/api/organizations/[organizationId]/rules/route";
+import type { OrganizationTeamsResponse } from "@/app/api/organizations/[organizationId]/teams/route";
+
+type OrganizationRuleItem = OrganizationRulesResponse["rules"][number];
+
+const ACTION_TYPE_OPTIONS: { value: ActionType; label: string }[] = [
+  { value: ActionType.ARCHIVE, label: "Archive" },
+  { value: ActionType.LABEL, label: "Label" },
+  { value: ActionType.DRAFT_EMAIL, label: "Draft reply" },
+  { value: ActionType.REPLY, label: "Reply" },
+  { value: ActionType.FORWARD, label: "Forward" },
+  { value: ActionType.SEND_EMAIL, label: "Send email" },
+  { value: ActionType.MARK_READ, label: "Mark read" },
+  { value: ActionType.MARK_SPAM, label: "Mark spam" },
+  { value: ActionType.STAR, label: "Star" },
+  { value: ActionType.MOVE_FOLDER, label: "Move to folder" },
+  { value: ActionType.DIGEST, label: "Digest" },
+];
+
+type ActionFieldName =
+  | "label"
+  | "to"
+  | "cc"
+  | "bcc"
+  | "subject"
+  | "content"
+  | "folderName";
+
+type ActionFieldConfig = {
+  name: ActionFieldName;
+  label: string;
+  textarea?: boolean;
+  required?: boolean;
+};
+
+const ACTION_FIELDS: Partial<Record<ActionType, ActionFieldConfig[]>> = {
+  [ActionType.LABEL]: [{ name: "label", label: "Label name", required: true }],
+  [ActionType.FORWARD]: [{ name: "to", label: "Forward to", required: true }],
+  [ActionType.SEND_EMAIL]: [
+    { name: "to", label: "To", required: true },
+    { name: "subject", label: "Subject" },
+    { name: "content", label: "Content", textarea: true },
+  ],
+  [ActionType.REPLY]: [
+    { name: "content", label: "Reply template (optional)", textarea: true },
+  ],
+  [ActionType.DRAFT_EMAIL]: [
+    { name: "content", label: "Draft template (optional)", textarea: true },
+  ],
+  [ActionType.MOVE_FOLDER]: [
+    { name: "folderName", label: "Folder name", required: true },
+  ],
+};
+
+type ActionFormValues = {
+  type: ActionType;
+  label: string;
+  to: string;
+  cc: string;
+  bcc: string;
+  subject: string;
+  content: string;
+  folderName: string;
+};
+
+type OrganizationRuleFormValues = {
+  name: string;
+  instructions: string;
+  from: string;
+  to: string;
+  subject: string;
+  teamIds: string[];
+  actions: ActionFormValues[];
+};
+
+export function OrganizationRuleDialog({
+  organizationId,
+  rule,
+  teams,
+  onClose,
+  onSuccess,
+}: {
+  organizationId: string;
+  rule?: OrganizationRuleItem;
+  teams: OrganizationTeamsResponse["teams"];
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<OrganizationRuleFormValues>({
+    defaultValues: rule ? toFormValues(rule) : emptyFormValues(),
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "actions",
+  });
+
+  const actions = watch("actions");
+  const teamIds = watch("teamIds");
+
+  const onSubmit = handleSubmit(async (data) => {
+    const payload = {
+      name: data.name,
+      instructions: emptyToNull(data.instructions),
+      from: emptyToNull(data.from),
+      to: emptyToNull(data.to),
+      subject: emptyToNull(data.subject),
+      teamIds: data.teamIds,
+      actions: data.actions.map((action) => ({
+        type: action.type,
+        label: emptyToNull(action.label),
+        to: emptyToNull(action.to),
+        cc: emptyToNull(action.cc),
+        bcc: emptyToNull(action.bcc),
+        subject: emptyToNull(action.subject),
+        content: emptyToNull(action.content),
+        folderName: emptyToNull(action.folderName),
+      })),
+    };
+
+    if (
+      !payload.instructions &&
+      !payload.from &&
+      !payload.to &&
+      !payload.subject
+    ) {
+      toastError({
+        description:
+          "Please add at least one condition (AI instructions, from, to, or subject)",
+      });
+      return;
+    }
+
+    const result = rule
+      ? await updateOrganizationRuleAction({ id: rule.id, ...payload })
+      : await createOrganizationRuleAction({ organizationId, ...payload });
+
+    if (result?.serverError || result?.validationErrors) {
+      toastError({
+        title: `Error ${rule ? "updating" : "creating"} rule`,
+        description:
+          result.serverError || "Please check the rule fields and try again.",
+      });
+      return;
+    }
+
+    const sync = result?.data?.sync;
+    toastSuccess({
+      description: sync
+        ? `Rule ${rule ? "updated" : "created"}. Applied to ${
+            sync.createdCount + sync.updatedCount
+          } member account${
+            sync.createdCount + sync.updatedCount === 1 ? "" : "s"
+          }.`
+        : `Rule ${rule ? "updated" : "created"}.`,
+    });
+
+    if (sync?.skipped.length) {
+      toastError({
+        title: "Some accounts were skipped",
+        description: sync.skipped
+          .map((s) => `${s.email}: ${s.reason}`)
+          .join("\n"),
+      });
+    }
+
+    onSuccess();
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {rule ? "Edit organization rule" : "New organization rule"}
+          </DialogTitle>
+          <DialogDescription>
+            This rule is applied to the inbox of every member it targets.
+            Members can see it but only organization admins can change it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={onSubmit} className="space-y-6">
+          <Input
+            type="text"
+            name="name"
+            label="Name"
+            placeholder="e.g. Security alerts"
+            registerProps={register("name", {
+              required: "Please enter a name",
+            })}
+            error={errors.name}
+          />
+
+          <div className="space-y-2">
+            <Label>Conditions</Label>
+            <Input
+              type="text"
+              name="instructions"
+              autosizeTextarea
+              rows={3}
+              label="AI instructions"
+              placeholder="e.g. Emails reporting a security incident or vulnerability"
+              registerProps={register("instructions")}
+              error={errors.instructions}
+            />
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              <Input
+                type="text"
+                name="from"
+                label="From"
+                placeholder="e.g. @vendor.com"
+                registerProps={register("from")}
+                error={errors.from}
+              />
+              <Input
+                type="text"
+                name="to"
+                label="To"
+                placeholder="e.g. support@"
+                registerProps={register("to")}
+                error={errors.to}
+              />
+              <Input
+                type="text"
+                name="subject"
+                label="Subject"
+                placeholder="e.g. [Incident]"
+                registerProps={register("subject")}
+                error={errors.subject}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Actions</Label>
+            {fields.map((field, index) => {
+              const actionType = actions[index]?.type;
+              const extraFields =
+                (actionType && ACTION_FIELDS[actionType]) || [];
+
+              return (
+                <div key={field.id} className="rounded-md border p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={actionType}
+                      onValueChange={(value) =>
+                        setValue(`actions.${index}.type`, value as ActionType, {
+                          shouldDirty: true,
+                        })
+                      }
+                    >
+                      <SelectTrigger className="w-[200px]">
+                        <SelectValue placeholder="Select an action" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ACTION_TYPE_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => remove(index)}
+                      disabled={fields.length === 1}
+                      aria-label="Remove action"
+                    >
+                      <XIcon className="size-4" />
+                    </Button>
+                  </div>
+
+                  {extraFields.map((fieldConfig) => (
+                    <Input
+                      key={fieldConfig.name}
+                      type="text"
+                      name={`actions.${index}.${fieldConfig.name}`}
+                      label={fieldConfig.label}
+                      autosizeTextarea={fieldConfig.textarea}
+                      rows={fieldConfig.textarea ? 3 : undefined}
+                      registerProps={register(
+                        `actions.${index}.${fieldConfig.name}`,
+                        fieldConfig.required
+                          ? {
+                              required: `Please enter a ${fieldConfig.label.toLowerCase()}`,
+                            }
+                          : undefined,
+                      )}
+                      error={errors.actions?.[index]?.[fieldConfig.name]}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => append(emptyAction())}
+              className="px-2 -ml-2"
+            >
+              <PlusIcon className="size-4 mr-2" />
+              Add action
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Applies to</Label>
+            <p className="text-sm text-muted-foreground">
+              {teams.length
+                ? "Select teams this rule applies to. Leave all unchecked to apply it to every member."
+                : "This rule applies to every member. Create teams on the rules page to target specific groups."}
+            </p>
+            {teams.map((team) => (
+              <div key={team.id} className="flex items-center gap-2">
+                <Checkbox
+                  id={`team-${team.id}`}
+                  checked={teamIds.includes(team.id)}
+                  onCheckedChange={(checked) => {
+                    setValue(
+                      "teamIds",
+                      checked
+                        ? [...teamIds, team.id]
+                        : teamIds.filter((id) => id !== team.id),
+                      { shouldDirty: true },
+                    );
+                  }}
+                />
+                <Label htmlFor={`team-${team.id}`} className="font-normal">
+                  {team.name}
+                </Label>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button type="submit" loading={isSubmitting}>
+              {rule ? "Save and sync" : "Create and sync"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function emptyAction(): ActionFormValues {
+  return {
+    type: ActionType.ARCHIVE,
+    label: "",
+    to: "",
+    cc: "",
+    bcc: "",
+    subject: "",
+    content: "",
+    folderName: "",
+  };
+}
+
+function emptyFormValues(): OrganizationRuleFormValues {
+  return {
+    name: "",
+    instructions: "",
+    from: "",
+    to: "",
+    subject: "",
+    teamIds: [],
+    actions: [emptyAction()],
+  };
+}
+
+function toFormValues(rule: OrganizationRuleItem): OrganizationRuleFormValues {
+  return {
+    name: rule.name,
+    instructions: rule.instructions ?? "",
+    from: rule.from ?? "",
+    to: rule.to ?? "",
+    subject: rule.subject ?? "",
+    teamIds: rule.teams.map((team) => team.id),
+    actions: rule.actions.length
+      ? rule.actions.map((action) => ({
+          type: action.type,
+          label: action.label ?? "",
+          to: action.to ?? "",
+          cc: action.cc ?? "",
+          bcc: action.bcc ?? "",
+          subject: action.subject ?? "",
+          content: action.content ?? "",
+          folderName: action.folderName ?? "",
+        }))
+      : [emptyAction()],
+  };
+}
+
+function emptyToNull(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrganizationRules.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrganizationRules.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  MoreHorizontalIcon,
+  PenIcon,
+  PlusIcon,
+  Trash2Icon,
+  XIcon,
+} from "lucide-react";
+import { LoadingContent } from "@/components/LoadingContent";
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { toastSuccess, toastError } from "@/components/Toast";
+import { TypographyH3 } from "@/components/Typography";
+import { TruncatedTooltipText } from "@/components/TruncatedTooltipText";
+import { conditionsToString } from "@/utils/condition";
+import {
+  getActionDisplay,
+  getActionIcon,
+  getVisibleActions,
+} from "@/utils/action-display";
+import { useOrganizationRules } from "@/hooks/useOrganizationRules";
+import { useOrganizationTeams } from "@/hooks/useOrganizationTeams";
+import { useDialogState } from "@/hooks/useDialogState";
+import {
+  createOrganizationTeamAction,
+  deleteOrganizationRuleAction,
+  deleteOrganizationTeamAction,
+  toggleOrganizationRuleAction,
+} from "@/utils/actions/organization-rule";
+import { OrganizationRuleDialog } from "./OrganizationRuleDialog";
+import type { OrganizationRulesResponse } from "@/app/api/organizations/[organizationId]/rules/route";
+
+type OrganizationRuleItem = OrganizationRulesResponse["rules"][number];
+
+export function OrganizationRules({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const { data, isLoading, error, mutate } =
+    useOrganizationRules(organizationId);
+  const {
+    data: teamsData,
+    isLoading: teamsLoading,
+    error: teamsError,
+    mutate: mutateTeams,
+  } = useOrganizationTeams(organizationId);
+
+  const ruleDialog = useDialogState<{ rule?: OrganizationRuleItem }>();
+
+  const rules = data?.rules ?? [];
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <div className="flex justify-between items-center">
+          <div>
+            <TypographyH3>Rules ({rules.length})</TypographyH3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Rules applied automatically to every member they target. Members
+              can't change them.
+            </p>
+          </div>
+          <Button size="sm" onClick={() => ruleDialog.onOpen({})}>
+            <PlusIcon className="mr-2 hidden size-4 md:block" />
+            Add Rule
+          </Button>
+        </div>
+
+        <Card className="mt-4">
+          <LoadingContent loading={isLoading} error={error}>
+            {rules.length ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-16">Enabled</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="hidden sm:table-cell">
+                      Conditions
+                    </TableHead>
+                    <TableHead>Actions</TableHead>
+                    <TableHead>Applies to</TableHead>
+                    <TableHead className="w-16">Accounts</TableHead>
+                    <TableHead className="w-10" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rules.map((rule) => (
+                    <OrganizationRuleRow
+                      key={rule.id}
+                      rule={rule}
+                      onEdit={() => ruleDialog.onOpen({ rule })}
+                      mutate={mutate}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <CardHeader>
+                <CardDescription className="flex flex-col items-center gap-4 py-16">
+                  No organization rules yet. Add one to apply it to every
+                  member's inbox.
+                </CardDescription>
+              </CardHeader>
+            )}
+          </LoadingContent>
+        </Card>
+      </div>
+
+      <div>
+        <TypographyH3>Teams</TypographyH3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Group members by role, like Engineering or Marketing, then target
+          rules at specific teams. Assign members to a team from the Members
+          tab.
+        </p>
+        <div className="mt-4">
+          <LoadingContent loading={teamsLoading} error={teamsError}>
+            <Teams
+              organizationId={organizationId}
+              teams={teamsData?.teams ?? []}
+              mutate={mutateTeams}
+            />
+          </LoadingContent>
+        </div>
+      </div>
+
+      {ruleDialog.isOpen && (
+        <OrganizationRuleDialog
+          organizationId={organizationId}
+          rule={ruleDialog.data?.rule}
+          teams={teamsData?.teams ?? []}
+          onClose={ruleDialog.onClose}
+          onSuccess={() => {
+            mutate();
+            ruleDialog.onClose();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function OrganizationRuleRow({
+  rule,
+  onEdit,
+  mutate,
+}: {
+  rule: OrganizationRuleItem;
+  onEdit: () => void;
+  mutate: () => void;
+}) {
+  return (
+    <TableRow className={!rule.enabled ? "bg-muted opacity-60" : ""}>
+      <TableCell className="text-center">
+        <Switch
+          size="sm"
+          checked={rule.enabled}
+          onCheckedChange={async (enabled) => {
+            const result = await toggleOrganizationRuleAction({
+              id: rule.id,
+              enabled,
+            });
+            if (result?.serverError) {
+              toastError({
+                description: `There was an error ${
+                  enabled ? "enabling" : "disabling"
+                } the rule. ${result.serverError}`,
+              });
+            }
+            mutate();
+          }}
+        />
+      </TableCell>
+      <TableCell className="font-medium">{rule.name}</TableCell>
+      <TableCell className="hidden sm:table-cell">
+        <TruncatedTooltipText
+          text={conditionsToString(rule)}
+          maxLength={50}
+          className="max-w-xs"
+        />
+      </TableCell>
+      <TableCell>
+        <div className="flex gap-1 flex-wrap">
+          {getVisibleActions(rule.actions).map((action) => {
+            const Icon = getActionIcon(action.type);
+            return (
+              <Badge key={action.id} variant="secondary" className="w-fit">
+                <Icon className="size-3 mr-1.5 hidden sm:block" />
+                {getActionDisplay(action, "google", [])}
+              </Badge>
+            );
+          })}
+        </div>
+      </TableCell>
+      <TableCell>
+        {rule.teams.length ? (
+          <div className="flex gap-1 flex-wrap">
+            {rule.teams.map((team) => (
+              <Badge key={team.id} variant="outline">
+                {team.name}
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">All members</span>
+        )}
+      </TableCell>
+      <TableCell className="text-center">{rule._count.managedRules}</TableCell>
+      <TableCell>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button aria-haspopup="true" size="icon" variant="ghost">
+              <MoreHorizontalIcon className="size-4" />
+              <span className="sr-only">Toggle menu</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onEdit}>
+              <PenIcon className="mr-2 size-4" />
+              Edit
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                const yes = confirm(
+                  `Are you sure you want to delete the rule "${rule.name}"? It will be removed from every member's account.`,
+                );
+                if (!yes) return;
+
+                toast.promise(
+                  async () => {
+                    const result = await deleteOrganizationRuleAction({
+                      id: rule.id,
+                    });
+                    if (result?.serverError) {
+                      throw new Error(result.serverError);
+                    }
+                    mutate();
+                  },
+                  {
+                    loading: "Deleting rule...",
+                    success: "Rule deleted",
+                    error: (error) => `Error deleting rule. ${error.message}`,
+                  },
+                );
+              }}
+            >
+              <Trash2Icon className="mr-2 size-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function Teams({
+  organizationId,
+  teams,
+  mutate,
+}: {
+  organizationId: string;
+  teams: { id: string; name: string; _count: { members: number } }[];
+  mutate: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+
+  const onCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    setIsCreating(true);
+    const result = await createOrganizationTeamAction({
+      organizationId,
+      name: trimmed,
+    });
+    setIsCreating(false);
+
+    if (result?.serverError) {
+      toastError({
+        title: "Error creating team",
+        description: result.serverError,
+      });
+      return;
+    }
+
+    setName("");
+    toastSuccess({ description: "Team created" });
+    mutate();
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {teams.map((team) => (
+          <Badge key={team.id} variant="secondary" className="gap-1.5 py-1">
+            {team.name}
+            <span className="text-muted-foreground">
+              ({team._count.members})
+            </span>
+            <button
+              type="button"
+              aria-label={`Delete team ${team.name}`}
+              onClick={async () => {
+                const yes = confirm(
+                  `Are you sure you want to delete the team "${team.name}"?`,
+                );
+                if (!yes) return;
+
+                const result = await deleteOrganizationTeamAction({
+                  id: team.id,
+                });
+                if (result?.serverError) {
+                  toastError({
+                    title: "Error deleting team",
+                    description: result.serverError,
+                  });
+                  return;
+                }
+                toastSuccess({ description: "Team deleted" });
+                mutate();
+              }}
+            >
+              <XIcon className="size-3" />
+            </button>
+          </Badge>
+        ))}
+        {teams.length === 0 && (
+          <span className="text-sm text-muted-foreground">No teams yet.</span>
+        )}
+      </div>
+
+      <div className="flex gap-2 max-w-sm">
+        <Input
+          value={name}
+          placeholder="e.g. Engineering"
+          onChange={(event) => setName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onCreate();
+            }
+          }}
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onCreate}
+          loading={isCreating}
+          disabled={!name.trim()}
+        >
+          Add Team
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/organization/[organizationId]/rules/page.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/page.tsx
@@ -1,0 +1,20 @@
+import { OrganizationTabs } from "@/app/(app)/organization/[organizationId]/OrganizationTabs";
+import { OrganizationRules } from "@/app/(app)/organization/[organizationId]/rules/OrganizationRules";
+import { PageWrapper } from "@/components/PageWrapper";
+
+export default async function OrganizationRulesPage({
+  params,
+}: {
+  params: Promise<{ organizationId: string }>;
+}) {
+  const { organizationId } = await params;
+
+  return (
+    <PageWrapper>
+      <OrganizationTabs organizationId={organizationId} />
+      <div className="mt-6">
+        <OrganizationRules organizationId={organizationId} />
+      </div>
+    </PageWrapper>
+  );
+}

--- a/apps/web/app/(landing)/components/page.tsx
+++ b/apps/web/app/(landing)/components/page.tsx
@@ -985,6 +985,7 @@ function getRule(): Rule {
     promptText: null,
     categoryFilterType: null,
     systemType: null,
+    organizationRuleId: null,
   };
 }
 

--- a/apps/web/app/api/organizations/[organizationId]/members/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/members/route.ts
@@ -47,6 +47,7 @@ async function getOrganizationMembers({
         role: true,
         createdAt: true,
         allowOrgAdminAnalytics: true,
+        team: { select: { id: true, name: true } },
         emailAccount: {
           select: {
             id: true,

--- a/apps/web/app/api/organizations/[organizationId]/rules/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/rules/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import prisma from "@/utils/prisma";
+import { withAuth } from "@/utils/middleware";
+import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
+
+export type OrganizationRulesResponse = Awaited<
+  ReturnType<typeof getOrganizationRules>
+>;
+
+export const GET = withAuth(
+  "organizations/rules",
+  async (request, { params }) => {
+    const { userId } = request.auth;
+    const { organizationId } = await params;
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 },
+      );
+    }
+
+    await fetchAndCheckIsAdmin({ organizationId, userId });
+
+    const result = await getOrganizationRules({ organizationId });
+
+    return NextResponse.json(result);
+  },
+);
+
+async function getOrganizationRules({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const rules = await prisma.organizationRule.findMany({
+    where: { organizationId },
+    include: {
+      actions: true,
+      teams: { select: { id: true, name: true } },
+      _count: { select: { managedRules: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return { rules };
+}

--- a/apps/web/app/api/organizations/[organizationId]/teams/route.ts
+++ b/apps/web/app/api/organizations/[organizationId]/teams/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import prisma from "@/utils/prisma";
+import { withAuth } from "@/utils/middleware";
+import { fetchAndCheckIsAdmin } from "@/utils/organizations/access";
+
+export type OrganizationTeamsResponse = Awaited<
+  ReturnType<typeof getOrganizationTeams>
+>;
+
+export const GET = withAuth(
+  "organizations/teams",
+  async (request, { params }) => {
+    const { userId } = request.auth;
+    const { organizationId } = await params;
+
+    if (!organizationId) {
+      return NextResponse.json(
+        { error: "Organization ID is required" },
+        { status: 400 },
+      );
+    }
+
+    await fetchAndCheckIsAdmin({ organizationId, userId });
+
+    const result = await getOrganizationTeams({ organizationId });
+
+    return NextResponse.json(result);
+  },
+);
+
+async function getOrganizationTeams({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const teams = await prisma.organizationTeam.findMany({
+    where: { organizationId },
+    select: {
+      id: true,
+      name: true,
+      _count: { select: { members: true, rules: true } },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  return { teams };
+}

--- a/apps/web/hooks/useOrganizationRules.ts
+++ b/apps/web/hooks/useOrganizationRules.ts
@@ -1,0 +1,8 @@
+import useSWR from "swr";
+import type { OrganizationRulesResponse } from "@/app/api/organizations/[organizationId]/rules/route";
+
+export function useOrganizationRules(organizationId: string) {
+  return useSWR<OrganizationRulesResponse>(
+    `/api/organizations/${organizationId}/rules`,
+  );
+}

--- a/apps/web/hooks/useOrganizationTeams.ts
+++ b/apps/web/hooks/useOrganizationTeams.ts
@@ -1,0 +1,8 @@
+import useSWR from "swr";
+import type { OrganizationTeamsResponse } from "@/app/api/organizations/[organizationId]/teams/route";
+
+export function useOrganizationTeams(organizationId: string | null) {
+  return useSWR<OrganizationTeamsResponse>(
+    organizationId ? `/api/organizations/${organizationId}/teams` : null,
+  );
+}

--- a/apps/web/prisma/migrations/20260609120000_add_organization_rules/migration.sql
+++ b/apps/web/prisma/migrations/20260609120000_add_organization_rules/migration.sql
@@ -1,0 +1,100 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "teamId" TEXT;
+
+-- AlterTable
+ALTER TABLE "Rule" ADD COLUMN     "organizationRuleId" TEXT;
+
+-- CreateTable
+CREATE TABLE "OrganizationTeam" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "OrganizationTeam_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationRule" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "runOnThreads" BOOLEAN NOT NULL DEFAULT false,
+    "conditionalOperator" "LogicalOperator" NOT NULL DEFAULT 'AND',
+    "instructions" TEXT,
+    "from" TEXT,
+    "to" TEXT,
+    "subject" TEXT,
+    "body" TEXT,
+
+    CONSTRAINT "OrganizationRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganizationRuleAction" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationRuleId" TEXT NOT NULL,
+    "type" "ActionType" NOT NULL,
+    "label" TEXT,
+    "subject" TEXT,
+    "content" TEXT,
+    "to" TEXT,
+    "cc" TEXT,
+    "bcc" TEXT,
+    "url" TEXT,
+    "folderName" TEXT,
+    "delayInMinutes" INTEGER,
+
+    CONSTRAINT "OrganizationRuleAction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_OrganizationRuleToOrganizationTeam" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_OrganizationRuleToOrganizationTeam_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationTeam_organizationId_name_key" ON "OrganizationTeam"("organizationId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationRule_organizationId_name_key" ON "OrganizationRule"("organizationId", "name");
+
+-- CreateIndex
+CREATE INDEX "OrganizationRuleAction_organizationRuleId_idx" ON "OrganizationRuleAction"("organizationRuleId");
+
+-- CreateIndex
+CREATE INDEX "_OrganizationRuleToOrganizationTeam_B_index" ON "_OrganizationRuleToOrganizationTeam"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Rule_organizationRuleId_emailAccountId_key" ON "Rule"("organizationRuleId", "emailAccountId");
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "OrganizationTeam"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationTeam" ADD CONSTRAINT "OrganizationTeam_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationRule" ADD CONSTRAINT "OrganizationRule_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganizationRuleAction" ADD CONSTRAINT "OrganizationRuleAction_organizationRuleId_fkey" FOREIGN KEY ("organizationRuleId") REFERENCES "OrganizationRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Rule" ADD CONSTRAINT "Rule_organizationRuleId_fkey" FOREIGN KEY ("organizationRuleId") REFERENCES "OrganizationRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrganizationRuleToOrganizationTeam" ADD CONSTRAINT "_OrganizationRuleToOrganizationTeam_A_fkey" FOREIGN KEY ("A") REFERENCES "OrganizationRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrganizationRuleToOrganizationTeam" ADD CONSTRAINT "_OrganizationRuleToOrganizationTeam_B_fkey" FOREIGN KEY ("B") REFERENCES "OrganizationTeam"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -219,33 +219,111 @@ model EmailAccount {
 }
 
 model Organization {
-  id           String         @id @default(cuid())
+  id           String             @id @default(cuid())
   name         String
-  slug         String         @unique
+  slug         String             @unique
   logo         String?
   metadata     Json?
-  createdAt    DateTime       @default(now())
-  updatedAt    DateTime       @updatedAt
+  createdAt    DateTime           @default(now())
+  updatedAt    DateTime           @updatedAt
   members      Member[]
   SsoProvider  SsoProvider[]
   ScimProvider ScimProvider[]
   sessions     Session[]
   invitations  Invitation[]
+  rules        OrganizationRule[]
+  teams        OrganizationTeam[]
 }
 
 model Member {
-  id                     String       @id @default(cuid())
+  id                     String            @id @default(cuid())
   organizationId         String
   emailAccountId         String
-  role                   String       @default("member") // "admin" | "member"
-  allowOrgAdminAnalytics Boolean      @default(false)
-  createdAt              DateTime     @default(now())
-  updatedAt              DateTime     @updatedAt
-  organization           Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  emailAccount           EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  role                   String            @default("member") // "admin" | "member"
+  allowOrgAdminAnalytics Boolean           @default(false)
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+  organization           Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  emailAccount           EmailAccount      @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  teamId                 String?
+  team                   OrganizationTeam? @relation(fields: [teamId], references: [id], onDelete: SetNull)
 
   @@unique([organizationId, emailAccountId])
   @@unique([emailAccountId])
+}
+
+// A team (job function) within an organization, e.g. "Engineering" or "Marketing".
+// Used to target organization rules at a subset of members.
+model OrganizationTeam {
+  id             String             @id @default(cuid())
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+  name           String
+  organizationId String
+  organization   Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  members        Member[]
+  rules          OrganizationRule[]
+
+  @@unique([organizationId, name])
+}
+
+// A rule managed by organization admins. It is provisioned into each targeted
+// member's email account as a Rule row (linked via Rule.organizationRuleId),
+// so the rule execution pipeline runs unchanged.
+model OrganizationRule {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  name                String
+  enabled             Boolean         @default(true)
+  runOnThreads        Boolean         @default(false)
+  conditionalOperator LogicalOperator @default(AND)
+
+  // ai condition
+  instructions String?
+
+  // static condition
+  from    String?
+  to      String?
+  subject String?
+  body    String?
+
+  actions OrganizationRuleAction[]
+
+  // teams this rule applies to; empty means it applies to all members
+  teams OrganizationTeam[]
+
+  managedRules Rule[]
+
+  @@unique([organizationId, name])
+}
+
+// Account-agnostic action definition for an organization rule. Account-specific
+// fields (labelId, folderId, messaging channels) are resolved per member account
+// when the rule is provisioned or executed.
+model OrganizationRuleAction {
+  id                 String           @id @default(cuid())
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  organizationRuleId String
+  organizationRule   OrganizationRule @relation(fields: [organizationRuleId], references: [id], onDelete: Cascade)
+  type               ActionType
+
+  label          String?
+  subject        String?
+  content        String?
+  to             String?
+  cc             String?
+  bcc            String?
+  url            String?
+  folderName     String?
+  delayInMinutes Int?
+
+  @@index([organizationRuleId])
 }
 
 model Invitation {
@@ -511,6 +589,10 @@ model Rule {
 
   systemType SystemType?
 
+  // set when this rule is provisioned from an organization rule; members cannot modify managed rules
+  organizationRuleId String?
+  organizationRule   OrganizationRule? @relation(fields: [organizationRuleId], references: [id], onDelete: Cascade)
+
   promptText String? // natural language for this rule for prompt file. prompt file is combination of these fields
 
   history RuleHistory[]
@@ -518,6 +600,7 @@ model Rule {
   @@unique([id, emailAccountId])
   @@unique([name, emailAccountId])
   @@unique([emailAccountId, systemType])
+  @@unique([organizationRuleId, emailAccountId])
   @@index([emailAccountId, enabled])
 }
 

--- a/apps/web/utils/actions/organization-rule.ts
+++ b/apps/web/utils/actions/organization-rule.ts
@@ -1,0 +1,320 @@
+"use server";
+
+import { actionClientUser } from "@/utils/actions/safe-action";
+import {
+  createOrganizationRuleBody,
+  updateOrganizationRuleBody,
+  deleteOrganizationRuleBody,
+  toggleOrganizationRuleBody,
+  createOrganizationTeamBody,
+  deleteOrganizationTeamBody,
+  updateMemberTeamBody,
+} from "@/utils/actions/organization-rule.validation";
+import prisma from "@/utils/prisma";
+import { SafeError } from "@/utils/error";
+import { isDuplicateError } from "@/utils/prisma-helpers";
+import { getAuthorizedOrganizationAdminMembership } from "@/utils/organizations/access";
+import {
+  syncOrganizationRule,
+  syncOrganizationRulesForMember,
+} from "@/utils/organizations/organization-rules";
+import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
+import type { CreateOrganizationRuleBody } from "@/utils/actions/organization-rule.validation";
+
+const ADMIN_ONLY_MESSAGE =
+  "Only organization owners or admins can manage organization rules.";
+
+export const createOrganizationRuleAction = actionClientUser
+  .metadata({ name: "createOrganizationRule" })
+  .inputSchema(createOrganizationRuleBody)
+  .action(
+    async ({
+      ctx: { userId, logger },
+      parsedInput: { organizationId, teamIds, actions, ...ruleFields },
+    }) => {
+      await getAuthorizedOrganizationAdminMembership({
+        organizationId,
+        userId,
+        unauthorizedMessage: ADMIN_ONLY_MESSAGE,
+      });
+
+      await assertCanUseDigestsIfNeeded(userId, actions);
+      await assertTeamsBelongToOrganization({ organizationId, teamIds });
+
+      let organizationRule: { id: string };
+      try {
+        organizationRule = await prisma.organizationRule.create({
+          data: {
+            organizationId,
+            ...toOrganizationRuleRecord(ruleFields),
+            actions: { createMany: { data: actions.map(toActionRecord) } },
+            ...connectTeams(teamIds),
+          },
+          select: { id: true },
+        });
+      } catch (error) {
+        throw translateDuplicateNameError(error);
+      }
+
+      const sync = await syncOrganizationRule({
+        organizationRuleId: organizationRule.id,
+        logger,
+      });
+
+      return { id: organizationRule.id, sync };
+    },
+  );
+
+export const updateOrganizationRuleAction = actionClientUser
+  .metadata({ name: "updateOrganizationRule" })
+  .inputSchema(updateOrganizationRuleBody)
+  .action(
+    async ({
+      ctx: { userId, logger },
+      parsedInput: { id, teamIds, actions, ...ruleFields },
+    }) => {
+      const { organizationId } = await getAuthorizedOrganizationRule({
+        organizationRuleId: id,
+        userId,
+      });
+
+      await assertCanUseDigestsIfNeeded(userId, actions);
+      await assertTeamsBelongToOrganization({ organizationId, teamIds });
+
+      try {
+        await prisma.organizationRule.update({
+          where: { id },
+          data: {
+            ...toOrganizationRuleRecord(ruleFields),
+            actions: {
+              deleteMany: {},
+              createMany: { data: actions.map(toActionRecord) },
+            },
+            teams: { set: (teamIds ?? []).map((teamId) => ({ id: teamId })) },
+          },
+        });
+      } catch (error) {
+        throw translateDuplicateNameError(error);
+      }
+
+      const sync = await syncOrganizationRule({
+        organizationRuleId: id,
+        logger,
+      });
+
+      return { id, sync };
+    },
+  );
+
+export const deleteOrganizationRuleAction = actionClientUser
+  .metadata({ name: "deleteOrganizationRule" })
+  .inputSchema(deleteOrganizationRuleBody)
+  .action(async ({ ctx: { userId, logger }, parsedInput: { id } }) => {
+    await getAuthorizedOrganizationRule({ organizationRuleId: id, userId });
+
+    // deleting cascades to the managed rules provisioned in member accounts
+    await prisma.organizationRule.delete({ where: { id } });
+
+    logger.info("Deleted organization rule", { organizationRuleId: id });
+  });
+
+export const toggleOrganizationRuleAction = actionClientUser
+  .metadata({ name: "toggleOrganizationRule" })
+  .inputSchema(toggleOrganizationRuleBody)
+  .action(async ({ ctx: { userId }, parsedInput: { id, enabled } }) => {
+    await getAuthorizedOrganizationRule({ organizationRuleId: id, userId });
+
+    await prisma.organizationRule.update({
+      where: { id },
+      data: { enabled },
+    });
+    await prisma.rule.updateMany({
+      where: { organizationRuleId: id },
+      data: { enabled },
+    });
+  });
+
+export const createOrganizationTeamAction = actionClientUser
+  .metadata({ name: "createOrganizationTeam" })
+  .inputSchema(createOrganizationTeamBody)
+  .action(
+    async ({ ctx: { userId }, parsedInput: { organizationId, name } }) => {
+      await getAuthorizedOrganizationAdminMembership({
+        organizationId,
+        userId,
+        unauthorizedMessage:
+          "Only organization owners or admins can manage teams.",
+      });
+
+      try {
+        return await prisma.organizationTeam.create({
+          data: { organizationId, name },
+          select: { id: true, name: true },
+        });
+      } catch (error) {
+        if (isDuplicateError(error, "name")) {
+          throw new SafeError("A team with this name already exists.");
+        }
+        throw error;
+      }
+    },
+  );
+
+export const deleteOrganizationTeamAction = actionClientUser
+  .metadata({ name: "deleteOrganizationTeam" })
+  .inputSchema(deleteOrganizationTeamBody)
+  .action(async ({ ctx: { userId }, parsedInput: { id } }) => {
+    const team = await prisma.organizationTeam.findUnique({
+      where: { id },
+      select: {
+        organizationId: true,
+        _count: { select: { rules: true } },
+      },
+    });
+
+    if (!team) throw new SafeError("Team not found.");
+
+    await getAuthorizedOrganizationAdminMembership({
+      organizationId: team.organizationId,
+      userId,
+      unauthorizedMessage:
+        "Only organization owners or admins can manage teams.",
+    });
+
+    // Deleting a team a rule targets would silently widen the rule to all
+    // members, so require admins to retarget those rules first.
+    if (team._count.rules > 0) {
+      throw new SafeError(
+        "This team is used by organization rules. Remove it from those rules first.",
+      );
+    }
+
+    await prisma.organizationTeam.delete({ where: { id } });
+  });
+
+export const updateMemberTeamAction = actionClientUser
+  .metadata({ name: "updateMemberTeam" })
+  .inputSchema(updateMemberTeamBody)
+  .action(
+    async ({ ctx: { userId, logger }, parsedInput: { memberId, teamId } }) => {
+      const member = await prisma.member.findUnique({
+        where: { id: memberId },
+        select: { organizationId: true, emailAccountId: true },
+      });
+
+      if (!member) throw new SafeError("Member not found.");
+
+      await getAuthorizedOrganizationAdminMembership({
+        organizationId: member.organizationId,
+        userId,
+        unauthorizedMessage:
+          "Only organization owners or admins can assign teams.",
+      });
+
+      if (teamId) {
+        const team = await prisma.organizationTeam.findFirst({
+          where: { id: teamId, organizationId: member.organizationId },
+          select: { id: true },
+        });
+        if (!team) throw new SafeError("Team not found.");
+      }
+
+      await prisma.member.update({
+        where: { id: memberId },
+        data: { teamId },
+      });
+
+      await syncOrganizationRulesForMember({
+        emailAccountId: member.emailAccountId,
+        organizationId: member.organizationId,
+        logger,
+      });
+    },
+  );
+
+async function getAuthorizedOrganizationRule({
+  organizationRuleId,
+  userId,
+}: {
+  organizationRuleId: string;
+  userId: string;
+}) {
+  const organizationRule = await prisma.organizationRule.findUnique({
+    where: { id: organizationRuleId },
+    select: { organizationId: true },
+  });
+
+  if (!organizationRule) throw new SafeError("Organization rule not found.");
+
+  await getAuthorizedOrganizationAdminMembership({
+    organizationId: organizationRule.organizationId,
+    userId,
+    unauthorizedMessage: ADMIN_ONLY_MESSAGE,
+  });
+
+  return organizationRule;
+}
+
+async function assertTeamsBelongToOrganization({
+  organizationId,
+  teamIds,
+}: {
+  organizationId: string;
+  teamIds?: string[];
+}) {
+  if (!teamIds?.length) return;
+
+  const teams = await prisma.organizationTeam.findMany({
+    where: { id: { in: teamIds }, organizationId },
+    select: { id: true },
+  });
+
+  if (teams.length !== new Set(teamIds).size) {
+    throw new SafeError("Team not found.");
+  }
+}
+
+function toOrganizationRuleRecord(
+  ruleFields: Omit<
+    CreateOrganizationRuleBody,
+    "organizationId" | "teamIds" | "actions"
+  >,
+) {
+  return {
+    name: ruleFields.name,
+    instructions: ruleFields.instructions ?? null,
+    from: ruleFields.from ?? null,
+    to: ruleFields.to ?? null,
+    subject: ruleFields.subject ?? null,
+    body: ruleFields.body ?? null,
+    conditionalOperator: ruleFields.conditionalOperator,
+    runOnThreads: ruleFields.runOnThreads,
+  };
+}
+
+function toActionRecord(action: CreateOrganizationRuleBody["actions"][number]) {
+  return {
+    type: action.type,
+    label: action.label ?? null,
+    subject: action.subject ?? null,
+    content: action.content ?? null,
+    to: action.to ?? null,
+    cc: action.cc ?? null,
+    bcc: action.bcc ?? null,
+    url: action.url ?? null,
+    folderName: action.folderName ?? null,
+    delayInMinutes: action.delayInMinutes ?? null,
+  };
+}
+
+function connectTeams(teamIds?: string[]) {
+  if (!teamIds?.length) return {};
+  return { teams: { connect: teamIds.map((id) => ({ id })) } };
+}
+
+function translateDuplicateNameError(error: unknown) {
+  if (isDuplicateError(error, "name")) {
+    return new SafeError("An organization rule with this name already exists.");
+  }
+  return error;
+}

--- a/apps/web/utils/actions/organization-rule.validation.ts
+++ b/apps/web/utils/actions/organization-rule.validation.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { portableActionSchema } from "@/utils/actions/rule.validation";
+
+// Messaging channels are connected per email account, so they can't be part of
+// an organization-wide rule definition.
+const organizationRuleAction = portableActionSchema.superRefine((data, ctx) => {
+  if (
+    data.type === ActionType.DRAFT_MESSAGING_CHANNEL ||
+    data.type === ActionType.NOTIFY_MESSAGING_CHANNEL
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "Messaging channel actions are not supported for organization rules",
+      path: ["type"],
+    });
+  }
+});
+
+const organizationRuleFields = z.object({
+  name: z.string().trim().min(1, "Please enter a name"),
+  instructions: z.string().nullish(),
+  from: z.string().nullish(),
+  to: z.string().nullish(),
+  subject: z.string().nullish(),
+  body: z.string().nullish(),
+  conditionalOperator: z
+    .enum([LogicalOperator.AND, LogicalOperator.OR])
+    .optional(),
+  runOnThreads: z.boolean().optional(),
+  actions: z
+    .array(organizationRuleAction)
+    .min(1, "You must have at least one action"),
+  // empty/undefined means the rule applies to every member
+  teamIds: z.array(z.string()).optional(),
+});
+
+function hasCondition(data: {
+  instructions?: string | null;
+  from?: string | null;
+  to?: string | null;
+  subject?: string | null;
+  body?: string | null;
+}) {
+  return !!(
+    data.instructions?.trim() ||
+    data.from?.trim() ||
+    data.to?.trim() ||
+    data.subject?.trim() ||
+    data.body?.trim()
+  );
+}
+
+const conditionRequiredMessage =
+  "Please add at least one condition (AI instructions, from, to, subject, or body)";
+
+export const createOrganizationRuleBody = organizationRuleFields
+  .extend({
+    organizationId: z.string().min(1, "Organization ID is required"),
+  })
+  .refine(hasCondition, {
+    message: conditionRequiredMessage,
+    path: ["instructions"],
+  });
+export type CreateOrganizationRuleBody = z.infer<
+  typeof createOrganizationRuleBody
+>;
+
+export const updateOrganizationRuleBody = organizationRuleFields
+  .extend({
+    id: z.string().min(1, "Rule ID is required"),
+  })
+  .refine(hasCondition, {
+    message: conditionRequiredMessage,
+    path: ["instructions"],
+  });
+export type UpdateOrganizationRuleBody = z.infer<
+  typeof updateOrganizationRuleBody
+>;
+
+export const deleteOrganizationRuleBody = z.object({
+  id: z.string().min(1, "Rule ID is required"),
+});
+export type DeleteOrganizationRuleBody = z.infer<
+  typeof deleteOrganizationRuleBody
+>;
+
+export const toggleOrganizationRuleBody = z.object({
+  id: z.string().min(1, "Rule ID is required"),
+  enabled: z.boolean(),
+});
+export type ToggleOrganizationRuleBody = z.infer<
+  typeof toggleOrganizationRuleBody
+>;
+
+export const createOrganizationTeamBody = z.object({
+  organizationId: z.string().min(1, "Organization ID is required"),
+  name: z
+    .string()
+    .trim()
+    .min(1, "Please enter a team name")
+    .max(40, "Please keep team names under 40 characters"),
+});
+export type CreateOrganizationTeamBody = z.infer<
+  typeof createOrganizationTeamBody
+>;
+
+export const deleteOrganizationTeamBody = z.object({
+  id: z.string().min(1, "Team ID is required"),
+});
+export type DeleteOrganizationTeamBody = z.infer<
+  typeof deleteOrganizationTeamBody
+>;
+
+export const updateMemberTeamBody = z.object({
+  memberId: z.string().min(1, "Member ID is required"),
+  teamId: z.string().nullable(),
+});
+export type UpdateMemberTeamBody = z.infer<typeof updateMemberTeamBody>;

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -24,6 +24,11 @@ import {
 import { env } from "@/env";
 import { slugify } from "@/utils/string";
 import { posthogCaptureEvent } from "@/utils/posthog";
+import {
+  removeOrganizationRulesForMember,
+  syncOrganizationRulesForMember,
+} from "@/utils/organizations/organization-rules";
+import { createScopedLogger } from "@/utils/logger";
 
 export const createOrganizationAction = actionClient
   .metadata({ name: "createOrganization" })
@@ -305,6 +310,23 @@ async function acceptInvitation({
     data: { status: "accepted" },
   });
 
+  after(async () => {
+    const logger = createScopedLogger("organization-rules").with({
+      emailAccountId,
+    });
+    try {
+      await syncOrganizationRulesForMember({
+        emailAccountId,
+        organizationId: invitation.organizationId,
+        logger,
+      });
+    } catch (error) {
+      logger.error("Failed to sync organization rules for new member", {
+        error,
+      });
+    }
+  });
+
   const premium = await getOrganizationPremium(invitation.organizationId);
   if (premium) {
     const emailAccount = await getUserFromEmailAccount(emailAccountId);
@@ -358,6 +380,11 @@ export const removeMemberAction = actionClientUser
     }
 
     await prisma.member.delete({ where: { id: memberId } });
+
+    await removeOrganizationRulesForMember({
+      emailAccountId: targetMember.emailAccountId,
+      organizationId: targetMember.organizationId,
+    });
   });
 
 export const updateMemberRoleAction = actionClientUser

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -503,15 +503,16 @@ export const toggleAllRulesAction = actionClient
   .metadata({ name: "toggleAllRules" })
   .inputSchema(toggleAllRulesBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput: { enabled } }) => {
+    // organization-managed rules are only toggled by organization admins
     if (enabled) {
       await prisma.rule.updateMany({
-        where: { emailAccountId },
+        where: { emailAccountId, organizationRuleId: null },
         data: { enabled },
       });
     } else {
       await prisma.$transaction([
         prisma.rule.updateMany({
-          where: { emailAccountId },
+          where: { emailAccountId, organizationRuleId: null },
           data: { enabled },
         }),
         prisma.emailAccount.update({

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -373,8 +373,9 @@ export const copyRulesFromAccountBody = z.object({
 });
 export type CopyRulesFromAccountBody = z.infer<typeof copyRulesFromAccountBody>;
 
-// Schema for importing rules from JSON export
-const importedAction = z
+// Account-agnostic action schema (no label/folder IDs or messaging channels).
+// Used for importing rules from JSON export and for organization rules.
+export const portableActionSchema = z
   .object({
     type: zodActionType,
     label: z.string().nullish(),
@@ -465,7 +466,7 @@ const importedRule = z
     categoryFilterType: z
       .enum([CategoryFilterType.INCLUDE, CategoryFilterType.EXCLUDE])
       .nullish(),
-    actions: z.array(importedAction).min(1),
+    actions: z.array(portableActionSchema).min(1),
     group: z.string().nullish(),
   })
   .refine(

--- a/apps/web/utils/organizations/organization-rules.test.ts
+++ b/apps/web/utils/organizations/organization-rules.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { Prisma } from "@/generated/prisma/client";
+import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import {
+  organizationRuleAppliesToMember,
+  syncOrganizationRule,
+  syncOrganizationRulesForMember,
+} from "@/utils/organizations/organization-rules";
+import {
+  createRuleWithResolvedActions,
+  replaceRuleWithResolvedActions,
+} from "@/utils/rule/rule";
+import { createScopedLogger } from "@/utils/logger";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/rule/rule", () => ({
+  createRuleWithResolvedActions: vi.fn(),
+  replaceRuleWithResolvedActions: vi.fn(),
+}));
+
+const logger = createScopedLogger("organization-rules-test");
+
+const mockedCreateRule = vi.mocked(createRuleWithResolvedActions);
+const mockedReplaceRule = vi.mocked(replaceRuleWithResolvedActions);
+
+function getOrganizationRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "org-rule-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    organizationId: "org-1",
+    name: "Security alerts",
+    enabled: true,
+    runOnThreads: false,
+    conditionalOperator: LogicalOperator.AND,
+    instructions: "Emails about security incidents",
+    from: null,
+    to: null,
+    subject: null,
+    body: null,
+    actions: [
+      {
+        id: "org-action-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        organizationRuleId: "org-rule-1",
+        type: ActionType.LABEL,
+        label: "Security",
+        subject: null,
+        content: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        url: null,
+        folderName: null,
+        delayInMinutes: null,
+      },
+    ],
+    teams: [],
+    ...overrides,
+  };
+}
+
+function getMember({
+  emailAccountId,
+  email,
+  teamId = null,
+}: {
+  emailAccountId: string;
+  email: string;
+  teamId?: string | null;
+}) {
+  return { teamId, emailAccount: { id: emailAccountId, email } };
+}
+
+describe("organizationRuleAppliesToMember", () => {
+  it("applies to every member when the rule has no teams", () => {
+    expect(
+      organizationRuleAppliesToMember({ ruleTeamIds: [], memberTeamId: null }),
+    ).toBe(true);
+    expect(
+      organizationRuleAppliesToMember({
+        ruleTeamIds: [],
+        memberTeamId: "team-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("applies only to members of targeted teams", () => {
+    expect(
+      organizationRuleAppliesToMember({
+        ruleTeamIds: ["team-1"],
+        memberTeamId: "team-1",
+      }),
+    ).toBe(true);
+    expect(
+      organizationRuleAppliesToMember({
+        ruleTeamIds: ["team-1"],
+        memberTeamId: "team-2",
+      }),
+    ).toBe(false);
+    expect(
+      organizationRuleAppliesToMember({
+        ruleTeamIds: ["team-1"],
+        memberTeamId: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("syncOrganizationRule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("provisions the rule into every member account when it has no teams", async () => {
+    prisma.organizationRule.findUnique.mockResolvedValue(
+      getOrganizationRule() as never,
+    );
+    prisma.member.findMany.mockResolvedValue([
+      getMember({ emailAccountId: "account-1", email: "a@org.com" }),
+      getMember({ emailAccountId: "account-2", email: "b@org.com" }),
+    ] as never);
+    prisma.rule.findMany.mockResolvedValue([]);
+
+    const result = await syncOrganizationRule({
+      organizationRuleId: "org-rule-1",
+      logger,
+    });
+
+    expect(result).toEqual({
+      createdCount: 2,
+      updatedCount: 0,
+      removedCount: 0,
+      skipped: [],
+    });
+    expect(mockedCreateRule).toHaveBeenCalledTimes(2);
+    expect(mockedCreateRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        data: expect.objectContaining({
+          name: "Security alerts",
+          organizationRuleId: "org-rule-1",
+          instructions: "Emails about security incidents",
+        }),
+        actions: [
+          expect.objectContaining({
+            type: ActionType.LABEL,
+            label: "Security",
+            labelId: null,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("only targets members of the rule's teams and removes copies from others", async () => {
+    prisma.organizationRule.findUnique.mockResolvedValue(
+      getOrganizationRule({ teams: [{ id: "team-eng" }] }) as never,
+    );
+    prisma.member.findMany.mockResolvedValue([
+      getMember({
+        emailAccountId: "account-1",
+        email: "dev@org.com",
+        teamId: "team-eng",
+      }),
+      getMember({
+        emailAccountId: "account-2",
+        email: "marketer@org.com",
+        teamId: "team-marketing",
+      }),
+    ] as never);
+    // account-2 previously had a managed copy (e.g. before re-targeting)
+    prisma.rule.findMany.mockResolvedValue([
+      { id: "rule-2", emailAccountId: "account-2" },
+    ] as never);
+    prisma.rule.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await syncOrganizationRule({
+      organizationRuleId: "org-rule-1",
+      logger,
+    });
+
+    expect(result).toEqual({
+      createdCount: 1,
+      updatedCount: 0,
+      removedCount: 1,
+      skipped: [],
+    });
+    expect(prisma.rule.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["rule-2"] }, organizationRuleId: "org-rule-1" },
+    });
+    expect(mockedCreateRule).toHaveBeenCalledTimes(1);
+    expect(mockedCreateRule).toHaveBeenCalledWith(
+      expect.objectContaining({ emailAccountId: "account-1" }),
+    );
+  });
+
+  it("updates already-provisioned copies in place", async () => {
+    prisma.organizationRule.findUnique.mockResolvedValue(
+      getOrganizationRule() as never,
+    );
+    prisma.member.findMany.mockResolvedValue([
+      getMember({ emailAccountId: "account-1", email: "a@org.com" }),
+    ] as never);
+    prisma.rule.findMany.mockResolvedValue([
+      { id: "managed-rule-1", emailAccountId: "account-1" },
+    ] as never);
+
+    const result = await syncOrganizationRule({
+      organizationRuleId: "org-rule-1",
+      logger,
+    });
+
+    expect(result.updatedCount).toBe(1);
+    expect(mockedCreateRule).not.toHaveBeenCalled();
+    expect(mockedReplaceRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ruleId: "managed-rule-1",
+        emailAccountId: "account-1",
+        allowOrganizationManaged: true,
+      }),
+    );
+  });
+
+  it("skips members whose account already has a rule with the same name", async () => {
+    prisma.organizationRule.findUnique.mockResolvedValue(
+      getOrganizationRule() as never,
+    );
+    prisma.member.findMany.mockResolvedValue([
+      getMember({ emailAccountId: "account-1", email: "a@org.com" }),
+      getMember({ emailAccountId: "account-2", email: "b@org.com" }),
+    ] as never);
+    prisma.rule.findMany.mockResolvedValue([]);
+
+    mockedCreateRule.mockImplementation(async ({ emailAccountId }) => {
+      if (emailAccountId === "account-2") {
+        throw new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed",
+          {
+            code: "P2002",
+            clientVersion: "test",
+            meta: { target: ["name", "emailAccountId"] },
+          },
+        );
+      }
+      return {} as never;
+    });
+
+    const result = await syncOrganizationRule({
+      organizationRuleId: "org-rule-1",
+      logger,
+    });
+
+    expect(result.createdCount).toBe(1);
+    expect(result.skipped).toEqual([
+      { email: "b@org.com", reason: expect.stringContaining("already exists") },
+    ]);
+  });
+});
+
+describe("syncOrganizationRulesForMember", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("provisions applicable rules and removes ones that no longer apply", async () => {
+    prisma.member.findFirst.mockResolvedValue({ teamId: "team-eng" } as never);
+    prisma.organizationRule.findMany.mockResolvedValue([
+      getOrganizationRule({ id: "org-rule-all", teams: [] }),
+      getOrganizationRule({
+        id: "org-rule-eng",
+        name: "Engineering rule",
+        teams: [{ id: "team-eng" }],
+      }),
+      getOrganizationRule({
+        id: "org-rule-marketing",
+        name: "Marketing rule",
+        teams: [{ id: "team-marketing" }],
+      }),
+    ] as never);
+    // member previously had a copy of the marketing rule (team change)
+    prisma.rule.findMany.mockResolvedValue([
+      { id: "managed-marketing", organizationRuleId: "org-rule-marketing" },
+    ] as never);
+    prisma.rule.deleteMany.mockResolvedValue({ count: 1 });
+
+    await syncOrganizationRulesForMember({
+      emailAccountId: "account-1",
+      organizationId: "org-1",
+      logger,
+    });
+
+    expect(prisma.rule.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["managed-marketing"] }, emailAccountId: "account-1" },
+    });
+    expect(mockedCreateRule).toHaveBeenCalledTimes(2);
+    expect(mockedCreateRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ organizationRuleId: "org-rule-all" }),
+      }),
+    );
+    expect(mockedCreateRule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ organizationRuleId: "org-rule-eng" }),
+      }),
+    );
+  });
+
+  it("removes all managed rules when the member no longer exists", async () => {
+    prisma.member.findFirst.mockResolvedValue(null);
+    prisma.organizationRule.findMany.mockResolvedValue([
+      getOrganizationRule(),
+    ] as never);
+    prisma.rule.findMany.mockResolvedValue([
+      { id: "managed-1", organizationRuleId: "org-rule-1" },
+    ] as never);
+    prisma.rule.deleteMany.mockResolvedValue({ count: 1 });
+
+    await syncOrganizationRulesForMember({
+      emailAccountId: "account-1",
+      organizationId: "org-1",
+      logger,
+    });
+
+    expect(prisma.rule.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["managed-1"] }, emailAccountId: "account-1" },
+    });
+    expect(mockedCreateRule).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/organizations/organization-rules.ts
+++ b/apps/web/utils/organizations/organization-rules.ts
@@ -1,0 +1,302 @@
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+import type { Prisma } from "@/generated/prisma/client";
+import {
+  createRuleWithResolvedActions,
+  replaceRuleWithResolvedActions,
+  type RuleActionCreateData,
+} from "@/utils/rule/rule";
+import { isDuplicateError } from "@/utils/prisma-helpers";
+import { SafeError } from "@/utils/error";
+
+const organizationRuleInclude = {
+  actions: true,
+  teams: { select: { id: true } },
+} satisfies Prisma.OrganizationRuleInclude;
+
+type OrganizationRuleWithRelations = Prisma.OrganizationRuleGetPayload<{
+  include: typeof organizationRuleInclude;
+}>;
+
+export type OrganizationRuleSyncResult = {
+  createdCount: number;
+  updatedCount: number;
+  removedCount: number;
+  skipped: { email: string; reason: string }[];
+};
+
+export function organizationRuleAppliesToMember({
+  ruleTeamIds,
+  memberTeamId,
+}: {
+  ruleTeamIds: string[];
+  memberTeamId: string | null;
+}) {
+  if (ruleTeamIds.length === 0) return true;
+  return !!memberTeamId && ruleTeamIds.includes(memberTeamId);
+}
+
+/**
+ * Provisions an organization rule into every targeted member's email account
+ * as a managed Rule row, updates already-provisioned copies, and removes
+ * copies from members the rule no longer targets.
+ */
+export async function syncOrganizationRule({
+  organizationRuleId,
+  logger,
+}: {
+  organizationRuleId: string;
+  logger: Logger;
+}): Promise<OrganizationRuleSyncResult> {
+  const organizationRule = await prisma.organizationRule.findUnique({
+    where: { id: organizationRuleId },
+    include: organizationRuleInclude,
+  });
+
+  if (!organizationRule) {
+    throw new SafeError("Organization rule not found");
+  }
+
+  const members = await prisma.member.findMany({
+    where: { organizationId: organizationRule.organizationId },
+    select: {
+      teamId: true,
+      emailAccount: { select: { id: true, email: true } },
+    },
+  });
+
+  const ruleTeamIds = organizationRule.teams.map((team) => team.id);
+  const targets = members.filter((member) =>
+    organizationRuleAppliesToMember({
+      ruleTeamIds,
+      memberTeamId: member.teamId,
+    }),
+  );
+
+  const existingManagedRules = await prisma.rule.findMany({
+    where: { organizationRuleId },
+    select: { id: true, emailAccountId: true },
+  });
+  const managedRuleByAccountId = new Map(
+    existingManagedRules.map((rule) => [rule.emailAccountId, rule.id]),
+  );
+
+  const result: OrganizationRuleSyncResult = {
+    createdCount: 0,
+    updatedCount: 0,
+    removedCount: 0,
+    skipped: [],
+  };
+
+  const targetAccountIds = new Set(
+    targets.map((member) => member.emailAccount.id),
+  );
+  const ruleIdsToRemove = existingManagedRules
+    .filter((rule) => !targetAccountIds.has(rule.emailAccountId))
+    .map((rule) => rule.id);
+
+  if (ruleIdsToRemove.length > 0) {
+    const { count } = await prisma.rule.deleteMany({
+      where: { id: { in: ruleIdsToRemove }, organizationRuleId },
+    });
+    result.removedCount = count;
+  }
+
+  for (const member of targets) {
+    const outcome = await applyOrganizationRuleToAccount({
+      organizationRule,
+      emailAccountId: member.emailAccount.id,
+      existingRuleId: managedRuleByAccountId.get(member.emailAccount.id),
+      logger,
+    });
+
+    if (outcome.status === "created") result.createdCount++;
+    else if (outcome.status === "updated") result.updatedCount++;
+    else
+      result.skipped.push({
+        email: member.emailAccount.email,
+        reason: outcome.reason,
+      });
+  }
+
+  logger.info("Synced organization rule to members", {
+    organizationRuleId,
+    organizationId: organizationRule.organizationId,
+    ...result,
+    skipped: result.skipped.length,
+  });
+
+  return result;
+}
+
+/**
+ * Brings a single member's email account in line with all of the
+ * organization's rules. Used when a member joins or changes team.
+ */
+export async function syncOrganizationRulesForMember({
+  emailAccountId,
+  organizationId,
+  logger,
+}: {
+  emailAccountId: string;
+  organizationId: string;
+  logger: Logger;
+}) {
+  const [member, organizationRules, existingManagedRules] = await Promise.all([
+    prisma.member.findFirst({
+      where: { emailAccountId, organizationId },
+      select: { teamId: true },
+    }),
+    prisma.organizationRule.findMany({
+      where: { organizationId },
+      include: organizationRuleInclude,
+    }),
+    prisma.rule.findMany({
+      where: { emailAccountId, organizationRule: { organizationId } },
+      select: { id: true, organizationRuleId: true },
+    }),
+  ]);
+
+  const applicableRules = member
+    ? organizationRules.filter((rule) =>
+        organizationRuleAppliesToMember({
+          ruleTeamIds: rule.teams.map((team) => team.id),
+          memberTeamId: member.teamId,
+        }),
+      )
+    : [];
+
+  const applicableRuleIds = new Set(applicableRules.map((rule) => rule.id));
+  const ruleIdsToRemove = existingManagedRules
+    .filter(
+      (rule) =>
+        !rule.organizationRuleId ||
+        !applicableRuleIds.has(rule.organizationRuleId),
+    )
+    .map((rule) => rule.id);
+
+  if (ruleIdsToRemove.length > 0) {
+    await prisma.rule.deleteMany({
+      where: { id: { in: ruleIdsToRemove }, emailAccountId },
+    });
+  }
+
+  for (const organizationRule of applicableRules) {
+    await applyOrganizationRuleToAccount({
+      organizationRule,
+      emailAccountId,
+      existingRuleId: existingManagedRules.find(
+        (rule) => rule.organizationRuleId === organizationRule.id,
+      )?.id,
+      logger,
+    });
+  }
+
+  logger.info("Synced organization rules for member", {
+    organizationId,
+    syncedEmailAccountId: emailAccountId,
+    applicableRules: applicableRules.length,
+    removedRules: ruleIdsToRemove.length,
+  });
+}
+
+export async function removeOrganizationRulesForMember({
+  emailAccountId,
+  organizationId,
+}: {
+  emailAccountId: string;
+  organizationId: string;
+}) {
+  await prisma.rule.deleteMany({
+    where: { emailAccountId, organizationRule: { organizationId } },
+  });
+}
+
+async function applyOrganizationRuleToAccount({
+  organizationRule,
+  emailAccountId,
+  existingRuleId,
+  logger,
+}: {
+  organizationRule: OrganizationRuleWithRelations;
+  emailAccountId: string;
+  existingRuleId?: string;
+  logger: Logger;
+}): Promise<
+  | { status: "created" }
+  | { status: "updated" }
+  | { status: "skipped"; reason: string }
+> {
+  const data = {
+    name: organizationRule.name,
+    enabled: organizationRule.enabled,
+    runOnThreads: organizationRule.runOnThreads,
+    conditionalOperator: organizationRule.conditionalOperator,
+    instructions: organizationRule.instructions,
+    from: organizationRule.from,
+    to: organizationRule.to,
+    subject: organizationRule.subject,
+    body: organizationRule.body,
+  };
+  const actions = organizationRule.actions.map(toRuleActionData);
+
+  try {
+    if (existingRuleId) {
+      await replaceRuleWithResolvedActions({
+        ruleId: existingRuleId,
+        emailAccountId,
+        data,
+        actions,
+        allowOrganizationManaged: true,
+      });
+      return { status: "updated" };
+    }
+
+    await createRuleWithResolvedActions({
+      emailAccountId,
+      data: { ...data, organizationRuleId: organizationRule.id },
+      actions,
+    });
+    return { status: "created" };
+  } catch (error) {
+    if (isDuplicateError(error, "name")) {
+      return {
+        status: "skipped",
+        reason: `A rule named "${organizationRule.name}" already exists in this account`,
+      };
+    }
+    if (error instanceof SafeError) {
+      return {
+        status: "skipped",
+        reason: error.safeMessage || "Rule could not be applied",
+      };
+    }
+
+    logger.error("Failed to apply organization rule to account", {
+      error,
+      organizationRuleId: organizationRule.id,
+      targetEmailAccountId: emailAccountId,
+    });
+    return { status: "skipped", reason: "Unexpected error" };
+  }
+}
+
+function toRuleActionData(
+  action: OrganizationRuleWithRelations["actions"][number],
+): RuleActionCreateData {
+  return {
+    type: action.type,
+    // keep label/folder names; account-specific IDs are resolved at execution time
+    label: action.label,
+    labelId: null,
+    subject: action.subject,
+    content: action.content,
+    to: action.to,
+    cc: action.cc,
+    bcc: action.bcc,
+    url: action.url,
+    folderName: action.folderName,
+    folderId: null,
+    delayInMinutes: action.delayInMinutes,
+  };
+}

--- a/apps/web/utils/rule/rule.test.ts
+++ b/apps/web/utils/rule/rule.test.ts
@@ -751,6 +751,74 @@ describe("draft messaging actions", () => {
   });
 });
 
+describe("organization-managed rules", () => {
+  beforeEach(resetRuleMocks);
+
+  function mockManagedRule() {
+    prisma.rule.findUnique.mockResolvedValue({
+      organizationRuleId: "org-rule-1",
+    } as any);
+  }
+
+  it("prevents deleting a managed rule", async () => {
+    mockManagedRule();
+
+    await expect(
+      deleteRule({ emailAccountId: EMAIL_ACCOUNT_ID, ruleId: RULE_ID }),
+    ).rejects.toThrow("managed by your organization");
+
+    expect(prisma.rule.delete).not.toHaveBeenCalled();
+  });
+
+  it("prevents toggling a managed rule", async () => {
+    mockManagedRule();
+
+    await expect(
+      setRuleEnabled({
+        ruleId: RULE_ID,
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        enabled: false,
+      }),
+    ).rejects.toThrow("managed by your organization");
+
+    expect(prisma.rule.update).not.toHaveBeenCalled();
+  });
+
+  it("prevents replacing a managed rule without organization access", async () => {
+    mockManagedRule();
+
+    await expect(
+      replaceRuleWithResolvedActions({
+        ruleId: RULE_ID,
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        data: { name: "New name" },
+        actions: [resolvedArchiveAction()],
+      }),
+    ).rejects.toThrow("managed by your organization");
+
+    expect(prisma.rule.update).not.toHaveBeenCalled();
+  });
+
+  it("prevents updating actions of a managed rule", async () => {
+    prisma.rule.findFirst.mockResolvedValue({
+      from: null,
+      organizationRuleId: "org-rule-1",
+    } as any);
+
+    await expect(
+      updateRuleActions({
+        ruleId: RULE_ID,
+        actions: [archiveAction()],
+        provider: "gmail",
+        emailAccountId: EMAIL_ACCOUNT_ID,
+        logger,
+      }),
+    ).rejects.toThrow("managed by your organization");
+
+    expect(prisma.rule.update).not.toHaveBeenCalled();
+  });
+});
+
 function resetRuleMocks() {
   vi.clearAllMocks();
   mockEnv.webhookActionsEnabled = true;

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -121,7 +121,28 @@ type RuleRecordData = {
   subject?: string | null;
   body?: string | null;
   groupId?: string | null;
+  organizationRuleId?: string | null;
 };
+
+export const ORGANIZATION_MANAGED_RULE_MESSAGE =
+  "This rule is managed by your organization and can only be changed by an organization admin.";
+
+export async function assertRuleNotOrganizationManaged({
+  ruleId,
+  emailAccountId,
+}: {
+  ruleId: string;
+  emailAccountId: string;
+}) {
+  const rule = await prisma.rule.findUnique({
+    where: { id: ruleId, emailAccountId },
+    select: { organizationRuleId: true },
+  });
+
+  if (rule?.organizationRuleId) {
+    throw new SafeError(ORGANIZATION_MANAGED_RULE_MESSAGE, 403);
+  }
+}
 
 async function updateRuleAndQueueHistory({
   ruleId,
@@ -134,6 +155,8 @@ async function updateRuleAndQueueHistory({
   data: Prisma.RuleUpdateInput;
   triggerType: RuleHistoryTrigger;
 }) {
+  await assertRuleNotOrganizationManaged({ ruleId, emailAccountId });
+
   const rule = await prisma.rule.update({
     where: { id: ruleId, emailAccountId },
     data,
@@ -268,6 +291,7 @@ export async function createRuleWithResolvedActions({
       subject: data.subject ?? undefined,
       body: data.body ?? undefined,
       groupId: data.groupId ?? undefined,
+      organizationRuleId: data.organizationRuleId ?? undefined,
       actions: {
         createMany: {
           data: addNestedActionOwnershipToInputs(actions, emailAccountId),
@@ -285,18 +309,25 @@ export async function replaceRuleWithResolvedActions({
   emailAccountId,
   data,
   actions,
+  allowOrganizationManaged = false,
 }: {
   ruleId: string;
   emailAccountId: string;
   data: RuleRecordData;
   actions: RuleActionCreateData[];
+  // only the organization rule sync may modify managed rules
+  allowOrganizationManaged?: boolean;
 }): Promise<RuleWithRelations> {
   assertWebhookActionsAllowed(actions);
 
   const existingRule = await prisma.rule.findUnique({
     where: { id: ruleId, emailAccountId },
-    select: RULE_SCOPE_SELECT,
+    select: { ...RULE_SCOPE_SELECT, organizationRuleId: true },
   });
+
+  if (existingRule?.organizationRuleId && !allowOrganizationManaged) {
+    throw new SafeError(ORGANIZATION_MANAGED_RULE_MESSAGE, 403);
+  }
 
   await assertNoSenderOnlyOverlap({
     emailAccountId,
@@ -598,11 +629,15 @@ export async function updateRuleActions({
 
   const existingRule = await prisma.rule.findFirst({
     where: { id: ruleId, emailAccountId },
-    select: { from: true },
+    select: { from: true, organizationRuleId: true },
   });
 
   if (!existingRule) {
     throw new Error("Rule not found");
+  }
+
+  if (existingRule.organizationRuleId) {
+    throw new SafeError(ORGANIZATION_MANAGED_RULE_MESSAGE, 403);
   }
 
   validateLowTrustStaticFromOutboundActions({
@@ -645,6 +680,8 @@ export async function deleteRule({
   ruleId: string;
   groupId?: string | null;
 }) {
+  await assertRuleNotOrganizationManaged({ ruleId, emailAccountId });
+
   if (groupId) {
     const deletedGroups = await prisma.group.deleteMany({
       where: { id: groupId, emailAccountId },


### PR DESCRIPTION
Organization admins can now define rules at the organization level that are automatically provisioned into every targeted member's email account as locked, managed copies of the rule. The existing rule execution pipeline runs them unchanged.

- New OrganizationRule + OrganizationRuleAction models, synced into member accounts via Rule.organizationRuleId (cascade delete)
- New OrganizationTeam model: members can be assigned a team (e.g. Engineering, Marketing) and rules can target specific teams; rules with no teams apply to every member
- Sync engine provisions/updates/removes managed rules on rule changes, member joins, team changes, and member removal
- Members cannot edit, delete, or toggle managed rules: guards in the core rule utilities cover server actions, chat tools, and the v1 API
- Org page gets a Rules tab (admin only) for managing rules and teams; members see a "Managed by org" badge on their rules list
