### PR TITLE
Refine email action link handling

### DIFF
--- a/apps/web/components/EmailMessageCell.tsx
+++ b/apps/web/components/EmailMessageCell.tsx
@@ -119,25 +119,29 @@ export function EmailMessageCell({
             )}
         {emailActions && (
           <div className="order-2 ml-auto flex shrink-0 items-center gap-2 text-muted-foreground sm:order-4 sm:ml-0">
-            <Link
-              className="hover:text-foreground"
-              href={emailActions.openUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Open in email"
-            >
-              <ExternalLinkIcon className="h-4 w-4" />
-            </Link>
-            <Tooltip content="View email">
-              <button
-                type="button"
+            {emailActions.openUrl && (
+              <Link
                 className="hover:text-foreground"
-                onClick={() => showEmail({ threadId, messageId })}
-                aria-label="View email"
+                href={emailActions.openUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open in email"
               >
-                <MailIcon className="h-4 w-4" />
-              </button>
-            </Tooltip>
+                <ExternalLinkIcon className="h-4 w-4" />
+              </Link>
+            )}
+            {emailActions.showViewEmailButton && (
+              <Tooltip content="View email">
+                <button
+                  type="button"
+                  className="hover:text-foreground"
+                  onClick={() => showEmail({ threadId, messageId })}
+                  aria-label="View email"
+                >
+                  <MailIcon className="h-4 w-4" />
+                </button>
+              </Tooltip>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/components/EmailMessageCellActions.test.ts
+++ b/apps/web/components/EmailMessageCellActions.test.ts
@@ -15,10 +15,11 @@ describe("getEmailMessageCellActions", () => {
     ).toEqual({
       openUrl:
         "https://outlook.office.com/mail/deeplink/read/outlook-message-1?ispopout=0",
+      showViewEmailButton: true,
     });
   });
 
-  it("falls back to the provider URL when Outlook has no external URL", () => {
+  it("does not use the generated fallback URL for Outlook", () => {
     expect(
       getEmailMessageCellActions({
         messageId: "outlook-message-1",
@@ -27,7 +28,23 @@ describe("getEmailMessageCellActions", () => {
         userEmail: "user@contoso.com",
       }),
     ).toEqual({
-      openUrl: "https://outlook.office.com/mail/inbox/id/outlook-message-1",
+      openUrl: undefined,
+      showViewEmailButton: true,
+    });
+  });
+
+  it("falls back to the provider URL for Gmail", () => {
+    expect(
+      getEmailMessageCellActions({
+        messageId: "message-1",
+        provider: "google",
+        threadId: "thread-1",
+        userEmail: "user@gmail.com",
+      }),
+    ).toEqual({
+      openUrl:
+        "https://mail.google.com/mail/u/?authuser=user%40gmail.com#all/message-1",
+      showViewEmailButton: true,
     });
   });
 

--- a/apps/web/components/EmailMessageCellActions.ts
+++ b/apps/web/components/EmailMessageCellActions.ts
@@ -1,4 +1,5 @@
 import { getEmailUrlForMessage } from "@/utils/url";
+import { isMicrosoftProvider } from "@/utils/email/provider-types";
 
 type GetEmailMessageCellActionsOptions = {
   externalUrl?: string;
@@ -19,9 +20,14 @@ export function getEmailMessageCellActions({
 }: GetEmailMessageCellActionsOptions) {
   if (hideViewEmailButton) return null;
 
+  const openUrl =
+    externalUrl ||
+    (isMicrosoftProvider(provider)
+      ? undefined
+      : getEmailUrlForMessage(messageId, threadId, userEmail, provider));
+
   return {
-    openUrl:
-      externalUrl ||
-      getEmailUrlForMessage(messageId, threadId, userEmail, provider),
+    openUrl,
+    showViewEmailButton: true,
   };
 }


### PR DESCRIPTION
Avoid showing generated external links for providers where that link is not reliable. Keep the in-app email view action available and preserve generated links for supported providers.

- Use provider-supplied external URLs when available
- Do not use the generated external fallback for unsupported provider links
- Add focused coverage for provider-specific action behavior

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

