### PR TITLE
Fix reconnect notification targeting

### DIFF
--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -9,7 +9,7 @@ import {
   handleReferralOnSignUp,
 } from "@/utils/auth";
 import prisma from "@/utils/__mocks__/prisma";
-import { clearSpecificErrorMessages } from "@/utils/error-messages";
+import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 
 vi.mock("better-auth", () => ({
   betterAuth: vi.fn((options: unknown) => ({
@@ -22,7 +22,7 @@ vi.mock("better-auth", () => ({
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/error-messages", () => ({
   addUserErrorMessage: vi.fn().mockResolvedValue(undefined),
-  clearSpecificErrorMessages: vi.fn().mockResolvedValue(undefined),
+  clearAccountDisconnectedErrorIfResolved: vi.fn().mockResolvedValue(undefined),
   ErrorType: {
     ACCOUNT_DISCONNECTED: "Account disconnected",
   },
@@ -164,10 +164,9 @@ describe("saveTokens", () => {
         }),
       }),
     );
-    expect(clearSpecificErrorMessages).toHaveBeenCalledWith(
+    expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        errorTypes: ["Account disconnected"],
       }),
     );
   });
@@ -209,10 +208,9 @@ describe("saveTokens", () => {
       }),
     });
     expect(prisma.emailAccount.update).not.toHaveBeenCalled();
-    expect(clearSpecificErrorMessages).toHaveBeenCalledWith(
+    expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        errorTypes: ["Account disconnected"],
       }),
     );
   });
@@ -236,7 +234,7 @@ describe("saveTokens", () => {
     });
 
     expect(result).toEqual({ status: "conflict" });
-    expect(clearSpecificErrorMessages).not.toHaveBeenCalled();
+    expect(clearAccountDisconnectedErrorIfResolved).not.toHaveBeenCalled();
   });
 
   it("clears disconnectedAt and error messages when saving tokens via providerAccountId", async () => {
@@ -266,10 +264,9 @@ describe("saveTokens", () => {
         }),
       }),
     );
-    expect(clearSpecificErrorMessages).toHaveBeenCalledWith(
+    expect(clearAccountDisconnectedErrorIfResolved).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        errorTypes: ["Account disconnected"],
       }),
     );
   });
@@ -292,7 +289,7 @@ describe("handleLinkAccount", () => {
 
     expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
     expect(prisma.emailAccount.upsert).not.toHaveBeenCalled();
-    expect(clearSpecificErrorMessages).not.toHaveBeenCalled();
+    expect(clearAccountDisconnectedErrorIfResolved).not.toHaveBeenCalled();
   });
 
   it("still requires an access token for mailbox providers", async () => {

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -42,7 +42,7 @@ import {
   updateAccountSeats,
 } from "@/utils/premium/seats";
 import { safeExpo } from "@/utils/mobile-auth/expo";
-import { clearSpecificErrorMessages, ErrorType } from "@/utils/error-messages";
+import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 import { getEnabledLoginProviders } from "@/utils/oauth/login-providers";
 import { getAppleClientSecret } from "@/utils/auth/apple-client-secret";
 import { assertCanGenerateScimToken } from "@/utils/auth/scim";
@@ -645,9 +645,8 @@ export async function handleLinkAccount(account: Account) {
         }),
       ]);
 
-      await clearSpecificErrorMessages({
+      await clearAccountDisconnectedErrorIfResolved({
         userId: account.userId,
-        errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
         logger,
       });
 
@@ -688,9 +687,8 @@ export async function handleLinkAccount(account: Account) {
       }),
     ]);
 
-    await clearSpecificErrorMessages({
+    await clearAccountDisconnectedErrorIfResolved({
       userId: account.userId,
-      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
       logger,
     });
 

--- a/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.test.ts
@@ -40,7 +40,7 @@ describe("cleanupInvalidTokens", () => {
     watchEmailsExpirationDate: new Date(Date.now() + 1000 * 60 * 60), // Valid expiration
   };
 
-  it("marks account as disconnected and sends email on invalid_grant when account is watched", async () => {
+  it("marks account as disconnected and sends email to the disconnected account on invalid_grant when account is watched", async () => {
     prisma.emailAccount.findUnique.mockResolvedValue(mockEmailAccount as any);
     prisma.account.updateMany.mockResolvedValue({ count: 1 });
 
@@ -61,7 +61,7 @@ describe("cleanupInvalidTokens", () => {
     expect(sendReconnectionEmail).toHaveBeenCalled();
     expect(sendReconnectionEmail).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "owner@example.com",
+        to: "test@example.com",
         emailProps: expect.objectContaining({
           email: "test@example.com",
         }),
@@ -93,7 +93,7 @@ describe("cleanupInvalidTokens", () => {
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        userEmail: "owner@example.com",
+        userEmail: "test@example.com",
         emailAccountId: "ea_1",
         errorType: "Account disconnected",
         errorMessage: expect.stringContaining("test@example.com"),
@@ -133,7 +133,7 @@ describe("cleanupInvalidTokens", () => {
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        userEmail: "owner@example.com",
+        userEmail: "test@example.com",
         emailAccountId: "ea_1",
         errorType: "Account disconnected",
         errorMessage: expect.stringContaining("missing required permissions"),
@@ -157,7 +157,7 @@ describe("cleanupInvalidTokens", () => {
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user_1",
-        userEmail: "owner@example.com",
+        userEmail: "test@example.com",
         emailAccountId: "ea_1",
         errorType: "Account disconnected",
         errorMessage: expect.stringContaining("security policy"),

--- a/apps/web/utils/auth/cleanup-invalid-tokens.ts
+++ b/apps/web/utils/auth/cleanup-invalid-tokens.ts
@@ -89,7 +89,7 @@ export async function cleanupInvalidTokens({
       ? await sendWatchedAccountReconnectionEmail({
           emailAccountId: emailAccount.id,
           email: emailAccount.email,
-          recipientEmail: emailAccount.user.email,
+          recipientEmail: emailAccount.email,
           watchEmailsExpirationDate: emailAccount.watchEmailsExpirationDate,
           logger,
         })
@@ -105,7 +105,7 @@ export async function cleanupInvalidTokens({
   } else {
     await addUserErrorMessageWithNotification({
       userId: emailAccount.userId,
-      userEmail: emailAccount.user.email,
+      userEmail: emailAccount.email,
       emailAccountId: emailAccount.id,
       errorType: ErrorType.ACCOUNT_DISCONNECTED,
       errorMessage,

--- a/apps/web/utils/auth/save-tokens.ts
+++ b/apps/web/utils/auth/save-tokens.ts
@@ -2,7 +2,7 @@ import prisma from "@/utils/prisma";
 import { encryptToken } from "@/utils/encryption";
 import { captureException } from "@/utils/error";
 import { createScopedLogger } from "@/utils/logger";
-import { clearSpecificErrorMessages, ErrorType } from "@/utils/error-messages";
+import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 
 const logger = createScopedLogger("auth");
 
@@ -74,9 +74,8 @@ export async function saveTokens({
       }
 
       if (emailAccount) {
-        await clearSpecificErrorMessages({
+        await clearAccountDisconnectedErrorIfResolved({
           userId: emailAccount.userId,
-          errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
           logger,
         });
       }
@@ -95,9 +94,8 @@ export async function saveTokens({
       select: { userId: true },
     });
 
-    await clearSpecificErrorMessages({
+    await clearAccountDisconnectedErrorIfResolved({
       userId: emailAccount.userId,
-      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
       logger,
     });
   } else {
@@ -121,9 +119,8 @@ export async function saveTokens({
       data,
     });
 
-    await clearSpecificErrorMessages({
+    await clearAccountDisconnectedErrorIfResolved({
       userId: account.userId,
-      errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
       logger,
     });
 

--- a/apps/web/utils/error-messages/index.test.ts
+++ b/apps/web/utils/error-messages/index.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { ErrorType, getUserErrorMessages } from "@/utils/error-messages";
+import {
+  clearAccountDisconnectedErrorIfResolved,
+  ErrorType,
+  getUserErrorMessages,
+} from "@/utils/error-messages";
+import { createTestLogger } from "@/__tests__/helpers";
 
 vi.mock("@/utils/prisma");
 vi.mock("@inboxzero/resend", () => ({
@@ -82,5 +87,63 @@ describe("getUserErrorMessages", () => {
 
     expect(result).toEqual(errorMessages);
     expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearAccountDisconnectedErrorIfResolved", () => {
+  const logger = createTestLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the disconnect error while another account remains disconnected", async () => {
+    prisma.emailAccount.count.mockResolvedValue(1);
+
+    await clearAccountDisconnectedErrorIfResolved({
+      userId: "user-1",
+      logger,
+    });
+
+    expect(prisma.emailAccount.count).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        account: { disconnectedAt: { not: null } },
+      },
+    });
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("clears the disconnect error when no accounts remain disconnected", async () => {
+    prisma.emailAccount.count.mockResolvedValue(0);
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.ACCOUNT_DISCONNECTED]: {
+          message: "Reconnect",
+          timestamp: "2026-06-24T04:00:40.506Z",
+        },
+        [ErrorType.INVALID_AI_MODEL]: {
+          message: "Invalid model",
+          timestamp: "2026-06-24T04:00:40.506Z",
+        },
+      },
+    } as any);
+
+    await clearAccountDisconnectedErrorIfResolved({
+      userId: "user-1",
+      logger,
+    });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        errorMessages: {
+          [ErrorType.INVALID_AI_MODEL]: {
+            message: "Invalid model",
+            timestamp: "2026-06-24T04:00:40.506Z",
+          },
+        },
+      },
+    });
   });
 });

--- a/apps/web/utils/error-messages/index.ts
+++ b/apps/web/utils/error-messages/index.ts
@@ -144,6 +144,39 @@ export async function clearSpecificErrorMessages({
   }
 }
 
+export async function clearAccountDisconnectedErrorIfResolved({
+  userId,
+  logger,
+}: {
+  userId: string;
+  logger: Logger;
+}): Promise<void> {
+  let disconnectedAccounts: number;
+  try {
+    disconnectedAccounts = await prisma.emailAccount.count({
+      where: {
+        userId,
+        account: { disconnectedAt: { not: null } },
+      },
+    });
+  } catch (error) {
+    logger.error("Error checking account disconnected errors:", {
+      userId,
+      error,
+    });
+    captureException(error, { extra: { userId } });
+    return;
+  }
+
+  if (disconnectedAccounts > 0) return;
+
+  await clearSpecificErrorMessages({
+    userId,
+    errorTypes: [ErrorType.ACCOUNT_DISCONNECTED],
+    logger,
+  });
+}
+
 const errorTypeConfig: Record<
   PersistedErrorType,
   { label: string; actionUrl: string; actionLabel: string }


### PR DESCRIPTION
Fix reconnect notification targeting and account-level disconnect alert handling.

- Send reconnect notifications to the affected mailbox.
- Keep account disconnect alerts until all disconnected accounts are resolved.
- Add focused regression coverage for notification targeting and alert clearing.

Validation:
- pnpm test utils/auth/cleanup-invalid-tokens.test.ts utils/auth.test.ts utils/error-messages/index.test.ts
- pnpm check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

