### PR TITLE
fix(a11y): add accessible name to hero demo video button

### DIFF
--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -95,7 +95,10 @@ export function HeroVideoPlayer() {
               asChild
               onClick={() => landingPageAnalytics.videoClicked(posthog)}
             >
-              <LiquidGlassButton className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+              <LiquidGlassButton
+                aria-label="Play product demo video"
+                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+              >
                 <div>
                   <Play className="translate-x-[2px]" />
                 </div>


### PR DESCRIPTION
### Problem

The hero "play" button that opens the demo-video dialog has no accessible name. Its only child is the `Play` SVG icon (no `<title>`/`aria-label`), and `LiquidGlassButton` renders a bare `<button>`, so a screen reader announces it as an unlabeled "button". That's WCAG 2.1 SC 4.1.2 (Name, Role, Value) / axe-core `button-name`. Reproducible on the live site (getinboxzero.com) and in `apps/web/app/(landing)/home/Hero.tsx`.

### Fix

Added `aria-label="Play product demo video"` to the `LiquidGlassButton` in `HeroVideoPlayer`. `LiquidGlassButton` spreads `{...props}` onto its native `<button>`, so the label lands directly on the button element. One-line behavioral change, no styling or markup restructure.

```diff
-              <LiquidGlassButton className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+              <LiquidGlassButton
+                aria-label="Play product demo video"
+                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+              >
```

### Verified

- `aria-label` is part of React's `AriaAttributes`, included in the component's `React.ButtonHTMLAttributes<HTMLButtonElement>` props — type-valid, no signature change.
- Ran Biome's a11y rule set against the changed file — clean, no warnings.
- Static/build verification only — I didn't add a unit test, since this is a self-evident accessible-name attribute and I couldn't see an existing a11y test pattern for the landing components to extend. Happy to wire one up (e.g. a `getByRole("button", { name: /play/i })` render test) if you'd prefer the change to come with a test.

For context: the rest of the landing page's a11y is already in good shape — the dialog has an `sr-only` `DialogTitle`, the iframe has a `title`, images have `alt` — this play button was the one spot missing a name, so it's a small, targeted fix.

— Charles ([choreless.dev](https://choreless.dev))

@elie222 — quick question on wording: I kept the label generic ("Play product demo video"). Would you rather it reference the actual video title, or stay generic so it doesn't drift if you swap the video? Easy to adjust.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

