### PR TITLE
Messaging: Fix Telegram sent draft notification rendering

### DIFF
--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -521,10 +521,10 @@ describe("handleRuleNotificationAction", () => {
       getDraft: vi.fn().mockResolvedValue({
         id: "draft-1",
         threadId: "thread-1",
-        textPlain: "Thanks for checking in.",
+        textPlain: "Use the account_name tag.",
         subject: "Re: Test subject",
         date: new Date().toISOString(),
-        snippet: "Thanks for checking in.",
+        snippet: "Use the account_name tag.",
         historyId: "1",
         internalDate: "1",
         headers: {
@@ -539,17 +539,17 @@ describe("handleRuleNotificationAction", () => {
       getMessage: vi.fn().mockResolvedValue({
         id: "message-1",
         threadId: "thread-1",
-        textPlain: "Original message body",
-        textHtml: "<p>Original message body</p>",
-        subject: "Test subject",
+        textPlain: "Original message_body",
+        textHtml: "<p>Original message_body</p>",
+        subject: "Question about [billing]_status",
         date: new Date().toISOString(),
-        snippet: "Original message body",
+        snippet: "Original message_body",
         historyId: "2",
         internalDate: "2",
         headers: {
-          from: "sender@example.com",
+          from: "Sender_Name <sender@example.com>",
           to: "user@example.com",
-          subject: "Test subject",
+          subject: "Question about [billing]_status",
           date: "Mon, 1 Jan 2024 11:00:00 +0000",
           "message-id": "<message-1@example.com>",
         },
@@ -564,7 +564,7 @@ describe("handleRuleNotificationAction", () => {
     mockNotificationContext({
       id: "action-1",
       type: ActionType.DRAFT_MESSAGING_CHANNEL,
-      content: "Thanks for checking in.",
+      content: "Use the account_name tag.",
       messagingChannel: {
         id: "channel-1",
         provider: MessagingProvider.TELEGRAM,
@@ -609,6 +609,21 @@ describe("handleRuleNotificationAction", () => {
 
     expect(cardText).toContain("Status: Reply sent.");
     expect(cardText).toContain("Open in Gmail");
+
+    const editedMessage = await renderTelegramEditedMessageForTest(card);
+    expect(editedMessage.text).toContain("Reply sent\\.");
+    expect(editedMessage.text).toContain("Sender\\_Name");
+    expect(editedMessage.text).toContain("\\[billing\\]\\_status");
+    expect(editedMessage.text).toContain("account\\_name");
+    expect(editedMessage.text).not.toContain("*✍️");
+    expect(editedMessage.text).not.toContain("_They wrote:_");
+    expect(JSON.stringify(editedMessage.replyMarkup)).toContain(
+      "Open in Gmail",
+    );
+    expect(JSON.stringify(editedMessage.replyMarkup)).not.toContain(
+      "Send reply",
+    );
+    expect(JSON.stringify(editedMessage.replyMarkup)).not.toContain("Dismiss");
   });
 
   it("authorizes Telegram send actions against the notification route target", async () => {
@@ -2697,6 +2712,34 @@ async function renderTelegramMessageTextForTest(message: unknown) {
   await adapter.postMessage("telegram-chat-1", message as never);
 
   return renderedText;
+}
+
+async function renderTelegramEditedMessageForTest(message: unknown) {
+  const adapter = new TelegramAdapter({ botToken: "test-token" });
+  let renderedText = "";
+  let replyMarkup: unknown;
+
+  (adapter as any).telegramFetch = async (
+    _method: string,
+    body: { chat_id: string; text: string; reply_markup?: unknown },
+  ) => {
+    renderedText = body.text;
+    replyMarkup = body.reply_markup;
+    return {
+      message_id: 1,
+      chat: { id: body.chat_id },
+      date: 0,
+      text: body.text,
+    };
+  };
+
+  await adapter.editMessage(
+    "telegram:telegram-chat-1",
+    "telegram-chat-1:1",
+    message as never,
+  );
+
+  return { text: renderedText, replyMarkup };
 }
 
 function getNotificationContext({

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1071,7 +1071,8 @@ async function sendDraftReplyFromNotification({
     context,
     logger,
     editMessage,
-    card: buildHandledNotificationCard({
+    card: buildHandledNotificationCardForProvider({
+      provider: context.messagingChannel?.provider,
       content: notificationContent,
       openLink: getNotificationOpenLink(context),
       status: "Reply sent.",
@@ -1990,6 +1991,46 @@ function buildTelegramNotificationCard({
   return Card({
     children,
   });
+}
+
+function buildTelegramHandledNotificationCard({
+  content,
+  openLink,
+  status,
+}: {
+  content: NotificationContent;
+  openLink?: NotificationOpenLink | null;
+  status: string;
+}): CardElement {
+  const children = buildNotificationCardBody(
+    sanitizeTelegramNotificationContent(content),
+  );
+  children.push(CardText(sanitizeTelegramCardText(`Status: ${status}`)));
+  if (openLink) {
+    children.push(Actions([LinkButton(openLink)]));
+  }
+
+  return Card({
+    children,
+  });
+}
+
+function buildHandledNotificationCardForProvider({
+  provider,
+  content,
+  openLink,
+  status,
+}: {
+  provider?: MessagingProvider | null;
+  content: NotificationContent;
+  openLink?: NotificationOpenLink | null;
+  status: string;
+}): CardElement {
+  if (provider === MessagingProvider.TELEGRAM) {
+    return buildTelegramHandledNotificationCard({ content, openLink, status });
+  }
+
+  return buildHandledNotificationCard({ content, openLink, status });
 }
 
 function sanitizeTelegramNotificationContent(


### PR DESCRIPTION
Fix Telegram sent draft notification updates so draft sends render the handled state instead of leaving stale action buttons.

- Use Telegram-specific sanitized handled cards after draft send
- Keep Slack and Teams on the existing handled-card rendering
- Strengthen the Telegram edit-payload test to verify escaped text and removed Send/Dismiss buttons
- Confirmed via Axiom that draft sends succeeded, then Telegram message edits failed on MarkdownV2 parsing

Verification:
- rtk pnpm test utils/messaging/rule-notifications.test.ts
- rtk pnpm exec biome check apps/web/utils/messaging/rule-notifications.ts apps/web/utils/messaging/rule-notifications.test.ts
- rtk git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

