### PR TITLE
perf: Add bounded Outlook backfill processing

### DIFF
--- a/apps/web/app/api/v1/rules/request.ts
+++ b/apps/web/app/api/v1/rules/request.ts
@@ -1,17 +1,22 @@
 import type { RuleRequestBody } from "@/app/api/v1/rules/validation";
+import type { CreateOrUpdateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+import { toCreateOrUpdateRuleCondition } from "@/utils/rule/create-rule-condition";
 
-export function toRuleWriteInput(body: RuleRequestBody) {
+type RuleWriteInput = {
+  name: string;
+  condition: CreateOrUpdateRuleSchema["condition"];
+  actions: CreateOrUpdateRuleSchema["actions"];
+  runOnThreads: boolean;
+};
+
+export function toRuleWriteInput(body: RuleRequestBody): RuleWriteInput {
   return {
     name: body.name,
-    condition: {
+    condition: toCreateOrUpdateRuleCondition({
       conditionalOperator: body.condition.conditionalOperator ?? null,
-      aiInstructions: body.condition.aiInstructions ?? null,
-      static: {
-        from: body.condition.static?.from ?? null,
-        to: body.condition.static?.to ?? null,
-        subject: body.condition.static?.subject ?? null,
-      },
-    },
+      aiInstructions: body.condition.aiInstructions,
+      static: body.condition.static,
+    }),
     actions: body.actions.map((action) => ({
       type: action.type,
       messagingChannelId: action.messagingChannelId ?? null,

--- a/apps/web/utils/actions/rule.ts
+++ b/apps/web/utils/actions/rule.ts
@@ -56,6 +56,7 @@ import { bulkProcessInboxEmails } from "@/utils/ai/choose-rule/bulk-process-emai
 import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import type { AttachmentSourceInput } from "@/utils/attachments/source-schema";
 import { assertCanUseDigestsIfNeeded } from "@/utils/premium/server";
+import { toCreateOrUpdateRuleCondition } from "@/utils/rule/create-rule-condition";
 
 export const createRuleAction = actionClient
   .metadata({ name: "createRule" })
@@ -86,15 +87,15 @@ export const createRuleAction = actionClient
         const rule = await createRule({
           result: {
             name,
-            condition: {
-              aiInstructions: conditions.instructions ?? null,
+            condition: toCreateOrUpdateRuleCondition({
+              aiInstructions: conditions.instructions,
               conditionalOperator: conditionalOperator || null,
               static: {
-                from: conditions.from || null,
-                to: conditions.to || null,
-                subject: conditions.subject || null,
+                from: conditions.from,
+                to: conditions.to,
+                subject: conditions.subject,
               },
-            },
+            }),
             actions: resolvedActions.map(mapActionToSanitizedFields),
           },
           emailAccountId,
@@ -141,15 +142,15 @@ export const updateRuleAction = actionClient
           ruleId: id,
           result: {
             name: name || "",
-            condition: {
-              aiInstructions: conditions.instructions ?? null,
+            condition: toCreateOrUpdateRuleCondition({
+              aiInstructions: conditions.instructions,
               conditionalOperator: conditionalOperator || null,
               static: {
-                from: conditions.from || null,
-                to: conditions.to || null,
-                subject: conditions.subject || null,
+                from: conditions.from,
+                to: conditions.to,
+                subject: conditions.subject,
               },
-            },
+            }),
             actions: resolvedActions.map(mapActionToSanitizedFields),
           },
           emailAccountId,

--- a/apps/web/utils/outlook/backfill-recent-messages.test.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.test.ts
@@ -112,4 +112,92 @@ describe("backfillRecentOutlookMessages", () => {
     expect(prisma.emailMessage.findMany).not.toHaveBeenCalled();
     expect(processHistoryForUser).not.toHaveBeenCalled();
   });
+
+  it("processes only the oldest unseen message per thread", async () => {
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessagesWithPagination: vi.fn().mockResolvedValue({
+        messages: [
+          {
+            id: "newer-thread-message",
+            threadId: "thread-shared",
+            date: "2026-04-16T09:00:00.000Z",
+          },
+          {
+            id: "oldest-thread-message",
+            threadId: "thread-shared",
+            date: "2026-04-16T07:00:00.000Z",
+          },
+          {
+            id: "other-thread-message",
+            threadId: "thread-other",
+            date: "2026-04-16T08:00:00.000Z",
+          },
+        ],
+      }),
+    } as any);
+    vi.mocked(prisma.emailMessage.findMany).mockResolvedValue([]);
+
+    const result = await backfillRecentOutlookMessages({
+      emailAccountId: "email-account-id",
+      emailAddress: "user@example.com",
+      after: new Date("2026-04-15T00:00:00.000Z"),
+      maxMessages: 5,
+      logger,
+    });
+
+    expect(result).toEqual({ processedCount: 2, candidateCount: 3 });
+    expect(processHistoryForUser).toHaveBeenCalledTimes(2);
+    expect(processHistoryForUser).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        resourceData: {
+          id: "oldest-thread-message",
+          conversationId: "thread-shared",
+        },
+      }),
+    );
+    expect(processHistoryForUser).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        resourceData: {
+          id: "other-thread-message",
+          conversationId: "thread-other",
+        },
+      }),
+    );
+  });
+
+  it("processes unseen messages with bounded concurrency", async () => {
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getMessagesWithPagination: vi.fn().mockResolvedValue({
+        messages: Array.from({ length: 6 }, (_, index) => ({
+          id: `message-${index + 1}`,
+          threadId: `thread-${index + 1}`,
+          date: `2026-04-16T0${index}:00:00.000Z`,
+        })),
+      }),
+    } as any);
+    vi.mocked(prisma.emailMessage.findMany).mockResolvedValue([]);
+
+    let active = 0;
+    let maxActive = 0;
+    vi.mocked(processHistoryForUser).mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      active--;
+    });
+
+    const result = await backfillRecentOutlookMessages({
+      emailAccountId: "email-account-id",
+      emailAddress: "user@example.com",
+      after: new Date("2026-04-15T00:00:00.000Z"),
+      maxMessages: 6,
+      logger,
+    });
+
+    expect(result).toEqual({ processedCount: 6, candidateCount: 6 });
+    expect(processHistoryForUser).toHaveBeenCalledTimes(6);
+    expect(maxActive).toBe(5);
+  });
 });

--- a/apps/web/utils/outlook/backfill-recent-messages.ts
+++ b/apps/web/utils/outlook/backfill-recent-messages.ts
@@ -4,8 +4,10 @@ import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import type { ParsedMessage } from "@/utils/types";
+import { runWithBoundedConcurrency } from "@/utils/async";
 
 const OUTLOOK_RECONCILE_PAGE_SIZE = 50;
+const OUTLOOK_RECONCILE_MESSAGE_CONCURRENCY = 5;
 
 export async function backfillRecentOutlookMessages({
   emailAccountId,
@@ -60,6 +62,7 @@ export async function backfillRecentOutlookMessages({
       (left, right) =>
         new Date(left.date).getTime() - new Date(right.date).getTime(),
     );
+  const unseenThreads = getOldestMessagePerThread(unseenMessages);
 
   logger.info("Reconciling recent Outlook messages", {
     after,
@@ -67,13 +70,15 @@ export async function backfillRecentOutlookMessages({
     pageCount,
     candidateCount: candidateMessages.length,
     unseenCount: unseenMessages.length,
+    unseenThreadCount: unseenThreads.length,
     subscriptionId,
   });
 
-  let processedCount = 0;
-  for (const message of unseenMessages) {
-    try {
-      await processHistoryForUser({
+  const results = await runWithBoundedConcurrency({
+    items: unseenThreads,
+    concurrency: OUTLOOK_RECONCILE_MESSAGE_CONCURRENCY,
+    run: (message) =>
+      processHistoryForUser({
         emailAddress,
         subscriptionId,
         resourceData: {
@@ -81,14 +86,20 @@ export async function backfillRecentOutlookMessages({
           conversationId: message.threadId,
         },
         logger: logger.with({ messageId: message.id }),
-      });
+      }),
+  });
+
+  let processedCount = 0;
+  for (const { item: message, result } of results) {
+    if (result.status === "fulfilled") {
       processedCount++;
-    } catch (error) {
-      logger.error("Failed to process message during backfill", {
-        messageId: message.id,
-        error,
-      });
+      continue;
     }
+
+    logger.error("Failed to process message during backfill", {
+      messageId: message.id,
+      error: result.reason,
+    });
   }
 
   logger.info("Finished reconciling recent Outlook messages", {
@@ -97,6 +108,7 @@ export async function backfillRecentOutlookMessages({
     pageCount,
     candidateCount: candidateMessages.length,
     unseenCount: unseenMessages.length,
+    unseenThreadCount: unseenThreads.length,
     processedCount,
     subscriptionId,
   });
@@ -105,6 +117,27 @@ export async function backfillRecentOutlookMessages({
     processedCount,
     candidateCount: candidateMessages.length,
   };
+}
+
+function getOldestMessagePerThread(messages: ParsedMessage[]) {
+  const messagesByThread = new Map<string, ParsedMessage>();
+
+  for (const message of messages) {
+    const existing = messagesByThread.get(message.threadId);
+    if (!existing) {
+      messagesByThread.set(message.threadId, message);
+      continue;
+    }
+
+    if (new Date(message.date).getTime() < new Date(existing.date).getTime()) {
+      messagesByThread.set(message.threadId, message);
+    }
+  }
+
+  return [...messagesByThread.values()].sort(
+    (left, right) =>
+      new Date(left.date).getTime() - new Date(right.date).getTime(),
+  );
 }
 
 async function listRecentMessages({

--- a/apps/web/utils/rule/create-rule-condition.ts
+++ b/apps/web/utils/rule/create-rule-condition.ts
@@ -1,0 +1,62 @@
+import type { CreateOrUpdateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+
+type RuleCondition = CreateOrUpdateRuleSchema["condition"];
+
+export function toCreateOrUpdateRuleCondition({
+  conditionalOperator,
+  aiInstructions,
+  static: staticInput,
+}: {
+  conditionalOperator: RuleCondition["conditionalOperator"];
+  aiInstructions?: string | null;
+  static?: {
+    from?: string | null;
+    to?: string | null;
+    subject?: string | null;
+  } | null;
+}): RuleCondition {
+  const staticCondition = {
+    from: valueOrNull(staticInput?.from),
+    to: valueOrNull(staticInput?.to),
+    subject: valueOrNull(staticInput?.subject),
+  };
+  const normalizedAiInstructions = valueOrNull(aiInstructions);
+
+  if (normalizedAiInstructions) {
+    return {
+      conditionalOperator,
+      aiInstructions: normalizedAiInstructions,
+      static: staticCondition,
+    };
+  }
+
+  if (staticCondition.from) {
+    return {
+      conditionalOperator,
+      aiInstructions: normalizedAiInstructions,
+      static: { ...staticCondition, from: staticCondition.from },
+    };
+  }
+
+  if (staticCondition.to) {
+    return {
+      conditionalOperator,
+      aiInstructions: normalizedAiInstructions,
+      static: { ...staticCondition, to: staticCondition.to },
+    };
+  }
+
+  if (staticCondition.subject) {
+    return {
+      conditionalOperator,
+      aiInstructions: normalizedAiInstructions,
+      static: { ...staticCondition, subject: staticCondition.subject },
+    };
+  }
+
+  throw new Error("A rule must include at least one condition");
+}
+
+function valueOrNull(value?: string | null) {
+  return value?.trim() ? value : null;
+}


### PR DESCRIPTION
Processes Outlook backfill work in bounded batches while avoiding repeated processing for multiple messages in the same thread.

- Use the existing bounded concurrency helper for unseen thread processing
- Deduplicate unseen messages by thread and process the oldest message per thread
- Keep processed counts based on fulfilled thread processing
- Add focused coverage for thread dedupe and the concurrency cap