### PR TITLE
Fix draft eval date handling

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -222,6 +222,7 @@ Alex`,
             writingStyle: null,
             mcpContext: null,
             meetingContext: null,
+            currentDate: new Date("2026-05-12T09:30:00Z"),
           });
 
           const testName = "booking-link-first scheduling request";
@@ -312,6 +313,7 @@ Morgan`,
             writingStyle: null,
             mcpContext: null,
             meetingContext: null,
+            currentDate: new Date("2026-05-12T09:30:00Z"),
           });
 
           const testName = "human-friendly timezone for suggested times";
@@ -1094,8 +1096,9 @@ Maya`,
       );
 
       test(
-        "uses supplied pricing terms when pricing context is provided",
+        "uses supplied pricing terms before the signing deadline",
         async () => {
+          const currentDate = new Date("2026-05-15T12:00:00Z");
           const messages = [
             {
               ...getEmail({
@@ -1124,23 +1127,27 @@ Maya`,
             writingStyle: null,
             mcpContext: null,
             meetingContext: null,
+            currentDate,
           });
 
-          const testName = "provided pricing context";
+          const testName = "provided pricing context before deadline";
           const judgeResult = await judgeEvalOutput({
             input: [
               formatThreadForJudge(messages),
+              "",
+              "## Today",
+              currentDate.toISOString(),
               "",
               "## Knowledge Base",
               "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
             ].join("\n"),
             output: result.reply,
             expected:
-              "A reply that uses the supplied pricing context to answer the sender with the approved annual price, renewal discount, and signing deadline, without inventing extra pricing terms.",
+              "A reply that uses the supplied pricing context to answer the sender with the approved annual price, renewal discount, and signing deadline. Since today is before May 31, the draft may state that the discount still applies if they sign by the deadline.",
             criterion: {
-              name: "Pricing context used",
+              name: "Pre-deadline pricing context used",
               description:
-                "The draft should communicate the supplied annual price, discount, and deadline. It should not depend on exact wording, but it must preserve those facts and avoid unsupported additional pricing details.",
+                "The draft should communicate the supplied annual price, discount, and deadline. Since today is before May 31, it may say the discount still applies if they sign by May 31. It should avoid unsupported additional pricing details.",
             },
           });
           const pass = judgeResult.pass;
@@ -1155,7 +1162,85 @@ Maya`,
 
           expect(
             pass,
-            `Draft should use the supplied pricing terms.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+            `Draft should use the supplied pre-deadline pricing terms.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "uses supplied pricing terms after the signing deadline",
+        async () => {
+          const currentDate = new Date("2026-06-15T12:00:00Z");
+          const messages = [
+            {
+              ...getEmail({
+                from: "Maya Chen <maya@customer.example>",
+                to: emailAccount.email,
+                subject: "Pricing confirmation",
+                content: `Hi,
+
+Can you confirm the annual price and whether the discount we discussed still applies?
+
+Thanks,
+Maya`,
+              }),
+              date: new Date("2026-05-03T11:00:00Z"),
+            },
+          ];
+
+          const result = await aiDraftReplyWithConfidence({
+            messages,
+            emailAccount,
+            knowledgeBaseContent:
+              "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
+            emailHistorySummary: null,
+            emailHistoryContext: null,
+            calendarAvailability: null,
+            writingStyle: null,
+            mcpContext: null,
+            meetingContext: null,
+            currentDate,
+          });
+
+          const testName = "provided pricing context after deadline";
+          const judgeResult = await judgeEvalOutput({
+            input: [
+              formatThreadForJudge(messages),
+              "",
+              "## Today",
+              currentDate.toISOString(),
+              "",
+              "## Knowledge Base",
+              "For this customer, the approved annual price is $4,800. A 15% renewal discount applies if they sign by May 31.",
+            ].join("\n"),
+            output: result.reply,
+            expected:
+              "A reply that uses the supplied pricing context to answer the sender with the approved annual price and explains that the May 31 signing deadline has passed, so the discount is no longer currently available unless separately re-approved.",
+            criterion: {
+              name: "Post-deadline pricing context used",
+              description:
+                "The draft should communicate the supplied annual price and correctly account for today's date being after the May 31 signing deadline. It should not offer the 15% discount as still available, and it should avoid unsupported additional pricing details.",
+            },
+          });
+          const pass = judgeResult.pass;
+
+          evalReporter.record({
+            testName,
+            model: model.label,
+            pass,
+            expected:
+              "$4,800; May 31 deadline has passed; no unsupported pricing terms",
+            actual: formatSemanticJudgeActual(result.reply, judgeResult),
+          });
+
+          expect(
+            pass,
+            `Draft should use the supplied post-deadline pricing terms.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
               judgeResult,
               null,
               2,

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 17;
+export const DRAFT_PIPELINE_VERSION = 18;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -37,7 +37,7 @@ Never use placeholders for the user's name. You do not need to sign off with the
 Do not invent information.
 Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
 When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
-Inline image markers such as [image] or [image: ...] mean a real image exists in the email. Do not say it is missing or unreadable; respond from the available text and image label.
+Inline image markers such as [image] or [image: ...] mean a real image exists in the email. Do not say it is missing, unreadable, unavailable, or needs to be resent; respond from the available text and image label.
 Treat email dates as message metadata, not calendar context.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -37,7 +37,7 @@ Never use placeholders for the user's name. You do not need to sign off with the
 Do not invent information.
 Ground facts, terms, statuses, dates, approvals, attachments, completed actions, and external changes in the thread or provided context.
 When key context is missing, still draft the most useful reply you can, but use lower confidence when the draft relies on assumptions or user-fillable details.
-Inline image markers such as [image] or [image: ...] mean a real image exists in the email. Do not say it is missing, unreadable, unavailable, or needs to be resent; respond from the available text and image label.
+Inline image markers such as [image] or [image: ...] mean the sender included a real image in the email, but only the marker and label are available in this prompt. Do not say the image is missing, unreadable, unavailable, or needs to be resent; respond from the available text and image label.
 Treat email dates as message metadata, not calendar context.
 Do not use em dashes unless the provided writing style explicitly calls for them.
 Don't suggest meeting times or mention availability unless specific calendar information is provided.

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -74,6 +74,7 @@ const getUserPrompt = ({
   meetingContext,
   attachmentContext,
   hasConfiguredSignature,
+  currentDate,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: DraftEmailAccount;
@@ -89,6 +90,7 @@ const getUserPrompt = ({
   meetingContext: string | null;
   attachmentContext: string | null;
   hasConfiguredSignature: boolean;
+  currentDate?: Date;
 }) => {
   const userAbout = emailAccount.about
     ? `Context about the user:
@@ -233,7 +235,7 @@ Here is the context of the email thread (from oldest to newest):
 ${getEmailListPrompt({ messages, messageMaxLength: 3000 })}
 
 Please write a reply to the email.
-${getTodayForLLM()}
+${getTodayForLLM(currentDate)}
 IMPORTANT: You are writing an email as ${emailAccount.email}. Write the reply from their perspective.`;
 };
 
@@ -271,6 +273,7 @@ export async function aiDraftReplyWithConfidence({
   meetingContext,
   attachmentContext = null,
   hasConfiguredSignature = false,
+  currentDate,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: DraftEmailAccount;
@@ -286,6 +289,7 @@ export async function aiDraftReplyWithConfidence({
   meetingContext: string | null;
   attachmentContext?: string | null;
   hasConfiguredSignature?: boolean;
+  currentDate?: Date;
 }): Promise<DraftReplyResult> {
   logger.info("Drafting email reply", {
     messageCount: messages.length,
@@ -324,6 +328,7 @@ export async function aiDraftReplyWithConfidence({
     meetingContext,
     attachmentContext,
     hasConfiguredSignature,
+    currentDate,
   });
 
   const modelOptions = getModelForUseCase(
@@ -386,6 +391,7 @@ export async function aiDraftReply({
   meetingContext,
   attachmentContext = null,
   hasConfiguredSignature = false,
+  currentDate,
 }: {
   messages: (EmailForLLM & { to: string })[];
   emailAccount: DraftEmailAccount;
@@ -401,6 +407,7 @@ export async function aiDraftReply({
   meetingContext: string | null;
   attachmentContext?: string | null;
   hasConfiguredSignature?: boolean;
+  currentDate?: Date;
 }) {
   const result = await aiDraftReplyWithConfidence({
     messages,
@@ -417,6 +424,7 @@ export async function aiDraftReply({
     meetingContext,
     attachmentContext,
     hasConfiguredSignature,
+    currentDate,
   });
 
   return result.reply;


### PR DESCRIPTION
Adds deterministic current-date injection for draft reply evals so date-sensitive scenarios are evaluated against the intended fixture date.

Updates draft reply eval coverage for scheduling availability and pricing deadline behavior, and clarifies inline image guidance for draft replies.