### PR TITLE
organizations: Add ownership deletion safeguards

### DIFF
--- a/apps/web/app/(app)/organization/[organizationId]/Members.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/Members.tsx
@@ -34,11 +34,14 @@ import {
   BarChartIcon,
   ShieldIcon,
   XIcon,
+  CrownIcon,
 } from "lucide-react";
 import { InviteMemberModal } from "@/components/InviteMemberModal";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
   cancelInvitationAction,
   removeMemberAction,
+  transferOwnershipAction,
   updateMemberRoleAction,
 } from "@/utils/actions/organization";
 import { toastSuccess, toastError } from "@/components/Toast";
@@ -61,6 +64,7 @@ export function Members({ organizationId }: { organizationId: string }) {
     useOrganizationMembers(organizationId);
   const { data: membership } = useOrganizationMembership();
   const isAdmin = hasOrganizationAdminRole(membership?.role ?? "");
+  const isOwner = membership?.role === "owner";
   const { data: executedRulesData } = useExecutedRulesCount(
     isAdmin ? organizationId : null,
   );
@@ -151,6 +155,18 @@ export function Members({ organizationId }: { organizationId: string }) {
     [handleAction],
   );
 
+  const handleTransferOwnership = useCallback(
+    (memberId: string) =>
+      handleAction(
+        memberId,
+        () => transferOwnershipAction({ organizationId, memberId }),
+        "Error transferring ownership",
+        "Ownership transferred successfully",
+        "Failed to transfer ownership",
+      ),
+    [handleAction, organizationId],
+  );
+
   return (
     <LoadingContent loading={isLoading} error={error}>
       <div>
@@ -176,11 +192,13 @@ export function Members({ organizationId }: { organizationId: string }) {
                 member={member}
                 onRemove={handleRemoveMember}
                 onUpdateRole={handleUpdateRole}
+                onTransferOwnership={handleTransferOwnership}
                 executedRulesCount={executedRulesStats?.executedRulesCount}
                 lastProcessedEmailAt={
                   executedRulesStats?.lastProcessedEmailAt ?? null
                 }
                 isAdmin={isAdmin}
+                isOwner={isOwner}
                 isPending={pendingMemberId === member.id}
               />
             );
@@ -242,21 +260,26 @@ function MemberCard({
   member,
   onRemove,
   onUpdateRole,
+  onTransferOwnership,
   executedRulesCount,
   lastProcessedEmailAt,
   isAdmin,
+  isOwner,
   isPending,
 }: {
   member: Member;
   onRemove: (memberId: string) => void;
   onUpdateRole: (memberId: string, role: "admin" | "member") => void;
+  onTransferOwnership: (memberId: string) => void;
   executedRulesCount?: number;
   lastProcessedEmailAt?: Date | string | null;
   isAdmin: boolean;
+  isOwner: boolean;
   isPending: boolean;
 }) {
   const { emailAccountId } = useAccount();
   const canChangeRole = member.role !== "owner";
+  const canTransferOwnership = isOwner && canChangeRole;
   const activityStatus = getMemberActivityStatus({
     allowOrgAdminAnalytics: member.allowOrgAdminAnalytics,
     disconnectedAt: member.emailAccount.disconnectedAt,
@@ -343,6 +366,26 @@ function MemberCard({
                     </DropdownMenuRadioGroup>
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
+              )}
+              {canTransferOwnership && (
+                <ConfirmDialog
+                  trigger={
+                    <DropdownMenuItem
+                      onSelect={(e: Event) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      disabled={isPending}
+                    >
+                      <CrownIcon className="mr-2 size-4" />
+                      Transfer ownership
+                    </DropdownMenuItem>
+                  }
+                  title="Transfer ownership"
+                  description={`Transfer organization ownership to ${member.emailAccount.name || member.emailAccount.email}? You will become an admin.`}
+                  confirmText="Transfer"
+                  onConfirm={() => onTransferOwnership(member.id)}
+                />
               )}
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/apps/web/prisma/migrations/20260630000000_enforce_organization_owner/migration.sql
+++ b/apps/web/prisma/migrations/20260630000000_enforce_organization_owner/migration.sql
@@ -1,0 +1,52 @@
+ALTER TABLE "Member" DROP CONSTRAINT "Member_emailAccountId_fkey";
+ALTER TABLE "Member" ADD CONSTRAINT "Member_emailAccountId_fkey" FOREIGN KEY ("emailAccountId") REFERENCES "EmailAccount"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE OR REPLACE FUNCTION "ensure_organization_keeps_owner"()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (
+    (TG_OP = 'DELETE' AND OLD."role" = 'owner') OR
+    (TG_OP = 'UPDATE' AND OLD."role" = 'owner' AND NEW."role" IS DISTINCT FROM 'owner')
+  ) THEN
+    -- Serialize owner removal/demotion per organization so concurrent changes
+    -- cannot each observe the other owner and leave the organization ownerless.
+    PERFORM 1
+    FROM "Organization"
+    WHERE "id" = OLD."organizationId"
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM "Member"
+      WHERE "organizationId" = OLD."organizationId"
+        AND "role" = 'owner'
+        AND "id" <> OLD."id"
+    ) THEN
+      RAISE EXCEPTION 'organization_must_have_owner'
+        USING ERRCODE = '23514',
+              CONSTRAINT = 'organization_must_have_owner';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "ensure_organization_keeps_owner_trigger" ON "Member";
+
+CREATE TRIGGER "ensure_organization_keeps_owner_trigger"
+BEFORE DELETE OR UPDATE OF "role" ON "Member"
+FOR EACH ROW
+EXECUTE FUNCTION "ensure_organization_keeps_owner"();

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -298,7 +298,7 @@ model Member {
   createdAt              DateTime     @default(now())
   updatedAt              DateTime     @updatedAt
   organization           Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  emailAccount           EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Cascade)
+  emailAccount           EmailAccount @relation(fields: [emailAccountId], references: [id], onDelete: Restrict)
 
   @@unique([organizationId, emailAccountId])
   @@unique([emailAccountId])

--- a/apps/web/utils/actions/organization.test.ts
+++ b/apps/web/utils/actions/organization.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
   removeMemberAction,
+  transferOwnershipAction,
   updateMemberRoleAction,
 } from "@/utils/actions/organization";
 
@@ -139,5 +140,89 @@ describe("removeMemberAction", () => {
 
     expect(result?.serverError).toBe("Only owners can remove other owners.");
     expect(prisma.member.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("transferOwnershipAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.member.update.mockResolvedValue({} as any);
+    prisma.$transaction.mockResolvedValue([] as any);
+  });
+
+  it("transfers ownership to another member and demotes the caller to admin", async () => {
+    prisma.member.findUnique.mockResolvedValue({
+      id: "member-2",
+      emailAccountId: "email-account-2",
+      organizationId: "org-1",
+      role: "admin",
+    } as any);
+    prisma.member.findFirst.mockResolvedValue({
+      id: "member-1",
+      role: "owner",
+      emailAccountId: "email-account-1",
+    } as any);
+
+    const result = await transferOwnershipAction({
+      organizationId: "org-1",
+      memberId: "member-2",
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledWith([
+      expect.anything(),
+      expect.anything(),
+    ]);
+    expect(prisma.member.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "member-2" },
+      data: { role: "owner" },
+    });
+    expect(prisma.member.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "member-1" },
+      data: { role: "admin" },
+    });
+    expect(result?.data).toEqual({ id: "member-2", role: "owner" });
+  });
+
+  it("blocks admins from transferring ownership", async () => {
+    prisma.member.findUnique.mockResolvedValue({
+      id: "member-2",
+      emailAccountId: "email-account-2",
+      organizationId: "org-1",
+      role: "member",
+    } as any);
+    prisma.member.findFirst.mockResolvedValue(null);
+
+    const result = await transferOwnershipAction({
+      organizationId: "org-1",
+      memberId: "member-2",
+    });
+
+    expect(result?.serverError).toBe(
+      "Only organization owners can transfer ownership.",
+    );
+    expect(prisma.member.update).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("prevents transferring ownership to yourself", async () => {
+    prisma.member.findUnique.mockResolvedValue({
+      id: "member-1",
+      emailAccountId: "email-account-1",
+      organizationId: "org-1",
+      role: "owner",
+    } as any);
+    prisma.member.findFirst.mockResolvedValue({
+      id: "member-1",
+      role: "owner",
+      emailAccountId: "email-account-1",
+    } as any);
+
+    const result = await transferOwnershipAction({
+      organizationId: "org-1",
+      memberId: "member-1",
+    });
+
+    expect(result?.serverError).toBe("You already own this organization.");
+    expect(prisma.member.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -7,6 +7,7 @@ import {
   inviteMembersBody,
   removeMemberBody,
   updateMemberRoleBody,
+  transferOwnershipBody,
   cancelInvitationBody,
   handleInvitationBody,
   updateAnalyticsConsentBody,
@@ -407,6 +408,61 @@ export const updateMemberRoleAction = actionClientUser
       select: { id: true, role: true },
     });
   });
+
+export const transferOwnershipAction = actionClientUser
+  .metadata({ name: "transferOwnership" })
+  .inputSchema(transferOwnershipBody)
+  .action(
+    async ({ ctx: { userId }, parsedInput: { organizationId, memberId } }) => {
+      const targetMember = await prisma.member.findUnique({
+        where: { id: memberId },
+        select: {
+          id: true,
+          emailAccountId: true,
+          organizationId: true,
+          role: true,
+        },
+      });
+
+      if (!targetMember || targetMember.organizationId !== organizationId) {
+        throw new SafeError("Member not found.");
+      }
+
+      const callerMembership = await prisma.member.findFirst({
+        where: {
+          organizationId,
+          role: "owner",
+          emailAccount: { userId },
+        },
+        select: { id: true, emailAccountId: true },
+      });
+
+      if (!callerMembership) {
+        throw new SafeError("Only organization owners can transfer ownership.");
+      }
+
+      if (targetMember.emailAccountId === callerMembership.emailAccountId) {
+        throw new SafeError("You already own this organization.");
+      }
+
+      if (targetMember.role === "owner") {
+        return { id: targetMember.id, role: targetMember.role };
+      }
+
+      await prisma.$transaction([
+        prisma.member.update({
+          where: { id: targetMember.id },
+          data: { role: "owner" },
+        }),
+        prisma.member.update({
+          where: { id: callerMembership.id },
+          data: { role: "admin" },
+        }),
+      ]);
+
+      return { id: targetMember.id, role: "owner" };
+    },
+  );
 
 export const cancelInvitationAction = actionClientUser
   .metadata({ name: "cancelInvitation" })

--- a/apps/web/utils/actions/organization.validation.ts
+++ b/apps/web/utils/actions/organization.validation.ts
@@ -59,6 +59,13 @@ export const updateMemberRoleBody = z.object({
 
 export type UpdateMemberRoleBody = z.infer<typeof updateMemberRoleBody>;
 
+export const transferOwnershipBody = z.object({
+  organizationId: z.string().min(1, "Organization ID is required"),
+  memberId: z.string().min(1, "Member ID is required"),
+});
+
+export type TransferOwnershipBody = z.infer<typeof transferOwnershipBody>;
+
 export const cancelInvitationBody = z.object({
   invitationId: z.string().min(1, "Invitation ID is required"),
 });

--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -3,7 +3,9 @@ import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/utils/__mocks__/prisma";
 import { updateAccountSeats } from "@/utils/premium/seats";
 import { aliasPosthogUser } from "@/utils/posthog";
-import { deleteEmailAccountAction } from "./user";
+import { betterAuthConfig } from "@/utils/auth";
+import { deleteUser } from "@/utils/user/delete";
+import { deleteAccountAction, deleteEmailAccountAction } from "./user";
 
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/auth", () => ({
@@ -12,7 +14,7 @@ vi.mock("@/utils/auth", () => ({
   })),
   betterAuthConfig: {
     api: {
-      signOut: vi.fn(),
+      signOut: vi.fn(() => Promise.resolve()),
     },
   },
 }));
@@ -21,7 +23,7 @@ vi.mock("next/headers", () => ({
 }));
 vi.mock("@sentry/nextjs", () => import("@/__tests__/mocks/sentry-nextjs.mock"));
 vi.mock("@/utils/cookies.server", () => ({
-  clearLastEmailAccountCookie: vi.fn(),
+  clearLastEmailAccountCookie: vi.fn(() => Promise.resolve()),
 }));
 vi.mock("@/utils/user/delete", () => ({
   deleteUser: vi.fn(),
@@ -49,6 +51,7 @@ describe("deleteEmailAccountAction", () => {
     prisma.$transaction.mockImplementation(async (operations) =>
       Promise.all(operations as Promise<unknown>[]),
     );
+    prisma.member.findMany.mockResolvedValue([]);
     prisma.emailAccount.findUnique.mockResolvedValue({
       email: "primary@example.com",
       accountId: "account-1",
@@ -200,6 +203,31 @@ describe("deleteEmailAccountAction", () => {
     expect(updateAccountSeats).not.toHaveBeenCalled();
   });
 
+  it("shows the ownership transfer message when membership blocks account deletion", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "alternate-email-account",
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: null,
+      },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.$transaction.mockRejectedValue(
+      newPrismaKnownError("Foreign key constraint failed", "P2003", {
+        field_name: "Member_emailAccountId_fkey",
+      }),
+    );
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBe(
+      "Transfer organization ownership before deleting this email account.",
+    );
+    expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+
   it("shows an action-specific fallback for unexpected delete failures", async () => {
     prisma.emailAccount.findMany.mockResolvedValue([
       {
@@ -219,6 +247,154 @@ describe("deleteEmailAccountAction", () => {
       "We couldn't delete this email account. Please contact support if this keeps happening.",
     );
     expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+
+  it("does not delete an email account when an organization would keep members but no owner", async () => {
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "primary-email-account", role: "owner" },
+          { emailAccountId: "other-email-account", role: "member" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBe(
+      "Transfer organization ownership before deleting this email account.",
+    );
+    expect(prisma.emailAccount.delete).not.toHaveBeenCalled();
+    expect(prisma.account.delete).not.toHaveBeenCalled();
+    expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+
+  it("deletes a solo organization before deleting its only email account", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "alternate-email-account",
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: null,
+      },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "primary-email-account", role: "owner" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.organization.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["org-1"] },
+        members: {
+          every: {
+            emailAccountId: { in: ["primary-email-account"] },
+          },
+        },
+      },
+    });
+    expect(prisma.emailAccount.delete).toHaveBeenCalled();
+  });
+
+  it("shows the ownership transfer message when the database rejects a raced owner deletion", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "alternate-email-account",
+        email: "alternate@example.com",
+        name: "Alternate",
+        image: null,
+      },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.$transaction.mockRejectedValue(
+      new Error("organization_must_have_owner"),
+    );
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "primary-email-account",
+    });
+
+    expect(result?.serverError).toBe(
+      "Transfer organization ownership before deleting this email account.",
+    );
+    expect(updateAccountSeats).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteAccountAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.emailAccount.findMany.mockResolvedValue([]);
+    prisma.member.findMany.mockResolvedValue([]);
+  });
+
+  it("does not sign out before blocking account deletion when an organization would keep members but no owner", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      { id: "primary-email-account" },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "primary-email-account", role: "owner" },
+          { emailAccountId: "other-email-account", role: "member" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await deleteAccountAction();
+
+    expect(result?.serverError).toBe(
+      "Transfer organization ownership before deleting your account.",
+    );
+    expect(betterAuthConfig.api.signOut).not.toHaveBeenCalled();
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("allows account deletion when every organization member belongs to the deleted user", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      { id: "primary-email-account" },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "primary-email-account", role: "owner" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await deleteAccountAction();
+
+    expect(result?.serverError).toBeUndefined();
+    expect(betterAuthConfig.api.signOut).toHaveBeenCalled();
+    expect(deleteUser).toHaveBeenCalledWith({
+      userId: "user-1",
+      logger: expect.anything(),
+    });
   });
 });
 

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -24,6 +24,16 @@ import {
 } from "@/utils/ai/draft-cleanup";
 import { isDuplicateError, isNotFoundError } from "@/utils/prisma-helpers";
 import type { Logger } from "@/utils/logger";
+import {
+  DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  DELETE_EMAIL_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  getDeletableOrganizationIdsOrThrow,
+  getDeletedAccountOwnershipImpact,
+  getDeleteSoloOrganizationsOperation,
+  getUserDeletionOwnershipImpact,
+  isMemberEmailAccountForeignKeyError,
+  isOrganizationOwnerInvariantError,
+} from "@/utils/organizations/ownership";
 
 export const saveAboutAction = actionClient
   .metadata({ name: "saveAbout" })
@@ -68,6 +78,8 @@ export const resetAnalyticsAction = actionClient
 export const deleteAccountAction = actionClientUser
   .metadata({ name: "deleteAccount" })
   .action(async ({ ctx: { userId, logger } }) => {
+    await assertUserAccountCanBeDeleted(userId);
+
     await clearLastEmailAccountCookie().catch((error) => {
       logger.error("Failed to clear last email account cookie", { error });
     });
@@ -125,8 +137,14 @@ export const deleteEmailAccountAction = actionClientUser
 
       if (!emailAccount) throw new SafeError("Email account not found");
       if (!emailAccount.accountId) throw new SafeError("Account id not found");
+      const organizationIdsToDelete =
+        await assertEmailAccountCanBeDeleted(emailAccountId);
 
       const isPrimaryAccount = emailAccount.email === emailAccount.user.email;
+      const deleteSoloOrganizationsOperation =
+        getDeleteSoloOrganizationsOperation(organizationIdsToDelete, [
+          emailAccountId,
+        ]);
 
       if (isPrimaryAccount) {
         // Check if there are other email accounts
@@ -155,6 +173,7 @@ export const deleteEmailAccountAction = actionClientUser
         await runDeleteEmailAccountTransaction(
           userId,
           [
+            deleteSoloOrganizationsOperation,
             prisma.user.update({
               where: {
                 id: userId,
@@ -192,6 +211,7 @@ export const deleteEmailAccountAction = actionClientUser
         await runDeleteEmailAccountTransaction(
           userId,
           [
+            deleteSoloOrganizationsOperation,
             prisma.emailAccount.delete({
               where: {
                 id: emailAccountId,
@@ -252,6 +272,13 @@ async function runDeleteEmailAccountTransaction(
     }
 
     if (
+      isOrganizationOwnerInvariantError(error) ||
+      isMemberEmailAccountForeignKeyError(error)
+    ) {
+      throw new SafeError(DELETE_EMAIL_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR);
+    }
+
+    if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2003"
     ) {
@@ -283,4 +310,24 @@ function getPrismaErrorMeta(error: unknown) {
   return error instanceof Prisma.PrismaClientKnownRequestError
     ? error.meta
     : undefined;
+}
+
+async function assertEmailAccountCanBeDeleted(emailAccountId: string) {
+  const ownershipImpact = await getDeletedAccountOwnershipImpact([
+    emailAccountId,
+  ]);
+
+  return getDeletableOrganizationIdsOrThrow(
+    ownershipImpact,
+    DELETE_EMAIL_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  );
+}
+
+async function assertUserAccountCanBeDeleted(userId: string) {
+  const ownershipImpact = await getUserDeletionOwnershipImpact(userId);
+
+  getDeletableOrganizationIdsOrThrow(
+    ownershipImpact,
+    DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  );
 }

--- a/apps/web/utils/organizations/ownership.test.ts
+++ b/apps/web/utils/organizations/ownership.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import {
+  getDeletedAccountOwnershipImpact,
+  getUserDeletionOwnershipImpact,
+} from "@/utils/organizations/ownership";
+
+vi.mock("@/utils/prisma");
+
+describe("getDeletedAccountOwnershipImpact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks organizations for deletion when deleted email accounts include every member", async () => {
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "owner" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await getDeletedAccountOwnershipImpact(["email-account-1"]);
+
+    expect(result.organizationsRequiringOwnershipTransfer).toEqual([]);
+    expect(result.organizationsToDelete).toEqual([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "owner" }],
+      },
+    ]);
+  });
+
+  it("requires ownership transfer when an organization would keep members but no owner", async () => {
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "email-account-1", role: "owner" },
+          { emailAccountId: "email-account-2", role: "member" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await getDeletedAccountOwnershipImpact(["email-account-1"]);
+
+    expect(result.organizationsRequiringOwnershipTransfer).toEqual([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "email-account-1", role: "owner" },
+          { emailAccountId: "email-account-2", role: "member" },
+        ],
+      },
+    ]);
+    expect(result.organizationsToDelete).toEqual([]);
+  });
+
+  it("ignores organizations with another owner outside the deleted accounts", async () => {
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "email-account-1", role: "owner" },
+          { emailAccountId: "email-account-2", role: "owner" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await getDeletedAccountOwnershipImpact(["email-account-1"]);
+
+    expect(result).toEqual({
+      organizationsRequiringOwnershipTransfer: [],
+      organizationsToDelete: [],
+    });
+  });
+});
+
+describe("getUserDeletionOwnershipImpact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("checks every email account owned by the deleted user", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      { id: "email-account-1" },
+      { id: "email-account-2" },
+    ] as Awaited<ReturnType<typeof prisma.emailAccount.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "email-account-1", role: "owner" },
+          { emailAccountId: "email-account-2", role: "member" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await getUserDeletionOwnershipImpact("user-1");
+
+    expect(result.organizationsToDelete).toHaveLength(1);
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      select: { id: true },
+    });
+  });
+});

--- a/apps/web/utils/organizations/ownership.ts
+++ b/apps/web/utils/organizations/ownership.ts
@@ -1,0 +1,139 @@
+import prisma from "@/utils/prisma";
+import { getErrorMessage, SafeError } from "@/utils/error";
+
+const ORGANIZATION_OWNER_CONSTRAINT_NAME = "organization_must_have_owner";
+const MEMBER_EMAIL_ACCOUNT_FK_CONSTRAINT_NAME = "Member_emailAccountId_fkey";
+
+export const DELETE_EMAIL_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR =
+  "Transfer organization ownership before deleting this email account.";
+
+export const DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR =
+  "Transfer organization ownership before deleting your account.";
+
+export async function getDeletedAccountOwnershipImpact(
+  emailAccountIds: string[],
+) {
+  const deletedEmailAccountIds = new Set(emailAccountIds);
+  if (deletedEmailAccountIds.size === 0) {
+    return {
+      organizationsRequiringOwnershipTransfer: [],
+      organizationsToDelete: [],
+    };
+  }
+
+  const ownerMemberships = await prisma.member.findMany({
+    where: {
+      emailAccountId: { in: [...deletedEmailAccountIds] },
+      role: "owner",
+    },
+    select: { organizationId: true },
+  });
+
+  const organizationIds = [
+    ...new Set(ownerMemberships.map((member) => member.organizationId)),
+  ];
+  if (organizationIds.length === 0) {
+    return {
+      organizationsRequiringOwnershipTransfer: [],
+      organizationsToDelete: [],
+    };
+  }
+
+  const organizations = await prisma.organization.findMany({
+    where: { id: { in: organizationIds } },
+    select: {
+      id: true,
+      name: true,
+      members: {
+        select: { emailAccountId: true, role: true },
+      },
+    },
+  });
+
+  const organizationsRequiringOwnershipTransfer = [];
+  const organizationsToDelete = [];
+
+  for (const organization of organizations) {
+    const keepsOwner = organization.members.some(
+      (member) =>
+        member.role === "owner" &&
+        !deletedEmailAccountIds.has(member.emailAccountId),
+    );
+    if (keepsOwner) continue;
+
+    const keepsAnyMember = organization.members.some(
+      (member) => !deletedEmailAccountIds.has(member.emailAccountId),
+    );
+
+    if (keepsAnyMember) {
+      organizationsRequiringOwnershipTransfer.push(organization);
+    } else {
+      organizationsToDelete.push(organization);
+    }
+  }
+
+  return { organizationsRequiringOwnershipTransfer, organizationsToDelete };
+}
+
+export async function getUserDeletionOwnershipImpact(userId: string) {
+  const emailAccounts = await prisma.emailAccount.findMany({
+    where: { userId },
+    select: { id: true },
+  });
+
+  return getDeletedAccountOwnershipImpact(
+    emailAccounts.map((account) => account.id),
+  );
+}
+
+export function getDeletableOrganizationIdsOrThrow(
+  ownershipImpact: Awaited<ReturnType<typeof getDeletedAccountOwnershipImpact>>,
+  errorMessage: string,
+) {
+  if (ownershipImpact.organizationsRequiringOwnershipTransfer.length > 0) {
+    throw new SafeError(errorMessage);
+  }
+
+  return ownershipImpact.organizationsToDelete.map(
+    (organization) => organization.id,
+  );
+}
+
+export function getDeleteSoloOrganizationsOperation(
+  organizationIds: string[],
+  deletedEmailAccountIds: string[],
+) {
+  return prisma.organization.deleteMany({
+    where: {
+      id: { in: organizationIds },
+      members: {
+        every: { emailAccountId: { in: deletedEmailAccountIds } },
+      },
+    },
+  });
+}
+
+export function isOrganizationOwnerInvariantError(error: unknown) {
+  return errorIncludesConstraint(error, ORGANIZATION_OWNER_CONSTRAINT_NAME);
+}
+
+export function isMemberEmailAccountForeignKeyError(error: unknown) {
+  return errorIncludesConstraint(
+    error,
+    MEMBER_EMAIL_ACCOUNT_FK_CONSTRAINT_NAME,
+  );
+}
+
+function errorIncludesConstraint(error: unknown, constraintName: string) {
+  const message = getErrorMessage(error);
+  if (message?.includes(constraintName)) return true;
+
+  if (typeof error !== "object" || error === null) return false;
+
+  const meta = (error as { meta?: unknown }).meta;
+  if (typeof meta !== "object" || meta === null) return false;
+
+  return Object.values(meta).some(
+    (value) => typeof value === "string" && value.includes(constraintName),
+  );
+}

--- a/apps/web/utils/user/delete.test.ts
+++ b/apps/web/utils/user/delete.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { deleteUser } from "@/utils/user/delete";
+
+vi.mock("@/utils/prisma");
+vi.mock("@inboxzero/loops", () => ({
+  deleteContact: vi.fn(),
+}));
+vi.mock("@inboxzero/resend", () => ({
+  deleteContact: vi.fn(),
+}));
+vi.mock("@inboxzero/tinybird-ai-analytics", () => ({
+  deleteTinybirdAiCalls: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/utils/posthog", () => ({
+  deletePosthogUser: vi.fn(() => Promise.resolve()),
+  trackUserDeleted: vi.fn(() => Promise.resolve()),
+  trackUserDeletionRequested: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/utils/email/watch-manager", () => ({
+  unwatchEmails: vi.fn(),
+}));
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: vi.fn(),
+}));
+vi.mock("@/utils/redis/research-cache", () => ({
+  clearCachedResearchForUser: vi.fn(() => Promise.resolve()),
+}));
+
+const logger = createTestLogger();
+
+describe("deleteUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.member.findMany.mockResolvedValue([]);
+  });
+
+  it("does not delete a user when their email accounts own an organization with remaining members", async () => {
+    prisma.account.findMany.mockResolvedValue([
+      {
+        provider: "google",
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+        emailAccount: {
+          id: "email-account-1",
+          email: "owner@example.com",
+          watchEmailsSubscriptionId: null,
+        },
+      },
+    ] as Awaited<ReturnType<typeof prisma.account.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "email-account-1", role: "owner" },
+          { emailAccountId: "email-account-2", role: "member" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    await expect(deleteUser({ userId: "user-1", logger })).rejects.toThrow(
+      "Transfer organization ownership before deleting your account.",
+    );
+
+    expect(prisma.user.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes solo organizations before deleting the user", async () => {
+    prisma.account.findMany.mockResolvedValue([
+      {
+        provider: "google",
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+        emailAccount: {
+          id: "email-account-1",
+          email: "owner@example.com",
+          watchEmailsSubscriptionId: null,
+        },
+      },
+    ] as Awaited<ReturnType<typeof prisma.account.findMany>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "owner" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+    prisma.executedRule.findMany.mockResolvedValue([]);
+    prisma.user.deleteMany.mockResolvedValue({ count: 1 } as any);
+
+    await deleteUser({ userId: "user-1", logger });
+
+    expect(prisma.organization.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["org-1"] },
+        members: {
+          every: {
+            emailAccountId: { in: ["email-account-1"] },
+          },
+        },
+      },
+    });
+    expect(prisma.user.deleteMany).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+    });
+  });
+
+  it("surfaces the ownership transfer message when the database rejects a raced user deletion", async () => {
+    prisma.account.findMany.mockResolvedValue([
+      {
+        provider: "google",
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+        emailAccount: {
+          id: "email-account-1",
+          email: "owner@example.com",
+          watchEmailsSubscriptionId: null,
+        },
+      },
+    ] as Awaited<ReturnType<typeof prisma.account.findMany>>);
+    prisma.executedRule.findMany.mockResolvedValue([]);
+    prisma.user.deleteMany.mockRejectedValue(
+      new Error("organization_must_have_owner"),
+    );
+
+    await expect(deleteUser({ userId: "user-1", logger })).rejects.toThrow(
+      "Transfer organization ownership before deleting your account.",
+    );
+  });
+
+  it("surfaces the ownership transfer message when membership blocks raced user deletion", async () => {
+    prisma.account.findMany.mockResolvedValue([
+      {
+        provider: "google",
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+        emailAccount: {
+          id: "email-account-1",
+          email: "owner@example.com",
+          watchEmailsSubscriptionId: null,
+        },
+      },
+    ] as Awaited<ReturnType<typeof prisma.account.findMany>>);
+    prisma.executedRule.findMany.mockResolvedValue([]);
+    prisma.user.deleteMany.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError(
+        "Foreign key constraint failed",
+        {
+          code: "P2003",
+          clientVersion: "test",
+          meta: { field_name: "Member_emailAccountId_fkey" },
+        },
+      ),
+    );
+
+    await expect(deleteUser({ userId: "user-1", logger })).rejects.toThrow(
+      "Transfer organization ownership before deleting your account.",
+    );
+  });
+});

--- a/apps/web/utils/user/delete.ts
+++ b/apps/web/utils/user/delete.ts
@@ -7,12 +7,20 @@ import {
   trackUserDeleted,
   trackUserDeletionRequested,
 } from "@/utils/posthog";
-import { captureException } from "@/utils/error";
+import { captureException, SafeError } from "@/utils/error";
 import { unwatchEmails } from "@/utils/email/watch-manager";
 import { createEmailProvider } from "@/utils/email/provider";
 import type { EmailProvider } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
 import { clearCachedResearchForUser } from "@/utils/redis/research-cache";
+import {
+  DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  getDeletableOrganizationIdsOrThrow,
+  getDeletedAccountOwnershipImpact,
+  getDeleteSoloOrganizationsOperation,
+  isMemberEmailAccountForeignKeyError,
+  isOrganizationOwnerInvariantError,
+} from "@/utils/organizations/ownership";
 
 export async function deleteUser({
   userId,
@@ -37,28 +45,15 @@ export async function deleteUser({
       },
     },
   });
-
-  const resourcesPromise = accounts.map(async (account) => {
-    if (!account.emailAccount) return Promise.resolve();
-
-    // Create email provider for unwatching
-    const emailProvider = account.access_token
-      ? await createEmailProvider({
-          emailAccountId: account.emailAccount.id,
-          provider: account.provider,
-          logger,
-        })
-      : null;
-
-    return deleteResources({
-      emailAccountId: account.emailAccount.id,
-      email: account.emailAccount.email,
-      userId,
-      emailProvider,
-      subscriptionId: account.emailAccount.watchEmailsSubscriptionId,
-      logger,
-    });
-  });
+  const emailAccountIds = accounts
+    .map((account) => account.emailAccount?.id)
+    .filter((id): id is string => Boolean(id));
+  const ownershipImpact =
+    await getDeletedAccountOwnershipImpact(emailAccountIds);
+  const organizationIdsToDelete = getDeletableOrganizationIdsOrThrow(
+    ownershipImpact,
+    DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR,
+  );
 
   logger.info("Deleting user resources");
 
@@ -81,6 +76,33 @@ export async function deleteUser({
       captureException(error);
     });
 
+    await deleteSoloOrganizations({
+      organizationIds: organizationIdsToDelete,
+      deletedEmailAccountIds: emailAccountIds,
+    });
+
+    const resourcesPromise = accounts.map(async (account) => {
+      if (!account.emailAccount) return Promise.resolve();
+
+      // Create email provider for unwatching
+      const emailProvider = account.access_token
+        ? await createEmailProvider({
+            emailAccountId: account.emailAccount.id,
+            provider: account.provider,
+            logger,
+          })
+        : null;
+
+      return deleteResources({
+        emailAccountId: account.emailAccount.id,
+        email: account.emailAccount.email,
+        userId,
+        emailProvider,
+        subscriptionId: account.emailAccount.watchEmailsSubscriptionId,
+        logger,
+      });
+    });
+
     // Then proceed with the regular deletion process
     const results = await Promise.allSettled(resourcesPromise);
 
@@ -98,13 +120,30 @@ export async function deleteUser({
       customError.cause = originalError;
 
       captureException(customError, { extra: { failures } });
+      throw originalError;
     }
   } catch (error) {
     logger.error("Error during user resources deletion process", {
       error,
     });
     captureException(error);
+    throw error;
   }
+}
+
+async function deleteSoloOrganizations({
+  organizationIds,
+  deletedEmailAccountIds,
+}: {
+  organizationIds: string[];
+  deletedEmailAccountIds: string[];
+}) {
+  if (organizationIds.length === 0) return;
+
+  await getDeleteSoloOrganizationsOperation(
+    organizationIds,
+    deletedEmailAccountIds,
+  );
 }
 
 async function deleteResources({
@@ -143,11 +182,18 @@ async function deleteResources({
     await deleteExecutedRulesInBatches({ emailAccountId, logger });
 
     logger.info("Deleting user");
-    await prisma.user.delete({ where: { id: userId } });
+    const deletedUser = await prisma.user.deleteMany({ where: { id: userId } });
 
     // PostHog tracks the completed delete after the database delete succeeds.
-    await trackUserDeleted(userId);
+    if (deletedUser.count > 0) await trackUserDeleted(userId);
   } catch (error) {
+    if (
+      isOrganizationOwnerInvariantError(error) ||
+      isMemberEmailAccountForeignKeyError(error)
+    ) {
+      throw new SafeError(DELETE_ACCOUNT_REQUIRES_OWNER_TRANSFER_ERROR);
+    }
+
     logger.error("Error during database user deletion process", {
       error,
     });


### PR DESCRIPTION
Prevents account deletion flows from leaving organizations without an owner and adds an ownership transfer path for organization owners.

- Block email account and user account deletion when it would remove the only organization owner
- Add an ownership transfer action and member menu entry
- Cover ownership guards and transfer behavior with focused tests

Validation:
- pnpm test utils/actions/organization.test.ts utils/actions/user.test.ts utils/user/delete.test.ts utils/organizations/ownership.test.ts
- pnpm lint

Performance impact: deletion preflight adds a small number of Prisma reads only on account deletion flows; ownership transfer performs two member updates in one transaction. These are not hot-path operations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

