### PR TITLE
Fix provider token refresh handling

### DIFF
--- a/apps/web/utils/email/provider-health.test.ts
+++ b/apps/web/utils/email/provider-health.test.ts
@@ -50,6 +50,21 @@ describe("provider health", () => {
     });
   });
 
+  it("ignores invalid access token failures from provider operations", async () => {
+    const logger = createMockLogger();
+
+    await recordEmailAccountProviderIssue({
+      emailAccountId: "email-account-1",
+      provider: "google",
+      error: new Error("Invalid access token"),
+      logger,
+      operation: "getThreadsWithLabel",
+    });
+
+    expect(cleanupInvalidTokens).not.toHaveBeenCalled();
+    expect(claimProviderIssueCleanupInRedis).not.toHaveBeenCalled();
+  });
+
   it("records insufficient Gmail permissions as action-required issues", async () => {
     const logger = createMockLogger();
 

--- a/apps/web/utils/email/provider-health.ts
+++ b/apps/web/utils/email/provider-health.ts
@@ -108,11 +108,7 @@ export function classifyEmailAccountProviderIssue({
     return { reason: "mail_service_not_enabled" };
   }
 
-  if (
-    isInvalidGrantError(error) ||
-    message?.includes("No refresh token") ||
-    message?.includes("Invalid access token")
-  ) {
+  if (isInvalidGrantError(error) || message?.includes("No refresh token")) {
     return { reason: "invalid_grant" };
   }
 

--- a/apps/web/utils/gmail/client.test.ts
+++ b/apps/web/utils/gmail/client.test.ts
@@ -161,6 +161,47 @@ describe("gmail oauth client configuration", () => {
     );
   });
 
+  it("reuses Gmail tokens that expire beyond the refresh buffer", async () => {
+    await getGmailClientWithRefresh({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 11 * 60 * 1000,
+      emailAccountId: "email-account-id",
+      logger,
+    });
+
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(saveTokens).not.toHaveBeenCalled();
+  });
+
+  it("refreshes Gmail tokens before they expire", async () => {
+    const nearExpiryExpiresAt = Date.now() + 60 * 1000;
+    refreshAccessToken.mockResolvedValue({
+      credentials: {
+        access_token: "new-access-token",
+        expiry_date: Date.now() + 3_600_000,
+      },
+    });
+
+    await getGmailClientWithRefresh({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: nearExpiryExpiresAt,
+      emailAccountId: "email-account-id",
+      logger,
+    });
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(saveTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedExpiresAt: nearExpiryExpiresAt,
+        tokens: expect.objectContaining({
+          access_token: "new-access-token",
+        }),
+      }),
+    );
+  });
+
   it("cleans up invalid Gmail tokens when refresh reports invalid_grant", async () => {
     refreshAccessToken.mockRejectedValue(
       new Error("invalid_grant: token has been expired or revoked"),

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -19,6 +19,8 @@ type AuthOptions = {
   expiresAt?: number | null;
 };
 
+const TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000;
+
 const getAuth = ({
   accessToken,
   refreshToken,
@@ -70,7 +72,9 @@ export const getGmailClientWithRefresh = async ({
   const g = gmail({ version: "v1", auth, rootUrl: getGoogleGmailApiRootUrl() });
 
   const expiryDate = expiresAt ? expiresAt : null;
-  if (expiryDate && expiryDate > Date.now()) return g;
+  if (expiryDate && expiryDate > Date.now() + TOKEN_REFRESH_BUFFER_MS) {
+    return g;
+  }
 
   // may throw `invalid_grant` error
   try {


### PR DESCRIPTION
Prevents transient provider operation authentication failures from being treated as reconnect-required account issues and refreshes Gmail tokens before they are near expiry.

- Keeps confirmed token revocation and missing refresh-token handling unchanged.
- Adds regression coverage for provider-operation invalid access token failures and near-expiry Gmail token refresh behavior.