### PR TITLE
Fix assistant rule update handling

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
@@ -416,6 +416,73 @@ describe.runIf(shouldRunEval)(
         );
 
         test(
+          "does not repeat a rule update after confirmed current rule output",
+          async () => {
+            const ruleRows = cloneRuleRows(patchRuleRows);
+            configureRuleEvalPrisma({
+              about,
+              ruleRows,
+            });
+            configureRuleEvalProvider({
+              mockCreateEmailProvider,
+              ruleRows,
+            });
+            mockPartialUpdateRule.mockImplementation(
+              async ({ ruleId, data }) => {
+                const rule = ruleRows.find(
+                  (candidate) => candidate.id === ruleId,
+                );
+                if (rule) {
+                  Object.assign(rule, data, {
+                    updatedAt: new Date("2026-03-13T00:01:00.000Z"),
+                  });
+                }
+
+                return { id: ruleId };
+              },
+            );
+
+            const { toolCalls, actual } = await runAssistantChat({
+              emailAccount,
+              messages: [
+                {
+                  role: "user",
+                  content: `Update my "${staticConditionRuleName}" rule so it only catches billing emails that need finance review.`,
+                },
+              ],
+            });
+
+            const updateCalls = getSuccessfulUpdateRuleCalls(
+              toolCalls,
+              staticConditionRuleName,
+            );
+            const updateCall = updateCalls[0];
+            const pass =
+              updateCalls.length === 1 &&
+              !!updateCall?.input.updates.condition &&
+              getPatchConditionInstructions(updateCall.input)
+                .toLowerCase()
+                .includes("finance") &&
+              outputHasCurrentRule(updateCall.output) &&
+              !hasSuccessfulRuleUpdateAfter(toolCalls, {
+                ruleName: staticConditionRuleName,
+                startIndex: updateCall.index,
+              }) &&
+              hasNoCreateDeleteOrLegacyRuleMutations(toolCalls);
+
+            evalReporter.record({
+              testName: "confirmed rule update does not repeat",
+              model: model.label,
+              pass,
+              actual: summarizeRuleMutationCalls(toolCalls) || actual,
+            });
+
+            expect(pass).toBe(true);
+          },
+          TIMEOUT,
+        );
+
+        test(
           "renames and updates actions in one patch without touching conditions",
           async () => {
             const { toolCalls, actual } = await runAssistantChat({
@@ -701,6 +768,26 @@ function hasSuccessfulRuleUpdateAfter(
     );
 }
 
+function getSuccessfulUpdateRuleCalls(
+  toolCalls: RecordedToolCall[],
+  ruleName: string,
+) {
+  return toolCalls.flatMap((toolCall, index) => {
+    if (toolCall.toolName !== "updateRule") return [];
+    if (!isUpdateRuleInput(toolCall.input)) return [];
+    if (toolCall.input.ruleName !== ruleName) return [];
+    if (!isSuccessfulOutput(toolCall.output)) return [];
+
+    return [
+      {
+        index,
+        input: toolCall.input,
+        output: toolCall.output,
+      },
+    ];
+  });
+}
+
 function isSuccessfulStatusOnlyUpdateOutput(
   output: unknown,
   enabled: boolean,
@@ -737,6 +824,14 @@ function isSuccessfulOutput(output: unknown): output is { success: true } {
     typeof output === "object" &&
     output !== null &&
     (output as { success?: unknown }).success === true
+  );
+}
+
+function outputHasCurrentRule(output: unknown) {
+  return (
+    isSuccessfulOutput(output) &&
+    typeof (output as { currentRule?: unknown }).currentRule === "object" &&
+    (output as { currentRule?: unknown }).currentRule !== null
   );
 }
 
@@ -820,4 +915,14 @@ function hasRuleReadBeforeUpdate(
       "getUserRulesAndSettings",
     ) >= 0
   );
+}
+
+function cloneRuleRows<T extends { updatedAt: Date; actions: unknown[] }>(
+  rules: T[],
+) {
+  return rules.map((rule) => ({
+    ...rule,
+    updatedAt: new Date(rule.updatedAt),
+    actions: rule.actions.map((action) => ({ ...action })),
+  }));
 }

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -23,6 +23,9 @@ const {
   mockSetRuleEnabled: vi.fn(),
   mockUpdateRuleActions: vi.fn(),
   mockPrisma: {
+    emailAccount: {
+      findUnique: vi.fn(),
+    },
     rule: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -66,6 +69,20 @@ describe("createRuleTool overlap guard", () => {
       riskMessages: [],
     });
     mockCreateRule.mockResolvedValue({ id: "new-rule-id" });
+    mockAssistantRuleSnapshot([
+      {
+        name: "Urgent Action Mail",
+        instructions: "Only urgent requests from this sender domain.",
+        from: "@company.example",
+      },
+      {
+        name: "Vendor Billing",
+        instructions: "Updated billing instructions.",
+        from: "billing@vendor.example",
+        subject: "invoice",
+        conditionalOperator: "AND",
+      },
+    ]);
     mockPrisma.rule.findMany.mockResolvedValue([
       {
         name: "Team Mail",
@@ -123,7 +140,15 @@ describe("createRuleTool overlap guard", () => {
       actions: defaultActions,
     });
 
-    expect(result).toEqual({ success: true, ruleId: "new-rule-id" });
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        ruleId: "new-rule-id",
+        currentRule: expect.objectContaining({
+          name: "Urgent Action Mail",
+        }),
+      }),
+    );
     expect(mockCreateRule).toHaveBeenCalledOnce();
   });
 });
@@ -132,6 +157,15 @@ describe("updateRuleTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPartialUpdateRule.mockResolvedValue({ id: "rule-id" });
+    mockAssistantRuleSnapshot([
+      {
+        name: "Vendor Billing",
+        instructions: "Updated billing instructions.",
+        from: "billing@vendor.example",
+        subject: "invoice",
+        conditionalOperator: "AND",
+      },
+    ]);
     mockPrisma.rule.findUnique.mockResolvedValue({
       id: "rule-id",
       name: "Vendor Billing",
@@ -173,6 +207,14 @@ describe("updateRuleTool", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.currentRule).toEqual(
+      expect.objectContaining({
+        name: "Vendor Billing",
+        conditions: expect.objectContaining({
+          aiInstructions: "Updated billing instructions.",
+        }),
+      }),
+    );
     expect(mockPartialUpdateRule).toHaveBeenCalledWith({
       ruleId: "rule-id",
       emailAccountId: "email-account-id",
@@ -363,3 +405,31 @@ describe("deleteRuleTool", () => {
     expect(mockSetRuleEnabled).not.toHaveBeenCalled();
   });
 });
+
+function mockAssistantRuleSnapshot(
+  rules: Array<{
+    name: string;
+    instructions: string | null;
+    from: string | null;
+    subject?: string | null;
+    conditionalOperator?: "AND" | "OR" | null;
+  }>,
+) {
+  mockPrisma.emailAccount.findUnique.mockResolvedValue({
+    about: null,
+    rulesRevision: 4,
+    rules: rules.map((rule) => ({
+      name: rule.name,
+      instructions: rule.instructions,
+      updatedAt: new Date("2026-04-27T00:01:00.000Z"),
+      from: rule.from,
+      to: null,
+      subject: rule.subject ?? null,
+      conditionalOperator: rule.conditionalOperator ?? null,
+      enabled: true,
+      runOnThreads: true,
+      actions: [],
+    })),
+    messagingChannels: [],
+  });
+}

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -317,7 +317,15 @@ export async function aiProcessAssistantChat({
       });
       await onStepFinish?.(step);
     },
-    onModelResolved,
+    onModelResolved: (resolvedModel) => {
+      logger.info("Assistant chat model resolved", {
+        chatId,
+        emailAccountId,
+        provider: resolvedModel.provider,
+        modelName: resolvedModel.modelName,
+      });
+      onModelResolved?.(resolvedModel);
+    },
     maxSteps: ASSISTANT_CHAT_MAX_STEPS,
     tools: allTools,
   });

--- a/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/create-rule-tool.ts
@@ -11,19 +11,25 @@ import {
 } from "@/utils/rule/sender-scope-overlap";
 import {
   buildCreateRuleSchemaFromChatToolInput,
+  loadRuleSnapshotAfterWrite,
   trackRuleToolCall,
 } from "./shared";
+import type { RuleReadState } from "../../chat-rule-state";
 
 export const createRuleTool = ({
   email,
   emailAccountId,
   provider,
   logger,
+  setRuleReadState,
+  onRulesStateExposed,
 }: {
   email: string;
   emailAccountId: string;
   provider: string;
   logger: Logger;
+  setRuleReadState?: (state: RuleReadState) => void;
+  onRulesStateExposed?: (rulesRevision: number) => void;
 }) =>
   tool({
     description: "Create a new rule.",
@@ -78,7 +84,21 @@ export const createRuleTool = ({
           enablement: { source: "chat" },
         });
 
-        return { success: true, ruleId: rule.id };
+        const snapshot = await loadRuleSnapshotAfterWrite({
+          emailAccountId,
+          logger,
+          setRuleReadState,
+          onRulesStateExposed,
+        });
+        const currentRule = snapshot?.rules.find(
+          (snapshotRule) => snapshotRule.name === resultPayload.name,
+        );
+
+        return {
+          success: true,
+          ruleId: rule.id,
+          currentRule,
+        };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 

--- a/apps/web/utils/ai/assistant/tools/rules/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/shared.ts
@@ -7,7 +7,12 @@ import type {
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { RULE_MANAGED_BY_ORGANIZATION_ERROR } from "@/utils/organizations/rules";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
-import type { RuleReadState } from "../../chat-rule-state";
+import {
+  type AssistantRuleSnapshot,
+  buildRuleReadState,
+  loadAssistantRuleSnapshot,
+  type RuleReadState,
+} from "../../chat-rule-state";
 
 export const emptyInputSchema = z.object({});
 
@@ -86,6 +91,30 @@ export async function trackRuleToolCall({
 }) {
   logger.info("Tracking tool call", { tool, email });
   return posthogCaptureEvent(email, "AI Assistant Chat Tool Call", { tool });
+}
+
+export async function loadRuleSnapshotAfterWrite({
+  emailAccountId,
+  logger,
+  setRuleReadState,
+  onRulesStateExposed,
+}: {
+  emailAccountId: string;
+  logger: Logger;
+  setRuleReadState?: (state: RuleReadState) => void;
+  onRulesStateExposed?: (rulesRevision: number) => void;
+}): Promise<AssistantRuleSnapshot | null> {
+  try {
+    const snapshot = await loadAssistantRuleSnapshot({ emailAccountId });
+    setRuleReadState?.(buildRuleReadState(snapshot));
+    onRulesStateExposed?.(snapshot.rulesRevision);
+    return snapshot;
+  } catch (error) {
+    logger.warn("Failed to refresh rule read state after rule write", {
+      error,
+    });
+    return null;
+  }
 }
 
 export function validateRuleWasReadRecently({

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -21,11 +21,15 @@ import {
   STATIC_FROM_CONDITION_DESCRIPTION,
 } from "@/utils/ai/rule/rule-condition-descriptions";
 import { hideToolErrorFromUser } from "../../tool-error-visibility";
-import type { RuleReadState } from "../../chat-rule-state";
+import type {
+  AssistantRuleSnapshot,
+  RuleReadState,
+} from "../../chat-rule-state";
 import {
   buildProviderRuleActionFields,
   buildHiddenRuleNotFoundError,
   buildVisibleOrgManagedRuleError,
+  loadRuleSnapshotAfterWrite,
   trackRuleToolCall,
   validateRuleWasReadRecently,
 } from "./shared";
@@ -35,19 +39,23 @@ export const updateRuleTool = ({
   emailAccountId,
   provider,
   logger,
+  setRuleReadState,
   getRuleReadState,
+  onRulesStateExposed,
   hasPendingRuleDeletion,
 }: {
   email: string;
   emailAccountId: string;
   provider: string;
   logger: Logger;
+  setRuleReadState?: (state: RuleReadState) => void;
   getRuleReadState?: () => RuleReadState | null;
+  onRulesStateExposed?: (rulesRevision: number) => void;
   hasPendingRuleDeletion?: (ruleName: string) => boolean;
 }) =>
   tool({
     description:
-      "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: include only the fields being changed, and omitted fields are preserved. Use updates.name to rename a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use updates.actions to replace the full action list; when changing actions, include every action that should remain. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
+      "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: include only the fields being changed, and omitted fields are preserved. Use updates.name to rename a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
     inputSchema: z
       .object({
         ruleName: z.string().describe("The exact current name of the rule."),
@@ -71,7 +79,7 @@ export const updateRuleTool = ({
               .min(1, "Rules must have at least one action.")
               .optional()
               .describe(
-                "The full replacement list of actions. Include existing actions that should remain.",
+                "The full replacement list of actions. Use only when the user explicitly asks to change actions/outcomes. Omit for condition-only, name-only, or enabled-state-only edits; omitted actions are preserved. To remove one action, include every action that should remain and omit the action being removed. Empty action lists are invalid.",
               ),
           })
           .refine((updates) => Object.keys(updates).length > 0, {
@@ -191,7 +199,6 @@ export const updateRuleTool = ({
           rule,
           originalActions,
         });
-
         if (effectiveUpdates.name || effectiveUpdates.condition) {
           await partialUpdateRule({
             ruleId: rule.id,
@@ -232,6 +239,17 @@ export const updateRuleTool = ({
           });
         }
 
+        const snapshot = await loadRuleSnapshotAfterWrite({
+          emailAccountId,
+          logger,
+          setRuleReadState,
+          onRulesStateExposed,
+        });
+        const currentRule = snapshot?.rules.find(
+          (snapshotRule) =>
+            snapshotRule.name === (effectiveUpdates.name ?? rule.name),
+        );
+
         return {
           success: true,
           ruleId: rule.id,
@@ -243,6 +261,7 @@ export const updateRuleTool = ({
           updatedConditions: effectiveUpdates.condition,
           originalActions,
           updatedActions: effectiveUpdates.actions,
+          currentRule,
         };
       } catch (error) {
         logger.error("Failed to update rule", { error, ruleName });
@@ -285,6 +304,7 @@ export type UpdateRuleOutput = {
     delayInMinutes?: number | null;
   }>;
   updatedActions?: RuleAction[];
+  currentRule?: AssistantRuleSnapshot["rules"][number];
 };
 
 type PatchCondition = {


### PR DESCRIPTION
Returns confirmed rule state from assistant rule create/update tools so the assistant can trust successful writes without depending on a follow-up read. Refreshes in-chat rule state after rule writes and logs resolved assistant model details. Keeps action edits scoped to explicit action changes so condition-only edits do not replace existing actions. Adds focused unit coverage for confirmed rule state on rule writes and an eval that catches repeated rule updates after a confirmed write.