### PR TITLE
Fix ownerless organization deletion

### DIFF
--- a/apps/web/utils/organizations/ownership.test.ts
+++ b/apps/web/utils/organizations/ownership.test.ts
@@ -36,6 +36,36 @@ describe("getDeletedAccountOwnershipImpact", () => {
     ]);
   });
 
+  it("marks ownerless organizations for deletion when deleted email accounts include every member", async () => {
+    prisma.member.findMany.mockImplementation(async (args) => {
+      const roleFilter = (
+        args as Parameters<typeof prisma.member.findMany>[0] | undefined
+      )?.where?.role;
+
+      return (roleFilter ? [] : [{ organizationId: "org-1" }]) as Awaited<
+        ReturnType<typeof prisma.member.findMany>
+      >;
+    });
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "admin" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await getDeletedAccountOwnershipImpact(["email-account-1"]);
+
+    expect(result.organizationsRequiringOwnershipTransfer).toEqual([]);
+    expect(result.organizationsToDelete).toEqual([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "admin" }],
+      },
+    ]);
+  });
+
   it("requires ownership transfer when an organization would keep members but no owner", async () => {
     prisma.member.findMany.mockResolvedValue([
       { organizationId: "org-1" },

--- a/apps/web/utils/organizations/ownership.ts
+++ b/apps/web/utils/organizations/ownership.ts
@@ -21,16 +21,17 @@ export async function getDeletedAccountOwnershipImpact(
     };
   }
 
-  const ownerMemberships = await prisma.member.findMany({
+  // Ownerless organizations have no owner row to discover, so start from every
+  // deleted membership.
+  const memberships = await prisma.member.findMany({
     where: {
       emailAccountId: { in: [...deletedEmailAccountIds] },
-      role: "owner",
     },
     select: { organizationId: true },
   });
 
   const organizationIds = [
-    ...new Set(ownerMemberships.map((member) => member.organizationId)),
+    ...new Set(memberships.map((member) => member.organizationId)),
   ];
   if (organizationIds.length === 0) {
     return {

--- a/apps/web/utils/user/delete.test.ts
+++ b/apps/web/utils/user/delete.test.ts
@@ -116,6 +116,56 @@ describe("deleteUser", () => {
     });
   });
 
+  it("deletes ownerless solo organizations before deleting the user", async () => {
+    prisma.account.findMany.mockResolvedValue([
+      {
+        provider: "google",
+        access_token: null,
+        refresh_token: null,
+        expires_at: null,
+        emailAccount: {
+          id: "email-account-1",
+          email: "admin@example.com",
+          watchEmailsSubscriptionId: null,
+        },
+      },
+    ] as Awaited<ReturnType<typeof prisma.account.findMany>>);
+    prisma.member.findMany.mockImplementation(async (args) => {
+      const roleFilter = (
+        args as Parameters<typeof prisma.member.findMany>[0] | undefined
+      )?.where?.role;
+
+      return (roleFilter ? [] : [{ organizationId: "org-1" }]) as Awaited<
+        ReturnType<typeof prisma.member.findMany>
+      >;
+    });
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [{ emailAccountId: "email-account-1", role: "admin" }],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+    prisma.executedRule.findMany.mockResolvedValue([]);
+    prisma.user.deleteMany.mockResolvedValue({ count: 1 } as any);
+
+    await deleteUser({ userId: "user-1", logger });
+
+    expect(prisma.organization.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["org-1"] },
+        members: {
+          every: {
+            emailAccountId: { in: ["email-account-1"] },
+          },
+        },
+      },
+    });
+    expect(prisma.user.deleteMany).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+    });
+  });
+
   it("surfaces the ownership transfer message when the database rejects a raced user deletion", async () => {
     prisma.account.findMany.mockResolvedValue([
       {


### PR DESCRIPTION
Prevents account deletion from being blocked when the account only belongs to ownerless solo organizations. The ownership impact check now considers all deleted memberships so empty owner lookups do not hide organizations that should be deleted.

- Detect organizations from all deleted memberships before ownership checks.
- Add focused coverage for ownerless solo organizations in ownership impact and user deletion flows.
- Tests: `pnpm test utils/organizations/ownership.test.ts utils/user/delete.test.ts`

Performance impact: Adds no new runtime work beyond widening one existing membership lookup by removing a role filter; no additional database or network calls, and low hot-path risk because this runs during account deletion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

