### PR TITLE
assistant-chat: Preserve rule text formatting

### DIFF
--- a/apps/web/components/assistant-chat/inline-rule-suggestion-card.tsx
+++ b/apps/web/components/assistant-chat/inline-rule-suggestion-card.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import {
   RuleSummaryCard,
   RuleSummaryRow,
+  RuleSummaryText,
 } from "@/components/assistant-chat/rule-summary-card";
 import { getActionDisplay, getActionIcon } from "@/utils/action-display";
 import { getActionColor } from "@/components/PlanBadge";
@@ -119,7 +120,11 @@ export function InlineRuleSuggestionCard({
         )
       }
     >
-      {whenText && <RuleSummaryRow label="When">{whenText}</RuleSummaryRow>}
+      {whenText && (
+        <RuleSummaryRow label="When">
+          <RuleSummaryText>{whenText}</RuleSummaryText>
+        </RuleSummaryRow>
+      )}
 
       {(actionText || suggestedActions.length > 0) && (
         <RuleSummaryRow label="Then">

--- a/apps/web/components/assistant-chat/rule-summary-card.tsx
+++ b/apps/web/components/assistant-chat/rule-summary-card.tsx
@@ -58,6 +58,10 @@ export function RuleSummaryRow({
   );
 }
 
+export function RuleSummaryText({ children }: { children: ReactNode }) {
+  return <p className="whitespace-pre-wrap break-words">{children}</p>;
+}
+
 export function RuleSummaryLabel({
   children,
   className,

--- a/apps/web/components/assistant-chat/tools.tsx
+++ b/apps/web/components/assistant-chat/tools.tsx
@@ -97,6 +97,7 @@ import {
   RuleSummaryCardHeader,
   RuleSummaryLabel,
   RuleSummaryRow,
+  RuleSummaryText,
 } from "@/components/assistant-chat/rule-summary-card";
 import { getPendingEmailSubjectPrefix } from "@/components/assistant-chat/helpers";
 
@@ -865,7 +866,7 @@ export function CreatedRuleToolCard({
       }
     >
       <RuleSummaryRow label="When">
-        <p>{conditionText}</p>
+        <RuleSummaryText>{conditionText}</RuleSummaryText>
       </RuleSummaryRow>
 
       <RuleSummaryRow label="Then">
@@ -1202,7 +1203,7 @@ export function UpdatedRuleConditions({
       <CardContent className="space-y-3 px-4 py-3.5">
         <div className="flex gap-4 text-sm">
           <FieldLabel className="pt-0.5">When</FieldLabel>
-          <p>{conditionText}</p>
+          <RuleSummaryText>{conditionText}</RuleSummaryText>
         </div>
 
         {actions && actions.length > 0 && (
@@ -1270,7 +1271,7 @@ export function UpdatedRuleActions({
         {conditionText && (
           <div className="flex gap-4 text-sm">
             <FieldLabel className="pt-0.5">When</FieldLabel>
-            <p>{conditionText}</p>
+            <RuleSummaryText>{conditionText}</RuleSummaryText>
           </div>
         )}
 
@@ -1358,7 +1359,7 @@ export function UpdatedRule({
         {conditionText && (
           <div className="flex gap-4 text-sm">
             <FieldLabel className="pt-0.5">When</FieldLabel>
-            <p>{conditionText}</p>
+            <RuleSummaryText>{conditionText}</RuleSummaryText>
           </div>
         )}
 


### PR DESCRIPTION
Preserves multiline formatting for rule condition text in assistant chat cards.

- Adds a shared rule summary text renderer that keeps authored line breaks while wrapping long content.
- Uses it for created, updated, and suggested rule cards.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

