### PR TITLE
Fix Outlook Teams meeting link generation for booking events

### DIFF
--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -7,6 +7,7 @@ const graphMocks = vi.hoisted(() => ({
   get: vi.fn(),
   patch: vi.fn(),
   post: vi.fn(),
+  select: vi.fn(),
 }));
 
 vi.mock("@/utils/outlook/calendar-client", () => ({
@@ -18,14 +19,23 @@ vi.mock("@/utils/outlook/calendar-client", () => ({
 describe("MicrosoftCalendarEventProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    graphMocks.select.mockReturnValue({
+      get: graphMocks.get,
+    });
     graphMocks.api.mockReturnValue({
       get: graphMocks.get,
       patch: graphMocks.patch,
       post: graphMocks.post,
+      select: graphMocks.select,
     });
   });
 
   it("creates Teams meetings for Microsoft Teams locations", async () => {
+    graphMocks.get.mockResolvedValue({
+      id: "calendar-id",
+      allowedOnlineMeetingProviders: ["teamsForBusiness"],
+      defaultOnlineMeetingProvider: "skypeForBusiness",
+    });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
       onlineMeeting: { joinUrl: "https://teams.example.com/join" },
@@ -46,6 +56,10 @@ describe("MicrosoftCalendarEventProvider", () => {
       title: "Intro call",
     });
 
+    expect(graphMocks.api).toHaveBeenCalledWith("/me/calendars/calendar-id");
+    expect(graphMocks.select).toHaveBeenCalledWith(
+      "id,allowedOnlineMeetingProviders,defaultOnlineMeetingProvider",
+    );
     expect(graphMocks.api).toHaveBeenCalledWith(
       "/me/calendars/calendar-id/events",
     );
@@ -72,21 +86,61 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
   });
 
+  it("omits the explicit Teams provider when Teams is the calendar default", async () => {
+    graphMocks.get.mockResolvedValue({
+      id: "calendar-id",
+      allowedOnlineMeetingProviders: ["teamsForBusiness"],
+      defaultOnlineMeetingProvider: "teamsForBusiness",
+    });
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      onlineMeeting: { joinUrl: "https://teams.example.com/join" },
+      webLink: "https://outlook.example.com/event",
+    });
+
+    const provider = createProvider();
+
+    await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    expect(graphMocks.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOnlineMeeting: true,
+        onlineMeetingProvider: undefined,
+      }),
+    );
+  });
+
   it("refetches the event when Graph initializes the Teams join URL asynchronously", async () => {
     // Graph sometimes returns the created event before onlineMeeting is
     // populated; a follow-up GET on the event resolves to the join URL.
+    graphMocks.get
+      .mockResolvedValueOnce({
+        id: "calendar-id",
+        allowedOnlineMeetingProviders: ["teamsForBusiness"],
+        defaultOnlineMeetingProvider: "skypeForBusiness",
+      })
+      .mockResolvedValueOnce({
+        id: "event-id",
+        isOnlineMeeting: true,
+        onlineMeetingProvider: "teamsForBusiness",
+        onlineMeeting: { joinUrl: "https://teams.example.com/join" },
+        webLink: "https://outlook.example.com/event",
+      });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
       isOnlineMeeting: true,
       onlineMeetingProvider: "teamsForBusiness",
       onlineMeeting: null,
-      webLink: "https://outlook.example.com/event",
-    });
-    graphMocks.get.mockResolvedValue({
-      id: "event-id",
-      isOnlineMeeting: true,
-      onlineMeetingProvider: "teamsForBusiness",
-      onlineMeeting: { joinUrl: "https://teams.example.com/join" },
       webLink: "https://outlook.example.com/event",
     });
 
@@ -113,14 +167,20 @@ describe("MicrosoftCalendarEventProvider", () => {
   });
 
   it("patches the event when Teams join URL is still missing after refetch", async () => {
+    graphMocks.get
+      .mockResolvedValueOnce({
+        id: "calendar-id",
+        allowedOnlineMeetingProviders: ["teamsForBusiness"],
+        defaultOnlineMeetingProvider: "skypeForBusiness",
+      })
+      .mockResolvedValueOnce({
+        id: "event-id",
+        isOnlineMeeting: false,
+        onlineMeetingProvider: "unknown",
+        onlineMeeting: null,
+        webLink: "https://outlook.example.com/event",
+      });
     graphMocks.post.mockResolvedValue({
-      id: "event-id",
-      isOnlineMeeting: false,
-      onlineMeetingProvider: "unknown",
-      onlineMeeting: null,
-      webLink: "https://outlook.example.com/event",
-    });
-    graphMocks.get.mockResolvedValue({
       id: "event-id",
       isOnlineMeeting: false,
       onlineMeetingProvider: "unknown",
@@ -155,6 +215,89 @@ describe("MicrosoftCalendarEventProvider", () => {
       onlineMeetingProvider: "teamsForBusiness",
     });
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
+  });
+
+  it("rejects Teams events when the destination calendar does not support Teams", async () => {
+    graphMocks.get.mockResolvedValue({
+      id: "calendar-id",
+      allowedOnlineMeetingProviders: ["skypeForBusiness"],
+      defaultOnlineMeetingProvider: "skypeForBusiness",
+    });
+
+    const provider = createProvider();
+
+    await expect(
+      provider.createEvent({
+        attendees: [{ email: "guest@example.com", name: "Guest User" }],
+        calendarId: "calendar-id",
+        description: "Meeting description",
+        endTime: new Date("2026-05-04T09:30:00.000Z"),
+        locationType: "MICROSOFT_TEAMS",
+        locationValue: null,
+        startTime: new Date("2026-05-04T09:00:00.000Z"),
+        timezone: "America/New_York",
+        title: "Intro call",
+      }),
+    ).rejects.toThrow("Microsoft Teams meetings are not supported");
+
+    expect(graphMocks.post).not.toHaveBeenCalled();
+  });
+
+  it("rejects Teams events when Graph creates the event without a Teams link", async () => {
+    vi.useFakeTimers();
+    try {
+      graphMocks.get
+        .mockResolvedValueOnce({
+          id: "calendar-id",
+          allowedOnlineMeetingProviders: ["teamsForBusiness"],
+          defaultOnlineMeetingProvider: "skypeForBusiness",
+        })
+        .mockResolvedValue({
+          id: "event-id",
+          isOnlineMeeting: false,
+          onlineMeetingProvider: "unknown",
+          onlineMeeting: null,
+          webLink: "https://outlook.example.com/event",
+        });
+      graphMocks.post.mockResolvedValue({
+        id: "event-id",
+        isOnlineMeeting: false,
+        onlineMeetingProvider: "unknown",
+        onlineMeeting: null,
+        webLink: "https://outlook.example.com/event",
+      });
+      graphMocks.patch.mockResolvedValue({
+        id: "event-id",
+        isOnlineMeeting: false,
+        onlineMeetingProvider: "unknown",
+        onlineMeeting: null,
+        webLink: "https://outlook.example.com/event",
+      });
+
+      const provider = createProvider();
+
+      const promise = provider.createEvent({
+        attendees: [{ email: "guest@example.com", name: "Guest User" }],
+        calendarId: "calendar-id",
+        description: "Meeting description",
+        endTime: new Date("2026-05-04T09:30:00.000Z"),
+        locationType: "MICROSOFT_TEAMS",
+        locationValue: null,
+        startTime: new Date("2026-05-04T09:00:00.000Z"),
+        timezone: "America/New_York",
+        title: "Intro call",
+      });
+
+      const assertion = expect(promise).rejects.toThrow(
+        "Microsoft Teams meeting link was not generated",
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id/cancel");
+      expect(graphMocks.post).toHaveBeenCalledWith({ comment: "" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not refetch when Teams was not requested", async () => {

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -11,6 +11,9 @@ import type {
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 
+const TEAMS_JOIN_URL_POLL_DELAYS_MS = [500, 1000, 2000] as const;
+const MICROSOFT_TEAMS_PROVIDER = "teamsForBusiness";
+
 export interface MicrosoftCalendarConnectionParams {
   accessToken: string | null;
   emailAccountId: string;
@@ -31,6 +34,13 @@ type MicrosoftEvent = {
   webLink?: string;
   onlineMeeting?: { joinUrl?: string };
   onlineMeetingUrl?: string;
+  isOnlineMeeting?: boolean;
+  onlineMeetingProvider?: string;
+};
+
+type MicrosoftCalendarOnlineMeetingSettings = {
+  allowedOnlineMeetingProviders?: string[];
+  defaultOnlineMeetingProvider?: string;
 };
 
 export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
@@ -128,6 +138,13 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
     const client = await this.getClient();
     const useMicrosoftTeams =
       input.locationType === BookingLinkLocationType.MICROSOFT_TEAMS;
+    const onlineMeetingFields = useMicrosoftTeams
+      ? await getTeamsOnlineMeetingFields({
+          calendarId: input.calendarId,
+          client,
+          logger: this.logger,
+        })
+      : {};
     const response: MicrosoftEvent = await client
       .api(`/me/calendars/${input.calendarId}/events`)
       .post({
@@ -151,10 +168,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           },
           type: "required",
         })),
-        isOnlineMeeting: useMicrosoftTeams,
-        onlineMeetingProvider: useMicrosoftTeams
-          ? "teamsForBusiness"
-          : undefined,
+        ...onlineMeetingFields,
         location:
           !useMicrosoftTeams && input.locationValue
             ? { displayName: input.locationValue }
@@ -167,17 +181,11 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
     // POST response sometimes returns before `onlineMeeting` is populated.
     // Refetch the event to retrieve the join URL when we asked for Teams.
     if (useMicrosoftTeams && !videoConferenceLink && response.id) {
-      try {
-        const refetched: MicrosoftEvent = await client
-          .api(`/me/events/${response.id}`)
-          .get();
-        videoConferenceLink = getJoinUrl(refetched);
-      } catch (error) {
-        this.logger.warn(
-          "Failed to refetch Microsoft event for Teams join URL",
-          { eventId: response.id, error },
-        );
-      }
+      videoConferenceLink = await pollForTeamsJoinUrl({
+        client,
+        eventId: response.id,
+        logger: this.logger,
+      });
     }
 
     if (useMicrosoftTeams && !videoConferenceLink && response.id) {
@@ -186,7 +194,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           .api(`/me/events/${response.id}`)
           .patch({
             isOnlineMeeting: true,
-            onlineMeetingProvider: "teamsForBusiness",
+            onlineMeetingProvider: MICROSOFT_TEAMS_PROVIDER,
           });
         videoConferenceLink = getJoinUrl(patched);
       } catch (error) {
@@ -195,6 +203,32 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           error,
         });
       }
+    }
+
+    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+      videoConferenceLink = await pollForTeamsJoinUrl({
+        client,
+        eventId: response.id,
+        logger: this.logger,
+      });
+    }
+
+    if (useMicrosoftTeams && !videoConferenceLink) {
+      this.logger.warn("Microsoft Teams link missing after event creation", {
+        eventId: response.id,
+        isOnlineMeeting: response.isOnlineMeeting,
+        onlineMeetingProvider: response.onlineMeetingProvider,
+      });
+
+      if (response.id) {
+        await cancelIncompleteMicrosoftEvent({
+          client,
+          eventId: response.id,
+          logger: this.logger,
+        });
+      }
+
+      throw new Error("Microsoft Teams meeting link was not generated");
     }
 
     return {
@@ -254,4 +288,121 @@ function formatMicrosoftUtcDateTime(date: Date) {
 
 function getJoinUrl(event: MicrosoftEvent): string | undefined {
   return event.onlineMeeting?.joinUrl || event.onlineMeetingUrl;
+}
+
+async function getTeamsOnlineMeetingFields({
+  calendarId,
+  client,
+  logger,
+}: {
+  calendarId: string;
+  client: Client;
+  logger: Logger;
+}) {
+  const settings = await getCalendarOnlineMeetingSettings({
+    calendarId,
+    client,
+    logger,
+  });
+
+  if (
+    settings?.allowedOnlineMeetingProviders &&
+    !settings.allowedOnlineMeetingProviders.includes(MICROSOFT_TEAMS_PROVIDER)
+  ) {
+    throw new Error("Microsoft Teams meetings are not supported");
+  }
+
+  return {
+    isOnlineMeeting: true,
+    onlineMeetingProvider:
+      settings?.defaultOnlineMeetingProvider === MICROSOFT_TEAMS_PROVIDER
+        ? undefined
+        : MICROSOFT_TEAMS_PROVIDER,
+  };
+}
+
+async function getCalendarOnlineMeetingSettings({
+  calendarId,
+  client,
+  logger,
+}: {
+  calendarId: string;
+  client: Client;
+  logger: Logger;
+}): Promise<MicrosoftCalendarOnlineMeetingSettings | null> {
+  try {
+    return await client
+      .api(`/me/calendars/${calendarId}`)
+      .select("id,allowedOnlineMeetingProviders,defaultOnlineMeetingProvider")
+      .get();
+  } catch (error) {
+    logger.warn("Failed to fetch Microsoft calendar meeting providers", {
+      calendarId,
+      error,
+    });
+    return null;
+  }
+}
+
+async function pollForTeamsJoinUrl({
+  client,
+  eventId,
+  logger,
+}: {
+  client: Client;
+  eventId: string;
+  logger: Logger;
+}) {
+  for (const delayMs of [0, ...TEAMS_JOIN_URL_POLL_DELAYS_MS]) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    try {
+      const event: MicrosoftEvent | undefined = await client
+        .api(`/me/events/${eventId}`)
+        .get();
+      if (!event) continue;
+
+      const joinUrl = getJoinUrl(event);
+      if (joinUrl) return joinUrl;
+
+      if (
+        event.isOnlineMeeting === false &&
+        event.onlineMeetingProvider === "unknown"
+      ) {
+        return;
+      }
+    } catch (error) {
+      logger.warn("Failed to refetch Microsoft event for Teams join URL", {
+        eventId,
+        error,
+      });
+    }
+  }
+
+  return;
+}
+
+async function cancelIncompleteMicrosoftEvent({
+  client,
+  eventId,
+  logger,
+}: {
+  client: Client;
+  eventId: string;
+  logger: Logger;
+}) {
+  try {
+    await client.api(`/me/events/${eventId}/cancel`).post({ comment: "" });
+  } catch (error) {
+    logger.error("Failed to cancel Microsoft event without Teams link", {
+      eventId,
+      error,
+    });
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary
- Fetch calendar online meeting settings before creating Outlook events and only set an explicit Teams provider when the calendar default is not Teams.
- Poll for the Teams join URL after event creation, retry with a patch when needed, and fail cleanly by canceling incomplete events when no link is generated.
- Reject Teams bookings when the target calendar does not support Teams meetings.

## Test plan
- [x] `pnpm exec vitest run utils/calendar/providers/microsoft-events.test.ts`
- [ ] Create a booking with a Microsoft Teams location on an Outlook calendar and verify the join link is returned
- [ ] Verify booking creation fails with a clear error when the calendar does not support Teams
- [ ] Verify incomplete events without a Teams link are canceled instead of left on the calendar


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

