### PR TITLE
rules: Shorten org-managed badge copy

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -252,7 +252,9 @@ export function Rules({
                         <div className="flex items-center gap-2">
                           {rule.name}
                           {isOrgManaged && (
-                            <Badge color="blue">Managed by organization</Badge>
+                            <Tooltip content="Managed by Organization">
+                              <Badge color="blue">Org</Badge>
+                            </Tooltip>
                           )}
                         </div>
                       </TableCell>


### PR DESCRIPTION
Shortens the org-managed rule badge in the assistant Rules table from "Managed by organization" to "Org" and keeps the full explanation available in a tooltip.

- Wraps the shortened badge with the existing Tooltip component
- Tooltip text: "Managed by Organization"

Demo:
- Captured locally on the Rules tab with seeded org-managed demo data: badge shows "Org" and hover tooltip shows "Managed by Organization".
- Local screenshot: /tmp/inbox-zero-demos/org-rule-badge-tooltip.png

Validation:
- pnpm --filter inbox-zero-ai exec biome check 'app/(app)/[emailAccountId]/assistant/Rules.tsx'

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

