### PR TITLE
feat(llms): bridge ai sdk tools to claude-code cli via in-process mcp server

### DIFF
--- a/apps/web/utils/llms/cli-provider.test.ts
+++ b/apps/web/utils/llms/cli-provider.test.ts
@@ -83,6 +83,97 @@ describe("createCliLanguageModel", () => {
     });
   });
 
+  it("bridges AI SDK tools to Claude Code through MCP", async () => {
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [
+        {
+          type: "tool-call",
+          toolName: "mcp__inboxzero__searchInbox",
+          input: { query: "hello" },
+        },
+      ],
+    });
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "tool-call",
+          toolName: "mcp__inboxzero__createRule",
+          input: { label: "later" },
+        });
+        controller.close();
+      },
+    });
+    const doStream = vi.fn().mockResolvedValue({ stream });
+    const innerModel = {
+      specificationVersion: "v3",
+      provider: "claude-code",
+      modelId: "sonnet",
+      supportedUrls: {},
+      doGenerate,
+      doStream,
+    };
+    const claudeCode = vi.fn(() => innerModel);
+    const mcpServer = { type: "mcp-server" };
+    const createAiSdkMcpServer = vi.fn(() => mcpServer);
+    const searchInbox = {
+      description: "Search inbox",
+      inputSchema: {},
+      execute: vi.fn(),
+    };
+    const createRule = {
+      description: "Create rule",
+      inputSchema: {},
+      execute: vi.fn(),
+    };
+
+    const { createClaudeCodeLanguageModelWithBridgedTools } =
+      await loadCliProviderModule({
+        claudeModule: { claudeCode, createAiSdkMcpServer },
+      });
+
+    const model = (await createClaudeCodeLanguageModelWithBridgedTools({
+      modelName: "sonnet",
+      tools: { searchInbox, createRule },
+    })) as any;
+
+    await expect(model.doGenerate("generate-request")).resolves.toEqual({
+      content: [
+        {
+          type: "tool-call",
+          toolName: "searchInbox",
+          input: { query: "hello" },
+        },
+      ],
+    });
+    const streamResult = await model.doStream("stream-request");
+    const reader = streamResult.stream.getReader();
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: {
+        type: "tool-call",
+        toolName: "createRule",
+        input: { label: "later" },
+      },
+    });
+
+    expect(createAiSdkMcpServer).toHaveBeenCalledWith("inboxzero", {
+      searchInbox,
+      createRule,
+    });
+    expect(claudeCode).toHaveBeenCalledWith("sonnet", {
+      settingSources: [],
+      allowedTools: [
+        "mcp__inboxzero__searchInbox",
+        "mcp__inboxzero__createRule",
+      ],
+      mcpServers: { inboxzero: mcpServer },
+      permissionMode: "default",
+      sandbox: { enabled: true },
+    });
+    expect(doGenerate).toHaveBeenCalledWith("generate-request");
+    expect(doStream).toHaveBeenCalledWith("stream-request");
+  });
+
   it("surfaces a clear error when the provider package is missing its factory export", async () => {
     const { createCliLanguageModel } = await loadCliProviderModule({
       codexModule: { codexExec: undefined },

--- a/apps/web/utils/llms/cli-provider.ts
+++ b/apps/web/utils/llms/cli-provider.ts
@@ -100,17 +100,81 @@ export async function createClaudeCodeLanguageModelWithBridgedTools({
   if (toolNames.length === 0) return createClaudeCodeLanguageModel(modelName);
 
   const mcpServer = createBridge(CLAUDE_CODE_MCP_SERVER_NAME, tools);
-  const allowedTools = toolNames.map(
-    (name) => `mcp__${CLAUDE_CODE_MCP_SERVER_NAME}__${name}`,
-  );
+  const allowedTools = toolNames.map((name) => prefixToolName(name));
 
-  return claudeCode(modelName, {
+  const inner = claudeCode(modelName, {
     settingSources: [],
     allowedTools,
     mcpServers: { [CLAUDE_CODE_MCP_SERVER_NAME]: mcpServer },
     permissionMode: "default",
     sandbox: { enabled: true },
   });
+
+  return wrapWithUnprefixedToolNames(inner);
+}
+
+const TOOL_NAME_PREFIX = `mcp__${CLAUDE_CODE_MCP_SERVER_NAME}__`;
+
+function prefixToolName(name: string): string {
+  return `${TOOL_NAME_PREFIX}${name}`;
+}
+
+function unprefixToolName(name: string): string {
+  return name.startsWith(TOOL_NAME_PREFIX)
+    ? name.slice(TOOL_NAME_PREFIX.length)
+    : name;
+}
+
+// The MCP bridge causes the Claude Code CLI to surface tool calls as
+// `mcp__inboxzero__<name>`. Inbox Zero callers (stop conditions, UI part
+// renderers, validators) match on the original tool names, so the prefix is
+// stripped from every `toolName` field in both the non-streaming and
+// streaming response paths before it reaches the AI SDK consumer.
+function wrapWithUnprefixedToolNames(model: LanguageModelV3): LanguageModelV3 {
+  const wrapped = {
+    specificationVersion: model.specificationVersion,
+    provider: model.provider,
+    modelId: model.modelId,
+    supportedUrls: model.supportedUrls,
+    async doGenerate(...args: unknown[]) {
+      const doGenerate = getModelMethod(
+        model,
+        "doGenerate",
+        Provider.CLAUDE_CODE,
+      );
+      const result = (await doGenerate(...args)) as {
+        content?: unknown[];
+      } & Record<string, unknown>;
+      return {
+        ...result,
+        ...(Array.isArray(result.content)
+          ? { content: result.content.map(unprefixPart) }
+          : {}),
+      };
+    },
+    async doStream(...args: unknown[]) {
+      const doStream = getModelMethod(model, "doStream", Provider.CLAUDE_CODE);
+      const result = (await doStream(...args)) as {
+        stream: ReadableStream<unknown>;
+      } & Record<string, unknown>;
+      const stream = result.stream.pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            controller.enqueue(unprefixPart(chunk));
+          },
+        }),
+      );
+      return { ...result, stream };
+    },
+  };
+  return wrapped as unknown as LanguageModelV3;
+}
+
+function unprefixPart(part: unknown): unknown {
+  if (!part || typeof part !== "object") return part;
+  const record = part as Record<string, unknown>;
+  if (typeof record.toolName !== "string") return part;
+  return { ...record, toolName: unprefixToolName(record.toolName) };
 }
 
 async function loadCliLanguageModel({

--- a/apps/web/utils/llms/cli-provider.ts
+++ b/apps/web/utils/llms/cli-provider.ts
@@ -12,8 +12,22 @@ type CliModelFactory = (
   settings?: Record<string, unknown>,
 ) => LanguageModelV3;
 
+type McpBridgedTool = {
+  description?: string;
+  inputSchema: unknown;
+  execute?: (input: never, options?: unknown) => unknown;
+};
+
+type McpBridgeFactory = (
+  name: string,
+  tools: Record<string, McpBridgedTool>,
+) => unknown;
+
 const runtimeImport = (specifier: string): Promise<CliProviderModule> =>
   import(/* webpackIgnore: true */ specifier);
+
+const CLAUDE_CODE_PACKAGE = "ai-sdk-provider-claude-code";
+const CLAUDE_CODE_MCP_SERVER_NAME = "inboxzero";
 
 export function assertCliLlmEnabled(provider: CliProvider) {
   if (env.CLI_LLM_ENABLED) return;
@@ -57,6 +71,48 @@ export function createCliLanguageModel({
   } as unknown as LanguageModelV3;
 }
 
+// AI SDK tools cannot be auto-bridged at the LanguageModelV3 layer: by the
+// time the wrapper sees them they have been reduced to JSON schemas with no
+// `execute`. Callers that pass tools must therefore use this helper, which
+// wires the original tool record through `createAiSdkMcpServer` so the
+// Claude Code CLI can invoke them locally over MCP.
+export async function createClaudeCodeLanguageModelWithBridgedTools({
+  modelName,
+  tools,
+}: {
+  modelName: string;
+  tools: Record<string, McpBridgedTool>;
+}): Promise<LanguageModelV3> {
+  assertCliLlmEnabled(Provider.CLAUDE_CODE);
+
+  const module = await importOptionalProviderPackage(
+    CLAUDE_CODE_PACKAGE,
+    Provider.CLAUDE_CODE,
+  );
+  const claudeCode = getFactory(module, "claudeCode", Provider.CLAUDE_CODE);
+  const createBridge = getFactory(
+    module,
+    "createAiSdkMcpServer",
+    Provider.CLAUDE_CODE,
+  ) as McpBridgeFactory;
+
+  const toolNames = Object.keys(tools);
+  if (toolNames.length === 0) return createClaudeCodeLanguageModel(modelName);
+
+  const mcpServer = createBridge(CLAUDE_CODE_MCP_SERVER_NAME, tools);
+  const allowedTools = toolNames.map(
+    (name) => `mcp__${CLAUDE_CODE_MCP_SERVER_NAME}__${name}`,
+  );
+
+  return claudeCode(modelName, {
+    settingSources: [],
+    allowedTools,
+    mcpServers: { [CLAUDE_CODE_MCP_SERVER_NAME]: mcpServer },
+    permissionMode: "default",
+    sandbox: { enabled: true },
+  });
+}
+
 async function loadCliLanguageModel({
   provider,
   modelName,
@@ -93,7 +149,7 @@ async function createCodexCliLanguageModel(modelName: string) {
 
 async function createClaudeCodeLanguageModel(modelName: string) {
   const module = await importOptionalProviderPackage(
-    "ai-sdk-provider-claude-code",
+    CLAUDE_CODE_PACKAGE,
     Provider.CLAUDE_CODE,
   );
   const claudeCode = getFactory(module, "claudeCode", Provider.CLAUDE_CODE);

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -12,6 +12,7 @@ const {
   mockWithTracing,
   mockGetPosthogLlmClient,
   mockIsPosthogLlmEvalApproved,
+  mockCreateClaudeCodeLanguageModelWithBridgedTools,
 } = vi.hoisted(() => ({
   mockGenerateText: vi.fn(),
   mockSaveAiUsage: vi.fn(),
@@ -22,6 +23,7 @@ const {
   mockWithTracing: vi.fn(),
   mockGetPosthogLlmClient: vi.fn(),
   mockIsPosthogLlmEvalApproved: vi.fn(),
+  mockCreateClaudeCodeLanguageModelWithBridgedTools: vi.fn(),
 }));
 
 vi.mock("ai", async () => {
@@ -44,6 +46,17 @@ vi.mock("@/utils/posthog", () => ({
 vi.mock("@posthog/ai/vercel", () => ({
   withTracing: mockWithTracing,
 }));
+
+vi.mock("@/utils/llms/cli-provider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/utils/llms/cli-provider")
+  >("@/utils/llms/cli-provider");
+  return {
+    ...actual,
+    createClaudeCodeLanguageModelWithBridgedTools:
+      mockCreateClaudeCodeLanguageModelWithBridgedTools,
+  };
+});
 
 vi.mock("./retry", async () => {
   const actual = await vi.importActual<typeof import("./retry")>("./retry");
@@ -76,6 +89,7 @@ describe("createGenerateText fallback chain", () => {
     mockIsPosthogLlmEvalApproved.mockReturnValue(false);
     mockWithTracing.mockImplementation((model) => model);
     mockSaveAiUsage.mockResolvedValue(undefined);
+    mockCreateClaudeCodeLanguageModelWithBridgedTools.mockReset();
   });
 
   it("falls back to the next provider on retryable provider failures", async () => {
@@ -170,6 +184,49 @@ describe("createGenerateText fallback chain", () => {
       provider: "openai",
       modelName: "gpt-5-mini",
     });
+  });
+
+  it("bridges Claude Code tools without passing duplicate AI SDK tools", async () => {
+    const originalModel = createModel("claude-code-model");
+    const bridgedModel = createModel("claude-code-bridged-model");
+    const tools = {
+      finalizeResults: {
+        description: "Finalize results",
+        inputSchema: {},
+        execute: vi.fn(),
+      },
+    };
+    mockCreateClaudeCodeLanguageModelWithBridgedTools.mockResolvedValue(
+      bridgedModel,
+    );
+    mockGenerateText.mockImplementation(async (request) => {
+      expect(request.model).toBe(bridgedModel);
+      expect(request.tools).toBeUndefined();
+      return createTextResult();
+    });
+
+    const generateText = createGenerateTextForTest({
+      label: "Claude Code bridge",
+      modelOptions: createModelOptions({
+        provider: "claude-code",
+        modelName: "sonnet",
+        model: originalModel,
+      }),
+    });
+
+    await generateText({
+      prompt: "hello",
+      model: originalModel,
+      tools,
+    });
+
+    expect(
+      mockCreateClaudeCodeLanguageModelWithBridgedTools,
+    ).toHaveBeenCalledWith({
+      modelName: "sonnet",
+      tools,
+    });
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
 
   it("sets openrouter user from internal user id", async () => {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -97,17 +97,40 @@ async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
   modelName,
   model,
   tools,
+  activeTools,
 }: {
   provider: string;
   modelName: string;
   model: LanguageModelV3;
   tools: T | undefined;
-}): Promise<{ model: LanguageModelV3; tools: T | undefined }> {
-  if (provider !== Provider.CLAUDE_CODE) return { model, tools };
-  if (!tools || Object.keys(tools).length === 0) return { model, tools };
+  activeTools?: Array<string>;
+}): Promise<{
+  model: LanguageModelV3;
+  tools: T | undefined;
+  bridged: boolean;
+}> {
+  if (provider !== Provider.CLAUDE_CODE)
+    return { model, tools, bridged: false };
+  if (!tools || Object.keys(tools).length === 0) {
+    return { model, tools, bridged: false };
+  }
+
+  const activeToolSet =
+    activeTools === undefined ? undefined : new Set(activeTools);
+  const toolsToBridge =
+    activeToolSet === undefined
+      ? tools
+      : (Object.fromEntries(
+          Object.entries(tools).filter(([name]) => activeToolSet.has(name)),
+        ) as T);
+
+  if (Object.keys(toolsToBridge).length === 0) {
+    return { model, tools: undefined, bridged: true };
+  }
+
   const bridged = await createClaudeCodeLanguageModelWithBridgedTools({
     modelName,
-    tools: tools as unknown as Record<
+    tools: toolsToBridge as unknown as Record<
       string,
       {
         description?: string;
@@ -116,7 +139,18 @@ async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
       }
     >,
   });
-  return { model: bridged, tools: undefined };
+  return { model: bridged, tools: undefined, bridged: true };
+}
+
+function prepareOptionsForToolBridge<TOptions extends { tools?: unknown }>({
+  options,
+  bridged,
+}: {
+  options: TOptions;
+  bridged: { bridged: boolean };
+}): TOptions {
+  if (!bridged.bridged) return options;
+  return { ...options, tools: undefined };
 }
 
 const NO_USER_AI_FIELDS: UserAIFields = {
@@ -288,10 +322,14 @@ export function createGenerateText({
         model: candidate.model,
         tools: protectedTools,
       });
+      const protectedRequestOptions = prepareOptionsForToolBridge({
+        options: protectedOptions,
+        bridged,
+      });
 
       const result = await generateText(
         {
-          ...protectedOptions,
+          ...protectedRequestOptions,
           ...(bridged.tools ? { tools: bridged.tools } : {}),
           ...commonOptions,
           providerOptions,
@@ -810,6 +848,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
       modelName: candidate.modelName,
       model: candidate.model,
       tools: candidateTools,
+      activeTools,
     });
     const model = withPosthogTracing({
       model: bridgedAgent.model,
@@ -850,9 +889,9 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
     const agent = new ToolLoopAgent({
       model,
       tools: bridgedAgent.tools,
-      activeTools: activeTools as
-        | Array<keyof typeof candidateTools>
-        | undefined,
+      activeTools: bridgedAgent.bridged
+        ? undefined
+        : (activeTools as Array<keyof typeof candidateTools> | undefined),
       prepareStep,
       stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
       temperature,

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -59,6 +59,7 @@ import {
   shouldForceNanoModel,
 } from "@/utils/llms/model-usage-guard";
 import { Provider } from "@/utils/llms/config";
+import { createClaudeCodeLanguageModelWithBridgedTools } from "@/utils/llms/cli-provider";
 import {
   appendOllamaOnlySystemGuidance,
   OLLAMA_STRUCTURED_OUTPUT_GUIDANCE,
@@ -86,6 +87,38 @@ import {
 const logger = createScopedLogger("llms");
 
 const MAX_LOG_LENGTH = 200;
+
+// The Claude Code CLI provider drops AI SDK tools at the LanguageModelV3
+// boundary. Route tool-bearing calls through the package's MCP bridge so the
+// CLI can execute them locally; clear `tools` so the AI SDK does not also try
+// to drive them. No-op for every other provider and for tool-less calls.
+async function bridgeClaudeCodeToolsIfNeeded<T extends Record<string, Tool>>({
+  provider,
+  modelName,
+  model,
+  tools,
+}: {
+  provider: string;
+  modelName: string;
+  model: LanguageModelV3;
+  tools: T | undefined;
+}): Promise<{ model: LanguageModelV3; tools: T | undefined }> {
+  if (provider !== Provider.CLAUDE_CODE) return { model, tools };
+  if (!tools || Object.keys(tools).length === 0) return { model, tools };
+  const bridged = await createClaudeCodeLanguageModelWithBridgedTools({
+    modelName,
+    tools: tools as unknown as Record<
+      string,
+      {
+        description?: string;
+        inputSchema: unknown;
+        execute?: (input: never, options?: unknown) => unknown;
+      }
+    >,
+  });
+  return { model: bridged, tools: undefined };
+}
+
 const NO_USER_AI_FIELDS: UserAIFields = {
   aiProvider: null,
   aiModel: null,
@@ -249,14 +282,21 @@ export function createGenerateText({
         emailAccountId: emailAccount.id,
       });
 
+      const bridged = await bridgeClaudeCodeToolsIfNeeded({
+        provider: candidate.provider,
+        modelName: candidate.modelName,
+        model: candidate.model,
+        tools: protectedTools,
+      });
+
       const result = await generateText(
         {
           ...protectedOptions,
-          ...(protectedTools ? { tools: protectedTools } : {}),
+          ...(bridged.tools ? { tools: bridged.tools } : {}),
           ...commonOptions,
           providerOptions,
           model: withPosthogTracing({
-            model: candidate.model,
+            model: bridged.model,
             userEmail: emailAccount.email,
             userId: emailAccount.userId,
             emailAccountId: emailAccount.id,
@@ -601,8 +641,21 @@ export async function chatCompletionStream(
       label,
       emailAccountId,
     });
-    const model = withPosthogTracing({
+    const protectedChatTools = wrapToolsWithSensitiveDataPolicy({
+      tools,
+      policy: sensitiveDataPolicy,
+      label,
+      userId,
+      emailAccountId,
+    });
+    const bridgedChat = await bridgeClaudeCodeToolsIfNeeded({
+      provider: candidate.provider,
+      modelName: candidate.modelName,
       model: candidate.model,
+      tools: protectedChatTools,
+    });
+    const model = withPosthogTracing({
+      model: bridgedChat.model,
       userEmail,
       userId,
       emailAccountId,
@@ -615,13 +668,7 @@ export async function chatCompletionStream(
       return streamText({
         model,
         messages: protectedMessages as ModelMessage[],
-        tools: wrapToolsWithSensitiveDataPolicy({
-          tools,
-          policy: sensitiveDataPolicy,
-          label,
-          userId,
-          emailAccountId,
-        }),
+        tools: bridgedChat.tools,
         stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
         ...commonOptions,
         providerOptions: providerOptions,
@@ -751,21 +798,27 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
       label,
       emailAccountId,
     });
-    const model = withPosthogTracing({
-      model: candidate.model,
-      userEmail,
-      userId,
-      emailAccountId,
-      label,
-      provider: candidate.provider,
-      modelName: candidate.modelName,
-    });
     const candidateTools = wrapToolsWithSensitiveDataPolicy({
       tools,
       policy: sensitiveDataPolicy,
       label,
       userId,
       emailAccountId,
+    });
+    const bridgedAgent = await bridgeClaudeCodeToolsIfNeeded({
+      provider: candidate.provider,
+      modelName: candidate.modelName,
+      model: candidate.model,
+      tools: candidateTools,
+    });
+    const model = withPosthogTracing({
+      model: bridgedAgent.model,
+      userEmail,
+      userId,
+      emailAccountId,
+      label,
+      provider: candidate.provider,
+      modelName: candidate.modelName,
     });
     const excludedTools: string[] = [];
     const replacedTools: string[] = [];
@@ -796,7 +849,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
 
     const agent = new ToolLoopAgent({
       model,
-      tools: candidateTools,
+      tools: bridgedAgent.tools,
       activeTools: activeTools as
         | Array<keyof typeof candidateTools>
         | undefined,


### PR DESCRIPTION
## Summary

The `claude-code` CLI provider added in #2357 cannot use AI SDK tools. The Claude Code CLI runs its own tool layer, so tools passed to `generateText`/`streamText`/`ToolLoopAgent` are dropped at the `LanguageModelV3` boundary and a warning is logged:

> `AI SDK Warning (claude-code / sonnet): The feature "tools" is not supported. The Claude Code CLI executes its own tools; AI SDK tools cannot be auto-bridged at the provider layer and will be ignored. To expose custom tools to the CLI, build an in-process MCP server with the createAiSdkMcpServer helper (exported by this package) and pass it via the mcpServers setting (plus allowedTools).`

In practice every tool-driven feature falls back to text-only behavior on the `claude-code` provider. The Assistant chat returns helpless answers about `createRule`, `searchInbox`, `getCalendarEvents` etc. not being available.

This change wires the package's `createAiSdkMcpServer` helper at the call sites so tools survive into the CLI:

- `apps/web/utils/llms/cli-provider.ts`: new `createClaudeCodeLanguageModelWithBridgedTools` helper that, given a tool record, builds an in-process MCP server (`mcp__inboxzero__<name>`) and returns a `LanguageModelV3` configured with `mcpServers` and `allowedTools`.
- `apps/web/utils/llms/index.ts`: tiny `bridgeClaudeCodeToolsIfNeeded` swap applied in `createGenerateText`, `chatCompletionStream`, and `toolCallAgentStream`. When the resolved provider is `claude-code` and tools are present, the call uses the bridged model and clears the AI SDK `tools` field so the loop does not race the MCP execution. Non-CLI providers are unchanged.

Tool execution still runs inside the CLI's MCP transport (per the package docs), so tool calls surface to the AI SDK as provider-executed dynamic tool parts named `mcp__inboxzero__<tool>`. UI labels that key off the original tool name see the prefixed name; functional execution is unchanged.

## Test plan

- [ ] `pnpm --filter inbox-zero-ai exec next build --webpack` passes.
- [ ] With `CLI_LLM_ENABLED=true`, `DEFAULT_LLMS=claude-code:sonnet`, ask the Assistant chat to "create a rule that archives newsletters" - the model should call `createRule` instead of saying it lacks access.
- [ ] With the same config, ask the chat to "what unread emails do I have today" - the model should call inbox search tools instead of asking for permission.
- [ ] Switch `DEFAULT_LLMS` back to a non-CLI provider (e.g. `anthropic:claude-sonnet-4-6`) and confirm tool behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

