### PR TITLE
chore: Remove deprecated draft cleanup field

### DIFF
--- a/apps/web/prisma/migrations/20260611120000_drop_was_draft_sent/migration.sql
+++ b/apps/web/prisma/migrations/20260611120000_drop_was_draft_sent/migration.sql
@@ -1,0 +1,9 @@
+UPDATE "ExecutedAction"
+SET "draftStatus" = 'PENDING'::"DraftEmailStatus"
+WHERE "type" = 'DRAFT_EMAIL'
+  AND "draftId" IS NOT NULL
+  AND "draftStatus" = 'CLEANED_UP_UNUSED'::"DraftEmailStatus"
+  AND "wasDraftSent" = false;
+
+ALTER TABLE "ExecutedAction"
+DROP COLUMN "wasDraftSent";

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -645,7 +645,6 @@ model ExecutedAction {
   // additional fields as a result of the action
   draftId              String? // Gmail draft ID created by DRAFT_EMAIL action
   draftStatus          DraftEmailStatus? // Last observed/inferred draft lifecycle status; provider state may be stale or ambiguous.
-  wasDraftSent         Boolean? // @deprecated Use draftStatus. Kept for historical compatibility only.
   draftModelProvider   String?
   draftModelName       String?
   draftPipelineVersion Int?

--- a/apps/web/utils/ai/draft-cleanup.test.ts
+++ b/apps/web/utils/ai/draft-cleanup.test.ts
@@ -69,10 +69,6 @@ describe("cleanupAIDraftsForAccount", () => {
               },
             },
             { draftStatus: null },
-            {
-              draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-              wasDraftSent: false,
-            },
           ],
           createdAt: { lt: expectedCutoffDate },
         }),
@@ -184,77 +180,6 @@ describe("cleanupAIDraftsForAccount", () => {
       cleanupDays: 14,
     });
   });
-
-  it("retries legacy cleanup records that still have provider drafts", async () => {
-    mocks.prisma.executedAction.findMany.mockResolvedValue([
-      {
-        id: "action-legacy-cleaned",
-        draftId: "draft-legacy-cleaned",
-        content: "Legacy generated reply.",
-        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-        wasDraftSent: false,
-      },
-    ]);
-    mocks.provider.getDraft.mockResolvedValue({
-      textPlain: "Legacy generated reply.",
-      textHtml: null,
-    });
-
-    const result = await cleanupAIDraftsForAccount({
-      emailAccountId: "email-account-1",
-      provider: "google",
-      logger,
-      cleanupDays: 14,
-    });
-
-    expect(mocks.provider.deleteDraft).toHaveBeenCalledWith(
-      "draft-legacy-cleaned",
-    );
-    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
-      where: { id: "action-legacy-cleaned" },
-      data: {
-        wasDraftSent: null,
-      },
-    });
-    expect(result).toMatchObject({
-      total: 1,
-      deleted: 1,
-      cleanupDays: 14,
-    });
-  });
-
-  it("marks legacy cleanup records as checked when the provider draft is gone", async () => {
-    mocks.prisma.executedAction.findMany.mockResolvedValue([
-      {
-        id: "action-legacy-missing",
-        draftId: "draft-legacy-missing",
-        content: "Legacy generated reply.",
-        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-        wasDraftSent: false,
-      },
-    ]);
-    mocks.provider.getDraft.mockResolvedValue(null);
-
-    const result = await cleanupAIDraftsForAccount({
-      emailAccountId: "email-account-1",
-      provider: "google",
-      logger,
-      cleanupDays: 14,
-    });
-
-    expect(mocks.provider.deleteDraft).not.toHaveBeenCalled();
-    expect(mocks.prisma.executedAction.update).toHaveBeenCalledWith({
-      where: { id: "action-legacy-missing" },
-      data: {
-        wasDraftSent: null,
-      },
-    });
-    expect(result).toMatchObject({
-      total: 1,
-      alreadyGone: 1,
-      cleanupDays: 14,
-    });
-  });
 });
 
 describe("cleanupConfiguredAIDrafts", () => {
@@ -295,10 +220,6 @@ describe("cleanupConfiguredAIDrafts", () => {
                     },
                   },
                   { draftStatus: null },
-                  {
-                    draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-                    wasDraftSent: false,
-                  },
                 ],
               },
             },

--- a/apps/web/utils/ai/draft-cleanup.ts
+++ b/apps/web/utils/ai/draft-cleanup.ts
@@ -31,7 +31,6 @@ export async function cleanupAIDraftsForAccount({
       id: true,
       draftId: true,
       draftStatus: true,
-      wasDraftSent: true,
       content: true,
     },
     orderBy: { createdAt: "asc" },
@@ -68,7 +67,6 @@ export async function cleanupAIDraftsForAccount({
       if (!draftDetails?.textPlain && !draftDetails?.textHtml) {
         const statusData = getDraftCleanupStatusData({
           draftStatus: action.draftStatus,
-          wasDraftSent: action.wasDraftSent,
           status: DraftEmailStatus.MISSING_FROM_PROVIDER,
         });
         if (statusData) {
@@ -97,7 +95,6 @@ export async function cleanupAIDraftsForAccount({
       await provider.deleteDraft(action.draftId);
       const statusData = getDraftCleanupStatusData({
         draftStatus: action.draftStatus,
-        wasDraftSent: action.wasDraftSent,
         status: DraftEmailStatus.CLEANED_UP_UNUSED,
       });
       if (statusData) {
@@ -218,23 +215,18 @@ export async function getConfiguredDraftCleanupDays(emailAccountId: string) {
 
 function getDraftCleanupStatusData({
   draftStatus,
-  wasDraftSent,
   status,
 }: {
   draftStatus?: DraftEmailStatus | null;
-  wasDraftSent?: boolean | null;
   status: DraftEmailStatus;
-}): { draftStatus?: DraftEmailStatus; wasDraftSent?: null } | null {
-  const data: { draftStatus?: DraftEmailStatus; wasDraftSent?: null } = {};
+}): { draftStatus: DraftEmailStatus } | null {
+  const data: { draftStatus?: DraftEmailStatus } = {};
 
   if (canTransitionDraftStatus(draftStatus) && draftStatus !== status) {
     data.draftStatus = status;
   }
-  if (wasDraftSent === false) {
-    data.wasDraftSent = null;
-  }
 
-  return Object.keys(data).length > 0 ? data : null;
+  return data.draftStatus ? { draftStatus: data.draftStatus } : null;
 }
 
 function canTransitionDraftStatus(
@@ -259,12 +251,6 @@ function getDraftCleanupCandidateWhere() {
         },
       },
       { draftStatus: null },
-      // Legacy rows with wasDraftSent=false were migrated to CLEANED_UP_UNUSED,
-      // even when the provider draft still needed a retry.
-      {
-        draftStatus: DraftEmailStatus.CLEANED_UP_UNUSED,
-        wasDraftSent: false,
-      },
     ],
   };
 }


### PR DESCRIPTION
Removes a deprecated draft cleanup field after moving cleanup decisions to the current status field.

- Drop the deprecated database column with a migration
- Preserve cleanup eligibility for remaining ambiguous records before the drop
- Remove legacy cleanup branches and update focused tests