### PR TITLE
analytics: Fix admin spend pipes

### DIFF
--- a/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_model_spend_by_period.pipe
@@ -1,4 +1,4 @@
-NODE admin_ai_model_spend_by_period
+NODE model_spend_by_period
 SQL >
   %
     SELECT
@@ -6,11 +6,11 @@ SQL >
       model,
       sum(cost) AS cost,
       count() AS calls
-    FROM aiCall
+    FROM aiCall AS ai_call
     WHERE
       timestamp >= {{ Int64(startTimestampMs) }}
       AND timestamp < {{ Int64(endTimestampMs) }}
-      AND cost > 0
+      AND ai_call.cost > 0
     GROUP BY provider, model
     ORDER BY cost DESC, calls DESC, provider ASC, model ASC
     LIMIT {{ Int32(limit) }}

--- a/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
+++ b/packages/tinybird-ai-analytics/pipes/admin_ai_user_model_spend_by_period.pipe
@@ -1,4 +1,4 @@
-NODE admin_ai_user_model_spend_by_period
+NODE user_model_spend_by_period
 SQL >
   %
     SELECT
@@ -25,14 +25,14 @@ SQL >
           model,
           sum(cost) AS cost,
           count() AS calls
-        FROM aiCall
+        FROM aiCall AS ai_call
         WHERE
           userId IN (
             SELECT arrayJoin(splitByChar(',', {{ String(userIdsCsv) }}))
           )
           AND timestamp >= {{ Int64(startTimestampMs) }}
           AND timestamp < {{ Int64(endTimestampMs) }}
-          AND cost > 0
+          AND ai_call.cost > 0
         GROUP BY userId, provider, model
       )
     )


### PR DESCRIPTION
Fixes the analytics pipe definitions used by the admin spend breakdown.

- Uses internal node names that Tinybird accepts for endpoint pipes.
- Qualifies the source cost column to avoid aggregate alias conflicts.
- Keeps the public pipe names unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

