### PR TITLE
org: Remove synced organization rules when a member is removed

### DIFF
--- a/apps/web/utils/actions/organization.test.ts
+++ b/apps/web/utils/actions/organization.test.ts
@@ -100,6 +100,35 @@ describe("removeMemberAction", () => {
     vi.clearAllMocks();
   });
 
+  it("deletes the member's org rule copies scoped to the organization, leaving personal rules untouched", async () => {
+    prisma.member.findUnique.mockResolvedValue({
+      id: "member-2",
+      emailAccountId: "email-account-2",
+      organizationId: "org-1",
+      role: "member",
+    } as any);
+    prisma.member.findFirst.mockResolvedValue({
+      role: "owner",
+      emailAccountId: "email-account-1",
+      emailAccount: { user: { premium: null } },
+    } as any);
+    prisma.rule.deleteMany.mockResolvedValue({ count: 2 } as any);
+    prisma.member.delete.mockResolvedValue({} as any);
+
+    const result = await removeMemberAction({ memberId: "member-2" });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.rule.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "email-account-2",
+        organizationRule: { organizationId: "org-1" },
+      },
+    });
+    expect(prisma.member.delete).toHaveBeenCalledWith({
+      where: { id: "member-2" },
+    });
+  });
+
   it("prevents callers from removing themselves", async () => {
     prisma.member.findUnique.mockResolvedValue({
       id: "member-1",

--- a/apps/web/utils/actions/organization.ts
+++ b/apps/web/utils/actions/organization.ts
@@ -26,7 +26,10 @@ import { env } from "@/env";
 import { slugify } from "@/utils/string";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { createScopedLogger } from "@/utils/logger";
-import { syncOrganizationRulesForNewMember } from "@/utils/organizations/rules";
+import {
+  deleteMemberOrganizationRuleCopies,
+  syncOrganizationRulesForNewMember,
+} from "@/utils/organizations/rules";
 
 export const createOrganizationAction = actionClient
   .metadata({ name: "createOrganization" })
@@ -384,6 +387,11 @@ export const removeMemberAction = actionClientUser
         });
       }
     }
+
+    await deleteMemberOrganizationRuleCopies({
+      emailAccountId: targetMember.emailAccountId,
+      organizationId: targetMember.organizationId,
+    });
 
     await prisma.member.delete({ where: { id: memberId } });
   });

--- a/apps/web/utils/organizations/rules.ts
+++ b/apps/web/utils/organizations/rules.ts
@@ -186,6 +186,20 @@ export async function deleteOrganizationRuleAndMemberCopies({
   });
 }
 
+// Removes the materialized org-rule copies for a member leaving an organization.
+// Personal rules (organizationRuleId null) never match the relation filter.
+export async function deleteMemberOrganizationRuleCopies({
+  emailAccountId,
+  organizationId,
+}: {
+  emailAccountId: string;
+  organizationId: string;
+}) {
+  await prisma.rule.deleteMany({
+    where: { emailAccountId, organizationRule: { organizationId } },
+  });
+}
+
 export async function setOrganizationRuleEnabled({
   organizationRuleId,
   organizationId,


### PR DESCRIPTION
## Root cause

`removeMemberAction` ended with `prisma.member.delete(...)` and never removed the member's materialized org-rule copies (Rule rows with `organizationRuleId` set). Those copies only cascade when the `OrganizationRule` itself is deleted (`deleteOrganizationRuleAndMemberCopies`), not when a Member is removed — so removed members kept active "Managed by organization" rules in their personal Assistant > Rules list.

## Fix

- New helper `deleteMemberOrganizationRuleCopies({ emailAccountId, organizationId })` in `apps/web/utils/organizations/rules.ts`, next to the existing sync/delete helpers. It deletes all of a member's org-rule copies scoped to the organization; personal rules (`organizationRuleId` null) never match the relation filter.
- `removeMemberAction` calls it before deleting the Member row.

Other member-exit paths were audited and need no change: email-account/user deletion cascades all of the account's rules, and organization deletion cascades `OrganizationRule` → member copies. `removeMemberAction` was the only non-cascading path (there is no separate leave-organization action).

## Test plan

- New test (written red first) in `apps/web/utils/actions/organization.test.ts`: removing a member deletes their org-rule copies scoped to the organization and then deletes the membership.
- `pnpm test utils/actions/organization.test.ts utils/organizations/rules.test.ts` — 28 tests pass.

Fixes INB-315
https://linear.app/inbox-zero-ai/issue/INB-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

