### PR TITLE
Fix booking integration test for updated calendar event titles

### DIFF
--- a/apps/web/__tests__/integration/public-booking-google.test.ts
+++ b/apps/web/__tests__/integration/public-booking-google.test.ts
@@ -146,7 +146,7 @@ describe.skipIf(!RUN_INTEGRATION_TESTS)(
       expect(events.data.items).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            summary: "Intro call",
+            summary: "Intro call with Guest User",
             start: expect.objectContaining({
               dateTime: "2030-01-07T09:00:00.000Z",
             }),


### PR DESCRIPTION
## Summary
- Updates the Google Calendar emulator integration test to expect the new provider event title format that includes the guest name
- Fixes CI failure introduced when calendar event titles were improved to include participant names

## Test plan
- [x] Run `public-booking-google.test.ts` integration test locally — passes
- [ ] Verify CI integration test suite passes


Made with [Cursor](https://cursor.com)