### PR TITLE
Track Google Ads click identifiers

### DIFF
--- a/apps/web/app/(landing)/welcome/utms.tsx
+++ b/apps/web/app/(landing)/welcome/utms.tsx
@@ -11,6 +11,11 @@ type UtmValues = {
   utmMedium?: string;
   utmSource?: string;
   utmTerm?: string;
+  gclid?: string;
+  gbraid?: string;
+  wbraid?: string;
+  gadCampaignId?: string;
+  gadSource?: string;
   affiliate?: string;
   referralCode?: string;
 };
@@ -43,6 +48,11 @@ export function extractUtmValues(cookies: ReadonlyRequestCookies): UtmValues {
     utmMedium: decodeCookieValue(cookies.get("utm_medium")?.value),
     utmSource: decodeCookieValue(cookies.get("utm_source")?.value),
     utmTerm: decodeCookieValue(cookies.get("utm_term")?.value),
+    gclid: decodeCookieValue(cookies.get("gclid")?.value),
+    gbraid: decodeCookieValue(cookies.get("gbraid")?.value),
+    wbraid: decodeCookieValue(cookies.get("wbraid")?.value),
+    gadCampaignId: decodeCookieValue(cookies.get("gad_campaignid")?.value),
+    gadSource: decodeCookieValue(cookies.get("gad_source")?.value),
     affiliate: decodeCookieValue(cookies.get("affiliate")?.value),
     referralCode: decodeCookieValue(cookies.get("referral_code")?.value),
   };
@@ -61,6 +71,8 @@ export async function fetchUserAndStoreUtms(
   userId: string,
   utmValues: UtmValues,
 ) {
+  if (!hasAttributionValue(utmValues)) return;
+
   const user = await prisma.user
     .findUnique({
       where: { id: userId },
@@ -76,6 +88,10 @@ export async function fetchUserAndStoreUtms(
   }
 }
 
+function hasAttributionValue(utmValues: UtmValues) {
+  return Object.values(utmValues).some(Boolean);
+}
+
 async function storeUtms(userId: string, utmValues: UtmValues) {
   logger.info("Storing utms", { userId });
 
@@ -84,6 +100,11 @@ async function storeUtms(userId: string, utmValues: UtmValues) {
     utmMedium: utmValues.utmMedium,
     utmSource: utmValues.utmSource,
     utmTerm: utmValues.utmTerm,
+    gclid: utmValues.gclid,
+    gbraid: utmValues.gbraid,
+    wbraid: utmValues.wbraid,
+    gadCampaignId: utmValues.gadCampaignId,
+    gadSource: utmValues.gadSource,
     affiliate: utmValues.affiliate,
     referralCode: utmValues.referralCode,
   };

--- a/apps/web/app/utm.tsx
+++ b/apps/web/app/utm.tsx
@@ -2,30 +2,38 @@
 
 import { useEffect } from "react";
 
+const ATTRIBUTION_PARAMS = [
+  { param: "utm_source", cookie: "utm_source" },
+  { param: "utm_medium", cookie: "utm_medium" },
+  { param: "utm_campaign", cookie: "utm_campaign" },
+  { param: "utm_term", cookie: "utm_term" },
+  { param: "aff_ref", cookie: "affiliate" },
+  { param: "ref", cookie: "referral_code" },
+  { param: "gclid", cookie: "gclid" },
+  { param: "gbraid", cookie: "gbraid" },
+  { param: "wbraid", cookie: "wbraid" },
+  { param: "gad_campaignid", cookie: "gad_campaignid" },
+  { param: "gad_source", cookie: "gad_source" },
+] as const;
+
 function setUtmCookies() {
   const urlParams = new URLSearchParams(window.location.search);
-  const utmSource = urlParams.get("utm_source");
-  const utmMedium = urlParams.get("utm_medium");
-  const utmCampaign = urlParams.get("utm_campaign");
-  const utmTerm = urlParams.get("utm_term");
-  const affiliate = urlParams.get("aff_ref");
-  const referralCode = urlParams.get("ref");
 
   // expires in 30 days
   const expires = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toUTCString();
 
-  if (utmSource)
-    document.cookie = `utm_source=${encodeURIComponent(utmSource)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
-  if (utmMedium)
-    document.cookie = `utm_medium=${encodeURIComponent(utmMedium)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
-  if (utmCampaign)
-    document.cookie = `utm_campaign=${encodeURIComponent(utmCampaign)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
-  if (utmTerm)
-    document.cookie = `utm_term=${encodeURIComponent(utmTerm)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
-  if (affiliate)
-    document.cookie = `affiliate=${encodeURIComponent(affiliate)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
-  if (referralCode)
-    document.cookie = `referral_code=${encodeURIComponent(referralCode)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
+  for (const { param, cookie } of ATTRIBUTION_PARAMS) {
+    const value = urlParams.get(param);
+    if (!value || hasCookie(cookie)) continue;
+
+    document.cookie = `${cookie}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
+  }
+}
+
+function hasCookie(name: string) {
+  return document.cookie
+    .split("; ")
+    .some((cookie) => cookie.startsWith(`${name}=`));
 }
 
 export function UTM() {


### PR DESCRIPTION
## Summary
- persist Google Ads auto-tagging params (gclid, gbraid, wbraid, gad_campaignid, gad_source) as first-touch cookies
- preserve existing attribution cookies on later tagged visits so first-touch values are not overwritten before they are stored
- store those values in User.utms alongside existing UTM/referral fields
- skip empty attribution writes so a missing-attribution visit does not lock User.utms to {}
- keep existing affiliate/referral cookie aliases intact

## Why
Google Ads brand traffic is currently visible in PostHog via initial URL, but mostly missing from DB attribution because auto-tagging params are not copied into attribution cookies. This makes future campaign and holdout analysis harder than it needs to be.

## Validation
- pnpm exec biome check --write apps/web/app/utm.tsx 'apps/web/app/(landing)/welcome/utms.tsx'
- pnpm exec biome check apps/web/app/utm.tsx 'apps/web/app/(landing)/welcome/utms.tsx'