### PR TITLE
chore: Centralize query param serialization

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -32,6 +32,7 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 import { fetchWithAccount } from "@/utils/fetch";
 import { Toggle } from "@/components/Toggle";
 import { hasTierAccess } from "@/utils/premium";
+import { createSearchParams } from "@/utils/url";
 import { BulkProcessActivityLog } from "@/app/(app)/[emailAccountId]/assistant/BulkProcessActivityLog";
 import {
   bulkRunReducer,
@@ -328,8 +329,7 @@ async function onRun(
       };
 
       const res = await fetchWithAccount({
-        // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-        url: `/api/threads?${new URLSearchParams(query as any).toString()}`,
+        url: `/api/threads?${createSearchParams(query).toString()}`,
         emailAccountId,
       });
 

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeSection.tsx
@@ -31,6 +31,7 @@ import {
   useNewsletterFilter,
   useBulkUnsubscribeShortcuts,
 } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks";
+import { createSearchParams } from "@/utils/url";
 import type { NewsletterFilterType } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
 import {
   isUnsubscribeSuggestion,
@@ -192,8 +193,7 @@ export function BulkUnsubscribe() {
     ...getDateRangeParams(dateRange),
     ...(search ? { search } : {}),
   };
-  // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-  const urlParams = new URLSearchParams(params as any);
+  const urlParams = createSearchParams(params);
   const { data, isLoading, isValidating, error, mutate } = useSWR<
     NewsletterStatsResponse,
     { error: string }

--- a/apps/web/app/(app)/[emailAccountId]/mail/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/page.tsx
@@ -11,6 +11,7 @@ import { refetchEmailListAtom } from "@/store/email";
 import { BetaBanner } from "@/app/(app)/[emailAccountId]/mail/BetaBanner";
 import { ClientOnly } from "@/components/ClientOnly";
 import { PermissionsCheck } from "@/app/(app)/[emailAccountId]/PermissionsCheck";
+import { createSearchParams } from "@/utils/url";
 
 export default function Mail(props: {
   searchParams: Promise<{ type?: string; labelId?: string }>;
@@ -36,8 +37,7 @@ export default function Mail(props: {
     if (pageIndex > 0 && previousPageData?.nextPageToken) {
       query.nextPageToken = previousPageData.nextPageToken;
     }
-    // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-    const queryParams = new URLSearchParams(query as any);
+    const queryParams = createSearchParams(query);
 
     return `/api/threads?${queryParams.toString()}`;
   };

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -27,6 +27,7 @@ import { usePremium } from "@/hooks/usePremium";
 import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 import { useOnboardingBulkUnsubscribeVariant } from "@/hooks/useFeatureFlags";
 import { extractDomainFromEmail } from "@/utils/email";
+import { createSearchParams } from "@/utils/url";
 
 type Newsletter = NewsletterStatsResponse["newsletters"][number];
 
@@ -58,8 +59,7 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
     includeMissingUnsubscribe: true,
     fromDate,
   };
-  // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-  const urlParams = new URLSearchParams(params as any);
+  const urlParams = createSearchParams(params);
   const { data, isLoading, mutate } = useSWR<NewsletterStatsResponse>(
     // Only fetch in the treatment arm; control never renders the list.
     isTreatment && emailAccountId

--- a/apps/web/app/(app)/[emailAccountId]/stats/EmailAnalytics.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/EmailAnalytics.tsx
@@ -7,7 +7,7 @@ import type { SendersResponse } from "@/app/api/user/stats/senders/route";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getDateRangeParams } from "@/app/(app)/[emailAccountId]/stats/params";
-import { getGmailSearchUrl } from "@/utils/url";
+import { createSearchParams, getGmailSearchUrl } from "@/utils/url";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { BarListCard } from "@/app/(app)/[emailAccountId]/stats/BarListCard";
 import { Mail, Send } from "lucide-react";
@@ -21,8 +21,7 @@ export function EmailAnalytics(props: {
   const params = getDateRangeParams(props.dateRange);
 
   const { data, isLoading, error } = useSWR<SendersResponse, { error: string }>(
-    // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-    `/api/user/stats/senders?${new URLSearchParams(params as any)}`,
+    `/api/user/stats/senders?${createSearchParams(params)}`,
     {
       refreshInterval: props.refreshInterval,
     },
@@ -33,8 +32,7 @@ export function EmailAnalytics(props: {
     isLoading: isLoadingRecipients,
     error: errorRecipients,
   } = useSWR<RecipientsResponse, { error: string }>(
-    // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-    `/api/user/stats/recipients?${new URLSearchParams(params as any)}`,
+    `/api/user/stats/recipients?${createSearchParams(params)}`,
     {
       refreshInterval: props.refreshInterval,
     },

--- a/apps/web/app/(app)/[emailAccountId]/stats/ResponseTimeAnalytics.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/ResponseTimeAnalytics.tsx
@@ -17,6 +17,7 @@ import type { ResponseTimeQuery } from "@/utils/stats/response-time/validation";
 import type { ResponseTimeResponse } from "@/utils/stats/response-time/controller";
 import { isDefined } from "@/utils/types";
 import { pluralize } from "@/utils/string";
+import { createSearchParams } from "@/utils/url";
 
 interface ResponseTimeAnalyticsProps {
   dateRange?: DateRange;
@@ -30,7 +31,7 @@ export function ResponseTimeAnalytics({
   const params: ResponseTimeQuery = getDateRangeParams(dateRange);
 
   const { data, isLoading, error } = useOrgSWR<ResponseTimeResponse>(
-    `/api/user/stats/response-time?${new URLSearchParams(params as Record<string, string>)}`,
+    `/api/user/stats/response-time?${createSearchParams(params)}`,
     { refreshInterval },
   );
 

--- a/apps/web/app/(app)/[emailAccountId]/stats/RuleStatsChart.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/RuleStatsChart.tsx
@@ -26,6 +26,7 @@ import type { RuleStatsResponse } from "@/app/api/user/stats/rule-stats/route";
 import { BarChart } from "./BarChart";
 import { CardBasic } from "@/components/ui/card";
 import { COLORS } from "@/utils/colors";
+import { createSearchParams } from "@/utils/url";
 
 interface RuleStatsChartProps {
   dateRange?: DateRange;
@@ -62,7 +63,7 @@ export function RuleStatsChart({ dateRange, title }: RuleStatsChartProps) {
   const params = getDateRangeParams(dateRange);
 
   const { data, isLoading, error } = useOrgSWR<RuleStatsResponse>(
-    `/api/user/stats/rule-stats?${new URLSearchParams(params as Record<string, string>)}`,
+    `/api/user/stats/rule-stats?${createSearchParams(params)}`,
   );
 
   const barChartData = useMemo(() => {

--- a/apps/web/app/(app)/[emailAccountId]/stats/StatsSummary.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/StatsSummary.tsx
@@ -8,6 +8,7 @@ import type { StatsByPeriodQuery } from "@/app/api/user/stats/by-period/validati
 import type { StatsByPeriodResponse } from "@/app/api/user/stats/by-period/controller";
 import { getDateRangeParams } from "./params";
 import { MainStatChart } from "@/app/(app)/[emailAccountId]/stats/MainStatChart";
+import { createSearchParams } from "@/utils/url";
 
 export function StatsSummary(props: {
   dateRange?: DateRange;
@@ -24,16 +25,9 @@ export function StatsSummary(props: {
   const { data, isLoading, error } = useOrgSWR<
     StatsByPeriodResponse,
     { error: string }
-  >(
-    `/api/user/stats/by-period?${new URLSearchParams(
-      Object.fromEntries(
-        Object.entries(params).map(([k, v]) => [k, v?.toString() ?? ""]),
-      ) as Record<string, string>,
-    )}`,
-    {
-      refreshInterval: props.refreshInterval,
-    },
-  );
+  >(`/api/user/stats/by-period?${createSearchParams(params)}`, {
+    refreshInterval: props.refreshInterval,
+  });
 
   return (
     <LoadingContent

--- a/apps/web/hooks/useThreads.ts
+++ b/apps/web/hooks/useThreads.ts
@@ -2,6 +2,7 @@ import useSWR from "swr";
 import type { ThreadsResponse } from "@/app/api/threads/route";
 import type { Thread as EmailThread } from "@/components/email-list/types";
 import type { ThreadsQuery } from "@/utils/threads/validation";
+import { createSearchParams } from "@/utils/url";
 
 export type Thread = EmailThread;
 
@@ -21,7 +22,6 @@ export function useThreads({
   if (fromEmail) query.fromEmail = fromEmail;
   if (limit) query.limit = limit;
   if (type) query.type = type;
-  // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-  const url = `/api/threads?${new URLSearchParams(query as any).toString()}`;
+  const url = `/api/threads?${createSearchParams(query).toString()}`;
   return useSWR<ThreadsResponse>(url, { refreshInterval });
 }

--- a/apps/web/utils/url.test.ts
+++ b/apps/web/utils/url.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  createSearchParams,
   getEmailUrl,
   getEmailUrlForMessage,
   getEmailUrlForOptionalMessage,
@@ -9,6 +10,37 @@ import {
   getGmailBasicSearchUrl,
   getGmailFilterSettingsUrl,
 } from "./url";
+
+describe("createSearchParams", () => {
+  it("coerces primitive and array values to URLSearchParams strings", () => {
+    const after = new Date("2026-07-01T00:00:00.000Z");
+    const params = createSearchParams({
+      query: "inbox",
+      limit: 25,
+      includeRead: false,
+      labelIds: ["Label_1", "Label_2"],
+      after,
+    });
+
+    expect(params.get("query")).toBe("inbox");
+    expect(params.get("limit")).toBe("25");
+    expect(params.get("includeRead")).toBe("false");
+    expect(params.get("labelIds")).toBe("Label_1,Label_2");
+    expect(params.get("after")).toBe(String(after));
+  });
+
+  it("omits nullish values", () => {
+    const params = createSearchParams({
+      keep: "value",
+      empty: "",
+      zero: 0,
+      missing: null,
+      unset: undefined,
+    });
+
+    expect(params.toString()).toBe("keep=value&empty=&zero=0");
+  });
+});
 
 describe("getEmailUrl", () => {
   it.each([

--- a/apps/web/utils/url.ts
+++ b/apps/web/utils/url.ts
@@ -1,5 +1,16 @@
 import { extractDomainFromEmail } from "@/utils/email";
 
+export function createSearchParams(params: Record<string, unknown>) {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) continue;
+    searchParams.set(key, String(value));
+  }
+
+  return searchParams;
+}
+
 function getGmailUrlForFragment(
   fragment: string,
   emailAddress?: string | null,


### PR DESCRIPTION
Centralizes URL query param serialization for thread, bulk unsubscribe, onboarding, and stats views so typed query objects no longer need repeated unsafe casts. Behavior is preserved while making the call sites simpler and easier to audit.

- Adds createSearchParams in the URL utility module
- Replaces repeated URLSearchParams casts across core app views and hooks
- Covers coercion and nullish omission behavior with focused URL utility tests

Validation:
- pnpm test utils/url.test.ts
- Focused Biome check on touched core files
- git diff --check

Performance impact: no new database or network calls; runtime work is the same small URLSearchParams construction already happening at these call sites.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

