### PR TITLE
Add server-side mobile auth start endpoint

### DIFF
--- a/apps/web/app/api/mobile-auth/start/route.test.ts
+++ b/apps/web/app/api/mobile-auth/start/route.test.ts
@@ -1,0 +1,160 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMobileAuthStateMock, handlerMock, mockEnv } = vi.hoisted(() => ({
+  createMobileAuthStateMock: vi.fn(),
+  handlerMock: vi.fn(),
+  mockEnv: {
+    MOBILE_AUTH_ORIGIN: "inboxzero://",
+    NEXT_PUBLIC_BASE_URL: "https://www.getinboxzero.com",
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: mockEnv,
+}));
+
+vi.mock("@/utils/auth", () => ({
+  betterAuthConfig: {
+    handler: handlerMock,
+  },
+}));
+
+vi.mock("@/utils/mobile-auth/oauth-code", () => ({
+  createMobileAuthState: createMobileAuthStateMock,
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware({ handleSafeErrors: true });
+});
+
+import { POST } from "./route";
+
+describe("mobile auth start route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.MOBILE_AUTH_ORIGIN = "inboxzero://";
+    mockEnv.NEXT_PUBLIC_BASE_URL = "https://www.getinboxzero.com";
+    createMobileAuthStateMock.mockReturnValue("state-1234567890");
+    handlerMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          redirect: false,
+          url: "https://accounts.google.com/o/oauth2/v2/auth?client_id=client",
+        }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "set-cookie":
+              "__Secure-better-auth.oauth_state=encrypted-oauth-state; Path=/; HttpOnly; Secure; SameSite=Lax",
+          },
+          status: 200,
+        },
+      ),
+    );
+  });
+
+  it("starts mobile social auth with a server-generated state", async () => {
+    const response = await POST(
+      new NextRequest("https://www.getinboxzero.com/api/mobile-auth/start", {
+        body: JSON.stringify({ provider: "google" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      authorizationURL:
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=client",
+      authSessionReturnUrl: "https://www.getinboxzero.com/auth-callback",
+      oauthState: "encrypted-oauth-state",
+      state: "state-1234567890",
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(handlerMock).toHaveBeenCalledOnce();
+    const [signInRequest] = handlerMock.mock.calls[0] as [Request];
+    expect(signInRequest.url).toBe(
+      "https://www.getinboxzero.com/api/auth/sign-in/social",
+    );
+    await expect(signInRequest.json()).resolves.toEqual({
+      provider: "google",
+      callbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
+      errorCallbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
+      newUserCallbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
+      disableRedirect: true,
+    });
+  });
+
+  it("returns a custom-scheme auth session return URL for local development", async () => {
+    mockEnv.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile-auth/start", {
+        body: JSON.stringify({ provider: "microsoft" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      authorizationURL:
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=client",
+      authSessionReturnUrl: "inboxzero://auth-callback",
+      oauthState: "encrypted-oauth-state",
+      state: "state-1234567890",
+    });
+    expect(handlerMock).toHaveBeenCalledOnce();
+    const [signInRequest] = handlerMock.mock.calls[0] as [Request];
+    expect(signInRequest.url).toBe(
+      "http://localhost:3000/api/auth/sign-in/social",
+    );
+    await expect(signInRequest.json()).resolves.toEqual(
+      expect.objectContaining({
+        callbackURL:
+          "http://localhost:3000/api/mobile-auth/callback?state=state-1234567890",
+        provider: "microsoft",
+      }),
+    );
+  });
+
+  it("returns a known error when Better Auth does not return a URL", async () => {
+    handlerMock.mockResolvedValue(
+      new Response(JSON.stringify({ redirect: false }), {
+        headers: {
+          "content-type": "application/json",
+        },
+        status: 200,
+      }),
+    );
+
+    const response = await POST(
+      new NextRequest("https://www.getinboxzero.com/api/mobile-auth/start", {
+        body: JSON.stringify({ provider: "google" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to start authentication",
+      isKnownError: true,
+    });
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/mobile-auth/start/route.ts
+++ b/apps/web/app/api/mobile-auth/start/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { env } from "@/env";
+import { betterAuthConfig } from "@/utils/auth";
+import { SafeError } from "@/utils/error";
+import { withError } from "@/utils/middleware";
+import { createMobileAuthState } from "@/utils/mobile-auth/oauth-code";
+
+const mobileAuthProviderSchema = z.enum(["apple", "google", "microsoft"]);
+
+const startMobileAuthSchema = z.object({
+  provider: mobileAuthProviderSchema,
+});
+
+export type StartMobileAuthResponse = {
+  authorizationURL: string;
+  authSessionReturnUrl: string;
+  oauthState: string;
+  state: string;
+};
+
+export const POST = withError("mobile-auth/start", async (request) => {
+  const body = startMobileAuthSchema.parse(await request.json());
+  const state = createMobileAuthState();
+  const webCallbackUrl = getMobileAuthWebCallbackUrl(state);
+
+  const signInResponse = await betterAuthConfig.handler(
+    new Request(new URL("/api/auth/sign-in/social", getBaseUrlOrigin()), {
+      body: JSON.stringify({
+        provider: body.provider,
+        callbackURL: webCallbackUrl,
+        errorCallbackURL: webCallbackUrl,
+        newUserCallbackURL: webCallbackUrl,
+        disableRedirect: true,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    }),
+  );
+  const signInBody = (await signInResponse.json().catch(() => null)) as {
+    url?: string;
+  } | null;
+  const oauthState = getOAuthStateCookieValue(
+    signInResponse.headers.get("set-cookie"),
+  );
+
+  if (!signInResponse.ok || !signInBody?.url || !oauthState) {
+    throw new SafeError("Failed to start authentication", 500);
+  }
+
+  const response: StartMobileAuthResponse = {
+    authorizationURL: signInBody.url,
+    authSessionReturnUrl: getAuthSessionReturnUrl(),
+    oauthState,
+    state,
+  };
+
+  return NextResponse.json(response, {
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+});
+
+function getMobileAuthWebCallbackUrl(state: string): string {
+  const callbackUrl = new URL("/api/mobile-auth/callback", getBaseUrlOrigin());
+  callbackUrl.searchParams.set("state", state);
+  return callbackUrl.toString();
+}
+
+function getAuthSessionReturnUrl(): string {
+  const baseUrl = new URL(env.NEXT_PUBLIC_BASE_URL);
+  if (baseUrl.protocol !== "https:" && env.MOBILE_AUTH_ORIGIN) {
+    const origin = env.MOBILE_AUTH_ORIGIN.endsWith("://")
+      ? env.MOBILE_AUTH_ORIGIN
+      : `${env.MOBILE_AUTH_ORIGIN.replace(/\/+$/u, "")}/`;
+    return new URL(`${origin}auth-callback`).toString();
+  }
+
+  return new URL("/auth-callback", baseUrl.origin).toString();
+}
+
+function getBaseUrlOrigin(): string {
+  return new URL(env.NEXT_PUBLIC_BASE_URL).origin;
+}
+
+function getOAuthStateCookieValue(setCookie: string | null): string | null {
+  if (!setCookie) return null;
+
+  for (const cookie of splitSetCookieHeader(setCookie)) {
+    const [nameValue] = cookie.split(";", 1);
+    const [name, ...valueParts] = (nameValue || "").split("=");
+    if (
+      name === "__Secure-better-auth.oauth_state" ||
+      name === "better-auth.oauth_state"
+    ) {
+      return valueParts.join("=") || null;
+    }
+  }
+
+  return null;
+}
+
+function splitSetCookieHeader(setCookie: string): string[] {
+  const parts: string[] = [];
+  let buffer = "";
+  let i = 0;
+
+  while (i < setCookie.length) {
+    const char = setCookie[i];
+    if (char === ",") {
+      const recent = buffer.toLowerCase();
+      const hasExpires = recent.includes("expires=");
+      const hasGmt = /gmt/i.test(recent);
+
+      if (hasExpires && !hasGmt) {
+        buffer += char;
+        i += 1;
+        continue;
+      }
+
+      if (buffer.trim()) {
+        parts.push(buffer.trim());
+        buffer = "";
+      }
+
+      i += 1;
+      if (setCookie[i] === " ") i += 1;
+      continue;
+    }
+
+    buffer += char;
+    i += 1;
+  }
+
+  if (buffer.trim()) {
+    parts.push(buffer.trim());
+  }
+
+  return parts;
+}

--- a/apps/web/utils/mobile-auth/oauth-code.test.ts
+++ b/apps/web/utils/mobile-auth/oauth-code.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/utils/prisma", () => ({
 import {
   consumeMobileAuthCode,
   createMobileAuthCode,
+  createMobileAuthState,
   isValidMobileAuthState,
 } from "./oauth-code";
 
@@ -34,6 +35,13 @@ describe("mobile auth OAuth code", () => {
     vi.clearAllMocks();
     prismaMock.verificationToken.create.mockResolvedValue({});
     prismaMock.verificationToken.deleteMany.mockResolvedValue({ count: 1 });
+  });
+
+  it("generates a valid server-side mobile auth state", () => {
+    const state = createMobileAuthState();
+
+    expect(state).toHaveLength(43);
+    expect(isValidMobileAuthState(state)).toBe(true);
   });
 
   it("stores a hashed one-time code bound to state and user", async () => {

--- a/apps/web/utils/mobile-auth/oauth-code.ts
+++ b/apps/web/utils/mobile-auth/oauth-code.ts
@@ -11,6 +11,10 @@ const MOBILE_AUTH_IDENTIFIER_PREFIX = "mobile-auth";
 const MOBILE_AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 const MOBILE_AUTH_STATE_REGEX = /^[A-Za-z0-9._~-]{16,256}$/u;
 
+export function createMobileAuthState(): string {
+  return randomBytes(32).toString("base64url");
+}
+
 export function isValidMobileAuthState(state: string): boolean {
   return MOBILE_AUTH_STATE_REGEX.test(state);
 }


### PR DESCRIPTION
## Summary
- add a mobile auth start endpoint that generates the mobile OAuth state on the server
- call Better Auth internally and return the authorization URL plus encrypted oauth state for the Expo proxy
- add coverage for production and local-dev return URLs

## Tests
- `env CI=true pnpm --filter inbox-zero-ai test -- --run apps/web/app/api/mobile-auth/start/route.test.ts apps/web/app/api/mobile-auth/callback/route.test.ts apps/web/app/api/mobile-auth/exchange-code/route.test.ts apps/web/utils/mobile-auth/oauth-code.test.ts`
- `pnpm exec biome check --write apps/web/app/api/mobile-auth/start/route.ts apps/web/app/api/mobile-auth/start/route.test.ts apps/web/utils/mobile-auth/oauth-code.ts apps/web/utils/mobile-auth/oauth-code.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

