### PR TITLE
INB-263 Adjust team invite initial state

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useForm, useFieldArray } from "react-hook-form";
-import { ArrowRightIcon, UsersIcon } from "lucide-react";
+import { ArrowRightIcon, PlusIcon, UsersIcon } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { PageHeading, TypographyP } from "@/components/Typography";
 import { IconCircle } from "@/app/(app)/[emailAccountId]/onboarding/IconCircle";
@@ -14,6 +14,7 @@ import {
   createOrganizationAndInviteAction,
 } from "@/utils/actions/organization";
 import { isValidEmail } from "@/utils/email";
+import { MAX_BULK_INVITES } from "@/utils/actions/organization.validation";
 
 type InviteFormValues = {
   emails: { email: string }[];
@@ -42,11 +43,12 @@ export function StepInviteTeam({
     formState: { errors, isSubmitting },
   } = useForm<InviteFormValues>({
     defaultValues: {
-      emails: [{ email: "" }, { email: "" }, { email: "" }],
+      emails: [{ email: "" }],
     },
   });
 
-  const { fields } = useFieldArray({ name: "emails", control });
+  const { fields, append } = useFieldArray({ name: "emails", control });
+  const canAddMore = fields.length < MAX_BULK_INVITES;
 
   const filledEmailCount = watch("emails").filter(
     (e) => e.email.trim().length > 0,
@@ -141,12 +143,25 @@ export function StepInviteTeam({
                 name={`emails.${i}.email`}
                 registerProps={register(`emails.${i}.email`, {
                   validate: (v) =>
-                    !v || isValidEmail(v) || "Enter a valid email",
+                    !v.trim() ||
+                    isValidEmail(v.trim()) ||
+                    "Enter a valid email",
                 })}
                 placeholder="name@company.com"
                 error={errors.emails?.[i]?.email}
               />
             ))}
+
+            <Button
+              type="button"
+              variant="ghost"
+              className="px-2 -ml-2"
+              onClick={() => append({ email: "" })}
+              disabled={!canAddMore}
+            >
+              <PlusIcon className="size-4 mr-2" />
+              Add another email
+            </Button>
           </div>
 
           <div className="flex flex-col gap-2 w-full max-w-xs mx-auto mt-6">

--- a/apps/web/components/InviteMemberModal.tsx
+++ b/apps/web/components/InviteMemberModal.tsx
@@ -115,10 +115,7 @@ function InviteForm({
     formState: { errors, isSubmitting },
   } = useForm<InviteFormValues>({
     defaultValues: {
-      invitations: [
-        { email: "", role: "member" },
-        { email: "", role: "member" },
-      ],
+      invitations: [{ email: "", role: "member" }],
     },
   });
 

--- a/apps/web/utils/actions/__tests__/organization-actions.test.ts
+++ b/apps/web/utils/actions/__tests__/organization-actions.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { createOrganizationAction } from "@/utils/actions/organization";
+import {
+  createOrganizationAction,
+  createOrganizationAndInviteAction,
+} from "@/utils/actions/organization";
+import { MAX_BULK_INVITES } from "@/utils/actions/organization.validation";
 
 const { mockEnv } = vi.hoisted(() => ({
   mockEnv: {
@@ -97,5 +101,18 @@ describe("organization actions", () => {
         allowOrgAdminAnalytics: true,
       },
     });
+  });
+
+  it("rejects oversized create-and-invite payloads before writing", async () => {
+    const result = await createOrganizationAndInviteAction("ea_1" as any, {
+      emails: Array.from(
+        { length: MAX_BULK_INVITES + 1 },
+        (_, index) => `user-${index}@test.com`,
+      ),
+    });
+
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.organization.create).not.toHaveBeenCalled();
+    expect(prisma.invitation.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/organization.validation.ts
+++ b/apps/web/utils/actions/organization.validation.ts
@@ -82,7 +82,11 @@ export const createOrganizationAndInviteBody = z.object({
         .email()
         .transform((val) => val.toLowerCase()),
     )
-    .min(1, "At least one email is required"),
+    .min(1, "At least one email is required")
+    .max(
+      MAX_BULK_INVITES,
+      `You can invite up to ${MAX_BULK_INVITES} people at a time`,
+    ),
   userName: z.string().nullable().optional(),
 });
 export type CreateOrganizationAndInviteBody = z.infer<


### PR DESCRIPTION
Updates the team invitation flow so users see a single email field first while still being able to add more invites when needed.

- Start the reusable invite modal with one invitation row instead of two
- Start onboarding invites with one email field and add an explicit add-another control capped by MAX_BULK_INVITES

Verification:
- pnpm exec biome check apps/web/components/InviteMemberModal.tsx apps/web/app/(app)/[emailAccountId]/onboarding/StepInviteTeam.tsx

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

