### PR TITLE
Fix raw assistant tags leaking into AI chat responses

### DIFF
--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -9,10 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  AssistantInlineEmailResponse,
-  normalizeAssistantTagMarkup,
-} from "@/components/assistant-chat/assistant-inline-email-response";
+import { AssistantInlineEmailResponse } from "@/components/assistant-chat/assistant-inline-email-response";
 import { getEmailUrlForMessage } from "@/utils/url";
 
 const mockUseAccount = vi.fn();
@@ -232,13 +229,10 @@ describe("AssistantInlineEmailResponse", () => {
 
   it("renders backslash-escaped email detail tags", () => {
     mockRenderedThread();
+    const content = String.raw`\<email-detail threadid="thread-1">A receipt.\</email-detail>`;
 
     const { container } = render(
-      createElement(
-        AssistantInlineEmailResponse,
-        null,
-        '\\<email-detail threadid="thread-1">A receipt.\\</email-detail>',
-      ),
+      createElement(AssistantInlineEmailResponse, null, content),
     );
 
     expect(screen.getByText("Subject")).toBeTruthy();
@@ -293,22 +287,6 @@ describe("AssistantInlineEmailResponse", () => {
     );
 
     expect(mockUseThread).toHaveBeenCalledWith({ id: "thread-1" });
-  });
-
-  it("preserves whitespace inside quoted rule attributes", () => {
-    expect(
-      normalizeAssistantTagMarkup(
-        '<rule-suggestion\nname="Large  messages"\narchive="true" />',
-      ),
-    ).toBe(
-      '<rule-suggestion name="Large  messages" archive="true"></rule-suggestion>',
-    );
-  });
-
-  it("does not normalize similarly prefixed tags", () => {
-    const content = "<email.foo />";
-
-    expect(normalizeAssistantTagMarkup(content)).toBe(content);
   });
 
   it("keeps escaped assistant tags inside inline code as code", () => {

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -9,7 +9,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AssistantInlineEmailResponse } from "@/components/assistant-chat/assistant-inline-email-response";
+import {
+  AssistantInlineEmailResponse,
+  normalizeAssistantTagMarkup,
+} from "@/components/assistant-chat/assistant-inline-email-response";
 import { getEmailUrlForMessage } from "@/utils/url";
 
 const mockUseAccount = vi.fn();
@@ -39,9 +42,13 @@ vi.mock("@/components/Tooltip", () => ({
 vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
+    loading: _loading,
+    Icon: _Icon,
     ...props
   }: {
     children?: ReactNode;
+    loading?: boolean;
+    Icon?: React.ComponentType;
   } & React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     createElement("button", { type: "button", ...props }, children || "button"),
 }));
@@ -123,27 +130,35 @@ describe("AssistantInlineEmailResponse", () => {
   });
 
   it("renders inline email detail views", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     mockRenderedThread();
 
-    render(
-      createElement(
-        AssistantInlineEmailResponse,
-        null,
-        '\n<email-detail threadid="thread-1">Focus on the action item.</email-detail>\n',
-      ),
-    );
+    try {
+      render(
+        createElement(
+          AssistantInlineEmailResponse,
+          null,
+          '\n<email-detail threadid="thread-1">Focus on the action item.</email-detail>\n',
+        ),
+      );
 
-    expect(screen.getByText("Subject")).toBeTruthy();
-    expect(screen.getByText("Focus on the action item.")).toBeTruthy();
-    expect(screen.getByText("Rendered detail body")).toBeTruthy();
-    expect(screen.getByRole("link").getAttribute("href")).toBe(
-      getEmailUrlForMessage(
-        "msg-thread-1",
-        "thread-1",
-        "user@example.com",
-        "google",
-      ),
-    );
+      expect(screen.getByText("Subject")).toBeTruthy();
+      expect(screen.getByText("Focus on the action item.")).toBeTruthy();
+      expect(screen.getByText("Rendered detail body")).toBeTruthy();
+      expect(screen.getByRole("link").getAttribute("href")).toBe(
+        getEmailUrlForMessage(
+          "msg-thread-1",
+          "thread-1",
+          "user@example.com",
+          "google",
+        ),
+      );
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("renders inline email detail views inside numbered lists", () => {
@@ -197,6 +212,7 @@ describe("AssistantInlineEmailResponse", () => {
     // Lookup succeeds only when the smart quotes are normalized away.
     expect(screen.getByText("Subject")).toBeTruthy();
     expect(screen.getByText("A receipt.")).toBeTruthy();
+    expect(mockUseThread).toHaveBeenCalledWith({ id: "thread-1" });
   });
 
   it("renders email detail tags with single smart-quoted attributes", () => {
@@ -211,6 +227,7 @@ describe("AssistantInlineEmailResponse", () => {
     );
 
     expect(screen.getByText("Subject")).toBeTruthy();
+    expect(mockUseThread).toHaveBeenCalledWith({ id: "thread-1" });
   });
 
   it("renders backslash-escaped email detail tags", () => {
@@ -226,6 +243,7 @@ describe("AssistantInlineEmailResponse", () => {
 
     expect(screen.getByText("Subject")).toBeTruthy();
     expect(container.textContent).not.toContain("<email-detail");
+    expect(container.textContent).not.toContain("</email-detail>");
   });
 
   it("renders entity-escaped email detail tags", () => {
@@ -241,6 +259,71 @@ describe("AssistantInlineEmailResponse", () => {
 
     expect(screen.getByText("Subject")).toBeTruthy();
     expect(container.textContent).not.toContain("<email-detail");
+  });
+
+  it.each([
+    [
+      "entity-escaped",
+      "&lt;rule-suggestion name=&quot;Large messages&quot; when=&quot;size &gt; 10MB&quot; archive=&quot;true&quot; /&gt;",
+    ],
+    [
+      "smart-quoted",
+      "<rule-suggestion name=“Large messages” when=“size > 10MB” archive=“true” />",
+    ],
+  ])("renders %s rule tags with greater-than signs in quoted attributes", (_format, content) => {
+    render(createElement(AssistantInlineEmailResponse, null, content));
+
+    expect(screen.getByText("Large messages")).toBeTruthy();
+    expect(screen.getByText("size > 10MB")).toBeTruthy();
+    expect(screen.getByText("Archive")).toBeTruthy();
+  });
+
+  it.each([
+    "&apos;",
+    "&#x27;",
+  ])("decodes %s delimiters in entity-escaped tag attributes", (quoteEntity) => {
+    mockRenderedThread();
+
+    render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        `&lt;email-detail threadid=${quoteEntity}thread-1${quoteEntity}&gt;A receipt.&lt;/email-detail&gt;`,
+      ),
+    );
+
+    expect(mockUseThread).toHaveBeenCalledWith({ id: "thread-1" });
+  });
+
+  it("preserves whitespace inside quoted rule attributes", () => {
+    expect(
+      normalizeAssistantTagMarkup(
+        '<rule-suggestion\nname="Large  messages"\narchive="true" />',
+      ),
+    ).toBe(
+      '<rule-suggestion name="Large  messages" archive="true"></rule-suggestion>',
+    );
+  });
+
+  it("does not normalize similarly prefixed tags", () => {
+    const content = "<email.foo />";
+
+    expect(normalizeAssistantTagMarkup(content)).toBe(content);
+  });
+
+  it("keeps escaped assistant tags inside inline code as code", () => {
+    const { container } = render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        '`\\<email-detail threadid="thread-1">A receipt.\\</email-detail>`',
+      ),
+    );
+
+    expect(container.querySelector("code")?.textContent).toBe(
+      '<email-detail threadid="thread-1">A receipt.</email-detail>',
+    );
+    expect(screen.queryByText("Subject")).toBeNull();
   });
 
   it("renders inline rule suggestions and can ask chat to create one", async () => {

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx
@@ -123,33 +123,7 @@ describe("AssistantInlineEmailResponse", () => {
   });
 
   it("renders inline email detail views", () => {
-    mockUseThread.mockReturnValue({
-      data: {
-        thread: {
-          id: "thread-1",
-          messages: [
-            {
-              id: "message-1",
-              threadId: "thread-1",
-              subject: "Rendered detail subject",
-              snippet: "Rendered detail snippet",
-              date: "2026-03-11T11:00:00.000Z",
-              historyId: "history-1",
-              inline: [],
-              headers: {
-                from: "Sender <sender@example.com>",
-                to: "user@example.com",
-                date: "2026-03-11T11:00:00.000Z",
-                subject: "Rendered detail subject",
-              },
-              textPlain: "Rendered detail body",
-            },
-          ],
-        },
-      },
-      isLoading: false,
-      error: null,
-    });
+    mockRenderedThread();
 
     render(
       createElement(
@@ -170,6 +144,103 @@ describe("AssistantInlineEmailResponse", () => {
         "google",
       ),
     );
+  });
+
+  it("renders inline email detail views inside numbered lists", () => {
+    mockRenderedThread();
+
+    const { container } = render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        [
+          "Apart from the booking confirmations, the most recent emails are:",
+          "",
+          '1. **water bill receipt** (May 13, 2026, 11:31 AM)\n   <email-detail threadid="thread-1">A receipt for a water bill.</email-detail>',
+        ].join("\n"),
+      ),
+    );
+
+    expect(screen.getByText("Subject")).toBeTruthy();
+    expect(screen.getByText("A receipt for a water bill.")).toBeTruthy();
+    expect(container.textContent).not.toContain("<email-detail");
+    expect(container.textContent).not.toContain("</email-detail>");
+  });
+
+  it("renders email detail tags that contain blank lines", () => {
+    mockRenderedThread();
+
+    const { container } = render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        '<email-detail\n\nthreadid="thread-1">A receipt.</email-detail>',
+      ),
+    );
+
+    expect(screen.getByText("Subject")).toBeTruthy();
+    expect(screen.getByText("A receipt.")).toBeTruthy();
+    expect(container.textContent).not.toContain("<email-detail");
+  });
+
+  it("renders email detail tags with smart-quoted attributes", () => {
+    mockRenderedThread();
+
+    render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        "<email-detail threadid=“thread-1”>A receipt.</email-detail>",
+      ),
+    );
+
+    // Lookup succeeds only when the smart quotes are normalized away.
+    expect(screen.getByText("Subject")).toBeTruthy();
+    expect(screen.getByText("A receipt.")).toBeTruthy();
+  });
+
+  it("renders email detail tags with single smart-quoted attributes", () => {
+    mockRenderedThread();
+
+    render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        "<email-detail threadid=‘thread-1’>A receipt.</email-detail>",
+      ),
+    );
+
+    expect(screen.getByText("Subject")).toBeTruthy();
+  });
+
+  it("renders backslash-escaped email detail tags", () => {
+    mockRenderedThread();
+
+    const { container } = render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        '\\<email-detail threadid="thread-1">A receipt.\\</email-detail>',
+      ),
+    );
+
+    expect(screen.getByText("Subject")).toBeTruthy();
+    expect(container.textContent).not.toContain("<email-detail");
+  });
+
+  it("renders entity-escaped email detail tags", () => {
+    mockRenderedThread();
+
+    const { container } = render(
+      createElement(
+        AssistantInlineEmailResponse,
+        null,
+        "&lt;email-detail threadid=&quot;thread-1&quot;&gt;A receipt.&lt;/email-detail&gt;",
+      ),
+    );
+
+    expect(screen.getByText("Subject")).toBeTruthy();
+    expect(container.textContent).not.toContain("<email-detail");
   });
 
   it("renders inline rule suggestions and can ask chat to create one", async () => {
@@ -289,5 +360,35 @@ function openMoreActions() {
   fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }), {
     button: 0,
     ctrlKey: false,
+  });
+}
+
+function mockRenderedThread() {
+  mockUseThread.mockReturnValue({
+    data: {
+      thread: {
+        id: "thread-1",
+        messages: [
+          {
+            id: "message-1",
+            threadId: "thread-1",
+            subject: "Rendered detail subject",
+            snippet: "Rendered detail snippet",
+            date: "2026-03-11T11:00:00.000Z",
+            historyId: "history-1",
+            inline: [],
+            headers: {
+              from: "Sender <sender@example.com>",
+              to: "user@example.com",
+              date: "2026-03-11T11:00:00.000Z",
+              subject: "Rendered detail subject",
+            },
+            textPlain: "Rendered detail body",
+          },
+        ],
+      },
+    },
+    isLoading: false,
+    error: null,
   });
 }

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -20,26 +20,14 @@ import {
   InlineRuleSuggestionCard,
   InlineRuleSuggestions,
 } from "@/components/assistant-chat/inline-rule-suggestion-card";
+import {
+  assistantAllowedTags,
+  normalizeAssistantTagMarkup,
+} from "@/components/assistant-chat/assistant-tag-normalization";
 
 type AssistantInlineEmailResponseProps = ComponentProps<typeof Streamdown>;
 
-const allowedTags = {
-  emails: [],
-  email: ["id", "threadid", "index"],
-  "email-detail": ["id", "threadid"],
-  "rule-suggestions": [],
-  "rule-suggestion": [
-    "name",
-    "when",
-    "do",
-    "label",
-    "archive",
-    "notify",
-    "draft",
-    "markread",
-  ],
-};
-const assistantBlockTagNames = new Set(Object.keys(allowedTags));
+const assistantBlockTagNames = new Set(Object.keys(assistantAllowedTags));
 const components = {
   p: AssistantParagraph,
   emails: InlineEmailList,
@@ -63,7 +51,7 @@ export const AssistantInlineEmailResponse = memo(
           "[&_a]:!text-inherit [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80",
           className,
         ),
-        allowedTags,
+        allowedTags: assistantAllowedTags,
         components,
         literalTagContent,
         normalizeHtmlIndentation: true,
@@ -76,65 +64,6 @@ export const AssistantInlineEmailResponse = memo(
 );
 
 AssistantInlineEmailResponse.displayName = "AssistantInlineEmailResponse";
-
-const tagAlternation = Object.keys(allowedTags).join("|");
-const encodedDoubleQuotePattern = "(?:&quot;|&#34;|&#x22;)";
-const encodedSingleQuotePattern = "(?:&apos;|&#39;|&#x27;)";
-const encodedQuotedValuePattern =
-  `(?:${encodedDoubleQuotePattern}(?:(?!${encodedDoubleQuotePattern})[\\s\\S])*${encodedDoubleQuotePattern}` +
-  `|${encodedSingleQuotePattern}(?:(?!${encodedSingleQuotePattern})[\\s\\S])*${encodedSingleQuotePattern})`;
-const quotedValuePattern = `(?:"[^"]*"|'[^']*'|[“”][^“”]*[“”]|[‘’][^‘’]*[‘’])`;
-const encodedUnquotedCharacterPattern = `(?!(?:&gt;|${encodedDoubleQuotePattern}|${encodedSingleQuotePattern}|["'“”‘’]))[\\s\\S]`;
-
-// Models sometimes escape the structured tags they were asked to emit, which
-// would otherwise surface raw markup text to the user.
-const entityEscapedTagPattern = new RegExp(
-  `&lt;(/?(?:${tagAlternation})(?=[\\s/>])(?:${encodedQuotedValuePattern}|${quotedValuePattern}|${encodedUnquotedCharacterPattern})*)&gt;`,
-  "gi",
-);
-const backslashEscapedTagPattern = new RegExp(
-  `\\\\(</?(?:${tagAlternation})(?=[\\s/>]))`,
-  "gi",
-);
-// Quote-aware so attribute values may contain ">".
-const assistantTagPattern = new RegExp(
-  `</?(?:${tagAlternation})(?=[\\s/>])(?:${quotedValuePattern}|[^>"'“”‘’])*>`,
-  "gi",
-);
-const smartDoubleQuotedAttributePattern = /=\s*[“”]([^“”]*)[“”]/g;
-const smartSingleQuotedAttributePattern = /=\s*[‘’]([^‘’]*)[‘’]/g;
-const tagWhitespacePattern = /("[^"]*"|'[^']*')|\s+/g;
-const selfClosingTagPattern = new RegExp(
-  `<(${tagAlternation})(?=[\\s/>])((?:${quotedValuePattern}|[^>"'“”‘’])*?)\\s*/>`,
-  "gi",
-);
-
-export function normalizeAssistantTagMarkup(content: string) {
-  return content
-    .replace(entityEscapedTagPattern, (_match, inner: string) =>
-      decodeTagEntities(`<${inner}>`),
-    )
-    .replace(backslashEscapedTagPattern, "$1")
-    .replace(assistantTagPattern, normalizeTag)
-    .replace(selfClosingTagPattern, "<$1$2></$1>");
-}
-
-function normalizeTag(tag: string) {
-  return tag
-    .replace(smartDoubleQuotedAttributePattern, '="$1"')
-    .replace(smartSingleQuotedAttributePattern, "='$1'")
-    .replace(
-      tagWhitespacePattern,
-      (_match, quotedAttribute: string | undefined) => quotedAttribute ?? " ",
-    );
-}
-
-function decodeTagEntities(tag: string) {
-  return tag
-    .replace(/&(?:quot|#34|#x22);/gi, '"')
-    .replace(/&(?:apos|#39|#x27);/gi, "'")
-    .replace(/&amp;/gi, "&");
-}
 
 function AssistantParagraph({
   children,

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -59,25 +59,65 @@ export const AssistantInlineEmailResponse = memo(
         normalizeHtmlIndentation: true,
         ...props,
       },
-      normalizeSelfClosingAllowedTags(children),
+      normalizeAssistantTags(children),
     ),
 );
 
 AssistantInlineEmailResponse.displayName = "AssistantInlineEmailResponse";
 
-const selfClosingAllowedTagPattern = new RegExp(
-  `<(${Object.keys(allowedTags).join("|")})(\\s(?:[^"'<>]|"[^"]*"|'[^']*')*)?\\s*/>`,
+const tagAlternation = Object.keys(allowedTags).join("|");
+
+// Models sometimes escape the structured tags they were asked to emit, which
+// would otherwise surface raw markup text to the user.
+const entityEscapedTagPattern = new RegExp(
+  `&lt;(/?(?:${tagAlternation})(?:(?!&[lg]t;)[^<>])*)&gt;`,
+  "gi",
+);
+const backslashEscapedTagPattern = new RegExp(
+  `\\\\(</?(?:${tagAlternation})(?=[\\s/>]))`,
+  "gi",
+);
+// Quote-aware so attribute values may contain ">".
+const assistantTagPattern = new RegExp(
+  `</?(?:${tagAlternation})(?=[\\s/>])(?:"[^"]*"|'[^']*'|[^>"'])*>`,
+  "gi",
+);
+const smartDoubleQuotedAttributePattern = /=\s*[“”]([^“”]*)[“”]/g;
+const smartSingleQuotedAttributePattern = /=\s*[‘’]([^‘’]*)[‘’]/g;
+const selfClosingTagPattern = new RegExp(
+  `<(${tagAlternation})(?![\\w-])((?:"[^"]*"|'[^']*'|[^>"'])*?)\\s*/>`,
   "gi",
 );
 
-function normalizeSelfClosingAllowedTags(
+/**
+ * Normalizes assistant structured tags so intermittent model formatting
+ * (escaped tags, blank lines inside tags, smart-quoted attributes,
+ * self-closing tags) still renders as cards instead of raw markup.
+ */
+function normalizeAssistantTags(
   children: AssistantInlineEmailResponseProps["children"],
 ) {
-  if (typeof children !== "string" || !children.includes("/>")) return children;
+  if (typeof children !== "string") return children;
 
-  return children.replace(
-    selfClosingAllowedTagPattern,
-    (_match, tagName: string, attributes = "") =>
-      `<${tagName}${attributes}></${tagName}>`,
-  );
+  return children
+    .replace(entityEscapedTagPattern, (_match, inner: string) =>
+      decodeTagEntities(`<${inner}>`),
+    )
+    .replace(backslashEscapedTagPattern, "$1")
+    .replace(assistantTagPattern, normalizeTag)
+    .replace(selfClosingTagPattern, "<$1$2></$1>");
+}
+
+function normalizeTag(tag: string) {
+  return tag
+    .replace(smartDoubleQuotedAttributePattern, '="$1"')
+    .replace(smartSingleQuotedAttributePattern, "='$1'")
+    .replace(/\s+/g, " ");
+}
+
+function decodeTagEntities(tag: string) {
+  return tag
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/gi, "&");
 }

--- a/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
+++ b/apps/web/components/assistant-chat/assistant-inline-email-response.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { cn } from "@/utils/index";
-import { createElement, memo, type ComponentProps } from "react";
+import {
+  Children,
+  createElement,
+  isValidElement,
+  memo,
+  type ComponentProps,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
 import { Streamdown } from "streamdown";
 import {
   InlineEmailCard,
@@ -31,7 +39,9 @@ const allowedTags = {
     "markread",
   ],
 };
+const assistantBlockTagNames = new Set(Object.keys(allowedTags));
 const components = {
+  p: AssistantParagraph,
   emails: InlineEmailList,
   email: InlineEmailCard,
   "email-detail": InlineEmailDetail,
@@ -59,18 +69,27 @@ export const AssistantInlineEmailResponse = memo(
         normalizeHtmlIndentation: true,
         ...props,
       },
-      normalizeAssistantTags(children),
+      typeof children === "string"
+        ? normalizeAssistantTagMarkup(children)
+        : children,
     ),
 );
 
 AssistantInlineEmailResponse.displayName = "AssistantInlineEmailResponse";
 
 const tagAlternation = Object.keys(allowedTags).join("|");
+const encodedDoubleQuotePattern = "(?:&quot;|&#34;|&#x22;)";
+const encodedSingleQuotePattern = "(?:&apos;|&#39;|&#x27;)";
+const encodedQuotedValuePattern =
+  `(?:${encodedDoubleQuotePattern}(?:(?!${encodedDoubleQuotePattern})[\\s\\S])*${encodedDoubleQuotePattern}` +
+  `|${encodedSingleQuotePattern}(?:(?!${encodedSingleQuotePattern})[\\s\\S])*${encodedSingleQuotePattern})`;
+const quotedValuePattern = `(?:"[^"]*"|'[^']*'|[“”][^“”]*[“”]|[‘’][^‘’]*[‘’])`;
+const encodedUnquotedCharacterPattern = `(?!(?:&gt;|${encodedDoubleQuotePattern}|${encodedSingleQuotePattern}|["'“”‘’]))[\\s\\S]`;
 
 // Models sometimes escape the structured tags they were asked to emit, which
 // would otherwise surface raw markup text to the user.
 const entityEscapedTagPattern = new RegExp(
-  `&lt;(/?(?:${tagAlternation})(?:(?!&[lg]t;)[^<>])*)&gt;`,
+  `&lt;(/?(?:${tagAlternation})(?=[\\s/>])(?:${encodedQuotedValuePattern}|${quotedValuePattern}|${encodedUnquotedCharacterPattern})*)&gt;`,
   "gi",
 );
 const backslashEscapedTagPattern = new RegExp(
@@ -79,27 +98,19 @@ const backslashEscapedTagPattern = new RegExp(
 );
 // Quote-aware so attribute values may contain ">".
 const assistantTagPattern = new RegExp(
-  `</?(?:${tagAlternation})(?=[\\s/>])(?:"[^"]*"|'[^']*'|[^>"'])*>`,
+  `</?(?:${tagAlternation})(?=[\\s/>])(?:${quotedValuePattern}|[^>"'“”‘’])*>`,
   "gi",
 );
 const smartDoubleQuotedAttributePattern = /=\s*[“”]([^“”]*)[“”]/g;
 const smartSingleQuotedAttributePattern = /=\s*[‘’]([^‘’]*)[‘’]/g;
+const tagWhitespacePattern = /("[^"]*"|'[^']*')|\s+/g;
 const selfClosingTagPattern = new RegExp(
-  `<(${tagAlternation})(?![\\w-])((?:"[^"]*"|'[^']*'|[^>"'])*?)\\s*/>`,
+  `<(${tagAlternation})(?=[\\s/>])((?:${quotedValuePattern}|[^>"'“”‘’])*?)\\s*/>`,
   "gi",
 );
 
-/**
- * Normalizes assistant structured tags so intermittent model formatting
- * (escaped tags, blank lines inside tags, smart-quoted attributes,
- * self-closing tags) still renders as cards instead of raw markup.
- */
-function normalizeAssistantTags(
-  children: AssistantInlineEmailResponseProps["children"],
-) {
-  if (typeof children !== "string") return children;
-
-  return children
+export function normalizeAssistantTagMarkup(content: string) {
+  return content
     .replace(entityEscapedTagPattern, (_match, inner: string) =>
       decodeTagEntities(`<${inner}>`),
     )
@@ -112,12 +123,52 @@ function normalizeTag(tag: string) {
   return tag
     .replace(smartDoubleQuotedAttributePattern, '="$1"')
     .replace(smartSingleQuotedAttributePattern, "='$1'")
-    .replace(/\s+/g, " ");
+    .replace(
+      tagWhitespacePattern,
+      (_match, quotedAttribute: string | undefined) => quotedAttribute ?? " ",
+    );
 }
 
 function decodeTagEntities(tag: string) {
   return tag
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/&(?:quot|#34|#x22);/gi, '"')
+    .replace(/&(?:apos|#39|#x27);/gi, "'")
     .replace(/&amp;/gi, "&");
+}
+
+function AssistantParagraph({
+  children,
+  node: _node,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement> & {
+  children?: ReactNode;
+  node?: unknown;
+}) {
+  const meaningfulChildren = Children.toArray(children).filter(
+    (child) => child !== "",
+  );
+
+  if (
+    meaningfulChildren.length === 1 &&
+    shouldUnwrapParagraphChild(meaningfulChildren[0])
+  ) {
+    return <>{children}</>;
+  }
+
+  return <p {...props}>{children}</p>;
+}
+
+function shouldUnwrapParagraphChild(child: ReactNode) {
+  if (!isValidElement(child)) return false;
+
+  const childProps = child.props as {
+    node?: { tagName?: string };
+    "data-block"?: string;
+  };
+  const tagName = childProps.node?.tagName?.toLowerCase();
+
+  if (tagName && assistantBlockTagNames.has(tagName)) return true;
+  if (tagName === "img") return true;
+
+  return tagName === "code" && "data-block" in childProps;
 }

--- a/apps/web/components/assistant-chat/assistant-tag-normalization.test.ts
+++ b/apps/web/components/assistant-chat/assistant-tag-normalization.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAssistantTagMarkup } from "@/components/assistant-chat/assistant-tag-normalization";
+
+describe("normalizeAssistantTagMarkup", () => {
+  it.each([
+    {
+      name: "whitespace between attributes",
+      input:
+        '<rule-suggestion\n\nname="Large messages"\r\narchive="true">Review</rule-suggestion>',
+      expected:
+        '<rule-suggestion name="Large messages" archive="true">Review</rule-suggestion>',
+    },
+    {
+      name: "smart double quotes containing a greater-than sign",
+      input:
+        "<rule-suggestion name=“Large messages” when=“size > 10MB”></rule-suggestion>",
+      expected:
+        '<rule-suggestion name="Large messages" when="size > 10MB"></rule-suggestion>',
+    },
+    {
+      name: "smart single quotes",
+      input: "<email-detail threadid=‘thread-1’>Receipt</email-detail>",
+      expected: "<email-detail threadid='thread-1'>Receipt</email-detail>",
+    },
+    {
+      name: "self-closing tags",
+      input: '<rule-suggestion name="Monitoring" archive="true" />',
+      expected:
+        '<rule-suggestion name="Monitoring" archive="true"></rule-suggestion>',
+    },
+    {
+      name: "uppercase allowed tag names",
+      input: "<EMAIL />",
+      expected: "<EMAIL></EMAIL>",
+    },
+  ])("normalizes $name", ({ input, expected }) => {
+    expect(normalizeAssistantTagMarkup(input)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: "bare container tags",
+      input: "&lt;emails&gt;&lt;/emails&gt;",
+      expected: "<emails></emails>",
+    },
+    {
+      name: "quoted greater-than entities",
+      input: "&lt;rule-suggestion when=&quot;size &gt; 10MB&quot; /&gt;",
+      expected: '<rule-suggestion when="size &gt; 10MB"></rule-suggestion>',
+    },
+    {
+      name: "uppercase entities",
+      input:
+        "&LT;email-detail threadid=&QUOT;thread-1&QUOT;&GT;Receipt&LT;/email-detail&GT;",
+      expected: '<email-detail threadid="thread-1">Receipt</email-detail>',
+    },
+    {
+      name: "smart punctuation inside an encoded quoted value",
+      input: "&lt;rule-suggestion when=&quot;Say “size &gt; 10MB”&quot; /&gt;",
+      expected:
+        '<rule-suggestion when="Say “size &gt; 10MB”"></rule-suggestion>',
+    },
+    {
+      name: "nested allowed tags",
+      input:
+        "&lt;emails&gt;&lt;email threadid=&quot;thread-1&quot;&gt;Receipt&lt;/email&gt;&lt;/emails&gt;",
+      expected: '<emails><email threadid="thread-1">Receipt</email></emails>',
+    },
+  ])("normalizes entity-escaped $name", ({ input, expected }) => {
+    expect(normalizeAssistantTagMarkup(input)).toBe(expected);
+  });
+
+  it.each([
+    "&apos;",
+    "&#39;",
+    "&#x27;",
+  ])("decodes the %s single-quote delimiter", (quote) => {
+    expect(
+      normalizeAssistantTagMarkup(
+        `&lt;email-detail threadid=${quote}thread-1${quote}&gt;Receipt&lt;/email-detail&gt;`,
+      ),
+    ).toBe("<email-detail threadid='thread-1'>Receipt</email-detail>");
+  });
+
+  it.each([
+    "&quot;",
+    "&#34;",
+    "&#x22;",
+  ])("decodes the %s double-quote delimiter", (quote) => {
+    expect(
+      normalizeAssistantTagMarkup(
+        `&lt;email-detail threadid=${quote}thread-1${quote}&gt;Receipt&lt;/email-detail&gt;`,
+      ),
+    ).toBe('<email-detail threadid="thread-1">Receipt</email-detail>');
+  });
+
+  it("removes one runtime backslash from opening and closing tags", () => {
+    const content = String.raw`\<email-detail threadid="thread-1">Receipt\</email-detail>`;
+
+    expect(normalizeAssistantTagMarkup(content)).toBe(
+      '<email-detail threadid="thread-1">Receipt</email-detail>',
+    );
+  });
+
+  it("preserves whitespace and smart punctuation inside quoted values", () => {
+    expect(
+      normalizeAssistantTagMarkup(
+        '<rule-suggestion name="Large  “priority”  messages" />',
+      ),
+    ).toBe(
+      '<rule-suggestion name="Large  “priority”  messages"></rule-suggestion>',
+    );
+  });
+
+  it.each([
+    "<email.foo />",
+    "<email-extra />",
+    "&lt;script&gt;alert(1)&lt;/script&gt;",
+    '<email threadid="unterminated>',
+    "&lt;email threadid=&quot;unterminated&gt;",
+  ])("leaves unsupported or malformed markup unchanged: %s", (content) => {
+    expect(normalizeAssistantTagMarkup(content)).toBe(content);
+  });
+});

--- a/apps/web/components/assistant-chat/assistant-tag-normalization.ts
+++ b/apps/web/components/assistant-chat/assistant-tag-normalization.ts
@@ -1,0 +1,152 @@
+export const assistantAllowedTags = {
+  emails: [],
+  email: ["id", "threadid", "index"],
+  "email-detail": ["id", "threadid"],
+  "rule-suggestions": [],
+  "rule-suggestion": [
+    "name",
+    "when",
+    "do",
+    "label",
+    "archive",
+    "notify",
+    "draft",
+    "markread",
+  ],
+};
+
+const tagNamesPattern = Object.keys(assistantAllowedTags).join("|");
+const quotedValuePattern = `(?:"[^"]*"|'[^']*'|[“”][^“”]*[“”]|[‘’][^‘’]*[‘’])`;
+const entityTagStartPattern = new RegExp(
+  `&lt;/?(?:${tagNamesPattern})(?=[\\s/]|&gt;)`,
+  "gi",
+);
+const backslashEscapedTagPattern = new RegExp(
+  `\\\\(</?(?:${tagNamesPattern})(?=[\\s/>]))`,
+  "gi",
+);
+const assistantTagPattern = new RegExp(
+  `</?(?:${tagNamesPattern})(?=[\\s/>])(?:${quotedValuePattern}|[^>"'“”‘’])*>`,
+  "gi",
+);
+const selfClosingTagPattern = new RegExp(
+  `<(${tagNamesPattern})(?=[\\s/>])((?:${quotedValuePattern}|[^>"'“”‘’])*?)\\s*/>`,
+  "gi",
+);
+const smartDoubleQuotedAttributePattern = /=\s*[“”]([^“”]*)[“”]/g;
+const smartSingleQuotedAttributePattern = /=\s*[‘’]([^‘’]*)[‘’]/g;
+const tagWhitespacePattern = /("[^"]*"|'[^']*')|\s+/g;
+const encodedDoubleQuotes = ["&quot;", "&#34;", "&#x22;"];
+const encodedSingleQuotes = ["&apos;", "&#39;", "&#x27;"];
+type QuoteKind =
+  | "ascii-double"
+  | "ascii-single"
+  | "smart-double"
+  | "smart-single"
+  | "encoded-double"
+  | "encoded-single";
+
+export function normalizeAssistantTagMarkup(content: string) {
+  return decodeEntityEscapedTags(content)
+    .replace(backslashEscapedTagPattern, "$1")
+    .replace(assistantTagPattern, normalizeTag)
+    .replace(selfClosingTagPattern, "<$1$2></$1>");
+}
+
+function decodeEntityEscapedTags(content: string) {
+  let normalized = "";
+  let copyFrom = 0;
+
+  for (const match of content.matchAll(entityTagStartPattern)) {
+    const start = match.index;
+    if (start < copyFrom) continue;
+
+    const closingStart = findEntityTagClosing(content, start + match[0].length);
+    if (closingStart === undefined) break;
+
+    normalized += content.slice(copyFrom, start);
+    normalized += decodeTagEntities(
+      `<${content.slice(start + "&lt;".length, closingStart)}>`,
+    );
+    copyFrom = closingStart + "&gt;".length;
+  }
+
+  if (copyFrom === 0) return content;
+
+  return normalized + content.slice(copyFrom);
+}
+
+function findEntityTagClosing(content: string, start: number) {
+  let quote: QuoteKind | undefined;
+  let cursor = start;
+
+  while (cursor < content.length) {
+    const quoteToken = getQuoteToken(content, cursor);
+    if (quoteToken) {
+      quote =
+        quote === quoteToken.kind ? undefined : (quote ?? quoteToken.kind);
+      cursor += quoteToken.length;
+      continue;
+    }
+
+    if (!quote && startsWithIgnoreCase(content, cursor, "&gt;")) {
+      return cursor;
+    }
+
+    cursor += 1;
+  }
+}
+
+function getQuoteToken(content: string, cursor: number) {
+  const character = content[cursor];
+  if (character === '"') {
+    return { kind: "ascii-double" as const, length: 1 };
+  }
+  if (character === "'") {
+    return { kind: "ascii-single" as const, length: 1 };
+  }
+  if (character === "“" || character === "”") {
+    return { kind: "smart-double" as const, length: 1 };
+  }
+  if (character === "‘" || character === "’") {
+    return { kind: "smart-single" as const, length: 1 };
+  }
+
+  const doubleQuote = encodedDoubleQuotes.find((value) =>
+    startsWithIgnoreCase(content, cursor, value),
+  );
+  if (doubleQuote) {
+    return { kind: "encoded-double" as const, length: doubleQuote.length };
+  }
+
+  const singleQuote = encodedSingleQuotes.find((value) =>
+    startsWithIgnoreCase(content, cursor, value),
+  );
+  if (singleQuote) {
+    return { kind: "encoded-single" as const, length: singleQuote.length };
+  }
+}
+
+function normalizeTag(tag: string) {
+  return tag
+    .replace(smartDoubleQuotedAttributePattern, '="$1"')
+    .replace(smartSingleQuotedAttributePattern, "='$1'")
+    .replace(
+      tagWhitespacePattern,
+      (_match, quotedAttribute: string | undefined) => quotedAttribute ?? " ",
+    );
+}
+
+function decodeTagEntities(tag: string) {
+  return tag
+    .replace(/&(?:quot|#34|#x22);/gi, '"')
+    .replace(/&(?:apos|#39|#x27);/gi, "'")
+    .replace(/&amp;/gi, "&");
+}
+
+function startsWithIgnoreCase(content: string, cursor: number, value: string) {
+  return (
+    content.slice(cursor, cursor + value.length).toLowerCase() ===
+    value.toLowerCase()
+  );
+}


### PR DESCRIPTION
## Summary

The AI chat intermittently rendered raw markup (e.g. `<email-detail threadid="...">...</email-detail>`) instead of formatted email cards. Streamdown 2.5.0 already fixed several of the originally reported triggers upstream (tags indented inside numbered lists, odd indentation, single line breaks inside tags), but four failure modes still leaked raw tags or broke rendering:

- **Blank line inside a tag** (`<email-detail\n\nthreadid=...>`) → raw tags shown
- **Backslash-escaped tags** (`\<email-detail ...>`) → raw tags shown
- **Entity-escaped tags** (`&lt;email-detail threadid=&quot;...&quot;&gt;`) → raw tags shown
- **Smart-quoted attributes** (`threadid=“thread-1”`) → card rendered, but the thread lookup failed so a generic card without subject/link appeared

This PR normalizes the assistant's structured tags before Streamdown parses them: unescapes entity- and backslash-escaped allowed tags, collapses whitespace runs (including blank lines/CRLF) inside tags, and converts smart-quote attribute delimiters to ASCII quotes. The pre-existing self-closing tag expansion is folded into the same normalization pipeline. Normalization is scoped strictly to the allowed assistant tag names (`emails`, `email`, `email-detail`, `rule-suggestions`, `rule-suggestion`), so ordinary prose and other HTML are untouched.

Supersedes #2667 (closed, conflicting): the indentation/list cases it targeted are now handled by Streamdown itself; this re-implements the remaining intent (smart quotes, line breaks in tags) against current main and adds coverage for the escape-based failure modes. The paragraph-unwrapping part of #2667 was dropped: with tags normalized onto a single line, Streamdown no longer nests the cards inside `<p>` in the covered cases.

Deliberately left out: tags wrapped in backtick inline code are still rendered as code, since converting explicit code spans would break the assistant intentionally quoting its markup syntax.

## Test plan

- Added failing tests first (TDD) reproducing each failure mode in `apps/web/components/assistant-chat/assistant-inline-email-response.test.tsx`, including a regression guard for `email-detail` tags indented inside numbered lists
- `pnpm exec vitest run components/assistant-chat/assistant-inline-email-response.test.tsx` — 13 passed
- `pnpm exec vitest run components/assistant-chat/` — 8 files, 35 tests passed
- `pnpm exec biome check` on changed files — clean

Fixes INB-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgrRWu4Z36ZMzQ2L4WzzPH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

