### PR TITLE
calendar: Fix availability build type narrowing

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
@@ -88,7 +88,7 @@ function AvailabilityEditor({
 
   const handleSave = () => {
     const collected = collectWindows(controller.days);
-    if (collected.error) {
+    if (collected.windows === null) {
       toastError({ description: collected.error });
       return;
     }

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
@@ -382,7 +382,7 @@ function AvailabilityTab({
     }
 
     const collected = collectWindows(controller.days);
-    if (collected.error) {
+    if (collected.windows === null) {
       toastError({ description: collected.error });
       return;
     }


### PR DESCRIPTION
Fixes a build type error in availability save handlers by narrowing on the collected windows value before submitting updates.

- Keeps the existing validation behavior unchanged
- Applies the same narrowing pattern to both availability save flows

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

