### PR TITLE
assistant: Open Outlook emails with provider links

### DIFF
--- a/apps/web/components/assistant-chat/email-lookup-context.tsx
+++ b/apps/web/components/assistant-chat/email-lookup-context.tsx
@@ -9,6 +9,7 @@ export type EmailMeta = {
   snippet: string;
   date: string;
   isUnread: boolean;
+  externalUrl?: string;
 };
 
 export type EmailLookup = Map<string, EmailMeta>;

--- a/apps/web/components/assistant-chat/inline-email-card.test.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.test.tsx
@@ -148,6 +148,19 @@ describe("InlineEmailCard", () => {
           },
         ],
         [
+          "outlook-thread-1",
+          {
+            messageId: "outlook-message-1",
+            from: "Outlook Sender",
+            subject: "Outlook Subject",
+            snippet: "Outlook Snippet",
+            date: "2026-03-11T12:30:00.000Z",
+            isUnread: false,
+            externalUrl:
+              "https://outlook.office.com/mail/deeplink/read/outlook-message-1?ispopout=0",
+          },
+        ],
+        [
           "thread-2",
           {
             messageId: "msg-thread-2",
@@ -206,6 +219,50 @@ describe("InlineEmailCard", () => {
     expect(mockQueueAction).toHaveBeenCalledWith("archive_threads", [
       "19cdca06580b38e9",
     ]);
+  });
+
+  it("uses the provider URL for Outlook open-in-email links", () => {
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      provider: "microsoft",
+      userEmail: "user@example.com",
+    });
+
+    render(
+      <InlineEmailCard threadid="outlook-thread-1" action="none">
+        Outlook message
+      </InlineEmailCard>,
+    );
+
+    openMoreActions();
+
+    expect(
+      screen
+        .getByRole("menuitem", { name: "Open in email" })
+        .getAttribute("href"),
+    ).toBe(
+      "https://outlook.office.com/mail/deeplink/read/outlook-message-1?ispopout=0",
+    );
+  });
+
+  it("does not show an Outlook open-in-email link without a provider URL", () => {
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      provider: "microsoft",
+      userEmail: "user@example.com",
+    });
+
+    render(
+      <InlineEmailCard threadid="thread-1" action="none">
+        Outlook message
+      </InlineEmailCard>,
+    );
+
+    openMoreActions();
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Open in email" }),
+    ).toBeNull();
   });
 
   it("renders the app email preview details from the menu", async () => {

--- a/apps/web/components/assistant-chat/inline-email-card.tsx
+++ b/apps/web/components/assistant-chat/inline-email-card.tsx
@@ -332,14 +332,13 @@ export function InlineEmailCard({
   const isArchived = !!threadId && !!listState?.archivedThreadIds.has(threadId);
   const isMarkedRead = !!threadId && !!listState?.readThreadIds.has(threadId);
 
-  const externalUrl = threadId
-    ? getEmailUrlForMessage(
-        meta?.messageId ?? threadId,
-        threadId,
-        userEmail,
-        provider,
-      )
-    : null;
+  const externalUrl = getInlineEmailExternalUrl({
+    threadId,
+    messageId: meta?.messageId,
+    externalUrl: meta?.externalUrl,
+    userEmail,
+    provider,
+  });
 
   async function handleArchive() {
     if (!threadId || actionState !== "idle") return;
@@ -551,14 +550,13 @@ export function InlineEmailDetail({
   const { provider, userEmail } = useAccount();
   const threadId = resolveInlineEmailThreadId({ id, threadid });
   const meta = threadId ? emailLookup.get(threadId) : undefined;
-  const externalUrl = threadId
-    ? getEmailUrlForMessage(
-        meta?.messageId ?? threadId,
-        threadId,
-        userEmail,
-        provider,
-      )
-    : null;
+  const externalUrl = getInlineEmailExternalUrl({
+    threadId,
+    messageId: meta?.messageId,
+    externalUrl: meta?.externalUrl,
+    userEmail,
+    provider,
+  });
 
   return (
     <div className="my-2 overflow-hidden rounded-lg border bg-card shadow-sm">
@@ -701,6 +699,31 @@ function resolveInlineEmailThreadId({
     return id.slice("user-content-".length) || undefined;
   }
   return id;
+}
+
+function getInlineEmailExternalUrl({
+  threadId,
+  messageId,
+  externalUrl,
+  userEmail,
+  provider,
+}: {
+  threadId?: string;
+  messageId?: string;
+  externalUrl?: string;
+  userEmail?: string | null;
+  provider?: string;
+}) {
+  if (externalUrl) return externalUrl;
+  if (!threadId) return null;
+  if (provider === "microsoft") return null;
+
+  return getEmailUrlForMessage(
+    messageId ?? threadId,
+    threadId,
+    userEmail,
+    provider,
+  );
 }
 
 function addThreadIds(current: Set<string>, threadIds: string[]) {

--- a/apps/web/components/assistant-chat/messages.tsx
+++ b/apps/web/components/assistant-chat/messages.tsx
@@ -122,6 +122,7 @@ function buildEmailLookup(messages: Array<ChatMessage>): EmailLookup {
               snippet: string;
               date: string;
               isUnread: boolean;
+              externalUrl?: string;
             }>
           | undefined;
         if (!items) continue;
@@ -134,6 +135,7 @@ function buildEmailLookup(messages: Array<ChatMessage>): EmailLookup {
               snippet: item.snippet,
               date: item.date,
               isUnread: item.isUnread,
+              externalUrl: item.externalUrl,
             });
           }
         }

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -201,6 +201,7 @@ export function SearchInboxResult({ output }: { output: unknown }) {
       snippet: string;
       date: string;
       isUnread: boolean;
+      externalUrl?: string;
     }>
   >(output, "messages");
 
@@ -424,9 +425,11 @@ export function ReadEmailResult({ output }: { output: unknown }) {
   const content = getOutputField<string>(output, "content");
   const messageId = getOutputField<string>(output, "messageId");
   const threadId = getOutputField<string>(output, "threadId");
+  const outputExternalUrl = getOutputField<string>(output, "externalUrl");
   const externalUrl = getExternalMessageUrl({
     messageId,
     threadId,
+    externalUrl: outputExternalUrl,
     userEmail,
     provider,
   });
@@ -2093,14 +2096,19 @@ function getAssistantEmailSuccessMessage(actionType: PendingEmailActionType) {
 function getExternalMessageUrl({
   messageId,
   threadId,
+  externalUrl,
   userEmail,
   provider,
 }: {
   messageId?: string;
   threadId?: string;
+  externalUrl?: string;
   userEmail?: string | null;
   provider?: string;
 }) {
+  if (externalUrl) return externalUrl;
+  if (provider === "microsoft") return null;
+
   return getEmailUrlForOptionalMessage({
     messageId,
     threadId,
@@ -2208,6 +2216,7 @@ type ToolEmailRow = {
   snippet?: string;
   date: string;
   isUnread: boolean;
+  externalUrl?: string;
 };
 
 function ToolEmailRows({ emails }: { emails: ToolEmailRow[] }) {
@@ -2228,6 +2237,7 @@ function ToolEmailRows({ emails }: { emails: ToolEmailRow[] }) {
         snippet: email.snippet || "",
         date: email.date,
         isUnread: email.isUnread,
+        externalUrl: email.externalUrl,
       },
     ]),
   );

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -830,6 +830,8 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
           {
             id: "m1",
             threadId: "t1",
+            externalUrl:
+              "https://outlook.office.com/mail/deeplink/read/m1?ispopout=0",
             snippet: "Can you take a look?",
             historyId: "",
             inline: [],
@@ -882,6 +884,9 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
     expect(result.messages).toHaveLength(1);
     expect(result.queryUsed).toBe('"sender@example.com"');
+    expect(result.messages[0].externalUrl).toBe(
+      "https://outlook.office.com/mail/deeplink/read/m1?ispopout=0",
+    );
   });
 
   it("searchInbox passes structured Outlook category and read-state filters", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -703,6 +703,7 @@ export const readEmailTool = ({
         return {
           messageId: message.id,
           threadId: message.threadId,
+          externalUrl: message.externalUrl,
           from: emailForLLM.from,
           to: emailForLLM.to,
           cc: emailForLLM.cc,
@@ -1521,6 +1522,7 @@ function mapMessageForSearchResult(
   return {
     messageId: message.id,
     threadId: message.threadId,
+    externalUrl: message.externalUrl,
     subject: message.subject,
     from: message.headers.from,
     to: message.headers.to,

--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -115,6 +115,22 @@ describe("convertMessage", () => {
       expect(result.labelIds).toContain("INBOX");
       expect(result.labelIds).toContain("uuid-urgent-123");
     });
+
+    it("preserves the Outlook web link for opening the exact message", () => {
+      const message: Message = {
+        id: "msg-123",
+        conversationId: "thread-456",
+        webLink:
+          "https://outlook.office.com/mail/deeplink/read/msg-123?ispopout=0",
+        isRead: true,
+      };
+
+      const result = convertMessage(message, {});
+
+      expect(result.externalUrl).toBe(
+        "https://outlook.office.com/mail/deeplink/read/msg-123?ispopout=0",
+      );
+    });
   });
 });
 

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -15,7 +15,7 @@ import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 // Standard fields to select when fetching messages from Microsoft Graph API
 // internetMessageId is the RFC 5322 Message-ID header, needed for cross-provider email threading
 export const MESSAGE_SELECT_FIELDS =
-  "id,conversationId,conversationIndex,internetMessageId,subject,bodyPreview,from,sender,toRecipients,ccRecipients,receivedDateTime,isDraft,isRead,body,categories,parentFolderId,hasAttachments";
+  "id,conversationId,conversationIndex,internetMessageId,subject,bodyPreview,from,sender,toRecipients,ccRecipients,receivedDateTime,isDraft,isRead,body,categories,parentFolderId,hasAttachments,webLink";
 
 // Expand attachments to get metadata (name, type, size) without fetching content
 export const MESSAGE_EXPAND_ATTACHMENTS =
@@ -953,6 +953,7 @@ export function convertMessage(
   return {
     id: message.id || "",
     threadId: message.conversationId || "",
+    externalUrl: message.webLink || undefined,
     snippet: message.bodyPreview || "",
     textPlain: bodyContent,
     textHtml: bodyContent,

--- a/apps/web/utils/types.ts
+++ b/apps/web/utils/types.ts
@@ -54,6 +54,7 @@ export interface ParsedMessage {
   bodyContentType?: "text" | "html"; // For Outlook: indicates which format the body was originally in
   conversationIndex?: string | null;
   date: string;
+  externalUrl?: string;
   headers: ParsedMessageHeaders;
   historyId: string;
   id: string;


### PR DESCRIPTION
Fixes INB-123. Outlook assistant email cards now use Microsoft Graph message web links for external open actions instead of constructing brittle Outlook URLs.

- Request and preserve Graph `webLink` on Outlook messages as `externalUrl`
- Pass `externalUrl` through assistant `searchInbox` and `readEmail` outputs into email-card lookup state
- For Outlook, render the external open action only when a provider URL exists; Gmail keeps existing generated links
- Add focused tests for Outlook message conversion, assistant output propagation, and card link behavior

Verification:
- `rtk pnpm test components/assistant-chat/assistant-inline-email-response.test.tsx components/assistant-chat/inline-email-card.test.tsx utils/outlook/message.test.ts utils/ai/assistant/chat-inbox-tools.test.ts`
- `rtk pnpm exec biome check apps/web/utils/types.ts apps/web/utils/outlook/message.ts apps/web/utils/outlook/message.test.ts apps/web/utils/ai/assistant/chat-inbox-tools.ts apps/web/utils/ai/assistant/chat-inbox-tools.test.ts apps/web/components/assistant-chat/email-lookup-context.tsx apps/web/components/assistant-chat/messages.tsx apps/web/components/assistant-chat/tools.tsx apps/web/components/assistant-chat/inline-email-card.tsx apps/web/components/assistant-chat/inline-email-card.test.tsx`
- `rtk git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

