### PR TITLE
Improve assistant error observability

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -33,6 +33,7 @@ import {
   saveLastSeenRulesRevision,
 } from "@/utils/ai/assistant/chat-seen-rules-revision";
 import { getToolFailureWarning } from "@/utils/ai/assistant/chat-response-guard";
+import { flushLoggerSafely } from "@/utils/logger-flush";
 
 export const maxDuration = 120;
 
@@ -269,6 +270,10 @@ export const POST = withEmailAccount("chat", async (request) => {
         const warning = getToolFailureWarning(responseMessage);
         if (!warning) return;
 
+        request.logger.warn("Assistant chat completed with tool failures", {
+          chatId: chat.id,
+        });
+
         const warningPartId = crypto.randomUUID();
         writer.write({ type: "text-start", id: warningPartId });
         writer.write({
@@ -301,12 +306,23 @@ export const POST = withEmailAccount("chat", async (request) => {
             logger: request.logger,
           });
         }
+
+        await flushLoggerSafely(request.logger, {
+          action: "assistant-chat",
+          flushReason: "chat-stream-finish",
+          chatId: chat.id,
+        });
       },
     });
 
     return createUIMessageStreamResponse({ stream });
   } catch (error) {
     request.logger.error("Error in assistant chat", { error });
+    await flushLoggerSafely(request.logger, {
+      action: "assistant-chat",
+      flushReason: "chat-error",
+      chatId: chat.id,
+    });
     return NextResponse.json(
       { error: "Error in assistant chat" },
       { status: 500 },

--- a/apps/web/utils/actions/ai-rule.test.ts
+++ b/apps/web/utils/actions/ai-rule.test.ts
@@ -166,6 +166,28 @@ describe("runRulesAction", () => {
       }),
     );
   });
+
+  it("flushes logs when a test-mode run fails before returning", async () => {
+    createEmailProviderMock.mockRejectedValueOnce(
+      new Error("provider unavailable"),
+    );
+
+    const result = await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: true,
+    });
+
+    expect(result?.serverError).toBe("An unknown error occurred.");
+    expect(flushLoggerSafelyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "runRules",
+        flushReason: "test-mode-error",
+        stage: "create-email-provider",
+      }),
+    );
+  });
 });
 
 describe("testAiCustomContentAction", () => {
@@ -230,6 +252,23 @@ describe("testAiCustomContentAction", () => {
       expect.objectContaining({
         action: "testAiCustomContent",
         flushReason: "test-mode",
+      }),
+    );
+  });
+
+  it("flushes logs when a custom content test run fails", async () => {
+    runRulesMock.mockRejectedValueOnce(new Error("rule execution failed"));
+
+    const result = await testAiCustomContentAction("account-1", {
+      content: "x",
+    });
+
+    expect(result?.serverError).toBe("An unknown error occurred.");
+    expect(flushLoggerSafelyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "testAiCustomContent",
+        flushReason: "test-mode-error",
       }),
     );
   });

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -56,7 +56,7 @@ export const runRulesAction = actionClient
         provider,
         logger,
       }).catch((error) => {
-        logger.error("Failed to create email provider", { error });
+        logger.warn("Failed to create email provider", { error });
         return flushAndRethrowRunRulesActionError({
           logger,
           error,
@@ -70,7 +70,7 @@ export const runRulesAction = actionClient
       const message = await emailProvider
         .getMessage(messageId)
         .catch((error) => {
-          logger.error("Failed to fetch message for rule execution", { error });
+          logger.warn("Failed to fetch message for rule execution", { error });
           return flushAndRethrowRunRulesActionError({
             logger,
             error,
@@ -263,7 +263,7 @@ export const testAiCustomContentAction = actionClient
 
         return result;
       } catch (error) {
-        logger.error("testAiCustomContent failed", { error });
+        logger.warn("testAiCustomContent failed", { error });
         await flushLoggerSafely(logger, {
           action: "testAiCustomContent",
           flushReason: "test-mode-error",

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -36,7 +36,12 @@ export const runRulesAction = actionClient
         logger.error("Failed to load email account for rule execution", {
           error,
         });
-        throw error;
+        return flushAndRethrowRunRulesActionError({
+          logger,
+          error,
+          isTest,
+          stage: "load-email-account",
+        });
       });
       logger.info("Loaded email account for rule execution", {
         emailAccountFound: Boolean(emailAccount),
@@ -52,7 +57,12 @@ export const runRulesAction = actionClient
         logger,
       }).catch((error) => {
         logger.error("Failed to create email provider", { error });
-        throw error;
+        return flushAndRethrowRunRulesActionError({
+          logger,
+          error,
+          isTest,
+          stage: "create-email-provider",
+        });
       });
       logger.info("Created email provider");
 
@@ -61,7 +71,12 @@ export const runRulesAction = actionClient
         .getMessage(messageId)
         .catch((error) => {
           logger.error("Failed to fetch message for rule execution", { error });
-          throw error;
+          return flushAndRethrowRunRulesActionError({
+            logger,
+            error,
+            isTest,
+            stage: "fetch-message",
+          });
         });
       logger.info("Fetched message for rule execution", {
         fetchedThreadId: message.threadId,
@@ -89,7 +104,12 @@ export const runRulesAction = actionClient
         : Promise.resolve([])
       ).catch((error) => {
         logger.error("Failed to load existing executed rules", { error });
-        throw error;
+        return flushAndRethrowRunRulesActionError({
+          logger,
+          error,
+          isTest,
+          stage: "load-existing-executed-rules",
+        });
       });
       logger.info("Loaded existing executed rules", {
         executedRuleCount: executedRules.length,
@@ -121,7 +141,12 @@ export const runRulesAction = actionClient
         })
         .catch((error) => {
           logger.error("Failed to load enabled rules for execution", { error });
-          throw error;
+          return flushAndRethrowRunRulesActionError({
+            logger,
+            error,
+            isTest,
+            stage: "load-enabled-rules",
+          });
         });
       logger.info("Loaded enabled rules for execution", {
         ruleCount: rules.length,
@@ -138,7 +163,12 @@ export const runRulesAction = actionClient
         modelType: "chat",
       }).catch((error) => {
         logger.error("runRules failed", { error });
-        throw error;
+        return flushAndRethrowRunRulesActionError({
+          logger,
+          error,
+          isTest,
+          stage: "run-rules",
+        });
       });
 
       logger.info("runRules completed", {
@@ -166,71 +196,80 @@ export const testAiCustomContentAction = actionClient
       ctx: { emailAccountId, provider, logger },
       parsedInput: { content },
     }) => {
-      const emailAccount = await getEmailAccountForRuleExecution({
-        emailAccountId,
-      });
-
-      if (!emailAccount) throw new SafeError("Email account not found");
-
-      const emailProvider = await createEmailProvider({
-        emailAccountId,
-        provider,
-        logger,
-      });
-
-      const rules = await prisma.rule.findMany({
-        where: {
+      try {
+        const emailAccount = await getEmailAccountForRuleExecution({
           emailAccountId,
-          enabled: true,
-          instructions: { not: null },
-        },
-        include: {
-          actions: true,
-        },
-      });
+        });
 
-      const testId = `testMessageId-${Date.now()}`;
+        if (!emailAccount) throw new SafeError("Email account not found");
 
-      const result = await runRules({
-        isTest: true,
-        provider: emailProvider,
-        logger,
-        message: {
-          id: testId,
-          // Match id so Gmail's isReplyInThread (which compares id !== threadId)
-          // treats this synthetic test message as the first message in a thread.
-          threadId: testId,
-          snippet: content,
-          textPlain: content,
-          headers: {
-            date: new Date().toISOString(),
-            from: "",
-            to: "",
-            subject: "",
+        const emailProvider = await createEmailProvider({
+          emailAccountId,
+          provider,
+          logger,
+        });
+
+        const rules = await prisma.rule.findMany({
+          where: {
+            emailAccountId,
+            enabled: true,
+            instructions: { not: null },
           },
-          historyId: "",
-          inline: [],
-          internalDate: new Date().toISOString(),
-          subject: "",
-          date: new Date().toISOString(),
-        },
-        rules,
-        emailAccount,
-        modelType: "chat",
-      });
+          include: {
+            actions: true,
+          },
+        });
 
-      logger.info("testAiCustomContent completed", {
-        resultCount: result.length,
-        matchedCount: result.filter((item) => !!item.rule).length,
-        skippedCount: result.filter((item) => !item.rule).length,
-      });
+        const testId = `testMessageId-${Date.now()}`;
 
-      await flushLoggerSafely(logger, {
-        action: "testAiCustomContent",
-        flushReason: "test-mode",
-      });
+        const result = await runRules({
+          isTest: true,
+          provider: emailProvider,
+          logger,
+          message: {
+            id: testId,
+            // Match id so Gmail's isReplyInThread (which compares id !== threadId)
+            // treats this synthetic test message as the first message in a thread.
+            threadId: testId,
+            snippet: content,
+            textPlain: content,
+            headers: {
+              date: new Date().toISOString(),
+              from: "",
+              to: "",
+              subject: "",
+            },
+            historyId: "",
+            inline: [],
+            internalDate: new Date().toISOString(),
+            subject: "",
+            date: new Date().toISOString(),
+          },
+          rules,
+          emailAccount,
+          modelType: "chat",
+        });
 
-      return result;
+        logger.info("testAiCustomContent completed", {
+          resultCount: result.length,
+          matchedCount: result.filter((item) => !!item.rule).length,
+          skippedCount: result.filter((item) => !item.rule).length,
+        });
+
+        await flushLoggerSafely(logger, {
+          action: "testAiCustomContent",
+          flushReason: "test-mode",
+        });
+
+        return result;
+      } catch (error) {
+        logger.error("testAiCustomContent failed", { error });
+        await flushLoggerSafely(logger, {
+          action: "testAiCustomContent",
+          flushReason: "test-mode-error",
+        });
+        throw error;
+      }
     },
   );
 
@@ -245,3 +284,27 @@ export const setRuleRunOnThreadsAction = actionClient
       await setRuleRunOnThreads({ ruleId, emailAccountId, runOnThreads });
     },
   );
+
+type FlushableLogger = Parameters<typeof flushLoggerSafely>[0];
+
+async function flushAndRethrowRunRulesActionError({
+  logger,
+  error,
+  isTest,
+  stage,
+}: {
+  logger: FlushableLogger;
+  error: unknown;
+  isTest?: boolean;
+  stage: string;
+}): Promise<never> {
+  if (isTest) {
+    await flushLoggerSafely(logger, {
+      action: "runRules",
+      flushReason: "test-mode-error",
+      stage,
+    });
+  }
+
+  throw error;
+}

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -23,17 +23,23 @@ vi.mock("@/utils/posthog", () => ({
 }));
 
 const {
+  flushLoggerSafelyMock,
   mockArchiveCategory,
   mockGetCategoryOverview,
   mockStartBulkCategorization,
   mockGetCategorizationProgress,
   mockGetCategorizationStatusSnapshot,
 } = vi.hoisted(() => ({
+  flushLoggerSafelyMock: vi.fn().mockResolvedValue(undefined),
   mockArchiveCategory: vi.fn(),
   mockGetCategoryOverview: vi.fn(),
   mockStartBulkCategorization: vi.fn(),
   mockGetCategorizationProgress: vi.fn(),
   mockGetCategorizationStatusSnapshot: vi.fn(),
+}));
+
+vi.mock("@/utils/logger-flush", () => ({
+  flushLoggerSafely: flushLoggerSafelyMock,
 }));
 
 vi.mock("@/utils/categorize/senders/archive-category", () => ({
@@ -1391,6 +1397,15 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       error: "Failed to search inbox",
     });
     expect(searchMessages).toHaveBeenCalledTimes(1);
+    expect(flushLoggerSafelyMock).toHaveBeenCalledWith(
+      logger,
+      expect.objectContaining({
+        action: "assistant-chat",
+        flushReason: "search-inbox-error",
+        provider: "google",
+        tool: "searchInbox",
+      }),
+    );
   });
 });
 

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -23,23 +23,17 @@ vi.mock("@/utils/posthog", () => ({
 }));
 
 const {
-  flushLoggerSafelyMock,
   mockArchiveCategory,
   mockGetCategoryOverview,
   mockStartBulkCategorization,
   mockGetCategorizationProgress,
   mockGetCategorizationStatusSnapshot,
 } = vi.hoisted(() => ({
-  flushLoggerSafelyMock: vi.fn().mockResolvedValue(undefined),
   mockArchiveCategory: vi.fn(),
   mockGetCategoryOverview: vi.fn(),
   mockStartBulkCategorization: vi.fn(),
   mockGetCategorizationProgress: vi.fn(),
   mockGetCategorizationStatusSnapshot: vi.fn(),
-}));
-
-vi.mock("@/utils/logger-flush", () => ({
-  flushLoggerSafely: flushLoggerSafelyMock,
 }));
 
 vi.mock("@/utils/categorize/senders/archive-category", () => ({
@@ -1397,15 +1391,6 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       error: "Failed to search inbox",
     });
     expect(searchMessages).toHaveBeenCalledTimes(1);
-    expect(flushLoggerSafelyMock).toHaveBeenCalledWith(
-      logger,
-      expect.objectContaining({
-        action: "assistant-chat",
-        flushReason: "search-inbox-error",
-        provider: "google",
-        tool: "searchInbox",
-      }),
-    );
   });
 });
 

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -1,6 +1,7 @@
 import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import type { Logger } from "@/utils/logger";
+import { flushLoggerSafely } from "@/utils/logger-flush";
 import prisma from "@/utils/prisma";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -579,7 +580,18 @@ const gmailSearchInboxTool = ({
           taxonomyNamesKey: "labelNames",
         });
       } catch (error) {
-        logger.error("Failed to search inbox", { error, query });
+        logger.error("Failed to search inbox", {
+          error,
+          query,
+          provider,
+          tool: "searchInbox",
+        });
+        await flushLoggerSafely(logger, {
+          action: "assistant-chat",
+          flushReason: "search-inbox-error",
+          provider,
+          tool: "searchInbox",
+        });
         return { queryUsed: query, error: "Failed to search inbox" };
       }
     },
@@ -643,7 +655,18 @@ const outlookSearchInboxTool = ({
           taxonomyNamesKey: "categoryNames",
         });
       } catch (error) {
-        logger.error("Failed to search inbox", { error, query });
+        logger.error("Failed to search inbox", {
+          error,
+          query,
+          provider,
+          tool: "searchInbox",
+        });
+        await flushLoggerSafely(logger, {
+          action: "assistant-chat",
+          flushReason: "search-inbox-error",
+          provider,
+          tool: "searchInbox",
+        });
         return buildMicrosoftSearchErrorResult({
           query,
           failures: [{ query, error }],

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -1,7 +1,6 @@
 import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import type { Logger } from "@/utils/logger";
-import { flushLoggerSafely } from "@/utils/logger-flush";
 import prisma from "@/utils/prisma";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { createEmailProvider } from "@/utils/email/provider";
@@ -579,19 +578,7 @@ const gmailSearchInboxTool = ({
           labels,
           taxonomyNamesKey: "labelNames",
         });
-      } catch (error) {
-        logger.warn("Failed to search inbox", {
-          error,
-          query,
-          provider,
-          tool: "searchInbox",
-        });
-        await flushLoggerSafely(logger, {
-          action: "assistant-chat",
-          flushReason: "search-inbox-error",
-          provider,
-          tool: "searchInbox",
-        });
+      } catch {
         return { queryUsed: query, error: "Failed to search inbox" };
       }
     },
@@ -636,18 +623,6 @@ const outlookSearchInboxTool = ({
         });
 
         if (!searchResult.result) {
-          logger.warn("Failed to search inbox", {
-            error: searchResult.lastError,
-            query,
-            provider,
-            tool: "searchInbox",
-          });
-          await flushLoggerSafely(logger, {
-            action: "assistant-chat",
-            flushReason: "search-inbox-error",
-            provider,
-            tool: "searchInbox",
-          });
           return buildMicrosoftSearchErrorResult({
             query,
             failures: searchResult.failures,
@@ -663,18 +638,6 @@ const outlookSearchInboxTool = ({
           taxonomyNamesKey: "categoryNames",
         });
       } catch (error) {
-        logger.warn("Failed to search inbox", {
-          error,
-          query,
-          provider,
-          tool: "searchInbox",
-        });
-        await flushLoggerSafely(logger, {
-          action: "assistant-chat",
-          flushReason: "search-inbox-error",
-          provider,
-          tool: "searchInbox",
-        });
         return buildMicrosoftSearchErrorResult({
           query,
           failures: [{ query, error }],

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -580,7 +580,7 @@ const gmailSearchInboxTool = ({
           taxonomyNamesKey: "labelNames",
         });
       } catch (error) {
-        logger.error("Failed to search inbox", {
+        logger.warn("Failed to search inbox", {
           error,
           query,
           provider,
@@ -636,9 +636,17 @@ const outlookSearchInboxTool = ({
         });
 
         if (!searchResult.result) {
-          logger.error("Failed to search inbox", {
+          logger.warn("Failed to search inbox", {
             error: searchResult.lastError,
             query,
+            provider,
+            tool: "searchInbox",
+          });
+          await flushLoggerSafely(logger, {
+            action: "assistant-chat",
+            flushReason: "search-inbox-error",
+            provider,
+            tool: "searchInbox",
           });
           return buildMicrosoftSearchErrorResult({
             query,
@@ -655,7 +663,7 @@ const outlookSearchInboxTool = ({
           taxonomyNamesKey: "categoryNames",
         });
       } catch (error) {
-        logger.error("Failed to search inbox", {
+        logger.warn("Failed to search inbox", {
           error,
           query,
           provider,

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -579,6 +579,7 @@ const gmailSearchInboxTool = ({
           taxonomyNamesKey: "labelNames",
         });
       } catch {
+        // Provider failures are logged and flushed at the provider boundary.
         return { queryUsed: query, error: "Failed to search inbox" };
       }
     },

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -9,6 +9,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
+import { flushLoggerSafely } from "@/utils/logger-flush";
 
 const MODULE = "ai-execute-act";
 
@@ -89,6 +90,10 @@ export async function executeAct({
           draftId,
           logger,
         });
+      } else if (action.type === ActionType.DRAFT_EMAIL) {
+        log.warn("Draft action completed without a draft ID", {
+          actionId: action.id,
+        });
       }
     } catch (error) {
       await logErrorWithDedupe({
@@ -100,6 +105,12 @@ export async function executeAct({
           emailAccountId: emailAccount.id,
           actionType: action.type,
         },
+      });
+      await flushLoggerSafely(log, {
+        action: "executeAct",
+        flushReason: "action-error",
+        executedRuleId: executedRule.id,
+        actionType: action.type,
       });
       await prisma.executedRule.update({
         where: { id: executedRule.id },

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -4,7 +4,8 @@ import { flushLoggerSafely } from "@/utils/logger-flush";
 import { getGmailClientForEmail } from "@/utils/email-account-client";
 import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
 
-const { gmailSearchMessagesMock } = vi.hoisted(() => ({
+const { gmailGetMessageMock, gmailSearchMessagesMock } = vi.hoisted(() => ({
+  gmailGetMessageMock: vi.fn(),
   gmailSearchMessagesMock: vi.fn(),
 }));
 
@@ -32,6 +33,10 @@ vi.mock("@/utils/email/google", () => ({
     searchMessages(...args: unknown[]) {
       return gmailSearchMessagesMock(...args);
     }
+
+    getMessage(...args: unknown[]) {
+      return gmailGetMessageMock(...args);
+    }
   },
 }));
 
@@ -47,6 +52,7 @@ describe("createEmailProvider", () => {
     vi.mocked(assertProviderNotRateLimited).mockResolvedValue(undefined);
     vi.mocked(getGmailClientForEmail).mockResolvedValue({} as any);
     vi.mocked(flushLoggerSafely).mockResolvedValue(undefined);
+    gmailGetMessageMock.mockResolvedValue({});
     gmailSearchMessagesMock.mockResolvedValue({ messages: [] });
   });
 
@@ -78,6 +84,33 @@ describe("createEmailProvider", () => {
         action: "createEmailProvider",
         flushReason: "provider-create-error",
         provider: "google",
+      }),
+    );
+  });
+
+  it("preserves provider creation failures when flushing logs fails", async () => {
+    const logger = createMockLogger();
+    vi.mocked(getGmailClientForEmail).mockRejectedValueOnce(
+      new Error("token refresh failed"),
+    );
+    vi.mocked(flushLoggerSafely).mockRejectedValueOnce(
+      new Error("flush failed"),
+    );
+
+    await expect(
+      createEmailProvider({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        logger,
+      }),
+    ).rejects.toThrow("token refresh failed");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to flush provider creation failure log",
+      expect.objectContaining({
+        provider: "google",
+        source: "create-email-provider",
+        error: expect.any(Error),
       }),
     );
   });
@@ -117,6 +150,64 @@ describe("createEmailProvider", () => {
         operation: "searchMessages",
       }),
     );
+  });
+
+  it("preserves async provider operation failures when flushing logs fails", async () => {
+    const logger = createMockLogger();
+    gmailSearchMessagesMock.mockRejectedValueOnce(
+      new Error("provider request failed"),
+    );
+    vi.mocked(flushLoggerSafely).mockRejectedValueOnce(
+      new Error("flush failed"),
+    );
+
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    await expect(
+      provider.searchMessages({ query: "in:inbox" }),
+    ).rejects.toThrow("provider request failed");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to log provider operation failure",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "searchMessages",
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("logs and flushes sync provider operation failures without changing thrown errors", async () => {
+    const logger = createMockLogger();
+    gmailGetMessageMock.mockImplementationOnce(() => {
+      throw new Error("provider sync failed");
+    });
+
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    expect(() => provider.getMessage("message-1")).toThrow(
+      "provider sync failed",
+    );
+    await vi.waitFor(() => {
+      expect(flushLoggerSafely).toHaveBeenCalledWith(
+        logger,
+        expect.objectContaining({
+          action: "emailProvider",
+          flushReason: "provider-operation-error",
+          provider: "google",
+          operation: "getMessage",
+        }),
+      );
+    });
   });
 });
 

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmailProvider } from "@/utils/email/provider";
+import { flushLoggerSafely } from "@/utils/logger-flush";
+import { getGmailClientForEmail } from "@/utils/email-account-client";
+import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
+
+const { gmailSearchMessagesMock } = vi.hoisted(() => ({
+  gmailSearchMessagesMock: vi.fn(),
+}));
+
+vi.mock("@/utils/email-account-client", () => ({
+  getGmailClientForEmail: vi.fn(),
+  getOutlookClientForEmail: vi.fn(),
+}));
+
+vi.mock("@/utils/email/rate-limit", () => ({
+  assertProviderNotRateLimited: vi.fn(),
+}));
+
+vi.mock("@/utils/logger-flush", () => ({
+  flushLoggerSafely: vi.fn(),
+}));
+
+vi.mock("@/utils/email/google", () => ({
+  GmailProvider: class {
+    readonly name = "google";
+
+    getAccessToken() {
+      return "access-token";
+    }
+
+    searchMessages(...args: unknown[]) {
+      return gmailSearchMessagesMock(...args);
+    }
+  },
+}));
+
+vi.mock("@/utils/email/microsoft", () => ({
+  OutlookProvider: class {
+    readonly name = "microsoft";
+  },
+}));
+
+describe("createEmailProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(assertProviderNotRateLimited).mockResolvedValue(undefined);
+    vi.mocked(getGmailClientForEmail).mockResolvedValue({} as any);
+    vi.mocked(flushLoggerSafely).mockResolvedValue(undefined);
+    gmailSearchMessagesMock.mockResolvedValue({ messages: [] });
+  });
+
+  it("logs and flushes provider creation failures", async () => {
+    const logger = createMockLogger();
+    vi.mocked(getGmailClientForEmail).mockRejectedValueOnce(
+      new Error("token refresh failed"),
+    );
+
+    await expect(
+      createEmailProvider({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        logger,
+      }),
+    ).rejects.toThrow("token refresh failed");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to create email provider",
+      expect.objectContaining({
+        provider: "google",
+        source: "create-email-provider",
+        error: expect.any(Error),
+      }),
+    );
+    expect(flushLoggerSafely).toHaveBeenCalledWith(
+      logger,
+      expect.objectContaining({
+        action: "createEmailProvider",
+        flushReason: "provider-create-error",
+        provider: "google",
+      }),
+    );
+  });
+
+  it("logs and flushes provider operation failures without changing sync methods", async () => {
+    const logger = createMockLogger();
+    gmailSearchMessagesMock.mockRejectedValueOnce(
+      new Error("provider request failed"),
+    );
+
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    expect(provider.getAccessToken()).toBe("access-token");
+    await expect(
+      provider.searchMessages({ query: "in:inbox" }),
+    ).rejects.toThrow("provider request failed");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Email provider operation failed",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "searchMessages",
+        error: expect.any(Error),
+      }),
+    );
+    expect(flushLoggerSafely).toHaveBeenCalledWith(
+      logger,
+      expect.objectContaining({
+        action: "emailProvider",
+        flushReason: "provider-operation-error",
+        provider: "google",
+        operation: "searchMessages",
+      }),
+    );
+  });
+});
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    with: vi.fn(),
+    flush: vi.fn(),
+  } as any;
+}

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -8,6 +8,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
 import { toRateLimitProvider } from "@/utils/email/rate-limit-mode-error";
 import type { Logger } from "@/utils/logger";
+import { flushLoggerSafely } from "@/utils/logger-flush";
 
 export async function createEmailProvider({
   emailAccountId,
@@ -21,18 +22,123 @@ export async function createEmailProvider({
   const rateLimitProvider = toRateLimitProvider(provider);
   if (!rateLimitProvider) throw new Error(`Unsupported provider: ${provider}`);
 
-  await assertProviderNotRateLimited({
-    emailAccountId,
-    provider: rateLimitProvider,
-    logger,
-    source: "create-email-provider",
-  });
+  try {
+    await assertProviderNotRateLimited({
+      emailAccountId,
+      provider: rateLimitProvider,
+      logger,
+      source: "create-email-provider",
+    });
 
-  if (rateLimitProvider === "google") {
-    const client = await getGmailClientForEmail({ emailAccountId, logger });
-    return new GmailProvider(client, logger, emailAccountId);
+    if (rateLimitProvider === "google") {
+      const client = await getGmailClientForEmail({ emailAccountId, logger });
+      return withProviderFailureLogging(
+        new GmailProvider(client, logger, emailAccountId),
+        { emailAccountId, provider: rateLimitProvider, logger },
+      );
+    }
+
+    const client = await getOutlookClientForEmail({ emailAccountId, logger });
+    return withProviderFailureLogging(new OutlookProvider(client, logger), {
+      emailAccountId,
+      provider: rateLimitProvider,
+      logger,
+    });
+  } catch (error) {
+    logger.warn("Failed to create email provider", {
+      error,
+      provider: rateLimitProvider,
+      source: "create-email-provider",
+    });
+    await flushLoggerSafely(logger, {
+      action: "createEmailProvider",
+      flushReason: "provider-create-error",
+      provider: rateLimitProvider,
+    });
+    throw error;
   }
+}
 
-  const client = await getOutlookClientForEmail({ emailAccountId, logger });
-  return new OutlookProvider(client, logger);
+function withProviderFailureLogging(
+  emailProvider: EmailProvider,
+  {
+    emailAccountId,
+    provider,
+    logger,
+  }: {
+    emailAccountId: string;
+    provider: "google" | "microsoft";
+    logger: Logger;
+  },
+): EmailProvider {
+  return new Proxy(emailProvider, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function") return value;
+
+      return (...args: unknown[]) => {
+        try {
+          const result = value.apply(target, args);
+          if (!isPromiseLike(result)) return result;
+
+          return result.catch(async (error: unknown) => {
+            await logProviderOperationFailure({
+              error,
+              emailAccountId,
+              provider,
+              logger,
+              operation: String(property),
+            });
+            throw error;
+          });
+        } catch (error) {
+          logger.warn("Email provider operation failed", {
+            error,
+            emailAccountId,
+            provider,
+            operation: String(property),
+          });
+          throw error;
+        }
+      };
+    },
+  }) as EmailProvider;
+}
+
+async function logProviderOperationFailure({
+  error,
+  emailAccountId,
+  provider,
+  logger,
+  operation,
+}: {
+  error: unknown;
+  emailAccountId: string;
+  provider: "google" | "microsoft";
+  logger: Logger;
+  operation: string;
+}) {
+  logger.warn("Email provider operation failed", {
+    error,
+    emailAccountId,
+    provider,
+    operation,
+  });
+  await flushLoggerSafely(logger, {
+    action: "emailProvider",
+    flushReason: "provider-operation-error",
+    provider,
+    operation,
+  });
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function" &&
+    "catch" in value &&
+    typeof value.catch === "function"
+  );
 }

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -54,6 +54,12 @@ export async function createEmailProvider({
       action: "createEmailProvider",
       flushReason: "provider-create-error",
       provider: rateLimitProvider,
+    }).catch((loggingError) => {
+      logger.warn("Failed to flush provider creation failure log", {
+        error: loggingError,
+        provider: rateLimitProvider,
+        source: "create-email-provider",
+      });
     });
     throw error;
   }
@@ -82,7 +88,7 @@ function withProviderFailureLogging(
           if (!isPromiseLike(result)) return result;
 
           return result.catch(async (error: unknown) => {
-            await logProviderOperationFailure({
+            await logProviderOperationFailureSafely({
               error,
               emailAccountId,
               provider,
@@ -92,17 +98,33 @@ function withProviderFailureLogging(
             throw error;
           });
         } catch (error) {
-          logger.warn("Email provider operation failed", {
+          logProviderOperationFailureSafely({
             error,
             emailAccountId,
             provider,
             operation: String(property),
-          });
+            logger,
+          }).catch(() => undefined);
           throw error;
         }
       };
     },
   }) as EmailProvider;
+}
+
+async function logProviderOperationFailureSafely(
+  input: ProviderOperationFailureLogInput,
+) {
+  try {
+    await logProviderOperationFailure(input);
+  } catch (loggingError) {
+    input.logger.warn("Failed to log provider operation failure", {
+      error: loggingError,
+      emailAccountId: input.emailAccountId,
+      provider: input.provider,
+      operation: input.operation,
+    });
+  }
 }
 
 async function logProviderOperationFailure({
@@ -131,6 +153,14 @@ async function logProviderOperationFailure({
     operation,
   });
 }
+
+type ProviderOperationFailureLogInput = {
+  error: unknown;
+  emailAccountId: string;
+  provider: "google" | "microsoft";
+  logger: Logger;
+  operation: string;
+};
 
 function isPromiseLike(value: unknown): value is Promise<unknown> {
   return (


### PR DESCRIPTION
Improve backend observability for assistant failure paths that can otherwise return generic errors.

- Flush logs for assistant chat tool failures and stream completion paths.
- Flush Assistant Test errors before returning generic failures.
- Add logging for draft action failures and missing draft identifiers.

Tests: pnpm --filter inbox-zero-ai test --run utils/actions/ai-rule.test.ts; pnpm --filter inbox-zero-ai test --run utils/ai/assistant/chat-inbox-tools.test.ts; pnpm --filter inbox-zero-ai test --run utils/ai/choose-rule/execute.test.ts; pnpm --filter inbox-zero-ai exec biome check utils/ai/assistant/chat-inbox-tools.ts app/api/chat/route.ts utils/actions/ai-rule.ts utils/ai/choose-rule/execute.ts utils/ai/assistant/chat-inbox-tools.test.ts utils/actions/ai-rule.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

