### PR TITLE
admin: Fix weekly usage cost accounting

### DIFF
--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -25,6 +25,7 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
+const SUB_CENT_USD = 0.01;
 
 export function AdminTopSpenders() {
   const { data, isLoading, error } = useAdminTopSpenders();
@@ -80,7 +81,7 @@ export function AdminTopSpenders() {
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      {currencyFormatter.format(spender.cost)}
+                      {formatCost(spender.cost)}
                     </TableCell>
                   </TableRow>
                 ))}
@@ -95,4 +96,10 @@ export function AdminTopSpenders() {
       </CardContent>
     </Card>
   );
+}
+
+function formatCost(cost: number) {
+  if (cost > 0 && cost < SUB_CENT_USD) return "<$0.01";
+
+  return currencyFormatter.format(cost);
 }

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -343,6 +343,52 @@ describe("saveAiUsage", () => {
     );
   });
 
+  it("uses zero provider-reported cost without falling back to estimates", async () => {
+    const usage: LanguageModelUsage = {
+      inputTokens: 1000,
+      outputTokens: 400,
+      totalTokens: 1400,
+    };
+    const estimatedCost = calculateUsageCost({
+      provider: "openrouter",
+      model: "openai/gpt-5.1",
+      usage,
+    });
+
+    expect(estimatedCost).toBeGreaterThan(0);
+
+    await saveAiUsage({
+      userId: "user-1",
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      provider: "openrouter",
+      model: "openai/gpt-5.1",
+      usage,
+      label: "assistant-chat",
+      providerReportedCost: 0,
+      providerUpstreamInferenceCost: 0.3456,
+      providerCostSource: "openrouter_usage",
+    });
+
+    expect(publishAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cost: 0,
+        estimatedCost,
+        providerReportedCost: 0,
+        providerUpstreamInferenceCost: 0.3456,
+      }),
+    );
+
+    expect(saveUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        emailAccountId: "email-account-1",
+        usage,
+        cost: 0,
+      }),
+    );
+  });
+
   it("uses upstream inference cost when provider cost is unavailable", async () => {
     const usage: LanguageModelUsage = {
       inputTokens: 1000,

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -292,7 +292,7 @@ describe("saveAiUsage", () => {
     );
   });
 
-  it("stores provider-reported cost separately from local estimates", async () => {
+  it("uses provider-reported cost for platform spend", async () => {
     const usage: LanguageModelUsage = {
       inputTokens: 1000,
       outputTokens: 400,
@@ -323,7 +323,7 @@ describe("saveAiUsage", () => {
 
     expect(publishAiCall).toHaveBeenCalledWith(
       expect.objectContaining({
-        cost: estimatedCost,
+        cost: 1.2345,
         estimatedCost,
         providerReportedCost: 1.2345,
         providerUpstreamInferenceCost: 0.3456,
@@ -338,7 +338,44 @@ describe("saveAiUsage", () => {
         userId: "user-1",
         emailAccountId: "email-account-1",
         usage,
-        cost: estimatedCost,
+        cost: 1.2345,
+      }),
+    );
+  });
+
+  it("uses upstream inference cost when provider cost is unavailable", async () => {
+    const usage: LanguageModelUsage = {
+      inputTokens: 1000,
+      outputTokens: 400,
+      totalTokens: 1400,
+    };
+
+    await saveAiUsage({
+      userId: "user-1",
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      provider: "openrouter",
+      model: "model-without-local-pricing",
+      usage,
+      label: "assistant-chat",
+      providerUpstreamInferenceCost: 0.3456,
+      providerCostSource: "openrouter_usage",
+    });
+
+    expect(publishAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cost: 0.3456,
+        estimatedCost: 0,
+        providerUpstreamInferenceCost: 0.3456,
+      }),
+    );
+
+    expect(saveUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        emailAccountId: "email-account-1",
+        usage,
+        cost: 0.3456,
       }),
     );
   });

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -73,7 +73,13 @@ export async function saveAiUsage({
 }) {
   const estimatedCost = calculateUsageCost({ provider, model, usage });
   const isUserApiKey = !!hasUserApiKey;
-  const platformCost = isUserApiKey ? 0 : estimatedCost;
+  const platformCost = isUserApiKey
+    ? 0
+    : getPlatformCost({
+        estimatedCost,
+        providerReportedCost,
+        providerUpstreamInferenceCost,
+      });
   const inputTokens = usage.inputTokens ?? 0;
   const outputTokens = usage.outputTokens ?? 0;
   const cachedInputTokens = usage.cachedInputTokens ?? 0;
@@ -180,6 +186,27 @@ function getModelPricing(options: {
   }
 
   return;
+}
+
+function getPlatformCost({
+  estimatedCost,
+  providerReportedCost,
+  providerUpstreamInferenceCost,
+}: {
+  estimatedCost: number;
+  providerReportedCost?: number;
+  providerUpstreamInferenceCost?: number;
+}) {
+  if (isPositiveFiniteNumber(providerReportedCost)) return providerReportedCost;
+  if (isPositiveFiniteNumber(providerUpstreamInferenceCost)) {
+    return providerUpstreamInferenceCost;
+  }
+
+  return estimatedCost;
+}
+
+function isPositiveFiniteNumber(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
 function buildModelLookupCandidates({

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -197,16 +197,18 @@ function getPlatformCost({
   providerReportedCost?: number;
   providerUpstreamInferenceCost?: number;
 }) {
-  if (isPositiveFiniteNumber(providerReportedCost)) return providerReportedCost;
-  if (isPositiveFiniteNumber(providerUpstreamInferenceCost)) {
+  if (isNonNegativeFiniteNumber(providerReportedCost)) {
+    return providerReportedCost;
+  }
+  if (isNonNegativeFiniteNumber(providerUpstreamInferenceCost)) {
     return providerUpstreamInferenceCost;
   }
 
   return estimatedCost;
 }
 
-function isPositiveFiniteNumber(value: number | undefined): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0;
+function isNonNegativeFiniteNumber(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
 function buildModelLookupCandidates({


### PR DESCRIPTION
Fixes weekly AI usage cost accounting so provider-reported costs are used for platform spend when available. Also clarifies sub-cent spend display in the admin leaderboard.

- Prefer reported provider cost, then upstream inference cost, then local estimated cost for platform spend
- Keep user-owned API key traffic at zero platform cost
- Display nonzero sub-cent admin costs as less than one cent

Tests:
- pnpm test utils/usage.test.ts
- pnpm test app/api/admin/top-spenders/route.test.ts
- pnpm --dir apps/web exec biome check utils/usage.ts utils/usage.test.ts 'app/(app)/admin/AdminTopSpenders.tsx'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

