### PR TITLE
email: Fix crash on missing headers and recreate deleted Outlook categories

### DIFF
--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -631,6 +631,65 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
   });
 });
 
+describe("OutlookProvider.labelMessage", () => {
+  it("recreates a deleted category by name and applies it", async () => {
+    vi.spyOn(outlookLabelModule, "getLabels").mockResolvedValue([]);
+    vi.spyOn(outlookLabelModule, "getLabel").mockResolvedValue(null);
+    const createLabelSpy = vi
+      .spyOn(outlookLabelModule, "createLabel")
+      .mockResolvedValue({ id: "new-category-id", displayName: "To Reply" });
+    const labelMessageSpy = vi
+      .spyOn(outlookLabelModule, "labelMessage")
+      .mockResolvedValue(undefined);
+
+    const provider = new OutlookProvider(
+      createMockOutlookClient([], {
+        responsesByApiPath: {
+          "/me/messages/message-1": () => ({ categories: [] }),
+        } as any,
+      }),
+    );
+
+    const result = await provider.labelMessage({
+      messageId: "message-1",
+      labelId: "deleted-category-id",
+      labelName: "To Reply",
+    });
+
+    expect(createLabelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "To Reply" }),
+    );
+    expect(labelMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "message-1",
+        categories: ["To Reply"],
+      }),
+    );
+    expect(result).toEqual({
+      usedFallback: true,
+      actualLabelId: "new-category-id",
+    });
+  });
+
+  it("skips the label action when the category is gone and no name is available", async () => {
+    vi.spyOn(outlookLabelModule, "getLabels").mockResolvedValue([]);
+    const createLabelSpy = vi.spyOn(outlookLabelModule, "createLabel");
+    const labelMessageSpy = vi.spyOn(outlookLabelModule, "labelMessage");
+
+    const provider = new OutlookProvider(createMockOutlookClient([]));
+
+    const result = await provider.labelMessage({
+      messageId: "message-1",
+      labelId: "deleted-category-id",
+      labelName: null,
+    });
+
+    expect(createLabelSpy).not.toHaveBeenCalled();
+    expect(labelMessageSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+});
+
 describe("OutlookProvider.getThreadsWithParticipant", () => {
   it("filters broad search results to exact participant matches", async () => {
     const participantEmail = "participant@example.com";

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -82,7 +82,6 @@ import {
   isRetryableError,
   withOutlookRetry,
 } from "@/utils/outlook/retry";
-import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
 
 export class OutlookProvider implements EmailProvider {
@@ -464,7 +463,7 @@ export class OutlookProvider implements EmailProvider {
     labelId: string;
     labelName: string | null;
   }): Promise<{ usedFallback?: boolean; actualLabelId?: string }> {
-    const { category, usedFallback } = await this.resolveCategoryWithFallback(
+    let { category, usedFallback } = await this.resolveCategoryWithFallback(
       labelId,
       labelName,
     );
@@ -477,22 +476,13 @@ export class OutlookProvider implements EmailProvider {
         );
         return {};
       }
-      await logErrorWithDedupe({
-        logger: this.logger,
-        message: "Category not found",
-        error: new Error("Category not found while labeling message"),
-        context: { labelId },
-        dedupeKeyParts: {
-          scope: "email/microsoft",
-          operation: "label-message-category-lookup",
-          labelId,
-        },
-        ttlSeconds: 15 * 60,
-        summaryIntervalSeconds: 5 * 60,
+      // mirror Gmail: recreate the deleted category by name and continue
+      this.logger.warn("Category was deleted, recreating by name", {
+        labelId,
+        labelName,
       });
-      throw new Error(
-        `Category with ID ${labelId}${labelName ? ` or name ${labelName}` : ""} not found`,
-      );
+      category = await this.createLabel(labelName);
+      usedFallback = true;
     }
 
     // Get current message categories to avoid replacing them

--- a/apps/web/utils/string.ts
+++ b/apps/web/utils/string.ts
@@ -1,6 +1,8 @@
 import he from "he";
 
-export function escapeHtml(text: string): string {
+// accepts nullish because provider messages can lack headers (drafts, calendar invites)
+export function escapeHtml(text: string | null | undefined): string {
+  if (!text) return "";
   return he.escape(text);
 }
 

--- a/apps/web/utils/string.ts
+++ b/apps/web/utils/string.ts
@@ -1,6 +1,5 @@
 import he from "he";
 
-// accepts nullish because provider messages can lack headers (drafts, calendar invites)
 export function escapeHtml(text: string | null | undefined): string {
   if (!text) return "";
   return he.escape(text);

--- a/apps/web/utils/stringify-email.test.ts
+++ b/apps/web/utils/stringify-email.test.ts
@@ -49,6 +49,28 @@ describe("stringifyEmail", () => {
     );
   });
 
+  it("handles messages without from or subject headers", () => {
+    // real provider messages can lack these headers (drafts, calendar invites)
+    const email = {
+      id: "1",
+      to: "to@example.com",
+      content: "Hello world",
+    } as EmailForLLM;
+
+    expect(stringifyEmail(email, 1000)).toBe(
+      "<from></from>\n" +
+        "<to>to@example.com</to>\n" +
+        "<subject></subject>\n" +
+        "<body>Hello world</body>",
+    );
+    expect(stringifyEmailSimple(email)).toBe(
+      "<from></from>\n<subject></subject>\n<body>Hello world</body>",
+    );
+    expect(stringifyEmailFromBody(email)).toBe(
+      "<from></from>\n<body>Hello world</body>",
+    );
+  });
+
   it("should omit optional fields when not provided", () => {
     const minimalEmail: EmailForLLM = {
       id: "1",


### PR DESCRIPTION
Fixes two recurring production errors found in log analysis.

- `escapeHtml` now tolerates nullish input. Provider messages can lack `from`/`subject` headers (drafts, calendar invites, some sent items), which crashed `stringifyEmail` with `Cannot read properties of undefined (reading 'replace')` and aborted the whole AI operation for that email (~75/week across webhook reply handling, runRules, and persona analysis).
- Outlook `labelMessage` now recreates a deleted category by name and continues, mirroring the existing Gmail fallback (`getOrCreateLabel`). Previously it threw, so any Outlook user who deleted a category their rules reference had permanently failing rule executions (~31/week).

Both fixes are covered by new unit tests (written failing first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

