### PR TITLE
Fix draft recipient filtering

### DIFF
--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -5,25 +5,29 @@ import { GmailLabel } from "@/utils/gmail/label";
 import * as gmailLabelModule from "@/utils/gmail/label";
 import { GmailProvider } from "./google";
 
-const { envMock, gmailMailMock, gmailDraftMock } = vi.hoisted(() => ({
-  envMock: {
-    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
-    EMAIL_ENCRYPT_SECRET: "test-encrypt-secret",
-    EMAIL_ENCRYPT_SALT: "test-encrypt-salt",
-  },
-  gmailMailMock: {
-    draftEmail: vi.fn().mockResolvedValue({ data: { id: "draft-1" } }),
-    forwardEmail: vi.fn(),
-    replyToEmail: vi.fn(),
-    sendEmailWithPlainText: vi.fn(),
-    sendEmailWithHtml: vi.fn(),
-  },
-  gmailDraftMock: {
-    getDraft: vi.fn(),
-    deleteDraft: vi.fn(),
-    sendDraft: vi.fn(),
-  },
-}));
+const { envMock, gmailMailMock, gmailDraftMock, gmailSignatureMock } =
+  vi.hoisted(() => ({
+    envMock: {
+      NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+      EMAIL_ENCRYPT_SECRET: "test-encrypt-secret",
+      EMAIL_ENCRYPT_SALT: "test-encrypt-salt",
+    },
+    gmailMailMock: {
+      draftEmail: vi.fn().mockResolvedValue({ data: { id: "draft-1" } }),
+      forwardEmail: vi.fn(),
+      replyToEmail: vi.fn(),
+      sendEmailWithPlainText: vi.fn(),
+      sendEmailWithHtml: vi.fn(),
+    },
+    gmailDraftMock: {
+      getDraft: vi.fn(),
+      deleteDraft: vi.fn(),
+      sendDraft: vi.fn(),
+    },
+    gmailSignatureMock: {
+      getGmailSignatures: vi.fn().mockResolvedValue([]),
+    },
+  }));
 
 vi.mock("@/env", () => ({
   env: envMock,
@@ -36,9 +40,14 @@ vi.mock("@/utils/gmail/mail", async (importOriginal) => {
 
 vi.mock("@/utils/gmail/draft", () => gmailDraftMock);
 
+vi.mock("@/utils/gmail/signature-settings", () => gmailSignatureMock);
+
 describe("GmailProvider.getLatestMessageInThread", () => {
   afterEach(() => {
     envMock.NEXT_PUBLIC_AUTO_DRAFT_DISABLED = false;
+    vi.clearAllMocks();
+    gmailMailMock.draftEmail.mockResolvedValue({ data: { id: "draft-1" } });
+    gmailSignatureMock.getGmailSignatures.mockResolvedValue([]);
   });
 
   it("returns latest non-draft message when newest message is a draft", async () => {
@@ -105,6 +114,37 @@ describe("GmailProvider.getLatestMessageInThread", () => {
 
     expect(result).toEqual({ draftId: "" });
     expect(gmailMailMock.draftEmail).not.toHaveBeenCalled();
+  });
+
+  it("passes Gmail send-as aliases when creating drafts", async () => {
+    gmailSignatureMock.getGmailSignatures.mockResolvedValue([
+      {
+        email: "user@example.com",
+        signature: "",
+        isDefault: true,
+      },
+      {
+        email: "alias@example.com",
+        signature: "",
+        isDefault: false,
+      },
+    ]);
+    const provider = new GmailProvider({} as any);
+    const message = createParsedMessage({
+      id: "message-1",
+      internalDate: "1000",
+    });
+    const args = { content: "Follow up" };
+
+    const result = await provider.draftEmail(message, args, "user@example.com");
+
+    expect(result).toEqual({ draftId: "draft-1" });
+    expect(gmailMailMock.draftEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      message,
+      args,
+      ["user@example.com", "alias@example.com"],
+    );
   });
 });
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -830,36 +830,29 @@ export class GmailProvider implements EmailProvider {
     });
 
     const userEmails = await this.getSelfEmailAddresses(userEmail);
+    const draftPromise = draftEmail(this.client, email, args, userEmails);
+    let result: Awaited<typeof draftPromise>;
 
     if (executedRule) {
-      // Run draft creation and previous draft deletion in parallel
-      const [result] = await Promise.all([
-        draftEmail(this.client, email, args, userEmails),
+      [result] = await Promise.all([
+        draftPromise,
         handlePreviousDraftDeletion({
           client: this,
           executedRule,
           logger: this.logger,
         }),
       ]);
-
-      const draftId = result.data.id || "";
-      this.logger.info("Gmail draft created successfully", {
-        draftId,
-        gmailMessageId: result.data.message?.id,
-      });
-
-      return { draftId };
     } else {
-      const result = await draftEmail(this.client, email, args, userEmails);
-
-      const draftId = result.data.id || "";
-      this.logger.info("Gmail draft created successfully", {
-        draftId,
-        gmailMessageId: result.data.message?.id,
-      });
-
-      return { draftId };
+      result = await draftPromise;
     }
+
+    const draftId = result.data.id || "";
+    this.logger.info("Gmail draft created successfully", {
+      draftId,
+      gmailMessageId: result.data.message?.id,
+    });
+
+    return { draftId };
   }
 
   async replyToEmail(

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -81,12 +81,14 @@ import { createScopedLogger, type Logger } from "@/utils/logger";
 import { getGmailSignatures } from "@/utils/gmail/signature-settings";
 import { withRateLimitRecording } from "@/utils/email/rate-limit";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
+import { extractUniqueEmailAddresses } from "@/utils/email";
 
 export class GmailProvider implements EmailProvider {
   readonly name = "google";
   private readonly client: gmail_v1.Gmail;
   private readonly logger: Logger;
   private readonly emailAccountId?: string;
+  private sendAsEmailAddressesPromise?: Promise<string[]>;
 
   constructor(
     client: gmail_v1.Gmail,
@@ -827,10 +829,12 @@ export class GmailProvider implements EmailProvider {
       contentLength: args.content?.length,
     });
 
+    const userEmails = await this.getSelfEmailAddresses(userEmail);
+
     if (executedRule) {
       // Run draft creation and previous draft deletion in parallel
       const [result] = await Promise.all([
-        draftEmail(this.client, email, args, userEmail),
+        draftEmail(this.client, email, args, userEmails),
         handlePreviousDraftDeletion({
           client: this,
           executedRule,
@@ -846,7 +850,7 @@ export class GmailProvider implements EmailProvider {
 
       return { draftId };
     } else {
-      const result = await draftEmail(this.client, email, args, userEmail);
+      const result = await draftEmail(this.client, email, args, userEmails);
 
       const draftId = result.data.id || "";
       this.logger.info("Gmail draft created successfully", {
@@ -1589,5 +1593,26 @@ export class GmailProvider implements EmailProvider {
       },
       operation,
     );
+  }
+
+  private async getSelfEmailAddresses(userEmail: string): Promise<string[]> {
+    try {
+      const sendAsEmailAddresses = await this.getSendAsEmailAddresses();
+      return extractUniqueEmailAddresses([userEmail, ...sendAsEmailAddresses]);
+    } catch (error) {
+      this.logger.warn("Failed to fetch Gmail send-as addresses", { error });
+      return extractUniqueEmailAddresses([userEmail]);
+    }
+  }
+
+  private getSendAsEmailAddresses(): Promise<string[]> {
+    this.sendAsEmailAddressesPromise ??= getGmailSignatures(this.client)
+      .then((signatures) => signatures.map((signature) => signature.email))
+      .catch((error) => {
+        this.sendAsEmailAddressesPromise = undefined;
+        throw error;
+      });
+
+    return this.sendAsEmailAddressesPromise;
   }
 }

--- a/apps/web/utils/email/reply-all.test.ts
+++ b/apps/web/utils/email/reply-all.test.ts
@@ -416,6 +416,27 @@ describe("buildReplyAllRecipients", () => {
     expect(result.cc).toContain("manager@example.com");
     expect(result.cc).toHaveLength(2);
   });
+
+  it("should exclude current user aliases from CC", () => {
+    const headers: ParsedMessageHeaders = {
+      from: "sender@example.com",
+      to: "User Alias <alias@example.com>, colleague@example.com",
+      cc: "other-alias@example.com, manager@example.com",
+      subject: "Test",
+      date: "2024-01-01",
+    };
+
+    const result = buildReplyAllRecipients(headers, undefined, [
+      "primary@example.com",
+      "alias@example.com",
+      "Other Alias <other-alias@example.com>",
+    ]);
+
+    expect(result.to).toBe("sender@example.com");
+    expect(result.cc).not.toContain("alias@example.com");
+    expect(result.cc).not.toContain("other-alias@example.com");
+    expect(result.cc).toEqual(["manager@example.com", "colleague@example.com"]);
+  });
 });
 
 describe("formatCcList", () => {

--- a/apps/web/utils/email/reply-all.ts
+++ b/apps/web/utils/email/reply-all.ts
@@ -12,20 +12,23 @@ export interface ReplyAllRecipients {
  *
  * @param headers - Original email headers
  * @param overrideTo - Optional override for the TO field (e.g., for drafts)
- * @param currentUserEmail - Current user's email to exclude from CC
+ * @param currentUserEmails - Current user's email addresses to exclude from CC
  * @returns Object with TO and CC recipients for reply-all
  */
 export function buildReplyAllRecipients(
   headers: ParsedMessageHeaders,
   overrideTo: string | undefined,
-  currentUserEmail: string,
+  currentUserEmails: string | string[],
 ): ReplyAllRecipients {
   // Determine the primary recipient (TO field)
   const replyToRaw = overrideTo || headers["reply-to"] || headers.from;
   const replyTo = extractEmailAddress(replyToRaw);
 
-  // Extract current user's email
-  const currentUser = extractEmailAddress(currentUserEmail);
+  const currentUserEmailSet = new Set(
+    (Array.isArray(currentUserEmails) ? currentUserEmails : [currentUserEmails])
+      .map((email) => extractEmailAddress(email).toLowerCase())
+      .filter(Boolean),
+  );
 
   // Build CC list for reply-all behavior
   const ccSet = new Set<string>();
@@ -34,14 +37,14 @@ export function buildReplyAllRecipients(
   addHeaderRecipientsToCcSet({
     headerValue: headers.cc,
     replyTo,
-    currentUser,
+    currentUserEmailSet,
     seenEmails,
     ccSet,
   });
   addHeaderRecipientsToCcSet({
     headerValue: headers.to,
     replyTo,
-    currentUser,
+    currentUserEmailSet,
     seenEmails,
     ccSet,
   });
@@ -94,13 +97,13 @@ export function mergeAndDedupeRecipients(
 function addHeaderRecipientsToCcSet({
   headerValue,
   replyTo,
-  currentUser,
+  currentUserEmailSet,
   seenEmails,
   ccSet,
 }: {
   headerValue: string | undefined;
   replyTo: string;
-  currentUser: string;
+  currentUserEmailSet: Set<string>;
   seenEmails: Set<string>;
   ccSet: Set<string>;
 }) {
@@ -114,7 +117,7 @@ function addHeaderRecipientsToCcSet({
       const normalizedEmail = email.toLowerCase();
       return (
         normalizedEmail !== replyTo.toLowerCase() &&
-        normalizedEmail !== currentUser.toLowerCase()
+        !currentUserEmailSet.has(normalizedEmail)
       );
     });
 

--- a/apps/web/utils/gmail/mail.ts
+++ b/apps/web/utils/gmail/mail.ts
@@ -280,7 +280,7 @@ export async function draftEmail(
     bcc?: string;
     attachments?: Attachment[];
   },
-  userEmail: string,
+  userEmails: string | string[],
 ) {
   const { html } = createReplyContent({
     textContent: args.content,
@@ -294,7 +294,7 @@ export async function draftEmail(
   const recipients = buildReplyAllRecipients(
     originalEmail.headers,
     args.to,
-    userEmail,
+    userEmails,
   );
 
   // Merge CC from reply-all with CC from args

--- a/apps/web/utils/outlook/mail.ts
+++ b/apps/web/utils/outlook/mail.ts
@@ -275,7 +275,7 @@ export async function draftEmail(
     bcc?: string;
     attachments?: Attachment[];
   },
-  userEmail: string,
+  userEmails: string | string[],
   logger: Logger,
 ) {
   const { html } = createOutlookReplyContent({
@@ -286,7 +286,7 @@ export async function draftEmail(
   const recipients = buildReplyAllRecipients(
     originalEmail.headers,
     args.to,
-    userEmail,
+    userEmails,
   );
 
   const overrideToRecipient = args.to


### PR DESCRIPTION
Fixes draft recipient filtering so known self addresses are not copied on generated reply-all drafts.

- Supports multiple self addresses in recipient filtering.
- Uses provider send-as addresses when creating Gmail drafts.
- Adds focused unit coverage for alias filtering.