### PR TITLE
feat(assistant): auto-send the fix-rule message instead of only populating the input

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -1,6 +1,6 @@
 import { MessageCircleIcon } from "lucide-react";
 import type { ChangeEvent } from "react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { ParsedMessage } from "@/utils/types";
 import type { RunRulesResult } from "@/utils/ai/choose-rule/run-rules";
@@ -24,6 +24,7 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { useChat } from "@/providers/ChatProvider";
+import { captureException } from "@/utils/error";
 import {
   NEW_RULE_ID as CONST_NEW_RULE_ID,
   NONE_RULE_ID as CONST_NONE_RULE_ID,
@@ -55,6 +56,7 @@ export function FixWithChat({
 
   const { setOpen } = useSidebar();
   const { setContext, submitTextMessage, chat } = useChat();
+  const isSubmittingRef = useRef(false);
 
   const selectedRuleName = useMemo(() => {
     if (!data) return null;
@@ -69,7 +71,10 @@ export function FixWithChat({
   };
 
   const handleSubmit = async () => {
-    if (!selectedRuleId) return;
+    // Guard against repeated submits while the async send is in flight (the
+    // modal closes asynchronously, so the button can be clicked again briefly).
+    if (!selectedRuleId || isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
 
     let input: string;
 
@@ -131,9 +136,15 @@ export function FixWithChat({
 
     // Auto-send the message instead of only populating the input. If the chat
     // is mid-response, fall back to populating the input so we don't interleave
-    // with an in-flight message.
+    // with an in-flight message. If the send fails, also fall back to
+    // populating the input so the generated text isn't lost.
     if (chat.status === "ready") {
-      await submitTextMessage(input);
+      try {
+        await submitTextMessage(input);
+      } catch (error) {
+        captureException(error);
+        setInput(input);
+      }
     } else {
       setInput(input);
     }
@@ -142,6 +153,7 @@ export function FixWithChat({
     setSelectedRuleId(null);
     setExplanation("");
     setShowExplanation(false);
+    isSubmittingRef.current = false;
   };
 
   const handleClose = (open: boolean) => {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -54,7 +54,7 @@ export function FixWithChat({
   const [showExplanation, setShowExplanation] = useState(false);
 
   const { setOpen } = useSidebar();
-  const { setContext } = useChat();
+  const { setContext, submitTextMessage, chat } = useChat();
 
   const selectedRuleName = useMemo(() => {
     if (!data) return null;
@@ -68,7 +68,7 @@ export function FixWithChat({
     setShowExplanation(true);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!selectedRuleId) return;
 
     let input: string;
@@ -126,9 +126,17 @@ export function FixWithChat({
     };
     setContext(context);
 
-    setInput(input);
     setOpen((arr) => [...arr, "chat-sidebar"]);
     setIsModalOpen(false);
+
+    // Auto-send the message instead of only populating the input. If the chat
+    // is mid-response, fall back to populating the input so we don't interleave
+    // with an in-flight message.
+    if (chat.status === "ready") {
+      await submitTextMessage(input);
+    } else {
+      setInput(input);
+    }
 
     // Reset state
     setSelectedRuleId(null);


### PR DESCRIPTION
### What
In the **Improve Rules** dialog (`FixWithChat`), after the user selects the expected rule (new / none / existing) and clicks **Next**, the generated message is now **sent automatically** to the assistant instead of merely being written into the chat input for the user to send manually.

### Why
The extra manual "press send" step is friction — the user already expressed full intent by choosing the rule and (optionally) an explanation. Auto-sending completes the action they started.

### How
- `FixWithChat` now pulls `submitTextMessage` and `chat` from `useChat()`.
- `handleSubmit` is `async`; after `setContext(...)` and opening the sidebar it calls `await submitTextMessage(input)`.
- `submitTextMessage(text)` takes the message as an **argument**, avoiding the `setInput` → submit state-closure race (the input would otherwise still be empty on the same tick).
- Guarded by `chat.status === "ready"`: if a response is already streaming/submitted, it **falls back to the previous behaviour** (`setInput(input)`) so we never interleave with an in-flight message.

### Scope
Only the `FixWithChat` ("Improve Rules") flow. The separate "Edit via AI" dropdown action (which intentionally lets you tweak the prompt before sending) is unchanged.

### Testing
Manual: select new/none/existing rule → Next → message is sent immediately; while a response is streaming, it populates the input instead.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

