### PR TITLE
[codex] Add admin Apple subscription sync

### DIFF
--- a/apps/web/app/(app)/admin/AdminUserControls.tsx
+++ b/apps/web/app/(app)/admin/AdminUserControls.tsx
@@ -17,6 +17,7 @@ import {
   adminDisableAllRulesAction,
   adminCleanupDraftsAction,
   adminLoadResponseTimeDataAction,
+  adminSyncAppleSubscriptionForUserAction,
   adminSyncStripeForUserAction,
 } from "@/utils/actions/admin";
 import { adminCheckPermissionsAction } from "@/utils/actions/permissions";
@@ -26,6 +27,8 @@ import { getActionErrorMessage } from "@/utils/error";
 export const AdminUserControls = () => {
   const [responseTimeMaxSentMessages, setResponseTimeMaxSentMessages] =
     useState(500);
+  const [appleOriginalTransactionId, setAppleOriginalTransactionId] =
+    useState("");
 
   const { execute: processHistory, isExecuting: isProcessing } = useAction(
     adminProcessHistoryAction,
@@ -104,6 +107,23 @@ export const AdminUserControls = () => {
       onError: (error) => {
         toastError({
           title: "Error syncing Stripe",
+          description: getActionErrorMessage(error.error),
+        });
+      },
+    },
+  );
+  const { execute: syncApple, isExecuting: isSyncingApple } = useAction(
+    adminSyncAppleSubscriptionForUserAction,
+    {
+      onSuccess: (result) => {
+        toastSuccess({
+          title: "Apple synced",
+          description: `Status: ${result.data?.appleSubscriptionStatus ?? "none"}; tier: ${result.data?.tier ?? "none"}`,
+        });
+      },
+      onError: (error) => {
+        toastError({
+          title: "Error syncing Apple",
           description: getActionErrorMessage(error.error),
         });
       },
@@ -206,6 +226,17 @@ export const AdminUserControls = () => {
             setResponseTimeMaxSentMessages(Number(event.target.value)),
         }}
       />
+      <Input
+        type="text"
+        name="appleOriginalTransactionId"
+        label="Apple original transaction ID"
+        placeholder="200000000000000"
+        registerProps={{
+          value: appleOriginalTransactionId,
+          onChange: (event: ChangeEvent<HTMLInputElement>) =>
+            setAppleOriginalTransactionId(event.target.value),
+        }}
+      />
       <div className="flex flex-wrap gap-2">
         <Button
           variant="outline"
@@ -243,6 +274,19 @@ export const AdminUserControls = () => {
           }}
         >
           Sync Stripe
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          loading={isSyncingApple}
+          onClick={() => {
+            syncApple({
+              email: getValues("email"),
+              transactionId: appleOriginalTransactionId,
+            });
+          }}
+        >
+          Sync Apple
         </Button>
         <Button
           variant="outline"

--- a/apps/web/utils/actions/admin.test.ts
+++ b/apps/web/utils/actions/admin.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { adminSyncStripeForUserAction } from "./admin";
+import {
+  adminSyncAppleSubscriptionForUserAction,
+  adminSyncStripeForUserAction,
+} from "./admin";
 
-const { mockAuth, mockSyncStripeDataToDb } = vi.hoisted(() => ({
-  mockAuth: vi.fn(),
-  mockSyncStripeDataToDb: vi.fn(),
-}));
+const { mockAuth, mockSyncAppleSubscriptionToDb, mockSyncStripeDataToDb } =
+  vi.hoisted(() => ({
+    mockAuth: vi.fn(),
+    mockSyncAppleSubscriptionToDb: vi.fn(),
+    mockSyncStripeDataToDb: vi.fn(),
+  }));
 
 vi.mock("server-only", () => ({}));
 vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
@@ -21,6 +26,9 @@ vi.mock("@/env", () => ({
 }));
 vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
   syncStripeDataToDb: mockSyncStripeDataToDb,
+}));
+vi.mock("@/ee/billing/apple", () => ({
+  syncAppleSubscriptionToDb: mockSyncAppleSubscriptionToDb,
 }));
 
 describe("adminSyncStripeForUserAction", () => {
@@ -173,5 +181,123 @@ describe("adminSyncStripeForUserAction", () => {
     expect(result?.serverError).toBe("Unauthorized");
     expect(prisma.user.findUnique).not.toHaveBeenCalled();
     expect(mockSyncStripeDataToDb).not.toHaveBeenCalled();
+  });
+});
+
+describe("adminSyncAppleSubscriptionForUserAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "admin-user", email: "admin@example.com" },
+    });
+  });
+
+  it("normalizes user email, syncs the Apple original transaction, and returns refreshed premium state", async () => {
+    const expiresAt = new Date("2026-07-21T00:00:00Z");
+    prisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      premium: null,
+    } as any);
+    mockSyncAppleSubscriptionToDb.mockResolvedValue({
+      id: "premium-1",
+      appleEnvironment: "Production",
+      appleExpiresAt: expiresAt,
+      appleProductId: "com.getinboxzero.starter.monthly.v2",
+      appleRevokedAt: null,
+      appleSubscriptionStatus: "ACTIVE",
+      tier: "STARTER_MONTHLY",
+    });
+
+    const result = await adminSyncAppleSubscriptionForUserAction({
+      email: "USER@EXAMPLE.COM ",
+      transactionId: " 200000000000000 ",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: "user@example.com" },
+      select: {
+        id: true,
+        premium: {
+          select: {
+            id: true,
+            stripeCustomerId: true,
+          },
+        },
+      },
+    });
+    expect(mockSyncAppleSubscriptionToDb).toHaveBeenCalledWith({
+      authenticatedUserId: "user-1",
+      logger: expect.anything(),
+      originalTransactionId: "200000000000000",
+    });
+    expect(result?.data).toEqual({
+      appleEnvironment: "Production",
+      appleExpiresAt: expiresAt,
+      appleProductId: "com.getinboxzero.starter.monthly.v2",
+      appleRevokedAt: null,
+      appleSubscriptionStatus: "ACTIVE",
+      tier: "STARTER_MONTHLY",
+    });
+  });
+
+  it("falls back to the owner of a matching email account", async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      user: {
+        id: "user-2",
+        premium: null,
+      },
+    } as any);
+    mockSyncAppleSubscriptionToDb.mockResolvedValue({
+      id: "premium-2",
+      appleEnvironment: "Production",
+      appleExpiresAt: null,
+      appleProductId: "com.getinboxzero.starter.monthly.v2",
+      appleRevokedAt: null,
+      appleSubscriptionStatus: "ACTIVE",
+      tier: "STARTER_MONTHLY",
+    });
+
+    const result = await adminSyncAppleSubscriptionForUserAction({
+      email: "alias@example.com",
+      transactionId: "200000000000000",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.emailAccount.findUnique).toHaveBeenCalledWith({
+      where: { email: "alias@example.com" },
+      select: {
+        user: {
+          select: {
+            id: true,
+            premium: {
+              select: {
+                id: true,
+                stripeCustomerId: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(mockSyncAppleSubscriptionToDb).toHaveBeenCalledWith({
+      authenticatedUserId: "user-2",
+      logger: expect.anything(),
+      originalTransactionId: "200000000000000",
+    });
+  });
+
+  it("rejects missing users before syncing Apple", async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.emailAccount.findUnique.mockResolvedValue(null);
+
+    const result = await adminSyncAppleSubscriptionForUserAction({
+      email: "missing@example.com",
+      transactionId: "200000000000000",
+    });
+
+    expect(result?.serverError).toBe("User not found");
+    expect(mockSyncAppleSubscriptionToDb).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -17,6 +17,7 @@ import {
   convertGmailUrlBody,
   getLabelsBody,
   watchEmailsBody,
+  syncAppleSubscriptionForUserBody,
   syncStripeForUserBody,
   getUserInfoBody,
   loadResponseTimeDataBody,
@@ -24,6 +25,7 @@ import {
   cleanupDraftsBody,
 } from "@/utils/actions/admin.validation";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
+import { syncAppleSubscriptionToDb } from "@/ee/billing/apple";
 import {
   cleanupAIDraftsForAccount,
   getConfiguredDraftCleanupDays,
@@ -191,6 +193,55 @@ export const adminSyncStripeForUserAction = adminActionClient
       tier: premium?.tier ?? null,
     };
   });
+
+export const adminSyncAppleSubscriptionForUserAction = adminActionClient
+  .metadata({ name: "adminSyncAppleSubscriptionForUser" })
+  .inputSchema(syncAppleSubscriptionForUserBody)
+  .action(
+    async ({ parsedInput: { email, transactionId }, ctx: { logger } }) => {
+      const normalizedEmail = email.toLowerCase();
+      const normalizedTransactionId = transactionId.trim();
+
+      const user = await findUserByUserOrAccountEmail(normalizedEmail);
+
+      if (!user) {
+        throw new SafeError("User not found");
+      }
+
+      logger.info("Starting admin Apple subscription sync for user", {
+        userId: user.id,
+        transactionId: normalizedTransactionId,
+      });
+
+      const premium = await syncAppleSubscriptionToDb({
+        authenticatedUserId: user.id,
+        logger,
+        originalTransactionId: normalizedTransactionId,
+      });
+
+      if (!premium) {
+        throw new SafeError("Apple subscription could not be mapped to a user");
+      }
+
+      logger.info("Finished admin Apple subscription sync for user", {
+        userId: user.id,
+        premiumId: premium.id,
+        appleProductId: premium.appleProductId,
+        appleSubscriptionStatus: premium.appleSubscriptionStatus,
+        appleExpiresAt: premium.appleExpiresAt,
+        tier: premium.tier,
+      });
+
+      return {
+        appleEnvironment: premium.appleEnvironment,
+        appleExpiresAt: premium.appleExpiresAt,
+        appleProductId: premium.appleProductId,
+        appleRevokedAt: premium.appleRevokedAt,
+        appleSubscriptionStatus: premium.appleSubscriptionStatus,
+        tier: premium.tier,
+      };
+    },
+  );
 
 export const adminSyncAllStripeCustomersToDbAction = adminActionClient
   .metadata({ name: "adminSyncAllStripeCustomersToDb" })

--- a/apps/web/utils/actions/admin.ts
+++ b/apps/web/utils/actions/admin.ts
@@ -200,7 +200,6 @@ export const adminSyncAppleSubscriptionForUserAction = adminActionClient
   .action(
     async ({ parsedInput: { email, transactionId }, ctx: { logger } }) => {
       const normalizedEmail = email.toLowerCase();
-      const normalizedTransactionId = transactionId.trim();
 
       const user = await findUserByUserOrAccountEmail(normalizedEmail);
 
@@ -210,13 +209,13 @@ export const adminSyncAppleSubscriptionForUserAction = adminActionClient
 
       logger.info("Starting admin Apple subscription sync for user", {
         userId: user.id,
-        transactionId: normalizedTransactionId,
+        transactionId,
       });
 
       const premium = await syncAppleSubscriptionToDb({
         authenticatedUserId: user.id,
         logger,
-        originalTransactionId: normalizedTransactionId,
+        originalTransactionId: transactionId,
       });
 
       if (!premium) {

--- a/apps/web/utils/actions/admin.validation.ts
+++ b/apps/web/utils/actions/admin.validation.ts
@@ -26,6 +26,14 @@ export const syncStripeForUserBody = z.object({
 });
 export type SyncStripeForUserBody = z.infer<typeof syncStripeForUserBody>;
 
+export const syncAppleSubscriptionForUserBody = z.object({
+  email: z.string().trim().email("Valid email address is required"),
+  transactionId: z.string().trim().min(1, "Transaction ID is required"),
+});
+export type SyncAppleSubscriptionForUserBody = z.infer<
+  typeof syncAppleSubscriptionForUserBody
+>;
+
 export const getUserInfoBody = z.object({
   email: z.string().trim().email("Valid email address is required"),
 });


### PR DESCRIPTION
## Summary

- Add an admin-only action to sync an Apple App Store subscription for a user by email and original transaction id.
- Add a `Sync Apple` control to the existing admin user controls next to the Stripe sync tool.
- Cover the new action with server-action tests for direct user email lookup, email-account fallback, and missing-user handling.

## Context

Apple subscription repair currently requires a direct backend sync call. This adds a reusable admin path that goes through the existing Apple verifier and subscription sync helper, so support can repair a subscription without manually editing premium rows.

## Validation

- `pnpm exec ultracite check apps/web/utils/actions/admin.ts apps/web/utils/actions/admin.validation.ts apps/web/app/'(app)'/admin/AdminUserControls.tsx apps/web/utils/actions/admin.test.ts`
- `pnpm --dir apps/web exec vitest run utils/actions/admin.test.ts`

No customer email, user id, transaction id, API key, or webhook token is included in this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

