### PR TITLE
Record provider account issues

### DIFF
--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { cleanupInvalidTokens } from "./cleanup-invalid-tokens";
 import { sendReconnectionEmail } from "@inboxzero/resend";
-import { addUserErrorMessage } from "@/utils/error-messages";
+import {
+  addUserErrorMessage,
+  addUserErrorMessageWithNotification,
+} from "@/utils/error-messages";
 import { createTestLogger } from "@/__tests__/helpers";
 
 const logger = createTestLogger();
@@ -13,6 +16,7 @@ vi.mock("@inboxzero/resend", () => ({
 }));
 vi.mock("@/utils/error-messages", () => ({
   addUserErrorMessage: vi.fn().mockResolvedValue(undefined),
+  addUserErrorMessageWithNotification: vi.fn().mockResolvedValue(undefined),
   ErrorType: {
     ACCOUNT_DISCONNECTED: "Account disconnected",
   },
@@ -62,7 +66,7 @@ describe("cleanupInvalidTokens", () => {
     );
   });
 
-  it("marks as disconnected but skips email if account is not watched", async () => {
+  it("marks as disconnected and sends action-required email if account is not watched", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue({
       ...mockEmailAccount,
       watchEmailsExpirationDate: null,
@@ -77,11 +81,15 @@ describe("cleanupInvalidTokens", () => {
 
     expect(prisma.account.updateMany).toHaveBeenCalled();
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
-    expect(addUserErrorMessage).toHaveBeenCalledWith(
-      "user_1",
-      "Account disconnected",
-      expect.stringContaining("test@example.com"),
-      logger,
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        userEmail: "test@example.com",
+        emailAccountId: "ea_1",
+        errorType: "Account disconnected",
+        errorMessage: expect.stringContaining("test@example.com"),
+        logger,
+      }),
     );
   });
 
@@ -101,7 +109,7 @@ describe("cleanupInvalidTokens", () => {
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
   });
 
-  it("does not send email for insufficient_permissions", async () => {
+  it("sends action-required email for insufficient permissions", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue(mockEmailAccount as any);
     prisma.account.updateMany.mockResolvedValue({ count: 1 });
 
@@ -113,6 +121,33 @@ describe("cleanupInvalidTokens", () => {
 
     expect(prisma.account.updateMany).toHaveBeenCalled();
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
-    expect(addUserErrorMessage).not.toHaveBeenCalled();
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        userEmail: "test@example.com",
+        emailAccountId: "ea_1",
+        errorType: "Account disconnected",
+        errorMessage: expect.stringContaining("missing required permissions"),
+        logger,
+      }),
+    );
+  });
+
+  it("sends action-required email for provider policy blocks", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue(mockEmailAccount as any);
+    prisma.account.updateMany.mockResolvedValue({ count: 1 });
+
+    await cleanupInvalidTokens({
+      emailAccountId: "ea_1",
+      reason: "policy_enforced",
+      logger,
+    });
+
+    expect(sendReconnectionEmail).not.toHaveBeenCalled();
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: expect.stringContaining("security policy"),
+      }),
+    );
   });
 });

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -35,6 +35,7 @@ describe("cleanupInvalidTokens", () => {
     email: "test@example.com",
     accountId: "acc_1",
     userId: "user_1",
+    user: { email: "owner@example.com" },
     account: { disconnectedAt: null },
     watchEmailsExpirationDate: new Date(Date.now() + 1000 * 60 * 60), // Valid expiration
   };
@@ -58,6 +59,14 @@ describe("cleanupInvalidTokens", () => {
       }),
     );
     expect(sendReconnectionEmail).toHaveBeenCalled();
+    expect(sendReconnectionEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "owner@example.com",
+        emailProps: expect.objectContaining({
+          email: "test@example.com",
+        }),
+      }),
+    );
     expect(addUserErrorMessage).toHaveBeenCalledWith(
       "user_1",
       "Account disconnected",
@@ -84,7 +93,7 @@ describe("cleanupInvalidTokens", () => {
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        userEmail: "test@example.com",
+        userEmail: "owner@example.com",
         emailAccountId: "ea_1",
         errorType: "Account disconnected",
         errorMessage: expect.stringContaining("test@example.com"),
@@ -124,7 +133,7 @@ describe("cleanupInvalidTokens", () => {
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        userEmail: "test@example.com",
+        userEmail: "owner@example.com",
         emailAccountId: "ea_1",
         errorType: "Account disconnected",
         errorMessage: expect.stringContaining("missing required permissions"),
@@ -143,10 +152,16 @@ describe("cleanupInvalidTokens", () => {
       logger,
     });
 
+    expect(prisma.account.updateMany).toHaveBeenCalled();
     expect(sendReconnectionEmail).not.toHaveBeenCalled();
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
+        userId: "user_1",
+        userEmail: "owner@example.com",
+        emailAccountId: "ea_1",
+        errorType: "Account disconnected",
         errorMessage: expect.stringContaining("security policy"),
+        logger,
       }),
     );
   });

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -2,7 +2,11 @@ import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
 import { sendReconnectionEmail } from "@inboxzero/resend";
 import { env } from "@/env";
-import { addUserErrorMessage, ErrorType } from "@/utils/error-messages";
+import {
+  addUserErrorMessage,
+  addUserErrorMessageWithNotification,
+  ErrorType,
+} from "@/utils/error-messages";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 
 /**
@@ -10,6 +14,8 @@ import { createUnsubscribeToken } from "@/utils/unsubscribe";
  * Used for:
  * - invalid_grant: User revoked access or tokens expired
  * - insufficientPermissions: User hasn't granted all required scopes
+ * - policy_enforced: Provider policy blocks access until user changes settings
+ * - mail_service_not_enabled: Provider mailbox is unavailable for this account
  */
 export async function cleanupInvalidTokens({
   emailAccountId,
@@ -17,7 +23,11 @@ export async function cleanupInvalidTokens({
   logger,
 }: {
   emailAccountId: string;
-  reason: "invalid_grant" | "insufficient_permissions";
+  reason:
+    | "invalid_grant"
+    | "insufficient_permissions"
+    | "policy_enforced"
+    | "mail_service_not_enabled";
   logger: Logger;
 }) {
   logger.info("Cleaning up invalid tokens", { reason });
@@ -65,46 +75,92 @@ export async function cleanupInvalidTokens({
     return;
   }
 
-  if (reason === "invalid_grant") {
-    const isWatched =
-      !!emailAccount.watchEmailsExpirationDate &&
-      emailAccount.watchEmailsExpirationDate > new Date();
-
-    if (isWatched) {
-      try {
-        const unsubscribeToken = await createUnsubscribeToken({
+  const errorMessage = getAccountActionRequiredMessage(
+    emailAccount.email,
+    reason,
+  );
+  const sentReconnectionEmail =
+    reason === "invalid_grant"
+      ? await sendWatchedAccountReconnectionEmail({
           emailAccountId: emailAccount.id,
-        });
-
-        await sendReconnectionEmail({
-          from: env.RESEND_FROM_EMAIL,
-          to: emailAccount.email,
-          emailProps: {
-            baseUrl: env.NEXT_PUBLIC_BASE_URL,
-            email: emailAccount.email,
-            unsubscribeToken,
-          },
-        });
-        logger.info("Reconnection email sent", { email: emailAccount.email });
-      } catch (error) {
-        logger.error("Failed to send reconnection email", {
           email: emailAccount.email,
-          error,
-        });
-      }
-    } else {
-      logger.info(
-        "Skipping reconnection email - account not currently watched",
-      );
-    }
+          watchEmailsExpirationDate: emailAccount.watchEmailsExpirationDate,
+          logger,
+        })
+      : false;
 
+  if (sentReconnectionEmail) {
     await addUserErrorMessage(
       emailAccount.userId,
       ErrorType.ACCOUNT_DISCONNECTED,
-      `The connection for ${emailAccount.email} was disconnected. Please reconnect your account to resume automation.`,
+      errorMessage,
       logger,
     );
+  } else {
+    await addUserErrorMessageWithNotification({
+      userId: emailAccount.userId,
+      userEmail: emailAccount.email,
+      emailAccountId: emailAccount.id,
+      errorType: ErrorType.ACCOUNT_DISCONNECTED,
+      errorMessage,
+      logger,
+    });
   }
 
   logger.info("Tokens cleared - user must re-authenticate", { reason });
+}
+
+async function sendWatchedAccountReconnectionEmail({
+  emailAccountId,
+  email,
+  watchEmailsExpirationDate,
+  logger,
+}: {
+  emailAccountId: string;
+  email: string;
+  watchEmailsExpirationDate: Date | null;
+  logger: Logger;
+}) {
+  const isWatched =
+    !!watchEmailsExpirationDate && watchEmailsExpirationDate > new Date();
+
+  if (!isWatched) {
+    logger.info("Skipping reconnection email - account not currently watched");
+    return false;
+  }
+
+  try {
+    const unsubscribeToken = await createUnsubscribeToken({ emailAccountId });
+
+    await sendReconnectionEmail({
+      from: env.RESEND_FROM_EMAIL,
+      to: email,
+      emailProps: {
+        baseUrl: env.NEXT_PUBLIC_BASE_URL,
+        email,
+        unsubscribeToken,
+      },
+    });
+    logger.info("Reconnection email sent", { email });
+    return true;
+  } catch (error) {
+    logger.error("Failed to send reconnection email", {
+      email,
+      error,
+    });
+    return false;
+  }
+}
+
+function getAccountActionRequiredMessage(email: string, reason: string) {
+  switch (reason) {
+    case "insufficient_permissions":
+      return `The connection for ${email} is missing required permissions. Please reconnect your account and approve the requested permissions to resume automation.`;
+    case "policy_enforced":
+      return `The connection for ${email} is blocked by your Google account security policy. Please review your Google security settings and reconnect your account to resume automation.`;
+    case "mail_service_not_enabled":
+      return `Gmail is not enabled for ${email}. Please enable Gmail for this account and reconnect it to resume automation.`;
+    default:
+      return `The connection for ${email} was disconnected. Please reconnect your account to resume automation.`;
+  }
 }

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -40,6 +40,11 @@ export async function cleanupInvalidTokens({
       accountId: true,
       userId: true,
       watchEmailsExpirationDate: true,
+      user: {
+        select: {
+          email: true,
+        },
+      },
       account: {
         select: {
           disconnectedAt: true,
@@ -84,6 +89,7 @@ export async function cleanupInvalidTokens({
       ? await sendWatchedAccountReconnectionEmail({
           emailAccountId: emailAccount.id,
           email: emailAccount.email,
+          recipientEmail: emailAccount.user.email,
           watchEmailsExpirationDate: emailAccount.watchEmailsExpirationDate,
           logger,
         })
@@ -99,7 +105,7 @@ export async function cleanupInvalidTokens({
   } else {
     await addUserErrorMessageWithNotification({
       userId: emailAccount.userId,
-      userEmail: emailAccount.email,
+      userEmail: emailAccount.user.email,
       emailAccountId: emailAccount.id,
       errorType: ErrorType.ACCOUNT_DISCONNECTED,
       errorMessage,
@@ -113,11 +119,13 @@ export async function cleanupInvalidTokens({
 async function sendWatchedAccountReconnectionEmail({
   emailAccountId,
   email,
+  recipientEmail,
   watchEmailsExpirationDate,
   logger,
 }: {
   emailAccountId: string;
   email: string;
+  recipientEmail: string;
   watchEmailsExpirationDate: Date | null;
   logger: Logger;
 }) {
@@ -134,14 +142,14 @@ async function sendWatchedAccountReconnectionEmail({
 
     await sendReconnectionEmail({
       from: env.RESEND_FROM_EMAIL,
-      to: email,
+      to: recipientEmail,
       emailProps: {
         baseUrl: env.NEXT_PUBLIC_BASE_URL,
         email,
         unsubscribeToken,
       },
     });
-    logger.info("Reconnection email sent", { email });
+    logger.info("Reconnection email sent", { email, recipientEmail });
     return true;
   } catch (error) {
     logger.error("Failed to send reconnection email", {
@@ -152,7 +160,14 @@ async function sendWatchedAccountReconnectionEmail({
   }
 }
 
-function getAccountActionRequiredMessage(email: string, reason: string) {
+function getAccountActionRequiredMessage(
+  email: string,
+  reason:
+    | "invalid_grant"
+    | "insufficient_permissions"
+    | "policy_enforced"
+    | "mail_service_not_enabled",
+) {
   switch (reason) {
     case "insufficient_permissions":
       return `The connection for ${email} is missing required permissions. Please reconnect your account and approve the requested permissions to resume automation.`;

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -4,25 +4,28 @@ import {
   classifyEmailAccountProviderIssue,
   recordEmailAccountProviderIssue,
 } from "@/utils/email/provider-health";
-import { redis } from "@/utils/redis";
+import {
+  claimProviderIssueCleanupInRedis,
+  releaseProviderIssueCleanupClaimInRedis,
+} from "@/utils/redis/provider-issue-cleanup";
 
 vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
   cleanupInvalidTokens: vi.fn(),
 }));
 
-vi.mock("@/utils/redis", () => ({
-  redis: {
-    set: vi.fn(),
-    del: vi.fn(),
-  },
+vi.mock("@/utils/redis/provider-issue-cleanup", () => ({
+  claimProviderIssueCleanupInRedis: vi.fn(),
+  releaseProviderIssueCleanupClaimInRedis: vi.fn(),
 }));
 
 describe("provider health", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(cleanupInvalidTokens).mockResolvedValue(undefined);
-    vi.mocked(redis.set).mockResolvedValue("OK");
-    vi.mocked(redis.del).mockResolvedValue(1);
+    vi.mocked(claimProviderIssueCleanupInRedis).mockResolvedValue(true);
+    vi.mocked(releaseProviderIssueCleanupClaimInRedis).mockResolvedValue(
+      undefined,
+    );
   });
 
   it("records missing refresh token failures as reconnect-required issues", async () => {
@@ -41,11 +44,10 @@ describe("provider health", () => {
       reason: "invalid_grant",
       logger,
     });
-    expect(redis.set).toHaveBeenCalledWith(
-      "provider-issue-cleanup:email-account-1:invalid_grant",
-      "1",
-      { ex: 900, nx: true },
-    );
+    expect(claimProviderIssueCleanupInRedis).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
   });
 
   it("records insufficient Gmail permissions as action-required issues", async () => {
@@ -68,7 +70,7 @@ describe("provider health", () => {
 
   it("skips cleanup when provider issue cleanup was recently claimed", async () => {
     const logger = createMockLogger();
-    vi.mocked(redis.set).mockResolvedValueOnce(null);
+    vi.mocked(claimProviderIssueCleanupInRedis).mockResolvedValueOnce(false);
 
     await recordEmailAccountProviderIssue({
       emailAccountId: "email-account-1",
@@ -92,7 +94,9 @@ describe("provider health", () => {
 
   it("falls back to cleanup when Redis claim fails", async () => {
     const logger = createMockLogger();
-    vi.mocked(redis.set).mockRejectedValueOnce(new Error("redis unavailable"));
+    vi.mocked(claimProviderIssueCleanupInRedis).mockRejectedValueOnce(
+      new Error("redis unavailable"),
+    );
 
     await recordEmailAccountProviderIssue({
       emailAccountId: "email-account-1",
@@ -163,9 +167,10 @@ describe("provider health", () => {
         error: expect.any(Error),
       }),
     );
-    expect(redis.del).toHaveBeenCalledWith(
-      "provider-issue-cleanup:email-account-1:invalid_grant",
-    );
+    expect(releaseProviderIssueCleanupClaimInRedis).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
   });
 
   it("records Google policy blocks as action-required issues", () => {

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -51,6 +51,52 @@ describe("provider health", () => {
     });
   });
 
+  it("records Outlook access denied as action-required permission issues", async () => {
+    const logger = createMockLogger();
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      error: new Error("Access is denied. Check credentials and try again."),
+      logger,
+      operation: "getMessage",
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "insufficient_permissions",
+      logger,
+    });
+  });
+
+  it("keeps provider error handling alive when cleanup fails", async () => {
+    const logger = createMockLogger();
+    vi.mocked(cleanupInvalidTokens).mockRejectedValueOnce(
+      new Error("cleanup failed"),
+    );
+
+    await expect(
+      recordEmailAccountProviderIssue({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        error: new Error("No refresh token"),
+        logger,
+        operation: "createEmailProvider",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to clean up provider account issue",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "createEmailProvider",
+        reason: "invalid_grant",
+        error: expect.any(Error),
+      }),
+    );
+  });
+
   it("records Google policy blocks as action-required issues", () => {
     expect(
       classifyEmailAccountProviderIssue({

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
+import {
+  classifyEmailAccountProviderIssue,
+  recordEmailAccountProviderIssue,
+} from "@/utils/email/provider-health";
+
+vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
+  cleanupInvalidTokens: vi.fn(),
+}));
+
+describe("provider health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cleanupInvalidTokens).mockResolvedValue(undefined);
+  });
+
+  it("records missing refresh token failures as reconnect-required issues", async () => {
+    const logger = createMockLogger();
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("No refresh token"),
+      logger,
+      operation: "createEmailProvider",
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+      logger,
+    });
+  });
+
+  it("records insufficient Gmail permissions as action-required issues", async () => {
+    const logger = createMockLogger();
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("Request had insufficient authentication scopes."),
+      logger,
+      operation: "getLabels",
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "insufficient_permissions",
+      logger,
+    });
+  });
+
+  it("records Google policy blocks as action-required issues", () => {
+    expect(
+      classifyEmailAccountProviderIssue({
+        provider: "google",
+        error: new Error("policy_enforced"),
+      }),
+    ).toEqual({ reason: "policy_enforced" });
+  });
+
+  it("records unavailable Gmail service as action-required issues", () => {
+    expect(
+      classifyEmailAccountProviderIssue({
+        provider: "google",
+        error: new Error("Mail service not enabled"),
+      }),
+    ).toEqual({ reason: "mail_service_not_enabled" });
+  });
+
+  it("ignores transient Outlook throttling failures", async () => {
+    const logger = createMockLogger();
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "microsoft",
+      error: new Error("Application is over its MailboxConcurrency limit."),
+      logger,
+      operation: "getMessage",
+    });
+
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+  });
+
+  it("ignores Outlook item-not-found failures", () => {
+    expect(
+      classifyEmailAccountProviderIssue({
+        provider: "microsoft",
+        error: new Error("The specified object was not found in the store."),
+      }),
+    ).toBeNull();
+  });
+});
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    with: vi.fn(),
+    flush: vi.fn(),
+  } as any;
+}

--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -4,15 +4,25 @@ import {
   classifyEmailAccountProviderIssue,
   recordEmailAccountProviderIssue,
 } from "@/utils/email/provider-health";
+import { redis } from "@/utils/redis";
 
 vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
   cleanupInvalidTokens: vi.fn(),
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    set: vi.fn(),
+    del: vi.fn(),
+  },
 }));
 
 describe("provider health", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(cleanupInvalidTokens).mockResolvedValue(undefined);
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(redis.del).mockResolvedValue(1);
   });
 
   it("records missing refresh token failures as reconnect-required issues", async () => {
@@ -31,6 +41,11 @@ describe("provider health", () => {
       reason: "invalid_grant",
       logger,
     });
+    expect(redis.set).toHaveBeenCalledWith(
+      "provider-issue-cleanup:email-account-1:invalid_grant",
+      "1",
+      { ex: 900, nx: true },
+    );
   });
 
   it("records insufficient Gmail permissions as action-required issues", async () => {
@@ -49,6 +64,59 @@ describe("provider health", () => {
       reason: "insufficient_permissions",
       logger,
     });
+  });
+
+  it("skips cleanup when provider issue cleanup was recently claimed", async () => {
+    const logger = createMockLogger();
+    vi.mocked(redis.set).mockResolvedValueOnce(null);
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("No refresh token"),
+      logger,
+      operation: "createEmailProvider",
+    });
+
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "Skipping duplicate provider issue cleanup",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "createEmailProvider",
+        reason: "invalid_grant",
+      }),
+    );
+  });
+
+  it("falls back to cleanup when Redis claim fails", async () => {
+    const logger = createMockLogger();
+    vi.mocked(redis.set).mockRejectedValueOnce(new Error("redis unavailable"));
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("No refresh token"),
+      logger,
+      operation: "createEmailProvider",
+    });
+
+    expect(cleanupInvalidTokens).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+      logger,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to claim provider issue cleanup",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "createEmailProvider",
+        reason: "invalid_grant",
+        error: expect.any(Error),
+      }),
+    );
   });
 
   it("records Outlook access denied as action-required permission issues", async () => {
@@ -94,6 +162,9 @@ describe("provider health", () => {
         reason: "invalid_grant",
         error: expect.any(Error),
       }),
+    );
+    expect(redis.del).toHaveBeenCalledWith(
+      "provider-issue-cleanup:email-account-1:invalid_grant",
     );
   });
 

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -1,0 +1,93 @@
+import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
+import {
+  getErrorMessage,
+  isGmailInsufficientPermissionsError,
+  isInvalidGrantError,
+  isOutlookItemNotFoundError,
+  isOutlookThrottlingError,
+} from "@/utils/error";
+import type { Logger } from "@/utils/logger";
+
+type ProviderIssueReason =
+  | "invalid_grant"
+  | "insufficient_permissions"
+  | "policy_enforced"
+  | "mail_service_not_enabled";
+
+type ProviderIssue = {
+  reason: ProviderIssueReason;
+};
+
+export async function recordEmailAccountProviderIssue({
+  emailAccountId,
+  provider,
+  error,
+  logger,
+  operation,
+}: {
+  emailAccountId: string;
+  provider: "google" | "microsoft";
+  error: unknown;
+  logger: Logger;
+  operation: string;
+}) {
+  const issue = classifyEmailAccountProviderIssue({ error, provider });
+  if (!issue) return;
+
+  logger.warn("Recording email account provider issue", {
+    emailAccountId,
+    provider,
+    operation,
+    reason: issue.reason,
+  });
+
+  await cleanupInvalidTokens({
+    emailAccountId,
+    reason: issue.reason,
+    logger,
+  });
+}
+
+export function classifyEmailAccountProviderIssue({
+  error,
+  provider,
+}: {
+  error: unknown;
+  provider: "google" | "microsoft";
+}): ProviderIssue | null {
+  const message = getErrorMessage(error);
+
+  if (
+    provider === "google" &&
+    (isGmailInsufficientPermissionsError(error) ||
+      message?.includes("Request had insufficient authentication scopes"))
+  ) {
+    return { reason: "insufficient_permissions" };
+  }
+
+  if (
+    provider === "google" &&
+    (message?.includes("policy_enforced") ||
+      message?.includes("Advanced Protection prevented your Google Account"))
+  ) {
+    return { reason: "policy_enforced" };
+  }
+
+  if (provider === "google" && message?.includes("Mail service not enabled")) {
+    return { reason: "mail_service_not_enabled" };
+  }
+
+  if (
+    isInvalidGrantError(error) ||
+    message?.includes("No refresh token") ||
+    message?.includes("Invalid access token")
+  ) {
+    return { reason: "invalid_grant" };
+  }
+
+  if (isOutlookThrottlingError(error) || isOutlookItemNotFoundError(error)) {
+    return null;
+  }
+
+  return null;
+}

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -6,9 +6,10 @@ import {
   isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
-import { redis } from "@/utils/redis";
-
-const PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS = 15 * 60;
+import {
+  claimProviderIssueCleanupInRedis,
+  releaseProviderIssueCleanupClaimInRedis,
+} from "@/utils/redis/provider-issue-cleanup";
 
 type ProviderIssueReason =
   | "invalid_grant"
@@ -132,16 +133,11 @@ async function claimProviderIssueCleanup({
   logger: Logger;
 }) {
   try {
-    const claimed = await redis.set(
-      getProviderIssueCleanupKey({ emailAccountId, reason }),
-      "1",
-      {
-        nx: true,
-        ex: PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS,
-      },
-    );
-
-    if (claimed === "OK") return true;
+    const claimed = await claimProviderIssueCleanupInRedis({
+      emailAccountId,
+      reason,
+    });
+    if (claimed) return true;
 
     logger.info("Skipping duplicate provider issue cleanup", {
       emailAccountId,
@@ -172,7 +168,7 @@ async function releaseProviderIssueCleanupClaim({
   logger: Logger;
 }) {
   try {
-    await redis.del(getProviderIssueCleanupKey({ emailAccountId, reason }));
+    await releaseProviderIssueCleanupClaimInRedis({ emailAccountId, reason });
   } catch (error) {
     logger.warn("Failed to release provider issue cleanup claim", {
       error,
@@ -180,14 +176,4 @@ async function releaseProviderIssueCleanupClaim({
       reason,
     });
   }
-}
-
-function getProviderIssueCleanupKey({
-  emailAccountId,
-  reason,
-}: {
-  emailAccountId: string;
-  reason: ProviderIssueReason;
-}) {
-  return `provider-issue-cleanup:${emailAccountId}:${reason}`;
 }

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -6,6 +6,9 @@ import {
   isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
+import { redis } from "@/utils/redis";
+
+const PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS = 15 * 60;
 
 type ProviderIssueReason =
   | "invalid_grant"
@@ -40,6 +43,15 @@ export async function recordEmailAccountProviderIssue({
     reason: issue.reason,
   });
 
+  const shouldRecord = await claimProviderIssueCleanup({
+    emailAccountId,
+    provider,
+    operation,
+    reason: issue.reason,
+    logger,
+  });
+  if (!shouldRecord) return;
+
   try {
     await cleanupInvalidTokens({
       emailAccountId,
@@ -53,6 +65,11 @@ export async function recordEmailAccountProviderIssue({
       provider,
       operation,
       reason: issue.reason,
+    });
+    await releaseProviderIssueCleanupClaim({
+      emailAccountId,
+      reason: issue.reason,
+      logger,
     });
   }
 }
@@ -99,4 +116,78 @@ export function classifyEmailAccountProviderIssue({
   }
 
   return null;
+}
+
+async function claimProviderIssueCleanup({
+  emailAccountId,
+  provider,
+  operation,
+  reason,
+  logger,
+}: {
+  emailAccountId: string;
+  provider: "google" | "microsoft";
+  operation: string;
+  reason: ProviderIssueReason;
+  logger: Logger;
+}) {
+  try {
+    const claimed = await redis.set(
+      getProviderIssueCleanupKey({ emailAccountId, reason }),
+      "1",
+      {
+        nx: true,
+        ex: PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS,
+      },
+    );
+
+    if (claimed === "OK") return true;
+
+    logger.info("Skipping duplicate provider issue cleanup", {
+      emailAccountId,
+      provider,
+      operation,
+      reason,
+    });
+    return false;
+  } catch (error) {
+    logger.warn("Failed to claim provider issue cleanup", {
+      error,
+      emailAccountId,
+      provider,
+      operation,
+      reason,
+    });
+    return true;
+  }
+}
+
+async function releaseProviderIssueCleanupClaim({
+  emailAccountId,
+  reason,
+  logger,
+}: {
+  emailAccountId: string;
+  reason: ProviderIssueReason;
+  logger: Logger;
+}) {
+  try {
+    await redis.del(getProviderIssueCleanupKey({ emailAccountId, reason }));
+  } catch (error) {
+    logger.warn("Failed to release provider issue cleanup claim", {
+      error,
+      emailAccountId,
+      reason,
+    });
+  }
+}
+
+function getProviderIssueCleanupKey({
+  emailAccountId,
+  reason,
+}: {
+  emailAccountId: string;
+  reason: ProviderIssueReason;
+}) {
+  return `provider-issue-cleanup:${emailAccountId}:${reason}`;
 }

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -3,8 +3,7 @@ import {
   getErrorMessage,
   isGmailInsufficientPermissionsError,
   isInvalidGrantError,
-  isOutlookItemNotFoundError,
-  isOutlookThrottlingError,
+  isOutlookAccessDeniedError,
 } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 
@@ -41,11 +40,21 @@ export async function recordEmailAccountProviderIssue({
     reason: issue.reason,
   });
 
-  await cleanupInvalidTokens({
-    emailAccountId,
-    reason: issue.reason,
-    logger,
-  });
+  try {
+    await cleanupInvalidTokens({
+      emailAccountId,
+      reason: issue.reason,
+      logger,
+    });
+  } catch (error) {
+    logger.warn("Failed to clean up provider account issue", {
+      error,
+      emailAccountId,
+      provider,
+      operation,
+      reason: issue.reason,
+    });
+  }
 }
 
 export function classifyEmailAccountProviderIssue({
@@ -62,6 +71,10 @@ export function classifyEmailAccountProviderIssue({
     (isGmailInsufficientPermissionsError(error) ||
       message?.includes("Request had insufficient authentication scopes"))
   ) {
+    return { reason: "insufficient_permissions" };
+  }
+
+  if (provider === "microsoft" && isOutlookAccessDeniedError(error)) {
     return { reason: "insufficient_permissions" };
   }
 
@@ -83,10 +96,6 @@ export function classifyEmailAccountProviderIssue({
     message?.includes("Invalid access token")
   ) {
     return { reason: "invalid_grant" };
-  }
-
-  if (isOutlookThrottlingError(error) || isOutlookItemNotFoundError(error)) {
-    return null;
   }
 
   return null;

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -126,6 +126,13 @@ describe("createEmailProvider", () => {
         error: expect.any(Error),
       }),
     );
+    expect(recordEmailAccountProviderIssue).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: expect.any(Error),
+      logger,
+      operation: "createEmailProvider",
+    });
   });
 
   it("logs and flushes provider operation failures without changing sync methods", async () => {
@@ -198,6 +205,45 @@ describe("createEmailProvider", () => {
         provider: "google",
         operation: "searchMessages",
         error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("flushes provider operation failures when recording the account issue fails", async () => {
+    const logger = createMockLogger();
+    gmailSearchMessagesMock.mockRejectedValueOnce(
+      new Error("provider request failed"),
+    );
+    vi.mocked(recordEmailAccountProviderIssue).mockRejectedValueOnce(
+      new Error("record failed"),
+    );
+
+    const provider = await createEmailProvider({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    await expect(
+      provider.searchMessages({ query: "in:inbox" }),
+    ).rejects.toThrow("provider request failed");
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Failed to record provider issue",
+      expect.objectContaining({
+        emailAccountId: "email-account-1",
+        provider: "google",
+        operation: "searchMessages",
+        error: expect.any(Error),
+      }),
+    );
+    expect(flushLoggerSafely).toHaveBeenCalledWith(
+      logger,
+      expect.objectContaining({
+        action: "emailProvider",
+        flushReason: "provider-operation-error",
+        provider: "google",
+        operation: "searchMessages",
       }),
     );
   });

--- a/apps/web/utils/email/provider.test.ts
+++ b/apps/web/utils/email/provider.test.ts
@@ -3,6 +3,7 @@ import { createEmailProvider } from "@/utils/email/provider";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 import { getGmailClientForEmail } from "@/utils/email-account-client";
 import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
+import { recordEmailAccountProviderIssue } from "@/utils/email/provider-health";
 
 const { gmailGetMessageMock, gmailSearchMessagesMock } = vi.hoisted(() => ({
   gmailGetMessageMock: vi.fn(),
@@ -20,6 +21,10 @@ vi.mock("@/utils/email/rate-limit", () => ({
 
 vi.mock("@/utils/logger-flush", () => ({
   flushLoggerSafely: vi.fn(),
+}));
+
+vi.mock("@/utils/email/provider-health", () => ({
+  recordEmailAccountProviderIssue: vi.fn(),
 }));
 
 vi.mock("@/utils/email/google", () => ({
@@ -52,6 +57,7 @@ describe("createEmailProvider", () => {
     vi.mocked(assertProviderNotRateLimited).mockResolvedValue(undefined);
     vi.mocked(getGmailClientForEmail).mockResolvedValue({} as any);
     vi.mocked(flushLoggerSafely).mockResolvedValue(undefined);
+    vi.mocked(recordEmailAccountProviderIssue).mockResolvedValue(undefined);
     gmailGetMessageMock.mockResolvedValue({});
     gmailSearchMessagesMock.mockResolvedValue({ messages: [] });
   });
@@ -86,6 +92,13 @@ describe("createEmailProvider", () => {
         provider: "google",
       }),
     );
+    expect(recordEmailAccountProviderIssue).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: expect.any(Error),
+      logger,
+      operation: "createEmailProvider",
+    });
   });
 
   it("preserves provider creation failures when flushing logs fails", async () => {
@@ -150,6 +163,13 @@ describe("createEmailProvider", () => {
         operation: "searchMessages",
       }),
     );
+    expect(recordEmailAccountProviderIssue).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: expect.any(Error),
+      logger,
+      operation: "searchMessages",
+    });
   });
 
   it("preserves async provider operation failures when flushing logs fails", async () => {

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -7,6 +7,7 @@ import { OutlookProvider } from "@/utils/email/microsoft";
 import type { EmailProvider } from "@/utils/email/types";
 import { assertProviderNotRateLimited } from "@/utils/email/rate-limit";
 import { toRateLimitProvider } from "@/utils/email/rate-limit-mode-error";
+import { recordEmailAccountProviderIssue } from "@/utils/email/provider-health";
 import type { Logger } from "@/utils/logger";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 
@@ -49,6 +50,19 @@ export async function createEmailProvider({
       error,
       provider: rateLimitProvider,
       source: "create-email-provider",
+    });
+    await recordEmailAccountProviderIssue({
+      emailAccountId,
+      provider: rateLimitProvider,
+      error,
+      logger,
+      operation: "createEmailProvider",
+    }).catch((recordError) => {
+      logger.warn("Failed to record provider creation issue", {
+        error: recordError,
+        provider: rateLimitProvider,
+        source: "create-email-provider",
+      });
     });
     await flushLoggerSafely(logger, {
       action: "createEmailProvider",
@@ -144,6 +158,13 @@ async function logProviderOperationFailure({
     error,
     emailAccountId,
     provider,
+    operation,
+  });
+  await recordEmailAccountProviderIssue({
+    emailAccountId,
+    provider,
+    error,
+    logger,
     operation,
   });
   await flushLoggerSafely(logger, {

--- a/apps/web/utils/email/provider.ts
+++ b/apps/web/utils/email/provider.ts
@@ -51,18 +51,12 @@ export async function createEmailProvider({
       provider: rateLimitProvider,
       source: "create-email-provider",
     });
-    await recordEmailAccountProviderIssue({
+    await recordProviderIssueSafely({
       emailAccountId,
       provider: rateLimitProvider,
       error,
       logger,
       operation: "createEmailProvider",
-    }).catch((recordError) => {
-      logger.warn("Failed to record provider creation issue", {
-        error: recordError,
-        provider: rateLimitProvider,
-        source: "create-email-provider",
-      });
     });
     await flushLoggerSafely(logger, {
       action: "createEmailProvider",
@@ -160,7 +154,7 @@ async function logProviderOperationFailure({
     provider,
     operation,
   });
-  await recordEmailAccountProviderIssue({
+  await recordProviderIssueSafely({
     emailAccountId,
     provider,
     error,
@@ -172,6 +166,29 @@ async function logProviderOperationFailure({
     flushReason: "provider-operation-error",
     provider,
     operation,
+  });
+}
+
+async function recordProviderIssueSafely({
+  emailAccountId,
+  provider,
+  error,
+  logger,
+  operation,
+}: ProviderOperationFailureLogInput) {
+  await recordEmailAccountProviderIssue({
+    emailAccountId,
+    provider,
+    error,
+    logger,
+    operation,
+  }).catch((recordError) => {
+    logger.warn("Failed to record provider issue", {
+      error: recordError,
+      emailAccountId,
+      provider,
+      operation,
+    });
   });
 }
 

--- a/apps/web/utils/redis/provider-issue-cleanup.test.ts
+++ b/apps/web/utils/redis/provider-issue-cleanup.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import {
+  claimProviderIssueCleanupInRedis,
+  releaseProviderIssueCleanupClaimInRedis,
+} from "@/utils/redis/provider-issue-cleanup";
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+describe("provider issue cleanup redis throttle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("claims provider issue cleanup with a short-lived key", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK");
+
+    const claimed = await claimProviderIssueCleanupInRedis({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
+
+    expect(claimed).toBe(true);
+    expect(redis.set).toHaveBeenCalledWith(
+      "provider-issue-cleanup:email-account-1:invalid_grant",
+      "1",
+      { ex: 900, nx: true },
+    );
+  });
+
+  it("returns false when provider issue cleanup was already claimed", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+
+    const claimed = await claimProviderIssueCleanupInRedis({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
+
+    expect(claimed).toBe(false);
+  });
+
+  it("releases provider issue cleanup claims", async () => {
+    vi.mocked(redis.del).mockResolvedValue(1);
+
+    await releaseProviderIssueCleanupClaimInRedis({
+      emailAccountId: "email-account-1",
+      reason: "invalid_grant",
+    });
+
+    expect(redis.del).toHaveBeenCalledWith(
+      "provider-issue-cleanup:email-account-1:invalid_grant",
+    );
+  });
+});

--- a/apps/web/utils/redis/provider-issue-cleanup.ts
+++ b/apps/web/utils/redis/provider-issue-cleanup.ts
@@ -1,0 +1,56 @@
+import "server-only";
+import { env } from "@/env";
+import { redis } from "@/utils/redis";
+
+const PROVIDER_ISSUE_CLEANUP_KEY_PREFIX = "provider-issue-cleanup";
+const PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS = 15 * 60;
+
+export async function claimProviderIssueCleanupInRedis({
+  emailAccountId,
+  reason,
+}: {
+  emailAccountId: string;
+  reason: string;
+}) {
+  if (!isProviderIssueCleanupRedisConfigured()) return true;
+
+  const claimed = await redis.set(
+    getProviderIssueCleanupKey({ emailAccountId, reason }),
+    "1",
+    {
+      nx: true,
+      ex: PROVIDER_ISSUE_CLEANUP_DEDUPE_TTL_SECONDS,
+    },
+  );
+
+  return claimed === "OK";
+}
+
+export async function releaseProviderIssueCleanupClaimInRedis({
+  emailAccountId,
+  reason,
+}: {
+  emailAccountId: string;
+  reason: string;
+}) {
+  if (!isProviderIssueCleanupRedisConfigured()) return;
+
+  await redis.del(getProviderIssueCleanupKey({ emailAccountId, reason }));
+}
+
+function isProviderIssueCleanupRedisConfigured() {
+  return (
+    env.NODE_ENV === "test" ||
+    Boolean(env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN)
+  );
+}
+
+function getProviderIssueCleanupKey({
+  emailAccountId,
+  reason,
+}: {
+  emailAccountId: string;
+  reason: string;
+}) {
+  return `${PROVIDER_ISSUE_CLEANUP_KEY_PREFIX}:${emailAccountId}:${reason}`;
+}


### PR DESCRIPTION
Adds centralized provider issue classification so durable account access failures are recorded from the provider boundary. Reuses the existing disconnected-account notification and in-app error message flow for missing auth, missing permissions, provider policy blocks, and unavailable mailbox cases. Leaves transient provider failures as logs only, with focused tests for classification, notification behavior, and provider wiring.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

