### PR TITLE
chore: Add evaluation run script

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,5 +2,13 @@
 
 [scripts]
 setup = "pnpm install --prefer-offline --frozen-lockfile"
-run = "pnpm dev-setup dev --url conductor"
 archive = "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types scripts/dev-setup.ts clean"
+
+[scripts.run.dev]
+command = "pnpm dev-setup dev --url conductor"
+default = true
+icon = "play"
+
+[scripts.run.evals]
+command = "EVAL_MODELS=deepseek-v4-flash-azure EVAL_RESULT_CACHE=readwrite pnpm --filter inbox-zero-ai test-ai __tests__/eval"
+icon = "flask-conical"


### PR DESCRIPTION
Adds a secondary Conductor run script for eval execution while keeping the existing development run script as the default.

- Converts the run command to named Conductor run scripts
- Adds an eval command scoped to the existing Azure DeepSeek preset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

