### PR TITLE
Recover empty availability table migration retry

### DIFF
--- a/apps/web/scripts/recover-booking-availability-migration.cjs
+++ b/apps/web/scripts/recover-booking-availability-migration.cjs
@@ -38,6 +38,27 @@ async function main() {
     }
 
     if (
+      state.availabilitySchedule &&
+      state.bookingWindow &&
+      !state.bookingLinkAvailabilityScheduleId
+    ) {
+      const availabilityScheduleCount =
+        await getAvailabilityScheduleCount(client);
+      if (availabilityScheduleCount !== 0) {
+        throw new Error(
+          `Unexpected non-empty AvailabilitySchedule table before ${MIGRATION_NAME}: ${availabilityScheduleCount} rows`,
+        );
+      }
+
+      console.log(
+        "[migration-recovery] Dropping empty AvailabilitySchedule table from failed retry.",
+      );
+      await client.query('DROP TABLE "AvailabilitySchedule"');
+      await resolveMigration("rolled-back");
+      return;
+    }
+
+    if (
       !state.availabilitySchedule ||
       !state.availabilityWindow ||
       !state.bookingLinkAvailabilityScheduleId
@@ -102,6 +123,13 @@ async function getSchemaState(client) {
       ) AS "bookingLinkTimezone"
   `);
   return result.rows[0];
+}
+
+async function getAvailabilityScheduleCount(client) {
+  const result = await client.query(
+    'SELECT COUNT(*)::integer AS count FROM "AvailabilitySchedule"',
+  );
+  return result.rows[0]?.count ?? 0;
 }
 
 async function completePartialMigration(client, state) {


### PR DESCRIPTION
## Summary
- handle the production state where the failed booking availability migration created an empty `AvailabilitySchedule` table but did not touch `BookingLink` or `BookingWindow`
- drop that empty table and mark the failed migration rolled back so the corrected migration can retry
- refuse recovery if the table is non-empty

## Verification
- pnpm exec biome check --write apps/web/scripts/recover-booking-availability-migration.cjs
- node --check apps/web/scripts/recover-booking-availability-migration.cjs
- pnpm --dir apps/web exec prisma validate --schema prisma/schema.prisma

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

