### PR TITLE
Derive follow-up notification snippets from the parsed message body

### DIFF
--- a/apps/web/utils/follow-up/copy.test.ts
+++ b/apps/web/utils/follow-up/copy.test.ts
@@ -23,4 +23,14 @@ describe("follow-up notification copy", () => {
     expect(snippet.length).toBeGreaterThan(280);
     expect(truncateSnippet(snippet)).toBe(snippet);
   });
+
+  it("ends a truncated snippet with an ellipsis so users know there is more", () => {
+    const maxChars = 100;
+    const snippet = "All work and no play makes Jack a dull boy. ".repeat(5);
+
+    const truncated = truncateSnippet(snippet, maxChars);
+
+    expect(truncated.length).toBeLessThanOrEqual(maxChars);
+    expect(truncated.endsWith("…")).toBe(true);
+  });
 });

--- a/apps/web/utils/follow-up/process.test.ts
+++ b/apps/web/utils/follow-up/process.test.ts
@@ -906,9 +906,30 @@ describe("processAccountFollowUps - dedup logic", () => {
     );
   });
 
-  it("derives the notification snippet from the message body instead of the provider preview", async () => {
-    const fullBody =
-      "The provider preview stops early but the email keeps going with enough detail for the user to recognize the thread and decide whether to follow up right away.";
+  const fullNotificationBody =
+    "The provider preview stops early but the email keeps going with enough detail for the user to recognize the thread and decide whether to follow up right away.";
+
+  it.each([
+    {
+      name: "derives the notification snippet from the message body instead of the provider preview",
+      providerSnippet: "The provider preview stops early",
+      textPlain: fullNotificationBody,
+      expectedSnippet: fullNotificationBody,
+    },
+    {
+      name: "falls back to the provider preview when the message has no body",
+      providerSnippet: "Preview from the provider",
+      textPlain: "",
+      expectedSnippet: "Preview from the provider",
+    },
+    {
+      name: "falls back to the provider preview when reply extraction removes the body",
+      providerSnippet: "Preview from the provider",
+      textPlain:
+        "On Tue, Jul 14, 2026 at 10:00 AM Alex <alex@example.com> wrote:\n> Prior message",
+      expectedSnippet: "Preview from the provider",
+    },
+  ])("$name", async ({ providerSnippet, textPlain, expectedSnippet }) => {
     const provider = createMockProvider({
       getThreadsWithLabel: vi
         .fn()
@@ -917,8 +938,9 @@ describe("processAccountFollowUps - dedup logic", () => {
         ]),
       getLatestMessageInThread: vi.fn().mockResolvedValue({
         ...mockAwaitingMessage("msg-snippet-source", OLD_DATE),
-        snippet: "The provider preview stops early",
-        textPlain: fullBody,
+        snippet: providerSnippet,
+        textPlain,
+        textHtml: "",
       }),
     });
     vi.mocked(createEmailProvider).mockResolvedValue(provider);
@@ -937,41 +959,7 @@ describe("processAccountFollowUps - dedup logic", () => {
     });
 
     expect(sendFollowUpNotification).toHaveBeenCalledWith(
-      expect.objectContaining({ snippet: fullBody }),
-    );
-  });
-
-  it("falls back to the provider preview when the message has no body", async () => {
-    const provider = createMockProvider({
-      getThreadsWithLabel: vi
-        .fn()
-        .mockResolvedValue([
-          { id: "thread-snippet-fallback", messages: [], snippet: "" },
-        ]),
-      getLatestMessageInThread: vi.fn().mockResolvedValue({
-        ...mockAwaitingMessage("msg-snippet-fallback", OLD_DATE),
-        snippet: "Preview from the provider",
-        textPlain: "",
-        textHtml: "",
-      }),
-    });
-    vi.mocked(createEmailProvider).mockResolvedValue(provider);
-    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
-      { id: "channel-1" } as any,
-    ]);
-    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
-    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
-      id: "tracker-snippet-fallback",
-    } as any);
-
-    await processAccountFollowUps({
-      emailAccount: createMockAccount(),
-      logger,
-    });
-
-    expect(sendFollowUpNotification).toHaveBeenCalledWith(
-      expect.objectContaining({ snippet: "Preview from the provider" }),
+      expect.objectContaining({ snippet: expectedSnippet }),
     );
   });
 

--- a/apps/web/utils/follow-up/process.test.ts
+++ b/apps/web/utils/follow-up/process.test.ts
@@ -906,6 +906,75 @@ describe("processAccountFollowUps - dedup logic", () => {
     );
   });
 
+  it("derives the notification snippet from the message body instead of the provider preview", async () => {
+    const fullBody =
+      "The provider preview stops early but the email keeps going with enough detail for the user to recognize the thread and decide whether to follow up right away.";
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-snippet-source", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi.fn().mockResolvedValue({
+        ...mockAwaitingMessage("msg-snippet-source", OLD_DATE),
+        snippet: "The provider preview stops early",
+        textPlain: fullBody,
+      }),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
+      { id: "channel-1" } as any,
+    ]);
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
+      id: "tracker-snippet-source",
+    } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(sendFollowUpNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ snippet: fullBody }),
+    );
+  });
+
+  it("falls back to the provider preview when the message has no body", async () => {
+    const provider = createMockProvider({
+      getThreadsWithLabel: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "thread-snippet-fallback", messages: [], snippet: "" },
+        ]),
+      getLatestMessageInThread: vi.fn().mockResolvedValue({
+        ...mockAwaitingMessage("msg-snippet-fallback", OLD_DATE),
+        snippet: "Preview from the provider",
+        textPlain: "",
+        textHtml: "",
+      }),
+    });
+    vi.mocked(createEmailProvider).mockResolvedValue(provider);
+    vi.mocked(getFollowUpNotificationChannels).mockResolvedValue([
+      { id: "channel-1" } as any,
+    ]);
+    vi.mocked(prisma.threadTracker.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.threadTracker.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.threadTracker.create).mockResolvedValue({
+      id: "tracker-snippet-fallback",
+    } as any);
+
+    await processAccountFollowUps({
+      emailAccount: createMockAccount(),
+      logger,
+    });
+
+    expect(sendFollowUpNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ snippet: "Preview from the provider" }),
+    );
+  });
+
   it("appends notification deliveries to existing tracker handles", async () => {
     const provider = createMockProvider({
       getThreadsWithLabel: vi

--- a/apps/web/utils/follow-up/process.ts
+++ b/apps/web/utils/follow-up/process.ts
@@ -44,6 +44,7 @@ import {
   isGoogleProvider,
   isMicrosoftProvider,
 } from "@/utils/email/provider-types";
+import { emailToContent } from "@/utils/mail";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import { getEmailUrlForOptionalMessage } from "@/utils/url";
 import { env } from "@/env";
@@ -581,7 +582,13 @@ async function processFollowUpsForType({
               end: now,
               timezone: emailAccount.timezone,
             }),
-            snippet: lastMessage.snippet || undefined,
+            // Provider previews are pre-truncated with no indicator; the full
+            // parsed body lets each channel truncate with an ellipsis instead.
+            snippet:
+              emailToContent(lastMessage, {
+                maxLength: 0,
+                extractReply: true,
+              }) || undefined,
             threadLink:
               getEmailUrlForOptionalMessage({
                 messageId: lastMessage.id,

--- a/apps/web/utils/follow-up/process.ts
+++ b/apps/web/utils/follow-up/process.ts
@@ -51,6 +51,8 @@ import { env } from "@/env";
 
 const FOLLOW_UP_ELIGIBILITY_WINDOW_MINUTES = 15;
 const FOLLOW_UP_THREAD_SCAN_LIMIT = 50;
+// Avoid carrying an entire email through channel fan-out beyond any preview limit.
+const FOLLOW_UP_SNIPPET_SOURCE_MAX_CHARS = 3000;
 
 const followUpReminderAccountSelect = {
   id: true,
@@ -586,9 +588,11 @@ async function processFollowUpsForType({
             // parsed body lets each channel truncate with an ellipsis instead.
             snippet:
               emailToContent(lastMessage, {
-                maxLength: 0,
+                maxLength: FOLLOW_UP_SNIPPET_SOURCE_MAX_CHARS,
                 extractReply: true,
-              }) || undefined,
+              }) ||
+              lastMessage.snippet ||
+              undefined,
             threadLink:
               getEmailUrlForOptionalMessage({
                 messageId: lastMessage.id,


### PR DESCRIPTION
## Summary

Follow-up notifications ("waiting for their reply" / "reply needed from you") showed only the provider's snippet — a pre-truncated ~100-200 char fragment with no truncation indicator — so long emails looked like they ended mid-thought with no "Show more" or ellipsis.

Every delivery channel (Slack blocks, Teams text, Telegram card) already truncates via `truncateSnippet`, which appends `…` when content exceeds the channel limit. The bug was upstream: the provider preview was always shorter than any channel limit, so that indicator never fired.

- `utils/follow-up/process.ts`: derive the notification snippet from the parsed message body via `emailToContent(lastMessage, { maxLength: 3000, extractReply: true })` instead of `lastMessage.snippet`. The source preview is capped at the longest channel limit, and channel-level truncation visibly marks the cut with `…`. If the body is missing or reply extraction yields no visible content, the provider preview is used as a fallback.
- `utils/follow-up/process.test.ts`: tests pinning full-body preference plus provider-preview fallback for missing and quote-only bodies.
- `utils/follow-up/copy.test.ts`: test locking the ellipsis indicator on truncated snippets.

Supersedes #2744, whose diff no longer applied after the #2809 refactor moved this logic to `utils/follow-up/`.

Fixes INB-287

## Test plan

- [x] `pnpm test utils/follow-up/process.test.ts utils/follow-up/copy.test.ts` — 35 passed (TDD: snippet-source test failed before the fix)
- [x] `pnpm test utils/follow-up utils/messaging/providers/slack` — 172 passed across 14 files
- [x] `pnpm exec biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

