### PR TITLE
build: Fix server package bundling

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -59,8 +59,11 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: process.env.SKIP_TYPE_CHECK === "true",
   },
   serverExternalPackages: [
+    "@chat-adapter/teams",
     "@sentry/nextjs",
     "@sentry/node",
+    "@vercel/queue",
+    "bullmq",
     "mammoth",
     "unpdf",
   ],


### PR DESCRIPTION
Fixes server package bundling during production builds.

- Externalizes server-only packages that use dynamic dependency loading
- Keeps Next from webpack-analyzing packages that are resolved at runtime
- Verified the CI-aligned app build locally

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

