### PR TITLE
auth: Handle linked email sign-in errors

### DIFF
--- a/apps/web/app/(landing)/login/error/page.tsx
+++ b/apps/web/app/(landing)/login/error/page.tsx
@@ -3,7 +3,10 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Suspense, useEffect } from "react";
-import { getRequiresReconsentDescription } from "@/app/(landing)/login/messages";
+import {
+  getEmailAlreadyLinkedDescription,
+  getRequiresReconsentDescription,
+} from "@/app/(landing)/login/messages";
 import { Button } from "@/components/ui/button";
 import { BasicLayout } from "@/components/layouts/BasicLayout";
 import { ErrorPage } from "@/components/ErrorPage";
@@ -13,7 +16,7 @@ import { Loading } from "@/components/Loading";
 import { WELCOME_PATH } from "@/utils/config";
 import { CrispChatLoggedOutVisible } from "@/components/CrispChat";
 import { getAndClearAuthErrorCookie } from "@/utils/auth-cookies";
-import { BRAND_NAME, SUPPORT_EMAIL } from "@/utils/branding";
+import { SUPPORT_EMAIL } from "@/utils/branding";
 
 const errorMessages: Record<string, { title: string; description: string }> = {
   email_not_found: {
@@ -28,7 +31,7 @@ const errorMessages: Record<string, { title: string; description: string }> = {
   },
   email_already_linked: {
     title: "Email Already Linked",
-    description: `This email address is already linked to another ${BRAND_NAME} account. Please sign in with the original account, or use a different email address.`,
+    description: getEmailAlreadyLinkedDescription(),
   },
   org_invite_invalid_code: {
     title: "Organization Invite Sign-in Failed",

--- a/apps/web/app/(landing)/login/messages.ts
+++ b/apps/web/app/(landing)/login/messages.ts
@@ -9,3 +9,13 @@ export function getRequiresReconsentDescription(options?: {
 
   return `${description} If this error persists please contact support at ${SUPPORT_EMAIL}`;
 }
+
+export function getEmailAlreadyLinkedDescription(options?: {
+  includeSupportText?: boolean;
+}) {
+  const description = `This mailbox is already connected to another ${BRAND_NAME} account. To use it, sign in with the original account that owns this mailbox, then reconnect the mailbox from Accounts if needed. If you can't access that account or believe this is a duplicate, contact support so we can help recover or merge the accounts.`;
+
+  if (!options?.includeSupportText) return description;
+
+  return `${description} You can use the support chat or email us at ${SUPPORT_EMAIL}.`;
+}

--- a/apps/web/app/(landing)/login/page.tsx
+++ b/apps/web/app/(landing)/login/page.tsx
@@ -3,7 +3,10 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { LoginForm } from "@/app/(landing)/login/LoginForm";
-import { getRequiresReconsentDescription } from "@/app/(landing)/login/messages";
+import {
+  getEmailAlreadyLinkedDescription,
+  getRequiresReconsentDescription,
+} from "@/app/(landing)/login/messages";
 import { env } from "@/env";
 import { auth } from "@/utils/auth";
 import { isGoogleOauthEmulationEnabled } from "@/utils/google/oauth";
@@ -166,7 +169,9 @@ function ErrorAlert({ error }: { error: string }) {
       <AlertBasic
         variant="destructive"
         title="Email Already Linked"
-        description={`This email address is already linked to another ${BRAND_NAME} account. Please sign in with the original account, or use a different email address. If this error persists please contact support at ${SUPPORT_EMAIL}`}
+        description={getEmailAlreadyLinkedDescription({
+          includeSupportText: true,
+        })}
       />
     );
   }

--- a/apps/web/utils/auth.test.ts
+++ b/apps/web/utils/auth.test.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { createReferral } from "@/utils/referral/referral-code";
 import { captureException } from "@/utils/error";
 import { saveTokens } from "@/utils/auth/save-tokens";
+import { createOutlookClient } from "@/utils/outlook/client";
 import {
   betterAuthConfig,
   handleLinkAccount,
@@ -11,14 +12,30 @@ import {
 import prisma from "@/utils/__mocks__/prisma";
 import { clearAccountDisconnectedErrorIfResolved } from "@/utils/error-messages";
 
-vi.mock("better-auth", () => ({
-  betterAuth: vi.fn((options: unknown) => ({
-    api: {
-      getSession: vi.fn(),
-    },
-    options,
-  })),
-}));
+vi.mock("better-auth", () => {
+  class APIError extends Error {
+    body?: { code?: string; message?: string };
+
+    constructor(_status: string, body?: { code?: string; message?: string }) {
+      super(body?.message);
+      this.body = body;
+    }
+
+    static from(status: string, body?: { code?: string; message?: string }) {
+      return new APIError(status, body);
+    }
+  }
+
+  return {
+    APIError,
+    betterAuth: vi.fn((options: unknown) => ({
+      api: {
+        getSession: vi.fn(),
+      },
+      options,
+    })),
+  };
+});
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/error-messages", () => ({
   addUserErrorMessage: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +51,9 @@ vi.mock("@googleapis/gmail", () => ({
   auth: {
     OAuth2: vi.fn(),
   },
+}));
+vi.mock("@/utils/outlook/client", () => ({
+  createOutlookClient: vi.fn(),
 }));
 vi.mock("@/utils/encryption", () => ({
   encryptToken: vi.fn((t) => t),
@@ -303,5 +323,36 @@ describe("handleLinkAccount", () => {
     ).rejects.toThrow("Missing access token during account linking.");
 
     expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("raises a Better Auth error code when the mailbox belongs to another user", async () => {
+    vi.mocked(createOutlookClient).mockReturnValue({
+      getUserProfile: vi.fn().mockResolvedValue({
+        mail: "user@example.com",
+        displayName: "Test User",
+      }),
+      getUserPhoto: vi.fn().mockResolvedValue(null),
+    } as any);
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      id: "email_account_1",
+      userId: "existing_user",
+      accountId: "existing_account",
+      account: { provider: "microsoft" },
+    } as any);
+
+    await expect(
+      handleLinkAccount({
+        id: "account_1",
+        userId: "new_user",
+        providerId: "microsoft",
+        accessToken: "access_token",
+      } as any),
+    ).rejects.toMatchObject({
+      message: "email_already_linked",
+      body: {
+        code: "email_already_linked",
+        message: "email_already_linked",
+      },
+    });
   });
 });

--- a/apps/web/utils/auth.ts
+++ b/apps/web/utils/auth.ts
@@ -6,7 +6,7 @@ import { oAuthProxy } from "better-auth/plugins";
 import { createContact as createLoopsContact } from "@inboxzero/loops";
 import { createContact as createResendContact } from "@inboxzero/resend";
 import type { Account, AuthContext } from "better-auth";
-import { betterAuth } from "better-auth";
+import { APIError, betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import { cookies, headers } from "next/headers";
@@ -49,6 +49,7 @@ import { assertCanGenerateScimToken } from "@/utils/auth/scim";
 import prisma from "@/utils/prisma";
 
 const logger = createScopedLogger("auth");
+const EMAIL_ALREADY_LINKED_ERROR = "email_already_linked";
 const useGoogleOauthEmulator = isGoogleOauthEmulationEnabled();
 const useMicrosoftOauthEmulator = isMicrosoftEmulationEnabled();
 
@@ -611,7 +612,10 @@ export async function handleLinkAccount(account: Account) {
         existingUserId: existingEmailAccount.userId,
         newUserId: account.userId,
       });
-      throw new Error("email_already_linked");
+      throw APIError.from("BAD_REQUEST", {
+        message: EMAIL_ALREADY_LINKED_ERROR,
+        code: EMAIL_ALREADY_LINKED_ERROR,
+      });
     }
 
     const crossProviderRelink =


### PR DESCRIPTION
Convert a mailbox ownership collision during social sign-in into a structured auth error so the callback reaches the app error page instead of a generic server error.

- Preserve the existing safety check for mailbox accounts already attached elsewhere.
- Show clearer recovery guidance for users who need to sign in with the original account or contact support for account recovery.
- Add a focused regression test for the auth hook error code.