### PR TITLE
fix(assistant): replace z.unknown() in settings tool with a typed union (fixes #2892)

### DIFF
--- a/apps/web/utils/ai/assistant/tools/settings/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/shared.ts
@@ -192,16 +192,42 @@ export const updateAssistantSettingsInputSchema = z.object({
     .describe("Structured settings changes to apply."),
 });
 
+const settingsPrimitiveValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+// The value accepted by a settings change depends on the path. Rather than
+// `z.unknown()` (which produces a typeless `{}` JSON Schema node that strict
+// "openai-compatible" endpoints reject when building a constrained-decoding
+// grammar - "Unrecognized schema"), we describe the full set of shapes any path
+// can take. The exact per-path type is still re-validated downstream against
+// `settingsChangeSchema`, so this only needs to be a permissive superset.
+const settingsLlmValueSchema = z.union([
+  settingsPrimitiveValueSchema,
+  z.array(settingsPrimitiveValueSchema),
+  draftKnowledgeUpsertSchema,
+  z.object({
+    title: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .describe("Title of the draft knowledge item to delete."),
+  }),
+  scheduledCheckInsConfigSchema,
+]);
+
 export const updateAssistantSettingsLlmChangeSchema = z
   .object({
     path: settingsPathSchema.describe(
       "Writable settings path (use a path returned by getAssistantCapabilities).",
     ),
-    value: z
-      .unknown()
-      .describe(
-        "Setting value for the path. Type depends on the path definition.",
-      ),
+    value: settingsLlmValueSchema.describe(
+      "Setting value for the path: a primitive (string, number, boolean, or null), an array of primitives, or an object whose shape depends on the path.",
+    ),
     mode: z
       .enum(["append", "replace"])
       .nullish()


### PR DESCRIPTION
Fixes #2892.

## Problem
The AI chat assistant is fully broken on strict-schema `openai-compatible` endpoints (llama.cpp / vLLM / LM Studio with structured outputs). The browser throws:
```
Error: JSON schema conversion failed: Unrecognized schema: {"description":"Setting value for the path. Type depends on the path definition."}
```
and the assistant returns nothing.

## Root cause
`updateAssistantSettings` declares its `value` as `z.unknown()`, which emits a JSON Schema node with no `type`. With `supportsStructuredOutputs: true` on the provider (`utils/llms/model.ts`), the tool schema goes to the endpoint’s structured-output path, where the server’s grammar builder (e.g. llama.cpp `json-schema-to-grammar`) rejects the typeless node — aborting the whole tool set.

## Fix
Replace `z.unknown()` with an explicit union of the value shapes the settings paths accept (primitives, arrays of primitives, and the existing object schemas). The per-path type is still re-validated downstream against the strict `settingsChangeSchema` discriminated union, so this only needs to be a permissive, fully-typed superset. A naive `z.record(...)` would emit `additionalProperties:false` with no `properties` and silently reject object values, so the union is the correct shape.

## Validation
Reproduced the emitted tool JSON Schema on the pinned SDK versions: the old schema emits the typeless node verbatim; the new one emits zero typeless nodes and accepts string/number/boolean/null/array/object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

