### PR TITLE
calendar: Reject overlapping availability windows

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.test.ts
@@ -57,6 +57,57 @@ describe("collectWindows", () => {
     expect(result.error).toBe("Add at least one available time range.");
   });
 
+  it("returns an error when ranges on the same day overlap", () => {
+    const days = buildDayState([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+      { weekday: 1, startMinutes: 10 * 60 + 30, endMinutes: 12 * 60 },
+    ]);
+
+    const result = collectWindows(days);
+
+    expect(result.windows).toBeNull();
+    expect(result.error).toBe("Monday: time ranges overlap.");
+  });
+
+  it("detects overlaps regardless of range order", () => {
+    const days = buildDayState([
+      { weekday: 4, startMinutes: 13 * 60, endMinutes: 15 * 60 },
+      { weekday: 4, startMinutes: 9 * 60, endMinutes: 14 * 60 },
+    ]);
+
+    const result = collectWindows(days);
+
+    expect(result.windows).toBeNull();
+    expect(result.error).toBe("Thursday: time ranges overlap.");
+  });
+
+  it("allows adjacent ranges on the same day", () => {
+    const days = buildDayState([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+      { weekday: 1, startMinutes: 11 * 60, endMinutes: 13 * 60 },
+    ]);
+
+    const result = collectWindows(days);
+
+    expect(result.error).toBeNull();
+    expect(result.windows).toEqual([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+      { weekday: 1, startMinutes: 11 * 60, endMinutes: 13 * 60 },
+    ]);
+  });
+
+  it("allows overlapping times on different days", () => {
+    const days = buildDayState([
+      { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+      { weekday: 2, startMinutes: 10 * 60, endMinutes: 12 * 60 },
+    ]);
+
+    const result = collectWindows(days);
+
+    expect(result.error).toBeNull();
+    expect(result.windows).toHaveLength(2);
+  });
+
   it("ignores ranges on disabled days", () => {
     const days = buildDayState([
       { weekday: 1, startMinutes: 9 * 60, endMinutes: 17 * 60 },

--- a/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.ts
+++ b/apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.ts
@@ -54,6 +54,7 @@ export function collectWindows(
   for (let weekday = 0; weekday < 7; weekday++) {
     const day = days[weekday];
     if (!day.enabled) continue;
+    const dayWindows: AvailabilityWindowInput[] = [];
     for (const range of day.ranges) {
       const start = parseTime(range.start);
       const end = parseTime(range.end);
@@ -63,8 +64,18 @@ export function collectWindows(
           error: `${DAY_LABELS[weekday]}: end time must be after start time.`,
         };
       }
-      windows.push({ weekday, startMinutes: start, endMinutes: end });
+      dayWindows.push({ weekday, startMinutes: start, endMinutes: end });
     }
+    dayWindows.sort((a, b) => a.startMinutes - b.startMinutes);
+    for (let i = 1; i < dayWindows.length; i++) {
+      if (dayWindows[i].startMinutes < dayWindows[i - 1].endMinutes) {
+        return {
+          windows: null,
+          error: `${DAY_LABELS[weekday]}: time ranges overlap.`,
+        };
+      }
+    }
+    windows.push(...dayWindows);
   }
 
   if (windows.length === 0) {

--- a/apps/web/utils/actions/booking.validation.test.ts
+++ b/apps/web/utils/actions/booking.validation.test.ts
@@ -3,6 +3,7 @@ import {
   createBookingLinkBody,
   publicBookingBody,
   updateBookingAvailabilityBody,
+  updateDefaultAvailabilityBody,
 } from "@/utils/actions/booking.validation";
 
 describe("booking action validation", () => {
@@ -36,6 +37,47 @@ describe("booking action validation", () => {
       timezone: "UTC",
       minimumNoticeMinutes: 0,
       windows: [{ weekday: 1, startMinutes: 17 * 60, endMinutes: 9 * 60 }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects overlapping availability windows on the same weekday", () => {
+    const result = updateBookingAvailabilityBody.safeParse({
+      bookingLinkId: "link-id",
+      timezone: "UTC",
+      minimumNoticeMinutes: 0,
+      windows: [
+        { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+        { weekday: 1, startMinutes: 10 * 60 + 30, endMinutes: 12 * 60 },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("allows adjacent windows on the same weekday and overlapping times on different weekdays", () => {
+    const result = updateBookingAvailabilityBody.safeParse({
+      bookingLinkId: "link-id",
+      timezone: "UTC",
+      minimumNoticeMinutes: 0,
+      windows: [
+        { weekday: 1, startMinutes: 9 * 60, endMinutes: 11 * 60 },
+        { weekday: 1, startMinutes: 11 * 60, endMinutes: 13 * 60 },
+        { weekday: 2, startMinutes: 10 * 60, endMinutes: 12 * 60 },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects overlapping windows in default availability updates", () => {
+    const result = updateDefaultAvailabilityBody.safeParse({
+      timezone: "UTC",
+      windows: [
+        { weekday: 3, startMinutes: 9 * 60, endMinutes: 12 * 60 },
+        { weekday: 3, startMinutes: 11 * 60, endMinutes: 14 * 60 },
+      ],
     });
 
     expect(result.success).toBe(false);

--- a/apps/web/utils/actions/booking.validation.ts
+++ b/apps/web/utils/actions/booking.validation.ts
@@ -92,11 +92,37 @@ export const bookingWindowBody = z
   });
 export type BookingWindowBody = z.infer<typeof bookingWindowBody>;
 
+const bookingWindowsSchema = z
+  .array(bookingWindowBody)
+  .min(1)
+  .superRefine((windows, ctx) => {
+    const byWeekday = new Map<number, BookingWindowBody[]>();
+    for (const window of windows) {
+      const list = byWeekday.get(window.weekday) ?? [];
+      list.push(window);
+      byWeekday.set(window.weekday, list);
+    }
+    for (const dayWindows of byWeekday.values()) {
+      const sorted = [...dayWindows].sort(
+        (a, b) => a.startMinutes - b.startMinutes,
+      );
+      for (let i = 1; i < sorted.length; i++) {
+        if (sorted[i].startMinutes < sorted[i - 1].endMinutes) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Availability windows on the same day must not overlap",
+          });
+          return;
+        }
+      }
+    }
+  });
+
 export const updateBookingAvailabilityBody = z.object({
   bookingLinkId: z.string(),
   timezone: timezoneSchema,
   minimumNoticeMinutes: nonNegativeMinutesSchema.max(365 * 24 * 60),
-  windows: z.array(bookingWindowBody).min(1),
+  windows: bookingWindowsSchema,
 });
 export type UpdateBookingAvailabilityBody = z.infer<
   typeof updateBookingAvailabilityBody
@@ -104,7 +130,7 @@ export type UpdateBookingAvailabilityBody = z.infer<
 
 export const updateDefaultAvailabilityBody = z.object({
   timezone: timezoneSchema,
-  windows: z.array(bookingWindowBody).min(1),
+  windows: bookingWindowsSchema,
 });
 export type UpdateDefaultAvailabilityBody = z.infer<
   typeof updateDefaultAvailabilityBody


### PR DESCRIPTION
## Root cause

No overlap validation existed on either side of the availability editor:

- Client: `collectWindows` in `apps/web/app/(app)/[emailAccountId]/calendars/availability-schedule.ts` only checked `end <= start` per range, so two windows on the same day (e.g. 9:00-11:00 and 10:30-12:00) were accepted.
- Server: `bookingWindowBody` in `apps/web/utils/actions/booking.validation.ts` only refined `endMinutes > startMinutes` per window; the `windows` arrays had no cross-window check.

## Fix

- `collectWindows` now sorts each day's ranges by start time and returns a clear per-day error (e.g. "Monday: time ranges overlap.") when a range starts before the previous one ends. The error surfaces through the existing toast path in `AvailabilitySection`.
- The booking `windows` arrays (`updateBookingAvailabilityBody` and `updateDefaultAvailabilityBody`) now share a `superRefine` that groups windows by weekday and rejects same-day overlaps.
- Adjacent windows (9:00-11:00 + 11:00-13:00) and overlapping times on different days remain valid.

## Test plan

- Added unit tests (TDD, red then green) in `availability-schedule.test.ts`: overlap rejected, order-independent detection, adjacent ranges allowed, different-day overlap allowed.
- Added validation tests in `booking.validation.test.ts`: same-weekday overlap rejected for both booking-link and default availability bodies; adjacent/different-day windows accepted.
- `pnpm test app/(app)/[emailAccountId]/calendars/availability-schedule.test.ts utils/actions/booking.validation.test.ts` — 15/15 pass.
- `pnpm test utils/actions/booking.test.ts` — passes.

Fixes INB-311
https://linear.app/inbox-zero-ai/issue/INB-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

