### PR TITLE
Remove availability from booking link settings

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/BookingLinksSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/BookingLinksSection.tsx
@@ -27,10 +27,7 @@ import {
 import { updateCalendarBookingLinkAction } from "@/utils/actions/calendar";
 import { updateBookingLinkBody } from "@/utils/actions/calendar.validation";
 import { getBookingLinkSlugSuggestion } from "@/utils/booking/slug";
-import {
-  ConfigureBookingLinkDialog,
-  type ConfigureBookingLinkTab,
-} from "./ConfigureBookingLinkDialog";
+import { ConfigureBookingLinkDialog } from "./ConfigureBookingLinkDialog";
 import { CreateBookingLinkDialog } from "./CreateBookingLinkDialog";
 
 type BookingLink = NonNullable<
@@ -69,8 +66,6 @@ function InboxZeroBookingLinkPanel() {
   const { emailAccountId, emailAccount } = useAccount();
   const { data, isLoading, error, mutate } = useBookingLinks();
   const [configureLinkId, setConfigureLinkId] = useState<string | null>(null);
-  const [configureInitialTab, setConfigureInitialTab] =
-    useState<ConfigureBookingLinkTab>("general");
   const [createOpen, setCreateOpen] = useState(false);
 
   const link = data?.bookingLinks[0] ?? null;
@@ -132,7 +127,6 @@ function InboxZeroBookingLinkPanel() {
             isToggling={isToggling}
             onToggle={handleToggle}
             onConfigure={() => {
-              setConfigureInitialTab("general");
               setConfigureLinkId(link.id);
             }}
           />
@@ -157,7 +151,6 @@ function InboxZeroBookingLinkPanel() {
             if (!newLinkId) return;
 
             setCreateOpen(false);
-            setConfigureInitialTab("availability");
             setConfigureLinkId(newLinkId);
             await mutate();
           }}
@@ -168,15 +161,12 @@ function InboxZeroBookingLinkPanel() {
       {configureLink ? (
         <ConfigureBookingLinkDialog
           link={configureLink}
-          initialTab={configureInitialTab}
           onClose={() => {
             setConfigureLinkId(null);
-            setConfigureInitialTab("general");
           }}
           onSaved={() => {
             mutate();
             setConfigureLinkId(null);
-            setConfigureInitialTab("general");
           }}
         />
       ) : null}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BookingLinkLocationType } from "@/generated/prisma/enums";
+import { ConfigureBookingLinkDialog } from "./ConfigureBookingLinkDialog";
+
+(globalThis as { React?: typeof React }).React = React;
+
+const mockUseBookingLinks = vi.fn();
+const mockUseAccount = vi.fn();
+
+vi.mock("@/hooks/useBookingLinks", () => ({
+  useBookingLinks: () => mockUseBookingLinks(),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+vi.mock("@/utils/actions/booking", () => ({
+  deleteBookingLinkAction: vi.fn(),
+  updateBookingLinkAction: vi.fn(),
+}));
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({ executeAsync: vi.fn(), isExecuting: false }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConfigureBookingLinkDialog", () => {
+  beforeEach(() => {
+    mockUseAccount.mockReturnValue({ emailAccountId: "email-account-id" });
+    mockUseBookingLinks.mockReturnValue({ data: bookingLinksData() });
+  });
+
+  it("does not show calendar availability as a booking link configuration tab", () => {
+    render(
+      <ConfigureBookingLinkDialog
+        link={bookingLinksData().bookingLinks[0]}
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "General" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Advanced" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Availability" })).toBeNull();
+  });
+});
+
+function bookingLinksData() {
+  return {
+    timezone: "UTC",
+    bookingLinks: [
+      {
+        id: "booking-link-id",
+        slug: "booking-link",
+        title: "Booking link",
+        description: "",
+        isActive: true,
+        durationMinutes: 30,
+        locationType: BookingLinkLocationType.GOOGLE_MEET,
+        locationValue: null,
+        minimumNoticeMinutes: 120,
+        maxDaysAhead: 60,
+        destinationCalendarId: "calendar-id",
+        destinationCalendar: {
+          id: "calendar-id",
+          name: "Primary calendar",
+          calendarId: "primary",
+          primary: true,
+        },
+        timezone: "UTC",
+        windows: [],
+      },
+    ],
+    calendarConnections: [
+      {
+        id: "connection-id",
+        provider: "google",
+        email: "user@example.com",
+        calendars: [
+          {
+            id: "calendar-id",
+            name: "Primary calendar",
+            primary: true,
+            timezone: "UTC",
+            isEnabled: true,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.tsx
@@ -31,7 +31,6 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { getActionErrorMessage } from "@/utils/error";
 import {
   deleteBookingLinkAction,
-  updateBookingAvailabilityAction,
   updateBookingLinkAction,
 } from "@/utils/actions/booking";
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
@@ -47,26 +46,22 @@ import {
   isProviderVideoLocationType,
 } from "./booking-calendar-helpers";
 import { VideoConferencingItem } from "./VideoConferencingItem";
-import { collectWindows } from "./availability-schedule";
-import { useWeeklyHours, WeeklyHoursEditor } from "./WeeklyHoursEditor";
 
 type BookingLink = NonNullable<
   ReturnType<typeof useBookingLinks>["data"]
 >["bookingLinks"][number];
-export type ConfigureBookingLinkTab = "general" | "availability" | "advanced";
+type ConfigureBookingLinkTab = "general" | "advanced";
 
 export function ConfigureBookingLinkDialog({
   link,
-  initialTab = "general",
   onClose,
   onSaved,
 }: {
   link: BookingLink;
-  initialTab?: ConfigureBookingLinkTab;
   onClose: () => void;
   onSaved: () => void;
 }) {
-  const [tab, setTab] = useState<ConfigureBookingLinkTab>(initialTab);
+  const [tab, setTab] = useState<ConfigureBookingLinkTab>("general");
 
   const publicUrl =
     typeof window !== "undefined"
@@ -107,12 +102,6 @@ export function ConfigureBookingLinkDialog({
               General
             </TabButton>
             <TabButton
-              active={tab === "availability"}
-              onClick={() => setTab("availability")}
-            >
-              Availability
-            </TabButton>
-            <TabButton
               active={tab === "advanced"}
               onClick={() => setTab("advanced")}
             >
@@ -122,9 +111,6 @@ export function ConfigureBookingLinkDialog({
         </div>
 
         {tab === "general" && <GeneralTab link={link} onSaved={onSaved} />}
-        {tab === "availability" && (
-          <AvailabilityTab link={link} onSaved={onSaved} />
-        )}
         {tab === "advanced" && <AdvancedTab link={link} onSaved={onSaved} />}
       </DialogContent>
     </Dialog>
@@ -169,6 +155,9 @@ function GeneralTab({
   const [title, setTitle] = useState(link.title);
   const [slug, setSlug] = useState(link.slug);
   const [duration, setDuration] = useState<number>(link.durationMinutes);
+  const [minimumNoticeHours, setMinimumNoticeHours] = useState(() =>
+    formatHours(link.minimumNoticeMinutes / 60),
+  );
   const defaultDestinationCalendarId = getDefaultDestinationCalendarId(data);
   const [destinationCalendarId, setDestinationCalendarId] = useState<string>(
     link.destinationCalendarId ?? defaultDestinationCalendarId,
@@ -210,6 +199,14 @@ function GeneralTab({
       : "/book/";
 
   const handleSave = async () => {
+    const minimumNoticeMinutes = parseMinimumNoticeHours(minimumNoticeHours);
+    if (minimumNoticeMinutes === null) {
+      toastError({
+        description: "Minimum notice must be 0 hours or more.",
+      });
+      return;
+    }
+
     try {
       const nextLocationType =
         videoEnabled && videoLocationType
@@ -227,6 +224,7 @@ function GeneralTab({
         title,
         description,
         durationMinutes: duration,
+        minimumNoticeMinutes,
         locationType: nextLocationType,
         locationValue: nextLocationValue,
         destinationCalendarId,
@@ -296,6 +294,31 @@ function GeneralTab({
           </div>
         </div>
 
+        <Item variant="outline">
+          <ItemContent>
+            <ItemTitle>Minimum notice</ItemTitle>
+            <ItemDescription>
+              Block new bookings this many hours into the future.
+            </ItemDescription>
+          </ItemContent>
+          <ItemActions>
+            <Input
+              type="number"
+              name="minimumNoticeHours"
+              min={0}
+              max={365 * 24}
+              step={0.25}
+              rightText="hours"
+              className="w-24 tabular-nums"
+              registerProps={{
+                value: minimumNoticeHours,
+                onChange: (event: ChangeEvent<HTMLInputElement>) =>
+                  setMinimumNoticeHours(event.target.value),
+              }}
+            />
+          </ItemActions>
+        </Item>
+
         <div>
           <Label name="destinationCalendarId" label="Add events to" />
           <Select
@@ -336,113 +359,6 @@ function GeneralTab({
               setDescription(event.target.value),
           }}
         />
-      </div>
-
-      <DialogFooter onSaved={onSaved} onSave={handleSave} loading={isSaving} />
-    </>
-  );
-}
-
-function AvailabilityTab({
-  link,
-  onSaved,
-}: {
-  link: BookingLink;
-  onSaved: () => void;
-}) {
-  const { emailAccountId } = useAccount();
-
-  const controller = useWeeklyHours(link.windows ?? []);
-  const timezone =
-    link.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
-  const [minimumNoticeHours, setMinimumNoticeHours] = useState(() =>
-    formatHours(link.minimumNoticeMinutes / 60),
-  );
-
-  const { executeAsync: updateAvailability, isExecuting: isSaving } = useAction(
-    updateBookingAvailabilityAction.bind(null, emailAccountId),
-    {
-      onError: (error) => {
-        toastError({
-          description:
-            getActionErrorMessage(error.error) ??
-            "Failed to update availability",
-        });
-      },
-    },
-  );
-
-  const handleSave = async () => {
-    const minimumNoticeMinutes = parseMinimumNoticeHours(minimumNoticeHours);
-    if (minimumNoticeMinutes === null) {
-      toastError({
-        description: "Minimum notice must be 0 hours or more.",
-      });
-      return;
-    }
-
-    const collected = collectWindows(controller.days);
-    if (collected.windows === null) {
-      toastError({ description: collected.error });
-      return;
-    }
-
-    try {
-      const result = await updateAvailability({
-        bookingLinkId: link.id,
-        minimumNoticeMinutes,
-        timezone,
-        windows: collected.windows,
-      });
-      if (hasActionResultError(result)) return;
-
-      toastSuccess({ description: "Availability updated" });
-      onSaved();
-    } catch (error) {
-      toastError({
-        description:
-          error instanceof Error
-            ? error.message
-            : "Failed to update availability",
-      });
-    }
-  };
-
-  return (
-    <>
-      <div className="space-y-4 overflow-y-auto px-6 py-5">
-        <ItemContent>
-          <ItemTitle>Weekly hours</ItemTitle>
-          <ItemDescription>
-            Hours shown in {timezone}. Change in Calendar settings.
-          </ItemDescription>
-        </ItemContent>
-        <WeeklyHoursEditor controller={controller} />
-
-        <Item variant="outline">
-          <ItemContent>
-            <ItemTitle>Minimum notice</ItemTitle>
-            <ItemDescription>
-              Block new bookings this many hours into the future.
-            </ItemDescription>
-          </ItemContent>
-          <ItemActions>
-            <Input
-              type="number"
-              name="minimumNoticeHours"
-              min={0}
-              max={365 * 24}
-              step={0.25}
-              rightText="hours"
-              className="w-24 tabular-nums"
-              registerProps={{
-                value: minimumNoticeHours,
-                onChange: (event: ChangeEvent<HTMLInputElement>) =>
-                  setMinimumNoticeHours(event.target.value),
-              }}
-            />
-          </ItemActions>
-        </Item>
       </div>
 
       <DialogFooter onSaved={onSaved} onSave={handleSave} loading={isSaving} />


### PR DESCRIPTION
Removes the calendar availability editor from the booking link configuration dialog so availability is managed from the calendar settings surface. Keeps booking-link-specific minimum notice in the general settings and updates the post-create configuration flow. Adds a focused component test covering the remaining dialog tabs.

Validation:
- pnpm --filter inbox-zero-ai lint
- pnpm test 'app/(app)/[emailAccountId]/calendars/ConfigureBookingLinkDialog.test.tsx'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

