### PR TITLE
Add proactive Inbox Health email recommending unsubscribes

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { subDays } from "date-fns/subDays";
 import { ChevronDown } from "lucide-react";
@@ -274,6 +275,29 @@ export function BulkUnsubscribe() {
   useEffect(() => {
     clearSelection();
   }, [filter]);
+
+  // Deep link from the inbox health email: ?select=suggested auto-selects the
+  // suggested rows once after the first rows load, then strips the param so
+  // re-renders and filter changes don't reselect.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const hasAppliedSelectParamRef = useRef(false);
+
+  useEffect(() => {
+    if (hasAppliedSelectParamRef.current) return;
+    if (searchParams.get("select") !== "suggested") return;
+    if (!rows) return;
+
+    hasAppliedSelectParamRef.current = true;
+    selectItems(rows.filter(isUnsubscribeSuggestion).map((row) => row.name));
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("select");
+    router.replace(nextParams.size ? `${pathname}?${nextParams}` : pathname, {
+      scroll: false,
+    });
+  }, [searchParams, rows, selectItems, router, pathname]);
 
   const isSomeSelected =
     Array.from(selected.values()).filter(Boolean).length > 0;

--- a/apps/web/app/api/resend/inbox-health/all/route.ts
+++ b/apps/web/app/api/resend/inbox-health/all/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { subDays } from "date-fns/subDays";
+import prisma from "@/utils/prisma";
+import { withError } from "@/utils/middleware";
+import {
+  getCronSecretHeader,
+  hasCronSecret,
+  hasPostCronSecret,
+} from "@/utils/cron";
+import { Frequency } from "@/generated/prisma/enums";
+import { captureException } from "@/utils/error";
+import type { Logger } from "@/utils/logger";
+import { getPremiumUserFilter } from "@/utils/premium";
+import type { SendInboxHealthEmailBody } from "../validation";
+import {
+  INBOX_HEALTH_INTERVAL_DAYS,
+  INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS,
+} from "../helpers";
+import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
+
+export const maxDuration = 300;
+const RESEND_INBOX_HEALTH_TOPIC = "resend-inbox-health";
+
+export const GET = withError(
+  "cron/resend/inbox-health/all",
+  async (request) => {
+    if (!hasCronSecret(request)) {
+      captureException(
+        new Error("Unauthorized request: api/resend/inbox-health/all"),
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const result = await sendInboxHealthAllUpdate(request.logger);
+
+    return NextResponse.json(result);
+  },
+);
+
+export const POST = withError(
+  "cron/resend/inbox-health/all",
+  async (request) => {
+    if (!(await hasPostCronSecret(request))) {
+      captureException(
+        new Error("Unauthorized cron request: api/resend/inbox-health/all"),
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const result = await sendInboxHealthAllUpdate(request.logger);
+
+    return NextResponse.json(result);
+  },
+);
+
+async function sendInboxHealthAllUpdate(logger: Logger) {
+  logger.info("Sending inbox health all update");
+
+  const now = new Date();
+
+  const emailAccounts = await prisma.emailAccount.findMany({
+    select: { id: true },
+    where: {
+      statsEmailFrequency: {
+        not: Frequency.NEVER,
+      },
+      ...getPremiumUserFilter(),
+      createdAt: {
+        lt: subDays(now, INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS),
+      },
+      OR: [
+        { lastInboxHealthEmailAt: null },
+        {
+          lastInboxHealthEmailAt: {
+            lt: subDays(now, INBOX_HEALTH_INTERVAL_DAYS),
+          },
+        },
+      ],
+    },
+  });
+
+  logger.info("Sending inbox health to users", {
+    count: emailAccounts.length,
+  });
+
+  for (const emailAccount of emailAccounts) {
+    try {
+      await enqueueBackgroundJob<SendInboxHealthEmailBody>({
+        topic: RESEND_INBOX_HEALTH_TOPIC,
+        body: { emailAccountId: emailAccount.id },
+        qstash: {
+          queueName: "email-inbox-health-all",
+          parallelism: 3,
+          path: "/api/resend/inbox-health",
+          headers: getCronSecretHeader(),
+        },
+        logger,
+      });
+    } catch (error) {
+      logger.error("Failed to enqueue inbox health send", {
+        emailAccountId: emailAccount.id,
+        error,
+      });
+    }
+  }
+
+  logger.info("All requests initiated", { count: emailAccounts.length });
+  return { count: emailAccounts.length };
+}

--- a/apps/web/app/api/resend/inbox-health/all/route.ts
+++ b/apps/web/app/api/resend/inbox-health/all/route.ts
@@ -83,6 +83,8 @@ async function sendInboxHealthAllUpdate(logger: Logger) {
     count: emailAccounts.length,
   });
 
+  const deduplicationDate = now.toISOString().slice(0, 10);
+
   for (const emailAccount of emailAccounts) {
     try {
       await enqueueBackgroundJob<SendInboxHealthEmailBody>({
@@ -93,6 +95,7 @@ async function sendInboxHealthAllUpdate(logger: Logger) {
           parallelism: 3,
           path: "/api/resend/inbox-health",
           headers: getCronSecretHeader(),
+          deduplicationId: `inbox-health:${emailAccount.id}:${deduplicationDate}`,
         },
         logger,
       });

--- a/apps/web/app/api/resend/inbox-health/helpers.test.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { subDays } from "date-fns/subDays";
+import { Frequency, NewsletterStatus } from "@/generated/prisma/enums";
+import {
+  getInboxHealthEmailData,
+  getInboxHealthSkipReason,
+  type InboxHealthSenderStats,
+} from "./helpers";
+
+describe("getInboxHealthEmailData", () => {
+  it("returns null when there are fewer than 5 suggestions", () => {
+    const senders = [
+      makeSender({ name: "a@example.com", value: 10 }),
+      makeSender({ name: "b@example.com", value: 10 }),
+      makeSender({ name: "c@example.com", value: 10 }),
+      makeSender({ name: "d@example.com", value: 10 }),
+    ];
+
+    expect(getInboxHealthEmailData(senders)).toBeNull();
+  });
+
+  it("ignores senders that are not unsubscribe suggestions", () => {
+    const senders = [
+      // 4 valid suggestions
+      ...makeSenders(4),
+      // well read
+      makeSender({ name: "read@example.com", value: 20, readEmails: 18 }),
+      // too few emails
+      makeSender({ name: "rare@example.com", value: 2 }),
+      // already handled
+      makeSender({
+        name: "handled@example.com",
+        value: 20,
+        status: NewsletterStatus.UNSUBSCRIBED,
+      }),
+    ];
+
+    expect(getInboxHealthEmailData(senders)).toBeNull();
+  });
+
+  it("builds email data when there are at least 5 suggestions", () => {
+    const senders = [
+      makeSender({ name: "a@example.com", fromName: "A", value: 30 }),
+      makeSender({ name: "b@example.com", fromName: "B", value: 10 }),
+      makeSender({
+        name: "c@example.com",
+        fromName: "C",
+        value: 50,
+        readEmails: 3,
+      }),
+      makeSender({ name: "d@example.com", fromName: "D", value: 20 }),
+      makeSender({ name: "e@example.com", fromName: "", value: 40 }),
+    ];
+
+    const data = getInboxHealthEmailData(senders);
+
+    expect(data).not.toBeNull();
+    expect(data?.suggestionCount).toBe(5);
+    // (30 + 10 + 50 + 20 + 40) * 4
+    expect(data?.yearlyEmailsAvoided).toBe(600);
+    // Sorted by email count descending
+    expect(data?.senders.map((sender) => sender.email)).toEqual([
+      "c@example.com",
+      "e@example.com",
+      "a@example.com",
+      "d@example.com",
+      "b@example.com",
+    ]);
+    // 3 / 50 = 6%
+    expect(data?.senders[0].readPercentage).toBe(6);
+    // Falls back to the email address when there is no display name
+    expect(data?.senders[1].name).toBe("e@example.com");
+  });
+
+  it("lists at most 10 senders but counts all suggestions", () => {
+    const senders = makeSenders(15);
+
+    const data = getInboxHealthEmailData(senders);
+
+    expect(data?.suggestionCount).toBe(15);
+    expect(data?.senders).toHaveLength(10);
+    // yearly estimate covers all 15 suggestions, not just the listed 10
+    expect(data?.yearlyEmailsAvoided).toBe(15 * 10 * 4);
+  });
+});
+
+describe("getInboxHealthSkipReason", () => {
+  const now = new Date("2026-06-12T00:00:00Z");
+  const eligibleAccount = {
+    statsEmailFrequency: Frequency.WEEKLY,
+    createdAt: subDays(now, 30),
+    lastInboxHealthEmailAt: null,
+    now,
+  };
+
+  it("allows sending for an eligible account", () => {
+    expect(getInboxHealthSkipReason(eligibleAccount)).toBeNull();
+  });
+
+  it("skips when the user opted out of stats emails", () => {
+    expect(
+      getInboxHealthSkipReason({
+        ...eligibleAccount,
+        statsEmailFrequency: Frequency.NEVER,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("skips accounts younger than 7 days", () => {
+    expect(
+      getInboxHealthSkipReason({
+        ...eligibleAccount,
+        createdAt: subDays(now, 6),
+      }),
+    ).not.toBeNull();
+
+    expect(
+      getInboxHealthSkipReason({
+        ...eligibleAccount,
+        createdAt: subDays(now, 8),
+      }),
+    ).toBeNull();
+  });
+
+  it("skips when an email was sent within the last 30 days", () => {
+    expect(
+      getInboxHealthSkipReason({
+        ...eligibleAccount,
+        lastInboxHealthEmailAt: subDays(now, 29),
+      }),
+    ).not.toBeNull();
+
+    expect(
+      getInboxHealthSkipReason({
+        ...eligibleAccount,
+        lastInboxHealthEmailAt: subDays(now, 31),
+      }),
+    ).toBeNull();
+  });
+});
+
+function makeSender(
+  overrides: Partial<InboxHealthSenderStats> & { name: string },
+): InboxHealthSenderStats {
+  return {
+    fromName: "Sender",
+    value: 10,
+    readEmails: 0,
+    ...overrides,
+  };
+}
+
+function makeSenders(count: number): InboxHealthSenderStats[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeSender({ name: `sender${i}@example.com`, value: 10 }),
+  );
+}

--- a/apps/web/app/api/resend/inbox-health/helpers.test.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.test.ts
@@ -33,6 +33,12 @@ describe("getInboxHealthEmailData", () => {
         value: 20,
         status: NewsletterStatus.UNSUBSCRIBED,
       }),
+      // already auto-archived by a provider filter
+      makeSender({
+        name: "auto-archived@example.com",
+        value: 20,
+        autoArchived: { id: "filter-1" },
+      }),
     ];
 
     expect(getInboxHealthEmailData(senders)).toBeNull();

--- a/apps/web/app/api/resend/inbox-health/helpers.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.ts
@@ -1,0 +1,74 @@
+import { subDays } from "date-fns/subDays";
+import { Frequency, type NewsletterStatus } from "@/generated/prisma/enums";
+import { isUnsubscribeSuggestion } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
+
+export const INBOX_HEALTH_MIN_SUGGESTIONS = 5;
+export const INBOX_HEALTH_MAX_LISTED_SENDERS = 10;
+export const INBOX_HEALTH_INTERVAL_DAYS = 30;
+export const INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS = 7;
+
+export type InboxHealthSenderStats = {
+  /** Sender email address */
+  name: string;
+  fromName: string;
+  /** Number of emails received in the last 3 months */
+  value: number;
+  readEmails: number;
+  status?: NewsletterStatus | null;
+};
+
+/**
+ * Decides whether an inbox health email is worth sending and shapes its
+ * content. Returns null when there are too few unsubscribe suggestions.
+ */
+export function getInboxHealthEmailData(senders: InboxHealthSenderStats[]) {
+  const suggestions = senders
+    .filter(isUnsubscribeSuggestion)
+    .sort((a, b) => b.value - a.value);
+
+  if (suggestions.length < INBOX_HEALTH_MIN_SUGGESTIONS) return null;
+
+  const threeMonthTotal = suggestions.reduce(
+    (sum, sender) => sum + sender.value,
+    0,
+  );
+
+  return {
+    suggestionCount: suggestions.length,
+    yearlyEmailsAvoided: Math.round(threeMonthTotal * 4),
+    senders: suggestions
+      .slice(0, INBOX_HEALTH_MAX_LISTED_SENDERS)
+      .map((sender) => ({
+        name: sender.fromName || sender.name,
+        email: sender.name,
+        count: sender.value,
+        readPercentage: Math.round((sender.readEmails / sender.value) * 100),
+      })),
+  };
+}
+
+export function getInboxHealthSkipReason({
+  statsEmailFrequency,
+  createdAt,
+  lastInboxHealthEmailAt,
+  now,
+}: {
+  statsEmailFrequency: Frequency;
+  createdAt: Date;
+  lastInboxHealthEmailAt: Date | null;
+  now: Date;
+}): string | null {
+  if (statsEmailFrequency === Frequency.NEVER) {
+    return "stats emails disabled";
+  }
+  if (createdAt > subDays(now, INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS)) {
+    return `account younger than ${INBOX_HEALTH_MIN_ACCOUNT_AGE_DAYS} days`;
+  }
+  if (
+    lastInboxHealthEmailAt &&
+    lastInboxHealthEmailAt > subDays(now, INBOX_HEALTH_INTERVAL_DAYS)
+  ) {
+    return `sent within the last ${INBOX_HEALTH_INTERVAL_DAYS} days`;
+  }
+  return null;
+}

--- a/apps/web/app/api/resend/inbox-health/helpers.ts
+++ b/apps/web/app/api/resend/inbox-health/helpers.ts
@@ -1,6 +1,7 @@
 import { subDays } from "date-fns/subDays";
 import { Frequency, type NewsletterStatus } from "@/generated/prisma/enums";
 import { isUnsubscribeSuggestion } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
+import type { EmailFilter } from "@/utils/email/types";
 
 export const INBOX_HEALTH_MIN_SUGGESTIONS = 5;
 export const INBOX_HEALTH_MAX_LISTED_SENDERS = 10;
@@ -14,6 +15,7 @@ export type InboxHealthSenderStats = {
   /** Number of emails received in the last 3 months */
   value: number;
   readEmails: number;
+  autoArchived?: EmailFilter;
   status?: NewsletterStatus | null;
 };
 

--- a/apps/web/app/api/resend/inbox-health/queue/route.ts
+++ b/apps/web/app/api/resend/inbox-health/queue/route.ts
@@ -1,0 +1,15 @@
+import { createForwardingQueueHandler } from "@/utils/queue/create-forwarding-queue-handler";
+import { sendInboxHealthEmailBody } from "../validation";
+
+export const maxDuration = 60;
+
+export const POST = createForwardingQueueHandler({
+  loggerScope: "resend/inbox-health/queue",
+  schema: sendInboxHealthEmailBody,
+  path: "/api/resend/inbox-health",
+  invalidPayloadMessage: "Invalid resend inbox health queue payload",
+  visibilityTimeoutSeconds: 55,
+  getLoggerContext: (payload) => ({
+    emailAccountId: payload.emailAccountId,
+  }),
+});

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -135,6 +135,12 @@ async function sendEmail({
 
   if (!emailAccount.account.refresh_token) {
     logger.warn("Skipping inbox health email: account has no refresh token");
+    // Bump the timestamp so the daily fan-out doesn't re-enqueue this
+    // disconnected account every day until it reconnects.
+    await prisma.emailAccount.update({
+      where: { id: emailAccountId },
+      data: { lastInboxHealthEmailAt: new Date() },
+    });
     return { success: false, message: "Account has no refresh token" };
   }
 

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -10,11 +10,16 @@ import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 import { getSenderEmailStats } from "@/utils/sender-stats";
-import { findNewsletterStatus } from "@/app/api/user/stats/newsletters/helpers";
+import {
+  findAutoArchiveFilter,
+  findNewsletterStatus,
+  getAutoArchiveFilters,
+} from "@/app/api/user/stats/newsletters/helpers";
 import {
   extractEmailAddress,
   getNewsletterSenderDisplayName,
 } from "@/utils/email";
+import { createEmailProvider } from "@/utils/email/provider";
 import { sendInboxHealthEmailBody } from "./validation";
 import { getInboxHealthEmailData, getInboxHealthSkipReason } from "./helpers";
 
@@ -98,6 +103,12 @@ async function sendEmail({
       createdAt: true,
       statsEmailFrequency: true,
       lastInboxHealthEmailAt: true,
+      account: {
+        select: {
+          provider: true,
+          refresh_token: true,
+        },
+      },
     },
   });
 
@@ -122,14 +133,27 @@ async function sendEmail({
     }
   }
 
-  const [senderStats, newsletterStatuses] = await Promise.all([
-    getSenderEmailStats({
-      emailAccountId,
-      fromDate: subMonths(now, 3).getTime(),
-      logger,
-    }),
-    findNewsletterStatus({ emailAccountId }),
-  ]);
+  if (!emailAccount.account.refresh_token) {
+    logger.warn("Skipping inbox health email: account has no refresh token");
+    return { success: false, message: "Account has no refresh token" };
+  }
+
+  const emailProvider = await createEmailProvider({
+    emailAccountId,
+    provider: emailAccount.account.provider,
+    logger,
+  });
+
+  const [senderStats, newsletterStatuses, autoArchiveFilters] =
+    await Promise.all([
+      getSenderEmailStats({
+        emailAccountId,
+        fromDate: subMonths(now, 3).getTime(),
+        logger,
+      }),
+      findNewsletterStatus({ emailAccountId }),
+      getAutoArchiveFilters(emailProvider, logger),
+    ]);
 
   const statusBySender = new Map(
     newsletterStatuses.map((newsletter) => [
@@ -150,6 +174,11 @@ async function sendEmail({
       }),
       value: stats.count,
       readEmails: stats.readEmails,
+      autoArchived: findAutoArchiveFilter(
+        autoArchiveFilters,
+        email,
+        emailProvider,
+      ),
       status: statusBySender.get(email),
     };
   });

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from "next/server";
+import { subMonths } from "date-fns/subMonths";
+import { sendInboxHealthEmail } from "@inboxzero/resend";
+import { withEmailAccount, withError } from "@/utils/middleware";
+import { env } from "@/env";
+import { hasCronSecret } from "@/utils/cron";
+import { isValidInternalApiKey } from "@/utils/internal-api";
+import { captureException } from "@/utils/error";
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+import { createUnsubscribeToken } from "@/utils/unsubscribe";
+import { getSenderEmailStats } from "@/utils/sender-stats";
+import { findNewsletterStatus } from "@/app/api/user/stats/newsletters/helpers";
+import {
+  extractEmailAddress,
+  getNewsletterSenderDisplayName,
+} from "@/utils/email";
+import { sendInboxHealthEmailBody } from "./validation";
+import { getInboxHealthEmailData, getInboxHealthSkipReason } from "./helpers";
+
+export const maxDuration = 60;
+
+export const GET = withEmailAccount("resend/inbox-health", async (request) => {
+  // send to self
+  const emailAccountId = request.auth.emailAccountId;
+
+  request.logger.info("Sending inbox health email to user GET", {
+    emailAccountId,
+  });
+
+  const result = await sendEmail({
+    emailAccountId,
+    force: true,
+    logger: request.logger,
+  });
+
+  return NextResponse.json(result);
+});
+
+export const POST = withError("resend/inbox-health", async (request) => {
+  const logger = request.logger;
+  if (
+    !hasCronSecret(request) &&
+    !isValidInternalApiKey(request.headers, logger)
+  ) {
+    logger.error("Unauthorized cron request");
+    captureException(new Error("Unauthorized cron request: resend"));
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const json = await request.json();
+  const { success, data, error } = sendInboxHealthEmailBody.safeParse(json);
+
+  if (!success) {
+    logger.error("Invalid request body", { error });
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+  const { emailAccountId } = data;
+
+  logger.info("Sending inbox health email to user POST", { emailAccountId });
+
+  try {
+    await sendEmail({ emailAccountId, logger });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error("Error sending inbox health email", { error });
+    captureException(error);
+    return NextResponse.json(
+      { success: false, error: "Error sending inbox health email" },
+      { status: 500 },
+    );
+  }
+});
+
+async function sendEmail({
+  emailAccountId,
+  force,
+  logger,
+}: {
+  emailAccountId: string;
+  force?: boolean;
+  logger: Logger;
+}) {
+  logger = logger.with({ emailAccountId, force });
+
+  logger.info("Sending inbox health email");
+
+  const now = new Date();
+
+  const emailAccount = await prisma.emailAccount.findUnique({
+    where: { id: emailAccountId },
+    select: {
+      userId: true,
+      email: true,
+      createdAt: true,
+      statsEmailFrequency: true,
+      lastInboxHealthEmailAt: true,
+    },
+  });
+
+  if (!emailAccount) {
+    logger.error("Email account not found");
+    return { success: false };
+  }
+
+  logger = logger.with({ userId: emailAccount.userId });
+
+  if (!force) {
+    const skipReason = getInboxHealthSkipReason({
+      statsEmailFrequency: emailAccount.statsEmailFrequency,
+      createdAt: emailAccount.createdAt,
+      lastInboxHealthEmailAt: emailAccount.lastInboxHealthEmailAt,
+      now,
+    });
+
+    if (skipReason) {
+      logger.info("Skipping inbox health email", { skipReason });
+      return { success: true, skipped: skipReason };
+    }
+  }
+
+  const [senderStats, newsletterStatuses] = await Promise.all([
+    getSenderEmailStats({
+      emailAccountId,
+      fromDate: subMonths(now, 3).getTime(),
+      logger,
+    }),
+    findNewsletterStatus({ emailAccountId }),
+  ]);
+
+  const statusBySender = new Map(
+    newsletterStatuses.map((newsletter) => [
+      newsletter.email,
+      newsletter.status,
+    ]),
+  );
+
+  const senders = senderStats.map((stats) => {
+    const email = extractEmailAddress(stats.from);
+    return {
+      name: email,
+      fromName: getNewsletterSenderDisplayName({
+        email,
+        fromName: stats.fromName,
+        minFromName: stats.minFromName,
+        maxFromName: stats.fromName,
+      }),
+      value: stats.count,
+      readEmails: stats.readEmails,
+      status: statusBySender.get(email),
+    };
+  });
+
+  const emailData = getInboxHealthEmailData(senders);
+
+  if (!emailData) {
+    logger.info("Not enough unsubscribe suggestions, skipping", {
+      senderCount: senders.length,
+    });
+    return { success: true, skipped: "not enough suggestions" };
+  }
+
+  logger.info("Sending inbox health email to user", {
+    suggestionCount: emailData.suggestionCount,
+    yearlyEmailsAvoided: emailData.yearlyEmailsAvoided,
+  });
+
+  const token = await createUnsubscribeToken({ emailAccountId });
+
+  await sendInboxHealthEmail({
+    from: env.RESEND_FROM_EMAIL,
+    to: emailAccount.email,
+    emailProps: {
+      baseUrl: env.NEXT_PUBLIC_BASE_URL,
+      emailAccountId,
+      unsubscribeToken: token,
+      ...emailData,
+    },
+  });
+
+  await prisma.emailAccount.update({
+    where: { id: emailAccountId },
+    data: { lastInboxHealthEmailAt: new Date() },
+  });
+
+  return { success: true };
+}

--- a/apps/web/app/api/resend/inbox-health/route.ts
+++ b/apps/web/app/api/resend/inbox-health/route.ts
@@ -160,6 +160,12 @@ async function sendEmail({
     logger.info("Not enough unsubscribe suggestions, skipping", {
       senderCount: senders.length,
     });
+    // Still bump the timestamp so the daily fan-out doesn't re-run the
+    // expensive stats query for this account until the next 30-day window.
+    await prisma.emailAccount.update({
+      where: { id: emailAccountId },
+      data: { lastInboxHealthEmailAt: new Date() },
+    });
     return { success: true, skipped: "not enough suggestions" };
   }
 

--- a/apps/web/app/api/resend/inbox-health/validation.ts
+++ b/apps/web/app/api/resend/inbox-health/validation.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const sendInboxHealthEmailBody = z.object({
+  emailAccountId: z.string(),
+});
+
+export type SendInboxHealthEmailBody = z.infer<typeof sendInboxHealthEmailBody>;

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -6,8 +6,7 @@ import {
   getNewsletterSenderDisplayName,
 } from "@/utils/email";
 import type { Logger } from "@/utils/logger";
-import prisma from "@/utils/prisma";
-import { Prisma } from "@/generated/prisma/client";
+import { getSenderEmailStats } from "@/utils/sender-stats";
 import type { EmailProvider } from "@/utils/email/types";
 import {
   getAutoArchiveFilters,
@@ -81,9 +80,18 @@ async function getEmailMessages(
   const types = getTypeFilters(options.types);
 
   const [counts, autoArchiveFilters, userNewsletters] = await Promise.all([
-    getNewsletterCounts({
-      ...options,
-      ...types,
+    getSenderEmailStats({
+      emailAccountId,
+      fromDate: options.fromDate,
+      toDate: options.toDate,
+      read: types.read,
+      unread: types.unread,
+      archived: types.archived,
+      unarchived: types.unarchived,
+      search: options.search,
+      orderBy: options.orderBy,
+      orderDirection: options.orderDirection,
+      limit: options.limit,
       logger,
     }),
     getAutoArchiveFilters(emailProvider, logger),
@@ -118,160 +126,6 @@ async function getEmailMessages(
   return {
     newsletters: filterNewsletters(newsletters, options.filters),
   };
-}
-
-type NewsletterCountResult = {
-  from: string;
-  fromName: string | null;
-  minFromName: string | null;
-  count: number;
-  inboxEmails: number;
-  readEmails: number;
-  unsubscribeLink: string | null;
-};
-
-type NewsletterCountRawResult = {
-  from: string;
-  fromName: string | null;
-  minFromName: string | null;
-  count: number;
-  inboxEmails: number;
-  readEmails: number;
-  unsubscribeLink: string | null;
-};
-
-async function getNewsletterCounts(
-  options: NewsletterStatsQuery & {
-    emailAccountId: string;
-    read?: boolean;
-    unread?: boolean;
-    archived?: boolean;
-    unarchived?: boolean;
-    all?: boolean;
-    andClause?: boolean;
-    logger: Logger;
-  },
-): Promise<NewsletterCountResult[]> {
-  const { logger } = options;
-  // Build WHERE conditions using Prisma.sql for type safety
-  const whereConditions: Prisma.Sql[] = [];
-
-  // Add date filters if provided
-  if (options.fromDate) {
-    const fromTimestamp = (options.fromDate / 1000).toString();
-    whereConditions.push(
-      Prisma.sql`"date" >= to_timestamp(${fromTimestamp}::double precision)`,
-    );
-  }
-
-  if (options.toDate) {
-    const toTimestamp = (options.toDate / 1000).toString();
-    whereConditions.push(
-      Prisma.sql`"date" <= to_timestamp(${toTimestamp}::double precision)`,
-    );
-  }
-
-  // Add read/unread filters
-  if (options.read) {
-    whereConditions.push(Prisma.sql`read = true`);
-  } else if (options.unread) {
-    whereConditions.push(Prisma.sql`read = false`);
-  }
-
-  // Add inbox/archived filters
-  if (options.unarchived) {
-    whereConditions.push(Prisma.sql`inbox = true`);
-  } else if (options.archived) {
-    whereConditions.push(Prisma.sql`inbox = false`);
-  }
-
-  // Always filter by emailAccountId
-  whereConditions.push(
-    Prisma.sql`"emailAccountId" = ${options.emailAccountId}`,
-  );
-
-  // Add search filter if provided - search both from (email) and fromName fields
-  if (options.search) {
-    const searchTerm = options.search.toLowerCase();
-    whereConditions.push(
-      Prisma.sql`(position(${searchTerm} in LOWER("from")) > 0 OR position(${searchTerm} in LOWER(COALESCE("fromName", ''))) > 0)`,
-    );
-  }
-
-  // Join conditions with AND
-  const whereClause =
-    whereConditions.length > 0
-      ? Prisma.sql`WHERE ${Prisma.join(whereConditions, " AND ")}`
-      : Prisma.empty;
-
-  // Build order by clause (safe, no user input)
-  const orderByClause = options.orderBy
-    ? getOrderByClause(options.orderBy, options.orderDirection)
-    : '"count" DESC';
-
-  // Build limit clause (safe, validated number)
-  const limitClause = options.limit ? `LIMIT ${options.limit}` : "";
-
-  // Build the complete query using Prisma.sql
-  const query = Prisma.sql`
-    WITH email_message_stats AS (
-      SELECT 
-        "from",
-        MAX(NULLIF("fromName", '')) as "fromName",
-        MIN(NULLIF("fromName", '')) as "minFromName",
-        COUNT(*)::int as "count",
-        SUM(CASE WHEN inbox = true THEN 1 ELSE 0 END)::int as "inboxEmails",
-        SUM(CASE WHEN read = true THEN 1 ELSE 0 END)::int as "readEmails",
-        MAX("unsubscribeLink") as "unsubscribeLink"
-      FROM "EmailMessage"
-      ${whereClause}
-      GROUP BY "from"
-    )
-    SELECT * FROM email_message_stats
-    ORDER BY ${Prisma.raw(orderByClause)}
-    ${Prisma.raw(limitClause)}
-  `;
-
-  try {
-    const results = await prisma.$queryRaw<NewsletterCountRawResult[]>(query);
-
-    // Convert BigInt values to regular numbers
-    return results.map((result) => ({
-      from: result.from,
-      fromName: result.fromName,
-      minFromName: result.minFromName,
-      count: result.count,
-      inboxEmails: result.inboxEmails,
-      readEmails: result.readEmails,
-      unsubscribeLink: result.unsubscribeLink,
-    }));
-  } catch (error) {
-    logger.error("getNewsletterCounts error", {
-      error,
-      errorStack: error instanceof Error ? error.stack : undefined,
-    });
-    return [];
-  }
-}
-
-function getOrderByClause(
-  orderBy: string,
-  orderDirection?: "asc" | "desc",
-): string {
-  const direction = orderDirection?.toUpperCase() || "DESC";
-
-  switch (orderBy) {
-    case "emails":
-      return `"count" ${direction}`;
-    case "unread":
-      // Sort by read percentage (lower = more unread)
-      return `"readEmails"::float / NULLIF("count", 0) ${direction}`;
-    case "unarchived":
-      // Sort by archived percentage (lower = more in inbox)
-      return `("count" - "inboxEmails")::float / NULLIF("count", 0) ${direction}`;
-    default:
-      return `"count" ${direction}`;
-  }
 }
 
 export const GET = withEmailProvider(

--- a/apps/web/prisma/migrations/20260612120000_add_last_inbox_health_email_at/migration.sql
+++ b/apps/web/prisma/migrations/20260612120000_add_last_inbox_health_email_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN "lastInboxHealthEmailAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "EmailAccount_lastInboxHealthEmailAt_idx" ON "EmailAccount"("lastInboxHealthEmailAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -143,6 +143,7 @@ model EmailAccount {
   statsEmailFrequency       Frequency            @default(WEEKLY)
   summaryEmailFrequency     Frequency            @default(WEEKLY)
   lastSummaryEmailAt        DateTime?
+  lastInboxHealthEmailAt    DateTime?
   coldEmailBlocker          ColdEmailSetting? // @deprecated
   coldEmailDigest           Boolean              @default(false) // @deprecated
   coldEmailPrompt           String? // @deprecated
@@ -214,6 +215,7 @@ model EmailAccount {
 
   @@index([userId])
   @@index([lastSummaryEmailAt])
+  @@index([lastInboxHealthEmailAt])
   @@index([watchEmailsSubscriptionId])
   @@index([watchEmailsSubscriptionHistory(ops: JsonbPathOps)], type: Gin)
 }

--- a/apps/web/utils/queue/dispatch.test.ts
+++ b/apps/web/utils/queue/dispatch.test.ts
@@ -119,6 +119,7 @@ describe("enqueueBackgroundJob", () => {
         queueName: "email-digest-all",
         parallelism: 3,
         path: "/api/resend/digest",
+        deduplicationId: "digest-account-1-2026-06-16",
       },
       logger: createTestLogger(),
     });
@@ -130,6 +131,7 @@ describe("enqueueBackgroundJob", () => {
       path: "/api/resend/digest",
       body: { id: "job-3" },
       headers: undefined,
+      deduplicationId: "digest-account-1-2026-06-16",
     });
     expect(mockEnqueueBullmqHttpJob).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/queue/dispatch.ts
+++ b/apps/web/utils/queue/dispatch.ts
@@ -22,6 +22,7 @@ export async function enqueueBackgroundJob<T>({
     parallelism: number;
     path: string;
     headers?: HeadersInit;
+    deduplicationId?: string;
   };
   logger: Logger;
 }) {
@@ -73,6 +74,7 @@ export async function enqueueBackgroundJob<T>({
     path: qstash.path,
     body,
     headers: qstash.headers,
+    deduplicationId: qstash.deduplicationId,
   });
 
   return env.QSTASH_TOKEN ? "qstash" : "internal-fallback";

--- a/apps/web/utils/sender-stats.ts
+++ b/apps/web/utils/sender-stats.ts
@@ -1,0 +1,159 @@
+import prisma from "@/utils/prisma";
+import { Prisma } from "@/generated/prisma/client";
+import type { Logger } from "@/utils/logger";
+
+export type SenderEmailStats = {
+  from: string;
+  fromName: string | null;
+  minFromName: string | null;
+  count: number;
+  inboxEmails: number;
+  readEmails: number;
+  unsubscribeLink: string | null;
+};
+
+export type SenderEmailStatsOptions = {
+  emailAccountId: string;
+  /** Unix timestamp in milliseconds */
+  fromDate?: number | null;
+  /** Unix timestamp in milliseconds */
+  toDate?: number | null;
+  read?: boolean;
+  unread?: boolean;
+  archived?: boolean;
+  unarchived?: boolean;
+  search?: string;
+  orderBy?: "emails" | "unread" | "unarchived";
+  orderDirection?: "asc" | "desc";
+  limit?: number | null;
+  logger: Logger;
+};
+
+/**
+ * Aggregates per-sender email stats from the EmailMessage table.
+ * Powers the bulk unsubscribe page and the inbox health email.
+ */
+export async function getSenderEmailStats(
+  options: SenderEmailStatsOptions,
+): Promise<SenderEmailStats[]> {
+  const { logger } = options;
+  // Build WHERE conditions using Prisma.sql for type safety
+  const whereConditions: Prisma.Sql[] = [];
+
+  // Add date filters if provided
+  if (options.fromDate) {
+    const fromTimestamp = (options.fromDate / 1000).toString();
+    whereConditions.push(
+      Prisma.sql`"date" >= to_timestamp(${fromTimestamp}::double precision)`,
+    );
+  }
+
+  if (options.toDate) {
+    const toTimestamp = (options.toDate / 1000).toString();
+    whereConditions.push(
+      Prisma.sql`"date" <= to_timestamp(${toTimestamp}::double precision)`,
+    );
+  }
+
+  // Add read/unread filters
+  if (options.read) {
+    whereConditions.push(Prisma.sql`read = true`);
+  } else if (options.unread) {
+    whereConditions.push(Prisma.sql`read = false`);
+  }
+
+  // Add inbox/archived filters
+  if (options.unarchived) {
+    whereConditions.push(Prisma.sql`inbox = true`);
+  } else if (options.archived) {
+    whereConditions.push(Prisma.sql`inbox = false`);
+  }
+
+  // Always filter by emailAccountId
+  whereConditions.push(
+    Prisma.sql`"emailAccountId" = ${options.emailAccountId}`,
+  );
+
+  // Add search filter if provided - search both from (email) and fromName fields
+  if (options.search) {
+    const searchTerm = options.search.toLowerCase();
+    whereConditions.push(
+      Prisma.sql`(position(${searchTerm} in LOWER("from")) > 0 OR position(${searchTerm} in LOWER(COALESCE("fromName", ''))) > 0)`,
+    );
+  }
+
+  // Join conditions with AND
+  const whereClause =
+    whereConditions.length > 0
+      ? Prisma.sql`WHERE ${Prisma.join(whereConditions, " AND ")}`
+      : Prisma.empty;
+
+  // Build order by clause (safe, no user input)
+  const orderByClause = options.orderBy
+    ? getOrderByClause(options.orderBy, options.orderDirection)
+    : '"count" DESC';
+
+  // Build limit clause (safe, validated number)
+  const limitClause = options.limit ? `LIMIT ${options.limit}` : "";
+
+  // Build the complete query using Prisma.sql
+  const query = Prisma.sql`
+    WITH email_message_stats AS (
+      SELECT 
+        "from",
+        MAX(NULLIF("fromName", '')) as "fromName",
+        MIN(NULLIF("fromName", '')) as "minFromName",
+        COUNT(*)::int as "count",
+        SUM(CASE WHEN inbox = true THEN 1 ELSE 0 END)::int as "inboxEmails",
+        SUM(CASE WHEN read = true THEN 1 ELSE 0 END)::int as "readEmails",
+        MAX("unsubscribeLink") as "unsubscribeLink"
+      FROM "EmailMessage"
+      ${whereClause}
+      GROUP BY "from"
+    )
+    SELECT * FROM email_message_stats
+    ORDER BY ${Prisma.raw(orderByClause)}
+    ${Prisma.raw(limitClause)}
+  `;
+
+  try {
+    const results = await prisma.$queryRaw<SenderEmailStats[]>(query);
+
+    // Convert BigInt values to regular numbers
+    return results.map((result) => ({
+      from: result.from,
+      fromName: result.fromName,
+      minFromName: result.minFromName,
+      count: result.count,
+      inboxEmails: result.inboxEmails,
+      readEmails: result.readEmails,
+      unsubscribeLink: result.unsubscribeLink,
+    }));
+  } catch (error) {
+    logger.error("getSenderEmailStats error", {
+      error,
+      errorStack: error instanceof Error ? error.stack : undefined,
+    });
+    return [];
+  }
+}
+
+function getOrderByClause(
+  orderBy: string,
+  orderDirection?: "asc" | "desc",
+): string {
+  const direction = orderDirection?.toUpperCase() || "DESC";
+
+  switch (orderBy) {
+    case "emails":
+      return `"count" ${direction}`;
+    case "unread":
+      // Sort by read percentage (lower = more unread)
+      return `"readEmails"::float / NULLIF("count", 0) ${direction}`;
+    case "unarchived":
+      // Sort by archived percentage (lower = more in inbox)
+      return `("count" - "inboxEmails")::float / NULLIF("count", 0) ${direction}`;
+    default:
+      return `"count" ${direction}`;
+  }
+}

--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -218,10 +218,14 @@ describe("publishToQstashQueue", () => {
       parallelism: 1,
       path: "/api/task",
       body: { id: "a" },
+      deduplicationId: "task-a-2026-06-16",
     });
 
     expect(mockQueueEnqueueJSON).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "https://worker.example.com/api/task" }),
+      expect.objectContaining({
+        url: "https://worker.example.com/api/task",
+        deduplicationId: "task-a-2026-06-16",
+      }),
     );
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -82,12 +82,14 @@ export async function publishToQstashQueue<T>({
   path,
   body,
   headers,
+  deduplicationId,
 }: {
   queueName: string;
   parallelism: number;
   path: string;
   body: T;
   headers?: HeadersInit;
+  deduplicationId?: string;
 }) {
   const client = getQstashClient();
   if (client) {
@@ -96,7 +98,12 @@ export async function publishToQstashQueue<T>({
     try {
       const queue = client.queue({ queueName });
       await queue.upsert({ parallelism });
-      return await queue.enqueueJSON({ url: qstashUrl, body, headers });
+      return await queue.enqueueJSON({
+        url: qstashUrl,
+        body,
+        headers,
+        deduplicationId,
+      });
     } catch (error) {
       logger.error("Failed to publish to Qstash queue", {
         qstashUrl,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -47,6 +47,15 @@
           "retryAfterSeconds": 60
         }
       ]
+    },
+    "app/api/resend/inbox-health/queue/route.ts": {
+      "experimentalTriggers": [
+        {
+          "type": "queue/v2beta",
+          "topic": "resend-inbox-health",
+          "retryAfterSeconds": 60
+        }
+      ]
     }
   },
   "rewrites": [
@@ -71,6 +80,10 @@
     {
       "path": "/api/resend/digest/all",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/resend/inbox-health/all",
+      "schedule": "0 8 * * *"
     },
     {
       "path": "/api/meeting-briefs",

--- a/apps/worker/src/runtime.mjs
+++ b/apps/worker/src/runtime.mjs
@@ -8,6 +8,7 @@ const DEFAULT_QUEUES = [
   { name: "digest-item-summarize", concurrency: 3 },
   { name: "email-summary-all", concurrency: 3 },
   { name: "email-digest-all", concurrency: 3 },
+  { name: "email-inbox-health-all", concurrency: 3 },
 ];
 
 export async function startWorkerRuntime({

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -242,6 +242,9 @@ cron:
     digest:
       schedule: "*/30 * * * *"
       path: /api/resend/digest/all
+    inbox-health:
+      schedule: "0 8 * * *"
+      path: /api/resend/inbox-health/all
     meeting-briefs:
       schedule: "*/15 * * * *"
       path: /api/meeting-briefs

--- a/packages/resend/emails/components/stats-email-footer.tsx
+++ b/packages/resend/emails/components/stats-email-footer.tsx
@@ -1,0 +1,32 @@
+import { Link, Section, Text } from "@react-email/components";
+
+export function StatsEmailFooter({
+  baseUrl,
+  unsubscribeToken,
+}: {
+  baseUrl: string;
+  unsubscribeToken: string;
+}) {
+  return (
+    <Section>
+      <Text>
+        You're receiving this email because you're subscribed to Inbox Zero
+        stats updates. You can change this in your{" "}
+        <Link
+          href={`${baseUrl}/settings#email-updates`}
+          className="text-[15px]"
+        >
+          settings
+        </Link>
+        .
+      </Text>
+
+      <Link
+        href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
+        className="text-[15px]"
+      >
+        Unsubscribe from emails like this
+      </Link>
+    </Section>
+  );
+}

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -1,0 +1,212 @@
+import {
+  Body,
+  Button,
+  Column,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+
+type SuggestedSender = {
+  name: string;
+  email: string;
+  count: number;
+  readPercentage: number;
+};
+
+export interface InboxHealthEmailProps {
+  baseUrl: string;
+  emailAccountId: string;
+  senders: SuggestedSender[];
+  suggestionCount: number;
+  unsubscribeToken: string;
+  yearlyEmailsAvoided: number;
+}
+
+export default function InboxHealthEmail(props: InboxHealthEmailProps) {
+  const {
+    baseUrl = "https://www.getinboxzero.com",
+    emailAccountId,
+    unsubscribeToken,
+    suggestionCount,
+    yearlyEmailsAvoided,
+    senders,
+  } = props;
+
+  const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?select=suggested`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        We found {suggestionCount.toString()} senders you rarely read. Clean
+        them up in one click.
+      </Preview>
+      <Tailwind>
+        <Body className="bg-white font-sans">
+          <Container className="mx-auto w-full max-w-[600px] p-0">
+            <Section className="p-8 text-center">
+              <Link href={baseUrl} className="text-[15px]">
+                <Img
+                  src={"https://www.getinboxzero.com/icon.png"}
+                  width="40"
+                  height="40"
+                  alt="Inbox Zero"
+                  className="mx-auto my-0"
+                />
+              </Link>
+
+              <Text className="mx-0 mb-8 mt-4 p-0 text-center text-2xl font-normal">
+                <span className="font-semibold tracking-tighter">
+                  Inbox Zero
+                </span>
+              </Text>
+
+              <Heading className="my-4 text-4xl font-medium leading-tight">
+                We found {suggestionCount} senders you rarely read
+              </Heading>
+              <Text className="mb-8 text-lg leading-8">
+                Unsubscribing from them could save you around{" "}
+                <span className="font-semibold">
+                  {yearlyEmailsAvoided.toLocaleString("en-US")} emails
+                </span>{" "}
+                a year.
+              </Text>
+            </Section>
+
+            <Section className="rounded-2xl bg-[#3b82f6]/5 bg-[radial-gradient(circle_at_bottom_right,#3b82f6_0%,transparent_60%)] p-8 text-center">
+              <Heading className="m-0 text-3xl font-medium text-[#1e40af]">
+                Rarely Read Senders
+              </Heading>
+              <Text className="mb-4 text-gray-900">
+                Based on the last 3 months of your inbox
+              </Text>
+
+              {senders.map((sender) => (
+                <SenderCard key={sender.email} sender={sender} />
+              ))}
+
+              <Section className="text-center mt-[32px] mb-[32px]">
+                <Button
+                  href={bulkUnsubscribeUrl}
+                  style={{
+                    background: "#000",
+                    color: "#fff",
+                    padding: "12px 20px",
+                    borderRadius: "5px",
+                  }}
+                >
+                  Unsubscribe in One Click
+                </Button>
+              </Section>
+            </Section>
+
+            <Footer baseUrl={baseUrl} unsubscribeToken={unsubscribeToken} />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}
+
+InboxHealthEmail.PreviewProps = {
+  baseUrl: "https://www.getinboxzero.com",
+  emailAccountId: "email-account-id",
+  unsubscribeToken: "123",
+  suggestionCount: 7,
+  yearlyEmailsAvoided: 1248,
+  senders: [
+    {
+      name: "Daily Deals",
+      email: "deals@shopping.example.com",
+      count: 92,
+      readPercentage: 2,
+    },
+    {
+      name: "Tech Newsletter",
+      email: "newsletter@technews.example.com",
+      count: 64,
+      readPercentage: 8,
+    },
+    {
+      name: "Promo Updates",
+      email: "promo@retailer.example.com",
+      count: 48,
+      readPercentage: 0,
+    },
+    {
+      name: "Webinar Invites",
+      email: "events@saas.example.com",
+      count: 35,
+      readPercentage: 11,
+    },
+    {
+      name: "Job Alerts",
+      email: "alerts@jobs.example.com",
+      count: 26,
+      readPercentage: 15,
+    },
+  ],
+} satisfies InboxHealthEmailProps;
+
+function SenderCard({ sender }: { sender: SuggestedSender }) {
+  return (
+    <Section className="my-3 rounded-lg bg-white/50 p-4 text-left shadow-sm border border-[#3b82f6]/20">
+      <Row>
+        <Column>
+          <Text className="m-0 font-semibold">
+            {sender.name || sender.email}
+          </Text>
+          <Text className="m-0 text-gray-600">{sender.email}</Text>
+        </Column>
+        <Column align="right">
+          <Text className="m-0 text-sm text-gray-500">
+            {sender.count} emails in the last 3 months
+          </Text>
+          <Text className="m-0 text-sm text-gray-500">
+            {sender.readPercentage}% read
+          </Text>
+        </Column>
+      </Row>
+    </Section>
+  );
+}
+
+function Footer({
+  baseUrl,
+  unsubscribeToken,
+}: {
+  baseUrl: string;
+  unsubscribeToken: string;
+}) {
+  return (
+    <Section>
+      <Text>
+        You're receiving this email because you're subscribed to Inbox Zero
+        stats updates. You can change this in your{" "}
+        <Link
+          href={`${baseUrl}/settings#email-updates`}
+          className="text-[15px]"
+        >
+          settings
+        </Link>
+        .
+      </Text>
+
+      <Link
+        href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
+        className="text-[15px]"
+      >
+        Unsubscribe from emails like this
+      </Link>
+    </Section>
+  );
+}

--- a/packages/resend/emails/inbox-health.tsx
+++ b/packages/resend/emails/inbox-health.tsx
@@ -14,6 +14,7 @@ import {
   Tailwind,
   Text,
 } from "@react-email/components";
+import { StatsEmailFooter } from "./components/stats-email-footer";
 
 type SuggestedSender = {
   name: string;
@@ -42,13 +43,13 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
   } = props;
 
   const bulkUnsubscribeUrl = `${baseUrl}/${emailAccountId}/bulk-unsubscribe?select=suggested`;
+  const senderCountText = getSenderCountText(suggestionCount);
 
   return (
     <Html>
       <Head />
       <Preview>
-        We found {suggestionCount.toString()} senders you rarely read. Clean
-        them up in one click.
+        We found {senderCountText} you rarely read. Clean them up in one click.
       </Preview>
       <Tailwind>
         <Body className="bg-white font-sans">
@@ -71,7 +72,7 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
               </Text>
 
               <Heading className="my-4 text-4xl font-medium leading-tight">
-                We found {suggestionCount} senders you rarely read
+                We found {senderCountText} you rarely read
               </Heading>
               <Text className="mb-8 text-lg leading-8">
                 Unsubscribing from them could save you around{" "}
@@ -109,7 +110,10 @@ export default function InboxHealthEmail(props: InboxHealthEmailProps) {
               </Section>
             </Section>
 
-            <Footer baseUrl={baseUrl} unsubscribeToken={unsubscribeToken} />
+            <StatsEmailFooter
+              baseUrl={baseUrl}
+              unsubscribeToken={unsubscribeToken}
+            />
           </Container>
         </Body>
       </Tailwind>
@@ -180,33 +184,6 @@ function SenderCard({ sender }: { sender: SuggestedSender }) {
   );
 }
 
-function Footer({
-  baseUrl,
-  unsubscribeToken,
-}: {
-  baseUrl: string;
-  unsubscribeToken: string;
-}) {
-  return (
-    <Section>
-      <Text>
-        You're receiving this email because you're subscribed to Inbox Zero
-        stats updates. You can change this in your{" "}
-        <Link
-          href={`${baseUrl}/settings#email-updates`}
-          className="text-[15px]"
-        >
-          settings
-        </Link>
-        .
-      </Text>
-
-      <Link
-        href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
-        className="text-[15px]"
-      >
-        Unsubscribe from emails like this
-      </Link>
-    </Section>
-  );
+export function getSenderCountText(count: number) {
+  return `${count} ${count === 1 ? "sender" : "senders"}`;
 }

--- a/packages/resend/emails/summary.tsx
+++ b/packages/resend/emails/summary.tsx
@@ -14,6 +14,7 @@ import {
   Row,
   Column,
 } from "@react-email/components";
+import { StatsEmailFooter } from "./components/stats-email-footer";
 
 type EmailItem = {
   from: string;
@@ -93,7 +94,10 @@ export default function SummaryEmail(props: SummaryEmailProps) {
 
             <ColdEmails coldEmailers={coldEmailers} baseUrl={baseUrl} />
 
-            <Footer baseUrl={baseUrl} unsubscribeToken={unsubscribeToken} />
+            <StatsEmailFooter
+              baseUrl={baseUrl}
+              unsubscribeToken={unsubscribeToken}
+            />
           </Container>
         </Body>
       </Tailwind>
@@ -286,37 +290,6 @@ function ColdEmails({
           </Button>
         </Section>
       )}
-    </Section>
-  );
-}
-
-function Footer({
-  baseUrl,
-  unsubscribeToken,
-}: {
-  baseUrl: string;
-  unsubscribeToken: string;
-}) {
-  return (
-    <Section>
-      <Text>
-        You're receiving this email because you're subscribed to Inbox Zero
-        stats updates. You can change this in your{" "}
-        <Link
-          href={`${baseUrl}/settings#email-updates`}
-          className="text-[15px]"
-        >
-          settings
-        </Link>
-        .
-      </Text>
-
-      <Link
-        href={`${baseUrl}/api/unsubscribe?token=${encodeURIComponent(unsubscribeToken)}`}
-        className="text-[15px]"
-      >
-        Unsubscribe from emails like this
-      </Link>
     </Section>
   );
 }

--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -7,6 +7,9 @@ import DigestEmail, {
   type DigestEmailProps,
   generateDigestSubject,
 } from "../emails/digest";
+import InboxHealthEmail, {
+  type InboxHealthEmailProps,
+} from "../emails/inbox-health";
 import InvitationEmail, {
   type InvitationEmailProps,
 } from "../emails/invitation";
@@ -210,6 +213,33 @@ export const sendDigestEmail = async ({
       {
         name: "category",
         value: "digest",
+      },
+    ],
+  });
+
+export const sendInboxHealthEmail = async ({
+  from,
+  to,
+  test,
+  emailProps,
+}: {
+  from: string;
+  to: string;
+  test?: boolean;
+  emailProps: InboxHealthEmailProps;
+}) =>
+  sendEmail({
+    from,
+    to,
+    subject: `We found ${emailProps.suggestionCount} senders you rarely read`,
+    react: <InboxHealthEmail {...emailProps} />,
+    test,
+    unsubscribeToken: emailProps.unsubscribeToken,
+    baseUrl: emailProps.baseUrl,
+    tags: [
+      {
+        name: "category",
+        value: "inbox-health",
       },
     ],
   });

--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -8,6 +8,7 @@ import DigestEmail, {
   generateDigestSubject,
 } from "../emails/digest";
 import InboxHealthEmail, {
+  getSenderCountText,
   type InboxHealthEmailProps,
 } from "../emails/inbox-health";
 import InvitationEmail, {
@@ -231,7 +232,7 @@ export const sendInboxHealthEmail = async ({
   sendEmail({
     from,
     to,
-    subject: `We found ${emailProps.suggestionCount} senders you rarely read`,
+    subject: `We found ${getSenderCountText(emailProps.suggestionCount)} you rarely read`,
     react: <InboxHealthEmail {...emailProps} />,
     test,
     unsubscribeToken: emailProps.unsubscribeToken,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a recurring "Inbox Health" product email that proactively tells users which senders they should unsubscribe from, with a deep link into the Bulk Unsubscriber with those senders pre-selected.

Stacked on #2826 (uses its `isUnsubscribeSuggestion` heuristic and the `?select=suggested` deep link).

## How it works

- **Template** (`packages/resend/emails/inbox-health.tsx`): "We found N senders you rarely read" with up to 10 sender cards (name, address, 3-month email count, read %), an estimated yearly email volume avoided, and a CTA to `/{emailAccountId}/bulk-unsubscribe?select=suggested`. Uses the standard `sendEmail` wrapper so it gets List-Unsubscribe headers.
- **Send route** (`/api/resend/inbox-health`): computes per-sender stats for the last 3 months (shared `getSenderEmailStats` helper extracted verbatim from the newsletters stats route — reviewed as behavior-preserving for the existing endpoint), excludes already-handled senders via `Newsletter` status, applies the suggestion heuristic, and only sends when there are at least 5 suggestions.
- **Gating**: at most once per 30 days per account (`lastInboxHealthEmailAt` on `EmailAccount`, new migration). The timestamp is also bumped on the "not enough suggestions" path so the daily fan-out doesn't re-run the stats query for never-qualifying accounts (review finding, fixed). Skips accounts younger than 7 days and respects the existing `statsEmailFrequency: NEVER` opt-out (already handled by `/api/unsubscribe`, which the email footer links to).
- **Fan-out** (`/api/resend/inbox-health/all`): mirrors the summary/digest pattern (cron-secret auth, per-account queue jobs); daily cron in `vercel.json` and the Helm chart; queue registered in the worker.

## Rendered email

![Inbox health email top: headline, yearly estimate, sender list](https://cursor.com/artifacts/c/art-0f308599-d5f7-4524-8d5c-6fd0f47aa0a3)
![Inbox health email bottom: CTA and unsubscribe footer](https://cursor.com/artifacts/c/art-78486a23-dba4-4a03-a88c-c74589b7ac48)

Deep-link CTA landing behavior (rows pre-selected, param stripped):

<a href="https://cursor.com/agents/bc-a236e0e3-37b1-49fe-876d-d80bc4883967/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeep_link_demo.mp4"><img src="https://cursor.com/artifacts/c/art-240008d6-cf5e-424e-8290-fae0f8d84f32" alt="deep_link_demo.mp4" /></a>

## Testing

- `pnpm test` — full unit suite passes (includes 8 new tests for thresholds, yearly estimate math, and all gating boundaries)
- Code-reviewed: `getSenderEmailStats` extraction verified byte-for-byte against the old SQL; auth, queue topic/name wiring, vercel.json/Helm syntax validated
- Manually exercised the live route against a seeded local account: unauthorized POST → 401; 4 suggestions → skipped (and timestamp bumped); immediate retry → 30-day-gate skip; 5 suggestions → full send path runs (`suggestionCount: 5` logged, Resend no-ops locally without an API key) and timestamp bumped
- Template rendered via the react-email preview server (screenshots)

## Known trade-off

The email computes suggestions without the provider auto-archive filter lookup (too costly in a cron), so in rare cases it can recommend a sender the user already auto-archives via a Gmail/Outlook filter; the deep-linked page applies the full heuristic and won't select those.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a236e0e3-37b1-49fe-876d-d80bc4883967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a236e0e3-37b1-49fe-876d-d80bc4883967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

