### PR TITLE
feat(assistant): sort the Improve Rules rule picker by name

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/FixWithChat.tsx
@@ -251,7 +251,9 @@ function RuleMismatch({
           items={[
             { id: NONE_RULE_ID, name: "❌ None" },
             { id: NEW_RULE_ID, name: "✨ New rule" },
-            ...rules,
+            ...[...rules].sort((a, b) =>
+              a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+            ),
           ]}
           onSelect={onSelectExpectedRuleId}
           itemClassName="h-auto min-h-10 justify-start whitespace-normal text-wrap py-2 text-left"


### PR DESCRIPTION
### What
In the **Improve Rules** dialog (`FixWithChat` → `RuleMismatch`), the "Which rule did you expect it to match?" list now shows the user's rules sorted alphabetically by name (case-insensitive). The **None** and **New rule** options remain pinned at the top.

### Why
The list previously rendered rules in `createdAt` order (the API order), which is hard to scan once you have many rules — you can't predict where a given rule will be. Alphabetical order makes a specific rule easy to find. (The main /automation rules table is already name-sorted via `sortRulesForAutomation`; this brings the picker in line.)

### How
One-line change: sort a copy of `rules` by `name.localeCompare(..., { sensitivity: "base" })` before spreading into the `ButtonList` items. No data/query changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

