### PR TITLE
logging: Fix categorization schema failures and downgrade expected errors

### DIFF
--- a/apps/web/app/api/ai/analyze-sender-pattern/route.ts
+++ b/apps/web/app/api/ai/analyze-sender-pattern/route.ts
@@ -111,7 +111,7 @@ async function process({
     }
 
     if (threadsWithMessages.length === 0) {
-      logger.error("No threads found from this sender", {
+      logger.info("No threads found from this sender", {
         provider: account.provider,
       });
 

--- a/apps/web/app/api/user/categorize/senders/batch/handle-batch.ts
+++ b/apps/web/app/api/user/categorize/senders/batch/handle-batch.ts
@@ -20,7 +20,6 @@ export async function handleBatchRequest(
     await handleBatchInternal(request);
     return NextResponse.json({ ok: true });
   } catch (error) {
-    // SafeErrors are expected rejections (e.g. no AI access), not bugs
     if (error instanceof SafeError) {
       request.logger.warn("Handle batch request error", { error });
     } else {

--- a/apps/web/app/api/user/categorize/senders/batch/handle-batch.ts
+++ b/apps/web/app/api/user/categorize/senders/batch/handle-batch.ts
@@ -20,7 +20,12 @@ export async function handleBatchRequest(
     await handleBatchInternal(request);
     return NextResponse.json({ ok: true });
   } catch (error) {
-    request.logger.error("Handle batch request error", { error });
+    // SafeErrors are expected rejections (e.g. no AI access), not bugs
+    if (error instanceof SafeError) {
+      request.logger.warn("Handle batch request error", { error });
+    } else {
+      request.logger.error("Handle batch request error", { error });
+    }
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },

--- a/apps/web/utils/actions/safe-action.ts
+++ b/apps/web/utils/actions/safe-action.ts
@@ -186,9 +186,6 @@ export const actionClientUser = baseClient.use(
     if (!session?.user) {
       // expected when the session has expired or the user logged out
       ctx.logger.warn("Unauthorized", metadata);
-      captureException(new Error(`Unauthorized: ${metadata.name}`), {
-        extra: metadata,
-      });
       throw new SafeError("Unauthorized");
     }
 

--- a/apps/web/utils/actions/safe-action.ts
+++ b/apps/web/utils/actions/safe-action.ts
@@ -37,9 +37,8 @@ const baseClient = createSafeActionClient({
         userEmail: context?.userEmail,
         emailAccountId: context?.emailAccountId,
       });
-    // SafeError is the "expected, user-facing rejection" type: below we already
-    // return its message to the client and skip Sentry capture, so log it as a
-    // warning rather than an error
+    // SafeErrors are expected user-facing rejections (shown to the client,
+    // never sent to Sentry), so they log as warnings
     if (error instanceof SafeError) {
       logger.warn("Server action error:", {
         metadata,

--- a/apps/web/utils/actions/safe-action.ts
+++ b/apps/web/utils/actions/safe-action.ts
@@ -37,11 +37,22 @@ const baseClient = createSafeActionClient({
         userEmail: context?.userEmail,
         emailAccountId: context?.emailAccountId,
       });
-    logger.error("Server action error:", {
-      metadata,
-      bindArgsClientInputs,
-      error,
-    });
+    // SafeError is the "expected, user-facing rejection" type: below we already
+    // return its message to the client and skip Sentry capture, so log it as a
+    // warning rather than an error
+    if (error instanceof SafeError) {
+      logger.warn("Server action error:", {
+        metadata,
+        bindArgsClientInputs,
+        error,
+      });
+    } else {
+      logger.error("Server action error:", {
+        metadata,
+        bindArgsClientInputs,
+        error,
+      });
+    }
     after(async () => {
       await flushLoggerSafely(logger, {
         action: metadata?.name,
@@ -128,7 +139,8 @@ export const actionClient = baseClient
       },
     });
     if (!emailAccount || emailAccount?.account.userId !== userId) {
-      ctx.logger.error("Unauthorized", metadata);
+      // expected with stale client state (e.g. account removed or switched)
+      ctx.logger.warn("Unauthorized", metadata);
       throw new SafeError("Unauthorized");
     }
 
@@ -172,7 +184,8 @@ export const actionClientUser = baseClient.use(
     const session = await auth();
 
     if (!session?.user) {
-      ctx.logger.error("Unauthorized", metadata);
+      // expected when the session has expired or the user logged out
+      ctx.logger.warn("Unauthorized", metadata);
       captureException(new Error(`Unauthorized: ${metadata.name}`), {
         extra: metadata,
       });

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
@@ -13,7 +13,7 @@ export const UNKNOWN_CATEGORY = "Other";
 const categorizeSendersSchema = z.object({
   senders: z.array(
     z.object({
-      // nullish: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      // reasoning models often omit this; a missing rationale shouldn't fail categorization
       rationale: z.string().nullish().describe("Keep it short."),
       sender: z.string(),
       category: z.string(), // not using enum, because sometimes the ai creates new categories, which throws an error. we prefer to handle this ourselves

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
@@ -13,8 +13,8 @@ export const UNKNOWN_CATEGORY = "Other";
 const categorizeSendersSchema = z.object({
   senders: z.array(
     z.object({
-      // optional: reasoning models often skip it, and a missing rationale shouldn't fail categorization
-      rationale: z.string().optional().describe("Keep it short."),
+      // nullish: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      rationale: z.string().nullish().describe("Keep it short."),
       sender: z.string(),
       category: z.string(), // not using enum, because sometimes the ai creates new categories, which throws an error. we prefer to handle this ourselves
     }),

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
@@ -13,7 +13,8 @@ export const UNKNOWN_CATEGORY = "Other";
 const categorizeSendersSchema = z.object({
   senders: z.array(
     z.object({
-      rationale: z.string().describe("Keep it short."),
+      // optional: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      rationale: z.string().optional().describe("Keep it short."),
       sender: z.string(),
       category: z.string(), // not using enum, because sometimes the ai creates new categories, which throws an error. we prefer to handle this ourselves
     }),

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
@@ -63,10 +63,10 @@ ${formatCategoriesForPrompt(categories)}
     system,
     prompt,
     schema: z.object({
-      // optional: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      // nullish: reasoning models often skip it, and a missing rationale shouldn't fail categorization
       rationale: z
         .string()
-        .optional()
+        .nullish()
         .describe("Keep it short. 1-2 sentences max."),
       category: z.string(),
     }),

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
@@ -63,7 +63,11 @@ ${formatCategoriesForPrompt(categories)}
     system,
     prompt,
     schema: z.object({
-      rationale: z.string().describe("Keep it short. 1-2 sentences max."),
+      // optional: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      rationale: z
+        .string()
+        .optional()
+        .describe("Keep it short. 1-2 sentences max."),
       category: z.string(),
     }),
   });

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
@@ -63,7 +63,7 @@ ${formatCategoriesForPrompt(categories)}
     system,
     prompt,
     schema: z.object({
-      // nullish: reasoning models often skip it, and a missing rationale shouldn't fail categorization
+      // reasoning models often omit this; a missing rationale shouldn't fail categorization
       rationale: z
         .string()
         .nullish()

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -77,7 +77,11 @@ import {
 } from "@/utils/outlook/folders";
 import { extractSignatureFromHtml } from "@/utils/email/signature-extraction";
 import { moveMessagesForSenders } from "@/utils/outlook/batch";
-import { withOutlookRetry } from "@/utils/outlook/retry";
+import {
+  extractErrorInfo,
+  isRetryableError,
+  withOutlookRetry,
+} from "@/utils/outlook/retry";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
 
@@ -126,12 +130,18 @@ export class OutlookProvider implements EmailProvider {
         snippet: messages[0]?.snippet || "",
       };
     } catch (error) {
-      this.logger.error("getThread failed", {
+      const context = {
         threadId,
         error,
         // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
         errorCode: (error as any)?.code,
-      });
+      };
+      // provider throttling is expected under load and handled by rate-limit state upstream
+      if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
+        this.logger.warn("getThread failed", context);
+      } else {
+        this.logger.error("getThread failed", context);
+      }
       throw error;
     }
   }
@@ -780,11 +790,16 @@ export class OutlookProvider implements EmailProvider {
     } catch (error) {
       // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
       const err = error as any;
-      this.logger.error("getThreadMessages failed", {
+      const context = {
         threadId,
         error,
         errorCode: err?.code,
-      });
+      };
+      if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
+        this.logger.warn("getThreadMessages failed", context);
+      } else {
+        this.logger.error("getThreadMessages failed", context);
+      }
       throw error;
     }
   }

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -136,7 +136,6 @@ export class OutlookProvider implements EmailProvider {
         // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
         errorCode: (error as any)?.code,
       };
-      // provider throttling is expected under load and handled by rate-limit state upstream
       if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
         this.logger.warn("getThread failed", context);
       } else {

--- a/apps/web/utils/follow-up/process.ts
+++ b/apps/web/utils/follow-up/process.ts
@@ -15,7 +15,7 @@ import { parseFollowUpNotificationDeliveries } from "@/utils/follow-up/notificat
 import { ThreadTrackerType, SystemType } from "@/generated/prisma/enums";
 import type { EmailProvider, EmailLabel } from "@/utils/email/types";
 import type { Logger } from "@/utils/logger";
-import { captureException } from "@/utils/error";
+import { captureException, SafeError } from "@/utils/error";
 import {
   getProviderRateLimitDelayMs,
   withRateLimitRecording,
@@ -786,6 +786,13 @@ async function processLoadedFollowUpReminderAccount({
         },
       );
       return "rate-limited";
+    }
+
+    if (error instanceof SafeError && error.message === "No refresh token") {
+      logger.warn(
+        "Skipping follow-up reminders for account without refresh token",
+      );
+      return "error";
     }
 
     logger.error("Failed to process follow-up reminders for user", {

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -30,7 +30,6 @@ export async function getBatchWithRetry<TRaw, TParsed>({
   if (!accessToken) throw new Error("No access token");
 
   if (retryCount > 3) {
-    // hitting the retry cap means sustained provider rate limiting, not a bug
     logger.warn("Too many batch retries", { ids, retryCount });
     return [];
   }

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -30,7 +30,8 @@ export async function getBatchWithRetry<TRaw, TParsed>({
   if (!accessToken) throw new Error("No access token");
 
   if (retryCount > 3) {
-    logger.error("Too many batch retries", { ids, retryCount });
+    // hitting the retry cap means sustained provider rate limiting, not a bug
+    logger.warn("Too many batch retries", { ids, retryCount });
     return [];
   }
 

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -63,7 +63,8 @@ export const getGmailClientWithRefresh = async ({
   logger: Logger;
 }): Promise<gmail_v1.Gmail> => {
   if (!refreshToken) {
-    logger.error("No refresh token", { emailAccountId });
+    // expected for disconnected accounts; callers handle the SafeError
+    logger.warn("No refresh token", { emailAccountId });
     throw new SafeError("No refresh token");
   }
 

--- a/apps/web/utils/gmail/client.ts
+++ b/apps/web/utils/gmail/client.ts
@@ -63,7 +63,7 @@ export const getGmailClientWithRefresh = async ({
   logger: Logger;
 }): Promise<gmail_v1.Gmail> => {
   if (!refreshToken) {
-    // expected for disconnected accounts; callers handle the SafeError
+    // expected for disconnected accounts
     logger.warn("No refresh token", { emailAccountId });
     throw new SafeError("No refresh token");
   }

--- a/apps/web/utils/log-error-with-dedupe.ts
+++ b/apps/web/utils/log-error-with-dedupe.ts
@@ -15,6 +15,7 @@ type DedupeLogInput = {
   ttlSeconds?: number;
   summaryIntervalSeconds?: number;
   enabled?: boolean;
+  level?: "error" | "warn";
 };
 
 const DEFAULT_TTL_SECONDS = 5 * 60;
@@ -30,9 +31,13 @@ export async function logErrorWithDedupe({
   ttlSeconds = DEFAULT_TTL_SECONDS,
   summaryIntervalSeconds = DEFAULT_SUMMARY_INTERVAL_SECONDS,
   enabled = true,
+  level = "error",
 }: DedupeLogInput): Promise<void> {
+  const log =
+    level === "warn" ? logger.warn.bind(logger) : logger.error.bind(logger);
+
   if (!enabled) {
-    logger.error(message, { ...context, error });
+    log(message, { ...context, error });
     return;
   }
 
@@ -61,11 +66,11 @@ export async function logErrorWithDedupe({
   if (decision.type === "summary") {
     payload.suppressedCount = decision.suppressedCount;
     payload.lastError = getErrorMessage(error);
-    logger.error(message, payload);
+    log(message, payload);
     return;
   }
 
-  logger.error(message, {
+  log(message, {
     ...payload,
     error,
   });

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -153,12 +153,18 @@ async function moveMessagesInBatches({
             ? JSON.stringify(body)
             : undefined;
 
-      logger.error("Failed to move message via batch", {
+      const context = {
         action,
         messageId,
         status: response.status,
         error: errorMessage,
-      });
+      };
+      // 429s are provider throttling, expected during bulk operations
+      if (response.status === 429) {
+        logger.warn("Failed to move message via batch", context);
+      } else {
+        logger.error("Failed to move message via batch", context);
+      }
     },
   });
 

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -159,7 +159,6 @@ async function moveMessagesInBatches({
         status: response.status,
         error: errorMessage,
       };
-      // 429s are provider throttling, expected during bulk operations
       if (response.status === 429) {
         logger.warn("Failed to move message via batch", context);
       } else {

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -118,7 +118,8 @@ export const getOutlookClientWithRefresh = async ({
   logger: Logger;
 }): Promise<OutlookClient> => {
   if (!refreshToken) {
-    logger.error("No refresh token", { emailAccountId });
+    // expected for disconnected accounts; callers handle the SafeError
+    logger.warn("No refresh token", { emailAccountId });
     throw new SafeError("No refresh token");
   }
 

--- a/apps/web/utils/outlook/client.ts
+++ b/apps/web/utils/outlook/client.ts
@@ -118,7 +118,7 @@ export const getOutlookClientWithRefresh = async ({
   logger: Logger;
 }): Promise<OutlookClient> => {
   if (!refreshToken) {
-    // expected for disconnected accounts; callers handle the SafeError
+    // expected for disconnected accounts
     logger.warn("No refresh token", { emailAccountId });
     throw new SafeError("No refresh token");
   }

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -9,7 +9,11 @@ import {
   getCategoryMap,
   getFolderIds,
 } from "@/utils/outlook/message";
-import { withOutlookRetry } from "@/utils/outlook/retry";
+import {
+  extractErrorInfo,
+  isRetryableError,
+  withOutlookRetry,
+} from "@/utils/outlook/retry";
 import { resolveMicrosoftGraphNextLink } from "@/utils/outlook/page-token";
 
 export async function getThread(
@@ -40,13 +44,19 @@ export async function getThread(
     // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
     const err = error as any;
 
-    logger.error("getThread failed", {
+    const context = {
       threadId,
       filter,
       error: error instanceof Error ? error.message : err,
       errorCode: err?.code,
       errorStatusCode: err?.statusCode,
-    });
+    };
+    // provider throttling is expected under load and handled by rate-limit state upstream
+    if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
+      logger.warn("getThread failed", context);
+    } else {
+      logger.error("getThread failed", context);
+    }
     throw error;
   }
 }

--- a/apps/web/utils/outlook/thread.ts
+++ b/apps/web/utils/outlook/thread.ts
@@ -51,7 +51,6 @@ export async function getThread(
       errorCode: err?.code,
       errorStatusCode: err?.statusCode,
     };
-    // provider throttling is expected under load and handled by rate-limit state upstream
     if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
       logger.warn("getThread failed", context);
     } else {

--- a/apps/web/utils/webhook/validate-webhook-account.ts
+++ b/apps/web/utils/webhook/validate-webhook-account.ts
@@ -118,6 +118,8 @@ export async function getWebhookEmailAccount(
     await logErrorWithDedupe({
       logger,
       message: "Account not found",
+      // expected: providers keep sending webhooks for a while after an account is deleted
+      level: "warn",
       context: {
         hasSubscriptionIdLookup: "watchEmailsSubscriptionId" in where,
       },


### PR DESCRIPTION
Reduces production error-log noise by fixing the top recurring failure at its root and downgrading known-expected conditions from error to warn/info. No user-facing behavior changes; all conditions are still logged and still throw/propagate as before.

- Fix: make the `rationale` field optional in both categorize-sender schemas. Reasoning models often return only `category`, which failed Zod validation and aborted categorization (the largest error cluster in production logs). The field is not consumed by any caller.
- Downgrade "No refresh token" to warn in the Gmail/Outlook client factories (expected for disconnected accounts; the SafeError still propagates and callers handle it).
- Follow-up reminders: log a warn instead of error + Sentry capture when processing is skipped due to a missing refresh token.
- Webhook "Account not found": add a `level` option to `logErrorWithDedupe` and log as warn (providers keep sending webhooks for a while after an account is deleted).
- Downgrade provider throttling (429) paths to warn: Outlook getThread/getThreadMessages/batch move and Gmail batch retry cap. Non-throttling failures remain error-level.
- Server actions: log SafeErrors as warn (they are expected user-facing rejections and already skip Sentry capture); unauthorized checks log warn. Unknown errors remain error + Sentry.
- "No threads found from this sender" in sender-pattern analysis: error → info (routine empty-result state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

