### PR TITLE
org: Fix Access Denied flash on organization pages

### DIFF
--- a/apps/web/app/(app)/organization/[organizationId]/rules/OrgRules.tsx
+++ b/apps/web/app/(app)/organization/[organizationId]/rules/OrgRules.tsx
@@ -6,6 +6,7 @@ import {
   PlusIcon,
   Trash2Icon,
 } from "lucide-react";
+import { Loading } from "@/components/Loading";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -53,7 +54,11 @@ export function OrgRules({ organizationId }: { organizationId: string }) {
 
   const ruleDialog = useDialogState<{ rule?: OrgRule }>();
 
-  if (!membershipLoading && !isAdmin) {
+  if (membershipLoading) {
+    return <Loading />;
+  }
+
+  if (!isAdmin) {
     return (
       <AccessDenied message="You don't have permission to manage organization rules. Only administrators can access this page." />
     );

--- a/apps/web/hooks/useOrganizationMembership.test.ts
+++ b/apps/web/hooks/useOrganizationMembership.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSWR = vi.fn();
+const mockUseAccount = vi.fn();
+
+vi.mock("swr", () => ({
+  default: (...args: Parameters<typeof mockUseSWR>) => mockUseSWR(...args),
+}));
+
+vi.mock("@/providers/EmailAccountProvider", () => ({
+  useAccount: () => mockUseAccount(),
+}));
+
+describe("useOrganizationMembership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+      mutate: vi.fn(),
+    });
+  });
+
+  it("reports loading while the email account context is still resolving", async () => {
+    mockUseAccount.mockReturnValue({ emailAccountId: "", isLoading: true });
+
+    const { useOrganizationMembership } = await import(
+      "./useOrganizationMembership"
+    );
+    const { result } = renderHook(() => useOrganizationMembership());
+
+    expect(mockUseSWR).toHaveBeenCalledWith(null);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("fetches membership once the email account is resolved", async () => {
+    mockUseAccount.mockReturnValue({
+      emailAccountId: "account-1",
+      isLoading: false,
+    });
+    mockUseSWR.mockReturnValue({
+      data: { role: "ADMIN" },
+      isLoading: false,
+      error: undefined,
+      mutate: vi.fn(),
+    });
+
+    const { useOrganizationMembership } = await import(
+      "./useOrganizationMembership"
+    );
+    const { result } = renderHook(() => useOrganizationMembership());
+
+    expect(mockUseSWR).toHaveBeenCalledWith([
+      "/api/user/organization-membership",
+      "account-1",
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual({ role: "ADMIN" });
+  });
+
+  it("is not loading when the context resolved without an email account", async () => {
+    mockUseAccount.mockReturnValue({ emailAccountId: "", isLoading: false });
+
+    const { useOrganizationMembership } = await import(
+      "./useOrganizationMembership"
+    );
+    const { result } = renderHook(() => useOrganizationMembership());
+
+    expect(mockUseSWR).toHaveBeenCalledWith(null);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/web/hooks/useOrganizationMembership.ts
+++ b/apps/web/hooks/useOrganizationMembership.ts
@@ -3,9 +3,19 @@ import type { GetOrganizationMembershipResponse } from "@/app/api/user/organizat
 import { useAccount } from "@/providers/EmailAccountProvider";
 
 export function useOrganizationMembership(emailAccountId?: string) {
-  const { emailAccountId: contextId } = useAccount();
-  const id = emailAccountId ?? contextId;
-  return useSWR<GetOrganizationMembershipResponse>(
+  const { emailAccountId: contextId, isLoading: isLoadingEmailAccount } =
+    useAccount();
+  const id = emailAccountId || contextId;
+  const swr = useSWR<GetOrganizationMembershipResponse>(
     id ? ["/api/user/organization-membership", id] : null,
   );
+
+  return {
+    ...swr,
+    // On organization routes there is no emailAccountId param, so the account
+    // context resolves asynchronously. While it does, the SWR key is null and
+    // SWR reports isLoading: false; treat membership as still loading so
+    // consumers don't misread the gap as "no access".
+    isLoading: swr.isLoading || (!id && isLoadingEmailAccount),
+  };
 }

--- a/apps/web/hooks/useOrganizationMembership.ts
+++ b/apps/web/hooks/useOrganizationMembership.ts
@@ -5,7 +5,7 @@ import { useAccount } from "@/providers/EmailAccountProvider";
 export function useOrganizationMembership(emailAccountId?: string) {
   const { emailAccountId: contextId, isLoading: isLoadingEmailAccount } =
     useAccount();
-  const id = emailAccountId || contextId;
+  const id = emailAccountId ?? contextId;
   const swr = useSWR<GetOrganizationMembershipResponse>(
     id ? ["/api/user/organization-membership", id] : null,
   );


### PR DESCRIPTION
## Root cause

Organization routes (`/organization/[organizationId]/...`) have no `emailAccountId` param, so `EmailAccountProvider` resolves the email account asynchronously via a fetch. During that window `useOrganizationMembership` had a null SWR key, and with a null key SWR reports `isLoading: false` with `data: undefined`. The admin guards in `OrgRules` (`!membershipLoading && !isAdmin`) and `OrgStats` misread that gap as "not an admin" and flashed the Access Denied screen on every refresh.

## Fix

- `useOrganizationMembership` now reports `isLoading: true` while the email account context is still resolving (same idiom as `useLabels`), so all consumers see the gap as loading rather than "no membership".
- `OrgRules` renders a loading spinner while membership is loading (mirroring `OrgStats`, which already had a skeleton for that state), instead of flashing the admin page shell.

## Test plan

- New colocated unit test `apps/web/hooks/useOrganizationMembership.test.ts` (TDD, failed before the fix):
  - reports loading while the email account context is resolving
  - fetches membership once the account is resolved
  - is not loading when the context resolved without an email account (Access Denied still shows correctly)
- `pnpm test hooks/useOrganizationMembership.test.ts` — 3 passed
- Biome check on changed files — clean

Fixes INB-314
Linear: https://linear.app/inbox-zero-ai/issue/INB-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

