### PR TITLE
usage: Fix cost accounting for active models

### DIFF
--- a/apps/web/scripts/generate-llm-pricing.ts
+++ b/apps/web/scripts/generate-llm-pricing.ts
@@ -140,7 +140,16 @@ function buildPricingMap(payload: OpenRouterModelsResponse) {
       .find(Boolean);
 
     if (!matchedPricing) {
-      unresolvedModels.push(targetModelId);
+      const staticPricing = STATIC_MODEL_PRICING[targetModelId];
+      if (staticPricing) {
+        pricingByModelId[targetModelId] = {
+          input: staticPricing.input,
+          output: staticPricing.output,
+          cachedInput: staticPricing.cachedInput ?? staticPricing.input,
+        };
+      } else {
+        unresolvedModels.push(targetModelId);
+      }
       continue;
     }
 

--- a/apps/web/scripts/generate-llm-pricing.ts
+++ b/apps/web/scripts/generate-llm-pricing.ts
@@ -138,22 +138,15 @@ function buildPricingMap(payload: OpenRouterModelsResponse) {
     const matchedPricing = candidateModelIds
       .map((candidateModelId) => openRouterPricingByModelId[candidateModelId])
       .find(Boolean);
+    const staticPricing = getStaticPricing(targetModelId);
 
-    if (!matchedPricing) {
-      const staticPricing = STATIC_MODEL_PRICING[targetModelId];
-      if (staticPricing) {
-        pricingByModelId[targetModelId] = {
-          input: staticPricing.input,
-          output: staticPricing.output,
-          cachedInput: staticPricing.cachedInput ?? staticPricing.input,
-        };
-      } else {
-        unresolvedModels.push(targetModelId);
-      }
-      continue;
+    if (matchedPricing) {
+      pricingByModelId[targetModelId] = matchedPricing;
+    } else if (staticPricing) {
+      pricingByModelId[targetModelId] = staticPricing;
+    } else {
+      unresolvedModels.push(targetModelId);
     }
-
-    pricingByModelId[targetModelId] = matchedPricing;
   }
 
   for (const [alias, canonicalModelId] of Object.entries(
@@ -178,6 +171,17 @@ function buildPricingMap(payload: OpenRouterModelsResponse) {
   return Object.fromEntries(
     Object.entries(pricingByModelId).sort(([a], [b]) => a.localeCompare(b)),
   );
+}
+
+function getStaticPricing(modelId: string): ModelPricing | undefined {
+  const staticPricing = STATIC_MODEL_PRICING[modelId];
+  if (!staticPricing) return;
+
+  return {
+    input: staticPricing.input,
+    output: staticPricing.output,
+    cachedInput: staticPricing.cachedInput ?? staticPricing.input,
+  };
 }
 
 function parsePricing(pricing: OpenRouterModel["pricing"]) {

--- a/apps/web/utils/llms/pricing.generated.ts
+++ b/apps/web/utils/llms/pricing.generated.ts
@@ -9,10 +9,30 @@ export type ModelPricing = {
 };
 
 export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
+  "anthropic.claude-3-5-haiku-20241022-v1:0": {
+    input: 8.000_000_000_000_001e-7,
+    output: 0.000_004,
+    cachedInput: 8.000_000_000_000_001e-7,
+  },
+  "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "anthropic.claude-sonnet-4-6": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
   "anthropic/claude-3.5-sonnet": {
-    input: 0.000_006,
-    output: 0.000_03,
-    cachedInput: 6e-7,
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
   },
   "anthropic/claude-3.7-sonnet": {
     input: 0.000_003,
@@ -55,14 +75,14 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     cachedInput: 3e-7,
   },
   "claude-3-5-sonnet-20240620": {
-    input: 0.000_006,
-    output: 0.000_03,
-    cachedInput: 6e-7,
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
   },
   "claude-3-5-sonnet-20241022": {
-    input: 0.000_006,
-    output: 0.000_03,
-    cachedInput: 6e-7,
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
   },
   "claude-3-7-sonnet-20250219": {
     input: 0.000_003,
@@ -89,10 +109,40 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_015,
     cachedInput: 3e-7,
   },
+  "DeepSeek-V4-Pro": {
+    input: 0.000_001_925,
+    output: 0.000_003_828,
+    cachedInput: 1.65e-7,
+  },
+  "deepseek/deepseek-v4-flash": {
+    input: 9e-8,
+    output: 1.8e-7,
+    cachedInput: 2e-8,
+  },
+  "eu.anthropic.claude-sonnet-4-6": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "gemini-1.5-flash-latest": {
+    input: 7.5e-8,
+    output: 3e-7,
+    cachedInput: 7.5e-8,
+  },
+  "gemini-1.5-pro-latest": {
+    input: 0.000_001_25,
+    output: 0.000_005,
+    cachedInput: 0.000_001_25,
+  },
   "gemini-2.0-flash": {
-    input: 1e-7,
-    output: 4e-7,
-    cachedInput: 2.5e-8,
+    input: 1.5e-7,
+    output: 6e-7,
+    cachedInput: 1.5e-7,
+  },
+  "gemini-2.0-flash-lite": {
+    input: 7.5e-8,
+    output: 3e-7,
+    cachedInput: 7.5e-8,
   },
   "gemini-2.5-flash": {
     input: 3e-7,
@@ -109,10 +159,40 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_003,
     cachedInput: 5e-8,
   },
+  "gemini-3-pro": {
+    input: 0.000_002,
+    output: 0.000_012,
+    cachedInput: 0.000_002,
+  },
+  "gemini-3-pro-preview": {
+    input: 0.000_002,
+    output: 0.000_012,
+    cachedInput: 0.000_002,
+  },
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    input: 0.000_001,
+    output: 0.000_005,
+    cachedInput: 1.000_000_000_000_000_1e-7,
+  },
+  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
   "google/gemini-2.0-flash-001": {
-    input: 1e-7,
-    output: 4e-7,
-    cachedInput: 2.5e-8,
+    input: 1.5e-7,
+    output: 6e-7,
+    cachedInput: 1.5e-7,
+  },
+  "google/gemini-2.5-flash-preview-05-20": {
+    input: 1.5e-7,
+    output: 6e-7,
+    cachedInput: 1.5e-7,
   },
   "google/gemini-2.5-pro": {
     input: 0.000_001_25,
@@ -124,15 +204,35 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_01,
     cachedInput: 1.25e-7,
   },
+  "google/gemini-2.5-pro-preview-03-25": {
+    input: 0.000_001_25,
+    output: 0.000_01,
+    cachedInput: 0.000_001_25,
+  },
+  "google/gemini-2.5-pro-preview-06-05": {
+    input: 0.000_001_25,
+    output: 0.000_01,
+    cachedInput: 0.000_001_25,
+  },
+  "google/gemini-3-flash": {
+    input: 5e-7,
+    output: 0.000_003,
+    cachedInput: 5e-7,
+  },
   "google/gemini-3-flash-preview": {
     input: 5e-7,
     output: 0.000_003,
     cachedInput: 5e-8,
   },
+  "google/gemini-3-pro": {
+    input: 0.000_002,
+    output: 0.000_012,
+    cachedInput: 0.000_002,
+  },
   "google/gemini-3-pro-preview": {
     input: 0.000_002,
     output: 0.000_012,
-    cachedInput: 2e-7,
+    cachedInput: 0.000_002,
   },
   "gpt-3.5-turbo-0125": {
     input: 5e-7,
@@ -147,7 +247,7 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
   "gpt-4o": {
     input: 0.000_002_5,
     output: 0.000_01,
-    cachedInput: 0.000_001_25,
+    cachedInput: 0.000_002_5,
   },
   "gpt-4o-mini": {
     input: 1.5e-7,
@@ -162,22 +262,17 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
   "gpt-5-nano": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 5e-9,
+    cachedInput: 1e-8,
   },
   "gpt-5.1": {
     input: 0.000_001_25,
     output: 0.000_01,
-    cachedInput: 1.25e-7,
+    cachedInput: 1.3e-7,
   },
-  "gemini-3-pro": {
-    input: 0.000_002,
-    output: 0.000_012,
-    cachedInput: 2e-7,
-  },
-  "gemini-3-pro-preview": {
-    input: 0.000_002,
-    output: 0.000_012,
-    cachedInput: 2e-7,
+  "gpt-5.4": {
+    input: 0.000_002_5,
+    output: 0.000_015,
+    cachedInput: 2.5e-7,
   },
   "gpt-5.4-mini": {
     input: 7.5e-7,
@@ -189,10 +284,10 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_001_25,
     cachedInput: 2e-8,
   },
-  "grok-4-fast": {
-    input: 2e-7,
-    output: 5e-7,
-    cachedInput: 5e-8,
+  "llama-3.3-70b-versatile": {
+    input: 5.9e-7,
+    output: 7.900_000_000_000_001e-7,
+    cachedInput: 5.9e-7,
   },
   "meta-llama/llama-4-maverick": {
     input: 1.5e-7,
@@ -200,28 +295,48 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     cachedInput: 1.5e-7,
   },
   "moonshotai/kimi-k2": {
-    input: 5e-7,
-    output: 0.000_002_4,
-    cachedInput: 5e-7,
+    input: 5.7e-7,
+    output: 0.000_002_3,
+    cachedInput: 5.7e-7,
   },
   "openai/gpt-5-nano": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 5e-9,
+    cachedInput: 1e-8,
   },
   "openai/gpt-5-nano-2025-08-07": {
     input: 5e-8,
     output: 4e-7,
-    cachedInput: 5e-9,
+    cachedInput: 1e-8,
   },
-  "x-ai/grok-4-fast": {
-    input: 2e-7,
-    output: 5e-7,
-    cachedInput: 5e-8,
+  "sonar-pro": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 0.000_003,
   },
-  "x-ai/grok-4-fast-2025-08-28": {
-    input: 2e-7,
-    output: 5e-7,
-    cachedInput: 5e-8,
+  "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+    input: 8.000_000_000_000_001e-7,
+    output: 0.000_004,
+    cachedInput: 8.000_000_000_000_001e-7,
+  },
+  "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    input: 0.000_003,
+    output: 0.000_015,
+    cachedInput: 3e-7,
   },
 };

--- a/apps/web/utils/llms/supported-model-pricing.ts
+++ b/apps/web/utils/llms/supported-model-pricing.ts
@@ -55,6 +55,11 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 15 / 1_000_000,
     cachedInput: 2.5 / 1_000_000,
   },
+  "gpt-5.4": {
+    input: 2.5 / 1_000_000,
+    output: 15 / 1_000_000,
+    cachedInput: 0.25 / 1_000_000,
+  },
   "gpt-5.4-mini": {
     input: 0.75 / 1_000_000,
     output: 4.5 / 1_000_000,
@@ -141,6 +146,15 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.2 / 1_000_000,
     cachedInput: 0.02 / 1_000_000,
   },
+  "DeepSeek-V4-Pro": {
+    input: 1.925 / 1_000_000,
+    output: 3.828 / 1_000_000,
+    cachedInput: 0.165 / 1_000_000,
+  },
+  "sonar-pro": {
+    input: 3 / 1_000_000,
+    output: 15 / 1_000_000,
+  },
   "meta-llama/llama-4-maverick": {
     input: 0.2 / 1_000_000,
     output: 0.85 / 1_000_000,
@@ -166,6 +180,7 @@ export const OPENROUTER_MODEL_ID_BY_SUPPORTED_MODEL: Partial<
   "gpt-4o-mini": "openai/gpt-4o-mini",
   "gpt-4-turbo": "openai/gpt-4-turbo",
   "gpt-4o": "openai/gpt-4o",
+  "gpt-5.4": "openai/gpt-5.4",
   "gpt-5.4-mini": "openai/gpt-5.4-mini",
   "gpt-5.4-nano": "openai/gpt-5.4-nano",
   "gpt-5-mini": "openai/gpt-5-mini",
@@ -180,4 +195,5 @@ export const OPENROUTER_MODEL_ID_BY_SUPPORTED_MODEL: Partial<
   "gemini-3-flash": "google/gemini-3-flash-preview",
   "gemini-3-pro": "google/gemini-3-pro-preview",
   "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+  "sonar-pro": "perplexity/sonar-pro",
 };

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -154,6 +154,9 @@ describe("calculateUsageCost", () => {
   it("estimates DeepSeek V4 Flash costs", () => {
     const provider = "openrouter";
     const model = "deepseek/deepseek-v4-flash";
+    const pricing = OPENROUTER_MODEL_PRICING[model];
+    if (!pricing) throw new Error("Expected pricing for deepseek-v4-flash");
+
     const usage: LanguageModelUsage = {
       inputTokens: 1000,
       cachedInputTokens: 250,
@@ -162,11 +165,50 @@ describe("calculateUsageCost", () => {
     };
 
     const expected =
-      750 * (0.1 / 1_000_000) +
-      250 * (0.02 / 1_000_000) +
-      500 * (0.2 / 1_000_000);
+      750 * pricing.input + 250 * pricing.cachedInput + 500 * pricing.output;
 
     expect(calculateUsageCost({ provider, model, usage })).toBe(expected);
+  });
+
+  it("estimates current platform model costs", () => {
+    const usage: LanguageModelUsage = {
+      inputTokens: 1000,
+      cachedInputTokens: 250,
+      outputTokens: 500,
+      totalTokens: 1500,
+    };
+
+    expect(
+      calculateUsageCost({
+        provider: "azure-foundry",
+        model: "DeepSeek-V4-Pro",
+        usage,
+      }),
+    ).toBeCloseTo(
+      750 * (1.925 / 1_000_000) +
+        250 * (0.165 / 1_000_000) +
+        500 * (3.828 / 1_000_000),
+    );
+
+    expect(
+      calculateUsageCost({
+        provider: "openrouter",
+        model: "openai/gpt-5.4",
+        usage,
+      }),
+    ).toBeCloseTo(
+      750 * (2.5 / 1_000_000) +
+        250 * (0.25 / 1_000_000) +
+        500 * (15 / 1_000_000),
+    );
+
+    expect(
+      calculateUsageCost({
+        provider: "perplexity",
+        model: "sonar-pro",
+        usage,
+      }),
+    ).toBeCloseTo(1000 * (3 / 1_000_000) + 500 * (15 / 1_000_000));
   });
 
   it("resolves prefixed OpenRouter pricing for non-prefixed model names", () => {
@@ -343,7 +385,7 @@ describe("saveAiUsage", () => {
     );
   });
 
-  it("uses zero provider-reported cost without falling back to estimates", async () => {
+  it("uses estimated cost when provider-reported cost is zero", async () => {
     const usage: LanguageModelUsage = {
       inputTokens: 1000,
       outputTokens: 400,
@@ -366,16 +408,51 @@ describe("saveAiUsage", () => {
       usage,
       label: "assistant-chat",
       providerReportedCost: 0,
-      providerUpstreamInferenceCost: 0.3456,
+      providerCostSource: "openrouter_usage",
+    });
+
+    expect(publishAiCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cost: estimatedCost,
+        estimatedCost,
+        providerReportedCost: 0,
+      }),
+    );
+
+    expect(saveUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        emailAccountId: "email-account-1",
+        usage,
+        cost: estimatedCost,
+      }),
+    );
+  });
+
+  it("keeps zero provider-reported cost when pricing is unavailable", async () => {
+    const usage: LanguageModelUsage = {
+      inputTokens: 1000,
+      outputTokens: 400,
+      totalTokens: 1400,
+    };
+
+    await saveAiUsage({
+      userId: "user-1",
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      provider: "openrouter",
+      model: "model-without-local-pricing",
+      usage,
+      label: "assistant-chat",
+      providerReportedCost: 0,
       providerCostSource: "openrouter_usage",
     });
 
     expect(publishAiCall).toHaveBeenCalledWith(
       expect.objectContaining({
         cost: 0,
-        estimatedCost,
+        estimatedCost: 0,
         providerReportedCost: 0,
-        providerUpstreamInferenceCost: 0.3456,
       }),
     );
 
@@ -461,7 +538,7 @@ describe("saveAiUsage", () => {
         model: "deepseek/deepseek-v4-flash",
         label: "eval-test",
         estimatedCost,
-        platformCost: estimatedCost,
+        platformCost: 0.000_18,
         providerReportedCost: 0.000_18,
         inputTokens: 1000,
         outputTokens: 400,

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -197,14 +197,25 @@ function getPlatformCost({
   providerReportedCost?: number;
   providerUpstreamInferenceCost?: number;
 }) {
-  if (isNonNegativeFiniteNumber(providerReportedCost)) {
+  if (isPositiveFiniteNumber(providerReportedCost)) {
     return providerReportedCost;
   }
+  if (isPositiveFiniteNumber(providerUpstreamInferenceCost)) {
+    return providerUpstreamInferenceCost;
+  }
+  if (estimatedCost > 0) return estimatedCost;
+
+  if (isNonNegativeFiniteNumber(providerReportedCost))
+    return providerReportedCost;
   if (isNonNegativeFiniteNumber(providerUpstreamInferenceCost)) {
     return providerUpstreamInferenceCost;
   }
 
   return estimatedCost;
+}
+
+function isPositiveFiniteNumber(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
 function isNonNegativeFiniteNumber(value: number | undefined): value is number {


### PR DESCRIPTION
Fixes usage cost accounting for active platform models and preserves historical pricing entries when refreshing provider pricing.

- Add pricing coverage for active platform models used in production
- Prefer positive provider-reported cost, then upstream cost, then local estimate
- Preserve historical supported model prices when provider catalog data no longer includes an older model

Tests:
- pnpm test utils/usage.test.ts
- pnpm test app/api/admin/top-spenders/route.test.ts
- pnpm --dir apps/web exec biome check scripts/generate-llm-pricing.ts utils/usage.ts utils/usage.test.ts utils/llms/supported-model-pricing.ts utils/llms/pricing.generated.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

