### PR TITLE
Fix booking availability migration temp table

### DIFF
--- a/apps/web/prisma/migrations/20260621140000_booking_availability_schedules/migration.sql
+++ b/apps/web/prisma/migrations/20260621140000_booking_availability_schedules/migration.sql
@@ -14,7 +14,7 @@ CREATE TABLE "AvailabilitySchedule" (
 CREATE TEMP TABLE "BookingLinkAvailabilityScheduleMigration" (
     "bookingLinkId" TEXT NOT NULL,
     "availabilityScheduleId" TEXT NOT NULL
-) ON COMMIT DROP;
+);
 
 INSERT INTO "BookingLinkAvailabilityScheduleMigration" (
     "bookingLinkId",
@@ -99,3 +99,5 @@ ALTER TABLE "BookingLink" ADD CONSTRAINT "BookingLink_availabilityScheduleId_ema
 
 -- AddForeignKey
 ALTER TABLE "AvailabilityWindow" ADD CONSTRAINT "AvailabilityWindow_availabilityScheduleId_fkey" FOREIGN KEY ("availabilityScheduleId") REFERENCES "AvailabilitySchedule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+DROP TABLE "BookingLinkAvailabilityScheduleMigration";


### PR DESCRIPTION
## Summary
- keep the booking availability migration temp table for the migration session instead of dropping it on every commit
- explicitly drop the temp table after the migration finishes

## Verification
- pnpm --dir apps/web exec prisma validate --schema prisma/schema.prisma

## Context
Production deploy recovery now marks the previous failed migration rolled back, but Prisma then retries this migration and fails because `ON COMMIT DROP` removes the temp table before the next statement can insert into it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

