### PR TITLE
fix: clarify rule risk headline for webhook actions

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -1109,7 +1109,8 @@ function PendingCreateRuleCardContent({
         <AlertTitle>Review before enabling</AlertTitle>
         <AlertDescription className="space-y-2 text-sm">
           <p>
-            This rule can send email automatically. Review it before enabling.
+            This rule can automatically send email or share email data. Review
+            it before enabling.
           </p>
           {riskMessages.length === 1 ? (
             <p className="text-muted-foreground">{riskMessages[0]}</p>


### PR DESCRIPTION
### Problem
The "Review before enabling" alert (`PendingCreateRuleCardContent` in `apps/web/components/assistant-chat/tools.tsx`) always renders the headline:

> This rule can send email automatically. Review it before enabling.

For a rule whose only risky action is `CALL_WEBHOOK`, this is inaccurate — the rule does not send an email, it POSTs email **data** to an external URL. The detail line right below it already says this correctly:

> Medium Risk: Webhook actions can send email data to an external URL…

So the headline over-claims for webhook-only rules.

### Fix
The component only receives `riskMessages: string[]` (not the action types), so rather than thread new props through just for copy, this rewords the shared headline to be accurate for both categories:

> This rule can automatically send email or share email data. Review it before enabling.

Covers reply/send/forward ("send email") and `CALL_WEBHOOK` ("share email data") without a conditional.

Copy-only change; no behaviour change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

