### PR TITLE
perf: Add bounded meeting brief processing

### DIFF
--- a/apps/web/app/api/meeting-briefs/route.test.ts
+++ b/apps/web/app/api/meeting-briefs/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  captureExceptionMock,
+  envMock,
+  mockPrisma,
+  processMeetingBriefingsMock,
+} = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+  envMock: {
+    CRON_SECRET: "cron-secret",
+  },
+  mockPrisma: {
+    emailAccount: {
+      findMany: vi.fn(),
+    },
+  },
+  processMeetingBriefingsMock: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: mockPrisma,
+}));
+
+vi.mock("@/utils/premium", () => ({
+  getPremiumUserFilter: vi.fn(() => ({})),
+}));
+
+vi.mock("@/utils/meeting-briefs/process", () => ({
+  processMeetingBriefings: (...args: unknown[]) =>
+    processMeetingBriefingsMock(...args),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
+
+import { GET } from "./route";
+
+describe("meeting briefs cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.CRON_SECRET = "cron-secret";
+  });
+
+  it("processes eligible accounts with bounded concurrency", async () => {
+    mockPrisma.emailAccount.findMany.mockResolvedValue(
+      Array.from({ length: 7 }, (_, index) => ({
+        id: `email-account-${index + 1}`,
+        email: `account-${index + 1}@example.test`,
+        meetingBriefingsMinutesBefore: 60,
+        account: { provider: "google" },
+      })),
+    );
+
+    let active = 0;
+    let maxActive = 0;
+    processMeetingBriefingsMock.mockImplementation(
+      async ({ emailAccountId }: { emailAccountId: string }) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        active--;
+
+        if (emailAccountId === "email-account-3") {
+          throw new Error("Processing failed");
+        }
+      },
+    );
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/meeting-briefs", {
+        headers: { authorization: "Bearer cron-secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      total: 7,
+      success: 6,
+      errors: 1,
+    });
+    expect(processMeetingBriefingsMock).toHaveBeenCalledTimes(7);
+    expect(maxActive).toBe(5);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/api/meeting-briefs/route.ts
+++ b/apps/web/app/api/meeting-briefs/route.ts
@@ -6,8 +6,10 @@ import { captureException } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import { getPremiumUserFilter } from "@/utils/premium";
 import { processMeetingBriefings } from "@/utils/meeting-briefs/process";
+import { runWithBoundedConcurrency } from "@/utils/async";
 
 export const maxDuration = 800;
+const MEETING_BRIEFING_ACCOUNT_CONCURRENCY = 5;
 
 export const GET = withError("meeting-briefs", async (request) => {
   if (!hasCronSecret(request)) {
@@ -62,28 +64,40 @@ async function processAllMeetingBriefings(logger: Logger) {
 
   logger.info("Found eligible accounts", { count: emailAccounts.length });
 
+  const results = await runWithBoundedConcurrency({
+    items: emailAccounts,
+    concurrency: MEETING_BRIEFING_ACCOUNT_CONCURRENCY,
+    run: (emailAccount) =>
+      processMeetingBriefings({
+        emailAccountId: emailAccount.id,
+        userEmail: emailAccount.email,
+        minutesBefore: emailAccount.meetingBriefingsMinutesBefore,
+        logger: logger.with({
+          emailAccountId: emailAccount.id,
+          email: emailAccount.email,
+        }),
+      }),
+  });
+
   let successCount = 0;
   let errorCount = 0;
 
-  for (const emailAccount of emailAccounts) {
+  for (const { item: emailAccount, result } of results) {
+    if (result.status === "fulfilled") {
+      successCount++;
+      continue;
+    }
+
     const log = logger.with({
       emailAccountId: emailAccount.id,
       email: emailAccount.email,
     });
 
-    try {
-      await processMeetingBriefings({
-        emailAccountId: emailAccount.id,
-        userEmail: emailAccount.email,
-        minutesBefore: emailAccount.meetingBriefingsMinutesBefore,
-        logger: log,
-      });
-      successCount++;
-    } catch (error) {
-      log.error("Failed to process meeting briefings for user", { error });
-      captureException(error);
-      errorCount++;
-    }
+    log.error("Failed to process meeting briefings for user", {
+      error: result.reason,
+    });
+    captureException(result.reason);
+    errorCount++;
   }
 
   logger.info("Completed processing meeting briefings", {


### PR DESCRIPTION
Processes eligible meeting brief accounts in bounded batches while preserving per-account error handling.

- Use existing bounded concurrency helper for account processing
- Preserve success and error counts in the route response
- Add focused route coverage for concurrency and error accounting