### PR TITLE
calendar: Simplify availability section UI

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/AvailabilitySection.tsx
@@ -98,7 +98,7 @@ function AvailabilityEditor({
 
   return (
     <div className="mt-4 space-y-4">
-      <WeeklyHoursEditor controller={controller} timezone={timezone} />
+      <WeeklyHoursEditor controller={controller} />
       <div className="flex justify-end">
         <Button onClick={handleSave} loading={isSaving}>
           Save

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
@@ -411,7 +411,15 @@ function AvailabilityTab({
   return (
     <>
       <div className="space-y-4 overflow-y-auto px-6 py-5">
-        <WeeklyHoursEditor controller={controller} timezone={timezone} />
+        <div>
+          <div className="text-sm font-semibold text-foreground">
+            Weekly hours
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Hours shown in {timezone}. Change in Calendar settings.
+          </p>
+        </div>
+        <WeeklyHoursEditor controller={controller} />
 
         <Item variant="outline">
           <ItemContent>

--- a/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/WeeklyHoursEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Info, Plus, X } from "lucide-react";
+import { Copy, Plus, X } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/utils";
 import {
@@ -102,10 +102,8 @@ export type WeeklyHoursController = ReturnType<typeof useWeeklyHours>;
 
 export function WeeklyHoursEditor({
   controller,
-  timezone,
 }: {
   controller: WeeklyHoursController;
-  timezone: string;
 }) {
   const {
     days,
@@ -118,15 +116,6 @@ export function WeeklyHoursEditor({
 
   return (
     <div className="space-y-4">
-      <div>
-        <div className="text-sm font-semibold text-foreground">
-          Weekly hours
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Hours shown in {timezone}. Change in Calendar settings.
-        </p>
-      </div>
-
       <div className="rounded-lg border bg-card">
         {DAY_LABELS.map((dayLabel, dayIndex) => {
           const day = days[dayIndex];
@@ -214,10 +203,9 @@ export function WeeklyHoursEditor({
         })}
       </div>
 
-      <div className="flex items-start gap-2.5 rounded-lg border bg-muted/40 px-3.5 py-3 text-xs text-muted-foreground">
-        <Info className="size-3.5 shrink-0 text-muted-foreground" />
+      <p className="text-xs text-muted-foreground">
         We hide times where you already have events on your connected calendar.
-      </div>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Simplifies the availability section on the calendars page, which had stacked, repetitive headings and a heavy note.

## Changes
- Remove the redundant "Weekly hours" heading and the "Hours shown in <timezone>" note from the standalone availability card. The card already has an "Availability" title + description, and a dedicated Timezone setting sits directly below, so both were duplicative.
- Lighten the busy-times note from a bordered/icon callout to a plain helper line.
- Preserve the weekly-hours heading and timezone line in the booking-link dialog by co-locating them there, since that surface has no nearby timezone control.

## Notes
No behavior changes; copy/layout only. The shared `WeeklyHoursEditor` is now a pure grid + helper line, with surrounding context owned by each call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

