### PR TITLE
Fix production Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,9 +28,14 @@ coverage
 .vscode
 
 # Local env files (do not bake secrets)
+.env
+.env.*
+**/.env
+**/.env.*
 *.env
 *.env.*
 !.env.example
+!**/.env.example
 
 # Docker
 Dockerfile*
@@ -40,4 +45,3 @@ Dockerfile*
 *.local
 _tmp
 .tmp
-

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -66,9 +66,6 @@ const nextConfig: NextConfig = {
   ],
   turbopack: {
     root: repoRoot,
-    resolveAlias: {
-      "zod/v4/core": zodV4CorePath,
-    },
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -34,7 +34,7 @@ COPY clone-marketing.sh clone-marketing.sh
 # Install deps with a hoisted node_modules layout so Turbopack resolves packages
 # from the workspace instead of following pnpm store symlinks outside package
 # peer dependency boundaries.
-RUN pnpm install --no-frozen-lockfile --prefer-offline --config.node-linker=hoisted
+RUN pnpm install --frozen-lockfile --prefer-offline --config.node-linker=hoisted
 
  # Copy the full repo
 COPY . .

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -5,6 +5,7 @@ WORKDIR /app
 
 RUN apk add --no-cache openssl
 RUN npm install -g pnpm@11.0.9
+RUN pnpm config set store-dir /app/.pnpm-store
 
 # Docker build layers are non-interactive; let pnpm handle module purges without a TTY.
 ENV CI=true
@@ -30,16 +31,17 @@ COPY apps/web/prisma/schema.prisma apps/web/prisma/schema.prisma
 # Copy postinstall script
 COPY clone-marketing.sh clone-marketing.sh
 
-# Install deps
-# Use shamefully-hoist to ensure all packages are available at root level for webpack resolution
-RUN pnpm install --no-frozen-lockfile --prefer-offline --shamefully-hoist
+# Install deps with a hoisted node_modules layout so Turbopack resolves packages
+# from the workspace instead of following pnpm store symlinks outside package
+# peer dependency boundaries.
+RUN pnpm install --no-frozen-lockfile --prefer-offline --config.node-linker=hoisted
 
  # Copy the full repo
 COPY . .
 
  # Build app (Next.js standalone)
 ENV NODE_ENV=production
-# Increase V8 heap for the webpack production build.
+# Increase V8 heap for the production build.
 ENV NODE_OPTIONS=--max_old_space_size=8192
 ARG NEXT_PUBLIC_BASE_URL="http://NEXT_PUBLIC_BASE_URL_PLACEHOLDER"
 ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
@@ -86,13 +88,18 @@ ENV QSTASH_CURRENT_SIGNING_KEY="dummy_qstash_curr_key_for_build"
 ENV QSTASH_NEXT_SIGNING_KEY="dummy_qstash_next_key_for_build"
 ENV DOCKER_BUILD="true"
 
-RUN npx prisma generate --schema=apps/web/prisma/schema.prisma \
- && cd apps/web \
- && pnpm exec next build --webpack \
- && cd ../.. \
- && pnpm --filter @inboxzero/worker deploy --legacy --prod /tmp/apps/worker \
+RUN rm -f /app/apps/web/.env && touch /app/apps/web/.env
+
+RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
+
+RUN cd /app/apps/web \
+ && pnpm exec next build \
  && cd /app \
+ && pnpm --filter inbox-zero-ai deploy --legacy --prod /tmp/apps/web \
+ && pnpm --filter @inboxzero/worker deploy --legacy --prod /tmp/apps/worker \
  && rm -rf apps/web/.next/cache
+
+RUN rm -f /app/apps/web/.env /app/apps/web/.next/standalone/apps/web/.env
 
 FROM node:24-alpine AS runner
 
@@ -107,7 +114,12 @@ COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder /app/apps/web/public ./apps/web/public
 COPY --from=builder /app/apps/web/prisma ./apps/web/prisma
+COPY --from=builder /tmp/apps/web/node_modules ./apps/web/node_modules
 COPY --from=builder /tmp/apps/worker ./apps/worker
+
+# Fail the image build if the standalone server is missing traced runtime deps.
+RUN test -f apps/web/server.js \
+ && node -e "require('node:module').createRequire('/app/apps/web/server.js')('next')"
 
 # Copy runtime scripts
 COPY docker/scripts /app/docker/scripts


### PR DESCRIPTION
Fixes the production Docker build to use the default Next.js build path while preserving standalone runtime dependencies.

- Uses a Docker builder dependency layout that Turbopack can resolve from the workspace.
- Keeps runtime dependencies available to the standalone server and validates that `server.js` can resolve `next` during image build.
- Excludes local env files from the Docker context and removes the build placeholder env file before creating the runtime image.

Validation: `docker build -f docker/Dockerfile.prod -t inbox-zero-prod-turbo-check .`; runtime `next` resolution check; final image env-file scan.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

