### PR TITLE
drive: Cascade folder tree selection

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
@@ -62,6 +62,12 @@ import {
 import { Input } from "@/components/Input";
 import { useDialogState } from "@/hooks/useDialogState";
 import { useDriveConnections } from "@/hooks/useDriveConnections";
+import {
+  applyFolderSelection,
+  buildFolderChildrenMap,
+  getFolderSelectionState,
+  type FolderChildrenMap,
+} from "./allowed-folder-selection";
 
 export function AllowedFolders({ emailAccountId }: { emailAccountId: string }) {
   const { data, isLoading, error, mutate } = useDriveFolders(emailAccountId);
@@ -108,6 +114,8 @@ function AllowedFoldersContent({
     [savedFolders],
   );
   const prevServerFolderIds = useRef(serverFolderIds);
+  const [childrenByParentId, setChildrenByParentId] =
+    useState<FolderChildrenMap>(() => buildFolderChildrenMap(availableFolders));
 
   useEffect(() => {
     if (serverFolderIds === prevServerFolderIds.current) return;
@@ -115,72 +123,98 @@ function AllowedFoldersContent({
     setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
   }, [savedFolders, serverFolderIds]);
 
-  const handleFolderToggle = useCallback(
-    async (folder: FolderItem, isChecked: boolean) => {
-      const folderPath = folder.path || folder.name;
+  useEffect(() => {
+    setChildrenByParentId(buildFolderChildrenMap(availableFolders));
+  }, [availableFolders]);
 
-      setOptimisticFolderIds((prev) => {
-        const next = new Set(prev);
-        if (isChecked) next.add(folder.id);
-        else next.delete(folder.id);
+  const handleChildrenLoaded = useCallback(
+    (parentId: string, children: FolderItem[]) => {
+      setChildrenByParentId((prev) => {
+        const existingChildren = prev.get(parentId);
+        if (
+          existingChildren &&
+          existingChildren.map((child) => child.id).join(",") ===
+            children.map((child) => child.id).join(",")
+        ) {
+          return prev;
+        }
+
+        const next = new Map(prev);
+        next.set(parentId, children);
         return next;
       });
+    },
+    [],
+  );
+
+  const handleFolderToggle = useCallback(
+    async (folder: FolderItem, isChecked: boolean) => {
+      const previousFolderIds = optimisticFolderIds;
+      const { nextFolderIds, changedFolders } = applyFolderSelection({
+        folder,
+        isChecked,
+        selectedFolderIds: previousFolderIds,
+        childrenByParentId,
+      });
+
+      setOptimisticFolderIds(nextFolderIds);
 
       try {
         if (isChecked) {
-          const result = await addFilingFolderAction(emailAccountId, {
-            folderId: folder.id,
-            folderName: folder.name,
-            folderPath,
-            driveConnectionId: folder.driveConnectionId,
-          });
+          const results = await Promise.all(
+            changedFolders.map((changedFolder) =>
+              addFilingFolderAction(emailAccountId, {
+                folderId: changedFolder.id,
+                folderName: changedFolder.name,
+                folderPath: changedFolder.path || changedFolder.name,
+                driveConnectionId: changedFolder.driveConnectionId,
+              }),
+            ),
+          );
+          const serverError = results.find(
+            (result) => result?.serverError,
+          )?.serverError;
 
-          if (result?.serverError) {
-            setOptimisticFolderIds((prev) => {
-              const next = new Set(prev);
-              next.delete(folder.id);
-              return next;
-            });
+          if (serverError) {
+            setOptimisticFolderIds(previousFolderIds);
             toastError({
               title: "Error adding folder",
-              description: result.serverError,
+              description: serverError,
             });
           } else {
             mutateFolders();
           }
         } else {
-          const result = await removeFilingFolderAction(emailAccountId, {
-            folderId: folder.id,
-          });
+          const results = await Promise.all(
+            changedFolders.map((changedFolder) =>
+              removeFilingFolderAction(emailAccountId, {
+                folderId: changedFolder.id,
+              }),
+            ),
+          );
+          const serverError = results.find(
+            (result) => result?.serverError,
+          )?.serverError;
 
-          if (result?.serverError) {
-            setOptimisticFolderIds((prev) => {
-              const next = new Set(prev);
-              next.add(folder.id);
-              return next;
-            });
+          if (serverError) {
+            setOptimisticFolderIds(previousFolderIds);
             toastError({
               title: "Error removing folder",
-              description: result.serverError,
+              description: serverError,
             });
           } else {
             mutateFolders();
           }
         }
       } catch {
-        setOptimisticFolderIds((prev) => {
-          const next = new Set(prev);
-          if (isChecked) next.delete(folder.id);
-          else next.add(folder.id);
-          return next;
-        });
+        setOptimisticFolderIds(previousFolderIds);
         toastError({
           title: isChecked ? "Error adding folder" : "Error removing folder",
           description: "Please try again.",
         });
       }
     },
-    [emailAccountId, mutateFolders],
+    [childrenByParentId, emailAccountId, mutateFolders, optimisticFolderIds],
   );
 
   const rootFolders = useMemo(() => {
@@ -198,17 +232,6 @@ function AllowedFoldersContent({
     }
 
     return roots;
-  }, [availableFolders]);
-
-  const folderChildrenMap = useMemo(() => {
-    const map = new Map<string, FolderItem[]>();
-    for (const folder of availableFolders) {
-      if (folder.parentId) {
-        if (!map.has(folder.parentId)) map.set(folder.parentId, []);
-        map.get(folder.parentId)!.push(folder);
-      }
-    }
-    return map;
   }, [availableFolders]);
 
   const savedFolderIds = optimisticFolderIds;
@@ -248,7 +271,9 @@ function AllowedFoldersContent({
                     onToggle={handleFolderToggle}
                     level={0}
                     parentPath=""
-                    knownChildren={folderChildrenMap.get(folder.id)}
+                    childrenByParentId={childrenByParentId}
+                    onChildrenLoaded={handleChildrenLoaded}
+                    knownChildren={childrenByParentId.get(folder.id)}
                   />
                 ))}
               </TreeView>
@@ -283,21 +308,24 @@ export function FolderNode({
   isLast,
   selectedFolderIds,
   onToggle,
+  onChildrenLoaded,
   level,
   parentPath,
+  childrenByParentId,
   knownChildren,
 }: {
   folder: FolderItem;
   isLast: boolean;
   selectedFolderIds: Set<string>;
   onToggle: (folder: FolderItem, isChecked: boolean) => void;
+  onChildrenLoaded: (parentId: string, children: FolderItem[]) => void;
   level: number;
   parentPath: string;
+  childrenByParentId: FolderChildrenMap;
   knownChildren?: FolderItem[];
 }) {
   const { expandedIds } = useTree();
   const isExpanded = expandedIds.has(folder.id);
-  const isSelected = selectedFolderIds.has(folder.id);
   const currentPath = parentPath ? `${parentPath}/${folder.name}` : folder.name;
 
   const { data: subfoldersData, isLoading: isLoadingSubfolders } =
@@ -310,8 +338,27 @@ export function FolderNode({
         : null,
     );
 
-  const subfolders = subfoldersData?.folders ?? knownChildren ?? [];
+  const rawSubfolders = knownChildren ?? subfoldersData?.folders ?? [];
+  const subfolders = useMemo(
+    () =>
+      rawSubfolders.map((subfolder) => ({
+        ...subfolder,
+        parentId: folder.id,
+        path: `${currentPath}/${subfolder.name}`,
+      })),
+    [currentPath, folder.id, rawSubfolders],
+  );
+  const checkboxState = getFolderSelectionState({
+    folderId: folder.id,
+    selectedFolderIds,
+    childrenByParentId,
+  });
   const hasLoadedChildren = subfolders.length > 0;
+
+  useEffect(() => {
+    if (!subfoldersData?.folders) return;
+    onChildrenLoaded(folder.id, subfolders);
+  }, [folder.id, onChildrenLoaded, subfolders, subfoldersData?.folders]);
 
   return (
     <TreeNode nodeId={folder.id} level={level} isLast={isLast}>
@@ -327,7 +374,7 @@ export function FolderNode({
         <div className="flex flex-1 items-center gap-2">
           <Checkbox
             id={`folder-${folder.id}`}
-            checked={isSelected}
+            checked={checkboxState}
             onCheckedChange={(checked) =>
               onToggle({ ...folder, path: currentPath }, checked === true)
             }
@@ -353,8 +400,11 @@ export function FolderNode({
               isLast={index === subfolders.length - 1}
               selectedFolderIds={selectedFolderIds}
               onToggle={onToggle}
+              onChildrenLoaded={onChildrenLoaded}
               level={level + 1}
               parentPath={currentPath}
+              childrenByParentId={childrenByParentId}
+              knownChildren={childrenByParentId.get(subfolder.id)}
             />
           ))
         ) : isExpanded && !isLoadingSubfolders ? (

--- a/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
@@ -66,6 +66,8 @@ import {
   applyFolderSelection,
   buildFolderChildrenMap,
   getFolderSelectionState,
+  getRootFolders,
+  mergeFolderChildren,
   type FolderChildrenMap,
 } from "./allowed-folder-selection";
 
@@ -129,20 +131,9 @@ function AllowedFoldersContent({
 
   const handleChildrenLoaded = useCallback(
     (parentId: string, children: FolderItem[]) => {
-      setChildrenByParentId((prev) => {
-        const existingChildren = prev.get(parentId);
-        if (
-          existingChildren &&
-          existingChildren.map((child) => child.id).join(",") ===
-            children.map((child) => child.id).join(",")
-        ) {
-          return prev;
-        }
-
-        const next = new Map(prev);
-        next.set(parentId, children);
-        return next;
-      });
+      setChildrenByParentId((prev) =>
+        mergeFolderChildren({ childrenByParentId: prev, parentId, children }),
+      );
     },
     [],
   );
@@ -217,22 +208,10 @@ function AllowedFoldersContent({
     [childrenByParentId, emailAccountId, mutateFolders, optimisticFolderIds],
   );
 
-  const rootFolders = useMemo(() => {
-    const folderMap = new Map<string, FolderItem>();
-    const roots: FolderItem[] = [];
-
-    for (const folder of availableFolders) {
-      folderMap.set(folder.id, folder);
-    }
-
-    for (const folder of availableFolders) {
-      if (!folder.parentId || !folderMap.has(folder.parentId)) {
-        roots.push(folder);
-      }
-    }
-
-    return roots;
-  }, [availableFolders]);
+  const rootFolders = useMemo(
+    () => getRootFolders(availableFolders),
+    [availableFolders],
+  );
 
   const savedFolderIds = optimisticFolderIds;
   const hasFolders = rootFolders.length > 0;

--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
@@ -57,6 +57,11 @@ import {
   FolderNode,
   NoFoldersFound,
 } from "./AllowedFolders";
+import {
+  applyFolderSelection,
+  buildFolderChildrenMap,
+  type FolderChildrenMap,
+} from "./allowed-folder-selection";
 import type {
   FolderItem,
   SavedFolder,
@@ -708,82 +713,132 @@ function SetupFolderSelection({
   const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
     () => new Set(savedFolders.map((f) => f.folderId)),
   );
+  const [childrenByParentId, setChildrenByParentId] =
+    useState<FolderChildrenMap>(() => buildFolderChildrenMap(availableFolders));
   // TODO: This assumes a single drive connection; swap to a selected connection ID when multi-connection UX exists.
   const driveConnectionId = connections[0]?.id ?? null;
 
   // Sync optimistic state when server data changes
   const serverFolderIds = savedFolders.map((f) => f.folderId).join(",");
   const prevServerFolderIds = useRef(serverFolderIds);
-  if (serverFolderIds !== prevServerFolderIds.current) {
+  useEffect(() => {
+    if (serverFolderIds === prevServerFolderIds.current) return;
     prevServerFolderIds.current = serverFolderIds;
     setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
-  }
+  }, [savedFolders, serverFolderIds]);
+
+  const initialChildrenByParentId = useMemo(
+    () => buildFolderChildrenMap(availableFolders),
+    [availableFolders],
+  );
+  useEffect(() => {
+    setChildrenByParentId(initialChildrenByParentId);
+  }, [initialChildrenByParentId]);
+
+  const handleChildrenLoaded = useCallback(
+    (parentId: string, children: FolderItem[]) => {
+      setChildrenByParentId((prev) => {
+        const existingChildren = prev.get(parentId);
+        if (
+          existingChildren &&
+          existingChildren.map((child) => child.id).join(",") ===
+            children.map((child) => child.id).join(",")
+        ) {
+          return prev;
+        }
+
+        const next = new Map(prev);
+        next.set(parentId, children);
+        return next;
+      });
+    },
+    [],
+  );
 
   const handleFolderToggle = useCallback(
     async (folder: FolderItem, isChecked: boolean) => {
-      const folderPath = folder.path || folder.name;
-
-      // Optimistic update
-      setOptimisticFolderIds((prev) => {
-        const next = new Set(prev);
-        if (isChecked) {
-          next.add(folder.id);
-        } else {
-          next.delete(folder.id);
-        }
-        return next;
+      const previousFolderIds = optimisticFolderIds;
+      const { nextFolderIds, changedFolders } = applyFolderSelection({
+        folder,
+        isChecked,
+        selectedFolderIds: previousFolderIds,
+        childrenByParentId,
       });
 
-      if (isChecked) {
-        analytics.captureAction("auto_file_folder_selected", {
-          saved_folder_count: optimisticFolderIds.size + 1,
-        });
-        const result = await addFilingFolderAction(emailAccountId, {
-          folderId: folder.id,
-          folderName: folder.name,
-          folderPath,
-          driveConnectionId: folder.driveConnectionId,
-        });
+      setOptimisticFolderIds(nextFolderIds);
 
-        if (result?.serverError) {
-          // Revert on error
-          setOptimisticFolderIds((prev) => {
-            const next = new Set(prev);
-            next.delete(folder.id);
-            return next;
+      try {
+        if (isChecked) {
+          analytics.captureAction("auto_file_folder_selected", {
+            saved_folder_count:
+              optimisticFolderIds.size + changedFolders.length,
           });
-          toastError({
-            title: "Error adding folder",
-            description: result.serverError,
-          });
-        } else {
-          mutateFolders();
-        }
-      } else {
-        analytics.captureAction("auto_file_folder_removed", {
-          saved_folder_count: Math.max(optimisticFolderIds.size - 1, 0),
-        });
-        const result = await removeFilingFolderAction(emailAccountId, {
-          folderId: folder.id,
-        });
+          const results = await Promise.all(
+            changedFolders.map((changedFolder) =>
+              addFilingFolderAction(emailAccountId, {
+                folderId: changedFolder.id,
+                folderName: changedFolder.name,
+                folderPath: changedFolder.path || changedFolder.name,
+                driveConnectionId: changedFolder.driveConnectionId,
+              }),
+            ),
+          );
+          const serverError = results.find(
+            (result) => result?.serverError,
+          )?.serverError;
 
-        if (result?.serverError) {
-          // Revert on error
-          setOptimisticFolderIds((prev) => {
-            const next = new Set(prev);
-            next.add(folder.id);
-            return next;
-          });
-          toastError({
-            title: "Error removing folder",
-            description: result.serverError,
-          });
+          if (serverError) {
+            setOptimisticFolderIds(previousFolderIds);
+            toastError({
+              title: "Error adding folder",
+              description: serverError,
+            });
+          } else {
+            mutateFolders();
+          }
         } else {
-          mutateFolders();
+          analytics.captureAction("auto_file_folder_removed", {
+            saved_folder_count: Math.max(
+              optimisticFolderIds.size - changedFolders.length,
+              0,
+            ),
+          });
+          const results = await Promise.all(
+            changedFolders.map((changedFolder) =>
+              removeFilingFolderAction(emailAccountId, {
+                folderId: changedFolder.id,
+              }),
+            ),
+          );
+          const serverError = results.find(
+            (result) => result?.serverError,
+          )?.serverError;
+
+          if (serverError) {
+            setOptimisticFolderIds(previousFolderIds);
+            toastError({
+              title: "Error removing folder",
+              description: serverError,
+            });
+          } else {
+            mutateFolders();
+          }
         }
+      } catch {
+        setOptimisticFolderIds(previousFolderIds);
+        toastError({
+          title: isChecked ? "Error adding folder" : "Error removing folder",
+          description: "Please try again.",
+        });
       }
     },
-    [analytics, emailAccountId, mutateFolders, optimisticFolderIds.size],
+    [
+      analytics,
+      childrenByParentId,
+      emailAccountId,
+      mutateFolders,
+      optimisticFolderIds,
+    ],
   );
 
   const rootFolders = useMemo(() => {
@@ -801,17 +856,6 @@ function SetupFolderSelection({
     }
 
     return roots;
-  }, [availableFolders]);
-
-  const folderChildrenMap = useMemo(() => {
-    const map = new Map<string, FolderItem[]>();
-    for (const folder of availableFolders) {
-      if (folder.parentId) {
-        if (!map.has(folder.parentId)) map.set(folder.parentId, []);
-        map.get(folder.parentId)!.push(folder);
-      }
-    }
-    return map;
   }, [availableFolders]);
 
   return (
@@ -853,7 +897,9 @@ function SetupFolderSelection({
                       onToggle={handleFolderToggle}
                       level={0}
                       parentPath=""
-                      knownChildren={folderChildrenMap.get(folder.id)}
+                      childrenByParentId={childrenByParentId}
+                      onChildrenLoaded={handleChildrenLoaded}
+                      knownChildren={childrenByParentId.get(folder.id)}
                     />
                   ))}
                 </TreeView>

--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -60,6 +60,8 @@ import {
 import {
   applyFolderSelection,
   buildFolderChildrenMap,
+  getRootFolders,
+  mergeFolderChildren,
   type FolderChildrenMap,
 } from "./allowed-folder-selection";
 import type {
@@ -727,30 +729,15 @@ function SetupFolderSelection({
     setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
   }, [savedFolders, serverFolderIds]);
 
-  const initialChildrenByParentId = useMemo(
-    () => buildFolderChildrenMap(availableFolders),
-    [availableFolders],
-  );
   useEffect(() => {
-    setChildrenByParentId(initialChildrenByParentId);
-  }, [initialChildrenByParentId]);
+    setChildrenByParentId(buildFolderChildrenMap(availableFolders));
+  }, [availableFolders]);
 
   const handleChildrenLoaded = useCallback(
     (parentId: string, children: FolderItem[]) => {
-      setChildrenByParentId((prev) => {
-        const existingChildren = prev.get(parentId);
-        if (
-          existingChildren &&
-          existingChildren.map((child) => child.id).join(",") ===
-            children.map((child) => child.id).join(",")
-        ) {
-          return prev;
-        }
-
-        const next = new Map(prev);
-        next.set(parentId, children);
-        return next;
-      });
+      setChildrenByParentId((prev) =>
+        mergeFolderChildren({ childrenByParentId: prev, parentId, children }),
+      );
     },
     [],
   );
@@ -841,22 +828,10 @@ function SetupFolderSelection({
     ],
   );
 
-  const rootFolders = useMemo(() => {
-    const folderMap = new Map<string, FolderItem>();
-    const roots: FolderItem[] = [];
-
-    for (const folder of availableFolders) {
-      folderMap.set(folder.id, folder);
-    }
-
-    for (const folder of availableFolders) {
-      if (!folder.parentId || !folderMap.has(folder.parentId)) {
-        roots.push(folder);
-      }
-    }
-
-    return roots;
-  }, [availableFolders]);
+  const rootFolders = useMemo(
+    () => getRootFolders(availableFolders),
+    [availableFolders],
+  );
 
   return (
     <div>

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { FolderItem } from "@/app/api/user/drive/folders/route";
+import {
+  applyFolderSelection,
+  buildFolderChildrenMap,
+  getFolderSelectionState,
+} from "./allowed-folder-selection";
+
+describe("allowed folder selection", () => {
+  it("selects a folder and its loaded descendants", () => {
+    const folders = [
+      folder("parent"),
+      folder("child-a", "parent"),
+      folder("child-b", "parent"),
+      folder("grandchild", "child-a"),
+    ];
+
+    const result = applyFolderSelection({
+      folder: folders[0],
+      isChecked: true,
+      selectedFolderIds: new Set(["existing"]),
+      childrenByParentId: buildFolderChildrenMap(folders),
+    });
+
+    expect([...result.nextFolderIds].sort()).toEqual([
+      "child-a",
+      "child-b",
+      "existing",
+      "grandchild",
+      "parent",
+    ]);
+    expect(
+      result.changedFolders.map((selectedFolder) => selectedFolder.id),
+    ).toEqual(["parent", "child-a", "grandchild", "child-b"]);
+  });
+
+  it("deselects a folder and its loaded descendants", () => {
+    const folders = [
+      folder("parent"),
+      folder("child-a", "parent"),
+      folder("child-b", "parent"),
+      folder("unrelated"),
+    ];
+
+    const result = applyFolderSelection({
+      folder: folders[0],
+      isChecked: false,
+      selectedFolderIds: new Set(["parent", "child-a", "unrelated"]),
+      childrenByParentId: buildFolderChildrenMap(folders),
+    });
+
+    expect([...result.nextFolderIds].sort()).toEqual(["unrelated"]);
+    expect(
+      result.changedFolders.map((selectedFolder) => selectedFolder.id),
+    ).toEqual(["parent", "child-a"]);
+  });
+
+  it("marks a parent as indeterminate when only some descendants are selected", () => {
+    const folders = [
+      folder("parent"),
+      folder("child-a", "parent"),
+      folder("child-b", "parent"),
+    ];
+
+    expect(
+      getFolderSelectionState({
+        folderId: "parent",
+        selectedFolderIds: new Set(["child-a"]),
+        childrenByParentId: buildFolderChildrenMap(folders),
+      }),
+    ).toBe("indeterminate");
+  });
+
+  it("marks a parent as checked when every loaded descendant is selected", () => {
+    const folders = [
+      folder("parent"),
+      folder("child-a", "parent"),
+      folder("child-b", "parent"),
+    ];
+
+    expect(
+      getFolderSelectionState({
+        folderId: "parent",
+        selectedFolderIds: new Set(["child-a", "child-b"]),
+        childrenByParentId: buildFolderChildrenMap(folders),
+      }),
+    ).toBe(true);
+  });
+});
+
+function folder(id: string, parentId?: string): FolderItem {
+  return {
+    id,
+    name: id,
+    path: id,
+    driveConnectionId: "drive-connection",
+    provider: "google",
+    parentId,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
@@ -4,9 +4,39 @@ import {
   applyFolderSelection,
   buildFolderChildrenMap,
   getFolderSelectionState,
+  getRootFolders,
+  mergeFolderChildren,
 } from "./allowed-folder-selection";
 
 describe("allowed folder selection", () => {
+  it("returns folders without a loaded parent as roots", () => {
+    const folders = [
+      folder("parent"),
+      folder("child", "parent"),
+      folder("orphan", "missing"),
+    ];
+
+    expect(getRootFolders(folders).map((root) => root.id)).toEqual([
+      "parent",
+      "orphan",
+    ]);
+  });
+
+  it("preserves the children map when loaded children have not changed", () => {
+    const childrenByParentId = buildFolderChildrenMap([
+      folder("parent"),
+      folder("child", "parent"),
+    ]);
+
+    expect(
+      mergeFolderChildren({
+        childrenByParentId,
+        parentId: "parent",
+        children: [folder("child", "parent")],
+      }),
+    ).toBe(childrenByParentId);
+  });
+
   it("selects a folder and its loaded descendants", () => {
     const folders = [
       folder("parent"),

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
@@ -1,0 +1,87 @@
+import type { FolderItem } from "@/app/api/user/drive/folders/route";
+
+export type FolderChildrenMap = Map<string, FolderItem[]>;
+export type FolderSelectionState = boolean | "indeterminate";
+
+export function buildFolderChildrenMap(folders: FolderItem[]) {
+  const map: FolderChildrenMap = new Map();
+
+  for (const folder of folders) {
+    if (!folder.parentId) continue;
+    const children = map.get(folder.parentId) ?? [];
+    children.push(folder);
+    map.set(folder.parentId, children);
+  }
+
+  return map;
+}
+
+export function getFolderSelectionState({
+  folderId,
+  selectedFolderIds,
+  childrenByParentId,
+}: {
+  folderId: string;
+  selectedFolderIds: Set<string>;
+  childrenByParentId: FolderChildrenMap;
+}): FolderSelectionState {
+  if (selectedFolderIds.has(folderId)) return true;
+
+  const descendants = getLoadedDescendants(folderId, childrenByParentId);
+  if (descendants.length === 0) return false;
+
+  const selectedDescendants = descendants.filter((folder) =>
+    selectedFolderIds.has(folder.id),
+  );
+
+  if (selectedDescendants.length === 0) return false;
+  if (selectedDescendants.length === descendants.length) return true;
+
+  return "indeterminate";
+}
+
+export function applyFolderSelection({
+  folder,
+  isChecked,
+  selectedFolderIds,
+  childrenByParentId,
+}: {
+  folder: FolderItem;
+  isChecked: boolean;
+  selectedFolderIds: Set<string>;
+  childrenByParentId: FolderChildrenMap;
+}) {
+  const nextFolderIds = new Set(selectedFolderIds);
+  const affectedFolders = [
+    folder,
+    ...getLoadedDescendants(folder.id, childrenByParentId),
+  ];
+
+  const changedFolders = affectedFolders.filter((affectedFolder) => {
+    const wasSelected = selectedFolderIds.has(affectedFolder.id);
+    if (isChecked) {
+      nextFolderIds.add(affectedFolder.id);
+      return !wasSelected;
+    }
+
+    nextFolderIds.delete(affectedFolder.id);
+    return wasSelected;
+  });
+
+  return { nextFolderIds, changedFolders };
+}
+
+function getLoadedDescendants(
+  folderId: string,
+  childrenByParentId: FolderChildrenMap,
+) {
+  const descendants: FolderItem[] = [];
+  const children = childrenByParentId.get(folderId) ?? [];
+
+  for (const child of children) {
+    descendants.push(child);
+    descendants.push(...getLoadedDescendants(child.id, childrenByParentId));
+  }
+
+  return descendants;
+}

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
@@ -16,6 +16,45 @@ export function buildFolderChildrenMap(folders: FolderItem[]) {
   return map;
 }
 
+export function getRootFolders(folders: FolderItem[]) {
+  const folderMap = new Map<string, FolderItem>();
+  const roots: FolderItem[] = [];
+
+  for (const folder of folders) {
+    folderMap.set(folder.id, folder);
+  }
+
+  for (const folder of folders) {
+    if (!folder.parentId || !folderMap.has(folder.parentId)) {
+      roots.push(folder);
+    }
+  }
+
+  return roots;
+}
+
+export function mergeFolderChildren({
+  childrenByParentId,
+  parentId,
+  children,
+}: {
+  childrenByParentId: FolderChildrenMap;
+  parentId: string;
+  children: FolderItem[];
+}) {
+  const existingChildren = childrenByParentId.get(parentId);
+  if (
+    existingChildren &&
+    getFolderIdsKey(existingChildren) === getFolderIdsKey(children)
+  ) {
+    return childrenByParentId;
+  }
+
+  const next = new Map(childrenByParentId);
+  next.set(parentId, children);
+  return next;
+}
+
 export function getFolderSelectionState({
   folderId,
   selectedFolderIds,
@@ -84,4 +123,8 @@ function getLoadedDescendants(
   }
 
   return descendants;
+}
+
+function getFolderIdsKey(folders: FolderItem[]) {
+  return folders.map((folder) => folder.id).join(",");
 }

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 
 import { cn } from "@/utils/index";
 
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
       className,
     )}
     {...props}
@@ -21,7 +21,11 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      {props.checked === "indeterminate" ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Check className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));


### PR DESCRIPTION
Updates folder tree selection so checking a folder applies to loaded descendants and child selections can reflect an indeterminate parent state.

- Shares selection logic between setup and settings flows.
- Adds unit coverage for cascade and indeterminate selection states.
- Updates shared checkbox rendering for indeterminate state.

Validation: pnpm test app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts; pnpm --filter inbox-zero-ai lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

