### PR TITLE
INB-175: Fix Slack assistant response truncation

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -404,14 +404,14 @@ describe("getMessagingAiGeneratedPostPayload", () => {
     });
   });
 
-  it("does not add the Teams disclosure to Slack assistant messages", () => {
+  it("uses Slack text instead of markdown_text for assistant messages", () => {
     expect(
       getMessagingAiGeneratedPostPayload({
         provider: "slack",
-        text: "Here is your summary.",
+        text: "**Here is your summary.**",
       }),
     ).toEqual({
-      markdown: "Here is your summary.",
+      raw: "*Here is your summary.*",
     });
   });
 

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -2850,7 +2850,7 @@ function getMessagingAssistantPostPayload({
   }
 
   if (provider === "slack") {
-    return { markdown: markdownToSlackMrkdwn(text) };
+    return { raw: markdownToSlackMrkdwn(text) };
   }
 
   return { markdown: text };


### PR DESCRIPTION
Fixes INB-175.

Slack assistant responses were sent through the Chat SDK markdown payload, which maps to Slack markdown_text. That field has a lower rendering limit than top-level text, so longer assistant responses could remain truncated after Slack expansion.

Changes:
- Send Slack assistant replies through top-level text while preserving Slack mrkdwn conversion.
- Add a focused regression test for the Slack payload field.

Verification:
- rtk pnpm test utils/messaging/chat-sdk/bot.test.ts
- rtk pnpm exec biome check apps/web/utils/messaging/chat-sdk/bot.ts apps/web/utils/messaging/chat-sdk/bot.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

