### PR TITLE
Add weekly archive activity update

### DIFF
--- a/apps/web/app/api/resend/summary/archived-emails.test.ts
+++ b/apps/web/app/api/resend/summary/archived-emails.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ActionType,
+  ExecutedRuleStatus,
+  ScheduledActionStatus,
+  SystemType,
+} from "@/generated/prisma/enums";
+import type { ParsedMessage } from "@/utils/types";
+import {
+  buildArchivedEmailSummaryItems,
+  getArchivedActionWhere,
+} from "./archived-emails";
+
+const { mockShouldSkipAutomatedArchiveForSender } = vi.hoisted(() => ({
+  mockShouldSkipAutomatedArchiveForSender: vi.fn(),
+}));
+
+vi.mock("@/utils/ai/automated-archive-exception", () => ({
+  shouldSkipAutomatedArchiveForSender: (
+    ...args: Parameters<typeof mockShouldSkipAutomatedArchiveForSender>
+  ) => mockShouldSkipAutomatedArchiveForSender(...args),
+}));
+
+describe("archived email summary", () => {
+  it("builds a filter for automated archive actions completed in the summary window", () => {
+    const cutOffDate = new Date("2026-06-01T00:00:00.000Z");
+
+    expect(
+      getArchivedActionWhere({
+        emailAccountId: "email-account-id",
+        cutOffDate,
+      }),
+    ).toEqual({
+      type: ActionType.ARCHIVE,
+      createdAt: { gt: cutOffDate },
+      executedRule: {
+        emailAccountId: "email-account-id",
+        automated: true,
+      },
+      OR: [
+        {
+          scheduledAction: {
+            is: { status: ScheduledActionStatus.COMPLETED },
+          },
+        },
+        {
+          scheduledAction: { is: null },
+          executedRule: { status: ExecutedRuleStatus.APPLIED },
+        },
+      ],
+    });
+  });
+
+  it("maps archived actions to message rows grouped by rule metadata", () => {
+    mockShouldSkipAutomatedArchiveForSender.mockReturnValue(false);
+
+    const archivedAt = new Date("2026-06-02T12:00:00.000Z");
+
+    expect(
+      buildArchivedEmailSummaryItems({
+        archivedActions: [
+          {
+            createdAt: archivedAt,
+            executedRule: {
+              messageId: "message-1",
+              rule: { name: "Marketing", systemType: SystemType.MARKETING },
+            },
+          },
+          {
+            createdAt: archivedAt,
+            executedRule: {
+              messageId: "message-2",
+              rule: null,
+            },
+          },
+        ],
+        messageMap: {
+          "message-1": getMessage({
+            id: "message-1",
+            from: "Sender <sender@example.com>",
+            subject: "Product update",
+            snippet: "Snippet fallback",
+          }),
+          "message-2": getMessage({
+            id: "message-2",
+            from: "Other <other@example.com>",
+            subject: "",
+            snippet: "Snippet fallback",
+          }),
+        },
+      }),
+    ).toEqual([
+      {
+        from: "Sender <sender@example.com>",
+        subject: "Product update",
+        sentAt: archivedAt,
+        ruleName: "Marketing",
+      },
+      {
+        from: "Other <other@example.com>",
+        subject: "Snippet fallback",
+        sentAt: archivedAt,
+        ruleName: "Automation rule",
+      },
+    ]);
+  });
+
+  it("skips missing messages and archive exceptions", () => {
+    mockShouldSkipAutomatedArchiveForSender.mockImplementation(({ from }) =>
+      from.includes("protected@example.com"),
+    );
+
+    expect(
+      buildArchivedEmailSummaryItems({
+        archivedActions: [
+          {
+            createdAt: new Date("2026-06-02T12:00:00.000Z"),
+            executedRule: {
+              messageId: "missing-message",
+              rule: { name: "Marketing", systemType: SystemType.MARKETING },
+            },
+          },
+          {
+            createdAt: new Date("2026-06-02T12:00:00.000Z"),
+            executedRule: {
+              messageId: "protected-message",
+              rule: { name: "Marketing", systemType: SystemType.MARKETING },
+            },
+          },
+        ],
+        messageMap: {
+          "protected-message": getMessage({
+            id: "protected-message",
+            from: "Protected <protected@example.com>",
+            subject: "Protected update",
+            snippet: "Snippet",
+          }),
+        },
+      }),
+    ).toEqual([]);
+  });
+});
+
+function getMessage({
+  id,
+  from,
+  subject,
+  snippet,
+}: {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+}): ParsedMessage {
+  return {
+    date: "2026-06-02T12:00:00.000Z",
+    headers: {
+      date: "2026-06-02T12:00:00.000Z",
+      from,
+      subject,
+      to: "user@example.com",
+    },
+    historyId: "history-id",
+    id,
+    inline: [],
+    snippet,
+    subject,
+    threadId: `thread-${id}`,
+  };
+}

--- a/apps/web/app/api/resend/summary/archived-emails.test.ts
+++ b/apps/web/app/api/resend/summary/archived-emails.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  ActionType,
-  ExecutedRuleStatus,
-  ScheduledActionStatus,
-  SystemType,
-} from "@/generated/prisma/enums";
+import { SystemType } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
-import {
-  buildArchivedEmailSummaryItems,
-  getArchivedActionWhere,
-} from "./archived-emails";
+import { buildArchivedEmailSummaryItems } from "./archived-emails";
 
 const { mockShouldSkipAutomatedArchiveForSender } = vi.hoisted(() => ({
   mockShouldSkipAutomatedArchiveForSender: vi.fn(),
@@ -22,35 +14,6 @@ vi.mock("@/utils/ai/automated-archive-exception", () => ({
 }));
 
 describe("archived email summary", () => {
-  it("builds a filter for automated archive actions completed in the summary window", () => {
-    const cutOffDate = new Date("2026-06-01T00:00:00.000Z");
-
-    expect(
-      getArchivedActionWhere({
-        emailAccountId: "email-account-id",
-        cutOffDate,
-      }),
-    ).toEqual({
-      type: ActionType.ARCHIVE,
-      createdAt: { gt: cutOffDate },
-      executedRule: {
-        emailAccountId: "email-account-id",
-        automated: true,
-      },
-      OR: [
-        {
-          scheduledAction: {
-            is: { status: ScheduledActionStatus.COMPLETED },
-          },
-        },
-        {
-          scheduledAction: { is: null },
-          executedRule: { status: ExecutedRuleStatus.APPLIED },
-        },
-      ],
-    });
-  });
-
   it("maps archived actions to message rows grouped by rule metadata", () => {
     mockShouldSkipAutomatedArchiveForSender.mockReturnValue(false);
 

--- a/apps/web/app/api/resend/summary/archived-emails.ts
+++ b/apps/web/app/api/resend/summary/archived-emails.ts
@@ -1,0 +1,95 @@
+import type { Prisma } from "@/generated/prisma/client";
+import {
+  ActionType,
+  ExecutedRuleStatus,
+  ScheduledActionStatus,
+  type SystemType,
+} from "@/generated/prisma/enums";
+import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
+import { decodeSnippet } from "@/utils/gmail/decode";
+import { getRuleName } from "@/utils/rule/consts";
+import type { ParsedMessage } from "@/utils/types";
+
+export const ARCHIVED_EMAIL_DISPLAY_LIMIT = 100;
+
+export type ArchivedEmailSummaryItem = {
+  from: string;
+  ruleName: string;
+  sentAt: Date;
+  subject: string;
+};
+
+type ArchivedActionSummary = {
+  createdAt: Date;
+  executedRule: {
+    messageId: string;
+    rule: { name: string; systemType: SystemType | null } | null;
+  };
+};
+
+export function getArchivedActionWhere({
+  emailAccountId,
+  cutOffDate,
+}: {
+  emailAccountId: string;
+  cutOffDate: Date;
+}) {
+  return {
+    type: ActionType.ARCHIVE,
+    createdAt: { gt: cutOffDate },
+    executedRule: {
+      emailAccountId,
+      automated: true,
+    },
+    OR: [
+      {
+        scheduledAction: {
+          is: { status: ScheduledActionStatus.COMPLETED },
+        },
+      },
+      {
+        scheduledAction: { is: null },
+        executedRule: { status: ExecutedRuleStatus.APPLIED },
+      },
+    ],
+  } satisfies Prisma.ExecutedActionWhereInput;
+}
+
+export function buildArchivedEmailSummaryItems({
+  archivedActions,
+  messageMap,
+}: {
+  archivedActions: ArchivedActionSummary[];
+  messageMap: Record<string, ParsedMessage | undefined>;
+}): ArchivedEmailSummaryItem[] {
+  return archivedActions.flatMap((action) => {
+    const message = messageMap[action.executedRule.messageId];
+    if (!message) return [];
+
+    if (
+      shouldSkipAutomatedArchiveForSender({
+        actionType: ActionType.ARCHIVE,
+        from: message.headers.from,
+      })
+    ) {
+      return [];
+    }
+
+    return {
+      from: message.headers.from || "Unknown",
+      subject: message.headers.subject || decodeSnippet(message.snippet) || "",
+      sentAt: action.createdAt,
+      ruleName: getArchivedRuleName(action.executedRule.rule),
+    };
+  });
+}
+
+function getArchivedRuleName(
+  rule: { name: string; systemType: SystemType | null } | null,
+) {
+  if (!rule) return "Automation rule";
+  return (
+    rule.name ||
+    (rule.systemType ? getRuleName(rule.systemType) : "Automation rule")
+  );
+}

--- a/apps/web/app/api/resend/summary/archived-emails.ts
+++ b/apps/web/app/api/resend/summary/archived-emails.ts
@@ -1,10 +1,4 @@
-import type { Prisma } from "@/generated/prisma/client";
-import {
-  ActionType,
-  ExecutedRuleStatus,
-  ScheduledActionStatus,
-  type SystemType,
-} from "@/generated/prisma/enums";
+import { ActionType, type SystemType } from "@/generated/prisma/enums";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { getRuleName } from "@/utils/rule/consts";
@@ -26,34 +20,6 @@ type ArchivedActionSummary = {
     rule: { name: string; systemType: SystemType | null } | null;
   };
 };
-
-export function getArchivedActionWhere({
-  emailAccountId,
-  cutOffDate,
-}: {
-  emailAccountId: string;
-  cutOffDate: Date;
-}) {
-  return {
-    type: ActionType.ARCHIVE,
-    createdAt: { gt: cutOffDate },
-    executedRule: {
-      emailAccountId,
-      automated: true,
-    },
-    OR: [
-      {
-        scheduledAction: {
-          is: { status: ScheduledActionStatus.COMPLETED },
-        },
-      },
-      {
-        scheduledAction: { is: null },
-        executedRule: { status: ExecutedRuleStatus.APPLIED },
-      },
-    ],
-  } satisfies Prisma.ExecutedActionWhereInput;
-}
 
 export function buildArchivedEmailSummaryItems({
   archivedActions,

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -1,0 +1,275 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { ActionType, SystemType } from "@/generated/prisma/enums";
+import type { ParsedMessage } from "@/utils/types";
+
+vi.mock("@/utils/prisma");
+
+const {
+  mockCreateEmailProvider,
+  mockCreateUnsubscribeToken,
+  mockHasCronSecret,
+  mockIsValidInternalApiKey,
+  mockSendSummaryEmail,
+} = vi.hoisted(() => ({
+  mockCreateEmailProvider: vi.fn(),
+  mockCreateUnsubscribeToken: vi.fn(),
+  mockHasCronSecret: vi.fn(),
+  mockIsValidInternalApiKey: vi.fn(),
+  mockSendSummaryEmail: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const {
+    createWithEmailAccountTestMiddleware,
+    createWithErrorTestMiddleware,
+  } = await vi.importActual<typeof import("@/__tests__/helpers")>(
+    "@/__tests__/helpers",
+  );
+
+  return {
+    ...createWithErrorTestMiddleware(),
+    ...createWithEmailAccountTestMiddleware({
+      auth: {
+        email: "user@example.com",
+        emailAccountId: "email-account-id",
+        userId: "user-1",
+      },
+    }),
+  };
+});
+
+vi.mock("@/utils/cron", () => ({
+  hasCronSecret: (...args: unknown[]) => mockHasCronSecret(...args),
+}));
+
+vi.mock("@/utils/internal-api", () => ({
+  isValidInternalApiKey: (...args: unknown[]) =>
+    mockIsValidInternalApiKey(...args),
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: unknown[]) => mockCreateEmailProvider(...args),
+}));
+
+vi.mock("@/utils/unsubscribe", () => ({
+  createUnsubscribeToken: (...args: unknown[]) =>
+    mockCreateUnsubscribeToken(...args),
+}));
+
+vi.mock("@inboxzero/resend", () => ({
+  sendSummaryEmail: (...args: unknown[]) => mockSendSummaryEmail(...args),
+}));
+
+import { POST } from "./route";
+
+describe("summary email route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasCronSecret.mockReturnValue(true);
+    mockIsValidInternalApiKey.mockReturnValue(false);
+    mockCreateUnsubscribeToken.mockResolvedValue("unsubscribe-token");
+    mockSendSummaryEmail.mockResolvedValue(undefined);
+  });
+
+  it("sends a weekly update when automated archive activity is the only reportable item", async () => {
+    const archivedAt = new Date("2026-06-28T12:00:00.000Z");
+    const getMessagesBatch = vi.fn().mockResolvedValue([
+      getMessage({
+        id: "archived-message-1",
+        from: "Marketing <marketing@example.com>",
+        subject: "Product update",
+        snippet: "Product update snippet",
+      }),
+      getMessage({
+        id: "archived-message-2",
+        from: "Newsletter <newsletter@example.com>",
+        subject: "",
+        snippet: "Newsletter snippet",
+      }),
+    ]);
+
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce({ lastSummaryEmailAt: null })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        email: "user@example.com",
+        account: {
+          provider: "google",
+          refresh_token: "refresh-token",
+        },
+      });
+    prisma.rule.findUnique.mockResolvedValue(null);
+    prisma.threadTracker.groupBy.mockResolvedValue([]);
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    prisma.executedAction.count.mockResolvedValue(2);
+    prisma.executedAction.findMany.mockResolvedValue([
+      {
+        id: "archive-action-1",
+        createdAt: archivedAt,
+        executedRule: {
+          messageId: "archived-message-1",
+          rule: { name: "Marketing", systemType: SystemType.MARKETING },
+        },
+      },
+      {
+        id: "archive-action-2",
+        createdAt: archivedAt,
+        executedRule: {
+          messageId: "archived-message-2",
+          rule: { name: "Newsletter", systemType: SystemType.NEWSLETTER },
+        },
+      },
+    ]);
+    prisma.emailAccount.update.mockResolvedValue({});
+    mockCreateEmailProvider.mockResolvedValue({ getMessagesBatch });
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/summary", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCreateEmailProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "email-account-id",
+        provider: "google",
+      }),
+    );
+    expect(getMessagesBatch).toHaveBeenCalledWith([
+      "archived-message-1",
+      "archived-message-2",
+    ]);
+    expect(mockSendSummaryEmail).toHaveBeenCalledWith({
+      from: expect.any(String),
+      to: "user@example.com",
+      emailProps: expect.objectContaining({
+        archivedEmailCount: 2,
+        archivedEmails: [
+          {
+            from: "Marketing <marketing@example.com>",
+            subject: "Product update",
+            sentAt: archivedAt,
+            ruleName: "Marketing",
+          },
+          {
+            from: "Newsletter <newsletter@example.com>",
+            subject: "Newsletter snippet",
+            sentAt: archivedAt,
+            ruleName: "Newsletter",
+          },
+        ],
+        coldEmailers: [],
+        unsubscribeToken: "unsubscribe-token",
+      }),
+    });
+    expect(prisma.emailAccount.update).toHaveBeenCalledWith({
+      where: { id: "email-account-id" },
+      data: { lastSummaryEmailAt: expect.any(Date) },
+    });
+  });
+
+  it("does not send when there is no weekly summary activity", async () => {
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce({ lastSummaryEmailAt: null })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        email: "user@example.com",
+        account: {
+          provider: "google",
+          refresh_token: "refresh-token",
+        },
+      });
+    prisma.rule.findUnique.mockResolvedValue(null);
+    prisma.threadTracker.groupBy.mockResolvedValue([]);
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    prisma.executedAction.count.mockResolvedValue(0);
+    prisma.executedAction.findMany.mockResolvedValue([]);
+    prisma.emailAccount.update.mockResolvedValue({});
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/summary", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSendSummaryEmail).not.toHaveBeenCalled();
+    expect(prisma.emailAccount.update).toHaveBeenCalled();
+  });
+
+  it("counts only completed archive actions in the weekly archive summary query", async () => {
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce({ lastSummaryEmailAt: null })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        email: "user@example.com",
+        account: {
+          provider: "google",
+          refresh_token: "refresh-token",
+        },
+      });
+    prisma.rule.findUnique.mockResolvedValue(null);
+    prisma.threadTracker.groupBy.mockResolvedValue([]);
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    prisma.executedAction.count.mockResolvedValue(0);
+    prisma.executedAction.findMany.mockResolvedValue([]);
+    prisma.emailAccount.update.mockResolvedValue({});
+
+    await POST(
+      new NextRequest("http://localhost:3000/api/resend/summary", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(prisma.executedAction.count).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        type: ActionType.ARCHIVE,
+        executedRule: expect.objectContaining({
+          emailAccountId: "email-account-id",
+          automated: true,
+        }),
+        OR: expect.any(Array),
+      }),
+    });
+  });
+});
+
+function getMessage({
+  id,
+  from,
+  subject,
+  snippet,
+}: {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+}): ParsedMessage {
+  return {
+    date: "2026-06-28T12:00:00.000Z",
+    headers: {
+      date: "2026-06-28T12:00:00.000Z",
+      from,
+      subject,
+      to: "user@example.com",
+    },
+    historyId: "history-id",
+    id,
+    inline: [],
+    snippet,
+    subject,
+    threadId: `thread-${id}`,
+  };
+}

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -206,6 +206,56 @@ describe("summary email route", () => {
     expect(prisma.emailAccount.update).toHaveBeenCalled();
   });
 
+  it("sends archive counts without fetching messages for unsupported providers", async () => {
+    const archivedAt = new Date("2026-06-28T12:00:00.000Z");
+
+    prisma.emailAccount.findUnique
+      .mockResolvedValueOnce({ lastSummaryEmailAt: null })
+      .mockResolvedValueOnce({
+        userId: "user-1",
+        email: "user@example.com",
+        account: {
+          provider: "unsupported",
+          refresh_token: "refresh-token",
+        },
+      });
+    prisma.rule.findUnique.mockResolvedValue(null);
+    prisma.threadTracker.groupBy.mockResolvedValue([]);
+    prisma.threadTracker.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    prisma.executedAction.count.mockResolvedValue(1);
+    prisma.executedAction.findMany.mockResolvedValue([
+      {
+        id: "archive-action-1",
+        createdAt: archivedAt,
+        executedRule: {
+          messageId: "archived-message-1",
+          rule: { name: "Marketing", systemType: SystemType.MARKETING },
+        },
+      },
+    ]);
+    prisma.emailAccount.update.mockResolvedValue({});
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/resend/summary", {
+        method: "POST",
+        body: JSON.stringify({ emailAccountId: "email-account-id" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+    expect(mockSendSummaryEmail).toHaveBeenCalledWith({
+      from: expect.any(String),
+      to: "user@example.com",
+      emailProps: expect.objectContaining({
+        archivedEmailCount: 1,
+        archivedEmails: [],
+      }),
+    });
+  });
+
   it("counts only completed archive actions in the weekly archive summary query", async () => {
     prisma.emailAccount.findUnique
       .mockResolvedValueOnce({ lastSummaryEmailAt: null })

--- a/apps/web/app/api/resend/summary/route.test.ts
+++ b/apps/web/app/api/resend/summary/route.test.ts
@@ -1,7 +1,12 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
-import { ActionType, SystemType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  ExecutedRuleStatus,
+  ScheduledActionStatus,
+  SystemType,
+} from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";
 
 vi.mock("@/utils/prisma");
@@ -290,7 +295,17 @@ describe("summary email route", () => {
           emailAccountId: "email-account-id",
           automated: true,
         }),
-        OR: expect.any(Array),
+        OR: [
+          {
+            scheduledAction: {
+              is: { status: ScheduledActionStatus.COMPLETED },
+            },
+          },
+          {
+            scheduledAction: { is: null },
+            executedRule: { status: ExecutedRuleStatus.APPLIED },
+          },
+        ],
       }),
     });
   });

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -9,10 +9,16 @@ import { captureException } from "@/utils/error";
 import prisma from "@/utils/prisma";
 import { SystemType, ThreadTrackerType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
-import { getMessagesBatch } from "@/utils/gmail/message";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 import { sendSummaryEmailBody } from "./validation";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { ParsedMessage } from "@/utils/types";
+import {
+  ARCHIVED_EMAIL_DISPLAY_LIMIT,
+  buildArchivedEmailSummaryItems,
+  getArchivedActionWhere,
+} from "./archived-emails";
 
 export const maxDuration = 60;
 
@@ -115,7 +121,8 @@ async function sendEmail({
       email: true,
       account: {
         select: {
-          access_token: true,
+          provider: true,
+          refresh_token: true,
         },
       },
     },
@@ -138,58 +145,92 @@ async function sendEmail({
     select: { id: true },
   });
 
+  const archivedActionWhere = getArchivedActionWhere({
+    emailAccountId,
+    cutOffDate,
+  });
+
   // Get counts and recent threads for each type
-  const [counts, needsReply, awaitingReply, coldExecutedRules] =
-    await Promise.all([
-      // total count
-      // NOTE: should really be distinct by threadId. this will cause a mismatch in some cases
-      prisma.threadTracker.groupBy({
-        by: ["type"],
-        where: {
-          emailAccountId,
-          resolved: false,
-        },
-        _count: true,
-      }),
-      // needs reply
-      prisma.threadTracker.findMany({
-        where: {
-          emailAccountId,
-          type: ThreadTrackerType.NEEDS_REPLY,
-          resolved: false,
-        },
-        orderBy: { sentAt: "desc" },
-        take: 20,
-        distinct: ["threadId"],
-      }),
-      // awaiting reply
-      prisma.threadTracker.findMany({
-        where: {
-          emailAccountId,
-          type: ThreadTrackerType.AWAITING,
-          resolved: false,
-          // only show emails that are more than 3 days overdue
-          sentAt: { lt: subHours(new Date(), 24 * 3) },
-        },
-        orderBy: { sentAt: "desc" },
-        take: 20,
-        distinct: ["threadId"],
-      }),
-      // cold emails
-      coldEmailRule
-        ? prisma.executedRule.findMany({
-            where: {
-              ruleId: coldEmailRule.id,
-              automated: true,
-              createdAt: { gt: cutOffDate },
+  const [
+    counts,
+    needsReply,
+    awaitingReply,
+    coldExecutedRules,
+    archivedEmailCount,
+    archivedActions,
+  ] = await Promise.all([
+    // total count
+    // NOTE: should really be distinct by threadId. this will cause a mismatch in some cases
+    prisma.threadTracker.groupBy({
+      by: ["type"],
+      where: {
+        emailAccountId,
+        resolved: false,
+      },
+      _count: true,
+    }),
+    // needs reply
+    prisma.threadTracker.findMany({
+      where: {
+        emailAccountId,
+        type: ThreadTrackerType.NEEDS_REPLY,
+        resolved: false,
+      },
+      orderBy: { sentAt: "desc" },
+      take: 20,
+      distinct: ["threadId"],
+    }),
+    // awaiting reply
+    prisma.threadTracker.findMany({
+      where: {
+        emailAccountId,
+        type: ThreadTrackerType.AWAITING,
+        resolved: false,
+        // only show emails that are more than 3 days overdue
+        sentAt: { lt: subHours(new Date(), 24 * 3) },
+      },
+      orderBy: { sentAt: "desc" },
+      take: 20,
+      distinct: ["threadId"],
+    }),
+    // cold emails
+    coldEmailRule
+      ? prisma.executedRule.findMany({
+          where: {
+            ruleId: coldEmailRule.id,
+            automated: true,
+            createdAt: { gt: cutOffDate },
+          },
+          select: {
+            messageId: true,
+            createdAt: true,
+          },
+        })
+      : Promise.resolve([]),
+    prisma.executedAction.count({
+      where: archivedActionWhere,
+    }),
+    prisma.executedAction.findMany({
+      where: archivedActionWhere,
+      orderBy: { createdAt: "desc" },
+      take: ARCHIVED_EMAIL_DISPLAY_LIMIT,
+      select: {
+        id: true,
+        createdAt: true,
+        executedRule: {
+          select: {
+            messageId: true,
+            rule: {
+              select: {
+                name: true,
+                systemType: true,
+              },
             },
-            select: {
-              messageId: true,
-              createdAt: true,
-            },
-          })
-        : Promise.resolve([]),
-    ]);
+          },
+        },
+      },
+    }),
+  ]);
 
   const typeCounts = Object.fromEntries(
     counts.map((count) => [count.type, count._count]),
@@ -200,19 +241,20 @@ async function sendEmail({
     ...needsReply.map((m) => m.messageId),
     ...awaitingReply.map((m) => m.messageId),
     ...coldExecutedRules.map((r) => r.messageId),
+    ...archivedActions.map((a) => a.executedRule.messageId),
   ];
 
   logger.info("Getting messages", {
     messagesCount: messageIds.length,
   });
 
-  const messages = emailAccount.account.access_token
-    ? await getMessagesBatch({
-        messageIds,
-        accessToken: emailAccount.account.access_token,
-        logger,
-      })
-    : [];
+  const messages = await getMessages({
+    emailAccountId,
+    provider: emailAccount.account.provider,
+    hasRefreshToken: !!emailAccount.account.refresh_token,
+    messageIds,
+    logger,
+  });
 
   const messageMap = Object.fromEntries(
     messages.map((message) => [message.id, message]),
@@ -245,7 +287,13 @@ async function sendEmail({
     };
   });
 
+  const archivedEmails = buildArchivedEmailSummaryItems({
+    archivedActions,
+    messageMap,
+  });
+
   const shouldSendEmail = !!(
+    archivedEmailCount ||
     coldEmailers.length ||
     typeCounts[ThreadTrackerType.NEEDS_REPLY] ||
     typeCounts[ThreadTrackerType.AWAITING] ||
@@ -254,6 +302,8 @@ async function sendEmail({
 
   logger.info("Sending summary email to user", {
     shouldSendEmail,
+    archivedEmailCount,
+    archivedEmailsShown: archivedEmails.length,
     coldEmailers: coldEmailers.length,
     needsReplyCount: typeCounts[ThreadTrackerType.NEEDS_REPLY],
     awaitingReplyCount: typeCounts[ThreadTrackerType.AWAITING],
@@ -274,6 +324,8 @@ async function sendEmail({
       to: userEmail,
       emailProps: {
         baseUrl: env.NEXT_PUBLIC_BASE_URL,
+        archivedEmailCount,
+        archivedEmails,
         coldEmailers,
         needsReplyCount: typeCounts[ThreadTrackerType.NEEDS_REPLY],
         awaitingReplyCount: typeCounts[ThreadTrackerType.AWAITING],
@@ -296,4 +348,42 @@ async function sendEmail({
   ]);
 
   return { success: true };
+}
+
+async function getMessages({
+  emailAccountId,
+  provider,
+  hasRefreshToken,
+  messageIds,
+  logger,
+}: {
+  emailAccountId: string;
+  provider: string;
+  hasRefreshToken: boolean;
+  messageIds: string[];
+  logger: Logger;
+}): Promise<ParsedMessage[]> {
+  const uniqueMessageIds = Array.from(new Set(messageIds)).filter(Boolean);
+  if (!uniqueMessageIds.length) return [];
+
+  if (!hasRefreshToken) {
+    logger.warn("Skipping summary message fetch: account has no refresh token");
+    return [];
+  }
+
+  const emailProvider = await createEmailProvider({
+    emailAccountId,
+    provider,
+    logger,
+  });
+
+  const messages: ParsedMessage[] = [];
+  const batchSize = 100;
+
+  for (let i = 0; i < uniqueMessageIds.length; i += batchSize) {
+    const batch = uniqueMessageIds.slice(i, i + batchSize);
+    messages.push(...(await emailProvider.getMessagesBatch(batch)));
+  }
+
+  return messages;
 }

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -13,6 +13,10 @@ import { decodeSnippet } from "@/utils/gmail/decode";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
 import { sendSummaryEmailBody } from "./validation";
 import { createEmailProvider } from "@/utils/email/provider";
+import {
+  isGoogleProvider,
+  isMicrosoftProvider,
+} from "@/utils/email/provider-types";
 import type { ParsedMessage } from "@/utils/types";
 import {
   ARCHIVED_EMAIL_DISPLAY_LIMIT,
@@ -368,6 +372,13 @@ async function getMessages({
 
   if (!hasRefreshToken) {
     logger.warn("Skipping summary message fetch: account has no refresh token");
+    return [];
+  }
+
+  if (!isGoogleProvider(provider) && !isMicrosoftProvider(provider)) {
+    logger.warn("Skipping summary message fetch: unsupported provider", {
+      provider,
+    });
     return [];
   }
 

--- a/apps/web/app/api/resend/summary/route.ts
+++ b/apps/web/app/api/resend/summary/route.ts
@@ -6,8 +6,15 @@ import { env } from "@/env";
 import { hasCronSecret } from "@/utils/cron";
 import { isValidInternalApiKey } from "@/utils/internal-api";
 import { captureException } from "@/utils/error";
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/prisma";
-import { SystemType, ThreadTrackerType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  ExecutedRuleStatus,
+  ScheduledActionStatus,
+  SystemType,
+  ThreadTrackerType,
+} from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { createUnsubscribeToken } from "@/utils/unsubscribe";
@@ -21,7 +28,6 @@ import type { ParsedMessage } from "@/utils/types";
 import {
   ARCHIVED_EMAIL_DISPLAY_LIMIT,
   buildArchivedEmailSummaryItems,
-  getArchivedActionWhere,
 } from "./archived-emails";
 
 export const maxDuration = 60;
@@ -149,10 +155,25 @@ async function sendEmail({
     select: { id: true },
   });
 
-  const archivedActionWhere = getArchivedActionWhere({
-    emailAccountId,
-    cutOffDate,
-  });
+  const archivedActionWhere = {
+    type: ActionType.ARCHIVE,
+    createdAt: { gt: cutOffDate },
+    executedRule: {
+      emailAccountId,
+      automated: true,
+    },
+    OR: [
+      {
+        scheduledAction: {
+          is: { status: ScheduledActionStatus.COMPLETED },
+        },
+      },
+      {
+        scheduledAction: { is: null },
+        executedRule: { status: ExecutedRuleStatus.APPLIED },
+      },
+    ],
+  } satisfies Prisma.ExecutedActionWhereInput;
 
   // Get counts and recent threads for each type
   const [

--- a/packages/resend/emails/summary.tsx
+++ b/packages/resend/emails/summary.tsx
@@ -21,7 +21,13 @@ type EmailItem = {
   sentAt: Date;
 };
 
+type ArchivedEmailItem = EmailItem & {
+  ruleName: string;
+};
+
 export interface SummaryEmailProps {
+  archivedEmailCount?: number;
+  archivedEmails?: ArchivedEmailItem[];
   awaitingReply?: EmailItem[];
   awaitingReplyCount?: number;
   baseUrl: string;
@@ -37,6 +43,8 @@ export interface SummaryEmailProps {
 export default function SummaryEmail(props: SummaryEmailProps) {
   const {
     baseUrl = "https://www.getinboxzero.com",
+    archivedEmailCount = 0,
+    archivedEmails = [],
     coldEmailers,
     needsReplyCount,
     awaitingReplyCount,
@@ -81,6 +89,12 @@ export default function SummaryEmail(props: SummaryEmailProps) {
               </Text>
             </Section>
 
+            <ArchivedEmails
+              archivedEmailCount={archivedEmailCount}
+              archivedEmails={archivedEmails}
+              baseUrl={baseUrl}
+            />
+
             <ReplyTracker
               needsReplyCount={needsReplyCount ?? 0}
               awaitingReplyCount={awaitingReplyCount ?? 0}
@@ -103,6 +117,27 @@ export default function SummaryEmail(props: SummaryEmailProps) {
 
 SummaryEmail.PreviewProps = {
   baseUrl: "https://www.getinboxzero.com",
+  archivedEmailCount: 8,
+  archivedEmails: [
+    {
+      from: "Updates <updates@example.com>",
+      subject: "New product features this week",
+      sentAt: new Date("2024-03-20"),
+      ruleName: "Marketing",
+    },
+    {
+      from: "Newsletter <newsletter@example.com>",
+      subject: "Weekly industry roundup",
+      sentAt: new Date("2024-03-19"),
+      ruleName: "Newsletter",
+    },
+    {
+      from: "Sales <sales@example.com>",
+      subject: "Quick question",
+      sentAt: new Date("2024-03-18"),
+      ruleName: "Cold Email",
+    },
+  ],
   coldEmailers: [
     {
       from: "James <james@example.com>",
@@ -156,6 +191,63 @@ SummaryEmail.PreviewProps = {
   // ],
   unsubscribeToken: "123",
 } satisfies SummaryEmailProps;
+
+function ArchivedEmails({
+  archivedEmailCount,
+  archivedEmails,
+  baseUrl,
+}: {
+  archivedEmailCount: number;
+  archivedEmails: ArchivedEmailItem[];
+  baseUrl: string;
+}) {
+  if (!archivedEmailCount) return null;
+
+  const archivedEmailGroups = groupArchivedEmailsByRule(archivedEmails);
+  const hiddenCount = Math.max(archivedEmailCount - archivedEmails.length, 0);
+
+  return (
+    <Section className="my-6 rounded-2xl bg-[#10b981]/5 bg-[radial-gradient(circle_at_bottom_right,#10b981_0%,transparent_60%)] p-8 text-center">
+      <Heading className="m-0 text-3xl font-medium text-[#047857]">
+        Archived For You
+      </Heading>
+      <Text className="my-4 text-5xl font-bold text-gray-900">
+        {archivedEmailCount}
+      </Text>
+      <Text className="mb-4 text-xl text-gray-900">emails this week</Text>
+
+      {archivedEmailGroups.map((group) => (
+        <div key={group.ruleName}>
+          <Text className="mt-6 mb-2 text-left text-sm font-semibold uppercase tracking-wide text-[#047857]">
+            {group.ruleName}
+          </Text>
+          <EmailList description="" emails={group.emails} />
+        </div>
+      ))}
+
+      {hiddenCount > 0 && (
+        <Text className="mt-4 text-sm text-gray-600">
+          And {hiddenCount} more archived email
+          {hiddenCount === 1 ? "" : "s"}.
+        </Text>
+      )}
+
+      <Section className="text-center mt-[32px] mb-[32px]">
+        <Button
+          href={`${baseUrl}/automation?tab=history`}
+          style={{
+            background: "#000",
+            color: "#fff",
+            padding: "12px 20px",
+            borderRadius: "5px",
+          }}
+        >
+          View Automation History
+        </Button>
+      </Section>
+    </Section>
+  );
+}
 
 function ReplyTracker({
   needsReplyCount,
@@ -358,4 +450,16 @@ function EmailList({
       ))}
     </div>
   );
+}
+
+function groupArchivedEmailsByRule(archivedEmails: ArchivedEmailItem[]) {
+  const groups = new Map<string, EmailItem[]>();
+
+  archivedEmails.forEach(({ ruleName, ...email }) => {
+    const emails = groups.get(ruleName) || [];
+    emails.push(email);
+    groups.set(ruleName, emails);
+  });
+
+  return Array.from(groups, ([ruleName, emails]) => ({ ruleName, emails }));
 }


### PR DESCRIPTION
Add archived automation activity to the weekly update email without AI summarization.

- Query automated archive actions from the weekly summary window
- Render archived message metadata grouped by rule in the summary email
- Add focused helper coverage for archive summary row building

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

