### PR TITLE
drive: Align Google Drive modal button styles

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx
@@ -137,6 +137,7 @@ export function ConnectDrive() {
               </div>
               <Button
                 size="sm"
+                variant="outline"
                 onClick={() => {
                   setGoogleDialogOpen(false);
                   handleConnectGoogle("limited");


### PR DESCRIPTION
Aligns the Connect buttons in the Google Drive access modal so Standard and Full access carry equal visual weight. This resolves INB-145.

- Uses the same outline button variant for both Google Drive access options
- Keeps the change scoped to the Connect Google Drive modal

Verification:
- pnpm exec biome check apps/web/app/(app)/[emailAccountId]/drive/ConnectDrive.tsx

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

