### PR TITLE
test(assistant): fix provider mock not applying in triage content eval

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -1,8 +1,7 @@
-import { afterAll, describe, expect, test } from "vitest";
-import { describeEvalMatrix } from "@/__tests__/eval/models";
-import { createEvalReporter } from "@/__tests__/eval/reporter";
-import { getMockMessage } from "@/__tests__/helpers";
-import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
+// Import test-utils first: it declares the vi.mock for the email provider and
+// prisma. Importing a module that pulls the real app graph (e.g.
+// assistant-chat-eval-utils) before this would bind the unmocked
+// createEmailProvider, so searchInbox would hit a real DB and return no content.
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -17,6 +16,11 @@ import {
   shouldRunEval,
   TIMEOUT,
 } from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+import { afterAll, describe, expect, test } from "vitest";
+import { describeEvalMatrix } from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { getMockMessage } from "@/__tests__/helpers";
+import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   formatSemanticJudgeActual,
   judgeEvalOutput,


### PR DESCRIPTION
The triage content-summary eval (added in #2845) could never pass: it imported a helper from `assistant-chat-eval-utils` before importing the `test-utils` module that declares the email-provider and prisma `vi.mock`, so the real `createEmailProvider` was bound and `searchInbox` hit a real DB and returned no email content. This reorders the imports so the mocks register before the app graph loads, and documents why the order matters. Verified the content eval now passes and that the provider mock is actually invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

