### PR TITLE
INB-202: Fix Outlook sign-in for linked accounts

### DIFF
--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -147,6 +147,12 @@ describe("outlook linking callback route", () => {
             id: "provider-account-id",
             userPrincipalName: "user@example.com",
           }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sub: "better-auth-subject",
+          }),
         }),
     );
 
@@ -192,6 +198,12 @@ describe("outlook linking callback route", () => {
           }),
         })
         .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sub: "better-auth-subject",
+          }),
+        })
+        .mockResolvedValueOnce({
           ok: false,
         }),
     );
@@ -203,7 +215,14 @@ describe("outlook linking callback route", () => {
     const redirectLocation = response.headers.get("location");
     expect(redirectLocation).toContain("success=account_created_and_linked");
     expect(mockHandleAccountLinking).toHaveBeenCalled();
-    expect(prisma.account.create).toHaveBeenCalled();
+    expect(prisma.account.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          provider: "microsoft",
+          providerAccountId: "better-auth-subject",
+        }),
+      }),
+    );
     expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("valid-auth-code", {
       success: "account_created_and_linked",
     });
@@ -285,6 +304,12 @@ describe("outlook linking callback route", () => {
             id: "provider-account-id",
             userPrincipalName: "user@example.com",
           }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sub: "better-auth-subject",
+          }),
         }),
     );
 
@@ -348,6 +373,12 @@ describe("outlook linking callback route", () => {
           json: async () => ({
             id: "provider-account-id",
             userPrincipalName: "user@example.com",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sub: "better-auth-subject",
           }),
         })
         .mockResolvedValueOnce({

--- a/apps/web/app/api/outlook/linking/callback/route.test.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.test.ts
@@ -325,6 +325,93 @@ describe("outlook linking callback route", () => {
     });
   });
 
+  it("falls back to a legacy Graph ID account and migrates it to the OIDC subject", async () => {
+    prisma.account.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "account-123",
+        userId: "user-123",
+        refresh_token: "stored-refresh-token",
+        user: { name: "Test User", email: "user@example.com" },
+        emailAccount: { id: "email-account-123" },
+      } as Awaited<ReturnType<typeof prisma.account.findUnique>>);
+    mockHandleAccountLinking.mockResolvedValue({
+      type: "update_tokens",
+      existingAccountId: "account-123",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            scope: "Mail.ReadWrite Mail.Send MailboxSettings.ReadWrite",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: "legacy-provider-account-id",
+            userPrincipalName: "user@example.com",
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            sub: "better-auth-subject",
+          }),
+        }),
+    );
+
+    const response = await GET(
+      createRequest("http://localhost:3000/api/outlook/linking/callback"),
+    );
+
+    expect(response.headers.get("location")).toContain(
+      "success=tokens_updated",
+    );
+    expect(prisma.account.findUnique).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          provider_providerAccountId: {
+            provider: "microsoft",
+            providerAccountId: "better-auth-subject",
+          },
+        },
+      }),
+    );
+    expect(prisma.account.findUnique).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          provider_providerAccountId: {
+            provider: "microsoft",
+            providerAccountId: "legacy-provider-account-id",
+          },
+        },
+      }),
+    );
+    expect(prisma.account.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "account-123" },
+        data: expect.objectContaining({
+          providerAccountId: "better-auth-subject",
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+        }),
+      }),
+    );
+    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("valid-auth-code", {
+      success: "tokens_updated",
+    });
+  });
+
   it("maps token exchange AADSTS errors through the shared Microsoft error handler", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -161,11 +161,13 @@ export const GET = withError("outlook/linking/callback", async (request) => {
     >["profile"];
     let providerEmail: string;
     let providerAccountId: string;
+    let legacyProviderAccountId: string | null = null;
 
     try {
       const result = await fetchMicrosoftUserProfile(tokens.access_token);
       profile = result.profile;
       providerEmail = result.email;
+      legacyProviderAccountId = profile.id || null;
 
       const oidcUserInfo = await fetchMicrosoftOidcUserInfo(
         tokens.access_token,
@@ -185,21 +187,16 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       throw error;
     }
 
-    const existingAccount = await prisma.account.findUnique({
-      where: {
-        provider_providerAccountId: {
-          provider: "microsoft",
-          providerAccountId,
-        },
-      },
-      select: {
-        id: true,
-        userId: true,
-        refresh_token: true,
-        user: { select: { name: true, email: true } },
-        emailAccount: true,
-      },
-    });
+    let existingAccount =
+      await findMicrosoftAccountByProviderAccountId(providerAccountId);
+    let shouldMigrateProviderAccountId = false;
+
+    if (!existingAccount && legacyProviderAccountId) {
+      existingAccount = await findMicrosoftAccountByProviderAccountId(
+        legacyProviderAccountId,
+      );
+      shouldMigrateProviderAccountId = !!existingAccount;
+    }
 
     assertMicrosoftLinkingConsent({
       targetUserId,
@@ -344,6 +341,7 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       await updateMicrosoftAccountTokens(
         linkingResult.existingAccountId,
         tokens,
+        shouldMigrateProviderAccountId ? { providerAccountId } : undefined,
       );
 
       logger.info("Successfully updated tokens for Microsoft account", {
@@ -378,6 +376,16 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       name: existingAccount?.user.name || null,
       logger,
     });
+
+    if (shouldMigrateProviderAccountId) {
+      await updateMicrosoftAccountTokens(
+        linkingResult.sourceAccountId,
+        tokens,
+        {
+          providerAccountId,
+        },
+      );
+    }
 
     const successMessage =
       mergeType === "full_merge"
@@ -485,13 +493,35 @@ function parseMicrosoftExpiresAt(tokens: MicrosoftTokens): Date | null {
   return null;
 }
 
+function findMicrosoftAccountByProviderAccountId(providerAccountId: string) {
+  return prisma.account.findUnique({
+    where: {
+      provider_providerAccountId: {
+        provider: "microsoft",
+        providerAccountId,
+      },
+    },
+    select: {
+      id: true,
+      userId: true,
+      refresh_token: true,
+      user: { select: { name: true, email: true } },
+      emailAccount: true,
+    },
+  });
+}
+
 async function updateMicrosoftAccountTokens(
   accountId: string,
   tokens: MicrosoftTokens,
+  options?: { providerAccountId?: string },
 ) {
   await prisma.account.update({
     where: { id: accountId },
     data: {
+      ...(options?.providerAccountId && {
+        providerAccountId: options.providerAccountId,
+      }),
       access_token: tokens.access_token,
       // Only update refresh_token if provider returned one (preserves existing token)
       ...(tokens.refresh_token != null && {

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -24,6 +24,7 @@ import {
 } from "@/utils/oauth/microsoft-oauth";
 import {
   fetchMicrosoftGraph,
+  fetchMicrosoftOidcUserInfo,
   fetchMicrosoftUserProfile,
   MicrosoftUserProfileError,
   requestMicrosoftToken,
@@ -159,11 +160,17 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       ReturnType<typeof fetchMicrosoftUserProfile>
     >["profile"];
     let providerEmail: string;
+    let providerAccountId: string;
 
     try {
       const result = await fetchMicrosoftUserProfile(tokens.access_token);
       profile = result.profile;
       providerEmail = result.email;
+
+      const oidcUserInfo = await fetchMicrosoftOidcUserInfo(
+        tokens.access_token,
+      );
+      providerAccountId = oidcUserInfo.sub;
     } catch (error) {
       if (error instanceof MicrosoftUserProfileError) {
         if (error.status) {
@@ -176,12 +183,6 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       }
 
       throw error;
-    }
-
-    const providerAccountId = profile.id;
-
-    if (!providerAccountId) {
-      throw new SafeError("Profile missing required id");
     }
 
     const existingAccount = await prisma.account.findUnique({

--- a/apps/web/scripts/migrate-microsoft-provider-account-ids.ts
+++ b/apps/web/scripts/migrate-microsoft-provider-account-ids.ts
@@ -1,0 +1,186 @@
+// Run with: `pnpm --filter inbox-zero-ai exec tsx scripts/migrate-microsoft-provider-account-ids.ts`
+// Apply changes with: `pnpm --filter inbox-zero-ai exec tsx scripts/migrate-microsoft-provider-account-ids.ts --apply`
+
+import "dotenv/config";
+import { env } from "@/env";
+import { decryptToken } from "@/utils/encryption";
+import {
+  fetchMicrosoftOidcUserInfo,
+  requestMicrosoftToken,
+} from "@/utils/microsoft/oauth";
+import { SCOPES as OUTLOOK_SCOPES } from "@/utils/outlook/scopes";
+import prisma from "@/utils/prisma";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type MicrosoftTokenResponse = {
+  access_token?: string;
+  error_description?: string;
+};
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+
+  if (!env.MICROSOFT_CLIENT_ID || !env.MICROSOFT_CLIENT_SECRET) {
+    throw new Error("Microsoft OAuth credentials are required");
+  }
+
+  const microsoftAccounts = await prisma.account.findMany({
+    where: { provider: "microsoft" },
+    select: {
+      id: true,
+      providerAccountId: true,
+      refresh_token: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const candidates = microsoftAccounts
+    .filter((account) => UUID_REGEX.test(account.providerAccountId))
+    .slice(0, options.limit);
+
+  const stats = {
+    candidates: candidates.length,
+    wouldUpdate: 0,
+    updated: 0,
+    skippedNoRefreshToken: 0,
+    skippedTokenError: 0,
+    skippedConflict: 0,
+    skippedSameSubject: 0,
+  };
+
+  for (const account of candidates) {
+    const refreshToken = getRefreshToken(account.refresh_token);
+
+    if (!refreshToken) {
+      stats.skippedNoRefreshToken += 1;
+      continue;
+    }
+
+    const subject = await getMicrosoftSubject(refreshToken).catch((error) => {
+      stats.skippedTokenError += 1;
+      console.warn("Failed to resolve Microsoft subject for account", {
+        accountId: account.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    });
+
+    if (!subject) continue;
+
+    if (subject === account.providerAccountId) {
+      stats.skippedSameSubject += 1;
+      continue;
+    }
+
+    const existingAccount = await prisma.account.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: "microsoft",
+          providerAccountId: subject,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existingAccount && existingAccount.id !== account.id) {
+      stats.skippedConflict += 1;
+      console.warn("Skipped Microsoft account with existing subject account", {
+        accountId: account.id,
+        existingAccountId: existingAccount.id,
+      });
+      continue;
+    }
+
+    if (options.apply) {
+      await prisma.account.update({
+        where: { id: account.id },
+        data: { providerAccountId: subject },
+      });
+      stats.updated += 1;
+    } else {
+      stats.wouldUpdate += 1;
+    }
+  }
+
+  console.log(JSON.stringify({ apply: options.apply, ...stats }, null, 2));
+}
+
+function parseOptions(args: string[]) {
+  let apply = false;
+  let limit = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === "--apply") {
+      apply = true;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --limit");
+      limit = Number.parseInt(value, 10);
+      if (!Number.isFinite(limit) || limit < 1) {
+        throw new Error("--limit must be a positive integer");
+      }
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printHelpAndExit();
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { apply, limit };
+}
+
+async function getMicrosoftSubject(refreshToken: string) {
+  const tokenResponse = await requestMicrosoftToken({
+    client_id: env.MICROSOFT_CLIENT_ID!,
+    client_secret: env.MICROSOFT_CLIENT_SECRET!,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    scope: OUTLOOK_SCOPES.join(" "),
+  });
+
+  const tokens = (await tokenResponse.json()) as MicrosoftTokenResponse;
+
+  if (!tokenResponse.ok || !tokens.access_token) {
+    throw new Error(tokens.error_description || "Failed to refresh token");
+  }
+
+  const oidcUserInfo = await fetchMicrosoftOidcUserInfo(tokens.access_token);
+  return oidcUserInfo.sub;
+}
+
+function getRefreshToken(value: string | null) {
+  if (!value) return null;
+
+  if (value.startsWith("v") || /^[0-9a-f]+$/i.test(value)) {
+    return decryptToken(value);
+  }
+
+  return value;
+}
+
+function printHelpAndExit(): never {
+  process.stdout.write(
+    "Usage: tsx scripts/migrate-microsoft-provider-account-ids.ts [--apply] [--limit N]\n",
+  );
+  process.exit(0);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/web/utils/microsoft/oauth.test.ts
+++ b/apps/web/utils/microsoft/oauth.test.ts
@@ -194,6 +194,21 @@ describe("microsoft oauth helpers", () => {
     ).rejects.toThrow("OIDC user info missing required subject");
   });
 
+  it("throws a typed error when the Microsoft OIDC user info request fails", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(
+      oauth.fetchMicrosoftOidcUserInfo("access-token"),
+    ).rejects.toMatchObject({
+      message: "Failed to fetch Microsoft OIDC user info",
+      status: 503,
+    });
+  });
+
   it("throws a typed error when the Microsoft profile request fails", async () => {
     const oauth = await importMicrosoftOauthModule();
     vi.stubGlobal(

--- a/apps/web/utils/microsoft/oauth.test.ts
+++ b/apps/web/utils/microsoft/oauth.test.ts
@@ -33,6 +33,9 @@ describe("microsoft oauth helpers", () => {
     expect(oauth.getMicrosoftGraphUrl("/me")).toBe(
       "https://graph.microsoft.com/v1.0/me",
     );
+    expect(oauth.getMicrosoftOidcUserInfoUrl()).toBe(
+      "https://graph.microsoft.com/oidc/userinfo",
+    );
     expect(oauth.getMicrosoftGraphClientOptions("token")).toEqual({});
   });
 
@@ -57,6 +60,9 @@ describe("microsoft oauth helpers", () => {
     );
     expect(oauth.getMicrosoftGraphUrl("me/photo/$value")).toBe(
       "http://localhost:4003/v1.0/me/photo/$value",
+    );
+    expect(oauth.getMicrosoftOidcUserInfoUrl()).toBe(
+      "http://localhost:4003/oidc/userinfo",
     );
     expect(oauth.getMicrosoftGraphClientOptions("emulator-token")).toEqual({
       baseUrl: "http://localhost:4003/",
@@ -143,6 +149,49 @@ describe("microsoft oauth helpers", () => {
       },
       email: "user@example.com",
     });
+  });
+
+  it("returns Microsoft OIDC user info with the Better Auth account subject", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sub: "better-auth-subject",
+        email: "user@example.com",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      oauth.fetchMicrosoftOidcUserInfo("access-token"),
+    ).resolves.toEqual({
+      sub: "better-auth-subject",
+      email: "user@example.com",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://graph.microsoft.com/oidc/userinfo",
+      {
+        headers: {
+          Authorization: "Bearer access-token",
+        },
+      },
+    );
+  });
+
+  it("throws when Microsoft OIDC user info is missing the subject", async () => {
+    const oauth = await importMicrosoftOauthModule();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ email: "user@example.com" }),
+      }),
+    );
+
+    await expect(
+      oauth.fetchMicrosoftOidcUserInfo("access-token"),
+    ).rejects.toThrow("OIDC user info missing required subject");
   });
 
   it("throws a typed error when the Microsoft profile request fails", async () => {

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -138,7 +138,7 @@ export async function fetchMicrosoftOidcUserInfo(accessToken: string) {
     );
   }
 
-  return profile;
+  return { ...profile, sub: profile.sub };
 }
 
 export async function fetchMicrosoftUserProfile(accessToken: string) {

--- a/apps/web/utils/microsoft/oauth.ts
+++ b/apps/web/utils/microsoft/oauth.ts
@@ -4,6 +4,7 @@ import { Agent, type Dispatcher } from "undici";
 const MICROSOFT_LOGIN_BASE_URL = "https://login.microsoftonline.com";
 const MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com";
 const MICROSOFT_GRAPH_API_VERSION = "v1.0";
+const MICROSOFT_OIDC_USERINFO_PATH = "/oidc/userinfo";
 const MICROSOFT_IPV4_RETRY_HOSTS = new Set([
   new URL(MICROSOFT_LOGIN_BASE_URL).hostname,
   new URL(MICROSOFT_GRAPH_BASE_URL).hostname,
@@ -31,6 +32,14 @@ type MicrosoftUserProfile = {
   displayName?: string | null;
   givenName?: string | null;
   surname?: string | null;
+};
+
+type MicrosoftOidcUserInfo = {
+  sub?: string | null;
+  email?: string | null;
+  preferred_username?: string | null;
+  name?: string | null;
+  email_verified?: boolean | null;
 };
 
 export class MicrosoftUserProfileError extends Error {
@@ -96,8 +105,40 @@ export function getMicrosoftGraphUrl(path: string) {
   return `${getMicrosoftGraphApiRootUrl()}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
+export function getMicrosoftOidcUserInfoUrl() {
+  const baseUrl = getMicrosoftBaseUrl();
+  return baseUrl
+    ? `${baseUrl}${MICROSOFT_OIDC_USERINFO_PATH}`
+    : `${MICROSOFT_GRAPH_BASE_URL}${MICROSOFT_OIDC_USERINFO_PATH}`;
+}
+
 export function fetchMicrosoftGraph(path: string, init?: RequestInit) {
   return fetchMicrosoftUrl(getMicrosoftGraphUrl(path), init);
+}
+
+export async function fetchMicrosoftOidcUserInfo(accessToken: string) {
+  const response = await fetchMicrosoftUrl(getMicrosoftOidcUserInfoUrl(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new MicrosoftUserProfileError(
+      "Failed to fetch Microsoft OIDC user info",
+      response.status,
+    );
+  }
+
+  const profile = (await response.json()) as MicrosoftOidcUserInfo;
+
+  if (!profile.sub) {
+    throw new MicrosoftUserProfileError(
+      "OIDC user info missing required subject",
+    );
+  }
+
+  return profile;
 }
 
 export async function fetchMicrosoftUserProfile(accessToken: string) {


### PR DESCRIPTION
Fixes INB-202

Linear: https://linear.app/issue/INB-202

Updates manual Outlook linking to store the Microsoft OIDC `sub`, matching Better Auth Microsoft sign-in defaults, while keeping Microsoft out of trusted email-based account linking. Adds a dry-run migration script for legacy Microsoft account rows that were stored with Graph UUID-style IDs.

- Fetches Microsoft OIDC userinfo during Outlook linking and persists `sub` as `providerAccountId`
- Keeps Graph `/me` for mailbox profile/email data only
- Adds focused coverage for OIDC userinfo and Outlook linking account creation
- Adds a dry-run-by-default script to migrate legacy Microsoft provider account IDs

Verification:
- `pnpm test utils/microsoft/oauth.test.ts app/api/outlook/linking/callback/route.test.ts utils/auth-login-providers.test.ts utils/auth.test.ts`
- `pnpm --filter inbox-zero-ai exec biome check utils/microsoft/oauth.ts utils/microsoft/oauth.test.ts app/api/outlook/linking/callback/route.ts app/api/outlook/linking/callback/route.test.ts scripts/migrate-microsoft-provider-account-ids.ts`

Performance impact: adds one Microsoft OIDC userinfo HTTP request during manual Outlook linking only. No added hot-path work for normal app usage; the migration script is manual and dry-run by default.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

