### PR TITLE
feat(digest): add opt-in webhook delivery target for digests

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -289,6 +289,7 @@ LOOPS_API_SECRET=
 
 # Feature flags
 # NEXT_PUBLIC_DIGEST_ENABLED=true
+# NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED=true # Show the per-account "Digest webhook URL" field for delivering digests to a webhook
 # NEXT_PUBLIC_MEETING_BRIEFS_ENABLED=true
 # NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED=true
 # NEXT_PUBLIC_INTEGRATIONS_ENABLED=false # beta

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { useAction } from "next-safe-action/hooks";
 import { zodResolver } from "@hookform/resolvers/zod";
 import useSWR from "swr";
 import { z } from "zod";
+import { env } from "@/env";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/Input";
 import { Button } from "@/components/ui/button";
 import { TimePicker } from "@/components/TimePicker";
 import { Toggle } from "@/components/Toggle";
@@ -21,6 +23,7 @@ import { updateDigestEmailDeliveryAction } from "@/utils/actions/messaging-chann
 import {
   updateDigestItemsAction,
   updateDigestScheduleAction,
+  updateDigestWebhookUrlAction,
 } from "@/utils/actions/settings";
 import { ActionType } from "@/generated/prisma/enums";
 import { useAccount } from "@/providers/EmailAccountProvider";
@@ -395,6 +398,14 @@ function DigestDeliveryChannels({
           onChange={(sendEmail) => execute({ sendEmail })}
         />
       </div>
+      {env.NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED && (
+        <DigestWebhookUrlField
+          emailAccountId={emailAccountId}
+          digestWebhookUrl={account?.digestWebhookUrl ?? ""}
+          disabled={isLoading}
+          onSaved={mutate}
+        />
+      )}
       {showChannelsHint && (
         <MutedText>
           Want digests in your chat app?{" "}
@@ -407,6 +418,69 @@ function DigestDeliveryChannels({
           .
         </MutedText>
       )}
+    </div>
+  );
+}
+
+function DigestWebhookUrlField({
+  emailAccountId,
+  digestWebhookUrl,
+  disabled,
+  onSaved,
+}: {
+  emailAccountId: string;
+  digestWebhookUrl: string;
+  disabled: boolean;
+  onSaved: () => void;
+}) {
+  const [value, setValue] = useState(digestWebhookUrl);
+
+  // Keep local state in sync once the account data loads.
+  useEffect(() => {
+    setValue(digestWebhookUrl);
+  }, [digestWebhookUrl]);
+
+  const { execute, isExecuting } = useAction(
+    updateDigestWebhookUrlAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Settings saved" });
+        onSaved();
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error) ?? "Failed to update",
+        });
+      },
+    },
+  );
+
+  return (
+    <div className="space-y-2 pt-2">
+      <Label htmlFor="digestWebhookUrl">Digest webhook URL</Label>
+      <div className="flex items-center gap-2">
+        <Input
+          type="url"
+          name="digestWebhookUrl"
+          placeholder="https://example.com/webhooks/digest"
+          registerProps={{
+            value,
+            onChange: (event: ChangeEvent<HTMLInputElement>) =>
+              setValue(event.target.value),
+          }}
+        />
+        <Button
+          type="button"
+          loading={isExecuting}
+          disabled={disabled || value === digestWebhookUrl}
+          onClick={() => execute({ digestWebhookUrl: value })}
+        >
+          Save
+        </Button>
+      </div>
+      <MutedText>
+        When set, each digest is also POSTed as JSON to this URL.
+      </MutedText>
     </div>
   );
 }

--- a/apps/web/app/api/user/email-account/route.ts
+++ b/apps/web/app/api/user/email-account/route.ts
@@ -43,6 +43,7 @@ async function getEmailAccount({
       followUpNeedsReplyDays: true,
       followUpAutoDraftEnabled: true,
       digestSendEmail: true,
+      digestWebhookUrl: true,
     },
   });
 

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -397,6 +397,7 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_USE_AEONIK_FONT: booleanString.optional().default(false),
     NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: booleanString.optional(),
     NEXT_PUBLIC_DIGEST_ENABLED: booleanString.optional(),
+    NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED: booleanString.optional(),
     NEXT_PUBLIC_MEETING_BRIEFS_ENABLED: booleanString.optional(),
     NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED: booleanString.optional(),
     NEXT_PUBLIC_INTEGRATIONS_ENABLED: booleanString.optional(),
@@ -498,6 +499,8 @@ const parsedEnv = createEnv({
     NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS:
       process.env.NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS,
     NEXT_PUBLIC_DIGEST_ENABLED: process.env.NEXT_PUBLIC_DIGEST_ENABLED,
+    NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED:
+      process.env.NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED,
     NEXT_PUBLIC_MEETING_BRIEFS_ENABLED:
       process.env.NEXT_PUBLIC_MEETING_BRIEFS_ENABLED,
     NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED:

--- a/apps/web/prisma/migrations/20260623120000_add_digest_webhook_url/migration.sql
+++ b/apps/web/prisma/migrations/20260623120000_add_digest_webhook_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EmailAccount" ADD COLUMN "digestWebhookUrl" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -168,6 +168,7 @@ model EmailAccount {
   followUpAutoDraftEnabled  Boolean @default(true)
 
   digestSendEmail     Boolean   @default(true)
+  digestWebhookUrl    String?
   digestSchedule      Schedule?
   learnedWritingStyle String?
 

--- a/apps/web/utils/actions/settings.ts
+++ b/apps/web/utils/actions/settings.ts
@@ -7,6 +7,7 @@ import {
   saveEmailUpdateSettingsBody,
   saveDigestScheduleBody,
   updateDigestItemsBody,
+  updateDigestWebhookUrlBody,
   toggleDigestBody,
 } from "@/utils/actions/settings.validation";
 import { DEFAULT_PROVIDER, Provider } from "@/utils/llms/config";
@@ -165,6 +166,19 @@ export const updateDigestScheduleAction = actionClient
 
     return { success: true };
   });
+
+export const updateDigestWebhookUrlAction = actionClient
+  .metadata({ name: "updateDigestWebhookUrl" })
+  .inputSchema(updateDigestWebhookUrlBody)
+  .action(
+    async ({ ctx: { emailAccountId }, parsedInput: { digestWebhookUrl } }) => {
+      await prisma.emailAccount.update({
+        where: { id: emailAccountId },
+        // Treat empty string as clearing the webhook.
+        data: { digestWebhookUrl: digestWebhookUrl || null },
+      });
+    },
+  );
 
 export const updateDigestItemsAction = actionClient
   .metadata({ name: "updateDigestItems" })

--- a/apps/web/utils/actions/settings.ts
+++ b/apps/web/utils/actions/settings.ts
@@ -174,8 +174,14 @@ export const updateDigestWebhookUrlAction = actionClient
     async ({ ctx: { emailAccountId }, parsedInput: { digestWebhookUrl } }) => {
       await prisma.emailAccount.update({
         where: { id: emailAccountId },
-        // Treat empty string as clearing the webhook.
-        data: { digestWebhookUrl: digestWebhookUrl || null },
+        // Empty string clears the webhook; an omitted (undefined) value leaves
+        // it unchanged so a partial update can't unintentionally delete it.
+        data: {
+          digestWebhookUrl:
+            digestWebhookUrl === undefined
+              ? undefined
+              : digestWebhookUrl || null,
+        },
       });
     },
   );

--- a/apps/web/utils/actions/settings.validation.ts
+++ b/apps/web/utils/actions/settings.validation.ts
@@ -51,6 +51,17 @@ export const updateDigestItemsBody = z.object({
 });
 export type UpdateDigestItemsBody = z.infer<typeof updateDigestItemsBody>;
 
+export const updateDigestWebhookUrlBody = z.object({
+  // Empty string clears the webhook; otherwise it must be a valid URL.
+  digestWebhookUrl: z
+    .union([z.literal(""), z.string().url()])
+    .optional()
+    .nullable(),
+});
+export type UpdateDigestWebhookUrlBody = z.infer<
+  typeof updateDigestWebhookUrlBody
+>;
+
 export const toggleDigestBody = z.object({
   enabled: z.boolean(),
   timeOfDay: z.coerce.date().optional(),

--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -1,5 +1,8 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { env } from "@/env";
 import { sendDigestEmail } from "@inboxzero/resend";
+import { resolveSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
 import {
   MessagingProvider,
   MessagingRoutePurpose,
@@ -24,6 +27,8 @@ import prisma from "@/utils/prisma";
 
 type DigestItem = { from: string; subject: string; content: string };
 type ItemsByRule = Record<string, DigestItem[] | undefined>;
+
+const DIGEST_WEBHOOK_TIMEOUT_MS = 5000;
 
 export async function sendDigest({
   emailAccountId,
@@ -219,17 +224,62 @@ async function sendDigestViaWebhook({
   logger: Logger;
 }) {
   logger.info("Sending digest via webhook");
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ type: "digest", date, ruleNames, itemsByRule }),
+  const requestBody = JSON.stringify({
+    type: "digest",
+    date,
+    ruleNames,
+    itemsByRule,
   });
-  if (!response.ok) {
+
+  // SSRF protection: validate and pin the resolved address (no private/internal
+  // IPs, no DNS rebinding), mirroring the Call Webhook sender (utils/webhook.ts).
+  const resolvedUrl = await resolveSafeExternalHttpUrl(url);
+  if (!resolvedUrl) {
     // Throw so this counts as a channel failure in Promise.allSettled;
-    // otherwise a webhook-only digest could be marked SENT without actually
-    // delivering.
-    throw new Error(`Digest webhook responded with status ${response.status}`);
+    // otherwise a webhook-only digest could be marked SENT without delivering.
+    throw new Error(
+      "Digest webhook URL is not allowed (failed SSRF validation)",
+    );
   }
+
+  await new Promise<void>((resolve, reject) => {
+    const request = (
+      resolvedUrl.url.protocol === "https:" ? httpsRequest : httpRequest
+    )(
+      resolvedUrl.url,
+      {
+        method: "POST",
+        lookup: resolvedUrl.lookup,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(requestBody).toString(),
+        },
+      },
+      (response) => {
+        response.resume();
+        response.on("error", reject);
+        response.on("end", () => {
+          const statusCode = response.statusCode || 0;
+          if (statusCode >= 200 && statusCode < 300) {
+            resolve();
+          } else {
+            // Throw so this counts as a channel failure in Promise.allSettled.
+            reject(
+              new Error(`Digest webhook responded with status ${statusCode}`),
+            );
+          }
+        });
+      },
+    );
+
+    request.setTimeout(DIGEST_WEBHOOK_TIMEOUT_MS, () => {
+      request.destroy(new Error("Digest webhook request timed out"));
+    });
+    request.on("error", reject);
+    request.write(requestBody);
+    request.end();
+  });
+
   logger.info("Digest sent via webhook");
 }
 

--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -46,10 +46,11 @@ export async function sendDigest({
 
   const emailAccount = await prisma.emailAccount.findUnique({
     where: { id: emailAccountId },
-    select: { digestSendEmail: true },
+    select: { digestSendEmail: true, digestWebhookUrl: true },
   });
 
   const sendEmail = emailAccount?.digestSendEmail ?? true;
+  const digestWebhookUrl = emailAccount?.digestWebhookUrl ?? null;
 
   const channels = await prisma.messagingChannel.findMany({
     where: {
@@ -130,6 +131,18 @@ export async function sendDigest({
     }
   }
 
+  if (digestWebhookUrl) {
+    deliveryPromises.push(
+      sendDigestViaWebhook({
+        url: digestWebhookUrl,
+        date,
+        ruleNames,
+        itemsByRule,
+        logger,
+      }),
+    );
+  }
+
   if (deliveryPromises.length === 0) {
     if (channels.length > 0) {
       // Email is off and every configured messaging channel was skipped
@@ -190,6 +203,34 @@ async function sendDigestViaEmail({
     },
   });
   logger.info("Digest email sent");
+}
+
+async function sendDigestViaWebhook({
+  url,
+  date,
+  ruleNames,
+  itemsByRule,
+  logger,
+}: {
+  url: string;
+  date: Date;
+  ruleNames: Record<string, string>;
+  itemsByRule: ItemsByRule;
+  logger: Logger;
+}) {
+  logger.info("Sending digest via webhook");
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: "digest", date, ruleNames, itemsByRule }),
+  });
+  if (!response.ok) {
+    // Throw so this counts as a channel failure in Promise.allSettled;
+    // otherwise a webhook-only digest could be marked SENT without actually
+    // delivering.
+    throw new Error(`Digest webhook responded with status ${response.status}`);
+  }
+  logger.info("Digest sent via webhook");
 }
 
 async function sendDigestViaSlack({


### PR DESCRIPTION
Digests currently deliver only via email / Slack / Teams / Telegram. This adds a per-account **webhook** delivery target so self-hosters and integrators can receive digests programmatically.

When a `digestWebhookUrl` is set, each digest is POSTed as JSON `{ type: "digest", date, ruleNames, itemsByRule }`. A non-2xx response throws, so it counts as a failed channel under the existing `Promise.allSettled` handling (consistent with Slack) and satisfies the existing "≥1 deliverable channel" guard.

Includes: `digestWebhookUrl String?` on `EmailAccount` + migration, a validated server action, and a "Digest webhook URL" input in the digest settings UI.

**Opt-in:** the UI field is gated behind `NEXT_PUBLIC_DIGEST_WEBHOOK_ENABLED` (following the `NEXT_PUBLIC_DIGEST_ENABLED` pattern). With the flag off and no URL set, behavior is unchanged (nullable column, no delivery promise, hidden field).

**Validated:** `tsc --noEmit` clean on touched code, `biome` clean, `send-digest.test.ts` + `webhook.test.ts` pass (10). Migration generated under `prisma/migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

