### PR TITLE
Fix draft reply channel fallback

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/draftReplyActions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/draftReplyActions.test.ts
@@ -25,6 +25,31 @@ describe("draftReplyActions", () => {
     ]);
   });
 
+  it("normalizes channel-less persisted chat drafts back to email drafts", () => {
+    const actions = normalizeDraftReplyActions([
+      {
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: null,
+        content: { value: "", setManually: false },
+      },
+      {
+        type: ActionType.DRAFT_MESSAGING_CHANNEL,
+        messagingChannelId: "   ",
+      },
+    ]);
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        type: ActionType.DRAFT_EMAIL,
+        messagingChannelId: null,
+      }),
+      expect.objectContaining({
+        type: ActionType.DRAFT_EMAIL,
+        messagingChannelId: null,
+      }),
+    ]);
+  });
+
   it("denormalizes all adjacent draft messaging actions with the email content", () => {
     const actions = denormalizeDraftReplyActions([
       {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/draftReplyActions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/draftReplyActions.ts
@@ -17,6 +17,13 @@ export function normalizeDraftReplyActions(actions: RuleFormAction[]) {
       };
     }
 
+    if (
+      action.type === ActionType.DRAFT_MESSAGING_CHANNEL &&
+      !action.messagingChannelId?.trim()
+    ) {
+      return buildDraftEmailAction(action);
+    }
+
     return action;
   });
 }


### PR DESCRIPTION
Ensures saved draft chat actions without a selected channel are treated as email drafts so existing rules do not fail chat destination validation.

- Converts missing or blank messaging channel IDs back to draft email actions during normalization.
- Adds regression coverage for null and whitespace channel IDs.
- Tests: pnpm test 'app/(app)/[emailAccountId]/assistant/draftReplyActions.test.ts'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

