### PR TITLE
assistant: Refine prompt guidance

### DIFF
--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -730,8 +730,6 @@ export function buildResolvedSystemPrompt({
 - For new rules, generate concise names. For edits or removals, fetch existing rules first and use exact names.
 - Prefer updating an existing rule over creating an overlapping duplicate. Do not create semantic duplicates like "Notification" and "Notifications".
 - For direct requests to change an existing rule's behavior, read rules then use the relevant rule update tool. Do not ask for another confirmation unless multiple rules are similar or required data is missing.
-- For enable, disable, pause, or resume requests, call updateRule with only updates.enabled. Do not include copied name, condition, or actions fields.
-- For delete requests, call getUserRulesAndSettings first, then call deleteRule exactly once with the exact rule name. Do not disable the same rule after requesting deletion.
 - If multiple fetched rules are similar, ask the user which one to update instead of guessing.
 - Use short concise rule names and real sender or domain values. Ask when required data is missing.
 - Rules can use {{variables}} in action fields to insert AI-generated content.`,

--- a/apps/web/utils/ai/assistant/tools/rules/delete-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/delete-rule-tool.ts
@@ -26,7 +26,7 @@ export const deleteRuleTool = ({
 }) =>
   tool({
     description:
-      "Request deletion of an existing custom rule after reading the user's current rules. First call getUserRulesAndSettings, then call this tool with the exact rule name from that result. Use updateRule with updates.enabled for enable, disable, pause, or resume. Delete requests return requiresConfirmation; explain that deletion is pending and no rule has been deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
+      "Request deletion of an existing custom rule after reading the user's current rules. Use this only with the exact rule name from getUserRulesAndSettings. Delete requests return requiresConfirmation; explain that deletion is pending and no rule has been deleted until the user confirms in the UI. Default/system rules cannot be deleted; disable them instead.",
     inputSchema: z.object({
       ruleName: z
         .string()
@@ -36,7 +36,6 @@ export const deleteRuleTool = ({
     }),
     execute: async ({ ruleName }) => {
       trackRuleToolCall({ tool: "delete_rule", email, logger });
-      markRuleDeletionPending?.(ruleName);
       try {
         const readValidationError = validateRuleWasReadRecently({
           ruleName,
@@ -92,6 +91,8 @@ export const deleteRuleTool = ({
             systemType: rule.systemType,
           };
         }
+
+        markRuleDeletionPending?.(rule.name);
 
         return {
           success: true,

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -46,7 +46,7 @@ export const updateRuleTool = ({
 }) =>
   tool({
     description:
-      "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: only fields included in updates are changed, and omitted fields are preserved. Include only the fields being changed; do not copy unchanged fields from the current rule into updates, even if you just read them. For enable, disable, pause, or resume requests, include only updates.enabled and omit name, condition, and actions. Use updates.name to rename a rule. Use updates.enabled to enable, disable, pause, or resume a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use updates.actions to replace the full action list; when changing actions, include every action that should remain. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
+      "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: include only the fields being changed, and omitted fields are preserved. Use updates.name to rename a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use updates.actions to replace the full action list; when changing actions, include every action that should remain. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
     inputSchema: z
       .object({
         ruleName: z.string().describe("The exact current name of the rule."),
@@ -62,7 +62,7 @@ export const updateRuleTool = ({
               .boolean()
               .optional()
               .describe(
-                "Whether the rule should be enabled. Use false for pause/disable, true for enable/resume. For enable-only or disable-only requests, this should be the only field in updates.",
+                "Whether the rule should be enabled. Use false for pause/disable, true for enable/resume. For enabled-state-only requests, this should be the only field in updates.",
               ),
             condition: createPatchConditionSchema().optional(),
             actions: z

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 18;
+export const DRAFT_PIPELINE_VERSION = 19;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -551,7 +551,7 @@ Do not suggest specific times. Acknowledge the request and suggest alternatives 
 
     parts.push(`Available time slots are in ${timezoneLabels}.
 If the sender requested or uses another timezone, express proposed times in that timezone after converting from the user's available slots.
-If you list specific times, include the user-facing timezone label shown for each slot. Do not write IANA Region/City timezone identifiers (the Continent/City form with a slash). Normal abbreviations such as EST, PST, IST, or GMT+3 are fine.
+If you list specific times, include the user-facing timezone label shown for each slot, not a raw timezone identifier.
 
 Available time slots:
 ${times}


### PR DESCRIPTION
Refines assistant rule-editing and draft-reply guidance to remove duplicate wording while preserving tool-local instructions.

Moves pending rule deletion tracking until after validation succeeds, so failed delete attempts do not block later valid updates.

Validation: pnpm install; rule-editing eval full run passed 9/10 with one transient provider error, the failed case passed on rerun; draft-reply eval passed 21/24 with timezone cases passing and unrelated grounding/confidence failures; app Vitest suite passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

