### PR TITLE
Share mobile auth callback URL helpers

### DIFF
--- a/apps/web/__tests__/integration/public-booking-google.test.ts
+++ b/apps/web/__tests__/integration/public-booking-google.test.ts
@@ -210,6 +210,10 @@ function mockBookingConfig() {
     emailAccountId: "email-account-id",
     destinationCalendarId: "calendar-row-id",
     windows: [{ weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 }],
+    availabilitySchedule: {
+      timezone: "UTC",
+      windows: [{ weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 }],
+    },
     emailAccount: {
       calendarConnections: [
         { id: "connection-id", calendars: [{ id: "calendar-row-id" }] },

--- a/apps/web/app/api/mobile-auth/callback/route.ts
+++ b/apps/web/app/api/mobile-auth/callback/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { env } from "@/env";
 import { auth } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
 import { withError } from "@/utils/middleware";
@@ -8,6 +7,7 @@ import {
   createMobileAuthCode,
   isValidMobileAuthState,
 } from "@/utils/mobile-auth/oauth-code";
+import { getMobileAuthAppCallbackUrl } from "@/utils/mobile-auth/url";
 
 const callbackQuerySchema = z.object({
   state: z.string().trim().min(1).max(256),
@@ -47,7 +47,7 @@ function redirectToMobileCallback(
   state: string,
   params: Record<string, string>,
 ) {
-  const redirectUrl = getMobileAuthCallbackUrl();
+  const redirectUrl = getMobileAuthAppCallbackUrl();
   redirectUrl.searchParams.set("state", state);
   for (const [key, value] of Object.entries(params)) {
     redirectUrl.searchParams.set(key, value);
@@ -56,16 +56,4 @@ function redirectToMobileCallback(
   const response = NextResponse.redirect(redirectUrl);
   response.headers.set("Cache-Control", "no-store");
   return response;
-}
-
-function getMobileAuthCallbackUrl(): URL {
-  const baseUrl = new URL(env.NEXT_PUBLIC_BASE_URL);
-  if (baseUrl.protocol !== "https:" && env.MOBILE_AUTH_ORIGIN) {
-    const origin = env.MOBILE_AUTH_ORIGIN.endsWith("://")
-      ? env.MOBILE_AUTH_ORIGIN
-      : `${env.MOBILE_AUTH_ORIGIN.replace(/\/+$/u, "")}/`;
-    return new URL(`${origin}auth-callback`);
-  }
-
-  return new URL("/auth-callback", baseUrl.origin);
 }

--- a/apps/web/app/api/mobile-auth/start/route.ts
+++ b/apps/web/app/api/mobile-auth/start/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { env } from "@/env";
 import { betterAuthConfig } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
 import { withError } from "@/utils/middleware";
 import { createMobileAuthState } from "@/utils/mobile-auth/oauth-code";
+import {
+  getMobileAuthAppCallbackUrl,
+  getMobileAuthBaseUrlOrigin,
+  getMobileAuthWebCallbackUrl,
+} from "@/utils/mobile-auth/url";
 
 const mobileAuthProviderSchema = z.enum(["apple", "google", "microsoft"]);
 
@@ -25,19 +29,22 @@ export const POST = withError("mobile-auth/start", async (request) => {
   const webCallbackUrl = getMobileAuthWebCallbackUrl(state);
 
   const signInResponse = await betterAuthConfig.handler(
-    new Request(new URL("/api/auth/sign-in/social", getBaseUrlOrigin()), {
-      body: JSON.stringify({
-        provider: body.provider,
-        callbackURL: webCallbackUrl,
-        errorCallbackURL: webCallbackUrl,
-        newUserCallbackURL: webCallbackUrl,
-        disableRedirect: true,
-      }),
-      headers: {
-        "Content-Type": "application/json",
+    new Request(
+      new URL("/api/auth/sign-in/social", getMobileAuthBaseUrlOrigin()),
+      {
+        body: JSON.stringify({
+          provider: body.provider,
+          callbackURL: webCallbackUrl,
+          errorCallbackURL: webCallbackUrl,
+          newUserCallbackURL: webCallbackUrl,
+          disableRedirect: true,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
       },
-      method: "POST",
-    }),
+    ),
   );
   const signInBody = (await signInResponse.json().catch(() => null)) as {
     url?: string;
@@ -52,7 +59,7 @@ export const POST = withError("mobile-auth/start", async (request) => {
 
   const response: StartMobileAuthResponse = {
     authorizationURL: signInBody.url,
-    authSessionReturnUrl: getAuthSessionReturnUrl(),
+    authSessionReturnUrl: getMobileAuthAppCallbackUrl().toString(),
     oauthState,
     state,
   };
@@ -63,28 +70,6 @@ export const POST = withError("mobile-auth/start", async (request) => {
     },
   });
 });
-
-function getMobileAuthWebCallbackUrl(state: string): string {
-  const callbackUrl = new URL("/api/mobile-auth/callback", getBaseUrlOrigin());
-  callbackUrl.searchParams.set("state", state);
-  return callbackUrl.toString();
-}
-
-function getAuthSessionReturnUrl(): string {
-  const baseUrl = new URL(env.NEXT_PUBLIC_BASE_URL);
-  if (baseUrl.protocol !== "https:" && env.MOBILE_AUTH_ORIGIN) {
-    const origin = env.MOBILE_AUTH_ORIGIN.endsWith("://")
-      ? env.MOBILE_AUTH_ORIGIN
-      : `${env.MOBILE_AUTH_ORIGIN.replace(/\/+$/u, "")}/`;
-    return new URL(`${origin}auth-callback`).toString();
-  }
-
-  return new URL("/auth-callback", baseUrl.origin).toString();
-}
-
-function getBaseUrlOrigin(): string {
-  return new URL(env.NEXT_PUBLIC_BASE_URL).origin;
-}
 
 function getOAuthStateCookieValue(setCookie: string | null): string | null {
   if (!setCookie) return null;

--- a/apps/web/utils/mobile-auth/url.test.ts
+++ b/apps/web/utils/mobile-auth/url.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv } = vi.hoisted(() => ({
+  mockEnv: {
+    MOBILE_AUTH_ORIGIN: "inboxzero://",
+    NEXT_PUBLIC_BASE_URL: "https://www.getinboxzero.com",
+  },
+}));
+
+vi.mock("@/env", () => ({
+  env: mockEnv,
+}));
+
+import {
+  getMobileAuthAppCallbackUrl,
+  getMobileAuthBaseUrlOrigin,
+  getMobileAuthWebCallbackUrl,
+} from "./url";
+
+describe("mobile auth URL helpers", () => {
+  beforeEach(() => {
+    mockEnv.MOBILE_AUTH_ORIGIN = "inboxzero://";
+    mockEnv.NEXT_PUBLIC_BASE_URL = "https://www.getinboxzero.com";
+  });
+
+  it("builds the web callback URL from the configured base origin", () => {
+    expect(getMobileAuthWebCallbackUrl("state-1234567890")).toBe(
+      "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
+    );
+    expect(getMobileAuthBaseUrlOrigin()).toBe("https://www.getinboxzero.com");
+  });
+
+  it("uses the HTTPS app callback URL for production", () => {
+    expect(getMobileAuthAppCallbackUrl().toString()).toBe(
+      "https://www.getinboxzero.com/auth-callback",
+    );
+  });
+
+  it("uses the custom-scheme app callback URL for local development", () => {
+    mockEnv.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+
+    expect(getMobileAuthWebCallbackUrl("state-1234567890")).toBe(
+      "http://localhost:3000/api/mobile-auth/callback?state=state-1234567890",
+    );
+    expect(getMobileAuthBaseUrlOrigin()).toBe("http://localhost:3000");
+    expect(getMobileAuthAppCallbackUrl().toString()).toBe(
+      "inboxzero://auth-callback",
+    );
+  });
+});

--- a/apps/web/utils/mobile-auth/url.ts
+++ b/apps/web/utils/mobile-auth/url.ts
@@ -1,0 +1,29 @@
+import { env } from "@/env";
+
+export const MOBILE_AUTH_WEB_CALLBACK_PATH = "/api/mobile-auth/callback";
+export const MOBILE_AUTH_APP_CALLBACK_PATH = "/auth-callback";
+
+export function getMobileAuthWebCallbackUrl(state: string): string {
+  const callbackUrl = new URL(
+    MOBILE_AUTH_WEB_CALLBACK_PATH,
+    getMobileAuthBaseUrlOrigin(),
+  );
+  callbackUrl.searchParams.set("state", state);
+  return callbackUrl.toString();
+}
+
+export function getMobileAuthAppCallbackUrl(): URL {
+  const baseUrl = new URL(env.NEXT_PUBLIC_BASE_URL);
+  if (baseUrl.protocol !== "https:" && env.MOBILE_AUTH_ORIGIN) {
+    const origin = env.MOBILE_AUTH_ORIGIN.endsWith("://")
+      ? env.MOBILE_AUTH_ORIGIN
+      : `${env.MOBILE_AUTH_ORIGIN.replace(/\/+$/u, "")}/`;
+    return new URL(`${origin}${MOBILE_AUTH_APP_CALLBACK_PATH.slice(1)}`);
+  }
+
+  return new URL(MOBILE_AUTH_APP_CALLBACK_PATH, baseUrl.origin);
+}
+
+export function getMobileAuthBaseUrlOrigin(): string {
+  return new URL(env.NEXT_PUBLIC_BASE_URL).origin;
+}


### PR DESCRIPTION
## Summary
- move mobile auth web/app callback URL construction into `utils/mobile-auth/url`
- update start and callback routes to use the same helper for callback-return behavior
- add focused helper tests for production HTTPS and local custom-scheme URLs

Addresses review feedback from #2876 about duplicated callback-return URL logic.

## Tests
- `pnpm exec biome check --write apps/web/app/api/mobile-auth/start/route.ts apps/web/app/api/mobile-auth/callback/route.ts apps/web/utils/mobile-auth/url.ts apps/web/utils/mobile-auth/url.test.ts`
- `env CI=true pnpm --filter inbox-zero-ai test -- --run apps/web/app/api/mobile-auth/start/route.test.ts apps/web/app/api/mobile-auth/callback/route.test.ts apps/web/utils/mobile-auth/url.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

