### PR TITLE
fix: make analytics date range picker reachable on mobile

### DIFF
--- a/apps/web/components/DatePickerWithRange.tsx
+++ b/apps/web/components/DatePickerWithRange.tsx
@@ -15,6 +15,7 @@ import {
 import { List } from "@/components/List";
 import { differenceInDays, subDays } from "date-fns";
 import { useMemo } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 function getRelativeDateLabel(days: number) {
   if (days === 1) return "Last day";
@@ -42,6 +43,7 @@ export function DatePickerWithRange({
   onSetDateDropdown,
 }: DatePickerWithRangeProps) {
   const now = useMemo(() => new Date(), []);
+  const isMobile = useIsMobile();
   const days =
     dateRange?.from && dateRange?.to
       ? differenceInDays(dateRange.to, dateRange.from)
@@ -78,14 +80,14 @@ export function DatePickerWithRange({
           <ChevronDown className="ml-2 h-4 w-4 text-gray-400" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
+      <PopoverContent className="w-auto max-h-[var(--radix-popover-content-available-height)] overflow-y-auto p-0">
         <Calendar
           initialFocus
           mode="range"
           defaultMonth={dateRange?.from}
           selected={dateRange}
           onSelect={onSetDateRange}
-          numberOfMonths={2}
+          numberOfMonths={isMobile ? 1 : 2}
           rightContent={
             <List
               value={

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -68,12 +68,12 @@ function Calendar({
         IconRight: () => <ChevronRight className="h-4 w-4" />,
         Months: ({ children }) => (
           <div className="flex flex-col sm:flex-row">
+            <div className="flex flex-col sm:flex-row">{children}</div>
             {rightContent ? (
-              <div className="order-first p-3 border-b border-gray-200 sm:order-last sm:border-b-0 sm:border-l">
+              <div className="order-first p-3 border-b border-gray-200 sm:order-none sm:border-b-0 sm:border-l">
                 {rightContent}
               </div>
             ) : null}
-            <div className="flex flex-col sm:flex-row">{children}</div>
           </div>
         ),
       }}

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -67,11 +67,13 @@ function Calendar({
         IconLeft: () => <ChevronLeft className="h-4 w-4" />,
         IconRight: () => <ChevronRight className="h-4 w-4" />,
         Months: ({ children }) => (
-          <div className="flex">
-            <div className="flex flex-row">{children}</div>
+          <div className="flex flex-col sm:flex-row">
             {rightContent ? (
-              <div className="p-3 border-l border-gray-200">{rightContent}</div>
+              <div className="order-first p-3 border-b border-gray-200 sm:order-last sm:border-b-0 sm:border-l">
+                {rightContent}
+              </div>
             ) : null}
+            <div className="flex flex-col sm:flex-row">{children}</div>
           </div>
         ),
       }}


### PR DESCRIPTION
The analytics date range popover rendered two months and the preset list in a fixed horizontal layout, which overflowed off-screen on narrow viewports and left the "All" preset unreachable in the PWA.

- Stack the preset list above the calendar on mobile and beside it on desktop, so all presets stay on-screen.
- Show a single month on mobile (two on desktop) to keep the popover compact.
- Constrain the popover height so it stays scrollable on short viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

