### PR TITLE
calendar: Fix conferencing fallback

### DIFF
--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -4,8 +4,9 @@ import { MicrosoftCalendarEventProvider } from "@/utils/calendar/providers/micro
 
 const graphMocks = vi.hoisted(() => ({
   api: vi.fn(),
-  post: vi.fn(),
   get: vi.fn(),
+  patch: vi.fn(),
+  post: vi.fn(),
 }));
 
 vi.mock("@/utils/outlook/calendar-client", () => ({
@@ -18,8 +19,9 @@ describe("MicrosoftCalendarEventProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     graphMocks.api.mockReturnValue({
-      post: graphMocks.post,
       get: graphMocks.get,
+      patch: graphMocks.patch,
+      post: graphMocks.post,
     });
   });
 
@@ -30,15 +32,7 @@ describe("MicrosoftCalendarEventProvider", () => {
       webLink: "https://outlook.example.com/event",
     });
 
-    const provider = new MicrosoftCalendarEventProvider(
-      {
-        accessToken: "access-token",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        refreshToken: "refresh-token",
-      },
-      createTestLogger(),
-    );
+    const provider = createProvider();
 
     const result = await provider.createEvent({
       attendees: [{ email: "guest@example.com", name: "Guest User" }],
@@ -96,15 +90,7 @@ describe("MicrosoftCalendarEventProvider", () => {
       webLink: "https://outlook.example.com/event",
     });
 
-    const provider = new MicrosoftCalendarEventProvider(
-      {
-        accessToken: "access-token",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        refreshToken: "refresh-token",
-      },
-      createTestLogger(),
-    );
+    const provider = createProvider();
 
     const result = await provider.createEvent({
       attendees: [{ email: "guest@example.com", name: "Guest User" }],
@@ -126,21 +112,58 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
   });
 
+  it("patches the event when Teams join URL is still missing after refetch", async () => {
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      isOnlineMeeting: false,
+      onlineMeetingProvider: "unknown",
+      onlineMeeting: null,
+      webLink: "https://outlook.example.com/event",
+    });
+    graphMocks.get.mockResolvedValue({
+      id: "event-id",
+      isOnlineMeeting: false,
+      onlineMeetingProvider: "unknown",
+      onlineMeeting: null,
+      webLink: "https://outlook.example.com/event",
+    });
+    graphMocks.patch.mockResolvedValue({
+      id: "event-id",
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
+      onlineMeeting: { joinUrl: "https://teams.example.com/join" },
+      webLink: "https://outlook.example.com/event",
+    });
+
+    const provider = createProvider();
+
+    const result = await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id");
+    expect(graphMocks.patch).toHaveBeenCalledWith({
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
+    });
+    expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
+  });
+
   it("does not refetch when Teams was not requested", async () => {
     graphMocks.post.mockResolvedValue({
       id: "event-id",
       webLink: "https://outlook.example.com/event",
     });
 
-    const provider = new MicrosoftCalendarEventProvider(
-      {
-        accessToken: "access-token",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        refreshToken: "refresh-token",
-      },
-      createTestLogger(),
-    );
+    const provider = createProvider();
 
     await provider.createEvent({
       attendees: [{ email: "guest@example.com", name: "Guest User" }],
@@ -158,15 +181,7 @@ describe("MicrosoftCalendarEventProvider", () => {
   });
 
   it("cancels events through the Graph cancel action so attendees are notified", async () => {
-    const provider = new MicrosoftCalendarEventProvider(
-      {
-        accessToken: "access-token",
-        emailAccountId: "email-account-id",
-        expiresAt: null,
-        refreshToken: "refresh-token",
-      },
-      createTestLogger(),
-    );
+    const provider = createProvider();
 
     await provider.cancelEvent({
       calendarId: "calendar-id",
@@ -177,3 +192,15 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(graphMocks.post).toHaveBeenCalledWith({ comment: "" });
   });
 });
+
+function createProvider() {
+  return new MicrosoftCalendarEventProvider(
+    {
+      accessToken: "access-token",
+      emailAccountId: "email-account-id",
+      expiresAt: null,
+      refreshToken: "refresh-token",
+    },
+    createTestLogger(),
+  );
+}

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -180,6 +180,23 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       }
     }
 
+    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+      try {
+        const patched: MicrosoftEvent = await client
+          .api(`/me/events/${response.id}`)
+          .patch({
+            isOnlineMeeting: true,
+            onlineMeetingProvider: "teamsForBusiness",
+          });
+        videoConferenceLink = getJoinUrl(patched);
+      } catch (error) {
+        this.logger.warn("Failed to enable Microsoft Teams on event", {
+          eventId: response.id,
+          error,
+        });
+      }
+    }
+
     return {
       id: response.id || "",
       providerCalendarId: input.calendarId,


### PR DESCRIPTION
Adds a fallback that updates a newly created calendar event when the provider does not return a conferencing link after creation and refetch.\n\n- Preserves the existing create-and-refetch behavior for successful responses.\n- Adds unit coverage for the missing-link fallback path.\n\nVerified with focused unit tests and file-level style checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

