### PR TITLE
fix(mail): prevent horizontal overflow in email list rows

### DIFF
--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -406,7 +406,7 @@ export function EmailList({
         <ResizeGroup
           left={
             <ul
-              className="divide-y divide-border overflow-y-auto scroll-smooth"
+              className="min-w-0 divide-y divide-border overflow-x-hidden overflow-y-auto scroll-smooth"
               ref={listRef}
             >
               {threads.map((thread) => {
@@ -502,7 +502,12 @@ function ResizeGroup({
 
   return (
     <ResizablePanelGroup direction={isMobile ? "vertical" : "horizontal"}>
-      <ResizablePanel style={{ overflow: "auto" }} defaultSize={50} minSize={0}>
+      <ResizablePanel
+        style={{ overflow: "auto" }}
+        defaultSize={50}
+        minSize={0}
+        className="min-w-0"
+      >
         {left}
       </ResizablePanel>
       <ResizableHandle withHandle />

--- a/apps/web/components/email-list/EmailListItem.tsx
+++ b/apps/web/components/email-list/EmailListItem.tsx
@@ -87,11 +87,11 @@ export const EmailListItem = forwardRef(
           }}
         >
           <div className="px-4">
-            <div className="mx-auto flex">
+            <div className="mx-auto flex min-w-0 w-full">
               {/* left */}
               <div
                 className={clsx(
-                  "flex flex-1 items-center overflow-hidden whitespace-nowrap text-sm leading-6",
+                  "flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-sm leading-6",
                   {
                     "font-semibold": isUnread,
                   },
@@ -132,10 +132,10 @@ export const EmailListItem = forwardRef(
                         </Link>
                       </Button>
                     )}
-                    <div className="ml-2 min-w-0 overflow-hidden text-foreground">
+                    <div className="ml-2 min-w-0 overflow-hidden truncate text-foreground">
                       {lastMessage.headers.subject}
                     </div>
-                    <div className="ml-4 mr-6 flex flex-1 items-center overflow-hidden truncate font-normal leading-5 text-muted-foreground">
+                    <div className="ml-4 mr-6 min-w-0 flex-1 overflow-hidden truncate font-normal leading-5 text-muted-foreground">
                       {decodedSnippet}
                     </div>
                   </>
@@ -143,7 +143,7 @@ export const EmailListItem = forwardRef(
               </div>
 
               {/* right */}
-              <div className="flex items-center justify-between">
+              <div className="flex shrink-0 items-center justify-between">
                 <div className="relative flex items-center">
                   <div
                     className="absolute right-0 z-20 hidden group-hover:block"
@@ -177,11 +177,11 @@ export const EmailListItem = forwardRef(
             </div>
 
             {splitView && (
-              <div className="mt-1.5 whitespace-nowrap text-sm leading-6">
-                <div className="min-w-0 overflow-hidden font-medium text-foreground">
+              <div className="mt-1.5 min-w-0 overflow-hidden text-sm leading-6">
+                <div className="min-w-0 overflow-hidden truncate font-medium text-foreground">
                   {lastMessage.headers.subject}
                 </div>
-                <div className="mr-6 mt-0.5 flex flex-1 items-center overflow-hidden truncate pl-1 font-normal leading-5 text-muted-foreground">
+                <div className="mr-6 mt-0.5 min-w-0 overflow-hidden truncate pl-1 font-normal leading-5 text-muted-foreground">
                   {decodedSnippet}
                 </div>
                 {cta && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes horizontal scrolling on the `/mail` screen where long email subjects and preview snippets were extending past the viewport edge instead of truncating.

## Root cause
Email list rows used `whitespace-nowrap` without proper flex shrinking constraints. The subject line was missing `truncate`, and flex children defaulted to `min-width: auto`, allowing content to expand beyond the available width.

## Changes
- **`EmailListItem`**: Add `min-w-0 w-full` to the row container; add `truncate` to subject lines; remove `flex` from snippet truncation containers; mark the date/actions column as `shrink-0`; apply the same truncation fixes in split-view mode.
- **`EmailList`**: Add `min-w-0 overflow-x-hidden` to the list `<ul>` and `min-w-0` to the resizable left panel.

## Scope
Changes are limited to `email-list` components used by `/mail` and `/no-reply`. No global layout changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5795b675-37c7-4feb-a80b-e484d085f5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5795b675-37c7-4feb-a80b-e484d085f5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

