### PR TITLE
build: Fix marketing build compatibility

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -245,7 +245,7 @@
   },
   "optionalDependencies": {
     "@sanity/client": "7.23.0",
-    "@sanity/icons": "5.0.0",
+    "@sanity/icons": "3.7.4",
     "@sanity/image-url": "2",
     "@sanity/vision": "6",
     "next-sanity": "13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,8 +721,8 @@ importers:
         specifier: 7.23.0
         version: 7.23.0
       '@sanity/icons':
-        specifier: 5.0.0
-        version: 5.0.0(react@19.2.7)
+        specifier: 3.7.4
+        version: 3.7.4(react@19.2.7)
       '@sanity/image-url':
         specifier: '2'
         version: 2.1.1
@@ -5163,12 +5163,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
-
-  '@sanity/icons@5.0.0':
-    resolution: {integrity: sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==}
-    engines: {node: '>=22.12'}
-    peerDependencies:
-      react: ^19
 
   '@sanity/id-utils@1.0.0':
     resolution: {integrity: sha512-2sb7tbdMDuUuVyocJPKG0gZBiOML/ovCe+mJiLrv1j69ODOfa2LfUjDVR+dRw/A/+XuxoJSSP8ebG7NiwTOgIA==}
@@ -16836,11 +16830,6 @@ snapshots:
   '@sanity/icons@3.7.4(react@19.2.7)':
     dependencies:
       react: 19.2.7
-
-  '@sanity/icons@5.0.0(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optional: true
 
   '@sanity/id-utils@1.0.0':
     dependencies:


### PR DESCRIPTION
Pins a compatible Sanity icon package version and updates the marketing pointer to the build type fix. This keeps the production build compatible with the cloned marketing routes.\n\nValidation: forced web production build passed with marketing cloned.\n\nPerformance impact: no runtime code path changes in the app, no added database work, and no added network calls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

