### PR TITLE
fix: Accept comma-separated Gmail scopes

### DIFF
--- a/apps/web/utils/gmail/permissions.test.ts
+++ b/apps/web/utils/gmail/permissions.test.ts
@@ -46,6 +46,24 @@ describe("handleGmailPermissionsCheck", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("accepts comma-separated stored scopes in Google OAuth emulation", async () => {
+    const oauth = await import("@/utils/google/oauth");
+    vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(true);
+
+    const result = await handleGmailPermissionsCheck({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      emailAccountId: "email-account-1",
+      grantedScope: SCOPES.join(","),
+    });
+
+    expect(result).toEqual({
+      hasAllPermissions: true,
+      missingScopes: [],
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("reports missing scopes from stored granted scopes in emulation", async () => {
     const oauth = await import("@/utils/google/oauth");
     vi.mocked(oauth.isGoogleOauthEmulationEnabled).mockReturnValue(true);

--- a/apps/web/utils/gmail/permissions.ts
+++ b/apps/web/utils/gmail/permissions.ts
@@ -47,7 +47,7 @@ async function checkGmailPermissions({
       };
     }
 
-    const grantedScopes = grantedScope.split(" ").filter(Boolean);
+    const grantedScopes = grantedScope.split(/[,\s]+/).filter(Boolean);
     const missingScopes = SCOPES.filter(
       (scope) => !grantedScopes.includes(scope),
     );


### PR DESCRIPTION
Normalizes stored Gmail OAuth scopes with comma or whitespace delimiters before checking required scopes. This prevents valid emulated Google sessions from being redirected to the permissions consent page.

- Supports comma-separated scope strings in Gmail permission checks
- Adds a regression test for Google OAuth emulation scope parsing

QA:
- pnpm --filter inbox-zero-ai test utils/gmail/permissions.test.ts -- --run
- Reran the failed Assistant writing-style browser flow after restart

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

