### PR TITLE
Fix rule condition update precedence

### DIFF
--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -178,6 +178,39 @@ describe("updateRuleTool", () => {
       },
     });
   });
+
+  it("keeps replacement AI instructions when clear flag is also present", async () => {
+    const result = await updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["Vendor Billing", "2026-04-27T00:00:00.000Z"],
+        ]),
+      }),
+    }).execute({
+      ruleName: "Vendor Billing",
+      updates: {
+        condition: {
+          aiInstructions: "Updated billing instructions.",
+          clearAiInstructions: true,
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPartialUpdateRule).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      data: {
+        instructions: "Updated billing instructions.",
+      },
+    });
+  });
 });
 
 describe("updateRuleStateTool", () => {

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -327,10 +327,10 @@ function buildConditionUpdateData(condition: PatchCondition) {
     conditionalOperator?: LogicalOperator;
   } = {};
 
-  if (condition.clearAiInstructions) {
-    data.instructions = null;
-  } else if ("aiInstructions" in condition) {
+  if (condition.aiInstructions !== undefined) {
     data.instructions = condition.aiInstructions;
+  } else if (condition.clearAiInstructions) {
+    data.instructions = null;
   }
 
   if (condition.conditionalOperator) {


### PR DESCRIPTION
Updates rule condition patch handling so replacement AI instructions take precedence over a simultaneous clear flag. This prevents contradictory assistant tool input from clearing rule instructions when a replacement value is provided.

- Added a regression test for the conflicting update payload.
- Validated with `pnpm test utils/ai/assistant/chat-rule-tools.test.ts` and `pnpm --filter inbox-zero-ai lint`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

