### PR TITLE
Use custom scheme for mobile auth callbacks

### DIFF
--- a/apps/web/app/api/mobile-auth/callback/route.test.ts
+++ b/apps/web/app/api/mobile-auth/callback/route.test.ts
@@ -81,6 +81,19 @@ describe("mobile auth callback route", () => {
     );
   });
 
+  it("redirects to the custom scheme when requested by the mobile client", async () => {
+    const response = await GET(
+      new NextRequest(
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+      ),
+      {} as never,
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "inboxzero://auth-callback?state=state-1234567890&code=one-time-code",
+    );
+  });
+
   it("redirects auth errors without minting a code when the web session is missing", async () => {
     authMock.mockResolvedValue(null);
 

--- a/apps/web/app/api/mobile-auth/callback/route.ts
+++ b/apps/web/app/api/mobile-auth/callback/route.ts
@@ -7,16 +7,25 @@ import {
   createMobileAuthCode,
   isValidMobileAuthState,
 } from "@/utils/mobile-auth/oauth-code";
-import { getMobileAuthAppCallbackUrl } from "@/utils/mobile-auth/url";
+import {
+  getMobileAuthAppCallbackUrl,
+  type MobileAuthReturnUrlMode,
+} from "@/utils/mobile-auth/url";
 
+const mobileAuthReturnUrlModeSchema = z.enum(["app-link", "custom-scheme"]);
 const callbackQuerySchema = z.object({
   state: z.string().trim().min(1).max(256),
+  returnUrlMode: mobileAuthReturnUrlModeSchema.optional(),
 });
 
 export const GET = withError("mobile-auth/callback", async (request) => {
   const query = callbackQuerySchema.parse({
     state: request.nextUrl.searchParams.get("state"),
+    returnUrlMode:
+      request.nextUrl.searchParams.get("returnUrlMode") ?? undefined,
   });
+  const returnUrlMode: MobileAuthReturnUrlMode =
+    query.returnUrlMode ?? "app-link";
 
   if (!isValidMobileAuthState(query.state)) {
     throw new SafeError("Invalid authentication state", 400);
@@ -25,10 +34,14 @@ export const GET = withError("mobile-auth/callback", async (request) => {
   const session = await auth(request.headers);
   const userId = session?.user?.id;
   if (!userId) {
-    return redirectToMobileCallback(query.state, {
-      error: "missing_session",
-      error_description: "Authentication session was not found",
-    });
+    return redirectToMobileCallback(
+      query.state,
+      {
+        error: "missing_session",
+        error_description: "Authentication session was not found",
+      },
+      returnUrlMode,
+    );
   }
 
   const code = await createMobileAuthCode({
@@ -40,14 +53,15 @@ export const GET = withError("mobile-auth/callback", async (request) => {
     userId,
   });
 
-  return redirectToMobileCallback(query.state, { code });
+  return redirectToMobileCallback(query.state, { code }, returnUrlMode);
 });
 
 function redirectToMobileCallback(
   state: string,
   params: Record<string, string>,
+  returnUrlMode?: MobileAuthReturnUrlMode,
 ) {
-  const redirectUrl = getMobileAuthAppCallbackUrl();
+  const redirectUrl = getMobileAuthAppCallbackUrl(returnUrlMode);
   redirectUrl.searchParams.set("state", state);
   for (const [key, value] of Object.entries(params)) {
     redirectUrl.searchParams.set(key, value);

--- a/apps/web/app/api/mobile-auth/start/route.test.ts
+++ b/apps/web/app/api/mobile-auth/start/route.test.ts
@@ -130,6 +130,42 @@ describe("mobile auth start route", () => {
     );
   });
 
+  it("starts mobile social auth with a custom-scheme return URL when requested", async () => {
+    const response = await POST(
+      new NextRequest("https://www.getinboxzero.com/api/mobile-auth/start", {
+        body: JSON.stringify({
+          provider: "google",
+          returnUrlMode: "custom-scheme",
+        }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      authorizationURL:
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=client",
+      authSessionReturnUrl: "inboxzero://auth-callback",
+      oauthState: "encrypted-oauth-state",
+      state: "state-1234567890",
+    });
+    expect(handlerMock).toHaveBeenCalledOnce();
+    const [signInRequest] = handlerMock.mock.calls[0] as [Request];
+    await expect(signInRequest.json()).resolves.toEqual({
+      provider: "google",
+      callbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+      errorCallbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+      newUserCallbackURL:
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+      disableRedirect: true,
+    });
+  });
+
   it("returns a known error when Better Auth does not return a URL", async () => {
     handlerMock.mockResolvedValue(
       new Response(JSON.stringify({ redirect: false }), {

--- a/apps/web/app/api/mobile-auth/start/route.ts
+++ b/apps/web/app/api/mobile-auth/start/route.ts
@@ -8,12 +8,15 @@ import {
   getMobileAuthAppCallbackUrl,
   getMobileAuthBaseUrlOrigin,
   getMobileAuthWebCallbackUrl,
+  type MobileAuthReturnUrlMode,
 } from "@/utils/mobile-auth/url";
 
 const mobileAuthProviderSchema = z.enum(["apple", "google", "microsoft"]);
+const mobileAuthReturnUrlModeSchema = z.enum(["app-link", "custom-scheme"]);
 
 const startMobileAuthSchema = z.object({
   provider: mobileAuthProviderSchema,
+  returnUrlMode: mobileAuthReturnUrlModeSchema.optional(),
 });
 
 export type StartMobileAuthResponse = {
@@ -26,7 +29,9 @@ export type StartMobileAuthResponse = {
 export const POST = withError("mobile-auth/start", async (request) => {
   const body = startMobileAuthSchema.parse(await request.json());
   const state = createMobileAuthState();
-  const webCallbackUrl = getMobileAuthWebCallbackUrl(state);
+  const returnUrlMode: MobileAuthReturnUrlMode =
+    body.returnUrlMode ?? "app-link";
+  const webCallbackUrl = getMobileAuthWebCallbackUrl(state, returnUrlMode);
 
   const signInResponse = await betterAuthConfig.handler(
     new Request(
@@ -59,7 +64,7 @@ export const POST = withError("mobile-auth/start", async (request) => {
 
   const response: StartMobileAuthResponse = {
     authorizationURL: signInBody.url,
-    authSessionReturnUrl: getMobileAuthAppCallbackUrl().toString(),
+    authSessionReturnUrl: getMobileAuthAppCallbackUrl(returnUrlMode).toString(),
     oauthState,
     state,
   };

--- a/apps/web/utils/mobile-auth/url.test.ts
+++ b/apps/web/utils/mobile-auth/url.test.ts
@@ -36,6 +36,17 @@ describe("mobile auth URL helpers", () => {
     );
   });
 
+  it("builds custom-scheme callback URLs when requested", () => {
+    expect(
+      getMobileAuthWebCallbackUrl("state-1234567890", "custom-scheme"),
+    ).toBe(
+      "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+    );
+    expect(getMobileAuthAppCallbackUrl("custom-scheme").toString()).toBe(
+      "inboxzero://auth-callback",
+    );
+  });
+
   it("uses the custom-scheme app callback URL for local development", () => {
     mockEnv.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
 

--- a/apps/web/utils/mobile-auth/url.ts
+++ b/apps/web/utils/mobile-auth/url.ts
@@ -3,22 +3,33 @@ import { env } from "@/env";
 export const MOBILE_AUTH_WEB_CALLBACK_PATH = "/api/mobile-auth/callback";
 export const MOBILE_AUTH_APP_CALLBACK_PATH = "/auth-callback";
 
-export function getMobileAuthWebCallbackUrl(state: string): string {
+export type MobileAuthReturnUrlMode = "app-link" | "custom-scheme";
+
+export function getMobileAuthWebCallbackUrl(
+  state: string,
+  returnUrlMode?: MobileAuthReturnUrlMode,
+): string {
   const callbackUrl = new URL(
     MOBILE_AUTH_WEB_CALLBACK_PATH,
     getMobileAuthBaseUrlOrigin(),
   );
   callbackUrl.searchParams.set("state", state);
+  if (returnUrlMode === "custom-scheme") {
+    callbackUrl.searchParams.set("returnUrlMode", returnUrlMode);
+  }
   return callbackUrl.toString();
 }
 
-export function getMobileAuthAppCallbackUrl(): URL {
+export function getMobileAuthAppCallbackUrl(
+  returnUrlMode?: MobileAuthReturnUrlMode,
+): URL {
+  if (returnUrlMode === "custom-scheme" && env.MOBILE_AUTH_ORIGIN) {
+    return new URL(getMobileAuthCustomSchemeOrigin());
+  }
+
   const baseUrl = new URL(env.NEXT_PUBLIC_BASE_URL);
   if (baseUrl.protocol !== "https:" && env.MOBILE_AUTH_ORIGIN) {
-    const origin = env.MOBILE_AUTH_ORIGIN.endsWith("://")
-      ? env.MOBILE_AUTH_ORIGIN
-      : `${env.MOBILE_AUTH_ORIGIN.replace(/\/+$/u, "")}/`;
-    return new URL(`${origin}${MOBILE_AUTH_APP_CALLBACK_PATH.slice(1)}`);
+    return new URL(getMobileAuthCustomSchemeOrigin());
   }
 
   return new URL(MOBILE_AUTH_APP_CALLBACK_PATH, baseUrl.origin);
@@ -26,4 +37,16 @@ export function getMobileAuthAppCallbackUrl(): URL {
 
 export function getMobileAuthBaseUrlOrigin(): string {
   return new URL(env.NEXT_PUBLIC_BASE_URL).origin;
+}
+
+function getMobileAuthCustomSchemeOrigin(): string {
+  const mobileAuthOrigin = env.MOBILE_AUTH_ORIGIN;
+  if (!mobileAuthOrigin) {
+    throw new Error("MOBILE_AUTH_ORIGIN is required for mobile custom scheme");
+  }
+
+  const origin = mobileAuthOrigin.endsWith("://")
+    ? mobileAuthOrigin
+    : `${mobileAuthOrigin.replace(/\/+$/u, "")}/`;
+  return `${origin}${MOBILE_AUTH_APP_CALLBACK_PATH.slice(1)}`;
 }


### PR DESCRIPTION
## Summary
- let mobile auth start requests opt into a custom-scheme return URL
- propagate the return URL mode through the Better Auth callback URL
- redirect callback completions to inboxzero://auth-callback for opted-in mobile clients while preserving HTTPS app-link behavior by default

## Tests
- pnpm --dir apps/web exec vitest run app/api/mobile-auth/start/route.test.ts app/api/mobile-auth/callback/route.test.ts utils/mobile-auth/url.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

