### PR TITLE
fix(ui): wrap long rule names in the fix-rule selection dialog

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -254,6 +254,7 @@ function RuleMismatch({
             ...rules,
           ]}
           onSelect={onSelectExpectedRuleId}
+          itemClassName="h-auto min-h-10 justify-start whitespace-normal text-wrap py-2 text-left"
         />
       </div>
     </div>

--- a/apps/web/components/ButtonList.tsx
+++ b/apps/web/components/ButtonList.tsx
@@ -11,6 +11,7 @@ type ButtonListItem = {
 interface ButtonListProps {
   columns?: number;
   emptyMessage: string;
+  itemClassName?: string;
   items: ButtonListItem[];
   onSelect: (id: string) => void;
   selectedId?: string;
@@ -24,6 +25,7 @@ export function ButtonList({
   selectedId,
   emptyMessage,
   columns = 1,
+  itemClassName,
 }: ButtonListProps) {
   return (
     <div>
@@ -44,7 +46,7 @@ export function ButtonList({
             key={item.id}
             variant={selectedId === item.id ? "default" : "outline"}
             onClick={() => onSelect(item.id)}
-            className="h-auto min-h-10 justify-start whitespace-normal text-wrap py-2 text-left"
+            className={itemClassName}
           >
             {item.name}
           </Button>

--- a/apps/web/components/ButtonList.tsx
+++ b/apps/web/components/ButtonList.tsx
@@ -44,6 +44,7 @@ export function ButtonList({
             key={item.id}
             variant={selectedId === item.id ? "default" : "outline"}
             onClick={() => onSelect(item.id)}
+            className="h-auto min-h-10 justify-start whitespace-normal text-wrap py-2 text-left"
           >
             {item.name}
           </Button>


### PR DESCRIPTION
Long, user-defined rule names previously clipped or overflowed in the "Fix" dialog because the base button enforces no-wrap with a fixed height.

- Add an opt-in `itemClassName` prop to `ButtonList`
- Use it in the fix-rule dialog to let buttons wrap to multiple lines, grow vertically, and left-align
- Other `ButtonList` usages (persona pickers) keep their existing centered layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

