### PR TITLE
INB-301 Fix legacy draft reply validation

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RuleForm.render.test.tsx
@@ -487,6 +487,59 @@ describe("RuleForm", () => {
     expect(screen.queryByText(/Disconnected/)).toBeNull();
   });
 
+  it("saves legacy channel-less draft reply actions without requiring a chat destination", async () => {
+    const view = render(
+      <RuleForm
+        alwaysEditMode
+        rule={{
+          id: "cmjzoasfv000004ld2qar07t3",
+          name: "Legacy draft reply rule",
+          instructions: null,
+          groupId: null,
+          runOnThreads: false,
+          digest: false,
+          conditionalOperator: LogicalOperator.AND,
+          conditions: [
+            {
+              type: ConditionType.STATIC,
+              from: "sender@example.com",
+              to: null,
+              subject: null,
+              body: null,
+              instructions: null,
+            },
+          ],
+          actions: [
+            {
+              id: "action-legacy-draft",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: null,
+              content: { value: "" },
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      within(view.container).getByRole("button", { name: "Save" }),
+    );
+
+    await waitFor(() => expect(mockUpdateRuleAction).toHaveBeenCalledTimes(1));
+
+    expect(mockUpdateRuleAction.mock.calls.at(-1)?.[1]).toMatchObject({
+      id: "cmjzoasfv000004ld2qar07t3",
+      actions: [
+        expect.objectContaining({
+          id: "action-legacy-draft",
+          type: ActionType.DRAFT_MESSAGING_CHANNEL,
+          messagingChannelId: null,
+        }),
+      ],
+    });
+    expect(screen.queryByText("Please choose a chat destination")).toBeNull();
+  });
+
   it("preserves the original action order when saving an unchanged rule", async () => {
     const view = render(
       <RuleForm

--- a/apps/web/utils/actions/rule.validation.test.ts
+++ b/apps/web/utils/actions/rule.validation.test.ts
@@ -307,6 +307,37 @@ describe("createRuleBody", () => {
       });
     });
 
+    describe("DRAFT_MESSAGING_CHANNEL action", () => {
+      it("requires messagingChannelId for new chat draft actions", () => {
+        const result = createRuleBody.safeParse({
+          ...validRule,
+          actions: [{ type: ActionType.DRAFT_MESSAGING_CHANNEL }],
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            "Please choose a chat destination",
+          );
+        }
+      });
+
+      it("allows persisted legacy chat draft actions without messagingChannelId", () => {
+        const result = createRuleBody.safeParse({
+          ...validRule,
+          actions: [
+            {
+              id: "action-legacy-draft",
+              type: ActionType.DRAFT_MESSAGING_CHANNEL,
+              messagingChannelId: null,
+            },
+          ],
+        });
+
+        expect(result.success).toBe(true);
+      });
+    });
+
     describe("CALL_WEBHOOK action", () => {
       it("requires url.value for CALL_WEBHOOK action", () => {
         const result = createRuleBody.safeParse({

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -200,7 +200,9 @@ const zodAction = z
 
     if (
       data.type === ActionType.DRAFT_MESSAGING_CHANNEL &&
-      !data.messagingChannelId
+      // Persisted legacy rows can be channel-less; keep them editable.
+      !data.messagingChannelId &&
+      !data.id
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
Fixes INB-301.\n\nAllows persisted legacy Draft Reply chat-draft actions without a messaging channel to be saved unchanged, while keeping the destination requirement for newly-created chat draft actions.\n\n- Adds validation coverage for new vs persisted channel-less chat draft actions\n- Adds a RuleForm regression for saving a legacy Draft Reply rule without the chat destination error\n\nPerformance impact: no runtime work added outside rule validation; no new database or network calls; low hot-path risk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

