### PR TITLE
assistant: Strip HTML from classification reason display

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.test.tsx
@@ -211,6 +211,53 @@ describe("getRuleResultReasonDisplay", () => {
     });
   });
 
+  it("passes plain text through unchanged", () => {
+    expect(getRuleResultReasonDisplay("The email is a newsletter.")).toEqual({
+      reason: "The email is a newsletter.",
+      actionFailureMessages: [],
+    });
+  });
+
+  it("strips literal HTML tags from the reason", () => {
+    expect(
+      getRuleResultReasonDisplay(
+        "<div><p>The email is a <strong>newsletter</strong>.</p></div>",
+      ).reason,
+    ).toBe("The email is a newsletter.");
+  });
+
+  it("separates adjacent block elements with a space", () => {
+    expect(
+      getRuleResultReasonDisplay("<p>Sender is known.</p><p>Rule applies.</p>")
+        .reason,
+    ).toBe("Sender is known. Rule applies.");
+  });
+
+  it("strips tags that were HTML-encoded and collapses leftover whitespace", () => {
+    expect(
+      getRuleResultReasonDisplay(
+        "&lt;p&gt;The sender confirmed the user&#x27;s   order.&lt;/p&gt;",
+      ).reason,
+    ).toBe("The sender confirmed the user's order.");
+  });
+
+  it("keeps comparison text that only looks like angle brackets", () => {
+    expect(
+      getRuleResultReasonDisplay("Priority is < 3 and score > 5.").reason,
+    ).toBe("Priority is < 3 and score > 5.");
+  });
+
+  it("still parses action failures when the reason contains HTML tags", () => {
+    expect(
+      getRuleResultReasonDisplay(
+        "<p>Rule matched.</p>\nAction failures: NOTIFY_SENDER:SEND_FAILED",
+      ),
+    ).toEqual({
+      reason: "Rule matched.",
+      actionFailureMessages: ["The sender notification could not be sent."],
+    });
+  });
+
   it("does not expose unknown internal action failure codes", () => {
     const display = getRuleResultReasonDisplay(
       "Rule matched\nAction failures: DRAFT_MESSAGING_CHANNEL:SOME_INTERNAL_CODE",

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx
@@ -325,8 +325,16 @@ export function getRuleResultReasonDisplay(reason: string): {
   const actionFailureMessages: string[] = [];
   const reasonLines: string[] = [];
 
-  for (const line of he.decode(reason).split(/\r?\n/)) {
-    const trimmedLine = line.trim();
+  // AI reasons sometimes include literal (or entity-encoded) HTML tags; strip
+  // them for display while keeping plain text like "a < b" intact. Block-level
+  // tags become whitespace so adjacent paragraphs don't run together.
+  const plainText = he
+    .decode(reason)
+    .replace(/<\/?(?:p|div|br|li|ul|ol|h[1-6])\b[^<>]*>/gi, " ")
+    .replace(/<\/?[a-z][^<>]*>/gi, "");
+
+  for (const line of plainText.split(/\r?\n/)) {
+    const trimmedLine = line.replace(/\s+/g, " ").trim();
     if (trimmedLine.startsWith("Action failures:")) {
       actionFailureMessages.push(
         ...getActionFailureMessages(
@@ -334,7 +342,7 @@ export function getRuleResultReasonDisplay(reason: string): {
         ),
       );
     } else {
-      reasonLines.push(line);
+      reasonLines.push(trimmedLine);
     }
   }
 


### PR DESCRIPTION
## Root cause

AI-produced classification reasons sometimes contain HTML tags — either literal (`<div>`, `<p>`, `<strong>`) or entity-encoded (`&lt;p&gt;`). PR #2860 added `he.decode` for entity decoding, but nothing stripped the tags themselves, so QA reopened INB-298 the same day: literal tags rendered as visible text in the Assistant Test tab tooltip (and entity-encoded tags now decoded *into* visible tags).

## Fix

In `getRuleResultReasonDisplay` (`apps/web/app/(app)/[emailAccountId]/assistant/ResultDisplay.tsx`): decode entities first, then strip HTML tags, then collapse whitespace per line. Block-level tags (`p`, `div`, `br`, `li`, `ul`, `ol`, headings) are replaced with whitespace so adjacent paragraphs don't run together; inline tags (`strong`, `em`, ...) are removed without inserting space so punctuation stays attached. Plain text like `a < b` is left intact. This is display sanitization of short AI text, not an HTML renderer.

This addresses the residual reopen after #2860.

## Test plan

- TDD: added unit tests to the colocated `ResultDisplay.test.tsx` (red before fix, green after):
  - literal tags stripped (`<div><p>...<strong>...</strong>.</p></div>` → clean sentence, no stray space before punctuation)
  - adjacent block elements separated by a space
  - entity-encoded tags stripped and whitespace collapsed
  - plain text passes through unchanged
  - comparison text (`a < 3`) preserved
  - action-failure parsing still works when the reason contains tags
- `pnpm test "app/(app)/[emailAccountId]/assistant/ResultDisplay.test.tsx"` — 12/12 passing (includes pre-existing entity-decoding and failure-code tests)
- Biome check clean

Fixes INB-298
https://linear.app/inbox-zero-ai/issue/INB-298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

