### PR TITLE
Handle duplicate feedback saves

### DIFF
--- a/apps/web/utils/rule/classification-feedback.test.ts
+++ b/apps/web/utils/rule/classification-feedback.test.ts
@@ -1,4 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
 import {
   saveClassificationFeedback,
   getClassificationFeedback,
@@ -45,6 +46,24 @@ describe("saveClassificationFeedback", () => {
         }),
       }),
     );
+  });
+
+  it("treats duplicate feedback races as already saved", async () => {
+    vi.mocked(prisma.classificationFeedback.upsert).mockRejectedValueOnce(
+      createDuplicateFeedbackError(),
+    );
+
+    await expect(
+      saveClassificationFeedback({
+        emailAccountId: "acc-1",
+        sender: "user@example.com",
+        ruleId: "rule-1",
+        threadId: "thread-1",
+        messageId: "msg-1",
+        eventType: ClassificationFeedbackEventType.LABEL_REMOVED,
+        logger,
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -222,3 +241,13 @@ describe("findRuleByLabelId", () => {
     expect(result).toBeNull();
   });
 });
+
+function createDuplicateFeedbackError() {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "5.0.0",
+    meta: {
+      target: ["emailAccountId", "sender", "ruleId", "messageId", "eventType"],
+    },
+  });
+}

--- a/apps/web/utils/rule/classification-feedback.ts
+++ b/apps/web/utils/rule/classification-feedback.ts
@@ -5,6 +5,7 @@ import {
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import type { EmailProvider } from "@/utils/email/types";
+import { isDuplicateError } from "@/utils/prisma-helpers";
 import { truncate } from "@/utils/string";
 
 const MAX_FEEDBACK_FOR_PROMPT = 10;
@@ -40,26 +41,48 @@ export async function saveClassificationFeedback({
     eventType,
   });
 
-  await prisma.classificationFeedback.upsert({
-    where: {
-      emailAccountId_sender_ruleId_messageId_eventType: {
+  const uniqueFeedbackKey = {
+    emailAccountId,
+    sender: normalizedSender,
+    ruleId,
+    messageId,
+    eventType,
+  };
+
+  try {
+    await prisma.classificationFeedback.upsert({
+      where: {
+        emailAccountId_sender_ruleId_messageId_eventType: uniqueFeedbackKey,
+      },
+      create: {
         emailAccountId,
         sender: normalizedSender,
         ruleId,
+        threadId,
         messageId,
         eventType,
       },
-    },
-    create: {
-      emailAccountId,
-      sender: normalizedSender,
+      update: {},
+    });
+  } catch (error) {
+    if (
+      !isDuplicateError(error, [
+        "emailAccountId",
+        "sender",
+        "ruleId",
+        "messageId",
+        "eventType",
+      ])
+    ) {
+      throw error;
+    }
+
+    logger.trace("Classification feedback already saved", {
       ruleId,
-      threadId,
       messageId,
       eventType,
-    },
-    update: {},
-  });
+    });
+  }
 }
 
 export async function getClassificationFeedback({


### PR DESCRIPTION
Fixes an idempotency edge case when concurrent processing attempts to save the same feedback record.\n\n- Treats duplicate feedback unique-constraint races as already saved\n- Keeps unrelated database errors bubbling up\n- Adds a focused regression test for the duplicate-save path

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

