### PR TITLE
feat(messaging): add Webhook channel provider for digest delivery

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -13,6 +13,7 @@ import {
   MoreVerticalIcon,
   Settings2Icon,
   SunIcon,
+  WebhookIcon,
 } from "lucide-react";
 import Image from "next/image";
 import { useAction } from "next-safe-action/hooks";
@@ -59,7 +60,11 @@ import {
   toggleRuleChannelAction,
   createMessagingLinkCodeAction,
   disconnectChannelAction,
+  createWebhookChannelAction,
+  updateWebhookChannelAction,
+  toggleWebhookDigestsAction,
 } from "@/utils/actions/messaging-channels";
+import { Input } from "@/components/ui/input";
 import { useSlackNotifications } from "@/app/(app)/[emailAccountId]/settings/ConnectedAppsSection";
 import { ProactiveUpdatesSetting } from "@/app/(app)/[emailAccountId]/assistant/settings/ProactiveUpdatesSetting";
 import { toastSuccess, toastError } from "@/components/Toast";
@@ -88,14 +93,44 @@ type LinkableProvider = "TEAMS" | "TELEGRAM";
 
 const PROVIDER_CONFIG: Record<
   MessagingProvider,
-  { name: string; logo: string }
+  { name: string; logo?: string; icon?: React.ElementType }
 > = {
   SLACK: { name: "Slack", logo: "/images/slack.svg" },
   TEAMS: { name: "Teams", logo: "/images/teams.png" },
   TELEGRAM: { name: "Telegram", logo: "/images/telegram.svg" },
+  WEBHOOK: { name: "Webhook", icon: WebhookIcon },
 };
 
-const PROVIDER_ORDER: MessagingProvider[] = ["SLACK", "TEAMS", "TELEGRAM"];
+const PROVIDER_ORDER: MessagingProvider[] = [
+  "SLACK",
+  "TEAMS",
+  "TELEGRAM",
+  "WEBHOOK",
+];
+
+function ProviderIcon({
+  provider,
+  className = "size-5",
+}: {
+  provider: MessagingProvider;
+  className?: string;
+}) {
+  const config = PROVIDER_CONFIG[provider];
+  if (config.logo) {
+    return (
+      <Image
+        src={config.logo}
+        alt={config.name}
+        width={20}
+        height={20}
+        className={className}
+        unoptimized
+      />
+    );
+  }
+  const Icon = config.icon ?? BellIcon;
+  return <Icon className={className} />;
+}
 
 const CHANNEL_FEATURES: Array<{
   purpose: MessagingFeatureRoutePurpose;
@@ -209,19 +244,38 @@ export function Channels() {
             );
 
             if (providerChannels.length > 0) {
-              return providerChannels.map((channel) => (
-                <ConnectedChannelSection
-                  key={channel.id}
-                  channel={channel}
-                  rules={visibleRules}
-                  emailAccountId={emailAccountId}
-                  hasDigestAccess={hasDigestAccess}
-                  onUpdate={onUpdate}
-                />
-              ));
+              return providerChannels.map((channel) =>
+                channel.provider === "WEBHOOK" ? (
+                  <WebhookChannelSection
+                    key={channel.id}
+                    channel={channel}
+                    emailAccountId={emailAccountId}
+                    hasDigestAccess={hasDigestAccess}
+                    onUpdate={onUpdate}
+                  />
+                ) : (
+                  <ConnectedChannelSection
+                    key={channel.id}
+                    channel={channel}
+                    rules={visibleRules}
+                    emailAccountId={emailAccountId}
+                    hasDigestAccess={hasDigestAccess}
+                    onUpdate={onUpdate}
+                  />
+                ),
+              );
             }
 
             if (unconnectedProviders.includes(provider)) {
+              if (provider === "WEBHOOK") {
+                return (
+                  <AddWebhookSection
+                    key={provider}
+                    emailAccountId={emailAccountId}
+                    onConnected={mutateChannels}
+                  />
+                );
+              }
               return (
                 <UnconnectedProviderSection
                   key={provider}
@@ -371,16 +425,7 @@ function ConnectedChannelSection({
 
   return (
     <SectionGroup
-      icon={
-        <Image
-          src={config.logo}
-          alt={config.name}
-          width={20}
-          height={20}
-          className="size-5"
-          unoptimized
-        />
-      }
+      icon={<ProviderIcon provider={channel.provider} />}
       title={config.name}
       badge={
         <div className="flex items-center gap-1">
@@ -512,7 +557,9 @@ function UnconnectedProviderSection({
   emailAccountId,
   onConnected,
 }: {
-  provider: MessagingProvider;
+  // Webhook channels are handled by AddWebhookSection, not this OAuth/link-code
+  // connect flow.
+  provider: Exclude<MessagingProvider, "WEBHOOK">;
   emailAccountId: string;
   onConnected: () => void;
 }) {
@@ -564,16 +611,7 @@ function UnconnectedProviderSection({
   return (
     <>
       <SectionGroup
-        icon={
-          <Image
-            src={config.logo}
-            alt={config.name}
-            width={20}
-            height={20}
-            className="size-5"
-            unoptimized
-          />
-        }
+        icon={<ProviderIcon provider={provider} />}
         title={config.name}
       >
         <ItemCard>
@@ -917,6 +955,289 @@ function FeatureRouteAction({
         )}
       </Dialog>
     </>
+  );
+}
+
+function WebhookForm({
+  emailAccountId,
+  channelId,
+  initialUrl,
+  initialHasSecret,
+  submitLabel,
+  onSaved,
+}: {
+  emailAccountId: string;
+  channelId?: string;
+  initialUrl?: string;
+  initialHasSecret?: boolean;
+  submitLabel: string;
+  onSaved: () => void;
+}) {
+  const analytics = useProductAnalytics("channels");
+  const [url, setUrl] = useState(initialUrl ?? "");
+  const [secret, setSecret] = useState("");
+
+  const onSuccess = () => {
+    analytics.captureAction(channelId ? "webhook_updated" : "webhook_created");
+    toastSuccess({ description: "Webhook saved" });
+    setSecret("");
+    onSaved();
+  };
+  const onError = (error: { error: unknown }) => {
+    toastError({
+      description:
+        getActionErrorMessage(
+          error.error as Parameters<typeof getActionErrorMessage>[0],
+        ) ?? "Failed to save webhook",
+    });
+  };
+
+  const create = useAction(
+    createWebhookChannelAction.bind(null, emailAccountId),
+    {
+      onSuccess,
+      onError,
+    },
+  );
+  const update = useAction(
+    updateWebhookChannelAction.bind(null, emailAccountId),
+    {
+      onSuccess,
+      onError,
+    },
+  );
+
+  const status = channelId ? update.status : create.status;
+  const isExecuting = status === "executing";
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return;
+    const trimmedSecret = secret.trim();
+    if (channelId) {
+      update.execute({
+        channelId,
+        webhookUrl: trimmedUrl,
+        webhookSecret: trimmedSecret || undefined,
+      });
+    } else {
+      create.execute({
+        webhookUrl: trimmedUrl,
+        webhookSecret: trimmedSecret || undefined,
+      });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`webhook-url-${channelId ?? "new"}`}
+          className="text-sm font-medium"
+        >
+          Webhook URL
+        </label>
+        <Input
+          id={`webhook-url-${channelId ?? "new"}`}
+          type="url"
+          required
+          placeholder="https://example.com/inbox-zero-webhook"
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <label
+          htmlFor={`webhook-secret-${channelId ?? "new"}`}
+          className="text-sm font-medium"
+        >
+          Secret (optional)
+        </label>
+        <Input
+          id={`webhook-secret-${channelId ?? "new"}`}
+          type="password"
+          autoComplete="off"
+          placeholder={
+            initialHasSecret ? "Leave blank to keep current secret" : "Optional"
+          }
+          value={secret}
+          onChange={(event) => setSecret(event.target.value)}
+        />
+        <MutedText className="text-xs">
+          Sent as the <code>X-Webhook-Secret</code> header so your endpoint can
+          verify the request.
+        </MutedText>
+      </div>
+      <Button type="submit" size="sm" disabled={isExecuting || !url.trim()}>
+        {submitLabel}
+      </Button>
+    </form>
+  );
+}
+
+function AddWebhookSection({
+  emailAccountId,
+  onConnected,
+}: {
+  emailAccountId: string;
+  onConnected: () => void;
+}) {
+  return (
+    <SectionGroup
+      icon={<ProviderIcon provider="WEBHOOK" />}
+      title={PROVIDER_CONFIG.WEBHOOK.name}
+    >
+      <ItemCard>
+        <Item size="sm">
+          <ItemContent className="space-y-3">
+            <div>
+              <ItemTitle>Add a webhook</ItemTitle>
+              <ItemDescription>
+                Deliver your digest to any HTTPS endpoint. No app or OAuth
+                required — just a URL.
+              </ItemDescription>
+            </div>
+            <WebhookForm
+              emailAccountId={emailAccountId}
+              submitLabel="Add webhook"
+              onSaved={onConnected}
+            />
+          </ItemContent>
+        </Item>
+      </ItemCard>
+    </SectionGroup>
+  );
+}
+
+function WebhookChannelSection({
+  channel,
+  emailAccountId,
+  hasDigestAccess,
+  onUpdate,
+}: {
+  channel: ChannelFromResponse;
+  emailAccountId: string;
+  hasDigestAccess: boolean;
+  onUpdate: () => void;
+}) {
+  const analytics = useProductAnalytics("channels");
+  const config = PROVIDER_CONFIG.WEBHOOK;
+  const digestsEnabled = channel.destinations.digests.enabled;
+
+  const { execute: executeDisconnect, status: disconnectStatus } = useAction(
+    disconnectChannelAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        analytics.captureAction("channel_disconnected", {
+          provider: "WEBHOOK",
+        });
+        toastSuccess({ description: `${config.name} removed` });
+        onUpdate();
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error) ?? "Failed to remove",
+        });
+      },
+    },
+  );
+
+  const { execute: executeToggleDigests, status: toggleStatus } = useAction(
+    toggleWebhookDigestsAction.bind(null, emailAccountId),
+    {
+      onSuccess: () => {
+        toastSuccess({ description: "Settings saved" });
+        onUpdate();
+      },
+      onError: (error) => {
+        toastError({
+          description: getActionErrorMessage(error.error) ?? "Failed to update",
+        });
+      },
+    },
+  );
+
+  return (
+    <SectionGroup
+      icon={<ProviderIcon provider="WEBHOOK" />}
+      title={config.name}
+      badge={
+        <div className="flex items-center gap-1">
+          <Badge color="green">Connected</Badge>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                disabled={disconnectStatus === "executing"}
+              >
+                <MoreVerticalIcon className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => executeDisconnect({ channelId: channel.id })}
+                className="text-destructive focus:text-destructive"
+              >
+                <LogOutIcon className="mr-2 h-4 w-4" />
+                Remove webhook
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      }
+    >
+      <ItemCard>
+        <Item size="sm">
+          <ItemContent className="space-y-3">
+            <div>
+              <ItemTitle>Endpoint</ItemTitle>
+              <ItemDescription className="break-all">
+                {channel.webhookUrl ?? "No URL set"}
+              </ItemDescription>
+            </div>
+            <WebhookForm
+              emailAccountId={emailAccountId}
+              channelId={channel.id}
+              initialUrl={channel.webhookUrl ?? ""}
+              submitLabel="Save changes"
+              onSaved={onUpdate}
+            />
+          </ItemContent>
+        </Item>
+      </ItemCard>
+
+      <ItemCard>
+        <Item size="sm">
+          <ItemContent>
+            <ItemTitle>Digests</ItemTitle>
+            <ItemDescription>
+              POST your scheduled digest to this webhook.
+            </ItemDescription>
+          </ItemContent>
+          <ItemActions>
+            {hasDigestAccess ? (
+              <Toggle
+                name={`webhook-digests-${channel.id}`}
+                enabled={digestsEnabled}
+                disabled={toggleStatus === "executing"}
+                onChange={(enabled) => {
+                  analytics.captureAction("feature_route_toggled", {
+                    purpose: MessagingRoutePurpose.DIGESTS,
+                    enabled,
+                  });
+                  executeToggleDigests({ channelId: channel.id, enabled });
+                }}
+              />
+            ) : (
+              <UpgradeToPlusButton tooltip="Upgrade to the Plus plan to deliver digests to a webhook." />
+            )}
+          </ItemActions>
+        </Item>
+      </ItemCard>
+    </SectionGroup>
   );
 }
 

--- a/apps/web/app/api/user/messaging-channels/route.test.ts
+++ b/apps/web/app/api/user/messaging-channels/route.test.ts
@@ -179,7 +179,9 @@ describe("GET /api/user/messaging-channels", () => {
     ]);
     expect(body.channels[0]).not.toHaveProperty("providerUserId");
     expect(body.channels[0]).not.toHaveProperty("accessToken");
-    expect(body.availableProviders).toEqual(["SLACK"]);
+    expect(body.channels[0]).not.toHaveProperty("webhookSecret");
+    // Webhook needs no OAuth app/bot token, so it is always available.
+    expect(body.availableProviders).toEqual(["SLACK", "WEBHOOK"]);
   });
 
   it("includes Teams as an available provider when app id, password, and tenant id are configured", async () => {
@@ -192,7 +194,7 @@ describe("GET /api/user/messaging-channels", () => {
     const response = await GET(createRequest());
     const body = await response.json();
 
-    expect(body.availableProviders).toEqual(["SLACK", "TEAMS"]);
+    expect(body.availableProviders).toEqual(["SLACK", "TEAMS", "WEBHOOK"]);
   });
 
   it("labels saved Slack channel routes as unavailable when the bot can no longer access the target", async () => {

--- a/apps/web/app/api/user/messaging-channels/route.ts
+++ b/apps/web/app/api/user/messaging-channels/route.ts
@@ -35,6 +35,7 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
       providerUserId: true,
       accessToken: true,
       isConnected: true,
+      webhookUrl: true,
       routes: {
         select: {
           purpose: true,
@@ -113,6 +114,9 @@ function getAvailableProviders(): MessagingProvider[] {
   if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) providers.push("SLACK");
   if (isTeamsBotConfigured()) providers.push("TEAMS");
   if (env.TELEGRAM_BOT_TOKEN) providers.push("TELEGRAM");
+  // Webhook channels need only a URL (no OAuth app / bot token), so they are
+  // always available — this is the digest delivery channel for self-hosters.
+  providers.push("WEBHOOK");
   return providers;
 }
 

--- a/apps/web/components/messaging/DeliveryChannelsSetting.tsx
+++ b/apps/web/components/messaging/DeliveryChannelsSetting.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { HashIcon, MailIcon, MessageCircleIcon, SendIcon } from "lucide-react";
+import {
+  HashIcon,
+  MailIcon,
+  MessageCircleIcon,
+  SendIcon,
+  WebhookIcon,
+} from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { SlackNotificationTargetSelect } from "@/components/SlackNotificationTargetSelect";
 import { Toggle } from "@/components/Toggle";
@@ -39,6 +45,11 @@ const PROVIDER_CONFIG: Record<
   TELEGRAM: {
     name: "Telegram",
     icon: SendIcon,
+    supportsTargetSelection: false,
+  },
+  WEBHOOK: {
+    name: "Webhook",
+    icon: WebhookIcon,
     supportsTargetSelection: false,
   },
 };

--- a/apps/web/prisma/migrations/20260623150000_add_webhook_messaging_provider/migration.sql
+++ b/apps/web/prisma/migrations/20260623150000_add_webhook_messaging_provider/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+-- Add the WEBHOOK value in its own migration. Postgres cannot use a newly
+-- added enum value in the same transaction that adds it, so the column
+-- additions live in a separate, later migration.
+ALTER TYPE "MessagingProvider" ADD VALUE IF NOT EXISTS 'WEBHOOK';

--- a/apps/web/prisma/migrations/20260623150100_add_webhook_channel_fields/migration.sql
+++ b/apps/web/prisma/migrations/20260623150100_add_webhook_channel_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "MessagingChannel" ADD COLUMN "webhookUrl" TEXT,
+ADD COLUMN "webhookSecret" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1303,6 +1303,11 @@ model MessagingChannel {
   refreshToken String?
   expiresAt    DateTime?
 
+  // Webhook provider target. Only set for provider=WEBHOOK channels.
+  // webhookSecret is encrypted via prisma-extensions.
+  webhookUrl    String?
+  webhookSecret String?
+
   emailAccountId  String
   emailAccount    EmailAccount     @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
   routes          MessagingRoute[]
@@ -1836,6 +1841,7 @@ enum MessagingProvider {
   SLACK
   TEAMS
   TELEGRAM
+  WEBHOOK
 }
 
 enum MessagingRoutePurpose {

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -10,6 +10,9 @@ import {
   linkSlackWorkspaceBody,
   createMessagingLinkCodeBody,
   toggleRuleChannelBody,
+  createWebhookChannelBody,
+  updateWebhookChannelBody,
+  toggleWebhookDigestsBody,
 } from "@/utils/actions/messaging-channels.validation";
 import prisma from "@/utils/prisma";
 import { SafeError } from "@/utils/error";
@@ -18,8 +21,9 @@ import {
   ActionType,
   MessagingProvider,
   MessagingRoutePurpose,
-  type MessagingRouteTargetType,
+  MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
+import { isSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
 import { generateMessagingLinkCode } from "@/utils/messaging/chat-sdk/link-code";
 import {
   DRAFT_REPLY_ACTION_TYPES,
@@ -198,6 +202,150 @@ export const disconnectChannelAction = actionClient
       throw error;
     }
   });
+
+// Webhook channels have no provider workspace, so they share a single
+// constant teamId per email account (one webhook channel per account). The
+// DIGESTS route's target is unused by webhook delivery (it POSTs to the
+// channel's webhookUrl) but a route row must exist for the channel to be
+// selected in send-digest.
+const WEBHOOK_CHANNEL_TEAM_ID = "";
+const WEBHOOK_ROUTE_TARGET_ID = "webhook";
+
+export const createWebhookChannelAction = actionClient
+  .metadata({ name: "createWebhookChannel" })
+  .inputSchema(createWebhookChannelBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { webhookUrl, webhookSecret },
+    }) => {
+      if (!isSafeExternalHttpUrl(webhookUrl)) {
+        throw new SafeError(
+          "Webhook URL must be a public http(s) URL (private and local addresses are not allowed)",
+        );
+      }
+
+      // One webhook channel per account: re-adding reconnects the existing row
+      // (disconnect leaves the row with isConnected=false).
+      await prisma.messagingChannel.upsert({
+        where: {
+          emailAccountId_provider_teamId: {
+            emailAccountId,
+            provider: MessagingProvider.WEBHOOK,
+            teamId: WEBHOOK_CHANNEL_TEAM_ID,
+          },
+        },
+        update: {
+          webhookUrl,
+          webhookSecret: webhookSecret || null,
+          isConnected: true,
+        },
+        create: {
+          provider: MessagingProvider.WEBHOOK,
+          teamId: WEBHOOK_CHANNEL_TEAM_ID,
+          emailAccountId,
+          webhookUrl,
+          webhookSecret: webhookSecret || null,
+          isConnected: true,
+        },
+      });
+    },
+  );
+
+export const updateWebhookChannelAction = actionClient
+  .metadata({ name: "updateWebhookChannel" })
+  .inputSchema(updateWebhookChannelBody)
+  .action(
+    async ({
+      ctx: { emailAccountId },
+      parsedInput: { channelId, webhookUrl, webhookSecret },
+    }) => {
+      if (!isSafeExternalHttpUrl(webhookUrl)) {
+        throw new SafeError(
+          "Webhook URL must be a public http(s) URL (private and local addresses are not allowed)",
+        );
+      }
+
+      const channel = await prisma.messagingChannel.findUnique({
+        where: { id_emailAccountId: { id: channelId, emailAccountId } },
+        select: { provider: true },
+      });
+
+      if (!channel) {
+        throw new SafeError("Messaging channel not found");
+      }
+      if (channel.provider !== MessagingProvider.WEBHOOK) {
+        throw new SafeError("Messaging channel is not a webhook");
+      }
+
+      await prisma.messagingChannel.update({
+        where: { id_emailAccountId: { id: channelId, emailAccountId } },
+        data: {
+          webhookUrl,
+          webhookSecret: webhookSecret || null,
+        },
+      });
+    },
+  );
+
+export const toggleWebhookDigestsAction = actionClient
+  .metadata({ name: "toggleWebhookDigests" })
+  .inputSchema(toggleWebhookDigestsBody)
+  .action(
+    async ({
+      ctx: { emailAccountId, userId },
+      parsedInput: { channelId, enabled },
+    }) => {
+      if (enabled) {
+        await assertCanUseDigests(userId);
+      }
+
+      const channel = await prisma.messagingChannel.findUnique({
+        where: { id_emailAccountId: { id: channelId, emailAccountId } },
+        select: { provider: true, webhookUrl: true },
+      });
+
+      if (!channel) {
+        throw new SafeError("Messaging channel not found");
+      }
+      if (channel.provider !== MessagingProvider.WEBHOOK) {
+        throw new SafeError("Messaging channel is not a webhook");
+      }
+
+      if (!enabled) {
+        await prisma.messagingRoute.deleteMany({
+          where: {
+            messagingChannelId: channelId,
+            purpose: MessagingRoutePurpose.DIGESTS,
+          },
+        });
+        return;
+      }
+
+      if (!channel.webhookUrl) {
+        throw new SafeError("Set a webhook URL before enabling digests");
+      }
+
+      // Seed the DIGESTS route directly. The target is unused by webhook
+      // delivery but a route row must exist for send-digest to pick up the
+      // channel.
+      await prisma.messagingRoute.upsert({
+        where: {
+          messagingChannelId_purpose: {
+            messagingChannelId: channelId,
+            purpose: MessagingRoutePurpose.DIGESTS,
+          },
+        },
+        update: {},
+        create: {
+          messagingChannelId: channelId,
+          purpose: MessagingRoutePurpose.DIGESTS,
+          targetType: MessagingRouteTargetType.CHANNEL,
+          targetId: WEBHOOK_ROUTE_TARGET_ID,
+        },
+      });
+    },
+  );
 
 export const linkSlackWorkspaceAction = actionClient
   .metadata({ name: "linkSlackWorkspace" })

--- a/apps/web/utils/actions/messaging-channels.ts
+++ b/apps/web/utils/actions/messaging-channels.ts
@@ -237,8 +237,12 @@ export const createWebhookChannelAction = actionClient
         },
         update: {
           webhookUrl,
-          webhookSecret: webhookSecret || null,
           isConnected: true,
+          // Only overwrite the secret when one is explicitly provided, so
+          // reconnecting an existing channel preserves its stored secret.
+          ...(webhookSecret !== undefined && {
+            webhookSecret: webhookSecret || null,
+          }),
         },
         create: {
           provider: MessagingProvider.WEBHOOK,
@@ -282,7 +286,12 @@ export const updateWebhookChannelAction = actionClient
         where: { id_emailAccountId: { id: channelId, emailAccountId } },
         data: {
           webhookUrl,
-          webhookSecret: webhookSecret || null,
+          // Only overwrite the secret when one is explicitly provided, so that
+          // editing only the URL (leaving the secret field blank) preserves the
+          // existing secret instead of clearing it.
+          ...(webhookSecret !== undefined && {
+            webhookSecret: webhookSecret || null,
+          }),
         },
       });
     },

--- a/apps/web/utils/actions/messaging-channels.validation.ts
+++ b/apps/web/utils/actions/messaging-channels.validation.ts
@@ -38,6 +38,22 @@ export const disconnectChannelBody = z.object({
   channelId: z.string().min(1),
 });
 
+export const createWebhookChannelBody = z.object({
+  webhookUrl: z.string().url(),
+  webhookSecret: z.string().trim().max(500).optional(),
+});
+
+export const updateWebhookChannelBody = z.object({
+  channelId: z.string().min(1),
+  webhookUrl: z.string().url(),
+  webhookSecret: z.string().trim().max(500).optional(),
+});
+
+export const toggleWebhookDigestsBody = z.object({
+  channelId: z.string().min(1),
+  enabled: z.boolean(),
+});
+
 export const linkSlackWorkspaceBody = z.object({
   teamId: z.string().min(1),
 });

--- a/apps/web/utils/analytics/product.ts
+++ b/apps/web/utils/analytics/product.ts
@@ -22,6 +22,8 @@ export const PRODUCT_ANALYTICS_ACTIONS = {
     featureRouteToggled: "feature_route_toggled",
     ruleChannelModeChanged: "rule_channel_mode_changed",
     ruleChannelToggled: "rule_channel_toggled",
+    webhookCreated: "webhook_created",
+    webhookUpdated: "webhook_updated",
   },
   calendars: {
     bookingLinkSaved: "calendar_booking_link_saved",

--- a/apps/web/utils/digest/send-digest.test.ts
+++ b/apps/web/utils/digest/send-digest.test.ts
@@ -12,6 +12,7 @@ import {
   sendDigestToSlack,
 } from "@/utils/messaging/providers/slack/send";
 import { sendAutomationMessage } from "@/utils/automation-jobs/messaging";
+import { sendDigestToWebhook } from "@/utils/messaging/providers/webhook/send";
 import { sendDigestEmail } from "@inboxzero/resend";
 
 vi.mock("@/utils/prisma");
@@ -21,6 +22,9 @@ vi.mock("@/utils/messaging/providers/slack/send", () => ({
 }));
 vi.mock("@/utils/automation-jobs/messaging", () => ({
   sendAutomationMessage: vi.fn(),
+}));
+vi.mock("@/utils/messaging/providers/webhook/send", () => ({
+  sendDigestToWebhook: vi.fn(),
 }));
 vi.mock("@inboxzero/resend", () => ({
   sendDigestEmail: vi.fn(),
@@ -52,6 +56,24 @@ const slackChannel = {
       purpose: MessagingRoutePurpose.DIGESTS,
       targetType: MessagingRouteTargetType.CHANNEL,
       targetId: "C1",
+    },
+  ],
+};
+
+const webhookChannel = {
+  id: "channel-webhook-1",
+  provider: MessagingProvider.WEBHOOK,
+  isConnected: true,
+  accessToken: null,
+  teamId: "",
+  providerUserId: null,
+  webhookUrl: "https://example.com/hook",
+  webhookSecret: "shh",
+  routes: [
+    {
+      purpose: MessagingRoutePurpose.DIGESTS,
+      targetType: MessagingRouteTargetType.CHANNEL,
+      targetId: "webhook",
     },
   ],
 };
@@ -126,6 +148,54 @@ describe("sendDigest", () => {
     (sendDigestToSlack as any).mockResolvedValue(undefined);
 
     await expect(sendDigest(baseArgs)).resolves.toBeUndefined();
+  });
+
+  it("POSTs the digest to a webhook channel with its url and secret", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      digestSendEmail: false,
+    } as any);
+    prisma.messagingChannel.findMany.mockResolvedValue([webhookChannel] as any);
+
+    await sendDigest(baseArgs);
+
+    expect(sendDigestEmail).not.toHaveBeenCalled();
+    expect(sendDigestToWebhook).toHaveBeenCalledTimes(1);
+    expect(sendDigestToWebhook).toHaveBeenCalledWith({
+      url: "https://example.com/hook",
+      secret: "shh",
+      payload: {
+        type: "digest",
+        date: baseArgs.date.toISOString(),
+        ruleNames: baseArgs.ruleNames,
+        itemsByRule: baseArgs.itemsByRule,
+      },
+    });
+  });
+
+  it("treats a webhook send failure as a failed channel", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      digestSendEmail: false,
+    } as any);
+    prisma.messagingChannel.findMany.mockResolvedValue([webhookChannel] as any);
+    (sendDigestToWebhook as any).mockRejectedValue(new Error("blocked"));
+
+    await expect(sendDigest(baseArgs)).rejects.toThrow(
+      /All digest delivery channels failed/,
+    );
+  });
+
+  it("skips a webhook channel with no url (non-operational)", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      digestSendEmail: false,
+    } as any);
+    prisma.messagingChannel.findMany.mockResolvedValue([
+      { ...webhookChannel, webhookUrl: null },
+    ] as any);
+
+    await expect(sendDigest(baseArgs)).rejects.toThrow(
+      /No deliverable digest channels/,
+    );
+    expect(sendDigestToWebhook).not.toHaveBeenCalled();
   });
 
   it("skips Slack when the access token is missing", async () => {

--- a/apps/web/utils/digest/send-digest.ts
+++ b/apps/web/utils/digest/send-digest.ts
@@ -15,6 +15,7 @@ import {
   resolveSlackRouteDestination,
   sendDigestToSlack,
 } from "@/utils/messaging/providers/slack/send";
+import { sendDigestToWebhook } from "@/utils/messaging/providers/webhook/send";
 import {
   getMessagingRoute,
   getMessagingRouteWhere,
@@ -64,6 +65,8 @@ export async function sendDigest({
       accessToken: true,
       teamId: true,
       providerUserId: true,
+      webhookUrl: true,
+      webhookSecret: true,
       routes: {
         select: { purpose: true, targetType: true, targetId: true },
       },
@@ -120,6 +123,19 @@ export async function sendDigest({
           sendDigestViaMessagingApp({
             channel,
             route,
+            date,
+            ruleNames,
+            itemsByRule,
+            logger,
+          }),
+        );
+        break;
+      case MessagingProvider.WEBHOOK:
+        if (!channel.webhookUrl) continue;
+        deliveryPromises.push(
+          sendDigestViaWebhook({
+            webhookUrl: channel.webhookUrl,
+            webhookSecret: channel.webhookSecret,
             date,
             ruleNames,
             itemsByRule,
@@ -262,6 +278,37 @@ async function sendDigestViaMessagingApp({
   });
 
   logger.info("Digest sent to messaging app", { provider: channel.provider });
+}
+
+async function sendDigestViaWebhook({
+  webhookUrl,
+  webhookSecret,
+  date,
+  ruleNames,
+  itemsByRule,
+  logger,
+}: {
+  webhookUrl: string;
+  webhookSecret: string | null;
+  date: Date;
+  ruleNames: Record<string, string>;
+  itemsByRule: ItemsByRule;
+  logger: Logger;
+}) {
+  logger.info("Sending digest to webhook");
+  // Throws on blocked (SSRF) or non-2xx so this counts as a failed channel
+  // under Promise.allSettled, preventing the digest from being marked SENT.
+  await sendDigestToWebhook({
+    url: webhookUrl,
+    secret: webhookSecret,
+    payload: {
+      type: "digest",
+      date: date.toISOString(),
+      ruleNames,
+      itemsByRule,
+    },
+  });
+  logger.info("Digest sent to webhook");
 }
 
 function formatDigestText({

--- a/apps/web/utils/messaging/channel-validity.ts
+++ b/apps/web/utils/messaging/channel-validity.ts
@@ -5,6 +5,7 @@ type MessagingChannelConnectionLike = {
   isConnected?: boolean;
   accessToken?: string | null;
   providerUserId?: string | null;
+  webhookUrl?: string | null;
 };
 
 type MessagingChannelWithRequiredFields =
@@ -19,6 +20,10 @@ type MessagingChannelWithRequiredFields =
     })
   | (MessagingChannelConnectionLike & {
       provider: "TELEGRAM";
+    })
+  | (MessagingChannelConnectionLike & {
+      provider: "WEBHOOK";
+      webhookUrl: string;
     });
 
 type OperationalMessagingChannel = MessagingChannelWithRequiredFields & {
@@ -35,6 +40,8 @@ export function hasRequiredMessagingConnectionFields(
       return Boolean(channel.providerUserId);
     case MessagingProvider.TELEGRAM:
       return true;
+    case MessagingProvider.WEBHOOK:
+      return Boolean(channel.webhookUrl);
     default:
       return true;
   }

--- a/apps/web/utils/messaging/platforms.ts
+++ b/apps/web/utils/messaging/platforms.ts
@@ -1,10 +1,14 @@
+// Lowercase platforms correspond to the real-time chat-SDK bot integrations.
+// Webhook is a one-way delivery provider with no bot platform, so it is
+// intentionally not a MessagingPlatform.
 export type MessagingPlatform = "slack" | "teams" | "telegram";
-export type MessagingProvider = "SLACK" | "TEAMS" | "TELEGRAM";
+export type MessagingProvider = "SLACK" | "TEAMS" | "TELEGRAM" | "WEBHOOK";
 
 const PROVIDER_NAMES: Record<MessagingProvider, string> = {
   SLACK: "Slack",
   TEAMS: "Teams",
   TELEGRAM: "Telegram",
+  WEBHOOK: "Webhook",
 };
 
 export function getMessagingProviderName(

--- a/apps/web/utils/messaging/providers/webhook/send.test.ts
+++ b/apps/web/utils/messaging/providers/webhook/send.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendDigestToWebhook } from "./send";
+
+const { httpsRequestMock, resolveSafeExternalHttpUrlMock } = vi.hoisted(() => ({
+  httpsRequestMock: vi.fn(),
+  resolveSafeExternalHttpUrlMock: vi.fn(),
+}));
+
+vi.mock("node:https", () => ({
+  request: httpsRequestMock,
+}));
+
+vi.mock("@/utils/network/safe-http-url", () => ({
+  resolveSafeExternalHttpUrl: (...args: unknown[]) =>
+    resolveSafeExternalHttpUrlMock(...args),
+}));
+
+const payload = {
+  type: "digest" as const,
+  date: "2026-04-21T09:00:00.000Z",
+  ruleNames: { newsletters: "Newsletters" },
+  itemsByRule: {
+    newsletters: [{ from: "Acme", subject: "Hello", content: "body" }],
+  },
+};
+
+describe("sendDigestToWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveSafeExternalHttpUrlMock.mockResolvedValue({
+      url: new URL("https://example.com/hook"),
+      lookup: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when the URL is blocked by SSRF protection", async () => {
+    resolveSafeExternalHttpUrlMock.mockResolvedValue(null);
+
+    await expect(
+      sendDigestToWebhook({
+        url: "http://169.254.169.254/latest",
+        secret: null,
+        payload,
+      }),
+    ).rejects.toThrow(/blocked by SSRF protection/);
+
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs with the secret header and resolves on a 2xx response", async () => {
+    const lookup = vi.fn();
+    resolveSafeExternalHttpUrlMock.mockResolvedValue({
+      url: new URL("https://example.com/hook"),
+      lookup,
+    });
+    queueHttpsResponse({ statusCode: 204 });
+
+    await expect(
+      sendDigestToWebhook({
+        url: "https://example.com/hook",
+        secret: "shh",
+        payload,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(httpsRequestMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "POST",
+        lookup,
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-Webhook-Secret": "shh",
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("omits the secret header when no secret is set", async () => {
+    queueHttpsResponse({ statusCode: 200 });
+
+    await sendDigestToWebhook({
+      url: "https://example.com/hook",
+      secret: null,
+      payload,
+    });
+
+    const headers = httpsRequestMock.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers).not.toHaveProperty("X-Webhook-Secret");
+  });
+
+  it("throws on a non-2xx response", async () => {
+    queueHttpsResponse({ statusCode: 500 });
+
+    await expect(
+      sendDigestToWebhook({
+        url: "https://example.com/hook",
+        secret: null,
+        payload,
+      }),
+    ).rejects.toThrow(/status 500/);
+  });
+});
+
+function queueHttpsResponse({ statusCode }: { statusCode: number }) {
+  httpsRequestMock.mockImplementationOnce(
+    (
+      _url: URL,
+      _options: Record<string, unknown>,
+      callback: (response: {
+        on: (event: string, handler: () => void) => void;
+        resume: () => void;
+        statusCode: number;
+      }) => void,
+    ) => {
+      const request = {
+        destroy: vi.fn(),
+        end: vi.fn(() => {
+          const response = {
+            on: vi.fn((event: string, handler: () => void) => {
+              if (event === "end") handler();
+            }),
+            resume: vi.fn(),
+            statusCode,
+          };
+          callback(response);
+        }),
+        on: vi.fn(),
+        setTimeout: vi.fn(),
+        write: vi.fn(),
+      };
+
+      return request;
+    },
+  );
+}

--- a/apps/web/utils/messaging/providers/webhook/send.ts
+++ b/apps/web/utils/messaging/providers/webhook/send.ts
@@ -40,6 +40,15 @@ export async function sendDigestToWebhook({
     throw new Error("Webhook URL blocked by SSRF protection");
   }
 
+  // Never transmit the shared webhook secret over plaintext HTTP: a network
+  // observer could capture `X-Webhook-Secret` and forge authenticated requests.
+  // Plain HTTP is still allowed when no secret is configured.
+  if (secret && resolvedUrl.url.protocol !== "https:") {
+    throw new Error(
+      "Webhook secret can only be sent over HTTPS; use an https:// URL or remove the secret",
+    );
+  }
+
   const requestBody = JSON.stringify(payload);
 
   const headers: Record<string, string> = {

--- a/apps/web/utils/messaging/providers/webhook/send.ts
+++ b/apps/web/utils/messaging/providers/webhook/send.ts
@@ -1,0 +1,80 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { resolveSafeExternalHttpUrl } from "@/utils/network/safe-http-url";
+
+const WEBHOOK_REQUEST_TIMEOUT_MS = 10_000;
+
+export type DigestWebhookItem = {
+  from: string;
+  subject: string;
+  content: string;
+};
+
+export type DigestWebhookPayload = {
+  type: "digest";
+  date: string;
+  ruleNames: Record<string, string>;
+  itemsByRule: Record<string, DigestWebhookItem[] | undefined>;
+};
+
+/**
+ * POST a digest payload to a user-configured webhook URL.
+ *
+ * SSRF-safe: the URL is validated and DNS-resolved to public addresses via
+ * {@link resolveSafeExternalHttpUrl}, and the request is pinned to those
+ * addresses (mirroring `utils/webhook.ts`). Unlike the rule webhook, this
+ * THROWS on a blocked or non-2xx response so the caller's `Promise.allSettled`
+ * counts it as a failed delivery channel.
+ */
+export async function sendDigestToWebhook({
+  url,
+  secret,
+  payload,
+}: {
+  url: string;
+  secret: string | null;
+  payload: DigestWebhookPayload;
+}): Promise<void> {
+  const resolvedUrl = await resolveSafeExternalHttpUrl(url);
+  if (!resolvedUrl) {
+    throw new Error("Webhook URL blocked by SSRF protection");
+  }
+
+  const requestBody = JSON.stringify(payload);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(requestBody).toString(),
+  };
+  if (secret) headers["X-Webhook-Secret"] = secret;
+
+  const statusCode = await new Promise<number>((resolve, reject) => {
+    const request = (
+      resolvedUrl.url.protocol === "https:" ? httpsRequest : httpRequest
+    )(
+      resolvedUrl.url,
+      {
+        method: "POST",
+        lookup: resolvedUrl.lookup,
+        headers,
+      },
+      (response) => {
+        response.resume();
+        response.on("error", reject);
+        response.on("end", () => resolve(response.statusCode || 0));
+      },
+    );
+
+    request.setTimeout(WEBHOOK_REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error("Webhook request timed out"));
+    });
+
+    request.on("error", reject);
+    request.write(requestBody);
+    request.end();
+  });
+
+  if (statusCode < 200 || statusCode >= 300) {
+    throw new Error(`Webhook responded with status ${statusCode}`);
+  }
+}

--- a/apps/web/utils/prisma-extensions.ts
+++ b/apps/web/utils/prisma-extensions.ts
@@ -16,7 +16,7 @@ const ENCRYPTED_FIELDS = {
   account: ["access_token", "refresh_token"],
   calendarConnection: ["accessToken", "refreshToken"],
   driveConnection: ["accessToken", "refreshToken"],
-  messagingChannel: ["accessToken", "refreshToken"],
+  messagingChannel: ["accessToken", "refreshToken", "webhookSecret"],
   mcpConnection: ["accessToken", "refreshToken", "apiKey"],
   mcpIntegration: ["oauthClientSecret"],
   user: ["aiApiKey", "webhookSecret"],


### PR DESCRIPTION
Supersedes #2898.

## Problem
Self-hosters cannot deliver digests to any chat channel without standing up an OAuth app (Slack) or bot token (Teams/Telegram). The account-level `digestWebhookUrl` in #2898 worked but lives outside the `MessagingChannel`/`MessagingRoute` framework and cannot be managed from the Channels page.

## Solution
Add `WEBHOOK` as a `MessagingProvider`. Users add a webhook on the **Channels** page with just a URL (+ optional secret) — no OAuth — and toggle it on for **Digests**. Digest sending POSTs `{ type: "digest", date, ruleNames, itemsByRule }` to the URL.

## SSRF-safe delivery
A new `sendDigestToWebhook` mirrors `utils/webhook.ts`: URL resolved via `resolveSafeExternalHttpUrl` and the request DNS-pinned to public addresses over `node:http`/`node:https` (no `fetch`). It **throws** on a blocked or non-2xx response so a failed webhook counts as a failed channel under `Promise.allSettled` and the digest is not marked SENT. The optional secret is sent as `X-Webhook-Secret`, stored **encrypted at rest** via prisma-extensions, and never returned by the API.

## Notes
- One webhook per account (`teamId=""`; create upserts so disconnect→re-add reconnects).
- Premium-gated: enabling Digests on a webhook calls `assertCanUseDigests`.
- Scoped to Digests; does not participate in rule notifications / meeting briefs / filings.
- Backwards compatible — new code only runs when a user adds a WEBHOOK channel.
- Two migrations: enum value (isolated, `ADD VALUE IF NOT EXISTS`) + `webhookUrl`/`webhookSecret` columns.

## Test plan
- `prisma generate`; `tsc --noEmit` clean on touched code; `biome` clean.
- Unit tests: `sendDigestToWebhook` (SSRF block, secret header, omitted secret, non-2xx throw); `sendDigest` WEBHOOK case (delivery, failure counts, non-operational skip); messaging-channels route (secret never returned, WEBHOOK available).
- Manual: add a webhook on Channels, enable Digests, trigger a digest, confirm POST + `X-Webhook-Secret`; confirm private/loopback URLs are rejected.
- Not yet run: migrations against a live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

