### PR TITLE
Fix account linking duplicate handling

### DIFF
--- a/apps/web/app/api/google/linking/callback/route.test.ts
+++ b/apps/web/app/api/google/linking/callback/route.test.ts
@@ -126,6 +126,7 @@ describe("google linking callback route", () => {
     mockFetchGoogleOpenIdProfile.mockResolvedValue({
       sub: "new-provider-account-id",
       email: "user@example.com",
+      email_verified: true,
       name: "Test User",
       picture: "https://example.com/avatar.png",
     });
@@ -168,6 +169,30 @@ describe("google linking callback route", () => {
     });
   });
 
+  it("rejects existing-account recovery when the Google email claim is unverified", async () => {
+    mockHandleAccountLinking.mockResolvedValue({
+      type: "update_existing_account",
+      existingAccountId: "existing-account-123",
+    });
+    mockFetchGoogleOpenIdProfile.mockResolvedValue({
+      sub: "new-provider-account-id",
+      email: "user@example.com",
+      email_verified: false,
+      name: "Test User",
+      picture: "https://example.com/avatar.png",
+    });
+
+    const response = await GET(
+      createRequest("http://localhost:3000/api/google/linking/callback"),
+    );
+
+    const redirectLocation = response.headers.get("location");
+    expect(redirectLocation).toContain("error=link_failed");
+    expect(redirectLocation).toContain("Google+email+claim+is+not+verified");
+    expect(prisma.account.update).not.toHaveBeenCalled();
+    expect(mockClearOAuthCode).toHaveBeenCalledWith("valid-auth-code");
+  });
+
   it("keeps the create path outside Google OAuth emulation", async () => {
     mockIsGoogleOauthEmulationEnabled.mockReturnValue(false);
     mockHandleAccountLinking.mockResolvedValue({
@@ -178,6 +203,7 @@ describe("google linking callback route", () => {
         getPayload: () => ({
           sub: "new-provider-account-id",
           email: "user@example.com",
+          email_verified: true,
           name: "Test User",
           picture: "https://example.com/avatar.png",
         }),

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -137,6 +137,8 @@ export const GET = withError("google/linking/callback", async (request) => {
     }
 
     if (linkingResult.type === "update_existing_account") {
+      assertVerifiedGoogleEmail(payload);
+
       logger.info(
         "Updating existing Google account with new providerAccountId",
         {
@@ -180,6 +182,8 @@ export const GET = withError("google/linking/callback", async (request) => {
         });
 
         if (existingEmulatedAccount) {
+          assertVerifiedGoogleEmail(payload);
+
           logger.info(
             "Updating existing Google emulator account for same user and email",
             {
@@ -329,6 +333,8 @@ export const GET = withError("google/linking/callback", async (request) => {
       targetUserId,
     });
 
+    assertVerifiedGoogleEmail(payload);
+
     const mergeType = await mergeAccount({
       sourceAccountId: linkingResult.sourceAccountId,
       sourceUserId: linkingResult.sourceUserId,
@@ -411,6 +417,12 @@ async function updateGoogleAccount({
       id_token: tokens.id_token,
     },
   });
+}
+
+function assertVerifiedGoogleEmail(payload: { email_verified?: boolean }) {
+  if (payload.email_verified !== true) {
+    throw new SafeError("Google email claim is not verified.");
+  }
 }
 
 async function getGoogleProfilePayload({

--- a/apps/web/app/api/google/linking/callback/route.ts
+++ b/apps/web/app/api/google/linking/callback/route.ts
@@ -136,6 +136,36 @@ export const GET = withError("google/linking/callback", async (request) => {
       return linkingResult.response;
     }
 
+    if (linkingResult.type === "update_existing_account") {
+      logger.info(
+        "Updating existing Google account with new providerAccountId",
+        {
+          email: providerEmail,
+          targetUserId,
+          accountId: linkingResult.existingAccountId,
+        },
+      );
+
+      await updateGoogleAccount({
+        accountId: linkingResult.existingAccountId,
+        providerAccountId,
+        tokens,
+      });
+
+      logger.info("OAuth linking callback completed", {
+        accountId: linkingResult.existingAccountId,
+        outcome: "tokens_updated",
+        providerEmailHash: hash(providerEmail),
+        providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
+      });
+
+      await setOAuthCodeResult(code, { success: "tokens_updated" });
+      return createAccountLinkingRedirect({
+        query: { success: "tokens_updated" },
+        stateCookieName: GOOGLE_LINKING_STATE_COOKIE_NAME,
+      });
+    }
+
     if (linkingResult.type === "continue_create") {
       if (isGoogleOauthEmulationEnabled()) {
         const existingEmulatedAccount = await prisma.emailAccount.findFirst({
@@ -306,6 +336,12 @@ export const GET = withError("google/linking/callback", async (request) => {
       email: providerEmail,
       name: existingAccount?.user.name || null,
       logger,
+    });
+
+    await updateGoogleAccount({
+      accountId: linkingResult.sourceAccountId,
+      providerAccountId,
+      tokens,
     });
 
     const successMessage =

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -221,6 +221,36 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       return linkingResult.response;
     }
 
+    if (linkingResult.type === "update_existing_account") {
+      logger.info(
+        "Updating existing Microsoft account with new providerAccountId",
+        {
+          email: providerEmail,
+          targetUserId,
+          accountId: linkingResult.existingAccountId,
+        },
+      );
+
+      await updateMicrosoftAccountTokens(
+        linkingResult.existingAccountId,
+        tokens,
+        { providerAccountId },
+      );
+
+      logger.info("OAuth linking callback completed", {
+        accountId: linkingResult.existingAccountId,
+        outcome: "tokens_updated",
+        providerEmailHash: hash(providerEmail),
+        providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
+      });
+
+      await setOAuthCodeResult(code, { success: "tokens_updated" });
+      return createAccountLinkingRedirect({
+        query: { success: "tokens_updated" },
+        stateCookieName: OUTLOOK_LINKING_STATE_COOKIE_NAME,
+      });
+    }
+
     if (linkingResult.type === "continue_create") {
       logger.info(
         "Creating new Microsoft account and linking to current user",
@@ -377,15 +407,9 @@ export const GET = withError("outlook/linking/callback", async (request) => {
       logger,
     });
 
-    if (shouldMigrateProviderAccountId) {
-      await updateMicrosoftAccountTokens(
-        linkingResult.sourceAccountId,
-        tokens,
-        {
-          providerAccountId,
-        },
-      );
-    }
+    await updateMicrosoftAccountTokens(linkingResult.sourceAccountId, tokens, {
+      providerAccountId,
+    });
 
     const successMessage =
       mergeType === "full_merge"

--- a/apps/web/app/api/outlook/linking/callback/route.ts
+++ b/apps/web/app/api/outlook/linking/callback/route.ts
@@ -237,17 +237,12 @@ export const GET = withError("outlook/linking/callback", async (request) => {
         { providerAccountId },
       );
 
-      logger.info("OAuth linking callback completed", {
+      return completeMicrosoftTokenUpdate({
         accountId: linkingResult.existingAccountId,
-        outcome: "tokens_updated",
-        providerEmailHash: hash(providerEmail),
-        providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
-      });
-
-      await setOAuthCodeResult(code, { success: "tokens_updated" });
-      return createAccountLinkingRedirect({
-        query: { success: "tokens_updated" },
-        stateCookieName: OUTLOOK_LINKING_STATE_COOKIE_NAME,
+        code,
+        logger,
+        providerEmail,
+        providerAccountId,
       });
     }
 
@@ -379,17 +374,12 @@ export const GET = withError("outlook/linking/callback", async (request) => {
         targetUserId,
         accountId: linkingResult.existingAccountId,
       });
-      logger.info("OAuth linking callback completed", {
+      return completeMicrosoftTokenUpdate({
         accountId: linkingResult.existingAccountId,
-        outcome: "tokens_updated",
-        providerEmailHash: hash(providerEmail),
-        providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
-      });
-
-      await setOAuthCodeResult(code, { success: "tokens_updated" });
-      return createAccountLinkingRedirect({
-        query: { success: "tokens_updated" },
-        stateCookieName: OUTLOOK_LINKING_STATE_COOKIE_NAME,
+        code,
+        logger,
+        providerEmail,
+        providerAccountId,
       });
     }
 
@@ -460,6 +450,33 @@ const MICROSOFT_LINKING_SCOPES_TO_VALIDATE = OUTLOOK_SCOPES.filter(
       scope,
     ),
 );
+
+async function completeMicrosoftTokenUpdate({
+  accountId,
+  code,
+  logger,
+  providerAccountId,
+  providerEmail,
+}: {
+  accountId: string;
+  code: string;
+  logger: Logger;
+  providerAccountId: string;
+  providerEmail: string;
+}) {
+  logger.info("OAuth linking callback completed", {
+    accountId,
+    outcome: "tokens_updated",
+    providerEmailHash: hash(providerEmail),
+    providerSubjectHash: hashOAuthAuditIdentifier(providerAccountId),
+  });
+
+  await setOAuthCodeResult(code, { success: "tokens_updated" });
+  return createAccountLinkingRedirect({
+    query: { success: "tokens_updated" },
+    stateCookieName: OUTLOOK_LINKING_STATE_COOKIE_NAME,
+  });
+}
 
 function assertMicrosoftLinkingConsent(params: {
   targetUserId: string;

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -43,6 +43,7 @@ describe("handleAccountLinking", () => {
       logger,
     );
     expect(result).toEqual({ type: "continue_create" });
+    expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
   });
 
   it("should return continue_create when no existing account", async () => {
@@ -114,7 +115,7 @@ describe("handleAccountLinking", () => {
     }
   });
 
-  it("should return merge when creating an account whose email belongs to a different user on the same provider", async () => {
+  it("should redirect with account_already_exists when creating an account whose email belongs to a different user on the same provider", async () => {
     mockExistingEmailAccount();
 
     const result = await handleAccountLinking({
@@ -127,11 +128,11 @@ describe("handleAccountLinking", () => {
       logger,
     });
 
-    expect(result).toEqual({
-      type: "merge",
-      sourceAccountId: "existing-account-id",
-      sourceUserId: "different-user-id",
-    });
+    expect(result.type).toBe("redirect");
+    if (result.type === "redirect") {
+      const url = new URL(result.response.headers.get("location") || "");
+      expect(url.searchParams.get("error")).toBe("account_already_exists");
+    }
   });
 
   it("should update the existing account when the provider account id changed for the same user", async () => {
@@ -151,26 +152,6 @@ describe("handleAccountLinking", () => {
       type: "update_existing_account",
       existingAccountId: "existing-account-id",
     });
-  });
-
-  it("should redirect with account_already_exists when an orphaned provider account would collide with another provider", async () => {
-    mockExistingEmailAccount({ provider: "microsoft" });
-
-    const result = await handleAccountLinking({
-      existingAccountId: "orphaned-account-id",
-      hasEmailAccount: false,
-      existingUserId: "orphaned-user-id",
-      targetUserId: "target-user-id",
-      provider: "google",
-      providerEmail: "existing@gmail.com",
-      logger,
-    });
-
-    expect(result.type).toBe("redirect");
-    if (result.type === "redirect") {
-      const url = new URL(result.response.headers.get("location") || "");
-      expect(url.searchParams.get("error")).toBe("account_already_exists");
-    }
   });
 
   it("redirects to logout when the linking session user no longer exists", async () => {

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -94,18 +94,98 @@ describe("handleAccountLinking", () => {
     });
   });
 
-  it("should redirect with account_already_exists when creating an account whose email belongs to a different user", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue(
-      getMockEmailAccountSelect({
+  it("should redirect with account_already_exists when creating an account whose email belongs to a different provider", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
         userId: "different-user-id",
         email: "existing@gmail.com",
-      }) as any,
-    );
+      }),
+      account: { provider: "microsoft" },
+    } as any);
 
     const result = await handleAccountLinking({
       existingAccountId: null,
       hasEmailAccount: false,
       existingUserId: null,
+      targetUserId: "target-user-id",
+      provider: "google",
+      providerEmail: "existing@gmail.com",
+      logger,
+    });
+
+    expect(result.type).toBe("redirect");
+    if (result.type === "redirect") {
+      const url = new URL(result.response.headers.get("location") || "");
+      expect(url.searchParams.get("error")).toBe("account_already_exists");
+    }
+  });
+
+  it("should return merge when creating an account whose email belongs to a different user on the same provider", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
+        accountId: "existing-account-id",
+        userId: "different-user-id",
+        email: "existing@gmail.com",
+      }),
+      account: { provider: "google" },
+    } as any);
+
+    const result = await handleAccountLinking({
+      existingAccountId: null,
+      hasEmailAccount: false,
+      existingUserId: null,
+      targetUserId: "target-user-id",
+      provider: "google",
+      providerEmail: "existing@gmail.com",
+      logger,
+    });
+
+    expect(result).toEqual({
+      type: "merge",
+      sourceAccountId: "existing-account-id",
+      sourceUserId: "different-user-id",
+    });
+  });
+
+  it("should update the existing account when the provider account id changed for the same user", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
+        accountId: "existing-account-id",
+        userId: "target-user-id",
+        email: "existing@gmail.com",
+      }),
+      account: { provider: "google" },
+    } as any);
+
+    const result = await handleAccountLinking({
+      existingAccountId: null,
+      hasEmailAccount: false,
+      existingUserId: null,
+      targetUserId: "target-user-id",
+      provider: "google",
+      providerEmail: "existing@gmail.com",
+      logger,
+    });
+
+    expect(result).toEqual({
+      type: "update_existing_account",
+      existingAccountId: "existing-account-id",
+    });
+  });
+
+  it("should redirect with account_already_exists when an orphaned provider account would collide with another provider", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      ...getMockEmailAccountSelect({
+        userId: "different-user-id",
+        email: "existing@gmail.com",
+      }),
+      account: { provider: "microsoft" },
+    } as any);
+
+    const result = await handleAccountLinking({
+      existingAccountId: "orphaned-account-id",
+      hasEmailAccount: false,
+      existingUserId: "orphaned-user-id",
       targetUserId: "target-user-id",
       provider: "google",
       providerEmail: "existing@gmail.com",

--- a/apps/web/utils/oauth/account-linking.test.ts
+++ b/apps/web/utils/oauth/account-linking.test.ts
@@ -95,13 +95,7 @@ describe("handleAccountLinking", () => {
   });
 
   it("should redirect with account_already_exists when creating an account whose email belongs to a different provider", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        userId: "different-user-id",
-        email: "existing@gmail.com",
-      }),
-      account: { provider: "microsoft" },
-    } as any);
+    mockExistingEmailAccount({ provider: "microsoft" });
 
     const result = await handleAccountLinking({
       existingAccountId: null,
@@ -121,14 +115,7 @@ describe("handleAccountLinking", () => {
   });
 
   it("should return merge when creating an account whose email belongs to a different user on the same provider", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        accountId: "existing-account-id",
-        userId: "different-user-id",
-        email: "existing@gmail.com",
-      }),
-      account: { provider: "google" },
-    } as any);
+    mockExistingEmailAccount();
 
     const result = await handleAccountLinking({
       existingAccountId: null,
@@ -148,14 +135,7 @@ describe("handleAccountLinking", () => {
   });
 
   it("should update the existing account when the provider account id changed for the same user", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        accountId: "existing-account-id",
-        userId: "target-user-id",
-        email: "existing@gmail.com",
-      }),
-      account: { provider: "google" },
-    } as any);
+    mockExistingEmailAccount({ userId: "target-user-id" });
 
     const result = await handleAccountLinking({
       existingAccountId: null,
@@ -174,13 +154,7 @@ describe("handleAccountLinking", () => {
   });
 
   it("should redirect with account_already_exists when an orphaned provider account would collide with another provider", async () => {
-    prisma.emailAccount.findUnique.mockResolvedValue({
-      ...getMockEmailAccountSelect({
-        userId: "different-user-id",
-        email: "existing@gmail.com",
-      }),
-      account: { provider: "microsoft" },
-    } as any);
+    mockExistingEmailAccount({ provider: "microsoft" });
 
     const result = await handleAccountLinking({
       existingAccountId: "orphaned-account-id",
@@ -221,3 +195,24 @@ describe("handleAccountLinking", () => {
     expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
   });
 });
+
+function mockExistingEmailAccount({
+  accountId = "existing-account-id",
+  email = "existing@gmail.com",
+  provider = "google",
+  userId = "different-user-id",
+}: {
+  accountId?: string;
+  email?: string;
+  provider?: "google" | "microsoft";
+  userId?: string;
+} = {}) {
+  prisma.emailAccount.findUnique.mockResolvedValue({
+    ...getMockEmailAccountSelect({
+      accountId,
+      email,
+      userId,
+    }),
+    account: { provider },
+  } as any);
+}

--- a/apps/web/utils/oauth/account-linking.ts
+++ b/apps/web/utils/oauth/account-linking.ts
@@ -27,6 +27,7 @@ export async function handleAccountLinking({
   | { type: "continue_create" }
   | { type: "redirect"; response: NextResponse }
   | { type: "merge"; sourceAccountId: string; sourceUserId: string }
+  | { type: "update_existing_account"; existingAccountId: string }
   | { type: "update_tokens"; existingAccountId: string }
 > {
   const hasActiveTargetUser = await hasActiveAccountLinkingUser({
@@ -52,21 +53,27 @@ export async function handleAccountLinking({
     });
 
     await cleanupOrphanedAccount(existingAccountId, logger);
-    return { type: "continue_create" };
   }
 
   if (!existingAccountId || !hasEmailAccount) {
     const existingEmailAccount = await prisma.emailAccount.findUnique({
       where: { email: providerEmail.trim().toLowerCase() },
-      select: { userId: true },
+      select: {
+        accountId: true,
+        userId: true,
+        account: { select: { provider: true } },
+      },
     });
 
-    if (existingEmailAccount && existingEmailAccount.userId !== targetUserId) {
+    if (!existingEmailAccount) return { type: "continue_create" };
+
+    if (existingEmailAccount.account.provider !== provider) {
       logger.warn(
-        "Create failed: account with this email already exists for a different user",
+        "Create failed: account with this email already exists for a different provider",
         {
           provider,
           email: providerEmail,
+          existingProvider: existingEmailAccount.account.provider,
           existingUserId: existingEmailAccount.userId,
           targetUserId,
         },
@@ -80,7 +87,38 @@ export async function handleAccountLinking({
       };
     }
 
-    return { type: "continue_create" };
+    if (existingEmailAccount.userId === targetUserId) {
+      logger.info(
+        "providerAccountId changed but EmailAccount exists for same user. Updating existing account.",
+        {
+          provider,
+          email: providerEmail,
+          targetUserId,
+          accountId: existingEmailAccount.accountId,
+        },
+      );
+
+      return {
+        type: "update_existing_account",
+        existingAccountId: existingEmailAccount.accountId,
+      };
+    }
+
+    logger.info(
+      "Account with this email exists for different user on same provider, merging accounts",
+      {
+        provider,
+        email: providerEmail,
+        existingUserId: existingEmailAccount.userId,
+        targetUserId,
+      },
+    );
+
+    return {
+      type: "merge",
+      sourceAccountId: existingEmailAccount.accountId,
+      sourceUserId: existingEmailAccount.userId,
+    };
   }
 
   if (existingUserId === targetUserId) {

--- a/apps/web/utils/oauth/account-linking.ts
+++ b/apps/web/utils/oauth/account-linking.ts
@@ -53,6 +53,7 @@ export async function handleAccountLinking({
     });
 
     await cleanupOrphanedAccount(existingAccountId, logger);
+    return { type: "continue_create" };
   }
 
   if (!existingAccountId || !hasEmailAccount) {
@@ -67,9 +68,9 @@ export async function handleAccountLinking({
 
     if (!existingEmailAccount) return { type: "continue_create" };
 
-    if (existingEmailAccount.account.provider !== provider) {
+    if (existingEmailAccount.userId !== targetUserId) {
       logger.warn(
-        "Create failed: account with this email already exists for a different provider",
+        "Create failed: account with this email already exists for a different user",
         {
           provider,
           email: providerEmail,
@@ -87,37 +88,38 @@ export async function handleAccountLinking({
       };
     }
 
-    if (existingEmailAccount.userId === targetUserId) {
-      logger.info(
-        "providerAccountId changed but EmailAccount exists for same user. Updating existing account.",
+    if (existingEmailAccount.account.provider !== provider) {
+      logger.warn(
+        "Create failed: account with this email already exists for a different provider",
         {
           provider,
           email: providerEmail,
+          existingProvider: existingEmailAccount.account.provider,
           targetUserId,
-          accountId: existingEmailAccount.accountId,
         },
       );
 
       return {
-        type: "update_existing_account",
-        existingAccountId: existingEmailAccount.accountId,
+        type: "redirect",
+        response: createAccountLinkingRedirect({
+          query: { error: "account_already_exists" },
+        }),
       };
     }
 
     logger.info(
-      "Account with this email exists for different user on same provider, merging accounts",
+      "providerAccountId changed but EmailAccount exists for same user. Updating existing account.",
       {
         provider,
         email: providerEmail,
-        existingUserId: existingEmailAccount.userId,
         targetUserId,
+        accountId: existingEmailAccount.accountId,
       },
     );
 
     return {
-      type: "merge",
-      sourceAccountId: existingEmailAccount.accountId,
-      sourceUserId: existingEmailAccount.userId,
+      type: "update_existing_account",
+      existingAccountId: existingEmailAccount.accountId,
     };
   }
 


### PR DESCRIPTION
Fixes OAuth account-linking duplicate-email handling so same-provider records can merge or update while cross-provider collisions still redirect.

- Restores provider-aware duplicate checks in the shared linking helper.
- Updates Google and Microsoft callbacks to refresh provider account IDs and tokens for recovered accounts.
- Adds focused tests for merge, update, and redirect duplicate cases.

Performance impact: Adds one account relation field to an existing duplicate-email lookup and token updates only on OAuth callback paths; no hot-path runtime impact.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

