### PR TITLE
Fix Outlook email cell actions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -414,6 +414,7 @@ function ProcessRulesRow({
               userEmail={userEmail}
               threadId={message.threadId}
               messageId={message.id}
+              externalUrl={message.externalUrl}
               labelIds={message.labelIds}
               collapseLabels={testMode}
             />

--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -123,6 +123,7 @@ export function EmailMessageCell({
               className="hover:text-foreground"
               href={emailActions.openUrl}
               target="_blank"
+              rel="noopener noreferrer"
               aria-label="Open in email"
             >
               <ExternalLinkIcon className="h-4 w-4" />

--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -2,7 +2,6 @@
 
 import { ExternalLinkIcon, MailIcon, TagsIcon } from "lucide-react";
 import Link from "next/link";
-import { getEmailUrlForMessage } from "@/utils/url";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { Tooltip } from "@/components/Tooltip";
 import { useDisplayedEmail } from "@/hooks/useDisplayedEmail";
@@ -13,8 +12,8 @@ import { Badge } from "@/components/ui/badge";
 import { useEmail } from "@/providers/EmailProvider";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { useMemo } from "react";
-import { isGoogleProvider } from "@/utils/email/provider-types";
 import { getEmailMessageCellLabels } from "@/components/EmailMessageCellLabels";
+import { getEmailMessageCellActions } from "@/components/EmailMessageCellActions";
 
 const MAX_VISIBLE_LABELS = 2;
 
@@ -26,6 +25,7 @@ export function EmailMessageCell({
   threadId,
   messageId,
   hideViewEmailButton,
+  externalUrl,
   labelIds,
   filterReplyTrackerLabels,
   collapseLabels,
@@ -37,6 +37,7 @@ export function EmailMessageCell({
   threadId: string;
   messageId: string;
   hideViewEmailButton?: boolean;
+  externalUrl?: string;
   labelIds?: string[];
   filterReplyTrackerLabels?: boolean;
   collapseLabels?: boolean;
@@ -56,7 +57,14 @@ export function EmailMessageCell({
     [labelIds, userLabels, filterReplyTrackerLabels, provider],
   );
 
-  const showIcons = !hideViewEmailButton && isGoogleProvider(provider);
+  const emailActions = getEmailMessageCellActions({
+    externalUrl,
+    hideViewEmailButton,
+    messageId,
+    provider,
+    threadId,
+    userEmail,
+  });
   const visibleLabels = labelsToDisplay?.slice(0, MAX_VISIBLE_LABELS) ?? [];
   const overflowLabels = labelsToDisplay?.slice(MAX_VISIBLE_LABELS) ?? [];
 
@@ -109,18 +117,13 @@ export function EmailMessageCell({
                 )}
               </div>
             )}
-        {showIcons && (
+        {emailActions && (
           <div className="order-2 ml-auto flex shrink-0 items-center gap-2 text-muted-foreground sm:order-4 sm:ml-0">
             <Link
               className="hover:text-foreground"
-              href={getEmailUrlForMessage(
-                messageId,
-                threadId,
-                userEmail,
-                provider,
-              )}
+              href={emailActions.openUrl}
               target="_blank"
-              aria-label="Open in Gmail"
+              aria-label="Open in email"
             >
               <ExternalLinkIcon className="h-4 w-4" />
             </Link>
@@ -182,6 +185,7 @@ export function EmailMessageCellWithData({
       }
       threadId={threadId}
       messageId={messageId}
+      externalUrl={firstMessage?.externalUrl}
       labelIds={firstMessage?.labelIds}
       hideViewEmailButton={emailNotFound || !!error}
     />

--- a/apps/web/components/EmailMessageCellActions.test.ts
+++ b/apps/web/components/EmailMessageCellActions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getEmailMessageCellActions } from "./EmailMessageCellActions";
+
+describe("getEmailMessageCellActions", () => {
+  it("shows Outlook actions and prefers the provider external URL", () => {
+    expect(
+      getEmailMessageCellActions({
+        externalUrl:
+          "https://outlook.office.com/mail/deeplink/read/outlook-message-1?ispopout=0",
+        messageId: "outlook-message-1",
+        provider: "microsoft",
+        threadId: "outlook-thread-1",
+        userEmail: "user@contoso.com",
+      }),
+    ).toEqual({
+      openUrl:
+        "https://outlook.office.com/mail/deeplink/read/outlook-message-1?ispopout=0",
+    });
+  });
+
+  it("falls back to the provider URL when Outlook has no external URL", () => {
+    expect(
+      getEmailMessageCellActions({
+        messageId: "outlook-message-1",
+        provider: "microsoft",
+        threadId: "outlook-thread-1",
+        userEmail: "user@contoso.com",
+      }),
+    ).toEqual({
+      openUrl: "https://outlook.office.com/mail/inbox/id/outlook-message-1",
+    });
+  });
+
+  it("hides actions when the email cell requests it", () => {
+    expect(
+      getEmailMessageCellActions({
+        hideViewEmailButton: true,
+        messageId: "message-1",
+        provider: "google",
+        threadId: "thread-1",
+        userEmail: "user@gmail.com",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/components/EmailMessageCellActions.ts
+++ b/apps/web/components/EmailMessageCellActions.ts
@@ -1,0 +1,27 @@
+import { getEmailUrlForMessage } from "@/utils/url";
+
+type GetEmailMessageCellActionsOptions = {
+  externalUrl?: string;
+  hideViewEmailButton?: boolean;
+  messageId: string;
+  provider?: string;
+  threadId: string;
+  userEmail?: string | null;
+};
+
+export function getEmailMessageCellActions({
+  externalUrl,
+  hideViewEmailButton,
+  messageId,
+  provider,
+  threadId,
+  userEmail,
+}: GetEmailMessageCellActionsOptions) {
+  if (hideViewEmailButton) return null;
+
+  return {
+    openUrl:
+      externalUrl ||
+      getEmailUrlForMessage(messageId, threadId, userEmail, provider),
+  };
+}

--- a/apps/web/components/EmailViewer.tsx
+++ b/apps/web/components/EmailViewer.tsx
@@ -9,7 +9,6 @@ import { LoadingContent } from "@/components/LoadingContent";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { isGoogleProvider } from "@/utils/email/provider-types";
-import { MutedText } from "@/components/Typography";
 
 export function EmailViewer() {
   const { provider } = useAccount();
@@ -18,6 +17,7 @@ export function EmailViewer() {
     useDisplayedEmail();
 
   const hideEmail = useCallback(() => showEmail(null), [showEmail]);
+  const supportsViewerReplies = isGoogleProvider(provider);
 
   return (
     <Sheet open={!!threadId} onOpenChange={hideEmail}>
@@ -27,18 +27,16 @@ export function EmailViewer() {
         className="overflow-y-auto bg-slate-100 p-0"
         overlay="transparent"
       >
-        {isGoogleProvider(provider) ? (
-          threadId && (
-            <ThreadContent
-              threadId={threadId}
-              showReplyButton={showReplyButton}
-              autoOpenReplyForMessageId={autoOpenReplyForMessageId ?? undefined}
-            />
-          )
-        ) : (
-          <div className="flex h-full items-center justify-center">
-            <MutedText>This feature isn't enabled for Outlook.</MutedText>
-          </div>
+        {threadId && (
+          <ThreadContent
+            threadId={threadId}
+            showReplyButton={supportsViewerReplies && showReplyButton}
+            autoOpenReplyForMessageId={
+              supportsViewerReplies
+                ? (autoOpenReplyForMessageId ?? undefined)
+                : undefined
+            }
+          />
         )}
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
Adds provider-aware email-cell actions so Outlook rows can expose the open-email action when an external URL is available. The email viewer now renders Outlook threads without reply controls instead of blocking the sheet.

- Passes provider external URLs into email message cells.
- Centralizes open-email URL selection with Outlook fallback coverage.
- Allows non-Google threads to render while keeping reply controls Google-only.
- Test: pnpm test components/EmailMessageCellActions.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

