### PR TITLE
calendar: Reuse Item primitives for booking dialog heading

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
@@ -411,14 +411,12 @@ function AvailabilityTab({
   return (
     <>
       <div className="space-y-4 overflow-y-auto px-6 py-5">
-        <div>
-          <div className="text-sm font-semibold text-foreground">
-            Weekly hours
-          </div>
-          <p className="text-xs text-muted-foreground">
+        <ItemContent>
+          <ItemTitle>Weekly hours</ItemTitle>
+          <ItemDescription>
             Hours shown in {timezone}. Change in Calendar settings.
-          </p>
-        </div>
+          </ItemDescription>
+        </ItemContent>
         <WeeklyHoursEditor controller={controller} />
 
         <Item variant="outline">


### PR DESCRIPTION
Follow-up to #2889 (review feedback). Replaces the hand-rolled Tailwind for the weekly-hours heading in the booking-link dialog with the shared `ItemTitle`/`ItemDescription` components.

## Why
The heading was using one-off `text-sm font-semibold` / `text-xs text-muted-foreground` markup. The same dialog's "Minimum notice" section already renders its label with `ItemTitle`/`ItemDescription`, so this reuses those primitives instead of reinventing them.

## Result
- No custom styling to maintain
- The two section headings in the Availability tab are now visually consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

