### PR TITLE
Improve connection error messaging

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -487,9 +487,15 @@ export function useSlackNotifications({
     }
 
     if (error === "connection_failed" || errorDetail) {
+      const description = appendSlackConnectionFailureDetails({
+        description: getSlackConnectionFailedDescription(resolvedReason),
+        errorReason,
+        errorDetail,
+      });
+
       toastError({
         title: "Slack connection failed",
-        description: getSlackConnectionFailedDescription(resolvedReason),
+        description,
       });
     }
 
@@ -511,26 +517,63 @@ export function useSlackNotifications({
 }
 
 function getSlackConnectionFailedDescription(
-  errorReason: string | null,
+  resolvedReason: string | null,
 ): string {
-  if (errorReason === "oauth_invalid_team_for_non_distributed_app") {
+  if (resolvedReason === "oauth_invalid_team_for_non_distributed_app") {
     return "This Slack app is not distributed to every workspace yet. Use the currently supported workspace or contact support.";
   }
 
-  if (errorReason === "oauth_invalid_code") {
+  if (resolvedReason === "oauth_invalid_code") {
     return "Slack returned an invalid or expired code. Please try connecting again.";
   }
 
   if (
-    errorReason === "missing_code" ||
-    errorReason === "missing_state" ||
-    errorReason === "invalid_state" ||
-    errorReason === "invalid_state_format"
+    resolvedReason === "missing_code" ||
+    resolvedReason === "missing_state" ||
+    resolvedReason === "invalid_state" ||
+    resolvedReason === "invalid_state_format"
   ) {
     return "Slack session validation failed. Please try connecting again.";
   }
 
   return "We couldn't complete the Slack connection. Please try again.";
+}
+
+function appendSlackConnectionFailureDetails({
+  description,
+  errorReason,
+  errorDetail,
+}: {
+  description: string;
+  errorReason: string | null;
+  errorDetail: string | null;
+}): string {
+  const details = formatSlackConnectionFailureDetails(
+    errorReason,
+    errorDetail,
+  );
+
+  if (!details) {
+    return description;
+  }
+
+  return `${description} Details: ${details}`;
+}
+
+function formatSlackConnectionFailureDetails(
+  errorReason: string | null,
+  errorDetail: string | null,
+): string | null {
+  const parts = [
+    errorReason && `reason ${sanitizeSlackConnectionFailureDetail(errorReason)}`,
+    errorDetail && `detail ${sanitizeSlackConnectionFailureDetail(errorDetail)}`,
+  ].filter(Boolean);
+
+  return parts.length ? parts.join("; ") : null;
+}
+
+function sanitizeSlackConnectionFailureDetail(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 160);
 }
 
 function resolveSlackErrorReason(


### PR DESCRIPTION
Improve connection failure feedback by including callback-provided details in the user-facing toast when available.

- Preserve existing friendly messages for known failures.
- Append compact sanitized reason/detail values for clearer support context.

Performance impact: UI-only string formatting on the settings page; no added runtime network calls, database work, or hot-path risk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

