### PR TITLE
Fix Gmail email message stats reconciliation

### DIFF
--- a/apps/web/app/api/cron/email-message-stats-reconciliation/route.test.ts
+++ b/apps/web/app/api/cron/email-message-stats-reconciliation/route.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { envMock, captureExceptionMock, reconcileMock } = vi.hoisted(() => ({
+  envMock: {
+    CRON_SECRET: "cron-secret",
+  },
+  captureExceptionMock: vi.fn(),
+  reconcileMock: vi.fn(),
+}));
+
+vi.mock("@/env", () => ({
+  env: envMock,
+}));
+
+vi.mock("@/utils/error", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+vi.mock("@/utils/email/email-message-stats-reconciliation", () => ({
+  reconcileConfiguredGmailEmailMessageStats: (...args: unknown[]) =>
+    reconcileMock(...args),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithErrorTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithErrorTestMiddleware();
+});
+
+import { GET, POST } from "./route";
+
+describe("email message stats reconciliation cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.CRON_SECRET = "cron-secret";
+    reconcileMock.mockResolvedValue({
+      dryRun: false,
+      accountsChecked: 1,
+      accountsSkipped: 0,
+      failedAccounts: 0,
+      totals: { checked: 1 },
+      accounts: [],
+    });
+  });
+
+  it("rejects GET requests without the cron bearer token", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/cron/email-message-stats-reconciliation",
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(reconcileMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs GET reconciliation with parsed query options", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/cron/email-message-stats-reconciliation?dryRun=true&emailAccountId=account-1&batchSize=5&accountLimit=2&sampleLimit=3&maxErrorsPerAccount=4",
+        {
+          headers: { authorization: "Bearer cron-secret" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      accountsChecked: 1,
+    });
+    expect(reconcileMock).toHaveBeenCalledWith({
+      logger: expect.anything(),
+      dryRun: true,
+      emailAccountId: "account-1",
+      accountLimit: 2,
+      batchSize: 5,
+      sampleLimit: 3,
+      maxErrorsPerAccount: 4,
+    });
+  });
+
+  it("uses defaults for blank GET numeric options", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/cron/email-message-stats-reconciliation?batchSize=&accountLimit=&sampleLimit=&maxErrorsPerAccount=",
+        {
+          headers: { authorization: "Bearer cron-secret" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(reconcileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountLimit: 10,
+        batchSize: 25,
+        sampleLimit: 20,
+        maxErrorsPerAccount: 5,
+      }),
+    );
+  });
+
+  it("rejects POST requests without the cron secret in the body", async () => {
+    const response = await POST(
+      new Request(
+        "http://localhost:3000/api/cron/email-message-stats-reconciliation",
+        {
+          method: "POST",
+          body: JSON.stringify({ CRON_SECRET: "wrong-secret" }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+    expect(reconcileMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs POST reconciliation with parsed body options", async () => {
+    const response = await POST(
+      new Request(
+        "http://localhost:3000/api/cron/email-message-stats-reconciliation",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            CRON_SECRET: "cron-secret",
+            dryRun: true,
+            emailAccountId: "account-1",
+            batchSize: 5,
+          }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(reconcileMock).toHaveBeenCalledWith({
+      logger: expect.anything(),
+      dryRun: true,
+      emailAccountId: "account-1",
+      accountLimit: 10,
+      batchSize: 5,
+      sampleLimit: 20,
+      maxErrorsPerAccount: 5,
+    });
+  });
+});

--- a/apps/web/app/api/cron/email-message-stats-reconciliation/route.ts
+++ b/apps/web/app/api/cron/email-message-stats-reconciliation/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { hasCronSecret, hasPostCronSecret } from "@/utils/cron";
+import { captureException } from "@/utils/error";
+import { reconcileConfiguredGmailEmailMessageStats } from "@/utils/email/email-message-stats-reconciliation";
+import { type RequestWithLogger, withError } from "@/utils/middleware";
+
+export const maxDuration = 300;
+
+export const GET = withError(
+  "cron/email-message-stats-reconciliation",
+  async (request) => {
+    if (!hasCronSecret(request)) {
+      captureException(
+        new Error(
+          "Unauthorized request: api/cron/email-message-stats-reconciliation",
+        ),
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    return runEmailMessageStatsReconciliation(
+      request,
+      parseGetOptions(request),
+    );
+  },
+);
+
+export const POST = withError(
+  "cron/email-message-stats-reconciliation",
+  async (request) => {
+    if (!(await hasPostCronSecret(request))) {
+      captureException(
+        new Error(
+          "Unauthorized cron request: api/cron/email-message-stats-reconciliation",
+        ),
+      );
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+
+    return runEmailMessageStatsReconciliation(request, parseBodyOptions(body));
+  },
+);
+
+async function runEmailMessageStatsReconciliation(
+  request: RequestWithLogger,
+  options: ReconciliationRouteOptions,
+) {
+  const result = await reconcileConfiguredGmailEmailMessageStats({
+    logger: request.logger,
+    ...options,
+  });
+
+  return NextResponse.json(result);
+}
+
+function parseGetOptions(request: Request): ReconciliationRouteOptions {
+  const url = new URL(request.url);
+
+  return {
+    emailAccountId: optionalString(url.searchParams.get("emailAccountId")),
+    dryRun: parseBoolean(url.searchParams.get("dryRun"), false),
+    accountLimit: parseIntegerOption(url.searchParams.get("accountLimit"), {
+      defaultValue: 10,
+      min: 1,
+      max: 100,
+    }),
+    batchSize: parseIntegerOption(url.searchParams.get("batchSize"), {
+      defaultValue: 25,
+      min: 1,
+      max: 100,
+    }),
+    sampleLimit: parseIntegerOption(url.searchParams.get("sampleLimit"), {
+      defaultValue: 20,
+      min: 0,
+      max: 100,
+    }),
+    maxErrorsPerAccount: parseIntegerOption(
+      url.searchParams.get("maxErrorsPerAccount"),
+      {
+        defaultValue: 5,
+        min: 1,
+        max: 50,
+      },
+    ),
+  };
+}
+
+function parseBodyOptions(body: unknown): ReconciliationRouteOptions {
+  const parsedBody = isObject(body) ? body : {};
+
+  return {
+    emailAccountId: optionalString(parsedBody.emailAccountId),
+    dryRun: parseBoolean(parsedBody.dryRun, false),
+    accountLimit: parseIntegerOption(parsedBody.accountLimit, {
+      defaultValue: 10,
+      min: 1,
+      max: 100,
+    }),
+    batchSize: parseIntegerOption(parsedBody.batchSize, {
+      defaultValue: 25,
+      min: 1,
+      max: 100,
+    }),
+    sampleLimit: parseIntegerOption(parsedBody.sampleLimit, {
+      defaultValue: 20,
+      min: 0,
+      max: 100,
+    }),
+    maxErrorsPerAccount: parseIntegerOption(parsedBody.maxErrorsPerAccount, {
+      defaultValue: 5,
+      min: 1,
+      max: 50,
+    }),
+  };
+}
+
+function parseIntegerOption(
+  value: unknown,
+  {
+    defaultValue,
+    min,
+    max,
+  }: {
+    defaultValue: number;
+    min: number;
+    max: number;
+  },
+) {
+  const numericValue =
+    typeof value === "number" ? value : parseNumericString(value);
+
+  if (!Number.isInteger(numericValue)) return defaultValue;
+  return Math.min(max, Math.max(min, numericValue));
+}
+
+function parseNumericString(value: unknown) {
+  if (typeof value !== "string") return Number.NaN;
+
+  const trimmed = value.trim();
+  if (!trimmed) return Number.NaN;
+
+  return +trimmed;
+}
+
+function parseBoolean(value: unknown, defaultValue: boolean) {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return defaultValue;
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+  return defaultValue;
+}
+
+function optionalString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+type ReconciliationRouteOptions = {
+  emailAccountId?: string;
+  dryRun: boolean;
+  accountLimit: number;
+  batchSize: number;
+  sampleLimit: number;
+  maxErrorsPerAccount: number;
+};

--- a/apps/web/utils/email/email-message-stats-reconciliation.test.ts
+++ b/apps/web/utils/email/email-message-stats-reconciliation.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockCreateEmailProvider,
+  mockDeleteEmailMessageStats,
+  mockReconcileEmailMessageStatsFromParsedMessage,
+} = vi.hoisted(() => ({
+  mockPrisma: {
+    emailMessage: {
+      findMany: vi.fn(),
+    },
+    emailAccount: {
+      findFirst: vi.fn(),
+    },
+    $queryRaw: vi.fn(),
+  },
+  mockCreateEmailProvider: vi.fn(),
+  mockDeleteEmailMessageStats: vi.fn(),
+  mockReconcileEmailMessageStatsFromParsedMessage: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: mockPrisma,
+}));
+
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: (...args: unknown[]) => mockCreateEmailProvider(...args),
+}));
+
+vi.mock("@/utils/email/email-message-stats", () => ({
+  deleteEmailMessageStats: (...args: unknown[]) =>
+    mockDeleteEmailMessageStats(...args),
+  reconcileEmailMessageStatsFromParsedMessage: (...args: unknown[]) =>
+    mockReconcileEmailMessageStatsFromParsedMessage(...args),
+  shouldExcludeFromEmailMessageStats: (message: { labelIds?: string[] }) =>
+    !!message.labelIds?.some((labelId) =>
+      ["TRASH", "SPAM", "DRAFT"].includes(labelId),
+    ),
+}));
+
+import {
+  reconcileConfiguredGmailEmailMessageStats,
+  reconcileEmailMessageStatsForAccount,
+} from "./email-message-stats-reconciliation";
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  flush: vi.fn(),
+  with: vi.fn(),
+};
+
+describe("EmailMessage stats reconciliation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger.with.mockReturnValue(logger);
+    mockDeleteEmailMessageStats.mockResolvedValue(undefined);
+    mockReconcileEmailMessageStatsFromParsedMessage.mockResolvedValue(true);
+  });
+
+  it("dry-runs Gmail not-found rows without deleting local stats", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockRejectedValue({ response: { status: 404 } }),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      checked: 1,
+      wouldDelete: 1,
+      deleted: 0,
+      errors: 0,
+    });
+    expect(result.samples[0]).toMatchObject({
+      action: "would-delete-not-found",
+      messageId: "msg-1",
+    });
+    expect(mockDeleteEmailMessageStats).not.toHaveBeenCalled();
+  });
+
+  it("deletes local stats when Gmail reports not found", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockRejectedValue({ response: { status: 404 } }),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+
+    expect(result).toMatchObject({
+      checked: 1,
+      deleted: 1,
+      deletedNotFound: 1,
+      errors: 0,
+    });
+    expect(mockDeleteEmailMessageStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        messageId: "msg-1",
+        threadId: "thread-1",
+        reason: "stats-reconciliation-message-not-found",
+      }),
+    );
+  });
+
+  it("does not delete local stats for non-Gmail errors that mention not found", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockRejectedValue(new Error("OAuth token not found")),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+
+    expect(result).toMatchObject({
+      checked: 1,
+      deleted: 0,
+      errors: 1,
+    });
+    expect(mockDeleteEmailMessageStats).not.toHaveBeenCalled();
+  });
+
+  it("deletes local stats when the current Gmail message is excluded", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockResolvedValue(
+        createMessage({
+          id: "msg-1",
+          threadId: "thread-1",
+          labelIds: ["TRASH"],
+        }),
+      ),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+
+    expect(result).toMatchObject({
+      deleted: 1,
+      deletedExcludedLabel: 1,
+      upserted: 0,
+    });
+    expect(
+      mockReconcileEmailMessageStatsFromParsedMessage,
+    ).not.toHaveBeenCalled();
+    expect(mockDeleteEmailMessageStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "stats-reconciliation-excluded-label",
+      }),
+    );
+  });
+
+  it("upserts current Gmail state for kept messages", async () => {
+    const message = createMessage({ id: "msg-1", threadId: "thread-1" });
+    const provider = createProvider({
+      getMessage: vi.fn().mockResolvedValue(message),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+
+    expect(result).toMatchObject({ upserted: 1, deleted: 0, errors: 0 });
+    expect(
+      mockReconcileEmailMessageStatsFromParsedMessage,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        message,
+        reason: "stats-reconciliation-current-state",
+      }),
+    );
+  });
+
+  it("removes the old local row when Gmail returns a changed thread id", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockResolvedValue(
+        createMessage({
+          id: "msg-1",
+          threadId: "new-thread",
+        }),
+      ),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "old-thread" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+    });
+
+    expect(result.threadIdChanged).toBe(1);
+    expect(mockDeleteEmailMessageStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "msg-1",
+        threadId: "old-thread",
+        reason: "stats-reconciliation-thread-id-changed",
+      }),
+    );
+  });
+
+  it("processes only batchSize rows and reports hasMore", async () => {
+    const provider = createProvider();
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+      { id: "row-2", messageId: "msg-2", threadId: "thread-2" },
+      { id: "row-3", messageId: "msg-3", threadId: "thread-3" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+      batchSize: 2,
+    });
+
+    expect(mockPrisma.emailMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 3 }),
+    );
+    expect(provider.getMessage).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ scanned: 2, checked: 2, hasMore: true });
+  });
+
+  it("reports hasMore when it stops before processing the fetched batch", async () => {
+    const provider = createProvider({
+      getMessage: vi.fn().mockRejectedValue(new Error("provider failed")),
+    });
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+      { id: "row-2", messageId: "msg-2", threadId: "thread-2" },
+    ]);
+
+    const result = await reconcileEmailMessageStatsForAccount({
+      emailAccountId: "account-1",
+      provider,
+      logger,
+      batchSize: 2,
+      maxErrorsPerAccount: 1,
+    });
+
+    expect(result).toMatchObject({
+      checked: 1,
+      errors: 1,
+      stoppedEarly: "max-errors",
+      hasMore: true,
+    });
+  });
+
+  it("continues configured account reconciliation after an account failure", async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([
+      { id: "account-1", provider: "google", localEmailMessageCount: 1 },
+      { id: "account-2", provider: "google", localEmailMessageCount: 1 },
+    ]);
+    mockPrisma.emailMessage.findMany.mockResolvedValue([
+      { id: "row-1", messageId: "msg-1", threadId: "thread-1" },
+    ]);
+    mockCreateEmailProvider
+      .mockRejectedValueOnce(new Error("provider failed"))
+      .mockResolvedValueOnce(createProvider());
+
+    const result = await reconcileConfiguredGmailEmailMessageStats({
+      logger,
+      batchSize: 1,
+    });
+
+    expect(result.failedAccounts).toBe(1);
+    expect(result.accountsChecked).toBe(1);
+    expect(result.totals.upserted).toBe(1);
+  });
+
+  it("skips explicit non-Google accounts", async () => {
+    mockPrisma.emailAccount.findFirst.mockResolvedValue({
+      id: "account-1",
+      account: { provider: "microsoft" },
+    });
+
+    const result = await reconcileConfiguredGmailEmailMessageStats({
+      logger,
+      emailAccountId: "account-1",
+    });
+
+    expect(result.accountsSkipped).toBe(1);
+    expect(mockCreateEmailProvider).not.toHaveBeenCalled();
+  });
+});
+
+function createProvider(overrides = {}) {
+  return {
+    name: "google",
+    getMessage: vi.fn().mockResolvedValue(createMessage()),
+    ...overrides,
+  } as never;
+}
+
+function createMessage(overrides = {}) {
+  return {
+    id: "msg-1",
+    threadId: "thread-1",
+    headers: {
+      from: "Sender <sender@example.com>",
+      to: "user@example.com",
+      subject: "Subject",
+    },
+    internalDate: Date.now().toString(),
+    textHtml: "",
+    labelIds: ["INBOX"],
+    ...overrides,
+  };
+}

--- a/apps/web/utils/email/email-message-stats-reconciliation.ts
+++ b/apps/web/utils/email/email-message-stats-reconciliation.ts
@@ -1,0 +1,521 @@
+import "server-only";
+
+import { Prisma } from "@/generated/prisma/client";
+import {
+  deleteEmailMessageStats,
+  reconcileEmailMessageStatsFromParsedMessage,
+  shouldExcludeFromEmailMessageStats,
+} from "@/utils/email/email-message-stats";
+import { createEmailProvider } from "@/utils/email/provider";
+import type { EmailProvider } from "@/utils/email/types";
+import { isGmailMessageNotFoundError } from "@/utils/gmail/errors";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+const DEFAULT_ACCOUNT_LIMIT = 10;
+const DEFAULT_BATCH_SIZE = 25;
+const DEFAULT_SAMPLE_LIMIT = 20;
+const DEFAULT_MAX_ERRORS_PER_ACCOUNT = 5;
+const DEFAULT_SOFT_TIME_LIMIT_MS = 270_000;
+const GOOGLE_PROVIDER = "google";
+
+type EmailMessageStatsReconciliationOptions = {
+  emailAccountId: string;
+  provider: EmailProvider;
+  logger: Logger;
+  dryRun?: boolean;
+  batchSize?: number;
+  sampleLimit?: number;
+  maxErrorsPerAccount?: number;
+  softTimeLimitMs?: number;
+  deadlineAt?: number;
+};
+
+type ConfiguredAccountsReconciliationOptions = {
+  logger: Logger;
+  emailAccountId?: string;
+  dryRun?: boolean;
+  accountLimit?: number;
+  batchSize?: number;
+  sampleLimit?: number;
+  maxErrorsPerAccount?: number;
+  softTimeLimitMs?: number;
+};
+
+type ReconciliationAction =
+  | "would-delete-not-found"
+  | "deleted-not-found"
+  | "would-delete-excluded-label"
+  | "deleted-excluded-label"
+  | "would-upsert"
+  | "upserted"
+  | "would-replace-thread-id"
+  | "replaced-thread-id"
+  | "error";
+
+type ReconciliationSample = {
+  messageId: string;
+  threadId: string;
+  action: ReconciliationAction;
+  labels?: string[];
+  error?: string;
+};
+
+type AccountReconciliationResult = {
+  emailAccountId: string;
+  dryRun: boolean;
+  scanned: number;
+  checked: number;
+  upserted: number;
+  wouldUpsert: number;
+  deleted: number;
+  wouldDelete: number;
+  deletedNotFound: number;
+  deletedExcludedLabel: number;
+  threadIdChanged: number;
+  errors: number;
+  stoppedEarly?: "max-errors" | "time-limit";
+  hasMore: boolean;
+  samples: ReconciliationSample[];
+};
+
+type ConfiguredAccountsReconciliationResult = {
+  dryRun: boolean;
+  accountsChecked: number;
+  accountsSkipped: number;
+  failedAccounts: number;
+  stoppedEarly?: "time-limit";
+  totals: Omit<
+    AccountReconciliationResult,
+    "emailAccountId" | "dryRun" | "stoppedEarly" | "hasMore" | "samples"
+  >;
+  accounts: AccountReconciliationResult[];
+};
+
+type EmailMessageStatsCandidate = {
+  id: string;
+  messageId: string;
+  threadId: string;
+};
+
+type AccountCandidate = {
+  id: string;
+  provider: string;
+  localEmailMessageCount: number | bigint;
+};
+
+export async function reconcileEmailMessageStatsForAccount({
+  emailAccountId,
+  provider,
+  logger,
+  dryRun = false,
+  batchSize = DEFAULT_BATCH_SIZE,
+  sampleLimit = DEFAULT_SAMPLE_LIMIT,
+  maxErrorsPerAccount = DEFAULT_MAX_ERRORS_PER_ACCOUNT,
+  softTimeLimitMs = DEFAULT_SOFT_TIME_LIMIT_MS,
+  deadlineAt: providedDeadlineAt,
+}: EmailMessageStatsReconciliationOptions): Promise<AccountReconciliationResult> {
+  const accountLogger = logger.with({ emailAccountId });
+  const deadlineAt = optionsDeadlineAt({
+    deadlineAt: providedDeadlineAt,
+    softTimeLimitMs,
+  });
+  const result = createEmptyAccountResult({ emailAccountId, dryRun });
+
+  if (provider.name !== GOOGLE_PROVIDER) return result;
+
+  const rows = await prisma.emailMessage.findMany({
+    where: { emailAccountId },
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: batchSize + 1,
+    select: {
+      id: true,
+      messageId: true,
+      threadId: true,
+    },
+  });
+
+  const candidates = rows.slice(0, batchSize);
+  result.scanned = candidates.length;
+
+  for (const row of candidates) {
+    if (Date.now() > deadlineAt) {
+      result.stoppedEarly = "time-limit";
+      break;
+    }
+
+    await reconcileEmailMessageStatsRow({
+      emailAccountId,
+      provider,
+      row,
+      logger: accountLogger,
+      dryRun,
+      result,
+      sampleLimit,
+    });
+
+    if (result.errors >= maxErrorsPerAccount) {
+      result.stoppedEarly = "max-errors";
+      break;
+    }
+  }
+
+  result.hasMore =
+    rows.length > batchSize ||
+    result.checked < candidates.length ||
+    !!result.stoppedEarly;
+
+  accountLogger.info("EmailMessage stats reconciliation completed", {
+    dryRun,
+    scanned: result.scanned,
+    checked: result.checked,
+    deleted: result.deleted,
+    wouldDelete: result.wouldDelete,
+    upserted: result.upserted,
+    wouldUpsert: result.wouldUpsert,
+    errors: result.errors,
+    hasMore: result.hasMore,
+    stoppedEarly: result.stoppedEarly,
+  });
+
+  return result;
+}
+
+export async function reconcileConfiguredGmailEmailMessageStats({
+  logger,
+  emailAccountId,
+  dryRun = false,
+  accountLimit = DEFAULT_ACCOUNT_LIMIT,
+  batchSize = DEFAULT_BATCH_SIZE,
+  sampleLimit = DEFAULT_SAMPLE_LIMIT,
+  maxErrorsPerAccount = DEFAULT_MAX_ERRORS_PER_ACCOUNT,
+  softTimeLimitMs = DEFAULT_SOFT_TIME_LIMIT_MS,
+}: ConfiguredAccountsReconciliationOptions): Promise<ConfiguredAccountsReconciliationResult> {
+  const deadlineAt = Date.now() + softTimeLimitMs;
+  const result = createEmptyConfiguredResult(dryRun);
+
+  const accounts = emailAccountId
+    ? await getExplicitAccountCandidate(emailAccountId)
+    : await getOldestGoogleAccountCandidates(accountLimit);
+
+  for (const account of accounts) {
+    if (Date.now() > deadlineAt) {
+      result.stoppedEarly = "time-limit";
+      break;
+    }
+
+    if (account.provider !== GOOGLE_PROVIDER) {
+      result.accountsSkipped += 1;
+      continue;
+    }
+
+    const accountLogger = logger.with({ emailAccountId: account.id });
+
+    try {
+      const provider = await createEmailProvider({
+        emailAccountId: account.id,
+        provider: account.provider,
+        logger: accountLogger,
+      });
+
+      const accountResult = await reconcileEmailMessageStatsForAccount({
+        emailAccountId: account.id,
+        provider,
+        logger: accountLogger,
+        dryRun,
+        batchSize,
+        sampleLimit,
+        maxErrorsPerAccount,
+        softTimeLimitMs,
+        deadlineAt,
+      });
+
+      result.accountsChecked += 1;
+      result.accounts.push(accountResult);
+      addAccountTotals(result, accountResult);
+      if (accountResult.stoppedEarly === "time-limit") {
+        result.stoppedEarly = "time-limit";
+        break;
+      }
+    } catch (error) {
+      accountLogger.error("EmailMessage stats reconciliation failed", {
+        error,
+      });
+      result.failedAccounts += 1;
+      result.totals.errors += 1;
+    }
+  }
+
+  return result;
+}
+
+async function reconcileEmailMessageStatsRow({
+  emailAccountId,
+  provider,
+  row,
+  logger,
+  dryRun,
+  result,
+  sampleLimit,
+}: {
+  emailAccountId: string;
+  provider: EmailProvider;
+  row: EmailMessageStatsCandidate;
+  logger: Logger;
+  dryRun: boolean;
+  result: AccountReconciliationResult;
+  sampleLimit: number;
+}) {
+  result.checked += 1;
+
+  try {
+    const message = await provider.getMessage(row.messageId);
+    const labels = message.labelIds ?? [];
+
+    if (shouldExcludeFromEmailMessageStats(message)) {
+      if (dryRun) {
+        result.wouldDelete += 1;
+        addSample(result, sampleLimit, {
+          messageId: row.messageId,
+          threadId: row.threadId,
+          action: "would-delete-excluded-label",
+          labels,
+        });
+      } else {
+        await deleteEmailMessageStats({
+          emailAccountId,
+          messageId: row.messageId,
+          threadId: row.threadId,
+          reason: "stats-reconciliation-excluded-label",
+          logger,
+        });
+        result.deleted += 1;
+        result.deletedExcludedLabel += 1;
+        addSample(result, sampleLimit, {
+          messageId: row.messageId,
+          threadId: row.threadId,
+          action: "deleted-excluded-label",
+          labels,
+        });
+      }
+      return;
+    }
+
+    if (dryRun) {
+      result.wouldUpsert += 1;
+      if (row.threadId !== message.threadId) result.threadIdChanged += 1;
+      addSample(result, sampleLimit, {
+        messageId: row.messageId,
+        threadId: row.threadId,
+        action:
+          row.threadId === message.threadId
+            ? "would-upsert"
+            : "would-replace-thread-id",
+        labels,
+      });
+      return;
+    }
+
+    await reconcileEmailMessageStatsFromParsedMessage({
+      emailAccountId,
+      message,
+      logger,
+      reason: "stats-reconciliation-current-state",
+    });
+    result.upserted += 1;
+
+    if (row.threadId !== message.threadId) {
+      await deleteEmailMessageStats({
+        emailAccountId,
+        messageId: row.messageId,
+        threadId: row.threadId,
+        reason: "stats-reconciliation-thread-id-changed",
+        logger,
+      });
+      result.threadIdChanged += 1;
+      addSample(result, sampleLimit, {
+        messageId: row.messageId,
+        threadId: row.threadId,
+        action: "replaced-thread-id",
+        labels,
+      });
+      return;
+    }
+
+    addSample(result, sampleLimit, {
+      messageId: row.messageId,
+      threadId: row.threadId,
+      action: "upserted",
+      labels,
+    });
+  } catch (error) {
+    if (isGmailMessageNotFoundError(error)) {
+      if (dryRun) {
+        result.wouldDelete += 1;
+        addSample(result, sampleLimit, {
+          messageId: row.messageId,
+          threadId: row.threadId,
+          action: "would-delete-not-found",
+        });
+      } else {
+        await deleteEmailMessageStats({
+          emailAccountId,
+          messageId: row.messageId,
+          threadId: row.threadId,
+          reason: "stats-reconciliation-message-not-found",
+          logger,
+        });
+        result.deleted += 1;
+        result.deletedNotFound += 1;
+        addSample(result, sampleLimit, {
+          messageId: row.messageId,
+          threadId: row.threadId,
+          action: "deleted-not-found",
+        });
+      }
+      return;
+    }
+
+    logger.error("Failed to reconcile EmailMessage stats row", {
+      messageId: row.messageId,
+      threadId: row.threadId,
+      error,
+    });
+    result.errors += 1;
+    addSample(result, sampleLimit, {
+      messageId: row.messageId,
+      threadId: row.threadId,
+      action: "error",
+      error: getErrorMessage(error),
+    });
+  }
+}
+
+async function getExplicitAccountCandidate(emailAccountId: string) {
+  const emailAccount = await prisma.emailAccount.findFirst({
+    where: {
+      id: emailAccountId,
+      account: { disconnectedAt: null },
+    },
+    select: {
+      id: true,
+      account: { select: { provider: true } },
+    },
+  });
+
+  if (!emailAccount) return [];
+
+  return [
+    {
+      id: emailAccount.id,
+      provider: emailAccount.account.provider,
+      localEmailMessageCount: 0,
+    },
+  ];
+}
+
+async function getOldestGoogleAccountCandidates(accountLimit: number) {
+  return prisma.$queryRaw<AccountCandidate[]>(Prisma.sql`
+    SELECT
+      ea."id",
+      a."provider",
+      COUNT(em."id") AS "localEmailMessageCount"
+    FROM "EmailAccount" ea
+    JOIN "Account" a ON a."id" = ea."accountId"
+    JOIN "EmailMessage" em ON em."emailAccountId" = ea."id"
+    WHERE a."provider" = ${GOOGLE_PROVIDER}
+      AND a."disconnectedAt" IS NULL
+    GROUP BY ea."id", a."provider"
+    ORDER BY MIN(em."updatedAt") ASC, ea."id" ASC
+    LIMIT ${accountLimit}
+  `);
+}
+
+function createEmptyAccountResult({
+  emailAccountId,
+  dryRun,
+}: {
+  emailAccountId: string;
+  dryRun: boolean;
+}): AccountReconciliationResult {
+  return {
+    emailAccountId,
+    dryRun,
+    scanned: 0,
+    checked: 0,
+    upserted: 0,
+    wouldUpsert: 0,
+    deleted: 0,
+    wouldDelete: 0,
+    deletedNotFound: 0,
+    deletedExcludedLabel: 0,
+    threadIdChanged: 0,
+    errors: 0,
+    hasMore: false,
+    samples: [],
+  };
+}
+
+function createEmptyConfiguredResult(
+  dryRun: boolean,
+): ConfiguredAccountsReconciliationResult {
+  return {
+    dryRun,
+    accountsChecked: 0,
+    accountsSkipped: 0,
+    failedAccounts: 0,
+    totals: {
+      scanned: 0,
+      checked: 0,
+      upserted: 0,
+      wouldUpsert: 0,
+      deleted: 0,
+      wouldDelete: 0,
+      deletedNotFound: 0,
+      deletedExcludedLabel: 0,
+      threadIdChanged: 0,
+      errors: 0,
+    },
+    accounts: [],
+  };
+}
+
+function optionsDeadlineAt({
+  deadlineAt,
+  softTimeLimitMs,
+}: {
+  deadlineAt?: number;
+  softTimeLimitMs: number;
+}) {
+  return deadlineAt ?? Date.now() + softTimeLimitMs;
+}
+
+function addAccountTotals(
+  configuredResult: ConfiguredAccountsReconciliationResult,
+  accountResult: AccountReconciliationResult,
+) {
+  configuredResult.totals.scanned += accountResult.scanned;
+  configuredResult.totals.checked += accountResult.checked;
+  configuredResult.totals.upserted += accountResult.upserted;
+  configuredResult.totals.wouldUpsert += accountResult.wouldUpsert;
+  configuredResult.totals.deleted += accountResult.deleted;
+  configuredResult.totals.wouldDelete += accountResult.wouldDelete;
+  configuredResult.totals.deletedNotFound += accountResult.deletedNotFound;
+  configuredResult.totals.deletedExcludedLabel +=
+    accountResult.deletedExcludedLabel;
+  configuredResult.totals.threadIdChanged += accountResult.threadIdChanged;
+  configuredResult.totals.errors += accountResult.errors;
+}
+
+function addSample(
+  result: AccountReconciliationResult,
+  sampleLimit: number,
+  sample: ReconciliationSample,
+) {
+  if (result.samples.length >= sampleLimit) return;
+  result.samples.push(sample);
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/web/utils/email/email-message-stats.ts
+++ b/apps/web/utils/email/email-message-stats.ts
@@ -1,0 +1,256 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@/generated/prisma/client";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+import { GmailLabel } from "@/utils/gmail/label";
+import { internalDateToDate } from "@/utils/date";
+import {
+  extractDomainFromEmail,
+  extractEmailAddress,
+  extractNameFromEmail,
+} from "@/utils/email";
+import { findUnsubscribeLink } from "@/utils/parse/parseHtml.server";
+import {
+  cleanUnsubscribeLink,
+  parseListUnsubscribeHeader,
+} from "@/utils/parse/unsubscribe";
+import type { ParsedMessage } from "@/utils/types";
+import { isDefined } from "@/utils/types";
+
+type EmailMessageStatsRow = {
+  threadId: string;
+  messageId: string;
+  from: string;
+  fromName: string;
+  fromDomain: string;
+  to: string;
+  date: Date;
+  unsubscribeLink: string | null | undefined;
+  read: boolean;
+  sent: boolean;
+  draft: boolean;
+  inbox: boolean;
+  emailAccountId: string;
+};
+
+export async function upsertEmailMessageStatsBatch({
+  emailAccountId,
+  messages,
+  logger,
+}: {
+  emailAccountId: string;
+  messages: ParsedMessage[];
+  logger: Logger;
+}) {
+  const emailsToSave = messages
+    .map((message) =>
+      toEmailMessageStatsRow({ emailAccountId, message, logger }),
+    )
+    .filter(isDefined);
+
+  logger.info("Saving", { count: emailsToSave.length });
+
+  await saveEmailMessages(emailsToSave);
+}
+
+export async function upsertEmailMessageStats({
+  emailAccountId,
+  message,
+  logger,
+}: {
+  emailAccountId: string;
+  message: ParsedMessage;
+  logger: Logger;
+}) {
+  await upsertEmailMessageStatsBatch({
+    emailAccountId,
+    messages: [message],
+    logger,
+  });
+}
+
+export async function deleteEmailMessageStats({
+  emailAccountId,
+  messageId,
+  threadId,
+  reason,
+  logger,
+}: {
+  emailAccountId: string;
+  messageId: string;
+  threadId?: string | null;
+  reason: string;
+  logger: Logger;
+}) {
+  const result = await prisma.emailMessage.deleteMany({
+    where: {
+      emailAccountId,
+      messageId,
+      ...(threadId ? { threadId } : {}),
+    },
+  });
+
+  logger.info("Deleted EmailMessage stats", {
+    emailAccountId,
+    messageId,
+    threadId,
+    reason,
+    deletedCount: result.count,
+  });
+}
+
+export async function reconcileEmailMessageStatsFromParsedMessage({
+  emailAccountId,
+  message,
+  logger,
+  reason,
+}: {
+  emailAccountId: string;
+  message: ParsedMessage;
+  logger: Logger;
+  reason: string;
+}) {
+  if (shouldExcludeFromEmailMessageStats(message)) {
+    await deleteEmailMessageStats({
+      emailAccountId,
+      messageId: message.id,
+      threadId: message.threadId,
+      reason,
+      logger,
+    });
+    return false;
+  }
+
+  await upsertEmailMessageStats({ emailAccountId, message, logger });
+  return true;
+}
+
+export function shouldExcludeFromEmailMessageStats(message: ParsedMessage) {
+  const labels = message.labelIds ?? [];
+  return (
+    labels.includes(GmailLabel.TRASH) ||
+    labels.includes(GmailLabel.SPAM) ||
+    labels.includes(GmailLabel.DRAFT)
+  );
+}
+
+function toEmailMessageStatsRow({
+  emailAccountId,
+  message,
+  logger,
+}: {
+  emailAccountId: string;
+  message: ParsedMessage;
+  logger: Logger;
+}): EmailMessageStatsRow | undefined {
+  const unsubscribeLink = mergeUnsubscribeSources({
+    htmlUnsubscribeLink: findUnsubscribeLink(message.textHtml),
+    listUnsubscribeHeader: message.headers["list-unsubscribe"],
+  });
+
+  const date = internalDateToDate(message.internalDate);
+  if (!date) {
+    logger.error("No date for email", {
+      messageId: message.id,
+      date: message.internalDate,
+    });
+    return;
+  }
+
+  return {
+    threadId: message.threadId,
+    messageId: message.id,
+    from: extractEmailAddress(message.headers.from),
+    fromName: extractNameFromEmail(message.headers.from),
+    fromDomain: extractDomainFromEmail(message.headers.from),
+    to: message.headers.to
+      ? extractEmailAddress(message.headers.to)
+      : "Missing",
+    date,
+    unsubscribeLink,
+    read: !message.labelIds?.includes(GmailLabel.UNREAD),
+    sent: !!message.labelIds?.includes(GmailLabel.SENT),
+    draft: !!message.labelIds?.includes(GmailLabel.DRAFT),
+    inbox: !!message.labelIds?.includes(GmailLabel.INBOX),
+    emailAccountId,
+  };
+}
+
+async function saveEmailMessages(emails: EmailMessageStatsRow[]) {
+  if (emails.length === 0) return;
+
+  const rows = emails.map(
+    (email) => Prisma.sql`(
+      ${randomUUID()}::text,
+      ${email.emailAccountId}::text,
+      ${email.threadId}::text,
+      ${email.messageId}::text,
+      ${email.date}::timestamp,
+      ${email.from}::text,
+      ${email.fromName}::text,
+      ${email.fromDomain}::text,
+      ${email.to}::text,
+      ${email.unsubscribeLink}::text,
+      ${email.read}::boolean,
+      ${email.sent}::boolean,
+      ${email.draft}::boolean,
+      ${email.inbox}::boolean,
+      NOW(),
+      NOW()
+    )`,
+  );
+
+  await prisma.$executeRaw`
+    INSERT INTO "EmailMessage" (
+      "id",
+      "emailAccountId",
+      "threadId",
+      "messageId",
+      "date",
+      "from",
+      "fromName",
+      "fromDomain",
+      "to",
+      "unsubscribeLink",
+      "read",
+      "sent",
+      "draft",
+      "inbox",
+      "createdAt",
+      "updatedAt"
+    )
+    VALUES ${Prisma.join(rows)}
+    ON CONFLICT ("emailAccountId", "threadId", "messageId") DO UPDATE SET
+      "date" = EXCLUDED."date",
+      "from" = EXCLUDED."from",
+      "fromName" = EXCLUDED."fromName",
+      "fromDomain" = EXCLUDED."fromDomain",
+      "to" = EXCLUDED."to",
+      "unsubscribeLink" = EXCLUDED."unsubscribeLink",
+      "read" = EXCLUDED."read",
+      "sent" = EXCLUDED."sent",
+      "draft" = EXCLUDED."draft",
+      "inbox" = EXCLUDED."inbox",
+      "updatedAt" = NOW()
+  `;
+}
+
+function mergeUnsubscribeSources({
+  htmlUnsubscribeLink,
+  listUnsubscribeHeader,
+}: {
+  htmlUnsubscribeLink?: string | null;
+  listUnsubscribeHeader?: string | null;
+}) {
+  if (!listUnsubscribeHeader) return cleanUnsubscribeLink(htmlUnsubscribeLink);
+
+  const normalizedHtmlLink = cleanUnsubscribeLink(htmlUnsubscribeLink);
+  if (!normalizedHtmlLink) return listUnsubscribeHeader;
+
+  const headerLinks = parseListUnsubscribeHeader(listUnsubscribeHeader);
+  if (headerLinks.includes(normalizedHtmlLink)) return listUnsubscribeHeader;
+
+  return `${listUnsubscribeHeader}, <${normalizedHtmlLink}>`;
+}

--- a/apps/web/utils/gmail/errors.ts
+++ b/apps/web/utils/gmail/errors.ts
@@ -1,0 +1,33 @@
+export function isGmailMessageNotFoundError(error: unknown): boolean {
+  const err = error as {
+    code?: unknown;
+    status?: unknown;
+    response?: {
+      status?: unknown;
+      data?: {
+        error?: {
+          code?: unknown;
+          status?: unknown;
+          message?: unknown;
+          errors?: Array<{ reason?: unknown; message?: unknown }>;
+        };
+      };
+    };
+    message?: unknown;
+  };
+
+  const code =
+    err.response?.data?.error?.code ??
+    err.response?.status ??
+    err.status ??
+    err.code;
+  if (code === 404 || code === "404") return true;
+
+  const status = err.response?.data?.error?.status;
+  if (status === "NOT_FOUND") return true;
+
+  const reasons = err.response?.data?.error?.errors?.map((item) => item.reason);
+  if (reasons?.includes("notFound")) return true;
+
+  return false;
+}

--- a/apps/web/utils/webhook/google/process-history-item.test.ts
+++ b/apps/web/utils/webhook/google/process-history-item.test.ts
@@ -12,6 +12,16 @@ import { getEmailAccount, createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
 import { handleOutboundMessage } from "@/utils/reply-tracker/handle-outbound";
 
+const {
+  reconcileStatsForCurrentGmailMessageMock,
+  reconcileStatsForDeletedMessageMock,
+  shouldReconcileStatsForLabelEventMock,
+} = vi.hoisted(() => ({
+  reconcileStatsForCurrentGmailMessageMock: vi.fn(),
+  reconcileStatsForDeletedMessageMock: vi.fn(),
+  shouldReconcileStatsForLabelEventMock: vi.fn(),
+}));
+
 const logger = createTestLogger();
 
 vi.mock("@/utils/prisma");
@@ -81,6 +91,15 @@ vi.mock("@/utils/reply-tracker/handle-outbound", () => ({
   handleOutboundMessage: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/utils/webhook/google/sync-email-message-stats", () => ({
+  reconcileStatsForCurrentGmailMessage: (...args: unknown[]) =>
+    reconcileStatsForCurrentGmailMessageMock(...args),
+  reconcileStatsForDeletedMessage: (...args: unknown[]) =>
+    reconcileStatsForDeletedMessageMock(...args),
+  shouldReconcileStatsForLabelEvent: (...args: unknown[]) =>
+    shouldReconcileStatsForLabelEventMock(...args),
+}));
+
 vi.mock("@/utils/gmail/label", async () => {
   const actual = await vi.importActual("@/utils/gmail/label");
   return {
@@ -104,6 +123,25 @@ vi.mock("@/utils/rule/learned-patterns", () => ({
 describe("processHistoryItem", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    shouldReconcileStatsForLabelEventMock.mockReturnValue(false);
+    reconcileStatsForDeletedMessageMock.mockResolvedValue(undefined);
+    reconcileStatsForCurrentGmailMessageMock.mockResolvedValue({
+      id: "123",
+      threadId: "thread-123",
+      labelIds: [GmailLabel.INBOX],
+      snippet: "Test email snippet",
+      historyId: "12345",
+      internalDate: "1704067200000",
+      sizeEstimate: 1024,
+      headers: {
+        from: "sender@example.com",
+        to: "user@test.com",
+        subject: "Test Email",
+        date: "2024-01-01T00:00:00Z",
+      },
+      textPlain: "Hello World",
+      textHtml: "<b>Hello World</b>",
+    });
   });
 
   const createHistoryItem = (
@@ -157,6 +195,128 @@ describe("processHistoryItem", () => {
       draftReplyConfidence: DraftReplyConfidence.ALL_EMAILS,
     };
   }
+
+  it("deletes local stats for Gmail message-deleted events without creating a provider", async () => {
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(
+      createHistoryItem(
+        "deleted-123",
+        undefined as any,
+        HistoryEventType.MESSAGE_DELETED,
+      ),
+      options,
+      logger,
+    );
+
+    expect(reconcileStatsForDeletedMessageMock).toHaveBeenCalledWith({
+      emailAccountId: options.emailAccount.id,
+      messageId: "deleted-123",
+      threadId: "thread-123",
+      logger: expect.anything(),
+    });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+  });
+
+  it("reconciles stats for Gmail archive events before preserving learning behavior", async () => {
+    shouldReconcileStatsForLabelEventMock.mockReturnValueOnce(true);
+
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(
+      createHistoryItem("123", "thread-123", HistoryEventType.LABEL_REMOVED, [
+        GmailLabel.INBOX,
+      ]),
+      options,
+      logger,
+    );
+
+    expect(shouldReconcileStatsForLabelEventMock).toHaveBeenCalledWith([
+      GmailLabel.INBOX,
+    ]);
+    expect(reconcileStatsForCurrentGmailMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: options.emailAccount.id,
+        messageId: "123",
+        threadId: "thread-123",
+        reason: "gmail-label-removed",
+      }),
+    );
+  });
+
+  it("reconciles stats for Gmail trash label additions", async () => {
+    shouldReconcileStatsForLabelEventMock.mockReturnValueOnce(true);
+
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(
+      createHistoryItem("123", "thread-123", HistoryEventType.LABEL_ADDED, [
+        GmailLabel.TRASH,
+      ]),
+      options,
+      logger,
+    );
+
+    expect(reconcileStatsForCurrentGmailMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: options.emailAccount.id,
+        messageId: "123",
+        threadId: "thread-123",
+        reason: "gmail-label-added",
+      }),
+    );
+  });
+
+  it("reconciles stats for Gmail read/unread label changes", async () => {
+    shouldReconcileStatsForLabelEventMock.mockReturnValueOnce(true);
+
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(
+      createHistoryItem("123", "thread-123", HistoryEventType.LABEL_ADDED, [
+        GmailLabel.UNREAD,
+      ]),
+      options,
+      logger,
+    );
+
+    expect(reconcileStatsForCurrentGmailMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "123",
+        reason: "gmail-label-added",
+      }),
+    );
+  });
+
+  it("reconciles message-added stats before shared processing", async () => {
+    const options = {
+      ...defaultOptions,
+      emailAccount: getDefaultEmailAccount(),
+    };
+
+    await processHistoryItem(createHistoryItem(), options, logger);
+
+    expect(reconcileStatsForCurrentGmailMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: options.emailAccount.id,
+        messageId: "123",
+        threadId: "thread-123",
+        reason: "gmail-message-added",
+      }),
+    );
+  });
 
   it("should skip if message is already being processed", async () => {
     vi.mocked(markMessageAsProcessing).mockResolvedValueOnce(false);
@@ -233,6 +393,7 @@ describe("processHistoryItem", () => {
     };
 
     vi.mocked(createEmailProvider).mockResolvedValueOnce(mockProvider as any);
+    reconcileStatsForCurrentGmailMessageMock.mockResolvedValueOnce(sentMessage);
 
     const options = {
       ...defaultOptions,

--- a/apps/web/utils/webhook/google/process-history-item.ts
+++ b/apps/web/utils/webhook/google/process-history-item.ts
@@ -8,14 +8,22 @@ import { processHistoryItem as processHistoryItemShared } from "@/utils/webhook/
 import { markMessageAsProcessing } from "@/utils/redis/message-processing";
 import { GmailLabel } from "@/utils/gmail/label";
 import type { Logger } from "@/utils/logger";
+import {
+  reconcileStatsForCurrentGmailMessage,
+  reconcileStatsForDeletedMessage,
+  shouldReconcileStatsForLabelEvent,
+} from "@/utils/webhook/google/sync-email-message-stats";
+
+type GmailHistoryItem =
+  | gmail_v1.Schema$HistoryMessageAdded
+  | gmail_v1.Schema$HistoryMessageDeleted
+  | gmail_v1.Schema$HistoryLabelAdded
+  | gmail_v1.Schema$HistoryLabelRemoved;
 
 export async function processHistoryItem(
   historyItem: {
     type: HistoryEventType;
-    item:
-      | gmail_v1.Schema$HistoryMessageAdded
-      | gmail_v1.Schema$HistoryLabelAdded
-      | gmail_v1.Schema$HistoryLabelRemoved;
+    item: GmailHistoryItem;
   },
   options: ProcessHistoryOptions,
   logger: Logger,
@@ -26,12 +34,24 @@ export async function processHistoryItem(
   const threadId = item.message?.threadId;
   const emailAccountId = emailAccount.id;
 
-  if (!messageId || !threadId) return;
+  if (!messageId) return;
 
   logger.info("Gmail history item received", {
     eventType: type,
-    labelIds: item.message?.labelIds,
+    labelIds: "labelIds" in item ? item.labelIds : undefined,
   });
+
+  if (type === HistoryEventType.MESSAGE_DELETED) {
+    await reconcileStatsForDeletedMessage({
+      emailAccountId,
+      messageId,
+      threadId,
+      logger,
+    });
+    return;
+  }
+
+  if (!threadId) return;
 
   const provider = await createEmailProvider({
     emailAccountId,
@@ -39,7 +59,17 @@ export async function processHistoryItem(
     logger,
   });
 
-  const lockAndProcessShared = async () => {
+  const reconcileCurrentMessage = async (reason: string) =>
+    reconcileStatsForCurrentGmailMessage({
+      emailAccountId,
+      messageId,
+      threadId,
+      provider,
+      logger,
+      reason,
+    });
+
+  const lockAndProcessShared = async (reason: string) => {
     const isFree = await markMessageAsProcessing({
       userEmail: emailAccount.email,
       messageId,
@@ -49,10 +79,13 @@ export async function processHistoryItem(
       return;
     }
 
+    const message = await reconcileCurrentMessage(reason);
+    if (!message) return;
+
     logger.info("Gmail lock acquired, calling shared processor");
 
     return processHistoryItemShared(
-      { messageId, threadId },
+      { messageId, threadId, message },
       {
         provider,
         emailAccount,
@@ -66,9 +99,15 @@ export async function processHistoryItem(
 
   // Handle Google-specific label events
   if (type === HistoryEventType.LABEL_REMOVED) {
+    const labelRemovedItem = item as gmail_v1.Schema$HistoryLabelRemoved;
+
+    if (shouldReconcileStatsForLabelEvent(labelRemovedItem.labelIds)) {
+      await reconcileCurrentMessage("gmail-label-removed");
+    }
+
     logger.info("Processing label removed event for learning");
     return handleLabelRemovedEvent(
-      item as gmail_v1.Schema$HistoryLabelRemoved,
+      labelRemovedItem,
       {
         emailAccount,
         provider,
@@ -79,7 +118,11 @@ export async function processHistoryItem(
     const labelAddedItem = item as gmail_v1.Schema$HistoryLabelAdded;
 
     if (labelAddedItem.labelIds?.includes(GmailLabel.SENT)) {
-      return lockAndProcessShared();
+      return lockAndProcessShared("gmail-sent-label-added");
+    }
+
+    if (shouldReconcileStatsForLabelEvent(labelAddedItem.labelIds)) {
+      await reconcileCurrentMessage("gmail-label-added");
     }
 
     logger.info("Processing label added event for learning");
@@ -93,5 +136,5 @@ export async function processHistoryItem(
     );
   }
 
-  return lockAndProcessShared();
+  return lockAndProcessShared("gmail-message-added");
 }

--- a/apps/web/utils/webhook/google/process-history.test.ts
+++ b/apps/web/utils/webhook/google/process-history.test.ts
@@ -211,7 +211,15 @@ describe("processHistoryForUser - 404 Handling", () => {
 
     expect(getHistory).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ startHistoryId: "1000" }),
+      expect.objectContaining({
+        startHistoryId: "1000",
+        historyTypes: [
+          "messageAdded",
+          "messageDeleted",
+          "labelAdded",
+          "labelRemoved",
+        ],
+      }),
       expect.any(Object),
     );
   });

--- a/apps/web/utils/webhook/google/process-history.ts
+++ b/apps/web/utils/webhook/google/process-history.ts
@@ -225,6 +225,7 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
   for (const h of history) {
     const historyMessages = [
       ...(h.messagesAdded || []),
+      ...(h.messagesDeleted || []),
       ...(h.labelsAdded || []),
       ...(h.labelsRemoved || []),
     ];
@@ -244,6 +245,10 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
           return isRelevant;
         })
         .map((m) => ({ type: HistoryEventType.MESSAGE_ADDED, item: m })),
+      ...(h.messagesDeleted || []).map((m) => ({
+        type: HistoryEventType.MESSAGE_DELETED,
+        item: m,
+      })),
       ...(h.labelsAdded || []).map((m) => ({
         type: HistoryEventType.LABEL_ADDED,
         item: m,
@@ -254,10 +259,7 @@ async function processHistory(options: ProcessHistoryOptions, logger: Logger) {
       })),
     ];
 
-    const uniqueEvents = uniqBy(
-      allEvents,
-      (e) => `${e.type}:${e.item.message?.id}`,
-    );
+    const uniqueEvents = uniqBy(allEvents, getHistoryEventDedupeKey);
 
     for (const event of uniqueEvents) {
       const log = logger.with({
@@ -311,6 +313,26 @@ async function updateLastSyncedHistoryId({
       OR CAST("lastSyncedHistoryId" AS NUMERIC) < CAST(${lastSyncedHistoryId} AS NUMERIC)
     )
   `;
+}
+
+function getHistoryEventDedupeKey(event: {
+  type: HistoryEventType;
+  item: {
+    message?: { id?: string | null } | null;
+    labelIds?: string[] | null;
+  };
+}) {
+  const messageId = event.item.message?.id ?? "missing-message-id";
+
+  if (
+    event.type === HistoryEventType.LABEL_ADDED ||
+    event.type === HistoryEventType.LABEL_REMOVED
+  ) {
+    const labelKey = [...(event.item.labelIds ?? [])].sort().join(",");
+    return `${event.type}:${messageId}:${labelKey}`;
+  }
+
+  return `${event.type}:${messageId}`;
 }
 
 const isInboxOrSentMessage = (message: {
@@ -419,7 +441,12 @@ async function fetchGmailHistoryResilient({
         gmail,
         {
           startHistoryId,
-          historyTypes: ["messageAdded", "labelAdded", "labelRemoved"],
+          historyTypes: [
+            "messageAdded",
+            "messageDeleted",
+            "labelAdded",
+            "labelRemoved",
+          ],
           maxResults: GMAIL_HISTORY_PAGE_SIZE,
           pageToken,
         },

--- a/apps/web/utils/webhook/google/sync-email-message-stats.ts
+++ b/apps/web/utils/webhook/google/sync-email-message-stats.ts
@@ -1,0 +1,84 @@
+import "server-only";
+
+import type { EmailProvider } from "@/utils/email/types";
+import { GmailLabel } from "@/utils/gmail/label";
+import { isGmailMessageNotFoundError } from "@/utils/gmail/errors";
+import type { Logger } from "@/utils/logger";
+import {
+  deleteEmailMessageStats,
+  reconcileEmailMessageStatsFromParsedMessage,
+} from "@/utils/email/email-message-stats";
+import type { ParsedMessage } from "@/utils/types";
+
+const STATS_RELEVANT_LABELS = new Set<string>([
+  GmailLabel.INBOX,
+  GmailLabel.UNREAD,
+  GmailLabel.SENT,
+  GmailLabel.TRASH,
+  GmailLabel.SPAM,
+  GmailLabel.DRAFT,
+]);
+
+export function shouldReconcileStatsForLabelEvent(labelIds?: string[] | null) {
+  return !!labelIds?.some((labelId) => STATS_RELEVANT_LABELS.has(labelId));
+}
+
+export async function reconcileStatsForDeletedMessage({
+  emailAccountId,
+  messageId,
+  threadId,
+  logger,
+}: {
+  emailAccountId: string;
+  messageId: string;
+  threadId?: string | null;
+  logger: Logger;
+}) {
+  await deleteEmailMessageStats({
+    emailAccountId,
+    messageId,
+    threadId,
+    reason: "gmail-message-deleted",
+    logger,
+  });
+}
+
+export async function reconcileStatsForCurrentGmailMessage({
+  emailAccountId,
+  messageId,
+  threadId,
+  provider,
+  logger,
+  reason,
+}: {
+  emailAccountId: string;
+  messageId: string;
+  threadId?: string | null;
+  provider: EmailProvider;
+  logger: Logger;
+  reason: string;
+}): Promise<ParsedMessage | null> {
+  try {
+    const message = await provider.getMessage(messageId);
+    const keptInStats = await reconcileEmailMessageStatsFromParsedMessage({
+      emailAccountId,
+      message,
+      logger,
+      reason,
+    });
+
+    return keptInStats ? message : null;
+  } catch (error) {
+    if (!isGmailMessageNotFoundError(error)) throw error;
+
+    await deleteEmailMessageStats({
+      emailAccountId,
+      messageId,
+      threadId,
+      reason: `${reason}-message-not-found`,
+      logger,
+    });
+
+    return null;
+  }
+}

--- a/apps/web/utils/webhook/google/types.ts
+++ b/apps/web/utils/webhook/google/types.ts
@@ -5,6 +5,7 @@ import type { EmailAccount } from "@/generated/prisma/client";
 
 export const HistoryEventType = {
   MESSAGE_ADDED: "messageAdded",
+  MESSAGE_DELETED: "messageDeleted",
   LABEL_ADDED: "labelAdded",
   LABEL_REMOVED: "labelRemoved",
 } as const;

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -91,6 +91,10 @@
     {
       "path": "/api/cron/draft-cleanup",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/email-message-stats-reconciliation",
+      "schedule": "30 4 * * *"
     }
   ]
 }

--- a/charts/inbox-zero/values.yaml
+++ b/charts/inbox-zero/values.yaml
@@ -117,6 +117,23 @@ existingConfigMap: ""
 extraEnv: []
 extraEnvFrom: []
 
+codexCli:
+  # Enables the experimental codex-cli LLM provider for trusted self-hosted
+  # deployments. Requires a Codex-enabled image and a Secret created from
+  # `codex login` auth/config files.
+  enabled: false
+  existingSecret: ""
+  mountPath: /root/.codex
+  secretMountPath: /var/run/inbox-zero/codex-cli
+  codexPath: /usr/local/bin/codex
+  allowNpx: false
+  # 0400 in decimal form for Kubernetes Secret volume defaultMode.
+  defaultMode: 256
+  # Optional Secret item mappings, for example:
+  # - key: auth.json
+  #   path: auth.json
+  items: []
+
 externalDatabase:
   # Set enabled=true to use managed Postgres instead of the bundled StatefulSet.
   # databaseUrl/directUrl are stored in the chart-created Secret. For production,
@@ -236,6 +253,9 @@ cron:
     draft-cleanup:
       schedule: "0 4 * * *"
       path: /api/cron/draft-cleanup
+    email-message-stats-reconciliation:
+      schedule: "30 4 * * *"
+      path: /api/cron/email-message-stats-reconciliation?batchSize=100&sampleLimit=0
     follow-up-reminders:
       schedule: "0 * * * *"
       path: /api/follow-up-reminders


### PR DESCRIPTION
## Summary

This fixes stale `EmailMessage` stats for Gmail accounts when messages are deleted from Gmail or move into labels that should not be counted in sender stats. The bulk unsubscribe sender counts are backed by the local `EmailMessage` table, so those rows need to be kept in sync with Gmail rather than only relying on the initial history import.

Changes included:

- centralize `EmailMessage` stats upsert/delete/reconcile helpers
- delete local stats when Gmail reports a message as not found
- remove local stats for Gmail messages in Trash, Spam, or Draft
- add a protected reconciliation cron endpoint to backfill already-stale rows
- schedule the reconciliation endpoint in Vercel and the Helm chart
- add focused tests for webhook sync and the reconciliation route

## Root Cause

Gmail webhooks/history can indicate that a message changed or disappeared, but the local stats table previously did not have a durable reconciliation path for deleted/excluded messages. That allowed sender counts, including bulk unsubscribe counts, to drift from the mailbox state.

## Validation

- `CI=true pnpm vitest --run utils/email/email-message-stats-reconciliation.test.ts app/api/cron/email-message-stats-reconciliation/route.test.ts utils/webhook/google/process-history.test.ts utils/webhook/google/process-history-item.test.ts`
- `CI=true pnpm biome check apps/web/app/api/cron/email-message-stats-reconciliation/route.ts apps/web/app/api/cron/email-message-stats-reconciliation/route.test.ts apps/web/utils/email/email-message-stats.ts apps/web/utils/email/email-message-stats-reconciliation.ts apps/web/utils/email/email-message-stats-reconciliation.test.ts apps/web/utils/gmail/errors.ts apps/web/utils/webhook/google/sync-email-message-stats.ts apps/web/utils/webhook/google/process-history.ts apps/web/utils/webhook/google/process-history.test.ts apps/web/utils/webhook/google/process-history-item.ts apps/web/utils/webhook/google/process-history-item.test.ts apps/web/utils/webhook/google/types.ts apps/web/vercel.json charts/inbox-zero/values.yaml`

## Notes

I am opening this as a draft because it is based on a self-hosted production bug report and the maintainers may want to adjust cron cadence, naming, or batching defaults before merging.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

