### PR TITLE
admin: Shorten spend section copy

### DIFF
--- a/apps/web/app/(app)/admin/AdminTopSpenders.tsx
+++ b/apps/web/app/(app)/admin/AdminTopSpenders.tsx
@@ -39,9 +39,8 @@ export function AdminTopSpenders() {
       <CardHeader>
         <CardTitle>Top Spenders</CardTitle>
         <CardDescription>
-          Last 7 days (same window as spend limiter). Nano-Limited shows who is
-          currently forced onto nano via the Redis spend guard. User Accounts
-          shows how many current email accounts that user has connected.
+          Last 7 days. Nano-Limited comes from Redis; User Accounts is connected
+          email accounts.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -106,7 +105,7 @@ export function AdminTopSpenders() {
               <div>
                 <h3 className="font-medium text-sm">Spend by Model</h3>
                 <p className="text-muted-foreground text-sm">
-                  Platform spend from Tinybird AI call analytics.
+                  Tinybird platform spend.
                 </p>
               </div>
 


### PR DESCRIPTION
Shortens the helper copy in the admin spend section.

- Reduces the top-spenders description.
- Simplifies the spend-by-model subtitle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

