### PR TITLE
settings: Fix digest schedule form and learned patterns dialog on small screens

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/settings/LearnedPatternsSetting.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/settings/LearnedPatternsSetting.tsx
@@ -29,7 +29,8 @@ export function LearnedPatternsSetting() {
               View
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-4xl">
+          {/* Scroll inside the content row (not DialogContent itself) so the close button stays visible */}
+          <DialogContent className="max-w-4xl grid-rows-[auto_minmax(0,1fr)] overflow-hidden">
             <DialogHeader>
               <DialogTitle>Learned patterns</DialogTitle>
               <DialogDescription>
@@ -41,7 +42,9 @@ export function LearnedPatternsSetting() {
                 or remove patterns that have been learned.
               </DialogDescription>
             </DialogHeader>
-            <Content />
+            <div className="min-w-0 overflow-y-auto">
+              <Content />
+            </div>
           </DialogContent>
         </Dialog>
       }

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestScheduleForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestScheduleForm.tsx
@@ -179,7 +179,7 @@ function DigestScheduleFormInner({
     <form onSubmit={handleSubmit(onSubmit)}>
       <Label className="mb-2 mt-4">Send the digest email</Label>
 
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
         <FormItem>
           <Label htmlFor="frequency-select">Every</Label>
           <Select
@@ -241,7 +241,8 @@ function DigestScheduleFormInner({
           </FormItem>
         )}
 
-        <div className="space-y-2">
+        {/* Pin to the third column so hiding the day select doesn't shift this cell */}
+        <div className="space-y-2 sm:col-start-3">
           <Label>at</Label>
           <div className="flex items-end gap-2">
             <FormItem>


### PR DESCRIPTION
## Root cause

**Digest schedule form** (`apps/web/app/(app)/[emailAccountId]/settings/DigestScheduleForm.tsx`): the field row used a hard-coded `grid grid-cols-3 gap-2` with no breakpoints, so on phones all three cells — including the "at" cell that nests three more selects (hour/minute/AM-PM) — were crushed onto one row. Additionally, when the schedule is "daily" the day-of-week field is conditionally unrendered, so grid auto-placement pulled the "at" cell from column 3 into column 2, shifting the layout as the user toggled frequency.

**Learned patterns dialog** (`apps/web/app/(app)/[emailAccountId]/assistant/settings/LearnedPatternsSetting.tsx`): `DialogContent` is itself the scroll container (`max-h-screen overflow-y-auto`) and the close X is absolutely positioned inside it, so on phones scrolling the long pattern list moved the X out of view. The patterns table also forced the dialog wider than the viewport: grid items default to `min-width: auto`, so the `Table` primitive's built-in `overflow-auto` wrapper never got a chance to shrink and scroll horizontally.

## Fix

- Digest schedule grid is now `grid-cols-1 sm:grid-cols-3` (fields stack on narrow screens) and the "at" cell is pinned with `sm:col-start-3`, so hiding the day select no longer shifts it.
- Learned patterns `DialogContent` gets `grid-rows-[auto_minmax(0,1fr)] overflow-hidden` and the body is wrapped in a `min-w-0 overflow-y-auto` div: vertical scrolling happens inside the content row (header and close X stay visible), and `min-w-0` lets the existing table `overflow-auto` wrapper scroll horizontally instead of widening the dialog. The shared `dialog.tsx` primitive is untouched (`cn` uses tailwind-merge, so the per-call overrides win).

## Test plan

- `pnpm exec biome check` on both files passes.
- Changes are className/JSX-only; no type surface changed.
- Manual check: on a narrow viewport the digest fields stack vertically; on `sm+` the "at" cell stays in column 3 for both daily and weekly. Learned patterns dialog keeps the close X visible while the pattern list scrolls internally, and a wide table scrolls horizontally within the dialog.

Part of INB-82
https://linear.app/inbox-zero-ai/issue/INB-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

