### PR TITLE
fix: require save for file picker selections

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.test.tsx
@@ -1,0 +1,152 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AttachmentSourceType } from "@/generated/prisma/enums";
+import { ActionAttachmentsField } from "./ActionAttachmentsField";
+
+const mockUseDriveConnections = vi.fn();
+const mockUseDriveSourceItems = vi.fn();
+const mockUseDriveSourceChildren = vi.fn();
+
+(globalThis as { React?: typeof React }).React = React;
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(globalThis as { ResizeObserver?: typeof MockResizeObserver }).ResizeObserver =
+  MockResizeObserver;
+
+vi.mock("@/hooks/useDriveConnections", () => ({
+  useDriveConnections: () => mockUseDriveConnections(),
+}));
+
+vi.mock("@/hooks/useDriveSourceItems", () => ({
+  useDriveSourceItems: () => mockUseDriveSourceItems(),
+}));
+
+vi.mock("@/hooks/useDriveSourceChildren", () => ({
+  useDriveSourceChildren: () => mockUseDriveSourceChildren(),
+}));
+
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+
+describe("ActionAttachmentsField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDriveConnections.mockReturnValue({
+      data: { connections: [{ id: "drive-connection-1" }] },
+    });
+    mockUseDriveSourceItems.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "file-1",
+            name: "Quarterly report.pdf",
+            path: "Quarterly report.pdf",
+            driveConnectionId: "drive-connection-1",
+            provider: "google",
+            type: "file",
+          },
+        ],
+      },
+      isLoading: false,
+      error: undefined,
+    });
+    mockUseDriveSourceChildren.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("applies always-attach selections only after saving the picker", () => {
+    const onChange = vi.fn();
+    renderField({ onChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Select files" }));
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        driveConnectionId: "drive-connection-1",
+        name: "Quarterly report.pdf",
+        sourceId: "file-1",
+        sourcePath: "Quarterly report.pdf",
+        type: AttachmentSourceType.FILE,
+      },
+    ]);
+  });
+
+  it("discards always-attach selections when the picker is canceled", () => {
+    const onChange = vi.fn();
+    renderField({ onChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Select files" }));
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("heading", {
+        name: "Select files to always attach",
+      }),
+    ).toBeNull();
+  });
+
+  it("discards AI source picker selections when the modal is closed", () => {
+    const onAttachmentSourcesChange = vi.fn();
+    renderField({ onAttachmentSourcesChange });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select sources for AI" }),
+    );
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onAttachmentSourcesChange).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("heading", {
+        name: "Select sources for AI to search",
+      }),
+    ).toBeNull();
+  });
+});
+
+function renderField({
+  onChange = vi.fn(),
+  onAttachmentSourcesChange = vi.fn(),
+}: {
+  onChange?: (
+    value: Parameters<typeof ActionAttachmentsField>[0]["value"],
+  ) => void;
+  onAttachmentSourcesChange?: (
+    value: Parameters<typeof ActionAttachmentsField>[0]["attachmentSources"],
+  ) => void;
+} = {}) {
+  render(
+    <ActionAttachmentsField
+      value={[]}
+      onChange={onChange}
+      emailAccountId="email-account-1"
+      contentSetManually
+      attachmentSources={[]}
+      onAttachmentSourcesChange={onAttachmentSourcesChange}
+    />,
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.tsx
@@ -23,6 +23,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -43,7 +45,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@/components/ui/empty";
-import type { DriveSourceItem } from "@/app/api/user/drive/source-items/route";
+import type { DriveSourceItem } from "@/utils/drive/source-items";
 
 export function ActionAttachmentsField({
   value,
@@ -64,8 +66,6 @@ export function ActionAttachmentsField({
 }) {
   const { data: connectionsData } = useDriveConnections();
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isPickerOpen, setIsPickerOpen] = useState(false);
-  const [isSourcePickerOpen, setIsSourcePickerOpen] = useState(false);
   const [isSourcesExpanded, setIsSourcesExpanded] = useState(false);
 
   const isConnected = (connectionsData?.connections.length ?? 0) > 0;
@@ -74,50 +74,14 @@ export function ActionAttachmentsField({
   const hasAiSources = aiSourceCount > 0;
   const totalCount = value.length + aiSourceCount;
 
-  const selectedKeys = useMemo(
-    () => new Set(value.map((source) => getSourceKey(source))),
-    [value],
-  );
-
-  const aiSourceKeys = useMemo(
-    () => new Set(attachmentSources.map((source) => getSourceKey(source))),
-    [attachmentSources],
-  );
-
   const toggleSource = (source: AttachmentSourceInput, checked: boolean) => {
-    const key = getSourceKey(source);
-    if (checked) {
-      onChange(
-        [...value, source].filter(
-          (item, index, all) =>
-            index ===
-            all.findIndex(
-              (candidate) => getSourceKey(candidate) === getSourceKey(item),
-            ),
-        ),
-      );
-    } else {
-      onChange(value.filter((item) => getSourceKey(item) !== key));
-    }
+    onChange(updateSelectedSources(value, source, checked));
   };
 
   const toggleAiSource = (source: AttachmentSourceInput, checked: boolean) => {
-    const key = getSourceKey(source);
-    if (checked) {
-      onAttachmentSourcesChange(
-        [...attachmentSources, source].filter(
-          (item, index, all) =>
-            index ===
-            all.findIndex(
-              (candidate) => getSourceKey(candidate) === getSourceKey(item),
-            ),
-        ),
-      );
-    } else {
-      onAttachmentSourcesChange(
-        attachmentSources.filter((item) => getSourceKey(item) !== key),
-      );
-    }
+    onAttachmentSourcesChange(
+      updateSelectedSources(attachmentSources, source, checked),
+    );
   };
 
   return (
@@ -179,29 +143,14 @@ export function ActionAttachmentsField({
             />
           )}
 
-          <Dialog open={isPickerOpen} onOpenChange={setIsPickerOpen}>
-            <DialogTrigger asChild>
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                className="h-auto p-0 text-xs mt-1"
-              >
-                <PlusIcon className="mr-1 size-3" />
-                Select files
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-3xl">
-              <DialogHeader>
-                <DialogTitle>Select files to always attach</DialogTitle>
-              </DialogHeader>
-              <AttachmentPicker
-                selectedKeys={selectedKeys}
-                onToggle={toggleSource}
-                allowFolderSelection={false}
-              />
-            </DialogContent>
-          </Dialog>
+          <AttachmentSourcePickerDialog
+            value={value}
+            onChange={onChange}
+            triggerLabel="Select files"
+            title="Select files to always attach"
+            description="Choose files that this rule should always attach after you save."
+            allowFolderSelection={false}
+          />
         </div>
       )}
 
@@ -236,35 +185,105 @@ export function ActionAttachmentsField({
             />
           )}
 
-          <Dialog
-            open={isSourcePickerOpen}
-            onOpenChange={setIsSourcePickerOpen}
-          >
-            <DialogTrigger asChild>
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                className="h-auto p-0 text-xs mt-1"
-              >
-                <PlusIcon className="mr-1 size-3" />
-                Select sources for AI
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-3xl">
-              <DialogHeader>
-                <DialogTitle>Select sources for AI to search</DialogTitle>
-              </DialogHeader>
-              <AttachmentPicker
-                selectedKeys={aiSourceKeys}
-                onToggle={toggleAiSource}
-                allowFolderSelection
-              />
-            </DialogContent>
-          </Dialog>
+          <AttachmentSourcePickerDialog
+            value={attachmentSources}
+            onChange={onAttachmentSourcesChange}
+            triggerLabel="Select sources for AI"
+            title="Select sources for AI to search"
+            description="Choose files or folders the AI can search after you save."
+            allowFolderSelection
+          />
         </div>
       )}
     </div>
+  );
+}
+
+function AttachmentSourcePickerDialog({
+  value,
+  onChange,
+  triggerLabel,
+  title,
+  description,
+  allowFolderSelection = false,
+}: {
+  value: AttachmentSourceInput[];
+  onChange: (value: AttachmentSourceInput[]) => void;
+  triggerLabel: string;
+  title: string;
+  description: string;
+  allowFolderSelection?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftSources, setDraftSources] = useState(value);
+
+  const selectedKeys = useMemo(
+    () => new Set(draftSources.map((source) => getSourceKey(source))),
+    [draftSources],
+  );
+
+  const openPicker = () => {
+    setDraftSources(value);
+    setIsOpen(true);
+  };
+
+  const cancelPicker = () => {
+    setDraftSources(value);
+    setIsOpen(false);
+  };
+
+  const savePicker = () => {
+    onChange(draftSources);
+    setIsOpen(false);
+  };
+
+  const toggleDraftSource = (
+    source: AttachmentSourceInput,
+    checked: boolean,
+  ) => {
+    setDraftSources((current) =>
+      updateSelectedSources(current, source, checked),
+    );
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => (open ? openPicker() : cancelPicker())}
+    >
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto p-0 text-xs mt-1"
+        >
+          <PlusIcon className="mr-1 size-3" />
+          {triggerLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <AttachmentPicker
+          selectedKeys={selectedKeys}
+          onToggle={toggleDraftSource}
+          allowFolderSelection={allowFolderSelection}
+        />
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={cancelPicker}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={savePicker}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -495,6 +514,24 @@ function toAttachmentSource(
 
 function getSourceKey(source: AttachmentSourceInput) {
   return `${source.driveConnectionId}:${source.type}:${source.sourceId}`;
+}
+
+function updateSelectedSources(
+  sources: AttachmentSourceInput[],
+  source: AttachmentSourceInput,
+  checked: boolean,
+) {
+  const key = getSourceKey(source);
+
+  if (!checked) {
+    return sources.filter((item) => getSourceKey(item) !== key);
+  }
+
+  if (sources.some((item) => getSourceKey(item) === key)) {
+    return sources;
+  }
+
+  return [...sources, source];
 }
 
 function getTreeNodeId(item: DriveSourceItem) {


### PR DESCRIPTION
## Summary
- Add explicit Save and Cancel actions to the always-attach and AI source picker dialogs
- Stage picker selections locally so Cancel, X, escape, and outside close discard changes
- Add focused regression tests for Save, Cancel, and close behavior

Linear: https://linear.app/issue/INB-148

## Verification
- pnpm check
- pnpm test 'app/(app)/[emailAccountId]/assistant/ActionAttachmentsField.test.tsx'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

