### PR TITLE
meeting-briefs: Cover cron interval in event lookahead window

### DIFF
--- a/apps/web/utils/meeting-briefs/fetch-upcoming-events.test.ts
+++ b/apps/web/utils/meeting-briefs/fetch-upcoming-events.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addMinutes } from "date-fns/addMinutes";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCalendarEventProviders } from "@/utils/calendar/event-provider";
 import type {
   CalendarEvent,
@@ -83,6 +84,60 @@ describe("fetchUpcomingEvents", () => {
 
     expect(events.map((event) => event.id)).toEqual(["earlier", "later"]);
   });
+
+  describe("lookahead window", () => {
+    const now = new Date("2024-01-20T09:00:00Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("includes events entering the lead window before the next cron tick", async () => {
+      // With minutesBefore=5 and a 15-minute cron, an event 18 minutes out
+      // would be missed entirely if the window were only [now, now + 5m]:
+      // its lead window [T-5, T] can fall between two cron ticks.
+      const provider = createWindowedProvider([
+        createEvent({
+          id: "between-ticks",
+          startTime: addMinutes(now, 18),
+        }),
+      ]);
+
+      vi.mocked(createCalendarEventProviders).mockResolvedValue([provider]);
+
+      const events = await fetchUpcomingEvents({
+        emailAccountId: "email-account-id",
+        minutesBefore: 5,
+        logger,
+      });
+
+      expect(events.map((event) => event.id)).toEqual(["between-ticks"]);
+    });
+
+    it("excludes events beyond the lead window plus one cron interval", async () => {
+      const provider = createWindowedProvider([
+        createEvent({
+          id: "too-far-out",
+          startTime: addMinutes(now, 25),
+        }),
+      ]);
+
+      vi.mocked(createCalendarEventProviders).mockResolvedValue([provider]);
+
+      const events = await fetchUpcomingEvents({
+        emailAccountId: "email-account-id",
+        minutesBefore: 5,
+        logger,
+      });
+
+      expect(events).toEqual([]);
+    });
+  });
 });
 
 describe("filterEventsWithExternalGuests", () => {
@@ -129,6 +184,21 @@ describe("filterEventsWithExternalGuests", () => {
 function createProvider(events: CalendarEvent[]): CalendarEventProvider {
   return {
     fetchEvents: vi.fn().mockResolvedValue(events),
+    fetchEventsWithAttendee: vi.fn().mockResolvedValue([]),
+  };
+}
+
+// Mimics the calendar API: only returns events within the requested window.
+function createWindowedProvider(
+  events: CalendarEvent[],
+): CalendarEventProvider {
+  return {
+    fetchEvents: vi.fn(
+      async ({ timeMin, timeMax }: { timeMin: Date; timeMax: Date }) =>
+        events.filter(
+          (event) => event.startTime >= timeMin && event.startTime <= timeMax,
+        ),
+    ),
     fetchEventsWithAttendee: vi.fn().mockResolvedValue([]),
   };
 }

--- a/apps/web/utils/meeting-briefs/fetch-upcoming-events.ts
+++ b/apps/web/utils/meeting-briefs/fetch-upcoming-events.ts
@@ -6,6 +6,13 @@ import { partitionAttendeesForBriefing } from "./attendees";
 
 const MAX_EVENTS_PER_PROVIDER = 20;
 
+// Must match the /api/meeting-briefs cron schedule in vercel.json.
+// The lookahead window extends by one cron interval so an event whose lead
+// window opens and closes between two cron ticks is still picked up at the
+// last tick before it starts. Duplicate sends are prevented by the
+// meetingBriefing unique-constraint claim in process.ts.
+const CRON_INTERVAL_MINUTES = 15;
+
 export async function fetchUpcomingEvents({
   emailAccountId,
   minutesBefore,
@@ -21,7 +28,7 @@ export async function fetchUpcomingEvents({
   }
 
   const timeMin = new Date();
-  const timeMax = addMinutes(timeMin, minutesBefore);
+  const timeMax = addMinutes(timeMin, minutesBefore + CRON_INTERVAL_MINUTES);
 
   const results = await Promise.allSettled(
     providers.map((provider) =>


### PR DESCRIPTION
## Root cause

The `/api/meeting-briefs` cron runs every 15 minutes (`apps/web/vercel.json`), but `fetchUpcomingEvents` queried calendar events in a window of exactly `[now, now + minutesBefore]`. Settings allow `minutesBefore` as low as 1 minute. With e.g. `minutesBefore=5`, a meeting only enters that window during `[T-5, T]` — if the cron last ticked at `T-12`, the next tick at `T+3` is after the meeting has already started, so the brief arrived late (or was pointless).

## Fix

Extend the lookahead window to `minutesBefore + CRON_INTERVAL_MINUTES` (15) so every meeting is picked up at the last cron tick before its lead window opens. The constant is documented as needing to match the vercel.json cron cadence.

Duplicate sends are already prevented: `processMeetingBriefings` pre-filters events with existing `meetingBriefing` rows, and `runMeetingBrief` claims each event via a unique-constraint insert (`claimMeetingBriefing` in `apps/web/utils/meeting-briefs/process.ts`), so an event seen by two consecutive ticks is only briefed once. Nothing downstream re-filters events to the narrow window.

## Test plan

- Added unit tests in `apps/web/utils/meeting-briefs/fetch-upcoming-events.test.ts` using a provider mock that filters by the requested window (mimicking the calendar API):
  - An event at `now + 18min` with `minutesBefore=5` IS included (failed before this fix).
  - An event beyond `minutesBefore + 15min` is still excluded.
- `pnpm test utils/meeting-briefs/` — 25 tests pass.
- `pnpm test app/api/meeting-briefs/route.test.ts` — passes.

Fixes INB-51
https://linear.app/inbox-zero-ai/issue/INB-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

