### PR TITLE
Bind mobile auth return mode to server state

### DIFF
--- a/apps/web/app/api/mobile-auth/callback/route.test.ts
+++ b/apps/web/app/api/mobile-auth/callback/route.test.ts
@@ -1,8 +1,14 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { authMock, createMobileAuthCodeMock, mockEnv } = vi.hoisted(() => ({
+const {
+  authMock,
+  consumeMobileAuthStateMock,
+  createMobileAuthCodeMock,
+  mockEnv,
+} = vi.hoisted(() => ({
   authMock: vi.fn(),
+  consumeMobileAuthStateMock: vi.fn(),
   createMobileAuthCodeMock: vi.fn(),
   mockEnv: {
     MOBILE_AUTH_ORIGIN: "inboxzero://",
@@ -24,6 +30,7 @@ vi.mock("@/utils/mobile-auth/oauth-code", async () => {
   >("@/utils/mobile-auth/oauth-code");
   return {
     isValidMobileAuthState: actual.isValidMobileAuthState,
+    consumeMobileAuthState: consumeMobileAuthStateMock,
     createMobileAuthCode: createMobileAuthCodeMock,
   };
 });
@@ -44,6 +51,7 @@ describe("mobile auth callback route", () => {
     mockEnv.MOBILE_AUTH_ORIGIN = "inboxzero://";
     mockEnv.NEXT_PUBLIC_BASE_URL = "https://www.getinboxzero.com";
     authMock.mockResolvedValue({ user: { id: "user-1" } });
+    consumeMobileAuthStateMock.mockResolvedValue({ returnUrlMode: "app-link" });
     createMobileAuthCodeMock.mockResolvedValue("one-time-code");
   });
 
@@ -56,6 +64,9 @@ describe("mobile auth callback route", () => {
     );
 
     expect(authMock).toHaveBeenCalledWith(expect.any(Headers));
+    expect(consumeMobileAuthStateMock).toHaveBeenCalledWith({
+      state: "state-1234567890",
+    });
     expect(createMobileAuthCodeMock).toHaveBeenCalledWith({
       state: "state-1234567890",
       userId: "user-1",
@@ -81,7 +92,26 @@ describe("mobile auth callback route", () => {
     );
   });
 
-  it("redirects to the custom scheme when requested by the mobile client", async () => {
+  it("redirects to the stored custom scheme mode", async () => {
+    consumeMobileAuthStateMock.mockResolvedValue({
+      returnUrlMode: "custom-scheme",
+    });
+
+    const response = await GET(
+      new NextRequest(
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
+      ),
+      {} as never,
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "inboxzero://auth-callback?state=state-1234567890&code=one-time-code",
+    );
+  });
+
+  it("ignores tampered return URL modes on callback URLs", async () => {
+    consumeMobileAuthStateMock.mockResolvedValue({ returnUrlMode: "app-link" });
+
     const response = await GET(
       new NextRequest(
         "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
@@ -90,7 +120,7 @@ describe("mobile auth callback route", () => {
     );
 
     expect(response.headers.get("location")).toBe(
-      "inboxzero://auth-callback?state=state-1234567890&code=one-time-code",
+      "https://www.getinboxzero.com/auth-callback?state=state-1234567890&code=one-time-code",
     );
   });
 

--- a/apps/web/app/api/mobile-auth/callback/route.ts
+++ b/apps/web/app/api/mobile-auth/callback/route.ts
@@ -4,32 +4,28 @@ import { auth } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
 import { withError } from "@/utils/middleware";
 import {
+  consumeMobileAuthState,
   createMobileAuthCode,
   isValidMobileAuthState,
 } from "@/utils/mobile-auth/oauth-code";
-import {
-  getMobileAuthAppCallbackUrl,
-  type MobileAuthReturnUrlMode,
-} from "@/utils/mobile-auth/url";
+import { getMobileAuthAppCallbackUrl } from "@/utils/mobile-auth/url";
 
-const mobileAuthReturnUrlModeSchema = z.enum(["app-link", "custom-scheme"]);
 const callbackQuerySchema = z.object({
   state: z.string().trim().min(1).max(256),
-  returnUrlMode: mobileAuthReturnUrlModeSchema.optional(),
 });
 
 export const GET = withError("mobile-auth/callback", async (request) => {
   const query = callbackQuerySchema.parse({
     state: request.nextUrl.searchParams.get("state"),
-    returnUrlMode:
-      request.nextUrl.searchParams.get("returnUrlMode") ?? undefined,
   });
-  const returnUrlMode: MobileAuthReturnUrlMode =
-    query.returnUrlMode ?? "app-link";
 
   if (!isValidMobileAuthState(query.state)) {
     throw new SafeError("Invalid authentication state", 400);
   }
+
+  const { returnUrlMode } = await consumeMobileAuthState({
+    state: query.state,
+  });
 
   const session = await auth(request.headers);
   const userId = session?.user?.id;
@@ -59,7 +55,7 @@ export const GET = withError("mobile-auth/callback", async (request) => {
 function redirectToMobileCallback(
   state: string,
   params: Record<string, string>,
-  returnUrlMode?: MobileAuthReturnUrlMode,
+  returnUrlMode?: Parameters<typeof getMobileAuthAppCallbackUrl>[0],
 ) {
   const redirectUrl = getMobileAuthAppCallbackUrl(returnUrlMode);
   redirectUrl.searchParams.set("state", state);

--- a/apps/web/app/api/mobile-auth/start/route.test.ts
+++ b/apps/web/app/api/mobile-auth/start/route.test.ts
@@ -1,13 +1,19 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createMobileAuthStateMock, handlerMock, mockEnv } = vi.hoisted(() => ({
+const {
+  createMobileAuthStateMock,
+  handlerMock,
+  mockEnv,
+  storeMobileAuthStateMock,
+} = vi.hoisted(() => ({
   createMobileAuthStateMock: vi.fn(),
   handlerMock: vi.fn(),
   mockEnv: {
     MOBILE_AUTH_ORIGIN: "inboxzero://",
     NEXT_PUBLIC_BASE_URL: "https://www.getinboxzero.com",
   },
+  storeMobileAuthStateMock: vi.fn(),
 }));
 
 vi.mock("@/env", () => ({
@@ -22,6 +28,7 @@ vi.mock("@/utils/auth", () => ({
 
 vi.mock("@/utils/mobile-auth/oauth-code", () => ({
   createMobileAuthState: createMobileAuthStateMock,
+  storeMobileAuthState: storeMobileAuthStateMock,
 }));
 
 vi.mock("@/utils/middleware", async () => {
@@ -40,6 +47,7 @@ describe("mobile auth start route", () => {
     mockEnv.MOBILE_AUTH_ORIGIN = "inboxzero://";
     mockEnv.NEXT_PUBLIC_BASE_URL = "https://www.getinboxzero.com";
     createMobileAuthStateMock.mockReturnValue("state-1234567890");
+    storeMobileAuthStateMock.mockResolvedValue(undefined);
     handlerMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -78,6 +86,10 @@ describe("mobile auth start route", () => {
       state: "state-1234567890",
     });
     expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(storeMobileAuthStateMock).toHaveBeenCalledWith({
+      returnUrlMode: "app-link",
+      state: "state-1234567890",
+    });
     expect(handlerMock).toHaveBeenCalledOnce();
     const [signInRequest] = handlerMock.mock.calls[0] as [Request];
     expect(signInRequest.url).toBe(
@@ -117,6 +129,10 @@ describe("mobile auth start route", () => {
       state: "state-1234567890",
     });
     expect(handlerMock).toHaveBeenCalledOnce();
+    expect(storeMobileAuthStateMock).toHaveBeenCalledWith({
+      returnUrlMode: "app-link",
+      state: "state-1234567890",
+    });
     const [signInRequest] = handlerMock.mock.calls[0] as [Request];
     expect(signInRequest.url).toBe(
       "http://localhost:3000/api/auth/sign-in/social",
@@ -153,15 +169,19 @@ describe("mobile auth start route", () => {
       state: "state-1234567890",
     });
     expect(handlerMock).toHaveBeenCalledOnce();
+    expect(storeMobileAuthStateMock).toHaveBeenCalledWith({
+      returnUrlMode: "custom-scheme",
+      state: "state-1234567890",
+    });
     const [signInRequest] = handlerMock.mock.calls[0] as [Request];
     await expect(signInRequest.json()).resolves.toEqual({
       provider: "google",
       callbackURL:
-        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
       errorCallbackURL:
-        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
       newUserCallbackURL:
-        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
+        "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890",
       disableRedirect: true,
     });
   });
@@ -192,5 +212,6 @@ describe("mobile auth start route", () => {
       isKnownError: true,
     });
     expect(response.status).toBe(500);
+    expect(storeMobileAuthStateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/mobile-auth/start/route.ts
+++ b/apps/web/app/api/mobile-auth/start/route.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import { betterAuthConfig } from "@/utils/auth";
 import { SafeError } from "@/utils/error";
 import { withError } from "@/utils/middleware";
-import { createMobileAuthState } from "@/utils/mobile-auth/oauth-code";
+import {
+  createMobileAuthState,
+  storeMobileAuthState,
+} from "@/utils/mobile-auth/oauth-code";
 import {
   getMobileAuthAppCallbackUrl,
   getMobileAuthBaseUrlOrigin,
@@ -31,7 +34,9 @@ export const POST = withError("mobile-auth/start", async (request) => {
   const state = createMobileAuthState();
   const returnUrlMode: MobileAuthReturnUrlMode =
     body.returnUrlMode ?? "app-link";
-  const webCallbackUrl = getMobileAuthWebCallbackUrl(state, returnUrlMode);
+  const authSessionReturnUrl =
+    getMobileAuthAppCallbackUrl(returnUrlMode).toString();
+  const webCallbackUrl = getMobileAuthWebCallbackUrl(state);
 
   const signInResponse = await betterAuthConfig.handler(
     new Request(
@@ -62,9 +67,14 @@ export const POST = withError("mobile-auth/start", async (request) => {
     throw new SafeError("Failed to start authentication", 500);
   }
 
+  await storeMobileAuthState({
+    returnUrlMode,
+    state,
+  });
+
   const response: StartMobileAuthResponse = {
     authorizationURL: signInBody.url,
-    authSessionReturnUrl: getMobileAuthAppCallbackUrl(returnUrlMode).toString(),
+    authSessionReturnUrl,
     oauthState,
     state,
   };

--- a/apps/web/utils/mobile-auth/oauth-code.test.ts
+++ b/apps/web/utils/mobile-auth/oauth-code.test.ts
@@ -24,10 +24,12 @@ vi.mock("@/utils/prisma", () => ({
 }));
 
 import {
+  consumeMobileAuthState,
   consumeMobileAuthCode,
   createMobileAuthCode,
   createMobileAuthState,
   isValidMobileAuthState,
+  storeMobileAuthState,
 } from "./oauth-code";
 
 describe("mobile auth OAuth code", () => {
@@ -54,7 +56,10 @@ describe("mobile auth OAuth code", () => {
     expect(prismaMock.verificationToken.deleteMany).toHaveBeenCalledWith({
       where: {
         expires: { lt: expect.any(Date) },
-        identifier: { startsWith: "mobile-auth:" },
+        OR: [
+          { identifier: { startsWith: "mobile-auth:" } },
+          { identifier: { startsWith: "mobile-auth-state:" } },
+        ],
       },
     });
     expect(prismaMock.verificationToken.create).toHaveBeenCalledWith({
@@ -64,6 +69,74 @@ describe("mobile auth OAuth code", () => {
         token: expect.not.stringContaining(code),
       }),
     });
+  });
+
+  it("stores return URL mode bound to state", async () => {
+    await storeMobileAuthState({
+      returnUrlMode: "custom-scheme",
+      state: "state-1234567890",
+    });
+
+    expect(prismaMock.verificationToken.deleteMany).toHaveBeenCalledWith({
+      where: {
+        expires: { lt: expect.any(Date) },
+        OR: [
+          { identifier: { startsWith: "mobile-auth:" } },
+          { identifier: { startsWith: "mobile-auth-state:" } },
+        ],
+      },
+    });
+    expect(prismaMock.verificationToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        expires: expect.any(Date),
+        identifier: "mobile-auth-state:custom-scheme",
+        token: expect.any(String),
+      }),
+    });
+    expect(
+      prismaMock.verificationToken.create.mock.calls[0][0].data.token,
+    ).not.toBe("state-1234567890");
+  });
+
+  it("consumes return URL mode bound to state", async () => {
+    prismaMock.verificationToken.findUnique.mockResolvedValue({
+      expires: new Date(Date.now() + 60_000),
+      identifier: "mobile-auth-state:custom-scheme",
+    });
+    prismaMock.verificationToken.delete.mockResolvedValue({});
+
+    await expect(
+      consumeMobileAuthState({
+        state: "state-1234567890",
+      }),
+    ).resolves.toEqual({ returnUrlMode: "custom-scheme" });
+    expect(prismaMock.verificationToken.delete).toHaveBeenCalledWith({
+      where: { token: expect.any(String) },
+    });
+  });
+
+  it("defaults missing return URL mode state records to app links for old flows", async () => {
+    prismaMock.verificationToken.findUnique.mockResolvedValue(null);
+
+    await expect(
+      consumeMobileAuthState({
+        state: "state-1234567890",
+      }),
+    ).resolves.toEqual({ returnUrlMode: "app-link" });
+  });
+
+  it("rejects malformed return URL mode records", async () => {
+    prismaMock.verificationToken.findUnique.mockResolvedValue({
+      expires: new Date(Date.now() + 60_000),
+      identifier: "mobile-auth-state:javascript-alert",
+    });
+
+    await expect(
+      consumeMobileAuthState({
+        state: "state-1234567890",
+      }),
+    ).rejects.toThrow("Invalid authentication state");
+    expect(prismaMock.verificationToken.delete).not.toHaveBeenCalled();
   });
 
   it("consumes a matching unused code once", async () => {

--- a/apps/web/utils/mobile-auth/oauth-code.ts
+++ b/apps/web/utils/mobile-auth/oauth-code.ts
@@ -2,12 +2,14 @@ import { createHmac, randomBytes } from "node:crypto";
 import { env } from "@/env";
 import { SafeError } from "@/utils/error";
 import { createScopedLogger } from "@/utils/logger";
+import type { MobileAuthReturnUrlMode } from "@/utils/mobile-auth/url";
 import prisma from "@/utils/prisma";
 import { isNotFoundError } from "@/utils/prisma-helpers";
 
 const logger = createScopedLogger("mobile-auth/oauth-code");
 
 const MOBILE_AUTH_IDENTIFIER_PREFIX = "mobile-auth";
+const MOBILE_AUTH_STATE_IDENTIFIER_PREFIX = "mobile-auth-state";
 const MOBILE_AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 const MOBILE_AUTH_STATE_REGEX = /^[A-Za-z0-9._~-]{16,256}$/u;
 
@@ -42,6 +44,62 @@ export async function createMobileAuthCode(input: {
   });
 
   return code;
+}
+
+export async function storeMobileAuthState(input: {
+  returnUrlMode: MobileAuthReturnUrlMode;
+  state: string;
+}): Promise<void> {
+  if (!isValidMobileAuthState(input.state)) {
+    throw new SafeError("Invalid authentication state", 400);
+  }
+
+  deleteExpiredMobileAuthTokens().catch(() => undefined);
+
+  await prisma.verificationToken.create({
+    data: {
+      expires: new Date(Date.now() + MOBILE_AUTH_CODE_TTL_MS),
+      identifier: createStateIdentifier(input.returnUrlMode),
+      token: hashMobileAuthState(input.state),
+    },
+  });
+}
+
+export async function consumeMobileAuthState(input: {
+  state: string;
+}): Promise<{ returnUrlMode: MobileAuthReturnUrlMode }> {
+  if (!isValidMobileAuthState(input.state)) {
+    throw new SafeError("Invalid authentication state", 400);
+  }
+
+  const token = hashMobileAuthState(input.state);
+  const record = await prisma.verificationToken.findUnique({
+    where: { token },
+    select: { identifier: true, expires: true },
+  });
+  if (!record) {
+    return { returnUrlMode: "app-link" };
+  }
+
+  const returnUrlMode = parseStateIdentifier(record.identifier);
+  if (!returnUrlMode) {
+    throw new SafeError("Invalid authentication state", 401);
+  }
+
+  if (record.expires <= new Date()) {
+    throw new SafeError("Invalid authentication state", 401);
+  }
+
+  try {
+    await prisma.verificationToken.delete({ where: { token } });
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      throw new SafeError("Invalid authentication state", 401);
+    }
+    throw error;
+  }
+
+  return { returnUrlMode };
 }
 
 export async function consumeMobileAuthCode(input: {
@@ -84,22 +142,48 @@ export async function consumeMobileAuthCode(input: {
 }
 
 async function deleteExpiredMobileAuthCodes() {
+  return deleteExpiredMobileAuthTokens();
+}
+
+async function deleteExpiredMobileAuthTokens() {
   try {
     await prisma.verificationToken.deleteMany({
       where: {
         expires: { lt: new Date() },
-        identifier: {
-          startsWith: `${MOBILE_AUTH_IDENTIFIER_PREFIX}:`,
-        },
+        OR: [
+          { identifier: { startsWith: `${MOBILE_AUTH_IDENTIFIER_PREFIX}:` } },
+          {
+            identifier: {
+              startsWith: `${MOBILE_AUTH_STATE_IDENTIFIER_PREFIX}:`,
+            },
+          },
+        ],
       },
     });
   } catch (error) {
-    logger.error("Failed to sweep expired mobile auth codes", { error });
+    logger.error("Failed to sweep expired mobile auth tokens", { error });
   }
 }
 
 function createIdentifier(input: { state: string; userId: string }): string {
   return `${MOBILE_AUTH_IDENTIFIER_PREFIX}:${input.state}:${input.userId}`;
+}
+
+function createStateIdentifier(returnUrlMode: MobileAuthReturnUrlMode): string {
+  return `${MOBILE_AUTH_STATE_IDENTIFIER_PREFIX}:${returnUrlMode}`;
+}
+
+function parseStateIdentifier(
+  identifier: string,
+): MobileAuthReturnUrlMode | null {
+  const parts = identifier.split(":");
+  if (parts.length !== 2) return null;
+  const [prefix, returnUrlMode] = parts;
+  if (prefix !== MOBILE_AUTH_STATE_IDENTIFIER_PREFIX) return null;
+  if (returnUrlMode !== "app-link" && returnUrlMode !== "custom-scheme") {
+    return null;
+  }
+  return returnUrlMode;
 }
 
 function parseIdentifier(
@@ -115,8 +199,18 @@ function parseIdentifier(
 }
 
 function hashMobileAuthCode(code: string): string {
+  return hashMobileAuthToken("code", code);
+}
+
+function hashMobileAuthState(state: string): string {
+  return hashMobileAuthToken("state", state);
+}
+
+function hashMobileAuthToken(scope: "code" | "state", value: string): string {
   const secret = env.AUTH_SECRET || env.NEXTAUTH_SECRET;
   if (!secret) throw new Error("Auth secret is required");
 
-  return createHmac("sha256", secret).update(code).digest("base64url");
+  return createHmac("sha256", secret)
+    .update(`${scope}:${value}`)
+    .digest("base64url");
 }

--- a/apps/web/utils/mobile-auth/url.test.ts
+++ b/apps/web/utils/mobile-auth/url.test.ts
@@ -37,13 +37,16 @@ describe("mobile auth URL helpers", () => {
   });
 
   it("builds custom-scheme callback URLs when requested", () => {
-    expect(
-      getMobileAuthWebCallbackUrl("state-1234567890", "custom-scheme"),
-    ).toBe(
-      "https://www.getinboxzero.com/api/mobile-auth/callback?state=state-1234567890&returnUrlMode=custom-scheme",
-    );
     expect(getMobileAuthAppCallbackUrl("custom-scheme").toString()).toBe(
       "inboxzero://auth-callback",
+    );
+  });
+
+  it("fails custom-scheme callback URL requests when the scheme is not configured", () => {
+    mockEnv.MOBILE_AUTH_ORIGIN = "";
+
+    expect(() => getMobileAuthAppCallbackUrl("custom-scheme")).toThrow(
+      "MOBILE_AUTH_ORIGIN is required for mobile custom scheme",
     );
   });
 

--- a/apps/web/utils/mobile-auth/url.ts
+++ b/apps/web/utils/mobile-auth/url.ts
@@ -5,25 +5,19 @@ export const MOBILE_AUTH_APP_CALLBACK_PATH = "/auth-callback";
 
 export type MobileAuthReturnUrlMode = "app-link" | "custom-scheme";
 
-export function getMobileAuthWebCallbackUrl(
-  state: string,
-  returnUrlMode?: MobileAuthReturnUrlMode,
-): string {
+export function getMobileAuthWebCallbackUrl(state: string): string {
   const callbackUrl = new URL(
     MOBILE_AUTH_WEB_CALLBACK_PATH,
     getMobileAuthBaseUrlOrigin(),
   );
   callbackUrl.searchParams.set("state", state);
-  if (returnUrlMode === "custom-scheme") {
-    callbackUrl.searchParams.set("returnUrlMode", returnUrlMode);
-  }
   return callbackUrl.toString();
 }
 
 export function getMobileAuthAppCallbackUrl(
   returnUrlMode?: MobileAuthReturnUrlMode,
 ): URL {
-  if (returnUrlMode === "custom-scheme" && env.MOBILE_AUTH_ORIGIN) {
+  if (returnUrlMode === "custom-scheme") {
     return new URL(getMobileAuthCustomSchemeOrigin());
   }
 


### PR DESCRIPTION
## Summary
- address cubic's PR #2880 comments by persisting the mobile auth return URL mode with the generated server state
- remove `returnUrlMode` from the web callback URL and ignore tampered callback query params
- fail fast when `custom-scheme` is requested without `MOBILE_AUTH_ORIGIN` instead of silently downgrading to app-link

## Tests
- pnpm exec biome check --write apps/web/app/api/mobile-auth/start/route.ts apps/web/app/api/mobile-auth/start/route.test.ts apps/web/app/api/mobile-auth/callback/route.ts apps/web/app/api/mobile-auth/callback/route.test.ts apps/web/utils/mobile-auth/oauth-code.ts apps/web/utils/mobile-auth/oauth-code.test.ts apps/web/utils/mobile-auth/url.ts apps/web/utils/mobile-auth/url.test.ts
- pnpm --dir apps/web exec vitest run app/api/mobile-auth/start/route.test.ts app/api/mobile-auth/callback/route.test.ts utils/mobile-auth/oauth-code.test.ts utils/mobile-auth/url.test.ts

## Review comments addressed
- https://github.com/elie222/inbox-zero/pull/2880#discussion_r3448497041
- https://github.com/elie222/inbox-zero/pull/2880#discussion_r3448497042

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

