### PR TITLE
calendar: Fix provider video location handling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/booking-calendar-helpers.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/booking-calendar-helpers.ts
@@ -1,8 +1,8 @@
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
 import {
-  isGoogleProvider,
-  isMicrosoftProvider,
-} from "@/utils/email/provider-types";
+  getProviderVideoLocationType,
+  isProviderVideoLocationType,
+} from "@/utils/booking/location";
 
 export type BookingLinkCalendarData = {
   calendarConnections: Array<{
@@ -47,26 +47,7 @@ export function getSelectedCalendarProvider(
   );
 }
 
-export function getProviderVideoLocationType(
-  provider: string | null | undefined,
-) {
-  if (isGoogleProvider(provider)) {
-    return BookingLinkLocationType.GOOGLE_MEET;
-  }
-  if (isMicrosoftProvider(provider)) {
-    return BookingLinkLocationType.MICROSOFT_TEAMS;
-  }
-  return null;
-}
-
-export function isProviderVideoLocationType(
-  locationType: BookingLinkLocationType,
-) {
-  return (
-    locationType === BookingLinkLocationType.GOOGLE_MEET ||
-    locationType === BookingLinkLocationType.MICROSOFT_TEAMS
-  );
-}
+export { getProviderVideoLocationType, isProviderVideoLocationType };
 
 export function getVideoLocationLabel(
   locationType: BookingLinkLocationType | null,

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -30,8 +30,8 @@ describe("booking actions", () => {
 
   it("creates a booking link with provider video and default windows", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue(null);
-    prisma.calendar.findFirst.mockResolvedValue({ id: "calendar-id" } as any);
-    prisma.calendar.findUnique.mockResolvedValue({
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "calendar-id",
       connection: { provider: "microsoft" },
     } as any);
     prisma.bookingLink.create.mockResolvedValue({
@@ -72,8 +72,8 @@ describe("booking actions", () => {
 
   it("anchors 45-minute calls to a 30-minute slot interval", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue(null);
-    prisma.calendar.findFirst.mockResolvedValue({ id: "calendar-id" } as any);
-    prisma.calendar.findUnique.mockResolvedValue({
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "calendar-id",
       connection: { provider: "google" },
     } as any);
     prisma.bookingLink.create.mockResolvedValue({
@@ -135,8 +135,8 @@ describe("booking actions", () => {
 
   it("creates a booking link without provider video when disabled", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue(null);
-    prisma.calendar.findFirst.mockResolvedValue({ id: "calendar-id" } as any);
-    prisma.calendar.findUnique.mockResolvedValue({
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "calendar-id",
       connection: { provider: "microsoft" },
     } as any);
     prisma.bookingLink.create.mockResolvedValue({
@@ -268,6 +268,66 @@ describe("booking actions", () => {
       }),
     );
     expect(prisma.bookingLink.update).not.toHaveBeenCalled();
+  });
+
+  it("normalizes requested provider video to the destination calendar provider", async () => {
+    prisma.bookingLink.findFirst.mockResolvedValue({
+      id: "booking-link-id",
+      locationType: BookingLinkLocationType.GOOGLE_MEET,
+      destinationCalendar: { connection: { provider: "google" } },
+    } as any);
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "microsoft-calendar-id",
+      connection: { provider: "microsoft" },
+    } as any);
+    prisma.bookingLink.update.mockResolvedValue({} as any);
+
+    const result = await updateBookingLinkAction("email-account-id", {
+      id: "booking-link-id",
+      destinationCalendarId: "microsoft-calendar-id",
+      locationType: BookingLinkLocationType.GOOGLE_MEET,
+      locationValue: "stale provider location",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.bookingLink.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          destinationCalendarId: "microsoft-calendar-id",
+          locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
+          locationValue: null,
+        }),
+      }),
+    );
+  });
+
+  it("updates existing provider video when only the destination calendar changes", async () => {
+    prisma.bookingLink.findFirst.mockResolvedValue({
+      id: "booking-link-id",
+      locationType: BookingLinkLocationType.GOOGLE_MEET,
+      destinationCalendar: { connection: { provider: "google" } },
+    } as any);
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "microsoft-calendar-id",
+      connection: { provider: "microsoft" },
+    } as any);
+    prisma.bookingLink.update.mockResolvedValue({} as any);
+
+    const result = await updateBookingLinkAction("email-account-id", {
+      id: "booking-link-id",
+      destinationCalendarId: "microsoft-calendar-id",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.bookingLink.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          destinationCalendarId: "microsoft-calendar-id",
+          locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
+          locationValue: null,
+        }),
+      }),
+    );
   });
 
   it("updates link minimum notice and other fields", async () => {

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -354,6 +354,31 @@ describe("booking actions", () => {
     );
   });
 
+  it("clears stale provider video when the destination calendar is cleared", async () => {
+    prisma.bookingLink.findFirst.mockResolvedValue({
+      id: "booking-link-id",
+      locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
+      destinationCalendar: { connection: { provider: "microsoft" } },
+    } as any);
+    prisma.calendar.findFirst.mockResolvedValue(null);
+    prisma.bookingLink.update.mockResolvedValue({} as any);
+
+    const result = await updateBookingLinkAction("email-account-id", {
+      id: "booking-link-id",
+      destinationCalendarId: null,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.bookingLink.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          destinationCalendarId: null,
+          locationType: BookingLinkLocationType.CUSTOM,
+        }),
+      }),
+    );
+  });
+
   it("updates link minimum notice and other fields", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue({
       id: "booking-link-id",

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -330,6 +330,30 @@ describe("booking actions", () => {
     );
   });
 
+  it("clears the destination calendar when a null update resolves to no default calendar", async () => {
+    prisma.bookingLink.findFirst.mockResolvedValue({
+      id: "booking-link-id",
+      locationType: BookingLinkLocationType.CUSTOM,
+      destinationCalendar: null,
+    } as any);
+    prisma.calendar.findFirst.mockResolvedValue(null);
+    prisma.bookingLink.update.mockResolvedValue({} as any);
+
+    const result = await updateBookingLinkAction("email-account-id", {
+      id: "booking-link-id",
+      destinationCalendarId: null,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.bookingLink.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          destinationCalendarId: null,
+        }),
+      }),
+    );
+  });
+
   it("updates link minimum notice and other fields", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue({
       id: "booking-link-id",

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -120,7 +120,7 @@ export const updateBookingLinkAction = actionClient
         maxDaysAhead: parsedInput.maxDaysAhead,
         ...(destinationCalendarId === undefined
           ? {}
-          : { destinationCalendarId: destinationCalendarId.id }),
+          : { destinationCalendarId: destinationCalendarId?.id ?? null }),
       },
     });
 

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -12,9 +12,9 @@ import { getSlotIntervalMinutes } from "@/utils/booking/policy";
 import prisma from "@/utils/prisma";
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
 import {
-  isGoogleProvider,
-  isMicrosoftProvider,
-} from "@/utils/email/provider-types";
+  getProviderVideoLocationType,
+  isProviderVideoLocationType,
+} from "@/utils/booking/location";
 
 export const createBookingLinkAction = actionClient
   .metadata({ name: "createBookingLink" })
@@ -23,18 +23,19 @@ export const createBookingLinkAction = actionClient
     await assertNoBookingLinkForAccount({ emailAccountId });
     await assertBookingLinkSlugAvailable({ slug: parsedInput.slug });
 
-    const destinationCalendarId = await getOwnedDestinationCalendarId({
+    const destinationCalendar = await getOwnedDestinationCalendar({
       emailAccountId,
       destinationCalendarId: parsedInput.destinationCalendarId,
     });
-    if (!destinationCalendarId) {
+    if (!destinationCalendar) {
       throw new SafeError("Connect your calendar to create a booking link");
     }
 
     const durationMinutes = parsedInput.durationMinutes;
     const slotIntervalMinutes = getSlotIntervalMinutes(durationMinutes);
     const defaultLocationType =
-      await getDefaultLocationTypeForDestinationCalendar(destinationCalendarId);
+      getProviderVideoLocationType(destinationCalendar.provider) ??
+      BookingLinkLocationType.CUSTOM;
     const locationType = parsedInput.videoEnabled
       ? defaultLocationType
       : BookingLinkLocationType.CUSTOM;
@@ -49,7 +50,7 @@ export const createBookingLinkAction = actionClient
         slotIntervalMinutes,
         locationType,
         emailAccountId,
-        ...(destinationCalendarId ? { destinationCalendarId } : {}),
+        destinationCalendarId: destinationCalendar.id,
         windows: {
           create: getDefaultWindows(),
         },
@@ -64,7 +65,7 @@ export const updateBookingLinkAction = actionClient
   .metadata({ name: "updateBookingLink" })
   .inputSchema(updateBookingLinkActionBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput }) => {
-    await ensureBookingLinkOwner({
+    const bookingLink = await ensureBookingLinkOwner({
       emailAccountId,
       bookingLinkId: parsedInput.id,
     });
@@ -79,10 +80,18 @@ export const updateBookingLinkAction = actionClient
     const destinationCalendarId =
       parsedInput.destinationCalendarId === undefined
         ? undefined
-        : await getOwnedDestinationCalendarId({
+        : await getOwnedDestinationCalendar({
             emailAccountId,
             destinationCalendarId: parsedInput.destinationCalendarId,
           });
+    const locationType = getUpdatedLocationType({
+      currentLocationType: bookingLink.locationType,
+      requestedLocationType: parsedInput.locationType,
+      destinationCalendarProvider:
+        destinationCalendarId?.provider ??
+        bookingLink.destinationCalendar?.connection.provider,
+      destinationCalendarChanged: destinationCalendarId !== undefined,
+    });
 
     await prisma.bookingLink.update({
       where: { id: parsedInput.id },
@@ -100,16 +109,18 @@ export const updateBookingLinkAction = actionClient
           parsedInput.durationMinutes === undefined
             ? undefined
             : getSlotIntervalMinutes(parsedInput.durationMinutes),
-        locationType: parsedInput.locationType,
+        locationType,
         locationValue:
-          parsedInput.locationValue === undefined
-            ? undefined
-            : emptyToNull(parsedInput.locationValue),
+          locationType && isProviderVideoLocationType(locationType)
+            ? null
+            : parsedInput.locationValue === undefined
+              ? undefined
+              : emptyToNull(parsedInput.locationValue),
         minimumNoticeMinutes: parsedInput.minimumNoticeMinutes,
         maxDaysAhead: parsedInput.maxDaysAhead,
         ...(destinationCalendarId === undefined
           ? {}
-          : { destinationCalendarId }),
+          : { destinationCalendarId: destinationCalendarId.id }),
       },
     });
 
@@ -160,7 +171,17 @@ async function ensureBookingLinkOwner({
 }) {
   const bookingLink = await prisma.bookingLink.findFirst({
     where: { id: bookingLinkId, emailAccountId },
-    select: { id: true },
+    select: {
+      id: true,
+      locationType: true,
+      destinationCalendar: {
+        select: {
+          connection: {
+            select: { provider: true },
+          },
+        },
+      },
+    },
   });
 
   if (!bookingLink) throw new SafeError("Booking link not found");
@@ -183,7 +204,7 @@ async function assertNoBookingLinkForAccount({
   }
 }
 
-async function getOwnedDestinationCalendarId({
+async function getOwnedDestinationCalendar({
   emailAccountId,
   destinationCalendarId,
 }: {
@@ -197,10 +218,17 @@ async function getOwnedDestinationCalendarId({
         connection: { emailAccountId, isConnected: true },
       },
       orderBy: [{ primary: "desc" }, { createdAt: "asc" }],
-      select: { id: true },
+      select: {
+        id: true,
+        connection: {
+          select: { provider: true },
+        },
+      },
     });
 
-    return calendar?.id ?? null;
+    return calendar
+      ? { id: calendar.id, provider: calendar.connection.provider }
+      : null;
   }
 
   const calendar = await prisma.calendar.findFirst({
@@ -209,12 +237,17 @@ async function getOwnedDestinationCalendarId({
       isEnabled: true,
       connection: { emailAccountId, isConnected: true },
     },
-    select: { id: true },
+    select: {
+      id: true,
+      connection: {
+        select: { provider: true },
+      },
+    },
   });
 
   if (!calendar) throw new SafeError("Destination calendar not found");
 
-  return calendar.id;
+  return { id: calendar.id, provider: calendar.connection.provider };
 }
 
 async function assertBookingLinkSlugAvailable({
@@ -237,31 +270,31 @@ async function assertBookingLinkSlugAvailable({
   }
 }
 
-async function getDefaultLocationTypeForDestinationCalendar(
-  destinationCalendarId: string | null,
-) {
-  if (!destinationCalendarId) return BookingLinkLocationType.CUSTOM;
+function getUpdatedLocationType({
+  currentLocationType,
+  requestedLocationType,
+  destinationCalendarProvider,
+  destinationCalendarChanged,
+}: {
+  currentLocationType: BookingLinkLocationType;
+  requestedLocationType?: BookingLinkLocationType;
+  destinationCalendarProvider?: string | null;
+  destinationCalendarChanged: boolean;
+}) {
+  const locationType = requestedLocationType ?? currentLocationType;
 
-  const calendar = await prisma.calendar.findUnique({
-    where: { id: destinationCalendarId },
-    select: {
-      connection: {
-        select: { provider: true },
-      },
-    },
-  });
-
-  return getProviderVideoLocationType(calendar?.connection.provider);
-}
-
-function getProviderVideoLocationType(provider: string | null | undefined) {
-  if (isGoogleProvider(provider)) {
-    return BookingLinkLocationType.GOOGLE_MEET;
+  if (!isProviderVideoLocationType(locationType)) {
+    return requestedLocationType;
   }
-  if (isMicrosoftProvider(provider)) {
-    return BookingLinkLocationType.MICROSOFT_TEAMS;
+
+  if (!requestedLocationType && !destinationCalendarChanged) {
+    return;
   }
-  return BookingLinkLocationType.CUSTOM;
+
+  return (
+    getProviderVideoLocationType(destinationCalendarProvider) ??
+    BookingLinkLocationType.CUSTOM
+  );
 }
 
 function getDefaultWindows() {

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -84,12 +84,14 @@ export const updateBookingLinkAction = actionClient
             emailAccountId,
             destinationCalendarId: parsedInput.destinationCalendarId,
           });
+    const destinationCalendarProvider =
+      destinationCalendarId === undefined
+        ? bookingLink.destinationCalendar?.connection.provider
+        : destinationCalendarId?.provider;
     const locationType = getUpdatedLocationType({
       currentLocationType: bookingLink.locationType,
       requestedLocationType: parsedInput.locationType,
-      destinationCalendarProvider:
-        destinationCalendarId?.provider ??
-        bookingLink.destinationCalendar?.connection.provider,
+      destinationCalendarProvider,
       destinationCalendarChanged: destinationCalendarId !== undefined,
     });
 

--- a/apps/web/utils/booking/location.ts
+++ b/apps/web/utils/booking/location.ts
@@ -1,0 +1,42 @@
+import { BookingLinkLocationType } from "@/generated/prisma/enums";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
+
+export function getProviderVideoLocationType(
+  provider: string | null | undefined,
+) {
+  if (isGoogleProvider(provider)) {
+    return BookingLinkLocationType.GOOGLE_MEET;
+  }
+  if (isMicrosoftProvider(provider)) {
+    return BookingLinkLocationType.MICROSOFT_TEAMS;
+  }
+  return null;
+}
+
+export function getProviderAlignedLocationType({
+  locationType,
+  provider,
+  fallbackLocationType = locationType,
+}: {
+  locationType: BookingLinkLocationType;
+  provider: string | null | undefined;
+  fallbackLocationType?: BookingLinkLocationType;
+}) {
+  if (!isProviderVideoLocationType(locationType)) {
+    return locationType;
+  }
+
+  return getProviderVideoLocationType(provider) ?? fallbackLocationType;
+}
+
+export function isProviderVideoLocationType(
+  locationType: BookingLinkLocationType,
+) {
+  return (
+    locationType === BookingLinkLocationType.GOOGLE_MEET ||
+    locationType === BookingLinkLocationType.MICROSOFT_TEAMS
+  );
+}

--- a/apps/web/utils/calendar/event-writer.test.ts
+++ b/apps/web/utils/calendar/event-writer.test.ts
@@ -5,6 +5,7 @@ import {
   cancelCalendarEvent,
   createCalendarEvent,
 } from "@/utils/calendar/event-writer";
+import { BookingLinkLocationType } from "@/generated/prisma/enums";
 
 const providerMocks = vi.hoisted(() => ({
   cancelEvent: vi.fn(),
@@ -197,7 +198,40 @@ describe("createCalendarEvent", () => {
     expect(providerMocks.createEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         calendarId: "microsoft-calendar",
+        locationType: "CUSTOM",
         title: "Intro call",
+      }),
+    );
+  });
+
+  it("normalizes stale provider video locations to the writable calendar provider", async () => {
+    prisma.calendar.findFirst.mockResolvedValue({
+      calendarId: "microsoft-calendar",
+      connection: {
+        id: "connection-id",
+        provider: "microsoft",
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: new Date("2026-05-04T00:00:00.000Z"),
+      },
+    });
+
+    await createCalendarEvent({
+      attendees: [{ name: "Guest User", email: "guest@example.com" }],
+      destinationCalendarId: "calendar-row-id",
+      emailAccountId: "email-account-id",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: BookingLinkLocationType.GOOGLE_MEET,
+      logger: createTestLogger(),
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "UTC",
+      title: "Intro call",
+    });
+
+    expect(providerMocks.createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarId: "microsoft-calendar",
+        locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
       }),
     );
   });

--- a/apps/web/utils/calendar/event-writer.ts
+++ b/apps/web/utils/calendar/event-writer.ts
@@ -7,6 +7,7 @@ import {
 } from "@/utils/email/provider-types";
 import { GoogleCalendarEventProvider } from "@/utils/calendar/providers/google-events";
 import { MicrosoftCalendarEventProvider } from "@/utils/calendar/providers/microsoft-events";
+import { getProviderAlignedLocationType } from "@/utils/booking/location";
 import type { BookingLinkLocationType } from "@/generated/prisma/enums";
 import type {
   CalendarEventAttendee,
@@ -64,7 +65,10 @@ export async function createCalendarEvent({
     endTime,
     timezone,
     attendees,
-    locationType,
+    locationType: getProviderAlignedLocationType({
+      locationType,
+      provider: destination.connection.provider,
+    }),
     locationValue,
   });
 


### PR DESCRIPTION
Ensure booking link video conferencing follows the selected calendar provider when events are created or link settings change.

- Centralize provider video location mapping
- Normalize provider-video locations at update and event-write boundaries
- Add regression coverage for stale provider-video configuration

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

