### PR TITLE
Fix rule condition display typing

### DIFF
--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -2315,7 +2315,7 @@ function ToolEmailRows({ emails }: { emails: ToolEmailRow[] }) {
   );
 }
 
-function buildConditionText(condition: {
+type ConditionTextInput = {
   aiInstructions?: string | null;
   static?: {
     from?: string | null;
@@ -2323,7 +2323,9 @@ function buildConditionText(condition: {
     subject?: string | null;
   } | null;
   conditionalOperator?: string | null;
-}): string {
+};
+
+function buildConditionText(condition: ConditionTextInput): string {
   const parts: string[] = [];
   if (condition.aiInstructions) parts.push(condition.aiInstructions);
   if (condition.static) {
@@ -2345,7 +2347,8 @@ function mergeUpdatedConditionsForDisplay({
   originalConditions: UpdateRuleOutput["originalConditions"];
   updatedConditions: NonNullable<UpdateRuleOutput["updatedConditions"]>;
 }) {
-  let staticCondition = originalConditions?.static;
+  let staticCondition: ConditionTextInput["static"] =
+    originalConditions?.static;
   if ("static" in updatedConditions) {
     staticCondition =
       updatedConditions.static === null

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -2367,7 +2367,7 @@ function mergeUpdatedConditionsForDisplay({
   }
 
   const conditionalOperator =
-    "conditionalOperator" in updatedConditions
+    updatedConditions.conditionalOperator != null
       ? updatedConditions.conditionalOperator
       : originalConditions?.conditionalOperator;
 


### PR DESCRIPTION
Fixes a build type-check issue in rule condition display handling.

- Adds an explicit condition display input type.
- Allows cleared static conditions to be represented consistently in the display helper.

Validation:
- pnpm --dir apps/web exec biome check components/assistant-chat/tools.tsx
- pnpm --filter inbox-zero-ai build:ci

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

