### PR TITLE
Fix assistant rule update handling

### DIFF
--- a/apps/web/components/assistant-chat/rule-summary-card.tsx
+++ b/apps/web/components/assistant-chat/rule-summary-card.tsx
@@ -6,16 +6,18 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 
 export function RuleSummaryCard({
   title,
+  status,
   actions,
   children,
 }: {
   title: string;
+  status?: ReactNode;
   actions?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <Card>
-      <RuleSummaryCardHeader title={title} actions={actions} />
+      <RuleSummaryCardHeader title={title} status={status} actions={actions} />
       <CardContent className="space-y-3 px-4 py-3.5">{children}</CardContent>
     </Card>
   );
@@ -23,14 +25,19 @@ export function RuleSummaryCard({
 
 export function RuleSummaryCardHeader({
   title,
+  status,
   actions,
 }: {
   title: string;
+  status?: ReactNode;
   actions?: ReactNode;
 }) {
   return (
-    <CardHeader className="flex flex-row items-center justify-between space-y-0 border-b px-4 py-3.5">
-      <h3 className="text-base font-semibold">{title}</h3>
+    <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 border-b px-4 py-3.5">
+      <div className="flex min-w-0 items-center gap-2">
+        <h3 className="truncate text-base font-semibold">{title}</h3>
+        {status}
+      </div>
       {actions}
     </CardHeader>
   );

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -64,7 +64,7 @@ import { InlineEmailCard } from "@/components/assistant-chat/inline-email-card";
 import { RuleDialog } from "@/app/(app)/[emailAccountId]/assistant/RuleDialog";
 import { useDialogState } from "@/hooks/useDialogState";
 import { Switch } from "@/components/ui/switch";
-import { Badge } from "@/components/Badge";
+import { Badge, type Color } from "@/components/Badge";
 import { getActionDisplay, getActionIcon } from "@/utils/action-display";
 import { getActionColor } from "@/components/PlanBadge";
 import type { ActionType } from "@/generated/prisma/enums";
@@ -845,15 +845,23 @@ export function CreatedRuleToolCard({
   preview?: boolean;
 }) {
   const conditionText = buildConditionText(args.condition);
+  const isCreated = Boolean(ruleId);
 
   return (
     <RuleSummaryCard
       title={args.name}
+      status={
+        <RuleStatusBadge
+          label={isCreated ? "Created" : "Pending"}
+          color={isCreated ? "green" : "yellow"}
+        />
+      }
       actions={
-        <>
-          {ruleId && <RuleActions ruleId={ruleId} />}
-          {preview && <RuleActionsPreview />}
-        </>
+        preview ? (
+          <RuleActionsPreview />
+        ) : ruleId ? (
+          <RuleActions ruleId={ruleId} />
+        ) : null
       }
     >
       <RuleSummaryRow label="When">
@@ -1183,8 +1191,9 @@ export function UpdatedRuleConditions({
 
   return (
     <Card>
-      <RuleToolCardHeader
+      <RuleSummaryCardHeader
         title={args.ruleName}
+        status={<RuleStatusBadge label="Updated" color="blue" />}
         actions={
           preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />
         }
@@ -1249,8 +1258,9 @@ export function UpdatedRuleActions({
 
   return (
     <Card>
-      <RuleToolCardHeader
+      <RuleSummaryCardHeader
         title={args.ruleName}
+        status={<RuleStatusBadge label="Updated" color="blue" />}
         actions={
           preview ? <RuleActionsPreview /> : <RuleActions ruleId={ruleId} />
         }
@@ -1294,15 +1304,34 @@ export function UpdatedRule({
 }) {
   const ruleId = output.ruleId;
   const title = output.updatedName || args.updates.name || args.ruleName;
-  const conditionText = args.updates.condition
-    ? buildConditionText(args.updates.condition)
+  const conditionText = output.updatedConditions
+    ? buildConditionText(output.updatedConditions)
     : null;
-  const actions = args.updates.actions;
+  const actions = output.updatedActions;
+  const nameChanged =
+    output.originalName &&
+    output.updatedName &&
+    output.originalName !== output.updatedName;
+  const enabledChanged =
+    output.originalEnabled !== undefined &&
+    output.updatedEnabled !== undefined &&
+    output.originalEnabled !== output.updatedEnabled;
+  const onlyEnabledChanged =
+    enabledChanged &&
+    !nameChanged &&
+    !output.updatedConditions &&
+    !output.updatedActions;
+  const status = getRuleUpdateStatus({
+    alreadyApplied: output.alreadyApplied,
+    onlyEnabledChanged,
+    updatedEnabled: output.updatedEnabled,
+  });
 
   return (
     <Card>
-      <RuleToolCardHeader
+      <RuleSummaryCardHeader
         title={title}
+        status={<RuleStatusBadge label={status.label} color={status.color} />}
         actions={
           preview ? (
             <RuleActionsPreview />
@@ -1313,10 +1342,10 @@ export function UpdatedRule({
       />
 
       <CardContent className="space-y-3 px-4 py-3.5">
-        {args.updates.name && (
+        {nameChanged && output.updatedName && (
           <div className="flex gap-4 text-sm">
             <FieldLabel className="pt-0.5">Name</FieldLabel>
-            <p>{args.updates.name}</p>
+            <p>{output.updatedName}</p>
           </div>
         )}
 
@@ -1327,10 +1356,10 @@ export function UpdatedRule({
           </div>
         )}
 
-        {args.updates.enabled !== undefined && (
+        {enabledChanged && output.updatedEnabled !== undefined && (
           <div className="flex gap-4 text-sm">
             <FieldLabel className="pt-0.5">Status</FieldLabel>
-            <p>{args.updates.enabled ? "Enabled" : "Disabled"}</p>
+            <p>{output.updatedEnabled ? "Enabled" : "Disabled"}</p>
           </div>
         )}
 
@@ -1341,17 +1370,15 @@ export function UpdatedRule({
           </div>
         )}
 
-        {output.originalName &&
-          output.updatedName &&
-          output.originalName !== output.updatedName && (
-            <ViewChangesCollapsible>
-              <CollapsibleDiffContent
-                title="Name:"
-                originalText={output.originalName}
-                updatedText={output.updatedName}
-              />
-            </ViewChangesCollapsible>
-          )}
+        {nameChanged && output.originalName && output.updatedName && (
+          <ViewChangesCollapsible>
+            <CollapsibleDiffContent
+              title="Name:"
+              originalText={output.originalName}
+              updatedText={output.updatedName}
+            />
+          </ViewChangesCollapsible>
+        )}
       </CardContent>
     </Card>
   );
@@ -1382,7 +1409,11 @@ export function UpdatedLearnedPatterns({
 
   return (
     <Card>
-      <RuleToolCardHeader title={args.ruleName} actions={actions} />
+      <RuleSummaryCardHeader
+        title={args.ruleName}
+        status={<RuleStatusBadge label="Patterns updated" color="blue" />}
+        actions={actions}
+      />
 
       <CardContent className="space-y-3 px-4 py-3.5">
         {args.learnedPatterns.map((pattern, i) => {
@@ -1423,8 +1454,11 @@ export function UpdatedRuleState({
 
   return (
     <Card>
-      <RuleToolCardHeader
+      <RuleSummaryCardHeader
         title={ruleName}
+        status={
+          <RuleStatusBadge label={label} color={enabled ? "green" : "gray"} />
+        }
         actions={
           preview ? (
             <RuleActionsPreview enabled={enabled} />
@@ -1800,14 +1834,31 @@ function LearnedPatternsActions({ ruleId }: { ruleId: string }) {
   );
 }
 
-function RuleToolCardHeader({
-  title,
-  actions,
+function RuleStatusBadge({ label, color }: { label: string; color: Color }) {
+  return (
+    <Badge color={color} className="shrink-0 text-[10px]">
+      {label}
+    </Badge>
+  );
+}
+
+function getRuleUpdateStatus({
+  alreadyApplied,
+  onlyEnabledChanged,
+  updatedEnabled,
 }: {
-  title: string;
-  actions: React.ReactNode;
-}) {
-  return <RuleSummaryCardHeader title={title} actions={actions} />;
+  alreadyApplied: boolean | undefined;
+  onlyEnabledChanged: boolean;
+  updatedEnabled: boolean | undefined;
+}): { label: string; color: Color } {
+  if (alreadyApplied) return { label: "Already applied", color: "gray" };
+
+  if (onlyEnabledChanged) {
+    return updatedEnabled
+      ? { label: "Enabled", color: "green" }
+      : { label: "Disabled", color: "gray" };
+  }
+  return { label: "Updated", color: "blue" };
 }
 
 function ExpandedToolCard({

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -1305,7 +1305,13 @@ export function UpdatedRule({
   const ruleId = output.ruleId;
   const title = output.updatedName || args.updates.name || args.ruleName;
   const conditionText = output.updatedConditions
-    ? buildConditionText(output.updatedConditions)
+    ? buildConditionText(
+        output.currentRule?.conditions ||
+          mergeUpdatedConditionsForDisplay({
+            originalConditions: output.originalConditions,
+            updatedConditions: output.updatedConditions,
+          }),
+      )
     : null;
   const actions = output.updatedActions;
   const nameChanged =
@@ -2330,6 +2336,43 @@ function buildConditionText(condition: {
     if (staticParts.length > 0) parts.push(staticParts.join(", "));
   }
   return parts.join(` ${condition.conditionalOperator || "AND"} `);
+}
+
+function mergeUpdatedConditionsForDisplay({
+  originalConditions,
+  updatedConditions,
+}: {
+  originalConditions: UpdateRuleOutput["originalConditions"];
+  updatedConditions: NonNullable<UpdateRuleOutput["updatedConditions"]>;
+}) {
+  let staticCondition = originalConditions?.static;
+  if ("static" in updatedConditions) {
+    staticCondition =
+      updatedConditions.static === null
+        ? null
+        : {
+            ...(originalConditions?.static || {}),
+            ...(updatedConditions.static || {}),
+          };
+  }
+
+  let aiInstructions = originalConditions?.aiInstructions;
+  if ("aiInstructions" in updatedConditions) {
+    aiInstructions = updatedConditions.aiInstructions;
+  } else if (updatedConditions.clearAiInstructions) {
+    aiInstructions = null;
+  }
+
+  const conditionalOperator =
+    "conditionalOperator" in updatedConditions
+      ? updatedConditions.conditionalOperator
+      : originalConditions?.conditionalOperator;
+
+  return {
+    aiInstructions,
+    static: staticCondition,
+    conditionalOperator,
+  };
 }
 
 function formatActionsForDiff(

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -367,6 +367,63 @@ describe("updateRuleTool", () => {
     expect(mockUpdateRuleActions).not.toHaveBeenCalled();
   });
 
+  it("applies static condition changes when copied instructions are included", async () => {
+    mockPrisma.rule.findUnique.mockResolvedValue(
+      vendorBillingRuleWithActions(),
+    );
+
+    const result = await updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["Vendor Billing", "2026-04-27T00:00:00.000Z"],
+        ]),
+      }),
+    }).execute({
+      ruleName: "Vendor Billing",
+      updates: {
+        condition: {
+          aiInstructions: "Billing notices.",
+          static: {
+            from: "accounts@vendor.example",
+            subject: "invoice",
+          },
+          conditionalOperator: "AND",
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        updatedConditions: {
+          aiInstructions: "Billing notices.",
+          static: {
+            from: "accounts@vendor.example",
+            subject: "invoice",
+          },
+          conditionalOperator: "AND",
+        },
+      }),
+    );
+    expect(result.alreadyApplied).toBeUndefined();
+    expect(mockPartialUpdateRule).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      data: {
+        instructions: "Billing notices.",
+        from: "accounts@vendor.example",
+        subject: "invoice",
+        conditionalOperator: "AND",
+      },
+    });
+  });
+
   it("blocks updates after deletion is pending for the same rule", async () => {
     const result = await updateRuleTool({
       email: "user@example.com",

--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -273,6 +273,100 @@ describe("updateRuleTool", () => {
     });
   });
 
+  it("returns alreadyApplied without writing when all requested fields match the rule", async () => {
+    mockPrisma.rule.findUnique.mockResolvedValue(
+      vendorBillingRuleWithActions(),
+    );
+
+    const result = await updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["Vendor Billing", "2026-04-27T00:00:00.000Z"],
+        ]),
+      }),
+    }).execute({
+      ruleName: "Vendor Billing",
+      updates: {
+        name: "Vendor Billing",
+        condition: {
+          aiInstructions: "Billing notices.",
+          static: {
+            from: "billing@vendor.example",
+            subject: "invoice",
+          },
+          conditionalOperator: "AND",
+        },
+        actions: vendorBillingActionsInput(),
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        alreadyApplied: true,
+        currentRule: expect.objectContaining({
+          name: "Vendor Billing",
+        }),
+      }),
+    );
+    expect(mockPartialUpdateRule).not.toHaveBeenCalled();
+    expect(mockUpdateRuleActions).not.toHaveBeenCalled();
+    expect(mockSetRuleEnabled).not.toHaveBeenCalled();
+  });
+
+  it("strips copied actions while applying a real condition change", async () => {
+    mockPrisma.rule.findUnique.mockResolvedValue(
+      vendorBillingRuleWithActions(),
+    );
+
+    const result = await updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ({
+        readAt: Date.now(),
+        rulesRevision: 3,
+        ruleUpdatedAtByName: new Map([
+          ["Vendor Billing", "2026-04-27T00:00:00.000Z"],
+        ]),
+      }),
+    }).execute({
+      ruleName: "Vendor Billing",
+      updates: {
+        condition: {
+          aiInstructions: "Billing notices that need finance review.",
+        },
+        actions: vendorBillingActionsInput(),
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        updatedConditions: {
+          aiInstructions: "Billing notices that need finance review.",
+        },
+        updatedActions: undefined,
+      }),
+    );
+    expect(result.alreadyApplied).toBeUndefined();
+    expect(mockPartialUpdateRule).toHaveBeenCalledWith({
+      ruleId: "rule-id",
+      emailAccountId: "email-account-id",
+      data: {
+        instructions: "Billing notices that need finance review.",
+      },
+    });
+    expect(mockUpdateRuleActions).not.toHaveBeenCalled();
+  });
+
   it("blocks updates after deletion is pending for the same rule", async () => {
     const result = await updateRuleTool({
       email: "user@example.com",
@@ -432,4 +526,60 @@ function mockAssistantRuleSnapshot(
     })),
     messagingChannels: [],
   });
+}
+
+function vendorBillingRuleWithActions() {
+  return {
+    id: "rule-id",
+    name: "Vendor Billing",
+    enabled: true,
+    updatedAt: new Date("2026-04-27T00:00:00.000Z"),
+    emailAccount: { rulesRevision: 3 },
+    instructions: "Billing notices.",
+    from: "billing@vendor.example",
+    to: null,
+    subject: "invoice",
+    conditionalOperator: "AND",
+    actions: [
+      {
+        type: ActionType.LABEL,
+        content: null,
+        label: "Vendor Billing",
+        to: null,
+        cc: null,
+        bcc: null,
+        subject: null,
+        url: null,
+        folderName: null,
+        delayInMinutes: null,
+      },
+      {
+        type: ActionType.ARCHIVE,
+        content: null,
+        label: null,
+        to: null,
+        cc: null,
+        bcc: null,
+        subject: null,
+        url: null,
+        folderName: null,
+        delayInMinutes: null,
+      },
+    ],
+  };
+}
+
+function vendorBillingActionsInput() {
+  return [
+    {
+      type: ActionType.LABEL,
+      fields: { label: "Vendor Billing" },
+      delayInMinutes: null,
+    },
+    {
+      type: ActionType.ARCHIVE,
+      fields: {},
+      delayInMinutes: null,
+    },
+  ];
 }

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -404,9 +404,15 @@ function conditionChangesRule(
   },
 ) {
   if ("aiInstructions" in condition) {
-    return condition.aiInstructions !== rule.instructions;
+    if (condition.aiInstructions !== rule.instructions) return true;
   }
-  if (condition.clearAiInstructions && rule.instructions !== null) return true;
+  if (
+    condition.clearAiInstructions &&
+    !("aiInstructions" in condition) &&
+    rule.instructions !== null
+  ) {
+    return true;
+  }
   if (
     "conditionalOperator" in condition &&
     condition.conditionalOperator !== rule.conditionalOperator

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -194,11 +194,43 @@ export const updateRuleTool = ({
           ),
           delayInMinutes: action.delayInMinutes,
         }));
+        const requestedChangesAlreadyMatchRule = !ruleUpdateHasChanges({
+          updates,
+          rule,
+          originalActions,
+        });
         const effectiveUpdates = normalizeRuleUpdates({
           updates,
           rule,
           originalActions,
         });
+        if (requestedChangesAlreadyMatchRule) {
+          const snapshot = await loadRuleSnapshotAfterWrite({
+            emailAccountId,
+            logger,
+            setRuleReadState,
+            onRulesStateExposed,
+          });
+          const currentRule = snapshot?.rules.find(
+            (snapshotRule) => snapshotRule.name === rule.name,
+          );
+
+          return {
+            success: true,
+            alreadyApplied: true,
+            message:
+              "The requested update already matches the current rule, so no write was applied.",
+            ruleId: rule.id,
+            originalName: rule.name,
+            updatedName: rule.name,
+            originalEnabled: rule.enabled,
+            updatedEnabled: rule.enabled,
+            originalConditions,
+            originalActions,
+            currentRule,
+          };
+        }
+
         if (effectiveUpdates.name || effectiveUpdates.condition) {
           await partialUpdateRule({
             ruleId: rule.id,
@@ -286,6 +318,8 @@ export type UpdateRuleTool = InferUITool<ReturnType<typeof updateRuleTool>>;
 
 export type UpdateRuleOutput = {
   success: boolean;
+  alreadyApplied?: boolean;
+  message?: string;
   ruleId?: string;
   error?: string;
   originalName?: string;
@@ -325,6 +359,67 @@ type RuleUpdatePatch = {
   actions?: RuleAction[];
 };
 
+function ruleUpdateHasChanges({
+  updates,
+  rule,
+  originalActions,
+}: {
+  updates: RuleUpdatePatch;
+  rule: {
+    conditionalOperator: LogicalOperator | null;
+    enabled: boolean;
+    from: string | null;
+    instructions: string | null;
+    name: string;
+    subject: string | null;
+    to: string | null;
+  };
+  originalActions: NonNullable<UpdateRuleOutput["originalActions"]>;
+}) {
+  if (updates.name !== undefined && updates.name !== rule.name) return true;
+  if (updates.enabled !== undefined && updates.enabled !== rule.enabled) {
+    return true;
+  }
+  if (updates.condition && conditionChangesRule(updates.condition, rule)) {
+    return true;
+  }
+  if (
+    updates.actions &&
+    !actionsLookCopiedFromRule(updates.actions, originalActions)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function conditionChangesRule(
+  condition: PatchCondition,
+  rule: {
+    conditionalOperator: LogicalOperator | null;
+    from: string | null;
+    instructions: string | null;
+    subject: string | null;
+    to: string | null;
+  },
+) {
+  if ("aiInstructions" in condition) {
+    return condition.aiInstructions !== rule.instructions;
+  }
+  if (condition.clearAiInstructions && rule.instructions !== null) return true;
+  if (
+    "conditionalOperator" in condition &&
+    condition.conditionalOperator !== rule.conditionalOperator
+  ) {
+    return true;
+  }
+  if ("static" in condition) {
+    return !staticLooksCopiedFromRule(condition.static, rule);
+  }
+
+  return false;
+}
+
 function normalizeRuleUpdates({
   updates,
   rule,
@@ -341,8 +436,6 @@ function normalizeRuleUpdates({
   };
   originalActions: NonNullable<UpdateRuleOutput["originalActions"]>;
 }): RuleUpdatePatch {
-  if (updates.enabled === undefined) return updates;
-
   const normalized = { ...updates };
   if (normalized.name === rule.name) normalized.name = undefined;
   if (
@@ -371,21 +464,7 @@ function conditionLooksCopiedFromRule(
     to: string | null;
   },
 ) {
-  if (condition.clearAiInstructions && condition.aiInstructions !== undefined) {
-    return true;
-  }
-
-  const instructionsMatch =
-    !("aiInstructions" in condition) ||
-    condition.aiInstructions === rule.instructions;
-  const operatorMatches =
-    !("conditionalOperator" in condition) ||
-    condition.conditionalOperator === rule.conditionalOperator;
-  const staticMatches =
-    !("static" in condition) ||
-    staticLooksCopiedFromRule(condition.static, rule);
-
-  return instructionsMatch && operatorMatches && staticMatches;
+  return !conditionChangesRule(condition, rule);
 }
 
 function staticLooksCopiedFromRule(


### PR DESCRIPTION
Fixes assistant rule update handling for repeated successful updates. Restores rule-card status labels, avoids rewriting when requested changes already match the current rule, strips copied action payloads from condition-only edits, and adds focused coverage for the repeated-update path.

Validation:
- pnpm --dir apps/web exec biome check components/assistant-chat/tools.tsx components/assistant-chat/rule-summary-card.tsx utils/ai/assistant/tools/rules/update-rule-tool.ts utils/ai/assistant/chat-rule-tools.test.ts __tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts
- pnpm test utils/ai/assistant/chat-rule-tools.test.ts
- pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-rule-editing-patch-semantics.test.ts -t "does not repeat a rule update after confirmed current rule output"