### PR TITLE
assistant: surface email content in chat triage summaries

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-test-utils.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
 import { beforeEach, vi } from "vitest";
 import {
-  captureAssistantChatToolCalls,
+  captureAssistantChatTrace,
   getFirstMatchingToolCall,
   getLastMatchingToolCall as getSharedLastMatchingToolCall,
   summarizeRecordedToolCalls,
@@ -230,7 +230,7 @@ export async function runAssistantChat({
   messages: ModelMessage[];
   inboxStats?: { total: number; unread: number } | null;
 }) {
-  const toolCalls = await captureAssistantChatToolCalls({
+  const trace = await captureAssistantChatTrace({
     messages,
     emailAccount,
     inboxStats,
@@ -238,8 +238,9 @@ export async function runAssistantChat({
   });
 
   return {
-    toolCalls,
-    actual: summarizeRecordedToolCalls(toolCalls, summarizeToolCall),
+    toolCalls: trace.toolCalls,
+    finalText: trace.finalText,
+    actual: summarizeRecordedToolCalls(trace.toolCalls, summarizeToolCall),
   };
 }
 

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -17,6 +17,10 @@ import {
   shouldRunEval,
   TIMEOUT,
 } from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+import {
+  formatSemanticJudgeActual,
+  judgeEvalOutput,
+} from "@/__tests__/eval/semantic-judge";
 
 // pnpm test-ai eval/assistant-chat-inbox-workflows
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-inbox-workflows
@@ -186,6 +190,104 @@ describe.runIf(shouldRunEval)(
                 return {
                   pass,
                   actual,
+                };
+              },
+            );
+
+            expect(record.pass, record.actual).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test.each(inboxWorkflowProviders)(
+          "triage summary describes each email's actual content, not just the recommended action [$label]",
+          async ({ provider, label }) => {
+            const testName = `triage summary surfaces email content (${label})`;
+            const searchMessages = [
+              getMockMessage({
+                id: "msg-content-1",
+                threadId: "thread-content-1",
+                from: "partnerships@brand.example",
+                subject: "Collaboration proposal",
+                snippet:
+                  "We'd love to sponsor a post on your blog for $1,500 and ship you our new device to review.",
+                labelIds: ["UNREAD", "Label_To Reply"],
+              }),
+              getMockMessage({
+                id: "msg-content-2",
+                threadId: "thread-content-2",
+                from: "receipts@payments.example",
+                subject: "Your payout has arrived",
+                snippet:
+                  "A payout of $4,200 has cleared to your bank. Upload the attached receipt to your bookkeeping by Friday.",
+                labelIds: ["UNREAD"],
+              }),
+              getMockMessage({
+                id: "msg-content-3",
+                threadId: "thread-content-3",
+                from: "noreply@analytics.example",
+                subject: "Daily metrics recap",
+                snippet:
+                  "Yesterday you had 32 new signups and $980 in new MRR. Churn held flat.",
+                labelIds: ["UNREAD"],
+              }),
+            ];
+            const inboxStats = { total: 120, unread: 9 };
+            const messages = [
+              {
+                role: "user" as const,
+                content: "Help me handle my inbox today.",
+              },
+            ];
+
+            const record = await evalReporter.recordCached(
+              {
+                testName,
+                model: model.label,
+                cacheKeyParts: [
+                  {
+                    model,
+                    provider,
+                    label,
+                    searchMessages: getStableMessageCacheKey(searchMessages),
+                    inboxStats,
+                    messages,
+                  },
+                ],
+              },
+              async () => {
+                mockSearchMessages.mockResolvedValueOnce({
+                  messages: searchMessages,
+                  nextPageToken: undefined,
+                });
+
+                const { finalText, actual } = await runAssistantChat({
+                  emailAccount: cloneEmailAccountForProvider(
+                    emailAccount,
+                    provider,
+                  ),
+                  inboxStats,
+                  messages,
+                });
+
+                const judge = finalText
+                  ? await judgeEvalOutput({
+                      criterion: {
+                        name: "Summarizes email content",
+                        description:
+                          "PASS only if, for the substantive emails, the response tells the user what the email actually says: its concrete content such as the specific ask, news, amount, or deadline (for example, a sponsorship offer with a dollar amount, a payout that cleared, or specific metrics). FAIL if the per-email text only restates what to do with it or which triage group it belongs to (for example, 'worth deciding whether to reply', 'product update, probably not urgent', or 'safe to archive') without conveying the email's actual content. Sorting emails into groups is fine and expected; the failure is summaries that describe only the recommended action or priority and never the substance of the message.",
+                      },
+                      input: messages[0].content,
+                      output: finalText,
+                    })
+                  : null;
+
+                return {
+                  pass: !!judge?.pass,
+                  actual:
+                    judge && finalText
+                      ? `${actual} | ${formatSemanticJudgeActual(finalText, judge)}`
+                      : `no assistant text | ${actual}`,
                 };
               },
             );

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -780,7 +780,7 @@ Inline email cards:
 - Number every <email> starting from 1, continuing across blocks within the same response (two groups of 4 are 1–8, not 1–4 twice). The index lets you map "#6" back to its threadid in later turns even if the list changes.
 - For a single email or thread, use <email-detail threadid="THREAD_ID">Brief context</email-detail>.
 - The threadid must be a threadId from searchInbox results (not the HTML id).
-- Inner text is your brief context or recommendation. Default to one sentence; use two only when the email has multiple parts that change how the user should act. Never pad.
+- Inner text must say what the email actually contains — its concrete ask, news, or detail (amounts, dates, requested actions) — drawn from the subject and snippet, so the user understands it without opening it. Do not just restate the group header or a recommendation like "worth deciding whether to reply"; the header already conveys what to do. Default to one sentence; use two only when the email has distinct parts the user needs to know. Never pad.
 - The UI resolves sender, subject, and date from the threadId — don't repeat them.
 - Group <emails> blocks under markdown ## headers when triage has categories.
 - Only render email widgets when they add clarity, not for every search result.`;


### PR DESCRIPTION
Triage summaries previously restated the model's recommendation, which duplicated the group header and never told the user what each email actually said. The inline email card guidance now directs the model to summarize the email's concrete content (ask, news, amounts, dates) from the snippet so users understand each message without opening it.

- Tighten the inline email card prompt rule in the assistant chat system prompt
- Add a semantic-judge eval asserting triage summaries describe content rather than only the recommended action
- Return finalText from the shared triage test runner so the eval can judge the assistant's reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

