### PR TITLE
llms: Improve local model base URL handling

### DIFF
--- a/apps/web/utils/llms/model.test.ts
+++ b/apps/web/utils/llms/model.test.ts
@@ -13,6 +13,7 @@ import { createGateway } from "@ai-sdk/gateway";
 import { createVertex } from "@ai-sdk/google-vertex";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { createOllama } from "ollama-ai-provider-v2";
 
 const TEST_AZURE_FOUNDRY_API_KEY = "test-azure-foundry-key";
 const TEST_AZURE_FOUNDRY_BASE_URL = "https://foundry.example.com/openai/v1";
@@ -479,6 +480,33 @@ describe("Models", () => {
       expect(result.provider).toBe(Provider.OLLAMA);
       expect(result.modelName).toBe("llama3");
       expect(result.model).toBeDefined();
+    });
+
+    it("should accept an Ollama server origin without /api", () => {
+      const userAi = defaultUserAi();
+
+      setDefaultLlms(Provider.OLLAMA, "llama3.2");
+      vi.mocked(env).OLLAMA_BASE_URL = "http://localhost:11434";
+
+      const result = getModel(userAi);
+
+      expect(result.provider).toBe(Provider.OLLAMA);
+      expect(createOllama).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/api",
+      });
+    });
+
+    it("should preserve explicit Ollama API base URLs", () => {
+      const userAi = defaultUserAi();
+
+      setDefaultLlms(Provider.OLLAMA, "llama3.2");
+      vi.mocked(env).OLLAMA_BASE_URL = "http://localhost:11434/api/";
+
+      getModel(userAi);
+
+      expect(createOllama).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/api",
+      });
     });
 
     it("should configure Anthropic model correctly without Bedrock credentials", () => {

--- a/apps/web/utils/llms/model.ts
+++ b/apps/web/utils/llms/model.ts
@@ -255,10 +255,11 @@ function selectModel(
     case "ollama": {
       const modelName = aiModel || env.OLLAMA_MODEL;
       if (!modelName) throw new SafeError("LLM model name is not set");
+      const baseURL = getOllamaBaseUrl();
       return {
         provider: Provider.OLLAMA,
         modelName,
-        model: createOllama({ baseURL: env.OLLAMA_BASE_URL })(modelName),
+        model: createOllama({ baseURL })(modelName),
       };
     }
     case Provider.OPENAI_COMPATIBLE: {
@@ -580,6 +581,23 @@ function getOpenAiCompatibleBaseUrl() {
     process.env.OPENAI_COMPATIBLE_BASE_URL ||
     "http://localhost:1234/v1"
   );
+}
+
+function getOllamaBaseUrl(): string | undefined {
+  const baseURL = env.OLLAMA_BASE_URL?.trim();
+  if (!baseURL) return;
+
+  try {
+    const url = new URL(baseURL);
+    if (url.pathname === "/" || url.pathname === "") {
+      url.pathname = "/api";
+      return url.toString();
+    }
+  } catch {
+    return baseURL;
+  }
+
+  return baseURL.replace(/\/+$/, "");
 }
 
 function getOpenAiCompatibleAuthOptions(apiKey: string | undefined) {

--- a/packages/cli/src/llm.ts
+++ b/packages/cli/src/llm.ts
@@ -34,6 +34,8 @@ const LLM_LINKS: Record<string, string> = {
   groq: "https://console.groq.com/keys",
 };
 
+const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/api";
+
 const DEFAULT_MODELS = {
   anthropic: {
     default: "claude-sonnet-4-6",
@@ -74,7 +76,7 @@ export function seedLlmPlaceholderCredentials(
   }
 
   if (provider === "ollama") {
-    env.OLLAMA_BASE_URL = "http://localhost:11434";
+    env.OLLAMA_BASE_URL = DEFAULT_OLLAMA_BASE_URL;
     env.OLLAMA_MODEL = "qwen3.5:4b";
     setRoleLlms(provider, env.OLLAMA_MODEL, env);
     return;
@@ -159,8 +161,8 @@ async function promptOllamaCreds(): Promise<{
       baseUrl: () =>
         text({
           message: "Ollama Base URL",
-          placeholder: "http://localhost:11434",
-          initialValue: "http://localhost:11434",
+          placeholder: DEFAULT_OLLAMA_BASE_URL,
+          initialValue: DEFAULT_OLLAMA_BASE_URL,
         }),
       model: () =>
         text({
@@ -174,7 +176,7 @@ async function promptOllamaCreds(): Promise<{
   );
 
   return {
-    baseUrl: creds.baseUrl || "http://localhost:11434",
+    baseUrl: creds.baseUrl || DEFAULT_OLLAMA_BASE_URL,
     model: creds.model,
   };
 }

--- a/packages/cli/src/setup-vercel.test.ts
+++ b/packages/cli/src/setup-vercel.test.ts
@@ -114,6 +114,19 @@ describe("buildVercelEnvValues", () => {
 });
 
 describe("seedLlmPlaceholderCredentials", () => {
+  it("fills ollama placeholder credentials with the API base URL", () => {
+    const env = {};
+
+    seedLlmPlaceholderCredentials("ollama", env);
+
+    expect(env).toMatchObject({
+      DEFAULT_LLMS: "ollama:qwen3.5:4b",
+      ECONOMY_LLMS: "ollama:qwen3.5:4b",
+      OLLAMA_BASE_URL: "http://localhost:11434/api",
+      OLLAMA_MODEL: "qwen3.5:4b",
+    });
+  });
+
   it("fills bedrock placeholder credentials with defaults", () => {
     const env = {};
 


### PR DESCRIPTION
Normalize local model server base URLs so default-origin configuration works without requiring provider-specific path knowledge. Update setup defaults and regression coverage for the accepted URL forms.

- Normalize local model server origins to the provider API path at runtime
- Align CLI setup defaults with the documented API base URL
- Add focused tests for runtime URL normalization and setup placeholders

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

