### PR TITLE
Fix Microsoft calendar booking fallback

### DIFF
--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -63,10 +63,10 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(graphMocks.api).toHaveBeenCalledWith(
       "/me/calendars/calendar-id/events",
     );
-    expect(graphMocks.post).toHaveBeenCalledWith(
+    const createPayload = graphMocks.post.mock.calls[0]?.[0];
+    expect(createPayload).toEqual(
       expect.objectContaining({
         isOnlineMeeting: true,
-        onlineMeetingProvider: "teamsForBusiness",
         location: undefined,
         start: {
           dateTime: "2026-05-04T09:00:00.0000000",
@@ -78,6 +78,7 @@ describe("MicrosoftCalendarEventProvider", () => {
         },
       }),
     );
+    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
     expect(result).toEqual({
       id: "event-id",
       providerCalendarId: "calendar-id",
@@ -112,12 +113,11 @@ describe("MicrosoftCalendarEventProvider", () => {
       title: "Intro call",
     });
 
-    expect(graphMocks.post).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isOnlineMeeting: true,
-        onlineMeetingProvider: undefined,
-      }),
+    const createPayload = graphMocks.post.mock.calls[0]?.[0];
+    expect(createPayload).toEqual(
+      expect.objectContaining({ isOnlineMeeting: true }),
     );
+    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
   });
 
   it("refetches the event when Graph initializes the Teams join URL asynchronously", async () => {
@@ -212,38 +212,47 @@ describe("MicrosoftCalendarEventProvider", () => {
     expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id");
     expect(graphMocks.patch).toHaveBeenCalledWith({
       isOnlineMeeting: true,
-      onlineMeetingProvider: "teamsForBusiness",
     });
     expect(result.videoConferenceLink).toBe("https://teams.example.com/join");
   });
 
-  it("rejects Teams events when the destination calendar does not support Teams", async () => {
+  it("creates a regular event when the destination calendar does not support Teams", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
       allowedOnlineMeetingProviders: ["skypeForBusiness"],
       defaultOnlineMeetingProvider: "skypeForBusiness",
     });
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      webLink: "https://outlook.example.com/event",
+    });
 
     const provider = createProvider();
 
-    await expect(
-      provider.createEvent({
-        attendees: [{ email: "guest@example.com", name: "Guest User" }],
-        calendarId: "calendar-id",
-        description: "Meeting description",
-        endTime: new Date("2026-05-04T09:30:00.000Z"),
-        locationType: "MICROSOFT_TEAMS",
-        locationValue: null,
-        startTime: new Date("2026-05-04T09:00:00.000Z"),
-        timezone: "America/New_York",
-        title: "Intro call",
-      }),
-    ).rejects.toThrow("Microsoft Teams meetings are not supported");
+    const result = await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
 
-    expect(graphMocks.post).not.toHaveBeenCalled();
+    const createPayload = graphMocks.post.mock.calls[0]?.[0];
+    expect(createPayload).not.toHaveProperty("isOnlineMeeting");
+    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
+    expect(result).toEqual({
+      id: "event-id",
+      providerCalendarId: "calendar-id",
+      eventUrl: "https://outlook.example.com/event",
+      videoConferenceLink: undefined,
+    });
   });
 
-  it("rejects Teams events when Graph creates the event without a Teams link", async () => {
+  it("keeps the Outlook event when Graph creates it without a Teams link", async () => {
     vi.useFakeTimers();
     try {
       graphMocks.get
@@ -288,13 +297,17 @@ describe("MicrosoftCalendarEventProvider", () => {
         title: "Intro call",
       });
 
-      const assertion = expect(promise).rejects.toThrow(
-        "Microsoft Teams meeting link was not generated",
-      );
+      const assertion = expect(promise).resolves.toEqual({
+        id: "event-id",
+        providerCalendarId: "calendar-id",
+        eventUrl: "https://outlook.example.com/event",
+        videoConferenceLink: undefined,
+      });
       await vi.runAllTimersAsync();
       await assertion;
-      expect(graphMocks.api).toHaveBeenCalledWith("/me/events/event-id/cancel");
-      expect(graphMocks.post).toHaveBeenCalledWith({ comment: "" });
+      expect(graphMocks.api).not.toHaveBeenCalledWith(
+        "/me/events/event-id/cancel",
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -34,7 +34,7 @@ describe("MicrosoftCalendarEventProvider", () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",
       allowedOnlineMeetingProviders: ["teamsForBusiness"],
-      defaultOnlineMeetingProvider: "skypeForBusiness",
+      defaultOnlineMeetingProvider: "teamsForBusiness",
     });
     graphMocks.post.mockResolvedValue({
       id: "event-id",
@@ -127,7 +127,7 @@ describe("MicrosoftCalendarEventProvider", () => {
       .mockResolvedValueOnce({
         id: "calendar-id",
         allowedOnlineMeetingProviders: ["teamsForBusiness"],
-        defaultOnlineMeetingProvider: "skypeForBusiness",
+        defaultOnlineMeetingProvider: "teamsForBusiness",
       })
       .mockResolvedValueOnce({
         id: "event-id",
@@ -171,7 +171,7 @@ describe("MicrosoftCalendarEventProvider", () => {
       .mockResolvedValueOnce({
         id: "calendar-id",
         allowedOnlineMeetingProviders: ["teamsForBusiness"],
-        defaultOnlineMeetingProvider: "skypeForBusiness",
+        defaultOnlineMeetingProvider: "teamsForBusiness",
       })
       .mockResolvedValueOnce({
         id: "event-id",
@@ -252,6 +252,44 @@ describe("MicrosoftCalendarEventProvider", () => {
     });
   });
 
+  it("creates a regular event when Teams is not the calendar default", async () => {
+    graphMocks.get.mockResolvedValue({
+      id: "calendar-id",
+      allowedOnlineMeetingProviders: ["teamsForBusiness", "skypeForBusiness"],
+      defaultOnlineMeetingProvider: "skypeForBusiness",
+    });
+    graphMocks.post.mockResolvedValue({
+      id: "event-id",
+      webLink: "https://outlook.example.com/event",
+    });
+
+    const provider = createProvider();
+
+    const result = await provider.createEvent({
+      attendees: [{ email: "guest@example.com", name: "Guest User" }],
+      calendarId: "calendar-id",
+      description: "Meeting description",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "MICROSOFT_TEAMS",
+      locationValue: null,
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "America/New_York",
+      title: "Intro call",
+    });
+
+    const createPayload = graphMocks.post.mock.calls[0]?.[0];
+    expect(createPayload).not.toHaveProperty("isOnlineMeeting");
+    expect(createPayload).not.toHaveProperty("onlineMeetingProvider");
+    expect(graphMocks.api).not.toHaveBeenCalledWith("/me/events/event-id");
+    expect(graphMocks.patch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      id: "event-id",
+      providerCalendarId: "calendar-id",
+      eventUrl: "https://outlook.example.com/event",
+      videoConferenceLink: undefined,
+    });
+  });
+
   it("keeps the Outlook event when Graph creates it without a Teams link", async () => {
     vi.useFakeTimers();
     try {
@@ -259,7 +297,7 @@ describe("MicrosoftCalendarEventProvider", () => {
         .mockResolvedValueOnce({
           id: "calendar-id",
           allowedOnlineMeetingProviders: ["teamsForBusiness"],
-          defaultOnlineMeetingProvider: "skypeForBusiness",
+          defaultOnlineMeetingProvider: "teamsForBusiness",
         })
         .mockResolvedValue({
           id: "event-id",

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -311,6 +311,21 @@ async function getTeamsOnlineMeetingFields({
     return null;
   }
 
+  if (
+    settings?.defaultOnlineMeetingProvider &&
+    settings.defaultOnlineMeetingProvider !== MICROSOFT_TEAMS_PROVIDER
+  ) {
+    logger.warn(
+      "Microsoft Teams is not the default online meeting provider for calendar",
+      {
+        calendarId,
+        allowedOnlineMeetingProviders: settings.allowedOnlineMeetingProviders,
+        defaultOnlineMeetingProvider: settings.defaultOnlineMeetingProvider,
+      },
+    );
+    return null;
+  }
+
   // Graph can ignore explicit teamsForBusiness on some Outlook calendars and
   // create a regular event instead, so let the calendar's online provider
   // settings drive Teams generation.

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -43,6 +43,10 @@ type MicrosoftCalendarOnlineMeetingSettings = {
   defaultOnlineMeetingProvider?: string;
 };
 
+type MicrosoftOnlineMeetingFields = {
+  isOnlineMeeting: true;
+};
+
 export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
   private readonly connection: MicrosoftCalendarConnectionParams;
   private readonly logger: Logger;
@@ -144,7 +148,8 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           client,
           logger: this.logger,
         })
-      : {};
+      : null;
+    const requestedMicrosoftTeams = Boolean(onlineMeetingFields);
     const response: MicrosoftEvent = await client
       .api(`/me/calendars/${input.calendarId}/events`)
       .post({
@@ -168,9 +173,9 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
           },
           type: "required",
         })),
-        ...onlineMeetingFields,
+        ...(onlineMeetingFields ?? {}),
         location:
-          !useMicrosoftTeams && input.locationValue
+          !requestedMicrosoftTeams && input.locationValue
             ? { displayName: input.locationValue }
             : undefined,
       });
@@ -180,7 +185,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
     // Graph initializes the Teams meeting after the event is created, so the
     // POST response sometimes returns before `onlineMeeting` is populated.
     // Refetch the event to retrieve the join URL when we asked for Teams.
-    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
       videoConferenceLink = await pollForTeamsJoinUrl({
         client,
         eventId: response.id,
@@ -188,13 +193,12 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       });
     }
 
-    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
       try {
         const patched: MicrosoftEvent = await client
           .api(`/me/events/${response.id}`)
           .patch({
             isOnlineMeeting: true,
-            onlineMeetingProvider: MICROSOFT_TEAMS_PROVIDER,
           });
         videoConferenceLink = getJoinUrl(patched);
       } catch (error) {
@@ -205,7 +209,7 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       }
     }
 
-    if (useMicrosoftTeams && !videoConferenceLink && response.id) {
+    if (requestedMicrosoftTeams && !videoConferenceLink && response.id) {
       videoConferenceLink = await pollForTeamsJoinUrl({
         client,
         eventId: response.id,
@@ -213,22 +217,12 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       });
     }
 
-    if (useMicrosoftTeams && !videoConferenceLink) {
+    if (requestedMicrosoftTeams && !videoConferenceLink) {
       this.logger.warn("Microsoft Teams link missing after event creation", {
         eventId: response.id,
         isOnlineMeeting: response.isOnlineMeeting,
         onlineMeetingProvider: response.onlineMeetingProvider,
       });
-
-      if (response.id) {
-        await cancelIncompleteMicrosoftEvent({
-          client,
-          eventId: response.id,
-          logger: this.logger,
-        });
-      }
-
-      throw new Error("Microsoft Teams meeting link was not generated");
     }
 
     return {
@@ -309,16 +303,18 @@ async function getTeamsOnlineMeetingFields({
     settings?.allowedOnlineMeetingProviders &&
     !settings.allowedOnlineMeetingProviders.includes(MICROSOFT_TEAMS_PROVIDER)
   ) {
-    throw new Error("Microsoft Teams meetings are not supported");
+    logger.warn("Microsoft Teams meetings are not supported for calendar", {
+      calendarId,
+      allowedOnlineMeetingProviders: settings.allowedOnlineMeetingProviders,
+      defaultOnlineMeetingProvider: settings.defaultOnlineMeetingProvider,
+    });
+    return null;
   }
 
-  return {
-    isOnlineMeeting: true,
-    onlineMeetingProvider:
-      settings?.defaultOnlineMeetingProvider === MICROSOFT_TEAMS_PROVIDER
-        ? undefined
-        : MICROSOFT_TEAMS_PROVIDER,
-  };
+  // Graph can ignore explicit teamsForBusiness on some Outlook calendars and
+  // create a regular event instead, so let the calendar's online provider
+  // settings drive Teams generation.
+  return { isOnlineMeeting: true } satisfies MicrosoftOnlineMeetingFields;
 }
 
 async function getCalendarOnlineMeetingSettings({
@@ -382,25 +378,6 @@ async function pollForTeamsJoinUrl({
   }
 
   return;
-}
-
-async function cancelIncompleteMicrosoftEvent({
-  client,
-  eventId,
-  logger,
-}: {
-  client: Client;
-  eventId: string;
-  logger: Logger;
-}) {
-  try {
-    await client.api(`/me/events/${eventId}/cancel`).post({ comment: "" });
-  } catch (error) {
-    logger.error("Failed to cancel Microsoft event without Teams link", {
-      eventId,
-      error,
-    });
-  }
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
Updates Microsoft calendar event creation so bookings keep the Outlook event when Teams link generation is unavailable instead of failing the booking flow. Teams-specific gaps are logged and the returned event may omit a video conference link.

- Stop sending explicit Teams provider fields and rely on calendar online meeting settings.
- Fall back to a regular Outlook event when Teams is unsupported or no join URL is generated.
- Updated focused Microsoft calendar provider tests.
- Test: `pnpm test utils/calendar/providers/microsoft-events.test.ts`.

Performance impact: No new database calls. Runtime work is unchanged for successful event creation; failed Teams-link paths keep existing Graph polling/patch attempts but no longer issue a cancel call, with low hot-path risk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

