### PR TITLE
Show and toggle sender label rules

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/common.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import {
   ArchiveIcon,
   ArchiveRestoreIcon,
+  CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   ExpandIcon,
@@ -40,7 +41,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { PremiumTooltip } from "@/components/PremiumAlert";
 import { NewsletterStatus } from "@/generated/prisma/enums";
 import { toastError, toastSuccess } from "@/components/Toast";
-import { createFilterAction } from "@/utils/actions/mail";
+import { createFilterAction, deleteFilterAction } from "@/utils/actions/mail";
 import { getGmailSearchUrl } from "@/utils/url";
 import { extractNameFromEmail } from "@/utils/email";
 import { Badge } from "@/components/ui/badge";
@@ -316,6 +317,27 @@ export function MoreDropdown<T extends Row>({
   const showAutoArchive = typeof hasUnsubscribeAccess === "boolean";
 
   const handleLabelClick = async (label: EmailLabel) => {
+    const activeFilter = getActiveLabelFilter(item, label);
+
+    if (activeFilter) {
+      const res = await deleteFilterAction(emailAccountId, {
+        id: activeFilter.id,
+      });
+      if (res?.serverError) {
+        toastError({
+          title: "Error",
+          description: `Failed to stop labeling ${item.name} as ${label.name}. ${res.serverError || ""}`,
+        });
+      } else {
+        toastSuccess({
+          title: "Success!",
+          description: `Stopped labeling ${item.name} as ${label.name}`,
+        });
+        await mutate();
+      }
+      return;
+    }
+
     const res = await createFilterAction(emailAccountId, {
       from: item.name,
       gmailLabelId: label.id,
@@ -330,6 +352,7 @@ export function MoreDropdown<T extends Row>({
         title: "Success!",
         description: `Added ${item.name} to ${label.name}`,
       });
+      await mutate();
     }
   };
 
@@ -379,7 +402,13 @@ export function MoreDropdown<T extends Row>({
                 <span>{labelMenuLabel}</span>
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
-                <LabelsSubMenu labels={labels} onClick={handleLabelClick} />
+                <LabelsSubMenu
+                  labels={labels}
+                  onClick={handleLabelClick}
+                  isLabelActive={(label) =>
+                    Boolean(getActiveLabelFilter(item, label))
+                  }
+                />
               </DropdownMenuPortal>
             </DropdownMenuSub>
           )}
@@ -437,19 +466,24 @@ export function MoreDropdown<T extends Row>({
           </SheetHeader>
           <div className="mt-4 max-h-[60vh] space-y-1 overflow-y-auto">
             {labels.length ? (
-              labels.map((label) => (
-                <button
-                  key={label.id}
-                  type="button"
-                  className="flex w-full items-center rounded-sm px-3 py-2 text-left text-sm hover:bg-accent"
-                  onClick={async () => {
-                    setLabelSheetOpen(false);
-                    await handleLabelClick(label);
-                  }}
-                >
-                  <span className="truncate">{label.name}</span>
-                </button>
-              ))
+              labels.map((label) => {
+                const active = Boolean(getActiveLabelFilter(item, label));
+
+                return (
+                  <button
+                    key={label.id}
+                    type="button"
+                    className="flex w-full items-center justify-between gap-3 rounded-sm px-3 py-2 text-left text-sm hover:bg-accent"
+                    onClick={async () => {
+                      setLabelSheetOpen(false);
+                      await handleLabelClick(label);
+                    }}
+                  >
+                    <span className="truncate">{label.name}</span>
+                    {active && <CheckIcon className="size-4 text-primary" />}
+                  </button>
+                );
+              })
             ) : (
               <p className="px-3 py-2 text-sm text-muted-foreground">
                 You don't have any {terminology.label.plural} yet.
@@ -491,4 +525,20 @@ export function HeaderButton(props: {
 
 async function noopRefetchPremium() {
   return null;
+}
+
+function getActiveLabelFilter<T extends Row>(item: T, label: EmailLabel) {
+  const labelId = normalizeLabelValue(label.id);
+  const labelName = normalizeLabelValue(label.name);
+
+  return item.labelFilters?.find((filter) => {
+    if (!filter.id) return false;
+
+    const filterLabelId = normalizeLabelValue(filter.labelId);
+    return filterLabelId === labelId || filterLabelId === labelName;
+  });
+}
+
+function normalizeLabelValue(value: string) {
+  return value.trim().toLowerCase();
 }

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/types.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/types.ts
@@ -16,6 +16,7 @@ export type Row = {
   unsubscribeLink?: string | null;
   status?: NewsletterStatus | null;
   autoArchived?: { id?: string | null };
+  labelFilters?: { id: string; labelId: string }[];
 };
 
 type Newsletter = NewsletterStatsResponse["newsletters"][number];

--- a/apps/web/app/api/user/stats/newsletters/helpers.test.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { EmailFilter } from "@/utils/email/types";
+import { GmailLabel } from "@/utils/gmail/label";
+import { findSenderLabelFilters } from "./helpers";
+
+describe("findSenderLabelFilters", () => {
+  it("returns label-only filters for the sender", () => {
+    const filters: EmailFilter[] = [
+      {
+        id: "filter-1",
+        criteria: { from: "updates@example.com" },
+        action: { addLabelIds: ["Label_123"] },
+      },
+      {
+        id: "filter-2",
+        criteria: { from: "other@example.com" },
+        action: { addLabelIds: ["Label_456"] },
+      },
+    ];
+
+    expect(findSenderLabelFilters(filters, "Updates <updates@example.com>")).toEqual([
+      { id: "filter-1", labelId: "Label_123" },
+    ]);
+  });
+
+  it("does not return auto-archive filters that also apply a label", () => {
+    const filters: EmailFilter[] = [
+      {
+        id: "archive-filter",
+        criteria: { from: "updates@example.com" },
+        action: {
+          removeLabelIds: [GmailLabel.INBOX],
+          addLabelIds: ["Label_123"],
+        },
+      },
+      {
+        id: "label-filter",
+        criteria: { from: "updates@example.com" },
+        action: { addLabelIds: ["Label_456"] },
+      },
+    ];
+
+    expect(findSenderLabelFilters(filters, "updates@example.com")).toEqual([
+      { id: "label-filter", labelId: "Label_456" },
+    ]);
+  });
+});

--- a/apps/web/app/api/user/stats/newsletters/helpers.test.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.test.ts
@@ -44,4 +44,47 @@ describe("findSenderLabelFilters", () => {
       { id: "label-filter", labelId: "Label_456" },
     ]);
   });
+
+  it("matches filters with a display-name sender criterion", () => {
+    const filters: EmailFilter[] = [
+      {
+        id: "filter-1",
+        criteria: { from: "Example Updates <updates@example.com>" },
+        action: { addLabelIds: ["Label_123"] },
+      },
+    ];
+
+    expect(findSenderLabelFilters(filters, "updates@example.com")).toEqual([
+      { id: "filter-1", labelId: "Label_123" },
+    ]);
+  });
+
+  it("does not match filters with empty sender criteria", () => {
+    const filters: EmailFilter[] = [
+      {
+        id: "filter-1",
+        criteria: { from: "" },
+        action: { addLabelIds: ["Label_123"] },
+      },
+      {
+        id: "filter-2",
+        criteria: {},
+        action: { addLabelIds: ["Label_456"] },
+      },
+    ];
+
+    expect(findSenderLabelFilters(filters, "updates@example.com")).toEqual([]);
+  });
+
+  it("does not match every filter when the sender email is empty", () => {
+    const filters: EmailFilter[] = [
+      {
+        id: "filter-1",
+        criteria: { from: "updates@example.com" },
+        action: { addLabelIds: ["Label_123"] },
+      },
+    ];
+
+    expect(findSenderLabelFilters(filters, "")).toEqual([]);
+  });
 });

--- a/apps/web/app/api/user/stats/newsletters/helpers.test.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.test.ts
@@ -18,9 +18,9 @@ describe("findSenderLabelFilters", () => {
       },
     ];
 
-    expect(findSenderLabelFilters(filters, "Updates <updates@example.com>")).toEqual([
-      { id: "filter-1", labelId: "Label_123" },
-    ]);
+    expect(
+      findSenderLabelFilters(filters, "Updates <updates@example.com>"),
+    ).toEqual([{ id: "filter-1", labelId: "Label_123" }]);
   });
 
   it("does not return auto-archive filters that also apply a label", () => {

--- a/apps/web/app/api/user/stats/newsletters/helpers.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.ts
@@ -9,19 +9,42 @@ export async function getAutoArchiveFilters(
   emailProvider: EmailProvider,
   logger: Logger,
 ) {
+  const filters = await getEmailFilters(emailProvider, logger);
+  return filters.filter((filter) => isAutoArchiveFilter(filter, emailProvider));
+}
+
+export async function getEmailFilters(
+  emailProvider: EmailProvider,
+  logger: Logger,
+) {
   try {
-    const filters = await emailProvider.getFiltersList();
-
-    const autoArchiveFilters = filters.filter((filter) =>
-      isAutoArchiveFilter(filter, emailProvider),
-    );
-
-    return autoArchiveFilters;
+    return await emailProvider.getFiltersList();
   } catch (error) {
-    logger.error("Error getting auto-archive filters", { error });
+    logger.error("Error getting email filters", { error });
     // Return empty array instead of throwing, so the newsletter stats still work
     return [];
   }
+}
+
+export function findSenderLabelFilters(
+  filters: EmailFilter[],
+  fromEmail: string,
+): { id: string; labelId: string }[] {
+  const from = extractEmailAddress(fromEmail).toLowerCase();
+
+  return filters.flatMap((filter) => {
+    const matchesSender = filter.criteria?.from
+      ?.toLowerCase()
+      .includes(from);
+    if (!matchesSender || isLabelWithArchiveFilter(filter)) return [];
+
+    return (
+      filter.action?.addLabelIds?.map((labelId) => ({
+        id: filter.id,
+        labelId,
+      })) ?? []
+    );
+  });
 }
 
 export function findAutoArchiveFilter(
@@ -101,4 +124,12 @@ function isGmailAutoArchiveFilter(filter: EmailFilter): boolean {
 function isOutlookAutoArchiveFilter(filter: EmailFilter): boolean {
   // For Outlook: check if it moves to archive folder (removeLabelIds contains "INBOX")
   return Boolean(filter.action?.removeLabelIds?.includes("INBOX"));
+}
+
+function isLabelWithArchiveFilter(filter: EmailFilter) {
+  return Boolean(
+    filter.action?.removeLabelIds?.includes(GmailLabel.INBOX) ||
+      filter.action?.removeLabelIds?.includes("INBOX") ||
+      filter.action?.addLabelIds?.includes(GmailLabel.TRASH),
+  );
 }

--- a/apps/web/app/api/user/stats/newsletters/helpers.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.ts
@@ -30,11 +30,12 @@ export function findSenderLabelFilters(
   filters: EmailFilter[],
   fromEmail: string,
 ): { id: string; labelId: string }[] {
-  const from = extractEmailAddress(fromEmail).toLowerCase();
-
   return filters.flatMap((filter) => {
-    const matchesSender = filter.criteria?.from?.toLowerCase().includes(from);
-    if (!matchesSender || isLabelWithArchiveFilter(filter)) return [];
+    if (
+      !filterMatchesSender(filter, fromEmail) ||
+      isLabelWithArchiveFilter(filter)
+    )
+      return [];
 
     return (
       filter.action?.addLabelIds?.map((labelId) => ({
@@ -50,13 +51,11 @@ export function findAutoArchiveFilter(
   fromEmail: string,
   emailProvider: EmailProvider,
 ) {
-  return autoArchiveFilters.find((filter) => {
-    const from = extractEmailAddress(fromEmail);
-    return (
-      filter.criteria?.from?.toLowerCase().includes(from.toLowerCase()) &&
-      isAutoArchiveFilter(filter, emailProvider)
-    );
-  });
+  return autoArchiveFilters.find(
+    (filter) =>
+      filterMatchesSender(filter, fromEmail) &&
+      isAutoArchiveFilter(filter, emailProvider),
+  );
 }
 
 export async function findNewsletterStatus({
@@ -130,4 +129,17 @@ function isLabelWithArchiveFilter(filter: EmailFilter) {
       filter.action?.removeLabelIds?.includes("INBOX") ||
       filter.action?.addLabelIds?.includes(GmailLabel.TRASH),
   );
+}
+
+function filterMatchesSender(filter: EmailFilter, fromEmail: string) {
+  const from = extractEmailAddress(fromEmail).toLowerCase();
+  if (!from) return false;
+
+  const rawFilterFrom = filter.criteria?.from?.trim().toLowerCase();
+  if (!rawFilterFrom) return false;
+
+  const normalizedFilterFrom =
+    extractEmailAddress(rawFilterFrom).toLowerCase() || rawFilterFrom;
+
+  return normalizedFilterFrom.includes(from);
 }

--- a/apps/web/app/api/user/stats/newsletters/helpers.ts
+++ b/apps/web/app/api/user/stats/newsletters/helpers.ts
@@ -33,9 +33,7 @@ export function findSenderLabelFilters(
   const from = extractEmailAddress(fromEmail).toLowerCase();
 
   return filters.flatMap((filter) => {
-    const matchesSender = filter.criteria?.from
-      ?.toLowerCase()
-      .includes(from);
+    const matchesSender = filter.criteria?.from?.toLowerCase().includes(from);
     if (!matchesSender || isLabelWithArchiveFilter(filter)) return [];
 
     return (

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -10,9 +10,10 @@ import prisma from "@/utils/prisma";
 import { Prisma } from "@/generated/prisma/client";
 import type { EmailProvider } from "@/utils/email/types";
 import {
-  getAutoArchiveFilters,
+  getEmailFilters,
   findNewsletterStatus,
   findAutoArchiveFilter,
+  findSenderLabelFilters,
   filterNewsletters,
 } from "@/app/api/user/stats/newsletters/helpers";
 
@@ -80,13 +81,13 @@ async function getEmailMessages(
   const { emailAccountId, emailProvider, logger } = options;
   const types = getTypeFilters(options.types);
 
-  const [counts, autoArchiveFilters, userNewsletters] = await Promise.all([
+  const [counts, emailFilters, userNewsletters] = await Promise.all([
     getNewsletterCounts({
       ...options,
       ...types,
       logger,
     }),
-    getAutoArchiveFilters(emailProvider, logger),
+    getEmailFilters(emailProvider, logger),
     findNewsletterStatus({ emailAccountId }),
   ]);
 
@@ -105,10 +106,11 @@ async function getEmailMessages(
       readEmails: email.readEmails,
       unsubscribeLink: email.unsubscribeLink,
       autoArchived: findAutoArchiveFilter(
-        autoArchiveFilters,
+        emailFilters,
         from,
         emailProvider,
       ),
+      labelFilters: findSenderLabelFilters(emailFilters, from),
       status: userNewsletters?.find((n) => n.email === from)?.status,
     };
   });

--- a/apps/web/app/api/user/stats/newsletters/route.ts
+++ b/apps/web/app/api/user/stats/newsletters/route.ts
@@ -105,11 +105,7 @@ async function getEmailMessages(
       inboxEmails: email.inboxEmails,
       readEmails: email.readEmails,
       unsubscribeLink: email.unsubscribeLink,
-      autoArchived: findAutoArchiveFilter(
-        emailFilters,
-        from,
-        emailProvider,
-      ),
+      autoArchived: findAutoArchiveFilter(emailFilters, from, emailProvider),
       labelFilters: findSenderLabelFilters(emailFilters, from),
       status: userNewsletters?.find((n) => n.email === from)?.status,
     };

--- a/apps/web/components/LabelsSubMenu.tsx
+++ b/apps/web/components/LabelsSubMenu.tsx
@@ -1,8 +1,8 @@
 import {
   DropdownMenuSubContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
-import { CheckIcon } from "lucide-react";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getEmailTerminology } from "@/utils/terminology";
@@ -26,14 +26,14 @@ export function LabelsSubMenu({
           const active = isLabelActive?.(label);
 
           return (
-            <DropdownMenuItem
+            <DropdownMenuCheckboxItem
               key={label.id}
-              onClick={() => onClick(label)}
-              className="flex items-center justify-between gap-3"
+              checked={active}
+              onCheckedChange={() => onClick(label)}
+              className="gap-3"
             >
               <span className="truncate">{label.name}</span>
-              {active && <CheckIcon className="size-4 text-primary" />}
-            </DropdownMenuItem>
+            </DropdownMenuCheckboxItem>
           );
         })
       ) : (

--- a/apps/web/components/LabelsSubMenu.tsx
+++ b/apps/web/components/LabelsSubMenu.tsx
@@ -2,6 +2,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import { CheckIcon } from "lucide-react";
 import type { EmailLabel } from "@/providers/email-label-types";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { getEmailTerminology } from "@/utils/terminology";
@@ -9,9 +10,11 @@ import { getEmailTerminology } from "@/utils/terminology";
 export function LabelsSubMenu({
   labels,
   onClick,
+  isLabelActive,
 }: {
   labels: EmailLabel[];
   onClick: (label: EmailLabel) => void;
+  isLabelActive?: (label: EmailLabel) => boolean;
 }) {
   const { provider } = useAccount();
   const terminology = getEmailTerminology(provider);
@@ -19,11 +22,20 @@ export function LabelsSubMenu({
   return (
     <DropdownMenuSubContent className="max-h-[415px] overflow-auto">
       {labels.length ? (
-        labels.map((label) => (
-          <DropdownMenuItem key={label.id} onClick={() => onClick(label)}>
-            {label.name}
-          </DropdownMenuItem>
-        ))
+        labels.map((label) => {
+          const active = isLabelActive?.(label);
+
+          return (
+            <DropdownMenuItem
+              key={label.id}
+              onClick={() => onClick(label)}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="truncate">{label.name}</span>
+              {active && <CheckIcon className="size-4 text-primary" />}
+            </DropdownMenuItem>
+          );
+        })
       ) : (
         <DropdownMenuItem>
           You don't have any {terminology.label.plural} yet.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds sender label-filter state to bulk unsubscribe stats rows.
- Shows a checkmark for labels already enabled for future emails from a sender.
- Lets users disable the saved sender label rule by selecting the checked label again.
- Uses native dropdown checkbox items for label toggle semantics.
- Hardens sender matching in newsletter stats: normalizes filter `from` criteria, rejects empty sender/criteria (addresses cubic review).

### Testing
- `pnpm test "app/api/user/stats/newsletters/helpers.test.ts"`
- `pnpm lint`
- Manual browser walkthrough on local Bulk Unsubscribe page with Google emulator, seeded sender stats, and real provider labels.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db1673ee-6398-4e78-b1f4-289c72c7c5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db1673ee-6398-4e78-b1f4-289c72c7c5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

