### PR TITLE
rules: Align organization rule editor with the personal editor

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -40,6 +40,7 @@ import { Label } from "@/components/ui/label";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Checkbox } from "@/components/ui/checkbox";
 import { canActionBeDelayed } from "@/utils/delayed-actions";
+import { DelayInputControls } from "@/components/DelayInputControls";
 import { FolderSelector } from "@/components/FolderSelector";
 import { cn } from "@/utils";
 import { WebhookDocumentationLink } from "@/components/WebhookDocumentation";
@@ -441,9 +442,13 @@ function ActionCard({
                     <>
                       <span className="text-muted-foreground">after</span>
                       <DelayInputControls
-                        index={index}
-                        delayInMinutes={delayValue}
-                        setValue={setValue}
+                        name={`delay-${index}`}
+                        value={delayValue}
+                        onChange={(minutes) =>
+                          setValue(`actions.${index}.delayInMinutes`, minutes, {
+                            shouldValidate: true,
+                          })
+                        }
                       />
                     </>
                   )}
@@ -606,9 +611,13 @@ function ActionCard({
         <div className="flex items-center space-x-2">
           <span className="text-muted-foreground">after</span>
           <DelayInputControls
-            index={index}
-            delayInMinutes={delayValue}
-            setValue={setValue}
+            name={`delay-${index}`}
+            value={delayValue}
+            onChange={(minutes) =>
+              setValue(`actions.${index}.delayInMinutes`, minutes, {
+                shouldValidate: true,
+              })
+            }
           />
         </div>
 
@@ -1342,76 +1351,6 @@ function VariableProTip() {
   );
 }
 
-function DelayInputControls({
-  index,
-  delayInMinutes,
-  setValue,
-}: {
-  index: number;
-  delayInMinutes: number | null | undefined;
-  setValue: ReturnType<typeof useForm<CreateRuleBody>>["setValue"];
-}) {
-  const { value: displayValue, unit } = getDisplayValueAndUnit(delayInMinutes);
-
-  const handleValueChange = (newValue: string, currentUnit: string) => {
-    const minutes = convertToMinutes(newValue, currentUnit);
-    setValue(`actions.${index}.delayInMinutes`, minutes, {
-      shouldValidate: true,
-    });
-  };
-
-  const handleUnitChange = (newUnit: string) => {
-    if (displayValue) {
-      const minutes = convertToMinutes(displayValue, newUnit);
-      setValue(`actions.${index}.delayInMinutes`, minutes);
-    }
-  };
-
-  const delayConfig = {
-    displayValue,
-    unit,
-    handleValueChange,
-    handleUnitChange,
-  };
-
-  return (
-    <div className="flex items-center space-x-2">
-      <Input
-        name={`delay-${index}`}
-        type="text"
-        placeholder="0"
-        className="w-20"
-        registerProps={{
-          value: delayConfig.displayValue,
-          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-            const value = e.target.value.replace(/[^0-9]/g, "");
-            delayConfig.handleValueChange(value, delayConfig.unit);
-          },
-        }}
-      />
-      <Select
-        value={delayConfig.unit}
-        onValueChange={delayConfig.handleUnitChange}
-      >
-        <SelectTrigger className="w-24">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="minutes">
-            {delayInMinutes === 1 ? "Minute" : "Minutes"}
-          </SelectItem>
-          <SelectItem value="hours">
-            {delayInMinutes === 60 ? "Hour" : "Hours"}
-          </SelectItem>
-          <SelectItem value="days">
-            {delayInMinutes === 1440 ? "Day" : "Days"}
-          </SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
-
 function renderFieldRows(
   fields: Array<(typeof actionInputs)[ActionType]["fields"][number]>,
   renderField: (
@@ -1451,36 +1390,4 @@ function renderFieldRows(
   }
 
   return rows;
-}
-
-// minutes to user-friendly UI format
-function getDisplayValueAndUnit(minutes: number | null | undefined) {
-  if (minutes === null || minutes === undefined)
-    return { value: "", unit: "hours" };
-  if (minutes === -1 || minutes <= 0) return { value: "", unit: "hours" };
-
-  if (minutes >= 1440 && minutes % 1440 === 0) {
-    return { value: (minutes / 1440).toString(), unit: "days" };
-  } else if (minutes >= 60 && minutes % 60 === 0) {
-    return { value: (minutes / 60).toString(), unit: "hours" };
-  } else {
-    return { value: minutes.toString(), unit: "minutes" };
-  }
-}
-
-// user-friendly UI format to minutes
-function convertToMinutes(value: string, unit: string) {
-  const numValue = Number.parseInt(value, 10);
-  if (Number.isNaN(numValue) || numValue <= 0) return -1;
-
-  switch (unit) {
-    case "minutes":
-      return numValue;
-    case "hours":
-      return numValue * 60;
-    case "days":
-      return numValue * 1440;
-    default:
-      return numValue;
-  }
 }

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgActionSteps.tsx
@@ -1,0 +1,306 @@
+import type {
+  Control,
+  UseFormRegister,
+  UseFormSetValue,
+  UseFormWatch,
+} from "react-hook-form";
+import { useWatch } from "react-hook-form";
+import { ActionType } from "@/generated/prisma/enums";
+import { Input } from "@/components/Input";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FormControl, FormItem } from "@/components/ui/form";
+import { RuleSteps } from "@/app/(app)/[emailAccountId]/assistant/RuleSteps";
+import { RuleStep } from "@/app/(app)/[emailAccountId]/assistant/RuleStep";
+import { DelayInputControls } from "@/components/DelayInputControls";
+import { canActionBeDelayed } from "@/utils/delayed-actions";
+import { ACTION_TYPE_LABELS, getActionIcon } from "@/utils/action-display";
+import { ORGANIZATION_RULE_ACTION_TYPES } from "@/utils/organizations/rule-action-types";
+import {
+  EMPTY_ORG_ACTION,
+  type OrgRuleFormValues,
+  type OrgActionFormValue,
+} from "./orgRuleForm";
+
+const ACTION_TYPE_OPTIONS = ORGANIZATION_RULE_ACTION_TYPES.map((value) => ({
+  value,
+  label: ACTION_TYPE_LABELS[value],
+  icon: getActionIcon(value),
+}));
+
+export function OrgActionSteps({
+  fields,
+  register,
+  control,
+  watch,
+  setValue,
+  append,
+  remove,
+}: {
+  fields: Array<{ id: string }>;
+  register: UseFormRegister<OrgRuleFormValues>;
+  control: Control<OrgRuleFormValues>;
+  watch: UseFormWatch<OrgRuleFormValues>;
+  setValue: UseFormSetValue<OrgRuleFormValues>;
+  append: (action: OrgActionFormValue) => void;
+  remove: (index: number) => void;
+}) {
+  const actions = useWatch({ control, name: "actions" }) ?? [];
+
+  return (
+    <RuleSteps
+      onAdd={() => append(EMPTY_ORG_ACTION)}
+      addButtonLabel="Add Action"
+      addButtonDisabled={false}
+    >
+      {fields.map((field, index) => (
+        <OrgActionCard
+          key={field.id}
+          index={index}
+          type={actions[index]?.type ?? ActionType.LABEL}
+          register={register}
+          watch={watch}
+          setValue={setValue}
+          onRemove={() => remove(index)}
+        />
+      ))}
+    </RuleSteps>
+  );
+}
+
+function OrgActionCard({
+  index,
+  type,
+  register,
+  watch,
+  setValue,
+  onRemove,
+}: {
+  index: number;
+  type: ActionType;
+  register: UseFormRegister<OrgRuleFormValues>;
+  watch: UseFormWatch<OrgRuleFormValues>;
+  setValue: UseFormSetValue<OrgRuleFormValues>;
+  onRemove: () => void;
+}) {
+  const selectedOption = ACTION_TYPE_OPTIONS.find(
+    (option) => option.value === type,
+  );
+  const SelectedIcon = selectedOption?.icon;
+  const delayValue = watch(`actions.${index}.delayInMinutes`);
+  const canDelay = canActionBeDelayed(type);
+  const delayEnabled = canDelay && delayValue != null;
+
+  const leftContent = (
+    <FormItem>
+      <Select
+        value={type}
+        onValueChange={(value) =>
+          setValue(`actions.${index}.type`, value as ActionType)
+        }
+      >
+        <FormControl>
+          <SelectTrigger className="w-[180px]">
+            {selectedOption ? (
+              <div className="flex items-center gap-2">
+                {SelectedIcon && <SelectedIcon className="size-4" />}
+                <span>{selectedOption.label}</span>
+              </div>
+            ) : (
+              <SelectValue placeholder="Select action" />
+            )}
+          </SelectTrigger>
+        </FormControl>
+        <SelectContent>
+          {ACTION_TYPE_OPTIONS.map((option) => {
+            const Icon = option.icon;
+            return (
+              <SelectItem key={option.value} value={option.value}>
+                <div className="flex items-center gap-2">
+                  {Icon && <Icon className="size-4" />}
+                  {option.label}
+                </div>
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </FormItem>
+  );
+
+  const actionFields = renderOrgActionFields({ index, type, register });
+  const delayControls = delayEnabled ? (
+    <div className="flex items-center space-x-2">
+      <span className="text-muted-foreground">after</span>
+      <DelayInputControls
+        name={`org-delay-${index}`}
+        value={delayValue}
+        onChange={(minutes) =>
+          setValue(`actions.${index}.delayInMinutes`, minutes, {
+            shouldValidate: true,
+          })
+        }
+      />
+    </div>
+  ) : null;
+
+  const rightContent =
+    actionFields || delayControls ? (
+      <Card className="space-y-4 p-4">
+        {actionFields}
+        {delayControls}
+      </Card>
+    ) : null;
+
+  return (
+    <RuleStep
+      onRemove={onRemove}
+      removeAriaLabel="Remove action"
+      leftContent={leftContent}
+      rightContent={rightContent}
+      onAddDelay={
+        canDelay
+          ? () =>
+              setValue(`actions.${index}.delayInMinutes`, 60, {
+                shouldValidate: true,
+              })
+          : undefined
+      }
+      onRemoveDelay={
+        canDelay
+          ? () =>
+              setValue(`actions.${index}.delayInMinutes`, null, {
+                shouldValidate: true,
+              })
+          : undefined
+      }
+      hasDelay={delayEnabled}
+    />
+  );
+}
+
+function renderOrgActionFields({
+  index,
+  type,
+  register,
+}: {
+  index: number;
+  type: ActionType;
+  register: UseFormRegister<OrgRuleFormValues>;
+}) {
+  const isSend = type === ActionType.SEND_EMAIL;
+  const isReply = type === ActionType.REPLY;
+  const isForward = type === ActionType.FORWARD;
+  const hasRecipients = isSend || isReply || isForward;
+
+  const rows: React.ReactNode[] = [];
+
+  if (type === ActionType.LABEL) {
+    rows.push(
+      <Input
+        key="label"
+        type="text"
+        name={`actions.${index}.label`}
+        label="Label name"
+        registerProps={register(`actions.${index}.label`)}
+        placeholder="e.g. Invoices"
+      />,
+    );
+  }
+
+  if (type === ActionType.MOVE_FOLDER) {
+    rows.push(
+      <Input
+        key="folderName"
+        type="text"
+        name={`actions.${index}.folderName`}
+        label="Folder name"
+        registerProps={register(`actions.${index}.folderName`)}
+      />,
+    );
+  }
+
+  if (type === ActionType.CALL_WEBHOOK) {
+    rows.push(
+      <Input
+        key="url"
+        type="text"
+        name={`actions.${index}.url`}
+        label="Webhook URL"
+        registerProps={register(`actions.${index}.url`)}
+      />,
+    );
+  }
+
+  if (isSend || isForward) {
+    rows.push(
+      <Input
+        key="to"
+        type="text"
+        name={`actions.${index}.to`}
+        label={isForward ? "Forward to" : "To"}
+        registerProps={register(`actions.${index}.to`)}
+      />,
+    );
+  }
+
+  if (isSend || isReply) {
+    rows.push(
+      <Input
+        key="subject"
+        type="text"
+        name={`actions.${index}.subject`}
+        label="Subject"
+        registerProps={register(`actions.${index}.subject`)}
+      />,
+    );
+  }
+
+  if (isSend || isReply || type === ActionType.DRAFT_EMAIL) {
+    rows.push(
+      <Input
+        key="content"
+        type="text"
+        as="textarea"
+        autosizeTextarea
+        rows={2}
+        name={`actions.${index}.content`}
+        label={
+          type === ActionType.DRAFT_EMAIL
+            ? "Draft content (optional)"
+            : "Content"
+        }
+        registerProps={register(`actions.${index}.content`)}
+      />,
+    );
+  }
+
+  if (hasRecipients) {
+    rows.push(
+      <div key="cc-bcc" className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Input
+          type="text"
+          name={`actions.${index}.cc`}
+          label="CC (optional)"
+          registerProps={register(`actions.${index}.cc`)}
+        />
+        <Input
+          type="text"
+          name={`actions.${index}.bcc`}
+          label="BCC (optional)"
+          registerProps={register(`actions.${index}.bcc`)}
+        />
+      </div>,
+    );
+  }
+
+  if (rows.length === 0) return null;
+
+  return <div className="space-y-3">{rows}</div>;
+}

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
@@ -227,28 +227,26 @@ export function OrgRuleDialog({
                 </button>
               </CollapsibleTrigger>
               <CollapsibleContent>
-                {isAdvancedOpen ? (
-                  <div className="rounded-md border">
-                    <div className="flex items-center justify-between gap-4 px-4 py-3">
-                      <div>
-                        <p className="text-sm font-medium">Apply to threads</p>
-                        <p className="text-sm text-muted-foreground">
-                          Run on every reply in a conversation, not just the
-                          first message.
-                        </p>
-                      </div>
-                      <div className="shrink-0">
-                        <Toggle
-                          name="runOnThreads"
-                          enabled={watch("runOnThreads")}
-                          onChange={(enabled) =>
-                            setValue("runOnThreads", enabled)
-                          }
-                        />
-                      </div>
+                <div className="rounded-md border">
+                  <div className="flex items-center justify-between gap-4 px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium">Apply to threads</p>
+                      <p className="text-sm text-muted-foreground">
+                        Run on every reply in a conversation, not just the first
+                        message.
+                      </p>
+                    </div>
+                    <div className="shrink-0">
+                      <Toggle
+                        name="runOnThreads"
+                        enabled={watch("runOnThreads")}
+                        onChange={(enabled) =>
+                          setValue("runOnThreads", enabled)
+                        }
+                      />
                     </div>
                   </div>
-                ) : null}
+                </div>
               </CollapsibleContent>
             </Collapsible>
 

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
@@ -122,7 +122,7 @@ export function OrgRuleDialog({
       from: conditionFieldValues.from || null,
       to: conditionFieldValues.to || null,
       subject: conditionFieldValues.subject || null,
-      body: conditionFieldValues.body || null,
+      body: formValues.body || null,
       conditionalOperator: formValues.conditionalOperator,
       runOnThreads: formValues.runOnThreads,
       actions,
@@ -266,7 +266,12 @@ export function OrgRuleDialog({
 }
 
 function toFormValues(rule?: OrgRule): OrgRuleFormValues {
-  const conditions = rule ? getConditions(rule) : [];
+  // The shared condition editor has no Body type, so drop any legacy body-only
+  // condition from the editable list and carry the value through separately
+  // rather than surfacing it as a phantom empty Subject condition.
+  const conditions = (rule ? getConditions(rule) : []).filter(
+    (condition) => !(condition.type === ConditionType.STATIC && condition.body),
+  );
   if (conditions.length === 0) {
     conditions.push(getEmptyCondition(ConditionType.AI));
   }
@@ -274,6 +279,7 @@ function toFormValues(rule?: OrgRule): OrgRuleFormValues {
   return {
     name: rule?.name ?? "",
     conditions,
+    body: rule?.body ?? null,
     conditionalOperator: rule?.conditionalOperator ?? LogicalOperator.AND,
     runOnThreads: rule?.runOnThreads ?? false,
     actions: rule?.actions.length

--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgRuleDialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
-import { useForm, useFieldArray, Controller } from "react-hook-form";
-import { TrashIcon, PlusIcon } from "lucide-react";
-import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { useMemo, useState } from "react";
+import { useForm, useFieldArray, type UseFormReturn } from "react-hook-form";
+import { InboxIcon, ZapIcon, ChevronRightIcon } from "lucide-react";
+import { LogicalOperator } from "@/generated/prisma/enums";
 import {
   Dialog,
   DialogContent,
@@ -12,73 +12,40 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/Input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Toggle } from "@/components/Toggle";
 import { toastError, toastSuccess } from "@/components/Toast";
+import { Form } from "@/components/ui/form";
+import { cn } from "@/utils";
 import { useAction } from "next-safe-action/hooks";
 import {
   createOrganizationRuleAction,
   updateOrganizationRuleAction,
 } from "@/utils/actions/organization-rule";
 import type { OrganizationRuleActionSchema } from "@/utils/actions/organization-rule.validation";
-import { ORGANIZATION_RULE_ACTION_TYPES } from "@/utils/organizations/rule-action-types";
-import { ACTION_TYPE_LABELS } from "@/utils/action-display";
-import { NINETY_DAYS_MINUTES } from "@/utils/date";
+import type { CreateRuleBody } from "@/utils/actions/rule.validation";
+import { ConditionType } from "@/utils/config";
+import {
+  getConditions,
+  getEmptyCondition,
+  flattenConditions,
+} from "@/utils/condition";
+import { createScopedLogger } from "@/utils/logger";
+import { ConditionSteps } from "@/app/(app)/[emailAccountId]/assistant/ConditionSteps";
+import { RuleSectionCard } from "@/app/(app)/[emailAccountId]/assistant/RuleSectionCard";
+import { OrgActionSteps } from "./OrgActionSteps";
+import { EMPTY_ORG_ACTION, type OrgRuleFormValues } from "./orgRuleForm";
 import type { OrganizationRulesResponse } from "@/app/api/organizations/[organizationId]/rules/route";
 
 type OrgRule = OrganizationRulesResponse["rules"][number];
 
-const ACTION_TYPE_OPTIONS = ORGANIZATION_RULE_ACTION_TYPES.map((value) => ({
-  value,
-  label: ACTION_TYPE_LABELS[value],
-}));
-
-type ActionFormValue = {
-  type: ActionType;
-  label: string;
-  subject: string;
-  content: string;
-  to: string;
-  cc: string;
-  bcc: string;
-  url: string;
-  folderName: string;
-  delayInMinutes: number | null;
-};
-
-type OrgRuleFormValues = {
-  name: string;
-  instructions: string;
-  from: string;
-  to: string;
-  subject: string;
-  body: string;
-  conditionalOperator: LogicalOperator;
-  runOnThreads: boolean;
-  actions: ActionFormValue[];
-};
-
-const EMPTY_ACTION: ActionFormValue = {
-  type: ActionType.LABEL,
-  label: "",
-  subject: "",
-  content: "",
-  to: "",
-  cc: "",
-  bcc: "",
-  url: "",
-  folderName: "",
-  delayInMinutes: null,
-};
+const logger = createScopedLogger("org-rule-dialog");
 
 export function OrgRuleDialog({
   organizationId,
@@ -97,25 +64,42 @@ export function OrgRuleDialog({
   // biome-ignore lint/correctness/useExhaustiveDependencies: isOpen forces a re-derive so reopening "New rule" starts clean.
   const values = useMemo(() => toFormValues(rule), [rule, isOpen]);
 
+  const form = useForm<OrgRuleFormValues>({ values });
   const {
     register,
     control,
     handleSubmit,
     watch,
+    setValue,
     formState: { errors },
-  } = useForm<OrgRuleFormValues>({ values });
+  } = form;
 
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: "actions",
-  });
-  const watchedActions = watch("actions");
+  const {
+    fields: conditionFields,
+    append: appendCondition,
+    remove: removeCondition,
+  } = useFieldArray({ control, name: "conditions" });
+  const {
+    fields: actionFields,
+    append: appendAction,
+    remove: removeAction,
+  } = useFieldArray({ control, name: "actions" });
 
   const createAction = useAction(createOrganizationRuleAction);
   const updateAction = useAction(updateOrganizationRuleAction);
   const isSubmitting = createAction.isExecuting || updateAction.isExecuting;
 
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+
+  const conditions = watch("conditions");
+  const conditionalOperator = watch("conditionalOperator");
+
   const onSubmit = handleSubmit(async (formValues) => {
+    const conditionFieldValues = flattenConditions(
+      formValues.conditions,
+      logger,
+    );
+
     const actions = formValues.actions.map((action) => ({
       type: action.type as OrganizationRuleActionSchema["type"],
       label: action.label || null,
@@ -126,16 +110,19 @@ export function OrgRuleDialog({
       bcc: action.bcc || null,
       url: action.url || null,
       folderName: action.folderName || null,
-      delayInMinutes: action.delayInMinutes ?? null,
+      delayInMinutes:
+        action.delayInMinutes && action.delayInMinutes > 0
+          ? action.delayInMinutes
+          : null,
     }));
 
     const shared = {
       name: formValues.name,
-      instructions: formValues.instructions || null,
-      from: formValues.from || null,
-      to: formValues.to || null,
-      subject: formValues.subject || null,
-      body: formValues.body || null,
+      instructions: conditionFieldValues.instructions || null,
+      from: conditionFieldValues.from || null,
+      to: conditionFieldValues.to || null,
+      subject: conditionFieldValues.subject || null,
+      body: conditionFieldValues.body || null,
       conditionalOperator: formValues.conditionalOperator,
       runOnThreads: formValues.runOnThreads,
       actions,
@@ -159,11 +146,14 @@ export function OrgRuleDialog({
       return;
     }
 
-    toastSuccess({
-      description: editing ? "Rule updated" : "Rule created",
-    });
+    toastSuccess({ description: editing ? "Rule updated" : "Rule created" });
     onSuccess();
   });
+
+  // ConditionSteps is typed against the personal-rule form, but only reads and
+  // writes `conditions` / `conditionalOperator`, which are identical in both
+  // forms. Casting here keeps the shared condition editor out of a generic.
+  const conditionStepsForm = form as unknown as UseFormReturn<CreateRuleBody>;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -177,289 +167,115 @@ export function OrgRuleDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={onSubmit} className="space-y-4">
-          <Input
-            type="text"
-            name="name"
-            label="Name"
-            registerProps={register("name")}
-            error={errors.name}
-            placeholder="e.g. Label invoices"
-          />
+        <Form {...form}>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <Input
+              type="text"
+              name="name"
+              label="Name"
+              registerProps={register("name", {
+                required: "Please enter a name",
+              })}
+              error={errors.name}
+              placeholder="e.g. Label invoices"
+            />
 
-          <Input
-            type="text"
-            as="textarea"
-            autosizeTextarea
-            rows={2}
-            name="instructions"
-            label="AI instructions"
-            explainText="Describe in natural language which emails this rule should match."
-            registerProps={register("instructions")}
-            error={errors.instructions}
-            placeholder="e.g. Emails that look like invoices or receipts"
-          />
-
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Input
-              type="text"
-              name="from"
-              label="From (static)"
-              registerProps={register("from")}
-              error={errors.from}
-              placeholder="e.g. @stripe.com"
-            />
-            <Input
-              type="text"
-              name="to"
-              label="To (static)"
-              registerProps={register("to")}
-              error={errors.to}
-            />
-            <Input
-              type="text"
-              name="subject"
-              label="Subject (static)"
-              registerProps={register("subject")}
-              error={errors.subject}
-            />
-            <Input
-              type="text"
-              name="body"
-              label="Body (static)"
-              registerProps={register("body")}
-              error={errors.body}
-            />
-          </div>
-
-          <div className="flex flex-wrap items-center gap-6">
-            <div className="space-y-1">
-              <Label>Match conditions with</Label>
-              <Controller
-                control={control}
-                name="conditionalOperator"
-                render={({ field }) => (
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger className="w-32">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={LogicalOperator.AND}>AND</SelectItem>
-                      <SelectItem value={LogicalOperator.OR}>OR</SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
+            <RuleSectionCard
+              icon={InboxIcon}
+              color="blue"
+              title="When I get an email"
+            >
+              <ConditionSteps
+                conditionFields={conditionFields}
+                conditionalOperator={conditionalOperator}
+                removeCondition={removeCondition}
+                watch={conditionStepsForm.watch}
+                setValue={conditionStepsForm.setValue}
+                register={conditionStepsForm.register}
+                errors={conditionStepsForm.formState.errors}
+                conditions={conditions}
+                ruleSystemType={null}
+                appendCondition={appendCondition}
               />
-            </div>
-            <Controller
-              control={control}
-              name="runOnThreads"
-              render={({ field }) => (
-                <div className="space-y-1">
-                  <Label>Apply to threads</Label>
-                  <Toggle
-                    name="runOnThreads"
-                    enabled={field.value}
-                    onChange={field.onChange}
-                  />
-                </div>
-              )}
-            />
-          </div>
+            </RuleSectionCard>
 
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <Label>Actions</Label>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => append(EMPTY_ACTION)}
-              >
-                <PlusIcon className="mr-2 size-4" />
-                Add action
-              </Button>
-            </div>
+            <RuleSectionCard icon={ZapIcon} color="green" title="Then">
+              <OrgActionSteps
+                fields={actionFields}
+                register={register}
+                control={control}
+                watch={watch}
+                setValue={setValue}
+                append={appendAction}
+                remove={removeAction}
+              />
+            </RuleSectionCard>
 
-            {fields.map((fieldItem, index) => {
-              const type = watchedActions?.[index]?.type ?? ActionType.LABEL;
-              return (
-                <div
-                  key={fieldItem.id}
-                  className="space-y-3 rounded-lg border p-3"
+            <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 py-2 text-sm font-medium text-left text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  <div className="flex items-center gap-2">
-                    <Controller
-                      control={control}
-                      name={`actions.${index}.type`}
-                      render={({ field }) => (
-                        <Select
-                          value={field.value}
-                          onValueChange={field.onChange}
-                        >
-                          <SelectTrigger className="w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {ACTION_TYPE_OPTIONS.map((option) => (
-                              <SelectItem
-                                key={option.value}
-                                value={option.value}
-                              >
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      )}
-                    />
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      disabled={fields.length === 1}
-                      onClick={() => remove(index)}
-                    >
-                      <TrashIcon className="size-4" />
-                    </Button>
+                  <ChevronRightIcon
+                    className={cn(
+                      "size-4 transition-transform",
+                      isAdvancedOpen && "rotate-90",
+                    )}
+                  />
+                  Advanced options
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                {isAdvancedOpen ? (
+                  <div className="rounded-md border">
+                    <div className="flex items-center justify-between gap-4 px-4 py-3">
+                      <div>
+                        <p className="text-sm font-medium">Apply to threads</p>
+                        <p className="text-sm text-muted-foreground">
+                          Run on every reply in a conversation, not just the
+                          first message.
+                        </p>
+                      </div>
+                      <div className="shrink-0">
+                        <Toggle
+                          name="runOnThreads"
+                          enabled={watch("runOnThreads")}
+                          onChange={(enabled) =>
+                            setValue("runOnThreads", enabled)
+                          }
+                        />
+                      </div>
+                    </div>
                   </div>
+                ) : null}
+              </CollapsibleContent>
+            </Collapsible>
 
-                  <ActionFields index={index} type={type} register={register} />
-                </div>
-              );
-            })}
-          </div>
-
-          <DialogFooter>
-            <Button type="submit" loading={isSubmitting}>
-              {editing ? "Save rule" : "Create rule"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" loading={isSubmitting}>
+                {editing ? "Save rule" : "Create rule"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );
 }
 
-function ActionFields({
-  index,
-  type,
-  register,
-}: {
-  index: number;
-  type: ActionType;
-  register: ReturnType<typeof useForm<OrgRuleFormValues>>["register"];
-}) {
-  const isSend = type === ActionType.SEND_EMAIL;
-  const isReply = type === ActionType.REPLY;
-  const isForward = type === ActionType.FORWARD;
-  const hasRecipients = isSend || isReply || isForward;
-
-  return (
-    <div className="space-y-3">
-      {type === ActionType.LABEL && (
-        <Input
-          type="text"
-          name={`actions.${index}.label`}
-          label="Label name"
-          registerProps={register(`actions.${index}.label`)}
-        />
-      )}
-
-      {type === ActionType.MOVE_FOLDER && (
-        <Input
-          type="text"
-          name={`actions.${index}.folderName`}
-          label="Folder name"
-          registerProps={register(`actions.${index}.folderName`)}
-        />
-      )}
-
-      {type === ActionType.CALL_WEBHOOK && (
-        <Input
-          type="text"
-          name={`actions.${index}.url`}
-          label="Webhook URL"
-          registerProps={register(`actions.${index}.url`)}
-        />
-      )}
-
-      {(isSend || isForward) && (
-        <Input
-          type="text"
-          name={`actions.${index}.to`}
-          label={isForward ? "Forward to" : "To"}
-          registerProps={register(`actions.${index}.to`)}
-        />
-      )}
-
-      {(isSend || isReply) && (
-        <Input
-          type="text"
-          name={`actions.${index}.subject`}
-          label="Subject"
-          registerProps={register(`actions.${index}.subject`)}
-        />
-      )}
-
-      {(isSend || isReply || type === ActionType.DRAFT_EMAIL) && (
-        <Input
-          type="text"
-          as="textarea"
-          autosizeTextarea
-          rows={2}
-          name={`actions.${index}.content`}
-          label={
-            type === ActionType.DRAFT_EMAIL
-              ? "Draft content (optional)"
-              : "Content"
-          }
-          registerProps={register(`actions.${index}.content`)}
-        />
-      )}
-
-      {hasRecipients && (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <Input
-            type="text"
-            name={`actions.${index}.cc`}
-            label="CC (optional)"
-            registerProps={register(`actions.${index}.cc`)}
-          />
-          <Input
-            type="text"
-            name={`actions.${index}.bcc`}
-            label="BCC (optional)"
-            registerProps={register(`actions.${index}.bcc`)}
-          />
-        </div>
-      )}
-
-      <Input
-        type="number"
-        name={`actions.${index}.delayInMinutes`}
-        label="Delay in minutes (optional)"
-        min={1}
-        max={NINETY_DAYS_MINUTES}
-        registerProps={register(`actions.${index}.delayInMinutes`, {
-          setValueAs: (value) =>
-            value === "" || value === null || value === undefined
-              ? null
-              : Number(value),
-        })}
-      />
-    </div>
-  );
-}
-
 function toFormValues(rule?: OrgRule): OrgRuleFormValues {
+  const conditions = rule ? getConditions(rule) : [];
+  if (conditions.length === 0) {
+    conditions.push(getEmptyCondition(ConditionType.AI));
+  }
+
   return {
     name: rule?.name ?? "",
-    instructions: rule?.instructions ?? "",
-    from: rule?.from ?? "",
-    to: rule?.to ?? "",
-    subject: rule?.subject ?? "",
-    body: rule?.body ?? "",
+    conditions,
     conditionalOperator: rule?.conditionalOperator ?? LogicalOperator.AND,
     runOnThreads: rule?.runOnThreads ?? false,
     actions: rule?.actions.length
@@ -475,6 +291,6 @@ function toFormValues(rule?: OrgRule): OrgRuleFormValues {
           folderName: action.folderName ?? "",
           delayInMinutes: action.delayInMinutes ?? null,
         }))
-      : [EMPTY_ACTION],
+      : [EMPTY_ORG_ACTION],
   };
 }

--- a/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
@@ -1,0 +1,36 @@
+import { ActionType, type LogicalOperator } from "@/generated/prisma/enums";
+import type { ZodCondition } from "@/utils/actions/rule.validation";
+
+export type OrgActionFormValue = {
+  type: ActionType;
+  label: string;
+  subject: string;
+  content: string;
+  to: string;
+  cc: string;
+  bcc: string;
+  url: string;
+  folderName: string;
+  delayInMinutes: number | null;
+};
+
+export type OrgRuleFormValues = {
+  name: string;
+  conditions: ZodCondition[];
+  conditionalOperator: LogicalOperator;
+  runOnThreads: boolean;
+  actions: OrgActionFormValue[];
+};
+
+export const EMPTY_ORG_ACTION: OrgActionFormValue = {
+  type: ActionType.LABEL,
+  label: "",
+  subject: "",
+  content: "",
+  to: "",
+  cc: "",
+  bcc: "",
+  url: "",
+  folderName: "",
+  delayInMinutes: null,
+};

--- a/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/orgRuleForm.ts
@@ -17,6 +17,9 @@ export type OrgActionFormValue = {
 export type OrgRuleFormValues = {
   name: string;
   conditions: ZodCondition[];
+  // Legacy body filter carried through untouched: the shared condition editor
+  // has no Body type (matching the personal editor), so it is not editable here.
+  body: string | null;
   conditionalOperator: LogicalOperator;
   runOnThreads: boolean;
   actions: OrgActionFormValue[];

--- a/apps/web/components/DelayInputControls.tsx
+++ b/apps/web/components/DelayInputControls.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Input } from "@/components/Input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function DelayInputControls({
+  value,
+  onChange,
+  name = "delay",
+}: {
+  value: number | null | undefined;
+  onChange: (minutes: number | null) => void;
+  name?: string;
+}) {
+  const { value: displayValue, unit } = getDisplayValueAndUnit(value);
+
+  const handleValueChange = (newValue: string, currentUnit: string) => {
+    onChange(convertToMinutes(newValue, currentUnit));
+  };
+
+  const handleUnitChange = (newUnit: string) => {
+    if (displayValue) {
+      onChange(convertToMinutes(displayValue, newUnit));
+    }
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Input
+        name={name}
+        type="text"
+        placeholder="0"
+        className="w-20"
+        registerProps={{
+          value: displayValue,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+            const nextValue = e.target.value.replace(/[^0-9]/g, "");
+            handleValueChange(nextValue, unit);
+          },
+        }}
+      />
+      <Select value={unit} onValueChange={handleUnitChange}>
+        <SelectTrigger className="w-24">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="minutes">
+            {value === 1 ? "Minute" : "Minutes"}
+          </SelectItem>
+          <SelectItem value="hours">
+            {value === 60 ? "Hour" : "Hours"}
+          </SelectItem>
+          <SelectItem value="days">
+            {value === 1440 ? "Day" : "Days"}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// minutes to user-friendly UI format
+function getDisplayValueAndUnit(minutes: number | null | undefined) {
+  if (minutes === null || minutes === undefined)
+    return { value: "", unit: "hours" };
+  if (minutes === -1 || minutes <= 0) return { value: "", unit: "hours" };
+
+  if (minutes >= 1440 && minutes % 1440 === 0) {
+    return { value: (minutes / 1440).toString(), unit: "days" };
+  } else if (minutes >= 60 && minutes % 60 === 0) {
+    return { value: (minutes / 60).toString(), unit: "hours" };
+  } else {
+    return { value: minutes.toString(), unit: "minutes" };
+  }
+}
+
+// user-friendly UI format to minutes
+function convertToMinutes(value: string, unit: string) {
+  const numValue = Number.parseInt(value, 10);
+  if (Number.isNaN(numValue) || numValue <= 0) return -1;
+
+  switch (unit) {
+    case "minutes":
+      return numValue;
+    case "hours":
+      return numValue * 60;
+    case "days":
+      return numValue * 1440;
+    default:
+      return numValue;
+  }
+}


### PR DESCRIPTION
## Summary

QA flagged that the organization rules editor looks quite different from the existing personal (email-account) rules editor. This reworks the org rule dialog to share the personal editor's format and components, leaving out account-specific features that don't apply to org rules.

## Changes

- **Conditions**: reuse the shared `ConditionSteps` + `RuleSectionCard` ("When I get an email") so the org condition builder matches the personal editor. Org rules store the same flat condition fields, so the dialog converts to/from the `conditions[]` UI shape via the existing `getConditions` / `flattenConditions` helpers.
- **Actions**: new org action editor ("Then") built on the shared `RuleSteps` / `RuleStep` primitives and the same icon + label action-type dropdown, with plain text fields (free-text label/folder name, to/cc/bcc/subject/content/url, delay). Account-only features (label/folder pickers, messaging channels, attachments, AI-generated values, draft-reply delivery, learned patterns) are intentionally left out since they don't apply to portable org rules.
- **Advanced options**: collapsible section with the "Apply to threads" toggle, matching the personal editor.
- **Cancel button** added to the dialog footer.
- **Shared `DelayInputControls`** extracted so the delay UX is defined once and used by both editors.

Server actions, validation schemas, and the API are unchanged — this is an editor-UI refactor.

## Verification

- Type-check (web package) and Biome are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

