### PR TITLE
Fix Turbopack workspace root

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 import { withAxiom } from "next-axiom";
 import nextMdx from "@next/mdx";
 import withSerwistInit from "@serwist/next";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { env } from "./env";
 import type { NextConfig } from "next";
@@ -15,6 +16,10 @@ const withMDX = nextMdx({
 const isDevelopment = process.env.NODE_ENV === "development";
 const isProductionBuild = process.env.NODE_ENV === "production";
 const repoRoot = path.resolve(import.meta.dirname, "../..");
+const nextPackageRoot = path.dirname(
+  realpathSync(require.resolve("next/package.json")),
+);
+const turbopackRoot = commonAncestorPath(repoRoot, nextPackageRoot);
 const zodV4CorePath = path.join(
   path.dirname(require.resolve("zod/package.json")),
   "v4/core/index.js",
@@ -68,7 +73,7 @@ const nextConfig: NextConfig = {
     "unpdf",
   ],
   turbopack: {
-    root: repoRoot,
+    root: turbopackRoot,
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],
@@ -448,3 +453,19 @@ const withSerwist = withSerwistInit({
 });
 
 export default withAxiom(withSerwist(exportConfig));
+
+function commonAncestorPath(firstPath: string, secondPath: string) {
+  const [firstParts, secondParts] = [firstPath, secondPath].map((value) =>
+    path.resolve(value).split(path.sep),
+  );
+  const commonParts: string[] = [];
+
+  for (let index = 0; index < firstParts.length; index += 1) {
+    if (firstParts[index] !== secondParts[index]) break;
+    commonParts.push(firstParts[index]);
+  }
+
+  return commonParts.length === 1 && commonParts[0] === ""
+    ? path.sep
+    : commonParts.join(path.sep);
+}


### PR DESCRIPTION
Updates the Turbopack root configuration so the development server starts correctly when dependencies resolve through a worktree-optimized package layout. This keeps the existing workspace setup optimization and keeps the dev server on Turbopack.

- Resolve the real Next.js package location
- Set Turbopack root to cover both the repository and resolved package path
- Preserve existing setup, run, and evaluation commands