### PR TITLE
Fix created item status display

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -44,6 +44,7 @@ export default function ToolsPage() {
           <MutedText>Created rules:</MutedText>
           <CreatedRuleToolCard
             preview
+            status="created"
             args={{
               name: "Hiring",
               condition: {
@@ -60,6 +61,7 @@ export default function ToolsPage() {
           />
           <CreatedRuleToolCard
             preview
+            status="created"
             args={{
               name: "Newsletter Archive",
               condition: {
@@ -80,6 +82,7 @@ export default function ToolsPage() {
           />
           <CreatedRuleToolCard
             preview
+            status="created"
             args={{
               name: "Billing Alerts",
               condition: {

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -839,13 +839,15 @@ export function CreatedRuleToolCard({
   args,
   ruleId,
   preview,
+  status,
 }: {
   args: CreateRuleTool["input"];
   ruleId?: string;
   preview?: boolean;
+  status?: "created" | "pending";
 }) {
   const conditionText = buildConditionText(args.condition);
-  const isCreated = Boolean(ruleId);
+  const isCreated = status ? status === "created" : Boolean(ruleId);
 
   return (
     <RuleSummaryCard


### PR DESCRIPTION
Fixes an incorrect status label for created preview items.\n\n- Adds an explicit status override for rule preview cards\n- Marks created component examples as created while preserving pending confirmation behavior\n\nValidation:\n- pnpm check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

