### PR TITLE
feat(webhooks): add opt-in extended Call Webhook payload (date, receivedAt, gmailUrl)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -59,6 +59,7 @@ NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS=true
 # NEXT_PUBLIC_SELF_HOSTED_LOGIN_FOOTER_TEXT= # Self-hosted: override the login footer notice. Set to none to hide it.
 # NEXT_PUBLIC_EXTERNAL_API_ENABLED=true # Enable the external API (v1 endpoints, API keys, API key UI)
 # NEXT_PUBLIC_WEBHOOK_ACTION_ENABLED=false # Self-hosted: disable outgoing webhook rule actions and webhook secret UI
+# WEBHOOK_EXTENDED_PAYLOAD=true # Include extra fields (date, receivedAt, gmailUrl) in the Call Webhook email payload. Off by default (backwards compatible)
 # NEXT_PUBLIC_AI_MODEL_SETTINGS_DISABLED=true # Self-hosted: hide user AI model settings and enforce deployment-managed model settings
 # AUTO_ENABLE_ORG_ANALYTICS=true # Self-hosted: default new org members to analytics enabled
 # NEXT_PUBLIC_CONVERSION_ANALYTICS_SCRIPT_URL= # Optional: private conversion analytics script URL

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -325,6 +325,10 @@ const parsedEnv = createEnv({
     APP_REVIEW_DEMO_ENABLED: booleanString.optional().default(false),
     APP_REVIEW_DEMO_ACCOUNTS: z.string().optional(),
     SSO_LOGIN_ENABLED: booleanString.optional().default(false),
+    // When true, the Call Webhook action's email payload includes the extra
+    // fields `date`, `receivedAt` and `gmailUrl`. Off by default so the payload
+    // stays backwards compatible for existing consumers.
+    WEBHOOK_EXTENDED_PAYLOAD: booleanString.optional().default(false),
   },
   client: {
     // stripe

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -405,6 +405,22 @@ const call_webhook: ActionFunction<{ url?: string | null }> = async ({
 }) => {
   if (!args.url) return;
 
+  const messageId = email.headers["message-id"] || "";
+
+  // Opt-in extra fields. Off by default so the payload stays exactly the
+  // original shape for existing consumers (backwards compatible).
+  const extendedFields = env.WEBHOOK_EXTENDED_PAYLOAD
+    ? {
+        date: email.headers.date,
+        receivedAt: email.internalDate,
+        gmailUrl: messageId
+          ? `https://mail.google.com/mail/u/0/#search/rfc822msgid:${encodeURIComponent(
+              messageId,
+            )}`
+          : `https://mail.google.com/mail/u/0/#all/${email.threadId}`,
+      }
+    : {};
+
   const payload = {
     email: {
       threadId: email.threadId,
@@ -413,9 +429,8 @@ const call_webhook: ActionFunction<{ url?: string | null }> = async ({
       from: email.headers.from,
       cc: email.headers.cc,
       bcc: email.headers.bcc,
-      headerMessageId: email.headers["message-id"] || "",
-      date: email.headers.date,
-      receivedAt: email.internalDate,
+      headerMessageId: messageId,
+      ...extendedFields,
     },
     executedRule: {
       id: executedRule.id,

--- a/apps/web/utils/ai/actions.ts
+++ b/apps/web/utils/ai/actions.ts
@@ -414,6 +414,8 @@ const call_webhook: ActionFunction<{ url?: string | null }> = async ({
       cc: email.headers.cc,
       bcc: email.headers.bcc,
       headerMessageId: email.headers["message-id"] || "",
+      date: email.headers.date,
+      receivedAt: email.internalDate,
     },
     executedRule: {
       id: executedRule.id,

--- a/apps/web/utils/webhook.ts
+++ b/apps/web/utils/webhook.ts
@@ -23,6 +23,10 @@ type WebhookPayload = {
     cc?: string;
     bcc?: string;
     headerMessageId: string;
+    /** The email's Date header, as supplied by the sender. */
+    date?: string;
+    /** Provider received timestamp (Gmail internalDate, ms-epoch string). */
+    receivedAt?: string | null;
   };
   executedRule: Pick<
     ExecutedRule,

--- a/apps/web/utils/webhook.ts
+++ b/apps/web/utils/webhook.ts
@@ -27,6 +27,8 @@ type WebhookPayload = {
     date?: string;
     /** Provider received timestamp (Gmail internalDate, ms-epoch string). */
     receivedAt?: string | null;
+    /** Gmail deep link to the message. */
+    gmailUrl?: string;
   };
   executedRule: Pick<
     ExecutedRule,


### PR DESCRIPTION
Adds three fields to the Call Webhook `email` payload — `date` (Date header), `receivedAt` (Gmail `internalDate`, ms-epoch), and `gmailUrl` (a Gmail deep link built from the RFC822 Message-ID, falling back to the thread view when that header is absent).

**Opt-in:** all three are gated behind a new server env flag `WEBHOOK_EXTENDED_PAYLOAD` (default `false`), spread conditionally into the payload. With it off, the payload is byte-identical to the original (`threadId, messageId, subject, from, cc, bcc, headerMessageId`); the new fields are optional on the `WebhookPayload` type. No change for existing consumers.

**Validated:** `tsc --noEmit` clean on touched code, `biome` clean, `utils/webhook.test.ts` passes. Flag documented in `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)