### PR TITLE
calendar: Mark Microsoft default calendar as primary and add writable fallback

### DIFF
--- a/apps/web/utils/calendar/event-writer.test.ts
+++ b/apps/web/utils/calendar/event-writer.test.ts
@@ -93,6 +93,54 @@ describe("createCalendarEvent", () => {
     });
   });
 
+  it("falls back to any enabled calendar when no destination is set and no primary exists", async () => {
+    // Microsoft accounts synced before primary tracking have no primary
+    // calendar row; booking links without an explicit destination must still
+    // find a writable calendar.
+    prisma.calendar.findFirst.mockResolvedValue({
+      calendarId: "microsoft-calendar",
+      connection: {
+        id: "connection-id",
+        provider: "microsoft",
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: new Date("2026-05-04T00:00:00.000Z"),
+      },
+    });
+
+    const result = await createCalendarEvent({
+      attendees: [{ name: "Guest User", email: "guest@example.com" }],
+      destinationCalendarId: null,
+      emailAccountId: "email-account-id",
+      endTime: new Date("2026-05-04T09:30:00.000Z"),
+      locationType: "CUSTOM",
+      logger: createTestLogger(),
+      startTime: new Date("2026-05-04T09:00:00.000Z"),
+      timezone: "UTC",
+      title: "Intro call",
+    });
+
+    expect(prisma.calendar.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          isEnabled: true,
+          connection: {
+            emailAccountId: "email-account-id",
+            isConnected: true,
+          },
+        },
+        orderBy: [{ primary: "desc" }, { createdAt: "asc" }],
+      }),
+    );
+    expect(providerMocks.createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ calendarId: "microsoft-calendar" }),
+    );
+    expect(result).toMatchObject({
+      provider: "microsoft",
+      providerConnectionId: "connection-id",
+    });
+  });
+
   it("looks up the connection by id when canceling, ignoring same-provider sibling connections", async () => {
     // The host has two Google connections that both expose a "primary"
     // calendar. Cancel must hit the connection that wrote the event, not

--- a/apps/web/utils/calendar/event-writer.ts
+++ b/apps/web/utils/calendar/event-writer.ts
@@ -191,9 +191,10 @@ async function getWritableCalendar({
   emailAccountId: string;
   destinationCalendarId?: string | null;
 }) {
-  const where = destinationCalendarId
-    ? { id: destinationCalendarId }
-    : { primary: true };
+  // Without an explicit destination, prefer the primary calendar (via
+  // orderBy) but accept any enabled calendar — accounts synced before
+  // Microsoft primary tracking have no primary row.
+  const where = destinationCalendarId ? { id: destinationCalendarId } : {};
   // Availability scans only consider enabled calendars, so writing to a
   // disabled one would silently bypass conflict detection.
   const calendar = await prisma.calendar.findFirst({

--- a/apps/web/utils/calendar/providers/microsoft.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/prisma";
+import { createTestLogger } from "@/__tests__/helpers";
+import { createMicrosoftCalendarProvider } from "@/utils/calendar/providers/microsoft";
+import {
+  fetchMicrosoftCalendars,
+  getCalendarClientWithRefresh,
+} from "@/utils/outlook/calendar-client";
+
+const logger = createTestLogger();
+
+vi.mock("@/utils/outlook/calendar-client", () => ({
+  fetchMicrosoftCalendars: vi.fn(),
+  getCalendarClientWithRefresh: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    calendar: { upsert: vi.fn() },
+    calendarConnection: { update: vi.fn() },
+  },
+}));
+
+vi.mock("../timezone-helpers", () => ({
+  autoPopulateTimezone: vi.fn(),
+}));
+
+describe("microsoft calendar sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the default calendar as primary so bookings without an explicit destination can target it", async () => {
+    vi.mocked(getCalendarClientWithRefresh).mockResolvedValue(
+      "calendar-client" as any,
+    );
+    vi.mocked(fetchMicrosoftCalendars).mockResolvedValue([
+      {
+        id: "default-calendar-id",
+        name: "Calendar",
+        isDefaultCalendar: true,
+      },
+      {
+        id: "secondary-calendar-id",
+        name: "Birthdays",
+        isDefaultCalendar: false,
+      },
+    ]);
+
+    const provider = createMicrosoftCalendarProvider(logger);
+
+    await provider.syncCalendars(
+      "connection-id",
+      "access-token",
+      "refresh-token",
+      "email-account-id",
+      new Date("2026-05-08T00:00:00.000Z"),
+    );
+
+    const upsertCalls = vi.mocked(prisma.calendar.upsert).mock.calls;
+    const defaultUpsert = upsertCalls.find(
+      ([call]) =>
+        (call as any).where.connectionId_calendarId.calendarId ===
+        "default-calendar-id",
+    )?.[0] as any;
+    const secondaryUpsert = upsertCalls.find(
+      ([call]) =>
+        (call as any).where.connectionId_calendarId.calendarId ===
+        "secondary-calendar-id",
+    )?.[0] as any;
+
+    expect(defaultUpsert.create).toMatchObject({
+      isEnabled: true,
+      primary: true,
+    });
+    expect(defaultUpsert.update).toMatchObject({ primary: true });
+
+    expect(secondaryUpsert.create).toMatchObject({
+      isEnabled: true,
+      primary: false,
+    });
+    expect(secondaryUpsert.update).toMatchObject({ primary: false });
+    // Re-syncing must not overwrite a user's manual toggle of isEnabled.
+    expect(defaultUpsert.update).not.toHaveProperty("isEnabled");
+    expect(secondaryUpsert.update).not.toHaveProperty("isEnabled");
+  });
+});

--- a/apps/web/utils/calendar/providers/microsoft.ts
+++ b/apps/web/utils/calendar/providers/microsoft.ts
@@ -95,6 +95,7 @@ export function createMicrosoftCalendarProvider(
               name: microsoftCalendar.name || "Untitled Calendar",
               description: microsoftCalendar.description,
               timezone: null,
+              primary: microsoftCalendar.isDefaultCalendar ?? false,
             },
             create: {
               connectionId,
@@ -102,6 +103,7 @@ export function createMicrosoftCalendarProvider(
               name: microsoftCalendar.name || "Untitled Calendar",
               description: microsoftCalendar.description,
               timezone: null,
+              primary: microsoftCalendar.isDefaultCalendar ?? false,
               isEnabled: true,
             },
           });


### PR DESCRIPTION
## Root cause

Public booking links failed with "Failed to create calendar event" for every Outlook-connected host (reopened after #2919, which only fixed the Teams conferencing fallback — the underlying event creation was still broken):

- Microsoft calendar sync never set `primary` on `Calendar` rows: the upsert in `apps/web/utils/calendar/providers/microsoft.ts` omitted it (schema default `false`), even though the Graph client fetches `isDefaultCalendar` and discarded it. The Google provider does set `primary`.
- When a booking link has no `destinationCalendarId`, the event writer fell back to `where: { primary: true }` (`apps/web/utils/calendar/event-writer.ts`). For Outlook hosts no row ever matched, so it threw `SafeError("Destination calendar not found")`, surfacing as "Failed to create calendar event" in `utils/booking/public.ts`.

## Fix

- Microsoft sync now sets `primary: calendar.isDefaultCalendar ?? false` in both the create and update branches of the upsert, mirroring the Google provider.
- The event writer's no-destination lookup no longer requires `primary: true`; it prefers the primary calendar via the existing `orderBy: [{ primary: "desc" }, { createdAt: "asc" }]` and otherwise falls back to any enabled calendar for the account, so already-synced Outlook accounts work without a resync.

## Test plan

- New `apps/web/utils/calendar/providers/microsoft.test.ts`: sync marks the default calendar `primary: true` (create + update) and non-default calendars `primary: false`, without clobbering user `isEnabled` toggles on re-sync.
- New case in `apps/web/utils/calendar/event-writer.test.ts`: with no destination calendar, the lookup does not hard-filter on `primary` and deterministically prefers primary, falling back to an enabled calendar; the event is created against it.
- Both written TDD (failed before the fix). `pnpm test utils/calendar utils/booking utils/actions/booking`: 17 files, 146 tests passing.

Fixes INB-309
https://linear.app/inbox-zero-ai/issue/INB-309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

