### PR TITLE
bulk-unsubscribe: Restore row auto archive action

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import Link from "next/link";
 import {
   ArchiveIcon,
+  ArchiveRestoreIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   ExpandIcon,
@@ -50,6 +51,7 @@ import {
   useApproveButton,
   useBulkArchive,
   useBulkDelete,
+  useBulkAutoArchive,
 } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks";
 import { ResubscribeDialog } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/ResubscribeDialog";
 import { LabelsSubMenu } from "@/components/LabelsSubMenu";
@@ -125,6 +127,10 @@ export function ActionCell<T extends Row>({
         labels={labels}
         posthog={posthog}
         mutate={mutate}
+        hasUnsubscribeAccess={hasUnsubscribeAccess}
+        refetchPremium={refetchPremium}
+        filter={filter}
+        openPremiumModal={openPremiumModal}
       />
     </>
   );
@@ -269,6 +275,10 @@ export function MoreDropdown<T extends Row>({
   labels,
   posthog,
   mutate,
+  hasUnsubscribeAccess,
+  refetchPremium,
+  filter,
+  openPremiumModal,
 }: {
   onOpenNewsletter?: (row: T) => void;
   item: T;
@@ -277,6 +287,10 @@ export function MoreDropdown<T extends Row>({
   labels: EmailLabel[];
   posthog: PostHog;
   mutate: () => Promise<unknown>;
+  hasUnsubscribeAccess?: boolean;
+  refetchPremium?: () => Promise<UserResponse | null | undefined>;
+  filter?: NewsletterFilterType;
+  openPremiumModal?: () => void;
 }) {
   const { provider } = useAccount();
   const terminology = getEmailTerminology(provider);
@@ -292,6 +306,14 @@ export function MoreDropdown<T extends Row>({
     posthog,
     emailAccountId,
   });
+  const { onBulkAutoArchive } = useBulkAutoArchive({
+    hasUnsubscribeAccess: hasUnsubscribeAccess ?? false,
+    mutate,
+    refetchPremium: refetchPremium ?? noopRefetchPremium,
+    emailAccountId,
+    filter: filter ?? "all",
+  });
+  const showAutoArchive = typeof hasUnsubscribeAccess === "boolean";
 
   const handleLabelClick = async (label: EmailLabel) => {
     const res = await createFilterAction(emailAccountId, {
@@ -365,6 +387,21 @@ export function MoreDropdown<T extends Row>({
           <DropdownMenuSeparator />
 
           {/* Bulk actions section */}
+          {showAutoArchive && (
+            <DropdownMenuItem
+              onClick={() => {
+                if (!hasUnsubscribeAccess) {
+                  openPremiumModal?.();
+                  return;
+                }
+
+                onBulkAutoArchive([item]);
+              }}
+            >
+              <ArchiveRestoreIcon className="mr-2 size-4" />
+              <span>Auto archive</span>
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem onClick={() => onBulkArchive([item])}>
             {isBulkArchiving ? (
               <ButtonLoader />
@@ -450,4 +487,8 @@ export function HeaderButton(props: {
       )}
     </Button>
   );
+}
+
+async function noopRefetchPremium() {
+  return null;
 }

--- a/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/ConnectedAppsSection.tsx
@@ -548,10 +548,7 @@ function appendSlackConnectionFailureDetails({
   errorReason: string | null;
   errorDetail: string | null;
 }): string {
-  const details = formatSlackConnectionFailureDetails(
-    errorReason,
-    errorDetail,
-  );
+  const details = formatSlackConnectionFailureDetails(errorReason, errorDetail);
 
   if (!details) {
     return description;
@@ -565,8 +562,10 @@ function formatSlackConnectionFailureDetails(
   errorDetail: string | null,
 ): string | null {
   const parts = [
-    errorReason && `reason ${sanitizeSlackConnectionFailureDetail(errorReason)}`,
-    errorDetail && `detail ${sanitizeSlackConnectionFailureDetail(errorDetail)}`,
+    errorReason &&
+      `reason ${sanitizeSlackConnectionFailureDetail(errorReason)}`,
+    errorDetail &&
+      `detail ${sanitizeSlackConnectionFailureDetail(errorDetail)}`,
   ].filter(Boolean);
 
   return parts.length ? parts.join("; ") : null;


### PR DESCRIPTION
Restores the row-level auto archive action in the sender dropdown so users can apply it without selecting rows first.

- Adds the auto archive action to row dropdowns when access context is available
- Reuses the existing bulk auto archive flow for consistent status updates and refetch behavior

Performance impact: No added page-load network calls. The new menu action only runs existing auto archive work when clicked, so hot-path risk is low.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

