### PR TITLE
Update scheduling availability data model

### DIFF
--- a/apps/web/app/api/user/booking-links/route.ts
+++ b/apps/web/app/api/user/booking-links/route.ts
@@ -30,7 +30,6 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
           locationValue: true,
           minimumNoticeMinutes: true,
           maxDaysAhead: true,
-          timezone: true,
           destinationCalendarId: true,
           destinationCalendar: {
             select: {
@@ -40,13 +39,18 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
               primary: true,
             },
           },
-          windows: {
-            orderBy: [{ weekday: "asc" }, { startMinutes: "asc" }],
+          availabilitySchedule: {
             select: {
-              id: true,
-              weekday: true,
-              startMinutes: true,
-              endMinutes: true,
+              timezone: true,
+              windows: {
+                orderBy: [{ weekday: "asc" }, { startMinutes: "asc" }],
+                select: {
+                  id: true,
+                  weekday: true,
+                  startMinutes: true,
+                  endMinutes: true,
+                },
+              },
             },
           },
         },
@@ -77,7 +81,13 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
 
   return {
     timezone: emailAccount.timezone,
-    bookingLinks: emailAccount.bookingLinks,
+    bookingLinks: emailAccount.bookingLinks.map(
+      ({ availabilitySchedule, ...bookingLink }) => ({
+        ...bookingLink,
+        timezone: availabilitySchedule.timezone,
+        windows: availabilitySchedule.windows,
+      }),
+    ),
     calendarConnections: emailAccount.calendarConnections,
   };
 }

--- a/apps/web/prisma/migrations/20260621140000_booking_availability_schedules/migration.sql
+++ b/apps/web/prisma/migrations/20260621140000_booking_availability_schedules/migration.sql
@@ -1,0 +1,101 @@
+-- CreateTable
+CREATE TABLE "AvailabilitySchedule" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "timezone" TEXT NOT NULL,
+    "emailAccountId" TEXT NOT NULL,
+
+    CONSTRAINT "AvailabilitySchedule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TEMP TABLE "BookingLinkAvailabilityScheduleMigration" (
+    "bookingLinkId" TEXT NOT NULL,
+    "availabilityScheduleId" TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO "BookingLinkAvailabilityScheduleMigration" (
+    "bookingLinkId",
+    "availabilityScheduleId"
+)
+SELECT
+    id,
+    gen_random_uuid()::text
+FROM "BookingLink";
+
+-- Copy existing booking link availability settings into reusable schedules.
+INSERT INTO "AvailabilitySchedule" (
+    "id",
+    "createdAt",
+    "updatedAt",
+    "name",
+    "isDefault",
+    "timezone",
+    "emailAccountId"
+)
+SELECT
+    mapping."availabilityScheduleId",
+    booking_link."createdAt",
+    booking_link."updatedAt",
+    'Default availability',
+    true,
+    booking_link."timezone",
+    booking_link."emailAccountId"
+FROM "BookingLink" booking_link
+INNER JOIN "BookingLinkAvailabilityScheduleMigration" mapping
+    ON mapping."bookingLinkId" = booking_link.id;
+
+-- Add the booking-link schedule pointer as nullable while existing rows are linked.
+ALTER TABLE "BookingLink" ADD COLUMN "availabilityScheduleId" TEXT;
+
+UPDATE "BookingLink" bl
+SET "availabilityScheduleId" = mapping."availabilityScheduleId"
+FROM "BookingLinkAvailabilityScheduleMigration" mapping
+WHERE mapping."bookingLinkId" = bl.id;
+
+-- Existing booking links must now point to an account-owned availability schedule.
+ALTER TABLE "BookingLink" ALTER COLUMN "availabilityScheduleId" SET NOT NULL;
+
+-- Rename booking windows to availability windows and attach each window to the
+-- schedule that replaced its booking-link parent.
+ALTER TABLE "BookingWindow" RENAME TO "AvailabilityWindow";
+ALTER TABLE "AvailabilityWindow" RENAME CONSTRAINT "BookingWindow_pkey" TO "AvailabilityWindow_pkey";
+ALTER INDEX "BookingWindow_bookingLinkId_idx" RENAME TO "AvailabilityWindow_bookingLinkId_idx";
+ALTER TABLE "AvailabilityWindow" DROP CONSTRAINT "BookingWindow_bookingLinkId_fkey";
+ALTER TABLE "AvailabilityWindow" RENAME COLUMN "bookingLinkId" TO "availabilityScheduleId";
+
+UPDATE "AvailabilityWindow" window
+SET "availabilityScheduleId" = bl."availabilityScheduleId"
+FROM "BookingLink" bl
+WHERE window."availabilityScheduleId" = bl.id;
+
+ALTER INDEX "AvailabilityWindow_bookingLinkId_idx" RENAME TO "AvailabilityWindow_availabilityScheduleId_idx";
+
+-- Drop old constraints/columns after data has moved.
+ALTER TABLE "BookingLink" DROP COLUMN "timezone";
+
+-- CreateIndex
+CREATE INDEX "AvailabilitySchedule_emailAccountId_idx" ON "AvailabilitySchedule"("emailAccountId");
+
+-- CreateIndex
+CREATE INDEX "AvailabilitySchedule_emailAccountId_isDefault_idx" ON "AvailabilitySchedule"("emailAccountId", "isDefault");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AvailabilitySchedule_emailAccountId_default_key" ON "AvailabilitySchedule"("emailAccountId") WHERE "isDefault" = true;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AvailabilitySchedule_id_emailAccountId_key" ON "AvailabilitySchedule"("id", "emailAccountId");
+
+-- CreateIndex
+CREATE INDEX "BookingLink_availabilityScheduleId_idx" ON "BookingLink"("availabilityScheduleId");
+
+-- AddForeignKey
+ALTER TABLE "AvailabilitySchedule" ADD CONSTRAINT "AvailabilitySchedule_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookingLink" ADD CONSTRAINT "BookingLink_availabilityScheduleId_emailAccountId_fkey" FOREIGN KEY ("availabilityScheduleId", "emailAccountId") REFERENCES "AvailabilitySchedule"("id", "emailAccountId") ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AvailabilityWindow" ADD CONSTRAINT "AvailabilityWindow_availabilityScheduleId_fkey" FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -201,6 +201,7 @@ model EmailAccount {
   invitations            Invitation[]
   ssoproviders           SsoProvider[]
   calendarConnections    CalendarConnection[]
+  availabilitySchedules  AvailabilitySchedule[]
   bookingLinks           BookingLink[]
   bookings               Booking[]
   mcpConnections         McpConnection[]
@@ -1187,20 +1188,41 @@ model BookingLink {
   locationValue        String?
   minimumNoticeMinutes Int                     @default(120)
   maxDaysAhead         Int                     @default(90)
-  timezone             String
 
   emailAccountId        String       @unique // temporary: relax when we support multiple booking links per account
   emailAccount          EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
   destinationCalendarId String?
   destinationCalendar   Calendar?    @relation(fields: [destinationCalendarId], references: [id], onDelete: SetNull)
+  availabilityScheduleId String
+  availabilitySchedule   AvailabilitySchedule @relation(fields: [availabilityScheduleId, emailAccountId], references: [id, emailAccountId], onDelete: NoAction)
 
-  windows  BookingWindow[]
   bookings Booking[]
 
   @@index([destinationCalendarId])
+  @@index([availabilityScheduleId])
 }
 
-model BookingWindow {
+model AvailabilitySchedule {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name      String
+  isDefault Boolean @default(false)
+  timezone  String
+
+  emailAccountId String
+  emailAccount   EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+
+  windows      AvailabilityWindow[]
+  bookingLinks BookingLink[]
+
+  @@index([emailAccountId])
+  @@index([emailAccountId, isDefault])
+  @@unique([id, emailAccountId])
+}
+
+model AvailabilityWindow {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1209,10 +1231,10 @@ model BookingWindow {
   startMinutes Int
   endMinutes   Int
 
-  bookingLinkId String
-  bookingLink   BookingLink @relation(fields: [bookingLinkId], references: [id], onDelete: Cascade)
+  availabilityScheduleId String
+  availabilitySchedule   AvailabilitySchedule @relation(fields: [availabilityScheduleId], references: [id], onDelete: Cascade)
 
-  @@index([bookingLinkId])
+  @@index([availabilityScheduleId])
 }
 
 model Booking {

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -50,12 +50,12 @@ describe("booking actions", () => {
     expect(prisma.bookingLink.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          emailAccountId: "email-account-id",
+          emailAccount: { connect: { id: "email-account-id" } },
           slug: "intro-call",
           durationMinutes: 30,
           slotIntervalMinutes: 30,
           locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
-          destinationCalendarId: "calendar-id",
+          destinationCalendar: { connect: { id: "calendar-id" } },
           availabilitySchedule: {
             create: expect.objectContaining({
               name: "Default availability",

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -26,6 +26,7 @@ describe("booking actions", () => {
         provider: "google",
       },
     } as any);
+    prisma.availabilitySchedule.findFirst.mockResolvedValue(null);
   });
 
   it("creates a booking link with provider video and default windows", async () => {
@@ -55,15 +56,21 @@ describe("booking actions", () => {
           slotIntervalMinutes: 30,
           locationType: BookingLinkLocationType.MICROSOFT_TEAMS,
           destinationCalendarId: "calendar-id",
-          timezone: "UTC",
-          windows: {
-            create: [
-              { weekday: 1, startMinutes: 540, endMinutes: 1020 },
-              { weekday: 2, startMinutes: 540, endMinutes: 1020 },
-              { weekday: 3, startMinutes: 540, endMinutes: 1020 },
-              { weekday: 4, startMinutes: 540, endMinutes: 1020 },
-              { weekday: 5, startMinutes: 540, endMinutes: 1020 },
-            ],
+          availabilitySchedule: {
+            create: expect.objectContaining({
+              name: "Default availability",
+              isDefault: true,
+              timezone: "UTC",
+              windows: {
+                create: [
+                  { weekday: 1, startMinutes: 540, endMinutes: 1020 },
+                  { weekday: 2, startMinutes: 540, endMinutes: 1020 },
+                  { weekday: 3, startMinutes: 540, endMinutes: 1020 },
+                  { weekday: 4, startMinutes: 540, endMinutes: 1020 },
+                  { weekday: 5, startMinutes: 540, endMinutes: 1020 },
+                ],
+              },
+            }),
           },
         }),
       }),
@@ -97,11 +104,45 @@ describe("booking actions", () => {
     );
   });
 
+  it("reuses an existing default availability schedule when recreating a booking link", async () => {
+    prisma.bookingLink.findFirst.mockResolvedValue(null);
+    prisma.availabilitySchedule.findFirst.mockResolvedValue({
+      id: "availability-schedule-id",
+    } as any);
+    prisma.calendar.findFirst.mockResolvedValue({
+      id: "calendar-id",
+      connection: { provider: "google" },
+    } as any);
+    prisma.bookingLink.create.mockResolvedValue({
+      id: "booking-link-id",
+    } as any);
+
+    const result = await createBookingLinkAction("email-account-id", {
+      title: "Intro call",
+      slug: "intro-call",
+      timezone: "UTC",
+      durationMinutes: 30,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.bookingLink.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          availabilitySchedule: {
+            connect: { id: "availability-schedule-id" },
+          },
+        }),
+      }),
+    );
+  });
+
   it("derives slot interval from duration on update", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue({
       id: "booking-link-id",
+      availabilityScheduleId: "availability-schedule-id",
     } as any);
     prisma.bookingLink.update.mockResolvedValue({} as any);
+    prisma.availabilitySchedule.update.mockResolvedValue({} as any);
 
     await updateBookingLinkAction("email-account-id", {
       id: "booking-link-id",
@@ -404,6 +445,7 @@ describe("booking actions", () => {
   it("replaces availability windows in one update call", async () => {
     prisma.bookingLink.findFirst.mockResolvedValue({
       id: "booking-link-id",
+      availabilityScheduleId: "availability-schedule-id",
     } as any);
     prisma.bookingLink.update.mockResolvedValue({} as any);
 
@@ -419,15 +461,20 @@ describe("booking actions", () => {
     });
 
     expect(result?.serverError).toBeUndefined();
-    expect(prisma.bookingLink.update).toHaveBeenCalledWith({
-      where: { id: "booking-link-id" },
+    expect(prisma.availabilitySchedule.update).toHaveBeenCalledWith({
+      where: { id: "availability-schedule-id" },
       data: {
         timezone: "America/New_York",
-        minimumNoticeMinutes: 240,
         windows: {
           deleteMany: {},
           create: windows,
         },
+      },
+    });
+    expect(prisma.bookingLink.update).toHaveBeenCalledWith({
+      where: { id: "booking-link-id" },
+      data: {
+        minimumNoticeMinutes: 240,
       },
     });
   });

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -39,21 +39,36 @@ export const createBookingLinkAction = actionClient
     const locationType = parsedInput.videoEnabled
       ? defaultLocationType
       : BookingLinkLocationType.CUSTOM;
+    const defaultAvailabilitySchedule =
+      await prisma.availabilitySchedule.findFirst({
+        where: { emailAccountId, isDefault: true },
+        orderBy: { createdAt: "asc" },
+        select: { id: true },
+      });
 
     const bookingLink = await prisma.bookingLink.create({
       data: {
         title: parsedInput.title,
         slug: parsedInput.slug,
         description: emptyToNull(parsedInput.description),
-        timezone: parsedInput.timezone,
         durationMinutes,
         slotIntervalMinutes,
         locationType,
         emailAccountId,
         destinationCalendarId: destinationCalendar.id,
-        windows: {
-          create: getDefaultWindows(),
-        },
+        availabilitySchedule: defaultAvailabilitySchedule
+          ? { connect: { id: defaultAvailabilitySchedule.id } }
+          : {
+              create: {
+                name: "Default availability",
+                isDefault: true,
+                timezone: parsedInput.timezone,
+                emailAccount: { connect: { id: emailAccountId } },
+                windows: {
+                  create: getDefaultWindows(),
+                },
+              },
+            },
       },
       select: { id: true },
     });
@@ -104,7 +119,6 @@ export const updateBookingLinkAction = actionClient
           parsedInput.description === undefined
             ? undefined
             : emptyToNull(parsedInput.description),
-        timezone: parsedInput.timezone,
         isActive: parsedInput.isActive,
         durationMinutes: parsedInput.durationMinutes,
         slotIntervalMinutes:
@@ -144,22 +158,29 @@ export const updateBookingAvailabilityAction = actionClient
   .metadata({ name: "updateBookingAvailability" })
   .inputSchema(updateBookingAvailabilityBody)
   .action(async ({ ctx: { emailAccountId }, parsedInput }) => {
-    await ensureBookingLinkOwner({
+    const bookingLink = await ensureBookingLinkOwner({
       emailAccountId,
       bookingLinkId: parsedInput.bookingLinkId,
     });
 
-    await prisma.bookingLink.update({
-      where: { id: parsedInput.bookingLinkId },
-      data: {
-        timezone: parsedInput.timezone,
-        minimumNoticeMinutes: parsedInput.minimumNoticeMinutes,
-        windows: {
-          deleteMany: {},
-          create: parsedInput.windows,
+    await Promise.all([
+      prisma.availabilitySchedule.update({
+        where: { id: bookingLink.availabilityScheduleId },
+        data: {
+          timezone: parsedInput.timezone,
+          windows: {
+            deleteMany: {},
+            create: parsedInput.windows,
+          },
         },
-      },
-    });
+      }),
+      prisma.bookingLink.update({
+        where: { id: parsedInput.bookingLinkId },
+        data: {
+          minimumNoticeMinutes: parsedInput.minimumNoticeMinutes,
+        },
+      }),
+    ]);
 
     return { success: true };
   });
@@ -175,6 +196,7 @@ async function ensureBookingLinkOwner({
     where: { id: bookingLinkId, emailAccountId },
     select: {
       id: true,
+      availabilityScheduleId: true,
       locationType: true,
       destinationCalendar: {
         select: {

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -54,8 +54,8 @@ export const createBookingLinkAction = actionClient
         durationMinutes,
         slotIntervalMinutes,
         locationType,
-        emailAccountId,
-        destinationCalendarId: destinationCalendar.id,
+        emailAccount: { connect: { id: emailAccountId } },
+        destinationCalendar: { connect: { id: destinationCalendar.id } },
         availabilitySchedule: defaultAvailabilitySchedule
           ? { connect: { id: defaultAvailabilitySchedule.id } }
           : {

--- a/apps/web/utils/actions/booking.validation.ts
+++ b/apps/web/utils/actions/booking.validation.ts
@@ -55,7 +55,6 @@ export const updateBookingLinkActionBody = z.object({
   title: z.string().trim().min(1).max(120).optional(),
   slug: slugSchema.optional(),
   description: z.string().trim().max(1000).optional().nullable(),
-  timezone: timezoneSchema.optional(),
   isActive: z.boolean().optional(),
   durationMinutes: positiveMinutesSchema.max(24 * 60).optional(),
   locationType: locationTypeSchema.optional(),

--- a/apps/web/utils/ai/calendar/availability.test.ts
+++ b/apps/web/utils/ai/calendar/availability.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { aiGetCalendarAvailability } from "@/utils/ai/calendar/availability";
+import { getUnifiedCalendarAvailability } from "@/utils/calendar/unified-availability";
 
 const { mockGenerateText, mockCreateGenerateText } = vi.hoisted(() => {
   const mockGenerateText = vi.fn();
@@ -26,6 +27,9 @@ vi.mock("@/utils/prisma", () => ({
   default: {
     calendarConnection: {
       findMany: vi.fn(),
+    },
+    availabilitySchedule: {
+      findFirst: vi.fn(),
     },
   },
 }));
@@ -61,6 +65,8 @@ describe("aiGetCalendarAvailability", () => {
         ],
       },
     ] as Awaited<ReturnType<typeof prisma.calendarConnection.findMany>>);
+    vi.mocked(prisma.availabilitySchedule.findFirst).mockResolvedValue(null);
+    vi.mocked(getUnifiedCalendarAvailability).mockResolvedValue([]);
   });
 
   it("returns the timezone used to generate suggested slots", async () => {
@@ -127,5 +133,59 @@ describe("aiGetCalendarAvailability", () => {
         ),
       }),
     );
+  });
+
+  it("filters suggested times outside the default availability schedule", async () => {
+    const prisma = (await import("@/utils/prisma")).default;
+    vi.mocked(prisma.availabilitySchedule.findFirst).mockResolvedValue({
+      timezone: "America/Los_Angeles",
+      windows: [{ weekday: 1, startMinutes: 9 * 60, endMinutes: 17 * 60 }],
+    } as Awaited<ReturnType<typeof prisma.availabilitySchedule.findFirst>>);
+    mockGenerateText.mockImplementation(async ({ tools }) => {
+      await tools.checkCalendarAvailability.execute({
+        timeMin: "2026-05-04T00:00:00.000Z",
+        timeMax: "2026-05-05T00:00:00.000Z",
+      });
+      await tools.returnSuggestedTimes.execute({
+        suggestedTimes: [
+          {
+            start: "2026-05-04 08:00",
+            end: "2026-05-04 08:30",
+          },
+          {
+            start: "2026-05-04 10:30",
+            end: "2026-05-04 11:00",
+          },
+        ],
+      });
+    });
+
+    const result = await aiGetCalendarAvailability({
+      emailAccount: {
+        ...getEmailAccount(),
+        timezone: "America/New_York",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          from: "sender@example.com",
+          to: "user@example.com",
+          subject: "Meeting",
+          content: "Can we meet Monday?",
+          date: new Date("2026-04-30T08:48:00.000Z"),
+        },
+      ],
+      logger: createTestLogger(),
+    });
+
+    expect(result).toEqual({
+      timezone: "America/Los_Angeles",
+      suggestedTimes: [
+        {
+          start: "2026-05-04 10:30",
+          end: "2026-05-04 11:00",
+        },
+      ],
+    });
   });
 });

--- a/apps/web/utils/ai/calendar/availability.ts
+++ b/apps/web/utils/ai/calendar/availability.ts
@@ -1,9 +1,12 @@
+import { TZDate } from "@date-fns/tz";
+import { expandWeeklyAvailability } from "@inboxzero/scheduling";
 import { z } from "zod";
 import { tool } from "ai";
 import type { Logger } from "@/utils/logger";
 import { createGenerateText } from "@/utils/llms";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { getUnifiedCalendarAvailability } from "@/utils/calendar/unified-availability";
+import { formatInUserTimezone } from "@/utils/date";
 import type { EmailAccountWithAI } from "@/utils/llms/types";
 import type { EmailForLLM } from "@/utils/types";
 import prisma from "@/utils/prisma";
@@ -31,6 +34,11 @@ const schema = z.object({
 export type CalendarAvailabilityContext = z.infer<typeof schema> & {
   timezone?: string | null;
 };
+
+type BusyPeriod = { start: string | Date; end: string | Date };
+type AvailabilityWindow = { startTime: string; endTime: string };
+
+const MODEL_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
 export async function aiGetCalendarAvailability({
   emailAccount,
@@ -61,24 +69,46 @@ export async function aiGetCalendarAvailability({
     return null;
   }
 
-  const calendarConnections = await prisma.calendarConnection.findMany({
-    where: {
-      emailAccountId: emailAccount.id,
-      isConnected: true,
-    },
-    include: {
-      calendars: {
-        where: { isEnabled: true },
-        select: {
-          calendarId: true,
-          timezone: true,
-          primary: true,
+  const [calendarConnections, defaultAvailabilitySchedule] = await Promise.all([
+    prisma.calendarConnection.findMany({
+      where: {
+        emailAccountId: emailAccount.id,
+        isConnected: true,
+      },
+      include: {
+        calendars: {
+          where: { isEnabled: true },
+          select: {
+            calendarId: true,
+            timezone: true,
+            primary: true,
+          },
         },
       },
-    },
-  });
+    }),
+    prisma.availabilitySchedule.findFirst({
+      where: {
+        emailAccountId: emailAccount.id,
+        isDefault: true,
+      },
+      orderBy: { createdAt: "asc" },
+      select: {
+        timezone: true,
+        windows: {
+          select: {
+            weekday: true,
+            startMinutes: true,
+            endMinutes: true,
+          },
+        },
+      },
+    }),
+  ]);
 
-  const userTimezone = getUserTimezone(emailAccount, calendarConnections);
+  const hasDefaultAvailabilitySchedule = defaultAvailabilitySchedule != null;
+  const userTimezone =
+    defaultAvailabilitySchedule?.timezone ??
+    getUserTimezone(emailAccount, calendarConnections);
 
   logger.trace("Determined user timezone", { userTimezone });
 
@@ -94,10 +124,12 @@ Your task is to:
 4. Suggest ONLY times that DO NOT overlap with busy periods
 5. Return time slots with start AND end times (infer duration from context: "quick call" = 30min, "meeting" = 60min)
 6. If there are NO available times (user is busy all day), set noAvailability=true and return empty suggestedTimes array
+${hasDefaultAvailabilitySchedule ? "7. When checkCalendarAvailability returns availabilityWindows, suggest ONLY times fully inside those windows." : ""}
 
 CRITICAL: Do NOT suggest times overlapping with busy periods.
 Example: If busy 2025-11-17 09:00 to 2025-11-17 17:00, suggest times AFTER 17:00 or BEFORE 09:00.
 Example: If busy all day (00:00 to 23:59), return empty array and set noAvailability=true.
+${hasDefaultAvailabilitySchedule ? "CRITICAL: Do NOT suggest times outside the returned availabilityWindows, even if the calendar is free then." : ""}
 
 Format: "YYYY-MM-DD HH:MM"
 If email mentions timezone (e.g., "5pm PST"), convert to ${userTimezone}.
@@ -128,6 +160,8 @@ ${threadContent}
   });
 
   let result: CalendarAvailabilityContext | null = null;
+  let lastBusyPeriods: BusyPeriod[] = [];
+  let lastAvailabilityWindows: AvailabilityWindow[] | null = null;
 
   await generateText({
     ...modelOptions,
@@ -168,7 +202,34 @@ ${threadContent}
               busyPeriods,
             });
 
-            return { busyPeriods };
+            lastBusyPeriods = busyPeriods;
+            lastAvailabilityWindows = defaultAvailabilitySchedule
+              ? expandWeeklyAvailability({
+                  start: startDate,
+                  end: endDate,
+                  timezone: userTimezone,
+                  rules: defaultAvailabilitySchedule.windows,
+                })
+              : null;
+
+            const availabilityWindows = lastAvailabilityWindows?.map(
+              (window) => ({
+                start: formatInUserTimezone(
+                  new Date(window.startTime),
+                  userTimezone,
+                  MODEL_TIME_FORMAT,
+                ),
+                end: formatInUserTimezone(
+                  new Date(window.endTime),
+                  userTimezone,
+                  MODEL_TIME_FORMAT,
+                ),
+              }),
+            );
+
+            return availabilityWindows
+              ? { busyPeriods, availabilityWindows }
+              : { busyPeriods };
           } catch (error) {
             logger.error("Error checking calendar availability", { error });
             return { busyPeriods: [] };
@@ -179,13 +240,85 @@ ${threadContent}
         description: "Return suggested times for a meeting",
         inputSchema: schema,
         execute: async (data) => {
-          result = { ...data, timezone: userTimezone };
+          const suggestedTimes = data.suggestedTimes.filter((slot) =>
+            isAllowedSuggestedSlot({
+              slot,
+              timezone: userTimezone,
+              busyPeriods: lastBusyPeriods,
+              availabilityWindows: lastAvailabilityWindows,
+            }),
+          );
+          const noAvailability =
+            data.noAvailability ||
+            (data.suggestedTimes.length > 0 && suggestedTimes.length === 0);
+
+          result = {
+            ...data,
+            suggestedTimes,
+            ...(noAvailability ? { noAvailability: true } : {}),
+            timezone: userTimezone,
+          };
         },
       }),
     },
   });
 
   return result;
+}
+
+function isAllowedSuggestedSlot({
+  slot,
+  timezone,
+  busyPeriods,
+  availabilityWindows,
+}: {
+  slot: z.infer<typeof timeSlotSchema>;
+  timezone: string;
+  busyPeriods: BusyPeriod[];
+  availabilityWindows: AvailabilityWindow[] | null;
+}) {
+  const start = parseModelLocalTime(slot.start, timezone);
+  const end = parseModelLocalTime(slot.end, timezone);
+
+  if (!start || !end || end <= start) return false;
+
+  if (
+    availabilityWindows &&
+    !availabilityWindows.some(
+      (window) =>
+        start >= new Date(window.startTime) && end <= new Date(window.endTime),
+    )
+  ) {
+    return false;
+  }
+
+  return !busyPeriods.some((busyPeriod) => {
+    const busyStart = new Date(busyPeriod.start);
+    const busyEnd = new Date(busyPeriod.end);
+
+    return start < busyEnd && end > busyStart;
+  });
+}
+
+function parseModelLocalTime(localTime: string, timezone: string) {
+  const match = localTime.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/);
+
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute] = match;
+  const date = new TZDate(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    0,
+    0,
+    timezone,
+  );
+
+  const utcDate = new Date(date.getTime());
+  return Number.isNaN(utcDate.getTime()) ? null : utcDate;
 }
 
 function getUserTimezone(

--- a/apps/web/utils/booking/emails.test.ts
+++ b/apps/web/utils/booking/emails.test.ts
@@ -179,7 +179,9 @@ function bookingEmailPayload(
       title: "Intro call",
       locationType: BookingLinkLocationType.CUSTOM,
       locationValue: "Conference room",
-      timezone: "UTC",
+      availabilitySchedule: {
+        timezone: "UTC",
+      },
       emailAccount: {
         email: "host@example.com",
         name: "Host User",

--- a/apps/web/utils/booking/emails.ts
+++ b/apps/web/utils/booking/emails.ts
@@ -23,7 +23,9 @@ type BookingEmailPayload = {
     title: string;
     locationType: BookingLinkLocationType;
     locationValue: string | null;
-    timezone: string;
+    availabilitySchedule: {
+      timezone: string;
+    };
     emailAccount: {
       email: string;
       name?: string | null;
@@ -47,6 +49,7 @@ export async function sendBookingConfirmationEmails({
   const link = booking.bookingLink;
   const host = link.emailAccount;
   const location = getLocationLabel(link);
+  const hostTimezone = link.availabilitySchedule.timezone;
   const guestParts = formatBookingParts({
     startTime: booking.startTime,
     endTime: booking.endTime,
@@ -55,7 +58,7 @@ export async function sendBookingConfirmationEmails({
   const hostParts = formatBookingParts({
     startTime: booking.startTime,
     endTime: booking.endTime,
-    timezone: link.timezone,
+    timezone: hostTimezone,
   });
 
   try {
@@ -93,7 +96,7 @@ export async function sendBookingConfirmationEmails({
           dateDay: hostParts.dateDay,
           dateWeekday: hostParts.dateWeekday,
           timeRange: hostParts.timeRange,
-          timezoneLabel: link.timezone,
+          timezoneLabel: hostTimezone,
           guestNote: booking.guestNote ?? null,
         },
       }),
@@ -124,6 +127,7 @@ export async function sendBookingRescheduledEmails({
   const link = booking.bookingLink;
   const host = link.emailAccount;
   const location = getLocationLabel(link);
+  const hostTimezone = link.availabilitySchedule.timezone;
   const guestParts = formatBookingParts({
     startTime: booking.startTime,
     endTime: booking.endTime,
@@ -132,7 +136,7 @@ export async function sendBookingRescheduledEmails({
   const hostParts = formatBookingParts({
     startTime: booking.startTime,
     endTime: booking.endTime,
-    timezone: link.timezone,
+    timezone: hostTimezone,
   });
 
   try {
@@ -168,7 +172,7 @@ export async function sendBookingRescheduledEmails({
           formattedTime: hostParts.formattedTime,
           previousFormattedTime: formatDateTimeInUserTimezone(
             previousStartTime,
-            link.timezone,
+            hostTimezone,
           ),
           guestEmail: booking.guestEmail,
           guestName: booking.guestName,
@@ -177,7 +181,7 @@ export async function sendBookingRescheduledEmails({
           dateDay: hostParts.dateDay,
           dateWeekday: hostParts.dateWeekday,
           timeRange: hostParts.timeRange,
-          timezoneLabel: link.timezone,
+          timezoneLabel: hostTimezone,
         },
       }),
     ]);
@@ -198,6 +202,7 @@ export async function sendBookingCancellationEmails({
 }) {
   const link = booking.bookingLink;
   const host = link.emailAccount;
+  const hostTimezone = link.availabilitySchedule.timezone;
 
   try {
     await sendHostBookingCancellationEmail({
@@ -207,7 +212,7 @@ export async function sendBookingCancellationEmails({
         eventTitle: link.title,
         formattedTime: formatDateTimeInUserTimezone(
           booking.startTime,
-          link.timezone,
+          hostTimezone,
         ),
         guestEmail: booking.guestEmail,
         guestName: booking.guestName,

--- a/apps/web/utils/booking/public.test.ts
+++ b/apps/web/utils/booking/public.test.ts
@@ -1041,10 +1041,12 @@ describe("public booking", () => {
       locationValue: "Video link",
       minimumNoticeMinutes: 0,
       maxDaysAhead: 30,
-      timezone: "UTC",
       emailAccountId: "email-account-id",
       destinationCalendarId: "calendar-row-id",
-      windows: [{ weekday: 1, startMinutes: 9 * 60, endMinutes: 10 * 60 }],
+      availabilitySchedule: {
+        timezone: "UTC",
+        windows: [{ weekday: 1, startMinutes: 9 * 60, endMinutes: 10 * 60 }],
+      },
       emailAccount: {
         calendarConnections: [
           { id: "connection-id", calendars: [{ id: "other-calendar-id" }] },
@@ -1092,12 +1094,14 @@ function mockBookingLinkConfig(
     locationValue: "Video link",
     minimumNoticeMinutes: 0,
     maxDaysAhead: 30,
-    timezone: "UTC",
     emailAccountId: "email-account-id",
     destinationCalendarId: "calendar-row-id",
-    windows: overrides.windows ?? [
-      { weekday: 1, startMinutes: 9 * 60, endMinutes: 10 * 60 },
-    ],
+    availabilitySchedule: {
+      timezone: "UTC",
+      windows: overrides.windows ?? [
+        { weekday: 1, startMinutes: 9 * 60, endMinutes: 10 * 60 },
+      ],
+    },
     emailAccount: {
       name: "Host User",
       calendarConnections: [
@@ -1149,7 +1153,9 @@ function bookingRecordBase() {
       slotIntervalMinutes: 30,
       locationType: BookingLinkLocationType.CUSTOM,
       locationValue: "Video link",
-      timezone: "UTC",
+      availabilitySchedule: {
+        timezone: "UTC",
+      },
       emailAccount: {
         email: "host@example.com",
         name: "Host User",

--- a/apps/web/utils/booking/public.ts
+++ b/apps/web/utils/booking/public.ts
@@ -102,7 +102,7 @@ export async function getPublicAvailability({
 
   return generateBookableSlots({
     now,
-    timezone: config.link.timezone,
+    timezone: config.timezone,
     start,
     end,
     rules: config.windows,
@@ -192,7 +192,7 @@ export async function createPublicBooking({
       }),
       startTime: selectedStartTime,
       endTime: selectedEndTime,
-      timezone: config.link.timezone,
+      timezone: config.timezone,
       attendees: [{ name: input.guestName, email: input.guestEmail }],
       locationType: config.link.locationType,
       locationValue: config.link.locationValue,
@@ -444,7 +444,7 @@ export async function reschedulePublicBooking({
         providerEventId: booking.providerEventId,
         startTime: newStartTime,
         endTime: newEndTime,
-        timezone: booking.bookingLink.timezone,
+        timezone: booking.bookingLink.availabilitySchedule.timezone,
         logger,
       });
     } catch (error) {
@@ -599,7 +599,9 @@ function getBookingHostInclude() {
         title: true,
         locationType: true,
         locationValue: true,
-        timezone: true,
+        availabilitySchedule: {
+          select: { timezone: true },
+        },
         emailAccount: {
           select: { email: true, name: true },
         },
@@ -620,14 +622,18 @@ async function loadPublicBookingLink(slug: string) {
       locationValue: true,
       minimumNoticeMinutes: true,
       maxDaysAhead: true,
-      timezone: true,
       emailAccountId: true,
       destinationCalendarId: true,
-      windows: {
+      availabilitySchedule: {
         select: {
-          weekday: true,
-          startMinutes: true,
-          endMinutes: true,
+          timezone: true,
+          windows: {
+            select: {
+              weekday: true,
+              startMinutes: true,
+              endMinutes: true,
+            },
+          },
         },
       },
       emailAccount: {
@@ -669,7 +675,8 @@ async function loadPublicBookingLink(slug: string) {
 
   return {
     link,
-    windows: link.windows.map((window) => ({
+    timezone: link.availabilitySchedule.timezone,
+    windows: link.availabilitySchedule.windows.map((window) => ({
       weekday: window.weekday,
       startMinutes: window.startMinutes,
       endMinutes: window.endMinutes,
@@ -706,7 +713,7 @@ async function assertSlotAvailable({
 
   const slotValidation = validateSelectedSlot({
     now: new Date(),
-    timezone: config.link.timezone,
+    timezone: config.timezone,
     start: startTime,
     end: endTime,
     selectedStartTime: startTime,
@@ -742,7 +749,7 @@ async function getBusyPeriods({
       emailAccountId: config.link.emailAccountId,
       startDate: start,
       endDate: end,
-      timezone: config.link.timezone,
+      timezone: config.timezone,
       logger,
       failClosed: true,
       excludeGoogleVirtualCalendars: true,


### PR DESCRIPTION
Refactors scheduling availability into reusable account-level schedules and updates booking and AI scheduling flows to use that data.

- Migrates existing booking link availability into reusable schedules without dropping existing window data
- Updates booking link create, update, public booking, and email flows to read availability from schedules
- Applies default availability schedules when AI suggests meeting times
- Reuses an existing default schedule when recreating a booking link

Validation:
- pnpm --filter inbox-zero-ai exec prisma validate --schema prisma/schema.prisma
- pnpm test utils/actions/booking.test.ts utils/ai/calendar/availability.test.ts
- pnpm test utils/ai/calendar/availability.test.ts utils/actions/booking.test.ts utils/booking/public.test.ts utils/booking/emails.test.ts
- pnpm lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

