### PR TITLE
Add default availability settings on calendars page

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import { Button } from "@/components/ui/button";
+import { CardBasic } from "@/components/ui/card";
+import { LoadingContent } from "@/components/LoadingContent";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toastError, toastSuccess } from "@/components/Toast";
+import type { GetAvailabilityResponse } from "@/app/api/user/availability/route";
+import { useDefaultAvailability } from "@/hooks/useDefaultAvailability";
+import { useAccount } from "@/providers/EmailAccountProvider";
+import { getActionErrorMessage } from "@/utils/error";
+import { updateDefaultAvailabilityAction } from "@/utils/actions/booking";
+import {
+  collectWindows,
+  DEFAULT_WEEKDAY_WINDOWS,
+} from "./availability-schedule";
+import { useWeeklyHours, WeeklyHoursEditor } from "./WeeklyHoursEditor";
+
+export function AvailabilitySection() {
+  const { data, isLoading, error, mutate } = useDefaultAvailability();
+
+  return (
+    <section className="space-y-3">
+      <CardBasic className="px-4 py-4">
+        <div className="mb-1">
+          <h3 className="font-medium">Availability</h3>
+          <p className="text-sm text-muted-foreground">
+            Set the hours your assistant can suggest when scheduling meetings
+            over email.
+          </p>
+        </div>
+
+        <LoadingContent
+          loading={isLoading}
+          error={error}
+          loadingComponent={
+            <Skeleton className="mt-4 h-96 w-full rounded-lg" />
+          }
+        >
+          {data ? (
+            <AvailabilityEditor
+              key={data.schedule ? "schedule" : "default"}
+              data={data}
+              onSaved={mutate}
+            />
+          ) : null}
+        </LoadingContent>
+      </CardBasic>
+    </section>
+  );
+}
+
+function AvailabilityEditor({
+  data,
+  onSaved,
+}: {
+  data: GetAvailabilityResponse;
+  onSaved: () => void;
+}) {
+  const { emailAccountId } = useAccount();
+
+  const controller = useWeeklyHours(
+    data.schedule?.windows ?? DEFAULT_WEEKDAY_WINDOWS,
+  );
+  const timezone =
+    data.schedule?.timezone ??
+    data.timezone ??
+    Intl.DateTimeFormat().resolvedOptions().timeZone ??
+    "UTC";
+
+  const { execute: updateAvailability, isExecuting: isSaving } = useAction(
+    updateDefaultAvailabilityAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Availability updated" });
+        onSaved();
+      },
+      onError: (actionError) => {
+        toastError({
+          description:
+            getActionErrorMessage(actionError.error) ??
+            "Failed to update availability",
+        });
+      },
+    },
+  );
+
+  const handleSave = () => {
+    const collected = collectWindows(controller.days);
+    if (collected.error) {
+      toastError({ description: collected.error });
+      return;
+    }
+
+    updateAvailability({ timezone, windows: collected.windows });
+  };
+
+  return (
+    <div className="mt-4 space-y-4">
+      <WeeklyHoursEditor controller={controller} timezone={timezone} />
+      <div className="flex justify-end">
+        <Button onClick={handleSave} loading={isSaving}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState, type ChangeEvent } from "react";
-import { Copy, Info, Plus, Trash2, X } from "lucide-react";
+import { useState, type ChangeEvent } from "react";
+import { Trash2, X } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { Input, Label } from "@/components/Input";
 import { Button } from "@/components/ui/button";
@@ -25,7 +25,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { toastError, toastSuccess } from "@/components/Toast";
 import { useBookingLinks } from "@/hooks/useBookingLinks";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -48,24 +47,13 @@ import {
   isProviderVideoLocationType,
 } from "./booking-calendar-helpers";
 import { VideoConferencingItem } from "./VideoConferencingItem";
+import { collectWindows } from "./availability-schedule";
+import { useWeeklyHours, WeeklyHoursEditor } from "./WeeklyHoursEditor";
 
 type BookingLink = NonNullable<
   ReturnType<typeof useBookingLinks>["data"]
 >["bookingLinks"][number];
 export type ConfigureBookingLinkTab = "general" | "availability" | "advanced";
-
-type Range = { start: string; end: string };
-type DayState = { enabled: boolean; ranges: Range[] };
-
-const DAY_LABELS = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-];
 
 export function ConfigureBookingLinkDialog({
   link,
@@ -364,100 +352,25 @@ function AvailabilityTab({
 }) {
   const { emailAccountId } = useAccount();
 
-  const initialDays = useMemo(
-    () => buildDayState(link.windows ?? []),
-    [link.windows],
-  );
-  const [days, setDays] = useState<DayState[]>(initialDays);
+  const controller = useWeeklyHours(link.windows ?? []);
   const timezone =
     link.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
   const [minimumNoticeHours, setMinimumNoticeHours] = useState(() =>
     formatHours(link.minimumNoticeMinutes / 60),
   );
 
-  const {
-    executeAsync: updateAvailability,
-    isExecuting: isUpdatingAvailability,
-  } = useAction(updateBookingAvailabilityAction.bind(null, emailAccountId), {
-    onError: (error) => {
-      toastError({
-        description:
-          getActionErrorMessage(error.error) ?? "Failed to update availability",
-      });
+  const { executeAsync: updateAvailability, isExecuting: isSaving } = useAction(
+    updateBookingAvailabilityAction.bind(null, emailAccountId),
+    {
+      onError: (error) => {
+        toastError({
+          description:
+            getActionErrorMessage(error.error) ??
+            "Failed to update availability",
+        });
+      },
     },
-  });
-
-  const isSaving = isUpdatingAvailability;
-
-  const updateDay = (index: number, next: Partial<DayState>) => {
-    setDays((prev) =>
-      prev.map((day, dayIndex) =>
-        dayIndex === index ? { ...day, ...next } : day,
-      ),
-    );
-  };
-
-  const addRange = (dayIndex: number) => {
-    setDays((prev) =>
-      prev.map((day, index) =>
-        index === dayIndex
-          ? {
-              ...day,
-              ranges: [
-                ...day.ranges,
-                nextRangeAfter(day.ranges[day.ranges.length - 1]),
-              ],
-            }
-          : day,
-      ),
-    );
-  };
-
-  const removeRange = (dayIndex: number, rangeIndex: number) => {
-    setDays((prev) =>
-      prev.map((day, index) =>
-        index === dayIndex
-          ? {
-              ...day,
-              ranges: day.ranges.filter((_, i) => i !== rangeIndex),
-            }
-          : day,
-      ),
-    );
-  };
-
-  const updateRange = (
-    dayIndex: number,
-    rangeIndex: number,
-    next: Partial<Range>,
-  ) => {
-    setDays((prev) =>
-      prev.map((day, index) =>
-        index === dayIndex
-          ? {
-              ...day,
-              ranges: day.ranges.map((range, i) =>
-                i === rangeIndex ? { ...range, ...next } : range,
-              ),
-            }
-          : day,
-      ),
-    );
-  };
-
-  const copyDayToOthers = (dayIndex: number) => {
-    const source = days[dayIndex];
-    setDays((prev) =>
-      prev.map((day, index) =>
-        index === dayIndex
-          ? day
-          : {
-              enabled: source.enabled,
-              ranges: source.ranges.map((range) => ({ ...range })),
-            },
-      ),
-    );
-  };
+  );
 
   const handleSave = async () => {
     const minimumNoticeMinutes = parseMinimumNoticeHours(minimumNoticeHours);
@@ -468,31 +381,9 @@ function AvailabilityTab({
       return;
     }
 
-    const windows: Array<{
-      weekday: number;
-      startMinutes: number;
-      endMinutes: number;
-    }> = [];
-    for (let weekday = 0; weekday < 7; weekday++) {
-      const day = days[weekday];
-      if (!day.enabled) continue;
-      for (const range of day.ranges) {
-        const start = parseTime(range.start);
-        const end = parseTime(range.end);
-        if (start === null || end === null || end <= start) {
-          toastError({
-            description: `${DAY_LABELS[weekday]}: end time must be after start time.`,
-          });
-          return;
-        }
-        windows.push({ weekday, startMinutes: start, endMinutes: end });
-      }
-    }
-
-    if (windows.length === 0) {
-      toastError({
-        description: "Add at least one available time range.",
-      });
+    const collected = collectWindows(controller.days);
+    if (collected.error) {
+      toastError({ description: collected.error });
       return;
     }
 
@@ -501,7 +392,7 @@ function AvailabilityTab({
         bookingLinkId: link.id,
         minimumNoticeMinutes,
         timezone,
-        windows,
+        windows: collected.windows,
       });
       if (hasActionResultError(result)) return;
 
@@ -520,107 +411,7 @@ function AvailabilityTab({
   return (
     <>
       <div className="space-y-4 overflow-y-auto px-6 py-5">
-        <div>
-          <div className="text-sm font-semibold text-foreground">
-            Weekly hours
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Hours shown in {timezone}. Change in Calendar settings.
-          </p>
-        </div>
-
-        <div className="rounded-lg border bg-card">
-          {DAY_LABELS.map((dayLabel, dayIndex) => {
-            const day = days[dayIndex];
-            return (
-              <div
-                key={dayLabel}
-                className="flex items-start gap-4 border-b px-4 py-3 last:border-b-0"
-              >
-                <div className="flex w-32 items-center gap-2.5 pt-1.5">
-                  <Switch
-                    checked={day.enabled}
-                    size="sm"
-                    onCheckedChange={(next) =>
-                      updateDay(dayIndex, {
-                        enabled: next,
-                        ranges:
-                          next && day.ranges.length === 0
-                            ? [{ start: "09:00", end: "17:00" }]
-                            : day.ranges,
-                      })
-                    }
-                    aria-label={`Toggle ${dayLabel}`}
-                  />
-                  <span
-                    className={cn(
-                      "text-sm",
-                      day.enabled
-                        ? "font-medium text-foreground"
-                        : "text-muted-foreground",
-                    )}
-                  >
-                    {dayLabel}
-                  </span>
-                </div>
-                <div className="flex flex-1 flex-col gap-2">
-                  {day.enabled ? (
-                    day.ranges.map((range, rangeIndex) => (
-                      <div key={rangeIndex} className="flex items-center gap-2">
-                        <TimeField
-                          value={range.start}
-                          onChange={(value) =>
-                            updateRange(dayIndex, rangeIndex, { start: value })
-                          }
-                        />
-                        <span className="text-sm text-muted-foreground">–</span>
-                        <TimeField
-                          value={range.end}
-                          onChange={(value) =>
-                            updateRange(dayIndex, rangeIndex, { end: value })
-                          }
-                        />
-                        {rangeIndex === 0 ? (
-                          <>
-                            <IconButton
-                              title="Add another range"
-                              onClick={() => addRange(dayIndex)}
-                            >
-                              <Plus className="size-4" />
-                            </IconButton>
-                            <IconButton
-                              title="Copy to other days"
-                              onClick={() => copyDayToOthers(dayIndex)}
-                            >
-                              <Copy className="size-3.5" />
-                            </IconButton>
-                          </>
-                        ) : (
-                          <IconButton
-                            title="Remove range"
-                            onClick={() => removeRange(dayIndex, rangeIndex)}
-                          >
-                            <X className="size-3.5" />
-                          </IconButton>
-                        )}
-                      </div>
-                    ))
-                  ) : (
-                    <div className="flex h-8 items-center text-sm text-muted-foreground">
-                      Unavailable
-                    </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="flex items-start gap-2.5 rounded-lg border bg-muted/40 px-3.5 py-3 text-xs text-muted-foreground">
-          <Info className="size-3.5 shrink-0 text-muted-foreground" />
-          We hide times where you already have events on your connected
-          calendar.
-        </div>
+        <WeeklyHoursEditor controller={controller} timezone={timezone} />
 
         <Item variant="outline">
           <ItemContent>
@@ -748,86 +539,6 @@ function DialogFooter({
   );
 }
 
-function TimeField({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-}) {
-  return (
-    <input
-      type="time"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      className="w-[110px] rounded-md border border-input bg-background px-2.5 py-1.5 text-center text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    />
-  );
-}
-
-function IconButton({
-  title,
-  onClick,
-  children,
-}: {
-  title: string;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      title={title}
-      aria-label={title}
-      onClick={onClick}
-      className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-    >
-      {children}
-    </button>
-  );
-}
-
-function buildDayState(
-  windows: Array<{
-    weekday: number;
-    startMinutes: number;
-    endMinutes: number;
-  }>,
-): DayState[] {
-  const byDay = new Map<number, Range[]>();
-  for (const window of windows) {
-    const list = byDay.get(window.weekday) ?? [];
-    list.push({
-      start: minutesToTime(window.startMinutes),
-      end: minutesToTime(window.endMinutes),
-    });
-    byDay.set(window.weekday, list);
-  }
-  return DAY_LABELS.map((_, weekday) => {
-    const ranges = byDay.get(weekday) ?? [];
-    return ranges.length
-      ? { enabled: true, ranges }
-      : { enabled: false, ranges: [] };
-  });
-}
-
-function nextRangeAfter(previous?: Range): Range {
-  if (!previous) return { start: "09:00", end: "17:00" };
-  const previousEnd = parseTime(previous.end) ?? 17 * 60;
-  const start = Math.min(previousEnd + 30, 23 * 60);
-  const end = Math.min(start + 60, 24 * 60 - 1);
-  return { start: minutesToTime(start), end: minutesToTime(end) };
-}
-
-function parseTime(value: string): number | null {
-  const match = value.match(/^(\d{1,2}):(\d{2})$/);
-  if (!match) return null;
-  const hours = Number(match[1]);
-  const minutes = Number(match[2]);
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
-  return hours * 60 + minutes;
-}
-
 function parseMinimumNoticeHours(value: string) {
   const hours = Number(value);
   if (!Number.isFinite(hours) || hours < 0 || hours > 365 * 24) return null;
@@ -836,12 +547,6 @@ function parseMinimumNoticeHours(value: string) {
 
 function formatHours(value: number) {
   return Number.isInteger(value) ? String(value) : String(value.toFixed(2));
-}
-
-function minutesToTime(value: number) {
-  const hours = Math.floor(value / 60);
-  const minutes = value % 60;
-  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
 function hasActionResultError(

--- a/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Info, Plus, X } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/utils";
+import {
+  type AvailabilityWindowInput,
+  type DayState,
+  type Range,
+  buildDayState,
+  DAY_LABELS,
+  nextRangeAfter,
+} from "./availability-schedule";
+
+export function useWeeklyHours(initialWindows: AvailabilityWindowInput[]) {
+  const [days, setDays] = useState<DayState[]>(() =>
+    buildDayState(initialWindows),
+  );
+
+  const updateDay = (index: number, next: Partial<DayState>) => {
+    setDays((prev) =>
+      prev.map((day, dayIndex) =>
+        dayIndex === index ? { ...day, ...next } : day,
+      ),
+    );
+  };
+
+  const addRange = (dayIndex: number) => {
+    setDays((prev) =>
+      prev.map((day, index) =>
+        index === dayIndex
+          ? {
+              ...day,
+              ranges: [
+                ...day.ranges,
+                nextRangeAfter(day.ranges[day.ranges.length - 1]),
+              ],
+            }
+          : day,
+      ),
+    );
+  };
+
+  const removeRange = (dayIndex: number, rangeIndex: number) => {
+    setDays((prev) =>
+      prev.map((day, index) =>
+        index === dayIndex
+          ? {
+              ...day,
+              ranges: day.ranges.filter((_, i) => i !== rangeIndex),
+            }
+          : day,
+      ),
+    );
+  };
+
+  const updateRange = (
+    dayIndex: number,
+    rangeIndex: number,
+    next: Partial<Range>,
+  ) => {
+    setDays((prev) =>
+      prev.map((day, index) =>
+        index === dayIndex
+          ? {
+              ...day,
+              ranges: day.ranges.map((range, i) =>
+                i === rangeIndex ? { ...range, ...next } : range,
+              ),
+            }
+          : day,
+      ),
+    );
+  };
+
+  const copyDayToOthers = (dayIndex: number) => {
+    const source = days[dayIndex];
+    setDays((prev) =>
+      prev.map((day, index) =>
+        index === dayIndex
+          ? day
+          : {
+              enabled: source.enabled,
+              ranges: source.ranges.map((range) => ({ ...range })),
+            },
+      ),
+    );
+  };
+
+  return {
+    days,
+    updateDay,
+    addRange,
+    removeRange,
+    updateRange,
+    copyDayToOthers,
+  };
+}
+
+export type WeeklyHoursController = ReturnType<typeof useWeeklyHours>;
+
+export function WeeklyHoursEditor({
+  controller,
+  timezone,
+}: {
+  controller: WeeklyHoursController;
+  timezone: string;
+}) {
+  const {
+    days,
+    updateDay,
+    addRange,
+    removeRange,
+    updateRange,
+    copyDayToOthers,
+  } = controller;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-sm font-semibold text-foreground">
+          Weekly hours
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Hours shown in {timezone}. Change in Calendar settings.
+        </p>
+      </div>
+
+      <div className="rounded-lg border bg-card">
+        {DAY_LABELS.map((dayLabel, dayIndex) => {
+          const day = days[dayIndex];
+          return (
+            <div
+              key={dayLabel}
+              className="flex items-start gap-4 border-b px-4 py-3 last:border-b-0"
+            >
+              <div className="flex w-32 items-center gap-2.5 pt-1.5">
+                <Switch
+                  checked={day.enabled}
+                  size="sm"
+                  onCheckedChange={(next) =>
+                    updateDay(dayIndex, {
+                      enabled: next,
+                      ranges:
+                        next && day.ranges.length === 0
+                          ? [{ start: "09:00", end: "17:00" }]
+                          : day.ranges,
+                    })
+                  }
+                  aria-label={`Toggle ${dayLabel}`}
+                />
+                <span
+                  className={cn(
+                    "text-sm",
+                    day.enabled
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {dayLabel}
+                </span>
+              </div>
+              <div className="flex flex-1 flex-col gap-2">
+                {day.enabled ? (
+                  day.ranges.map((range, rangeIndex) => (
+                    <div key={rangeIndex} className="flex items-center gap-2">
+                      <TimeField
+                        value={range.start}
+                        onChange={(value) =>
+                          updateRange(dayIndex, rangeIndex, { start: value })
+                        }
+                      />
+                      <span className="text-sm text-muted-foreground">–</span>
+                      <TimeField
+                        value={range.end}
+                        onChange={(value) =>
+                          updateRange(dayIndex, rangeIndex, { end: value })
+                        }
+                      />
+                      {rangeIndex === 0 ? (
+                        <>
+                          <IconButton
+                            title="Add another range"
+                            onClick={() => addRange(dayIndex)}
+                          >
+                            <Plus className="size-4" />
+                          </IconButton>
+                          <IconButton
+                            title="Copy to other days"
+                            onClick={() => copyDayToOthers(dayIndex)}
+                          >
+                            <Copy className="size-3.5" />
+                          </IconButton>
+                        </>
+                      ) : (
+                        <IconButton
+                          title="Remove range"
+                          onClick={() => removeRange(dayIndex, rangeIndex)}
+                        >
+                          <X className="size-3.5" />
+                        </IconButton>
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <div className="flex h-8 items-center text-sm text-muted-foreground">
+                    Unavailable
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-start gap-2.5 rounded-lg border bg-muted/40 px-3.5 py-3 text-xs text-muted-foreground">
+        <Info className="size-3.5 shrink-0 text-muted-foreground" />
+        We hide times where you already have events on your connected calendar.
+      </div>
+    </div>
+  );
+}
+
+function TimeField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <input
+      type="time"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="w-[110px] rounded-md border border-input bg-background px-2.5 py-1.5 text-center text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    />
+  );
+}
+
+function IconButton({
+  title,
+  onClick,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-label={title}
+      onClick={onClick}
+      className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDayState,
+  collectWindows,
+  DEFAULT_WEEKDAY_WINDOWS,
+} from "./availability-schedule";
+
+describe("buildDayState", () => {
+  it("groups windows by weekday and marks days without windows unavailable", () => {
+    const days = buildDayState([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 12 * 60 },
+      { weekday: 1, startMinutes: 13 * 60, endMinutes: 17 * 60 },
+      { weekday: 3, startMinutes: 10 * 60, endMinutes: 11 * 60 },
+    ]);
+
+    expect(days[0]).toEqual({ enabled: false, ranges: [] });
+    expect(days[1]).toEqual({
+      enabled: true,
+      ranges: [
+        { start: "09:00", end: "12:00" },
+        { start: "13:00", end: "17:00" },
+      ],
+    });
+    expect(days[3]).toEqual({
+      enabled: true,
+      ranges: [{ start: "10:00", end: "11:00" }],
+    });
+  });
+
+  it("round-trips through collectWindows for the default schedule", () => {
+    const { windows, error } = collectWindows(
+      buildDayState(DEFAULT_WEEKDAY_WINDOWS),
+    );
+
+    expect(error).toBeNull();
+    expect(windows).toEqual(DEFAULT_WEEKDAY_WINDOWS);
+  });
+});
+
+describe("collectWindows", () => {
+  it("returns an error when a range ends before it starts", () => {
+    const days = buildDayState([
+      { weekday: 2, startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    ]);
+    days[2].ranges[0] = { start: "17:00", end: "09:00" };
+
+    const result = collectWindows(days);
+
+    expect(result.windows).toBeNull();
+    expect(result.error).toContain("Tuesday");
+  });
+
+  it("returns an error when no day is enabled", () => {
+    const result = collectWindows(buildDayState([]));
+
+    expect(result.windows).toBeNull();
+    expect(result.error).toBe("Add at least one available time range.");
+  });
+
+  it("ignores ranges on disabled days", () => {
+    const days = buildDayState([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    ]);
+    days[2] = { enabled: false, ranges: [{ start: "10:00", end: "08:00" }] };
+
+    const result = collectWindows(days);
+
+    expect(result.error).toBeNull();
+    expect(result.windows).toEqual([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    ]);
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.ts
@@ -1,0 +1,98 @@
+export type AvailabilityWindowInput = {
+  weekday: number;
+  startMinutes: number;
+  endMinutes: number;
+};
+
+export type Range = { start: string; end: string };
+export type DayState = { enabled: boolean; ranges: Range[] };
+
+export const DAY_LABELS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+// Monday to Friday, 9:00 to 17:00. Mirrors the default schedule created
+// alongside a booking link so the standalone editor feels usable immediately.
+export const DEFAULT_WEEKDAY_WINDOWS: AvailabilityWindowInput[] = [
+  1, 2, 3, 4, 5,
+].map((weekday) => ({
+  weekday,
+  startMinutes: 9 * 60,
+  endMinutes: 17 * 60,
+}));
+
+export function buildDayState(windows: AvailabilityWindowInput[]): DayState[] {
+  const byDay = new Map<number, Range[]>();
+  for (const window of windows) {
+    const list = byDay.get(window.weekday) ?? [];
+    list.push({
+      start: minutesToTime(window.startMinutes),
+      end: minutesToTime(window.endMinutes),
+    });
+    byDay.set(window.weekday, list);
+  }
+  return DAY_LABELS.map((_, weekday) => {
+    const ranges = byDay.get(weekday) ?? [];
+    return ranges.length
+      ? { enabled: true, ranges }
+      : { enabled: false, ranges: [] };
+  });
+}
+
+export function collectWindows(
+  days: DayState[],
+):
+  | { windows: AvailabilityWindowInput[]; error: null }
+  | { windows: null; error: string } {
+  const windows: AvailabilityWindowInput[] = [];
+  for (let weekday = 0; weekday < 7; weekday++) {
+    const day = days[weekday];
+    if (!day.enabled) continue;
+    for (const range of day.ranges) {
+      const start = parseTime(range.start);
+      const end = parseTime(range.end);
+      if (start === null || end === null || end <= start) {
+        return {
+          windows: null,
+          error: `${DAY_LABELS[weekday]}: end time must be after start time.`,
+        };
+      }
+      windows.push({ weekday, startMinutes: start, endMinutes: end });
+    }
+  }
+
+  if (windows.length === 0) {
+    return { windows: null, error: "Add at least one available time range." };
+  }
+
+  return { windows, error: null };
+}
+
+export function nextRangeAfter(previous?: Range): Range {
+  if (!previous) return { start: "09:00", end: "17:00" };
+  const previousEnd = parseTime(previous.end) ?? 17 * 60;
+  const start = Math.min(previousEnd + 30, 23 * 60);
+  const end = Math.min(start + 60, 24 * 60 - 1);
+  return { start: minutesToTime(start), end: minutesToTime(end) };
+}
+
+export function parseTime(value: string): number | null {
+  const match = value.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+export function minutesToTime(value: number) {
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/page.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { CalendarConnections } from "./CalendarConnections";
 import { CalendarSettings } from "./CalendarSettings";
 import { BookingLinksSection } from "./BookingLinksSection";
+import { AvailabilitySection } from "./AvailabilitySection";
 import { TimezoneDetector } from "./TimezoneDetector";
 
 export default async function CalendarsPage() {
@@ -16,6 +17,7 @@ export default async function CalendarsPage() {
       <div className="mt-6 max-w-4xl space-y-4">
         <CalendarConnections />
         <BookingLinksSection />
+        <AvailabilitySection />
         <CalendarSettings />
       </div>
     </PageWrapper>

--- a/apps/web/app/api/user/availability/route.ts
+++ b/apps/web/app/api/user/availability/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { withEmailAccount } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { SafeError } from "@/utils/error";
+
+export type GetAvailabilityResponse = Awaited<ReturnType<typeof getData>>;
+
+export const GET = withEmailAccount("user/availability", async (request) => {
+  const { emailAccountId } = request.auth;
+
+  const result = await getData({ emailAccountId });
+  return NextResponse.json(result);
+});
+
+async function getData({ emailAccountId }: { emailAccountId: string }) {
+  const [emailAccount, schedule] = await Promise.all([
+    prisma.emailAccount.findUnique({
+      where: { id: emailAccountId },
+      select: { timezone: true },
+    }),
+    prisma.availabilitySchedule.findFirst({
+      where: { emailAccountId, isDefault: true },
+      orderBy: { createdAt: "asc" },
+      select: {
+        timezone: true,
+        windows: {
+          orderBy: [{ weekday: "asc" }, { startMinutes: "asc" }],
+          select: {
+            id: true,
+            weekday: true,
+            startMinutes: true,
+            endMinutes: true,
+          },
+        },
+      },
+    }),
+  ]);
+
+  if (!emailAccount) throw new SafeError("User not found", 404);
+
+  return { timezone: emailAccount.timezone, schedule };
+}

--- a/apps/web/hooks/useDefaultAvailability.ts
+++ b/apps/web/hooks/useDefaultAvailability.ts
@@ -1,0 +1,6 @@
+import useSWR from "swr";
+import type { GetAvailabilityResponse } from "@/app/api/user/availability/route";
+
+export function useDefaultAvailability() {
+  return useSWR<GetAvailabilityResponse>("/api/user/availability");
+}

--- a/apps/web/utils/actions/booking.test.ts
+++ b/apps/web/utils/actions/booking.test.ts
@@ -6,6 +6,7 @@ import {
   deleteBookingLinkAction,
   updateBookingAvailabilityAction,
   updateBookingLinkAction,
+  updateDefaultAvailabilityAction,
 } from "@/utils/actions/booking";
 
 vi.mock("server-only", () => ({}));
@@ -502,6 +503,71 @@ describe("booking actions", () => {
     expect(result?.validationErrors).toBeDefined();
     expect(prisma.bookingLink.findFirst).not.toHaveBeenCalled();
     expect(prisma.bookingLink.update).not.toHaveBeenCalled();
+  });
+
+  it("creates a default availability schedule when none exists", async () => {
+    prisma.availabilitySchedule.findFirst.mockResolvedValue(null);
+    prisma.availabilitySchedule.create.mockResolvedValue({} as any);
+
+    const windows = [
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 17 * 60 },
+      { weekday: 2, startMinutes: 9 * 60, endMinutes: 17 * 60 },
+    ];
+    const result = await updateDefaultAvailabilityAction("email-account-id", {
+      timezone: "America/New_York",
+      windows,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.availabilitySchedule.create).toHaveBeenCalledWith({
+      data: {
+        name: "Default availability",
+        isDefault: true,
+        timezone: "America/New_York",
+        emailAccount: { connect: { id: "email-account-id" } },
+        windows: { create: windows },
+      },
+    });
+    expect(prisma.availabilitySchedule.update).not.toHaveBeenCalled();
+  });
+
+  it("replaces windows on the existing default availability schedule", async () => {
+    prisma.availabilitySchedule.findFirst.mockResolvedValue({
+      id: "availability-schedule-id",
+    } as any);
+    prisma.availabilitySchedule.update.mockResolvedValue({} as any);
+
+    const windows = [
+      { weekday: 4, startMinutes: 10 * 60, endMinutes: 16 * 60 },
+    ];
+    const result = await updateDefaultAvailabilityAction("email-account-id", {
+      timezone: "Europe/London",
+      windows,
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.availabilitySchedule.update).toHaveBeenCalledWith({
+      where: { id: "availability-schedule-id" },
+      data: {
+        timezone: "Europe/London",
+        windows: {
+          deleteMany: {},
+          create: windows,
+        },
+      },
+    });
+    expect(prisma.availabilitySchedule.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects default availability updates with no windows", async () => {
+    const result = await updateDefaultAvailabilityAction("email-account-id", {
+      timezone: "UTC",
+      windows: [],
+    });
+
+    expect(result?.validationErrors).toBeDefined();
+    expect(prisma.availabilitySchedule.create).not.toHaveBeenCalled();
+    expect(prisma.availabilitySchedule.update).not.toHaveBeenCalled();
   });
 
   it("deletes an owned booking link", async () => {

--- a/apps/web/utils/actions/booking.ts
+++ b/apps/web/utils/actions/booking.ts
@@ -7,6 +7,7 @@ import {
   deleteBookingLinkBody,
   updateBookingAvailabilityBody,
   updateBookingLinkActionBody,
+  updateDefaultAvailabilityBody,
 } from "@/utils/actions/booking.validation";
 import { getSlotIntervalMinutes } from "@/utils/booking/policy";
 import prisma from "@/utils/prisma";
@@ -181,6 +182,45 @@ export const updateBookingAvailabilityAction = actionClient
         },
       }),
     ]);
+
+    return { success: true };
+  });
+
+// Edits the account's default availability schedule directly, independent of a
+// booking link. The same schedule constrains AI-suggested meeting times and any
+// booking link, so users without a booking link can still set their hours.
+export const updateDefaultAvailabilityAction = actionClient
+  .metadata({ name: "updateDefaultAvailability" })
+  .inputSchema(updateDefaultAvailabilityBody)
+  .action(async ({ ctx: { emailAccountId }, parsedInput }) => {
+    const existingSchedule = await prisma.availabilitySchedule.findFirst({
+      where: { emailAccountId, isDefault: true },
+      orderBy: { createdAt: "asc" },
+      select: { id: true },
+    });
+
+    if (existingSchedule) {
+      await prisma.availabilitySchedule.update({
+        where: { id: existingSchedule.id },
+        data: {
+          timezone: parsedInput.timezone,
+          windows: {
+            deleteMany: {},
+            create: parsedInput.windows,
+          },
+        },
+      });
+    } else {
+      await prisma.availabilitySchedule.create({
+        data: {
+          name: "Default availability",
+          isDefault: true,
+          timezone: parsedInput.timezone,
+          emailAccount: { connect: { id: emailAccountId } },
+          windows: { create: parsedInput.windows },
+        },
+      });
+    }
 
     return { success: true };
   });

--- a/apps/web/utils/actions/booking.validation.ts
+++ b/apps/web/utils/actions/booking.validation.ts
@@ -102,6 +102,14 @@ export type UpdateBookingAvailabilityBody = z.infer<
   typeof updateBookingAvailabilityBody
 >;
 
+export const updateDefaultAvailabilityBody = z.object({
+  timezone: timezoneSchema,
+  windows: z.array(bookingWindowBody).min(1),
+});
+export type UpdateDefaultAvailabilityBody = z.infer<
+  typeof updateDefaultAvailabilityBody
+>;
+
 export const publicBookingBody = z.object({
   slug: slugSchema,
   startTime: z.string().datetime(),


### PR DESCRIPTION
## Summary
- Add an Availability section to the calendars page so users can set account-level weekly hours without configuring a booking link.
- Extract shared weekly hours UI and validation into reusable modules used by both the new section and the booking link availability tab.
- Add API route, hook, and server action to fetch and persist the default availability schedule.

## Test plan
- [x] Unit tests pass for availability schedule helpers and booking actions
- [ ] Open the calendars page and verify the Availability section loads with default weekday hours
- [ ] Edit weekly hours, save, and confirm the schedule persists after refresh
- [ ] Open a booking link's availability tab and confirm the shared editor still works
- [ ] Verify validation errors for invalid time ranges and empty schedules


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

