### PR TITLE
Fix package dependency resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,8 @@ overrides:
   vite: 7.3.6
   webpack: 5.106.2
 
+packageExtensionsChecksum: sha256-m/XXBrCDeU981EvNI2KoDcWBzdw6AArS5CoqlTGz8CU=
+
 importers:
 
   .:
@@ -24617,6 +24619,7 @@ snapshots:
   tiptap-markdown@0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.26.1)):
     dependencies:
       '@tiptap/core': 2.27.2(@tiptap/pm@2.26.1)
+      '@tiptap/pm': 2.26.1
       '@types/markdown-it': 13.0.9
       markdown-it: 14.1.1
       markdown-it-task-lists: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,11 @@ overrides:
   vite: "7.3.6"
   webpack: "5.106.2"
 
+packageExtensions:
+  tiptap-markdown:
+    dependencies:
+      "@tiptap/pm": "2.26.1"
+
 # Only reviewed dependencies may run install scripts.
 allowBuilds:
   "@google/genai": true


### PR DESCRIPTION
Fixes package metadata so a bundled editor dependency can resolve its required peer package during app bundling.

- Adds a pnpm package extension for the missing dependency edge
- Regenerates the lockfile so fresh installs produce the correct graph

Verification:
- Confirmed the nested package can resolve the required module
- Confirmed the editor package import succeeds

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

