### PR TITLE
onboarding: Improve unsubscribe suggestions

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts
@@ -44,6 +44,15 @@ describe("isUnsubscribeSuggestion", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not require an unsubscribe link by default", () => {
+    expect(
+      isUnsubscribeSuggestion({
+        value: 10,
+        readEmails: 0,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("getUnsubscribeSuggestions", () => {
@@ -69,5 +78,27 @@ describe("getUnsubscribeSuggestions", () => {
     expect(getUnsubscribeSuggestions([{ value: 10, readEmails: 8 }])).toEqual(
       [],
     );
+  });
+
+  it("can keep only low-read senders with automatic unsubscribe links", () => {
+    const automatic = {
+      name: "automatic",
+      value: 30,
+      readEmails: 1,
+      unsubscribeLink: "https://example.com/unsubscribe",
+    };
+    const manual = {
+      name: "manual",
+      value: 40,
+      readEmails: 1,
+      unsubscribeLink: "mailto:unsubscribe@example.com",
+    };
+    const missing = { name: "missing", value: 50, readEmails: 1 };
+
+    expect(
+      getUnsubscribeSuggestions([missing, manual, automatic], {
+        requireAutomaticUnsubscribeLink: true,
+      }),
+    ).toEqual([automatic]);
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.ts
@@ -1,25 +1,43 @@
 import type { NewsletterStatus } from "@/generated/prisma/enums";
+import { getHttpUnsubscribeLink } from "@/utils/parse/unsubscribe";
 
 export const SUGGESTION_READ_RATE_THRESHOLD = 20;
 // Require enough emails that a low read rate is signal, not noise
 export const SUGGESTION_MIN_EMAILS = 3;
 
-export function isUnsubscribeSuggestion(item: {
+type UnsubscribeSuggestionItem = {
   value: number;
   readEmails: number;
   status?: NewsletterStatus | null;
   autoArchived?: unknown;
-}): boolean {
+  unsubscribeLink?: string | null;
+};
+
+export function isUnsubscribeSuggestion(item: UnsubscribeSuggestionItem) {
   if (item.status || item.autoArchived) return false;
   if (item.value < SUGGESTION_MIN_EMAILS) return false;
   const readRate = (item.readEmails / item.value) * 100;
   return readRate < SUGGESTION_READ_RATE_THRESHOLD;
 }
 
-export function getUnsubscribeSuggestions<
-  T extends Parameters<typeof isUnsubscribeSuggestion>[0],
->(items: T[]): T[] {
+export function getUnsubscribeSuggestions<T extends UnsubscribeSuggestionItem>(
+  items: T[],
+  options?: { requireAutomaticUnsubscribeLink?: boolean },
+): T[] {
   return items
     .filter(isUnsubscribeSuggestion)
+    .filter(
+      (item) =>
+        !options?.requireAutomaticUnsubscribeLink ||
+        hasAutomaticUnsubscribeLink(item),
+    )
     .sort((a, b) => b.value - a.value);
+}
+
+export function hasAutomaticUnsubscribeLink(item: {
+  unsubscribeLink?: string | null;
+}) {
+  return Boolean(
+    getHttpUnsubscribeLink({ unsubscribeLink: item.unsubscribeLink }),
+  );
 }

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -13,7 +13,10 @@ import { Progress } from "@/components/ui/progress";
 import { ButtonCheckbox } from "@/components/ButtonCheckbox";
 import { DomainIcon } from "@/components/charts/DomainIcon";
 import { BulkUnsubscribeIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illustrations/BulkUnsubscribeIllustration";
-import { getUnsubscribeSuggestions } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
+import {
+  getUnsubscribeSuggestions,
+  hasAutomaticUnsubscribeLink,
+} from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions";
 import { useBulkUnsubscribe } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks";
 import type {
   NewsletterStatsQuery,
@@ -69,13 +72,24 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
     },
   );
 
-  const suggestions = useMemo(
+  const lowReadSuggestions = useMemo(
     () => getUnsubscribeSuggestions(data?.newsletters ?? []),
+    [data],
+  );
+  const suggestions = useMemo(
+    () =>
+      getUnsubscribeSuggestions(data?.newsletters ?? [], {
+        requireAutomaticUnsubscribeLink: true,
+      }),
     [data],
   );
   const previewSenders = useMemo(
     () => suggestions.slice(0, PREVIEW_COUNT),
     [suggestions],
+  );
+  const lowReadSuggestionsWithAutomaticUnsubscribe = useMemo(
+    () => lowReadSuggestions.filter(hasAutomaticUnsubscribeLink).length,
+    [lowReadSuggestions],
   );
 
   // Track which previewed senders the user opted out of, so selection needs no
@@ -107,11 +121,18 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
       variant,
       shownCount: previewSenders.length,
       totalSuggestions: suggestions.length,
+      lowReadSuggestionCount: lowReadSuggestions.length,
+      lowReadSuggestionWithAutomaticUnsubscribeCount:
+        lowReadSuggestionsWithAutomaticUnsubscribe,
+      lowReadSuggestionMissingAutomaticUnsubscribeCount:
+        lowReadSuggestions.length - lowReadSuggestionsWithAutomaticUnsubscribe,
     });
   }, [
     isTreatment,
     previewSenders.length,
     suggestions.length,
+    lowReadSuggestions.length,
+    lowReadSuggestionsWithAutomaticUnsubscribe,
     variant,
     posthog,
   ]);
@@ -154,7 +175,20 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
       onSkip();
       return;
     }
+
+    posthog?.capture("onboarding_unsubscribe_cta_clicked", {
+      variant,
+      selectedCount: selectedSenders.length,
+      totalSuggestions: suggestions.length,
+      hasUnsubscribeAccess,
+    });
+
     if (!hasUnsubscribeAccess) {
+      posthog?.capture("onboarding_unsubscribe_upgrade_prompt_shown", {
+        variant,
+        selectedCount: selectedSenders.length,
+        totalSuggestions: suggestions.length,
+      });
       openModal();
       return;
     }


### PR DESCRIPTION
Refines onboarding unsubscribe suggestions to prefer senders with automatic unsubscribe links while preserving the existing broader suggestion behavior elsewhere.

- Adds aggregate-only onboarding telemetry for suggestion availability and CTA gating.
- Covers the stricter suggestion option with focused unit tests.

Validation: pnpm exec ultracite check on touched files; pnpm test app/(app)/[emailAccountId]/bulk-unsubscribe/suggestions.test.ts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

