### PR TITLE
booking: Improve event titles

### DIFF
--- a/apps/web/utils/booking/public.test.ts
+++ b/apps/web/utils/booking/public.test.ts
@@ -238,7 +238,7 @@ describe("public booking", () => {
         locationValue: "Video link",
         startTime: new Date("2026-05-04T09:00:00.000Z"),
         timezone: "UTC",
-        title: "Intro call",
+        title: "Intro call between Host User and Guest <User>",
       }),
     );
     const calendarEventCall = vi.mocked(createCalendarEvent).mock.calls[0][0];
@@ -1099,6 +1099,7 @@ function mockBookingLinkConfig(
       { weekday: 1, startMinutes: 9 * 60, endMinutes: 10 * 60 },
     ],
     emailAccount: {
+      name: "Host User",
       calendarConnections: [
         { id: "connection-id", calendars: [{ id: "calendar-row-id" }] },
       ],

--- a/apps/web/utils/booking/public.ts
+++ b/apps/web/utils/booking/public.ts
@@ -176,7 +176,11 @@ export async function createPublicBooking({
     createdEvent = await createCalendarEvent({
       emailAccountId: config.link.emailAccountId,
       destinationCalendarId: config.link.destinationCalendarId,
-      title: config.link.title,
+      title: getProviderEventTitle({
+        bookingLinkTitle: config.link.title,
+        guestName: input.guestName,
+        hostName: config.link.emailAccount.name,
+      }),
       description: getProviderEventDescription({
         guestName: input.guestName,
         guestEmail: input.guestEmail,
@@ -628,6 +632,7 @@ async function loadPublicBookingLink(slug: string) {
       },
       emailAccount: {
         select: {
+          name: true,
           calendarConnections: {
             where: { isConnected: true },
             select: {
@@ -913,6 +918,29 @@ function getProviderEventDescription({
   ]
     .filter((line) => line !== null)
     .join("\n");
+}
+
+function getProviderEventTitle({
+  bookingLinkTitle,
+  guestName,
+  hostName,
+}: {
+  bookingLinkTitle: string;
+  guestName: string;
+  hostName: string | null;
+}) {
+  const title = cleanCalendarTitleText(bookingLinkTitle) || "Meeting";
+  const host = hostName ? cleanCalendarTitleText(hostName) : "";
+  const guest = cleanCalendarTitleText(guestName);
+  const participant = guest || host;
+  const participants = host && guest ? ` between ${host} and ${guest}` : "";
+  const fallbackParticipant = participant ? ` with ${participant}` : "";
+
+  return `${title}${participants || fallbackParticipant}`;
+}
+
+function cleanCalendarTitleText(value: string) {
+  return cleanCalendarDescriptionText(value).replace(/\s+/g, " ").trim();
 }
 
 function cleanCalendarDescriptionText(value: string) {


### PR DESCRIPTION
Updates calendar events created from booking links so invite titles include the configured booking title and participant context.

- Formats provider event titles from existing booking-link and attendee data
- Covers the title behavior in the public booking unit test

Performance impact: Adds a small string-formatting step during booking creation and selects one existing account name field with the booking-link query. No new network calls or broad hot-path work.