### PR TITLE
admin: Add model spend breakdown

### DIFF
--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -26,6 +26,7 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
+const numberFormatter = new Intl.NumberFormat("en-US");
 const SUB_CENT_USD = 0.01;
 
 export function AdminTopSpenders() {
@@ -122,9 +123,7 @@ export function AdminTopSpenders() {
                   </TableHeader>
                   <TableBody>
                     {modelSpend.map((model, index) => (
-                      <TableRow
-                        key={`${model.provider}:${model.model}:${index}`}
-                      >
+                      <TableRow key={`${model.provider}:${model.model}`}>
                         <TableCell>{index + 1}</TableCell>
                         <TableCell className="font-mono text-xs">
                           {model.provider}
@@ -155,9 +154,8 @@ export function AdminTopSpenders() {
   );
 }
 
-type ModelSpend = NonNullable<
-  NonNullable<GetAdminTopSpendersResponse["topSpenders"][number]>["modelSpend"]
->;
+type TopSpender = GetAdminTopSpendersResponse["topSpenders"][number];
+type ModelSpend = TopSpender["modelSpend"];
 
 function ModelSpendList({ modelSpend }: { modelSpend: ModelSpend }) {
   if (!modelSpend.length) {
@@ -188,5 +186,3 @@ function formatCost(cost: number) {
 
   return currencyFormatter.format(cost);
 }
-
-const numberFormatter = new Intl.NumberFormat("en-US");

--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { useAdminTopSpenders } from "@/hooks/useAdminTopSpenders";
+import type { GetAdminTopSpendersResponse } from "@/app/api/admin/top-spenders/route";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -30,6 +31,7 @@ const SUB_CENT_USD = 0.01;
 export function AdminTopSpenders() {
   const { data, isLoading, error } = useAdminTopSpenders();
   const topSpenders = data?.topSpenders ?? [];
+  const modelSpend = data?.modelSpend ?? [];
 
   return (
     <Card className="max-w-5xl">
@@ -43,58 +45,141 @@ export function AdminTopSpenders() {
       </CardHeader>
       <CardContent>
         <LoadingContent loading={isLoading} error={error}>
-          {topSpenders.length ? (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-16">Rank</TableHead>
-                  <TableHead>Email Account ID</TableHead>
-                  <TableHead>Email</TableHead>
-                  <TableHead>User Accounts</TableHead>
-                  <TableHead>Nano-Limited</TableHead>
-                  <TableHead className="text-right">Cost</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {topSpenders.map((spender, index) => (
-                  <TableRow
-                    key={
-                      ("userId" in spender ? spender.userId : spender.email) ??
-                      index
-                    }
-                  >
-                    <TableCell>{index + 1}</TableCell>
-                    <TableCell className="font-mono text-xs">
-                      {spender.emailAccountId ?? "-"}
-                    </TableCell>
-                    <TableCell className="font-mono text-xs sm:text-sm">
-                      {spender.email ?? "-"}
-                    </TableCell>
-                    <TableCell>
-                      {spender.userEmailAccountCount ?? "-"}
-                    </TableCell>
-                    <TableCell>
-                      {spender.nanoLimitedBySpendGuard ? (
-                        <Badge variant="red">Yes</Badge>
-                      ) : (
-                        <Badge variant="green">No</Badge>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {formatCost(spender.cost)}
-                    </TableCell>
+          <div className="space-y-8">
+            {topSpenders.length ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-16">Rank</TableHead>
+                    <TableHead>Email Account ID</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>User Accounts</TableHead>
+                    <TableHead>Top Models</TableHead>
+                    <TableHead>Nano-Limited</TableHead>
+                    <TableHead className="text-right">Cost</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No usage cost recorded in the past 7 days.
-            </p>
-          )}
+                </TableHeader>
+                <TableBody>
+                  {topSpenders.map((spender, index) => (
+                    <TableRow
+                      key={
+                        ("userId" in spender
+                          ? spender.userId
+                          : spender.email) ?? index
+                      }
+                    >
+                      <TableCell>{index + 1}</TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {spender.emailAccountId ?? "-"}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs sm:text-sm">
+                        {spender.email ?? "-"}
+                      </TableCell>
+                      <TableCell>
+                        {spender.userEmailAccountCount ?? "-"}
+                      </TableCell>
+                      <TableCell>
+                        <ModelSpendList modelSpend={spender.modelSpend} />
+                      </TableCell>
+                      <TableCell>
+                        {spender.nanoLimitedBySpendGuard ? (
+                          <Badge variant="red">Yes</Badge>
+                        ) : (
+                          <Badge variant="green">No</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCost(spender.cost)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No usage cost recorded in the past 7 days.
+              </p>
+            )}
+
+            <section className="space-y-3">
+              <div>
+                <h3 className="font-medium text-sm">Spend by Model</h3>
+                <p className="text-muted-foreground text-sm">
+                  Platform spend from Tinybird AI call analytics.
+                </p>
+              </div>
+
+              {modelSpend.length ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-16">Rank</TableHead>
+                      <TableHead>Provider</TableHead>
+                      <TableHead>Model</TableHead>
+                      <TableHead className="text-right">Calls</TableHead>
+                      <TableHead className="text-right">Cost</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {modelSpend.map((model, index) => (
+                      <TableRow
+                        key={`${model.provider}:${model.model}:${index}`}
+                      >
+                        <TableCell>{index + 1}</TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {model.provider}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs sm:text-sm">
+                          {model.model}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {numberFormatter.format(model.calls)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatCost(model.cost)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No model spend recorded in Tinybird for this window.
+                </p>
+              )}
+            </section>
+          </div>
         </LoadingContent>
       </CardContent>
     </Card>
+  );
+}
+
+type ModelSpend = NonNullable<
+  NonNullable<GetAdminTopSpendersResponse["topSpenders"][number]>["modelSpend"]
+>;
+
+function ModelSpendList({ modelSpend }: { modelSpend: ModelSpend }) {
+  if (!modelSpend.length) {
+    return <span className="text-muted-foreground text-sm">-</span>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {modelSpend.map((model) => (
+        <div
+          className="flex max-w-72 justify-between gap-3 text-xs"
+          key={`${model.provider}:${model.model}`}
+        >
+          <span className="truncate font-mono">
+            {model.provider}/{model.model}
+          </span>
+          <span className="shrink-0 tabular-nums">
+            {formatCost(model.cost)}
+          </span>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -103,3 +188,5 @@ function formatCost(cost: number) {
 
   return currencyFormatter.format(cost);
 }
+
+const numberFormatter = new Intl.NumberFormat("en-US");

--- a/apps/web/app/api/admin/top-spenders/route.test.ts
+++ b/apps/web/app/api/admin/top-spenders/route.test.ts
@@ -1,7 +1,10 @@
 import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
+import {
+  getTopWeeklyUsageCosts,
+  getWeeklyUsageCostWindow,
+} from "@/utils/redis/usage";
 import {
   getAdminAiModelSpendByPeriod,
   getAdminAiUserModelSpendByPeriod,
@@ -17,6 +20,7 @@ vi.mock("@/utils/middleware", async () => {
 });
 vi.mock("@/utils/redis/usage", () => ({
   getTopWeeklyUsageCosts: vi.fn(),
+  getWeeklyUsageCostWindow: vi.fn(),
 }));
 vi.mock("@inboxzero/tinybird-ai-analytics", () => ({
   getAdminAiModelSpendByPeriod: vi.fn(),
@@ -47,6 +51,10 @@ describe("GET /api/admin/top-spenders", () => {
     vi.mocked(getTopWeeklyUsageCosts).mockResolvedValue([
       { email: "account@example.com", cost: 3 },
     ]);
+    vi.mocked(getWeeklyUsageCostWindow).mockReturnValue({
+      startTimestampMs: Date.UTC(2026, 1, 18),
+      endTimestampMs: Date.UTC(2026, 1, 25),
+    });
     vi.mocked(getAdminAiModelSpendByPeriod).mockResolvedValue([
       {
         provider: "openrouter",
@@ -91,6 +99,9 @@ describe("GET /api/admin/top-spenders", () => {
       where: { email: { in: ["account@example.com"] } },
       select: { id: true, email: true, userId: true },
     });
+    expect(getWeeklyUsageCostWindow).toHaveBeenCalledWith(
+      new Date("2026-02-24T15:30:00.000Z"),
+    );
     expect(getAdminAiModelSpendByPeriod).toHaveBeenCalledWith({
       startTimestampMs: Date.UTC(2026, 1, 18),
       endTimestampMs: Date.UTC(2026, 1, 25),

--- a/apps/web/app/api/admin/top-spenders/route.test.ts
+++ b/apps/web/app/api/admin/top-spenders/route.test.ts
@@ -1,7 +1,11 @@
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
+import {
+  getAdminAiModelSpendByPeriod,
+  getAdminAiUserModelSpendByPeriod,
+} from "@inboxzero/tinybird-ai-analytics";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/middleware", async () => {
@@ -13,6 +17,10 @@ vi.mock("@/utils/middleware", async () => {
 });
 vi.mock("@/utils/redis/usage", () => ({
   getTopWeeklyUsageCosts: vi.fn(),
+}));
+vi.mock("@inboxzero/tinybird-ai-analytics", () => ({
+  getAdminAiModelSpendByPeriod: vi.fn(),
+  getAdminAiUserModelSpendByPeriod: vi.fn(),
 }));
 vi.mock("@/env", () => ({
   env: {
@@ -28,9 +36,33 @@ describe("GET /api/admin/top-spenders", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("maps legacy email-keyed weekly spend to the owning user", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-24T15:30:00.000Z"));
+
     vi.mocked(getTopWeeklyUsageCosts).mockResolvedValue([
       { email: "account@example.com", cost: 3 },
+    ]);
+    vi.mocked(getAdminAiModelSpendByPeriod).mockResolvedValue([
+      {
+        provider: "openrouter",
+        model: "openai/example-model",
+        cost: 2.5,
+        calls: 10,
+      },
+    ]);
+    vi.mocked(getAdminAiUserModelSpendByPeriod).mockResolvedValue([
+      {
+        userId: "user-1",
+        provider: "openrouter",
+        model: "openai/example-model",
+        cost: 1.25,
+        calls: 5,
+      },
     ]);
     prisma.emailAccount.findMany.mockResolvedValue([
       {
@@ -59,13 +91,41 @@ describe("GET /api/admin/top-spenders", () => {
       where: { email: { in: ["account@example.com"] } },
       select: { id: true, email: true, userId: true },
     });
+    expect(getAdminAiModelSpendByPeriod).toHaveBeenCalledWith({
+      startTimestampMs: Date.UTC(2026, 1, 18),
+      endTimestampMs: Date.UTC(2026, 1, 25),
+      limit: 25,
+    });
+    expect(getAdminAiUserModelSpendByPeriod).toHaveBeenCalledWith({
+      userIds: ["user-1"],
+      startTimestampMs: Date.UTC(2026, 1, 18),
+      endTimestampMs: Date.UTC(2026, 1, 25),
+      perUserLimit: 3,
+    });
     expect(data.topSpenders).toEqual([
       {
         email: "account@example.com",
         cost: 3,
         emailAccountId: "email-account-1",
         userEmailAccountCount: 1,
+        modelSpend: [
+          {
+            userId: "user-1",
+            provider: "openrouter",
+            model: "openai/example-model",
+            cost: 1.25,
+            calls: 5,
+          },
+        ],
         nanoLimitedBySpendGuard: true,
+      },
+    ]);
+    expect(data.modelSpend).toEqual([
+      {
+        provider: "openrouter",
+        model: "openai/example-model",
+        cost: 2.5,
+        calls: 10,
       },
     ]);
   });

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { env } from "@/env";
 import prisma from "@/utils/prisma";
 import { withAdmin } from "@/utils/middleware";
-import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
+import {
+  getTopWeeklyUsageCosts,
+  getWeeklyUsageCostWindow,
+} from "@/utils/redis/usage";
 import { createScopedLogger } from "@/utils/logger";
 import {
   getAdminAiModelSpendByPeriod,
@@ -12,7 +15,6 @@ import {
 export type GetAdminTopSpendersResponse = Awaited<ReturnType<typeof getData>>;
 
 const logger = createScopedLogger("admin/top-spenders");
-const SPEND_WINDOW_DAYS = 7;
 const TOP_SPENDER_LIMIT = 25;
 const MODEL_SPEND_LIMIT = 25;
 const USER_MODEL_SPEND_LIMIT = 3;
@@ -24,7 +26,7 @@ export const GET = withAdmin("admin/top-spenders", async () => {
 
 async function getData() {
   const now = new Date();
-  const { startTimestampMs, endTimestampMs } = getSpendWindow(now);
+  const { startTimestampMs, endTimestampMs } = getWeeklyUsageCostWindow(now);
   const [topSpenders, modelSpend] = await Promise.all([
     getTopWeeklyUsageCosts({ limit: TOP_SPENDER_LIMIT, now }),
     getModelSpend({ startTimestampMs, endTimestampMs }),
@@ -149,20 +151,4 @@ function groupUserModelSpendByUserId<T extends { userId: string }>(
   }
 
   return userModelSpendByUserId;
-}
-
-function getSpendWindow(now: Date) {
-  const start = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  start.setUTCDate(start.getUTCDate() - (SPEND_WINDOW_DAYS - 1));
-
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
-  );
-
-  return {
-    startTimestampMs: start.getTime(),
-    endTimestampMs: end.getTime(),
-  };
 }

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -13,6 +13,7 @@ export type GetAdminTopSpendersResponse = Awaited<ReturnType<typeof getData>>;
 
 const logger = createScopedLogger("admin/top-spenders");
 const SPEND_WINDOW_DAYS = 7;
+const TOP_SPENDER_LIMIT = 25;
 const MODEL_SPEND_LIMIT = 25;
 const USER_MODEL_SPEND_LIMIT = 3;
 
@@ -25,7 +26,7 @@ async function getData() {
   const now = new Date();
   const { startTimestampMs, endTimestampMs } = getSpendWindow(now);
   const [topSpenders, modelSpend] = await Promise.all([
-    getTopWeeklyUsageCosts({ limit: 25, now }),
+    getTopWeeklyUsageCosts({ limit: TOP_SPENDER_LIMIT, now }),
     getModelSpend({ startTimestampMs, endTimestampMs }),
   ]);
 
@@ -71,12 +72,7 @@ async function getData() {
     startTimestampMs,
     endTimestampMs,
   });
-  const userModelSpendByUserId = new Map<string, typeof userModelSpend>();
-  for (const spend of userModelSpend) {
-    const current = userModelSpendByUserId.get(spend.userId) ?? [];
-    current.push(spend);
-    userModelSpendByUserId.set(spend.userId, current);
-  }
+  const userModelSpendByUserId = groupUserModelSpendByUserId(userModelSpend);
 
   const nanoWeeklySpendLimitUsd = env.AI_NANO_WEEKLY_SPEND_LIMIT_USD ?? null;
   const nanoModelConfigured = !!env.NANO_LLMS;
@@ -125,22 +121,6 @@ async function getModelSpend(options: {
   }
 }
 
-function getSpendWindow(now: Date) {
-  const start = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  start.setUTCDate(start.getUTCDate() - (SPEND_WINDOW_DAYS - 1));
-
-  const end = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
-  );
-
-  return {
-    startTimestampMs: start.getTime(),
-    endTimestampMs: end.getTime(),
-  };
-}
-
 async function getUserModelSpend(options: {
   userIds: string[];
   startTimestampMs: number;
@@ -155,4 +135,34 @@ async function getUserModelSpend(options: {
     logger.error("Failed to load admin user model spend", { error });
     return [];
   }
+}
+
+function groupUserModelSpendByUserId<T extends { userId: string }>(
+  userModelSpend: T[],
+) {
+  const userModelSpendByUserId = new Map<string, T[]>();
+
+  for (const spend of userModelSpend) {
+    const current = userModelSpendByUserId.get(spend.userId) ?? [];
+    current.push(spend);
+    userModelSpendByUserId.set(spend.userId, current);
+  }
+
+  return userModelSpendByUserId;
+}
+
+function getSpendWindow(now: Date) {
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  start.setUTCDate(start.getUTCDate() - (SPEND_WINDOW_DAYS - 1));
+
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  );
+
+  return {
+    startTimestampMs: start.getTime(),
+    endTimestampMs: end.getTime(),
+  };
 }

--- a/apps/web/app/api/admin/top-spenders/route.ts
+++ b/apps/web/app/api/admin/top-spenders/route.ts
@@ -3,8 +3,18 @@ import { env } from "@/env";
 import prisma from "@/utils/prisma";
 import { withAdmin } from "@/utils/middleware";
 import { getTopWeeklyUsageCosts } from "@/utils/redis/usage";
+import { createScopedLogger } from "@/utils/logger";
+import {
+  getAdminAiModelSpendByPeriod,
+  getAdminAiUserModelSpendByPeriod,
+} from "@inboxzero/tinybird-ai-analytics";
 
 export type GetAdminTopSpendersResponse = Awaited<ReturnType<typeof getData>>;
+
+const logger = createScopedLogger("admin/top-spenders");
+const SPEND_WINDOW_DAYS = 7;
+const MODEL_SPEND_LIMIT = 25;
+const USER_MODEL_SPEND_LIMIT = 3;
 
 export const GET = withAdmin("admin/top-spenders", async () => {
   const result = await getData();
@@ -12,8 +22,12 @@ export const GET = withAdmin("admin/top-spenders", async () => {
 });
 
 async function getData() {
-  const topSpenders = await getTopWeeklyUsageCosts({ limit: 25 });
-  if (!topSpenders.length) return { topSpenders: [] };
+  const now = new Date();
+  const { startTimestampMs, endTimestampMs } = getSpendWindow(now);
+  const [topSpenders, modelSpend] = await Promise.all([
+    getTopWeeklyUsageCosts({ limit: 25, now }),
+    getModelSpend({ startTimestampMs, endTimestampMs }),
+  ]);
 
   const emails = topSpenders.flatMap((spender) =>
     "email" in spender ? [spender.email] : [],
@@ -52,6 +66,17 @@ async function getData() {
     emailAccounts.map((account) => [account.email, account]),
   );
   const usersById = new Map(users.map((user) => [user.id, user]));
+  const userModelSpend = await getUserModelSpend({
+    userIds,
+    startTimestampMs,
+    endTimestampMs,
+  });
+  const userModelSpendByUserId = new Map<string, typeof userModelSpend>();
+  for (const spend of userModelSpend) {
+    const current = userModelSpendByUserId.get(spend.userId) ?? [];
+    current.push(spend);
+    userModelSpendByUserId.set(spend.userId, current);
+  }
 
   const nanoWeeklySpendLimitUsd = env.AI_NANO_WEEKLY_SPEND_LIMIT_USD ?? null;
   const nanoModelConfigured = !!env.NANO_LLMS;
@@ -73,6 +98,7 @@ async function getData() {
         email: "email" in spender ? spender.email : (user?.email ?? null),
         emailAccountId: primaryEmailAccount?.id ?? null,
         userEmailAccountCount: user?.emailAccounts.length ?? 0,
+        modelSpend: userId ? (userModelSpendByUserId.get(userId) ?? []) : [],
         nanoLimitedBySpendGuard:
           nanoLimiterEnabled &&
           nanoWeeklySpendLimitUsd !== null &&
@@ -80,5 +106,53 @@ async function getData() {
           spender.cost >= nanoWeeklySpendLimitUsd,
       };
     }),
+    modelSpend,
   };
+}
+
+async function getModelSpend(options: {
+  startTimestampMs: number;
+  endTimestampMs: number;
+}) {
+  try {
+    return await getAdminAiModelSpendByPeriod({
+      ...options,
+      limit: MODEL_SPEND_LIMIT,
+    });
+  } catch (error) {
+    logger.error("Failed to load admin model spend", { error });
+    return [];
+  }
+}
+
+function getSpendWindow(now: Date) {
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  start.setUTCDate(start.getUTCDate() - (SPEND_WINDOW_DAYS - 1));
+
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  );
+
+  return {
+    startTimestampMs: start.getTime(),
+    endTimestampMs: end.getTime(),
+  };
+}
+
+async function getUserModelSpend(options: {
+  userIds: string[];
+  startTimestampMs: number;
+  endTimestampMs: number;
+}) {
+  try {
+    return await getAdminAiUserModelSpendByPeriod({
+      ...options,
+      perUserLimit: USER_MODEL_SPEND_LIMIT,
+    });
+  } catch (error) {
+    logger.error("Failed to load admin user model spend", { error });
+    return [];
+  }
 }

--- a/apps/web/utils/redis/usage.test.ts
+++ b/apps/web/utils/redis/usage.test.ts
@@ -3,6 +3,7 @@ import { redis } from "@/utils/redis";
 import {
   getTopWeeklyUsageCosts,
   getUsage,
+  getWeeklyUsageCostWindow,
   getWeeklyUsageCost,
   saveUsage,
 } from "@/utils/redis/usage";
@@ -386,6 +387,13 @@ describe("redis usage tracking", () => {
     expect(redis.hgetall).not.toHaveBeenCalledWith(
       "usage-weekly-cost:user:user-3:2026-02-10",
     );
+  });
+
+  it("returns the UTC day window used by weekly usage costs", () => {
+    expect(getWeeklyUsageCostWindow(NOW)).toEqual({
+      startTimestampMs: Date.UTC(2026, 1, 18),
+      endTimestampMs: Date.UTC(2026, 1, 25),
+    });
   });
 
   it("returns legacy weekly spenders before they have been migrated", async () => {

--- a/apps/web/utils/redis/usage.ts
+++ b/apps/web/utils/redis/usage.ts
@@ -425,6 +425,24 @@ export async function getTopWeeklyUsageCosts({
     .slice(0, limit);
 }
 
+export function getWeeklyUsageCostWindow(now: Date) {
+  const days = getWeeklyUsageCostDays(now);
+  const latestDay = days[0];
+  const earliestDay = days.at(-1);
+
+  if (!latestDay || !earliestDay) {
+    return { startTimestampMs: 0, endTimestampMs: 0 };
+  }
+
+  const end = new Date(`${latestDay}T00:00:00.000Z`);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  return {
+    startTimestampMs: new Date(`${earliestDay}T00:00:00.000Z`).getTime(),
+    endTimestampMs: end.getTime(),
+  };
+}
+
 function getUsageIncrementOperations(
   key: string,
   usage: LanguageModelUsage,

--- a/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
@@ -12,7 +12,7 @@ SQL >
       AND timestamp < {{ Int64(endTimestampMs) }}
       AND cost > 0
     GROUP BY provider, model
-    ORDER BY cost DESC
+    ORDER BY cost DESC, calls DESC, provider ASC, model ASC
     LIMIT {{ Int32(limit) }}
 
 TYPE endpoint

--- a/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
@@ -1,0 +1,18 @@
+NODE admin_ai_model_spend_by_period
+SQL >
+  %
+    SELECT
+      provider,
+      model,
+      sum(cost) AS cost,
+      count() AS calls
+    FROM aiCall
+    WHERE
+      timestamp >= {{ Int64(startTimestampMs) }}
+      AND timestamp < {{ Int64(endTimestampMs) }}
+      AND cost > 0
+    GROUP BY provider, model
+    ORDER BY cost DESC
+    LIMIT {{ Int32(limit) }}
+
+TYPE endpoint

--- a/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
@@ -1,0 +1,39 @@
+NODE admin_ai_user_model_spend_by_period
+SQL >
+  %
+    SELECT
+      userId,
+      provider,
+      model,
+      cost,
+      calls
+    FROM (
+      SELECT
+        userId,
+        provider,
+        model,
+        cost,
+        calls,
+        row_number() OVER (PARTITION BY userId ORDER BY cost DESC) AS modelRank
+      FROM (
+        SELECT
+          userId,
+          provider,
+          model,
+          sum(cost) AS cost,
+          count() AS calls
+        FROM aiCall
+        WHERE
+          userId IN (
+            SELECT arrayJoin(splitByChar(',', {{ String(userIdsCsv) }}))
+          )
+          AND timestamp >= {{ Int64(startTimestampMs) }}
+          AND timestamp < {{ Int64(endTimestampMs) }}
+          AND cost > 0
+        GROUP BY userId, provider, model
+      )
+    )
+    WHERE modelRank <= {{ Int32(perUserLimit) }}
+    ORDER BY userId, cost DESC
+
+TYPE endpoint

--- a/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
@@ -14,7 +14,10 @@ SQL >
         model,
         cost,
         calls,
-        row_number() OVER (PARTITION BY userId ORDER BY cost DESC) AS modelRank
+        row_number() OVER (
+          PARTITION BY userId
+          ORDER BY cost DESC, calls DESC, provider ASC, model ASC
+        ) AS modelRank
       FROM (
         SELECT
           userId,
@@ -34,6 +37,6 @@ SQL >
       )
     )
     WHERE modelRank <= {{ Int32(perUserLimit) }}
-    ORDER BY userId, cost DESC
+    ORDER BY userId ASC, cost DESC, calls DESC, provider ASC, model ASC
 
 TYPE endpoint

--- a/packages/tinybird-ai-analytics/src/query.ts
+++ b/packages/tinybird-ai-analytics/src/query.ts
@@ -5,6 +5,17 @@ const aiGenerationCountSchema = z.object({
   count: z.number(),
 });
 
+const adminAiModelSpendSchema = z.object({
+  provider: z.string(),
+  model: z.string(),
+  cost: z.number(),
+  calls: z.number().int(),
+});
+
+const adminAiUserModelSpendSchema = adminAiModelSpendSchema.extend({
+  userId: z.string(),
+});
+
 const tb = getTinybird();
 
 const getAiGenerationsByAccountsAndPeriod = tb
@@ -16,6 +27,31 @@ const getAiGenerationsByAccountsAndPeriod = tb
         endTimestampMs: z.number().int(),
       }),
       data: aiGenerationCountSchema,
+    })
+  : null;
+
+const getAdminAiModelSpendByPeriodPipe = tb
+  ? tb.buildPipe({
+      pipe: "admin_ai_model_spend_by_period",
+      parameters: z.object({
+        startTimestampMs: z.number().int(),
+        endTimestampMs: z.number().int(),
+        limit: z.number().int(),
+      }),
+      data: adminAiModelSpendSchema,
+    })
+  : null;
+
+const getAdminAiUserModelSpendByPeriodPipe = tb
+  ? tb.buildPipe({
+      pipe: "admin_ai_user_model_spend_by_period",
+      parameters: z.object({
+        userIdsCsv: z.string().min(1),
+        startTimestampMs: z.number().int(),
+        endTimestampMs: z.number().int(),
+        perUserLimit: z.number().int(),
+      }),
+      data: adminAiUserModelSpendSchema,
     })
   : null;
 
@@ -37,4 +73,37 @@ export async function getAiGenerationCountByEmailAccounts(options: {
   });
 
   return result.data.at(0)?.count ?? 0;
+}
+
+export async function getAdminAiModelSpendByPeriod(options: {
+  startTimestampMs: number;
+  endTimestampMs: number;
+  limit: number;
+}) {
+  if (!getAdminAiModelSpendByPeriodPipe) return [];
+
+  const result = await getAdminAiModelSpendByPeriodPipe(options);
+  return result.data;
+}
+
+export async function getAdminAiUserModelSpendByPeriod(options: {
+  userIds: string[];
+  startTimestampMs: number;
+  endTimestampMs: number;
+  perUserLimit: number;
+}) {
+  const { userIds, startTimestampMs, endTimestampMs, perUserLimit } = options;
+
+  if (!getAdminAiUserModelSpendByPeriodPipe || userIds.length === 0) {
+    return [];
+  }
+
+  return (
+    await getAdminAiUserModelSpendByPeriodPipe({
+      userIdsCsv: userIds.join(","),
+      startTimestampMs,
+      endTimestampMs,
+      perUserLimit,
+    })
+  ).data;
 }


### PR DESCRIPTION
Adds admin model spend breakdowns using analytics alongside the existing top spender data.

- Adds analytics query helpers and pipe definitions for model spend.
- Shows aggregate model spend and top models for each top user in the admin view.
- Keeps the admin route resilient when analytics queries are unavailable and covers the UTC spend window in tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

