### PR TITLE
rules: Skip draft actions during historical processing

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -374,7 +374,9 @@ async function onRun(
       onThreadsQueued(threadsToQueue);
       totalProcessed += threadsToQueue.length;
 
-      runAiRules(emailAccountId, threadsToQueue, false);
+      runAiRules(emailAccountId, threadsToQueue, false, {
+        skipDraftReplies: true,
+      });
 
       if (aborted) {
         onComplete("cancelled", totalProcessed);

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -160,7 +160,8 @@ export function BulkRunRules() {
             <DialogTitle>Bulk Process Emails</DialogTitle>
             <DialogDescription>
               Run your rules on emails in your inbox that haven't been handled
-              yet.
+              yet. Draft replies are skipped for past emails and will be
+              generated for new incoming emails.
             </DialogDescription>
           </DialogHeader>
           {progressMessage && (
@@ -374,9 +375,7 @@ async function onRun(
       onThreadsQueued(threadsToQueue);
       totalProcessed += threadsToQueue.length;
 
-      runAiRules(emailAccountId, threadsToQueue, false, {
-        skipDraftReplies: true,
-      });
+      runAiRules(emailAccountId, threadsToQueue, false, true);
 
       if (aborted) {
         onComplete("cancelled", totalProcessed);

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
@@ -90,20 +90,15 @@ export function StepInboxProcessedView({
   const hasEmails = !!data && data.emails.length > 0;
   const { label } = getEmailTerminology(provider);
   const pastVerb = isMicrosoftProvider(provider) ? "categorized" : "labeled";
-  const hasDrafts = (data?.draftCount ?? 0) > 0;
 
   return (
     <div className="w-full max-w-xl">
       <div className="mb-6 text-center">
         <PageHeading className="mb-3">
-          {hasDrafts
-            ? `${label.pluralCapitalized} and drafts are ready`
-            : `${label.pluralCapitalized} are ready`}
+          {label.pluralCapitalized} are ready
         </PageHeading>
         <TypographyP className="text-muted-foreground">
-          {hasDrafts
-            ? `We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails and drafted replies. Nothing was archived.`
-            : `We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails. Nothing was archived.`}
+          {`We ${pastVerb} your last ${ONBOARDING_PROCESS_EMAILS_COUNT} emails. Draft replies will start with new incoming emails. Nothing was archived.`}
         </TypographyP>
       </div>
 

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -24,7 +24,7 @@ export const runRulesAction = actionClient
   .action(
     async ({
       ctx: { emailAccountId, provider, logger: ctxLogger },
-      parsedInput: { messageId, threadId, rerun, isTest },
+      parsedInput: { messageId, threadId, rerun, isTest, skipDraftReplies },
     }): Promise<RunRulesResult[]> => {
       const logger = ctxLogger.with({ messageId, threadId });
 
@@ -162,6 +162,7 @@ export const runRulesAction = actionClient
         emailAccount,
         logger,
         modelType: "chat",
+        skipDraftReplies,
       }).catch((error) => {
         logger.error("runRules failed", { error });
         return flushAndRethrowRunRulesActionError({

--- a/apps/web/utils/actions/ai-rule.validation.ts
+++ b/apps/web/utils/actions/ai-rule.validation.ts
@@ -10,5 +10,6 @@ export const runRulesBody = z.object({
   threadId: z.string(),
   rerun: z.boolean().nullish(),
   isTest: z.boolean(),
+  skipDraftReplies: z.boolean().optional(),
 });
 export type RunRulesBody = z.infer<typeof runRulesBody>;

--- a/apps/web/utils/ai/choose-rule/bulk-process-emails.ts
+++ b/apps/web/utils/ai/choose-rule/bulk-process-emails.ts
@@ -74,6 +74,7 @@ export async function bulkProcessInboxEmails({
           modelType: "economy",
           logger,
           skipArchive,
+          skipDraftReplies: true,
         });
         processedCount++;
       } catch (error) {

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -454,6 +454,52 @@ describe("runRules draft attribution persistence", () => {
     ]);
   });
 
+  it("skips draft reply actions before generating action args when requested", async () => {
+    const bulkRule = createRule("bulk-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "label-action-1",
+        type: ActionType.LABEL,
+        label: "To Reply",
+      }),
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+    ]);
+
+    mockMatchingRules([{ rule: bulkRule, matchReasons: [] }]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    vi.mocked(getActionItemsWithAiArgs).mockImplementation(
+      async ({ selectedRule }) => {
+        expect(
+          selectedRule.actions.some(
+            (action) => action.type === ActionType.DRAFT_EMAIL,
+          ),
+        ).toBe(false);
+
+        return selectedRule.actions.map((action) => ({
+          ...action,
+          type: action.type as ActionType,
+        }));
+      },
+    );
+
+    const createSpy = mockExecutedRuleCreate({ rule: bulkRule });
+
+    await runRulesWithDefaults({
+      rules: [bulkRule],
+      skipDraftReplies: true,
+    });
+
+    const createdActions = getCreatedActionItems(createSpy);
+    expect(createdActions).toEqual([
+      expect.objectContaining({
+        type: ActionType.LABEL,
+        label: "To Reply",
+      }),
+    ]);
+  });
+
   it("persists a null draft pipeline version when draft attribution is missing", async () => {
     const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
       getAction({

--- a/apps/web/utils/ai/choose-rule/run-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.test.ts
@@ -500,6 +500,37 @@ describe("runRules draft attribution persistence", () => {
     ]);
   });
 
+  it("records draft-only historical matches as skipped after draft replies are removed", async () => {
+    const draftOnlyRule = createRule("draft-only-rule", SystemType.TO_REPLY, [
+      getAction({
+        id: "draft-action-1",
+        type: ActionType.DRAFT_EMAIL,
+      }),
+    ]);
+
+    mockMatchingRules([{ rule: draftOnlyRule, matchReasons: [] }]);
+    prisma.executedRule.findFirst.mockResolvedValue(null);
+    prisma.executedRule.create.mockResolvedValue({} as any);
+
+    const result = await runRulesWithDefaults({
+      rules: [draftOnlyRule],
+      skipDraftReplies: true,
+    });
+
+    expect(getActionItemsWithAiArgs).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      expect.objectContaining({
+        rule: null,
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+    ]);
+    expect(prisma.executedRule.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: ExecutedRuleStatus.SKIPPED,
+      }),
+    });
+  });
+
   it("persists a null draft pipeline version when draft attribution is missing", async () => {
     const draftRule = createRule("draft-rule", SystemType.TO_REPLY, [
       getAction({

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -109,6 +109,7 @@ export async function runRules({
   modelType,
   logger,
   skipArchive,
+  skipDraftReplies,
 }: {
   provider: EmailProvider;
   message: ParsedMessage;
@@ -118,6 +119,7 @@ export async function runRules({
   modelType: ModelType;
   logger: Logger;
   skipArchive?: boolean;
+  skipDraftReplies?: boolean;
 }): Promise<RunRulesResult[]> {
   const batchTimestamp = new Date(); // Single timestamp for this batch execution
   const { regularRules, conversationRules } = prepareRulesWithMetaRule(rules);
@@ -191,7 +193,11 @@ export async function runRules({
     }
   }
 
-  const finalMatches = limitDraftEmailActions(matchesWithFlags, logger);
+  const executableMatches = skipDraftReplies
+    ? removeDraftReplyActionsFromMatches(matchesWithFlags, logger)
+    : matchesWithFlags;
+
+  const finalMatches = limitDraftEmailActions(executableMatches, logger);
 
   logger.trace("Matching rule", () => ({
     module: MODULE,
@@ -273,6 +279,31 @@ export async function runRules({
   }
 
   return executedRules;
+}
+
+function removeDraftReplyActionsFromMatches<
+  T extends { rule: RuleWithActions; matchReasons?: MatchReason[] },
+>(matches: T[], logger: Logger): T[] {
+  const matchesWithDrafts = matches.filter((match) =>
+    match.rule.actions.some((action) => isDraftReplyActionType(action.type)),
+  );
+
+  if (!matchesWithDrafts.length) return matches;
+
+  logger.info("Skipping draft reply actions for historical rule processing", {
+    module: MODULE,
+    ruleCount: matchesWithDrafts.length,
+  });
+
+  return matches.map((match) => ({
+    ...match,
+    rule: {
+      ...match.rule,
+      actions: match.rule.actions.filter(
+        (action) => !isDraftReplyActionType(action.type),
+      ),
+    },
+  }));
 }
 
 function prepareRulesWithMetaRule(rules: RuleWithActions[]): {

--- a/apps/web/utils/ai/choose-rule/run-rules.ts
+++ b/apps/web/utils/ai/choose-rule/run-rules.ts
@@ -295,15 +295,17 @@ function removeDraftReplyActionsFromMatches<
     ruleCount: matchesWithDrafts.length,
   });
 
-  return matches.map((match) => ({
-    ...match,
-    rule: {
-      ...match.rule,
-      actions: match.rule.actions.filter(
-        (action) => !isDraftReplyActionType(action.type),
-      ),
-    },
-  }));
+  return matches
+    .map((match) => ({
+      ...match,
+      rule: {
+        ...match.rule,
+        actions: match.rule.actions.filter(
+          (action) => !isDraftReplyActionType(action.type),
+        ),
+      },
+    }))
+    .filter((match) => match.rule.actions.length > 0);
 }
 
 function prepareRulesWithMetaRule(rules: RuleWithActions[]): {

--- a/apps/web/utils/queue/email-actions.ts
+++ b/apps/web/utils/queue/email-actions.ts
@@ -10,6 +10,7 @@ export const runAiRules = async (
   emailAccountId: string,
   threadsArray: ThreadsResponse["threads"],
   rerun: boolean,
+  options: { skipDraftReplies?: boolean } = {},
 ) => {
   const threads = threadsArray.filter(isDefined);
   const threadIds = threads.map((t) => t.id);
@@ -24,6 +25,7 @@ export const runAiRules = async (
         threadId: thread.id,
         rerun,
         isTest: false,
+        skipDraftReplies: options.skipDraftReplies,
       });
       removeFromAiQueueAtom(thread.id);
     }),

--- a/apps/web/utils/queue/email-actions.ts
+++ b/apps/web/utils/queue/email-actions.ts
@@ -10,7 +10,7 @@ export const runAiRules = async (
   emailAccountId: string,
   threadsArray: ThreadsResponse["threads"],
   rerun: boolean,
-  options: { skipDraftReplies?: boolean } = {},
+  skipDraftReplies = false,
 ) => {
   const threads = threadsArray.filter(isDefined);
   const threadIds = threads.map((t) => t.id);
@@ -25,7 +25,7 @@ export const runAiRules = async (
         threadId: thread.id,
         rerun,
         isTest: false,
-        skipDraftReplies: options.skipDraftReplies,
+        skipDraftReplies,
       });
       removeFromAiQueueAtom(thread.id);
     }),


### PR DESCRIPTION
Prevents historical and bulk rule processing from creating draft reply actions while preserving other rule actions. Live rule execution keeps the existing draft behavior.

- Adds an opt-out flag for draft reply actions in rule execution
- Uses the opt-out for onboarding and past-email bulk processing
- Covers the historical-processing path with a focused unit test

Test: pnpm test utils/ai/choose-rule/run-rules.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

