### PR TITLE
Limit prompt history for pattern detection

### DIFF
--- a/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.test.ts
+++ b/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.test.ts
@@ -60,9 +60,9 @@ describe("aiDetectRecurringPattern", () => {
 
     const prompt = generateObjectMock.mock.calls[0][0].prompt;
 
-    expect(prompt.match(/<email>/g)).toHaveLength(20);
-    expect(prompt).not.toContain("Unique body 4");
-    expect(prompt).toContain("Unique body 5");
+    expect(prompt.match(/<email>/g)).toHaveLength(10);
+    expect(prompt).not.toContain("Unique body 14");
+    expect(prompt).toContain("Unique body 15");
     expect(prompt).toContain("Unique body 24");
   });
 });

--- a/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.test.ts
+++ b/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getEmail,
+  getEmailAccount,
+  createTestLogger,
+} from "@/__tests__/helpers";
+import { aiDetectRecurringPattern } from "./ai-detect-recurring-pattern";
+
+const { createGenerateObjectMock, generateObjectMock, getModelForUseCaseMock } =
+  vi.hoisted(() => ({
+    createGenerateObjectMock: vi.fn(),
+    generateObjectMock: vi.fn(),
+    getModelForUseCaseMock: vi.fn(),
+  }));
+
+vi.mock("@/utils/llms", () => ({
+  createGenerateObject: createGenerateObjectMock,
+}));
+
+vi.mock("@/utils/llms/use-cases", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/llms/use-cases")>(
+    "@/utils/llms/use-cases",
+  );
+
+  return {
+    ...actual,
+    getModelForUseCase: getModelForUseCaseMock,
+  };
+});
+
+describe("aiDetectRecurringPattern", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createGenerateObjectMock.mockReturnValue(generateObjectMock);
+    generateObjectMock.mockResolvedValue({
+      object: {
+        matchedRule: null,
+        explanation: "No recurring pattern.",
+      },
+    });
+    getModelForUseCaseMock.mockReturnValue({ model: "test-model" });
+  });
+
+  it("limits sender history included in the prompt", async () => {
+    const emails = Array.from({ length: 25 }, (_, index) =>
+      getEmail({
+        id: `email-${index}`,
+        from: "updates@example.com",
+        subject: `Sample ${index}`,
+        content: `Unique body ${index}`,
+      }),
+    );
+
+    await aiDetectRecurringPattern({
+      emails,
+      emailAccount: getEmailAccount(),
+      rules: [{ name: "Updates", instructions: "Messages with updates" }],
+      logger: createTestLogger(),
+    });
+
+    const prompt = generateObjectMock.mock.calls[0][0].prompt;
+
+    expect(prompt.match(/<email>/g)).toHaveLength(20);
+    expect(prompt).not.toContain("Unique body 4");
+    expect(prompt).toContain("Unique body 5");
+    expect(prompt).toContain("Unique body 24");
+  });
+});

--- a/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
+++ b/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
@@ -18,7 +18,7 @@ const schema = z.object({
 });
 export type DetectPatternResult = z.infer<typeof schema>;
 
-const MAX_PATTERN_SAMPLE_EMAILS = 20;
+const MAX_PATTERN_SAMPLE_EMAILS = 10;
 
 export async function aiDetectRecurringPattern({
   emails,

--- a/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
+++ b/apps/web/utils/ai/choose-rule/ai-detect-recurring-pattern.ts
@@ -18,6 +18,8 @@ const schema = z.object({
 });
 export type DetectPatternResult = z.infer<typeof schema>;
 
+const MAX_PATTERN_SAMPLE_EMAILS = 20;
+
 export async function aiDetectRecurringPattern({
   emails,
   emailAccount,
@@ -39,6 +41,13 @@ export async function aiDetectRecurringPattern({
   const senderEmail = emails[0].from;
 
   if (!senderEmail) return null;
+
+  if (emails.length > MAX_PATTERN_SAMPLE_EMAILS) {
+    logger.info("Truncating sender pattern history for prompt", {
+      emailCount: emails.length,
+      sampledEmailCount: MAX_PATTERN_SAMPLE_EMAILS,
+    });
+  }
 
   const system = `You are an AI assistant that helps analyze if a sender's emails should consistently be matched to a specific rule.
 
@@ -90,7 +99,11 @@ If you're not confident (at least 90% certain) that a single rule should handle 
 <sender>${senderEmail}</sender>
 
 <sample_emails>
-${getEmailListPrompt({ messages: emails, messageMaxLength: 500 })}
+${getEmailListPrompt({
+  messages: emails,
+  messageMaxLength: 500,
+  maxMessages: MAX_PATTERN_SAMPLE_EMAILS,
+})}
 </sample_emails>`;
 
   try {


### PR DESCRIPTION
Limits the amount of message history included in a recurring-pattern prompt so oversized histories do not exceed model context limits.

- caps the serialized email sample used by the detector
- adds a regression test for bounded prompt history

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

