### PR TITLE
docs: clarify CRON_SECRET usage for scheduled tasks

### DIFF
--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -130,7 +130,7 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `NEXT_PUBLIC_IS_RESEND_CONFIGURED` | No | Client-side flag indicating if Resend is configured | — |
 | **Other** ||||
 | `API_KEY_SALT` | No* | Salt used to hash external API keys. Generate with `openssl rand -hex 32`. Required when `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true`. | — |
-| `CRON_SECRET` | No | Secret for cron job authentication | — |
+| `CRON_SECRET` | No | Shared secret that authenticates calls to the scheduled-task endpoints (`/api/cron/*`, `/api/watch/all`, `/api/meeting-briefs`, `/api/follow-up-reminders`). Required if you trigger these endpoints yourself instead of using the bundled Docker Compose `cron` container. Generate with `openssl rand -hex 32`. See [Scheduled Tasks](/hosting/self-hosting#scheduled-tasks). | — |
 | `HEALTH_API_KEY` | No | API key for health checks | — |
 | `WEBHOOK_URL` | No | External webhook URL | — |
 | `INTERNAL_API_URL` | No | Preferred callback base URL for QStash and server-side internal callbacks | `NEXT_PUBLIC_BASE_URL` |

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -158,6 +158,10 @@ The Docker Compose setup includes a `cron` container that handles scheduled task
 
 Replace `YOUR_CRON_SECRET` with the value of `CRON_SECRET` from your `.env` file.
 
+<Info>
+  These endpoints accept the secret as a `GET` header (`Authorization: Bearer YOUR_CRON_SECRET`, as above) or in a `POST` JSON body (`{ "CRON_SECRET": "YOUR_CRON_SECRET" }`).
+</Info>
+
 ## Optional: Background Job Backends
 
 Inbox Zero supports multiple background job backends for self-hosted deployments:


### PR DESCRIPTION
Improves the documentation for `CRON_SECRET`, addressing issue #536 where its usage was unclear in the setup docs.

- Expanded the `CRON_SECRET` entry in the environment variables reference to explain which endpoints it guards, when it's needed, how to generate it, and a link to the Scheduled Tasks section.
- Added a note to the Scheduled Tasks section documenting that endpoints accept the secret either as a GET `Authorization: Bearer` header or in a POST JSON body.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

