### PR TITLE
assistant: Auto-close draft reply action menu on select

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx
@@ -849,22 +849,12 @@ function ActionCard({
   const moreOptions = (
     <>
       {showDeliveryActions ? (
-        <DropdownMenuItem
-          onClick={(event) => {
-            event.preventDefault();
-            setDeliveryDialogOpen(true);
-          }}
-        >
+        <DropdownMenuItem onClick={() => setDeliveryDialogOpen(true)}>
           {deliverySummary ? "Delivery options" : "Configure delivery"}
         </DropdownMenuItem>
       ) : null}
       {showAttachmentsAction ? (
-        <DropdownMenuItem
-          onClick={(event) => {
-            event.preventDefault();
-            setAttachmentsDialogOpen(true);
-          }}
-        >
+        <DropdownMenuItem onClick={() => setAttachmentsDialogOpen(true)}>
           <PaperclipIcon className="mr-2 size-4" />
           Configure attachments
         </DropdownMenuItem>


### PR DESCRIPTION
## Root cause

In the Assistant rule editor, the "Configure attachments" and "Configure delivery" items in the Draft Reply action's "..." dropdown called `event.preventDefault()` in their `onClick` handlers (`apps/web/app/(app)/[emailAccountId]/assistant/ActionSteps.tsx`). Radix's `DropdownMenuItem` treats a defaulted-prevented select event as "keep the menu open", so the dropdown stayed open until the user clicked elsewhere.

## Fix

Removed the `event.preventDefault()` calls (and the now-unused event params). The dialogs these items open are controlled by independent state (`deliveryDialogOpen` / `attachmentsDialogOpen`) and rendered as siblings outside the dropdown content, so they open correctly after the menu closes — matching the behavior of the other items like "Use AI draft" in `RuleStep.tsx`.

## Test plan

- Biome lint on the touched file: clean.
- App type-check filtered to the touched file: no errors.
- Verified by reading the code that both dialogs are mounted outside `DropdownMenuContent` and controlled by separate open state, so close-on-select cannot unmount them.
- Skipped a unit test per repo guidance (would only restate implementation details of a one-line UI behavior).

Fixes INB-218
https://linear.app/inbox-zero-ai/issue/INB-218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

