### PR TITLE
feat(llms): add OpenAI Compatible and Ollama to the model provider dropdown

### DIFF
--- a/apps/web/utils/llms/config.ts
+++ b/apps/web/utils/llms/config.ts
@@ -26,4 +26,6 @@ export const providerOptions: { label: string; value: string }[] = [
   { label: "Groq", value: Provider.GROQ },
   { label: "OpenRouter", value: Provider.OPENROUTER },
   { label: "Vercel AI Gateway", value: Provider.AI_GATEWAY },
+  { label: "OpenAI Compatible", value: Provider.OPENAI_COMPATIBLE },
+  { label: "Ollama", value: Provider.OLLAMA },
 ];


### PR DESCRIPTION
Both `openai-compatible` and `ollama` are valid `Provider` values and fully wired in `getModel()`, but they were missing from `providerOptions` in `apps/web/utils/llms/config.ts` — so self-hosters running a local LLM (llama.cpp / vLLM / LM Studio / Ollama) could configure them via env but **could not select them in Settings → Model**.

This adds both to the dropdown. Two-line change; no behaviour change for existing providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

