### PR TITLE
Add notification when email watch lapses so users can reconnect

### DIFF
--- a/apps/web/app/api/watch/all/route.ts
+++ b/apps/web/app/api/watch/all/route.ts
@@ -4,6 +4,7 @@ import { withError } from "@/utils/middleware";
 import { captureException } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import { ensureEmailAccountsWatched } from "@/utils/email/watch-manager";
+import { notifyLapsedWatches } from "@/utils/email/notify-lapsed-watches";
 
 export const maxDuration = 800;
 
@@ -28,6 +29,16 @@ export const POST = withError("watch/all", async (request) => {
 async function watchAllEmails(logger: Logger) {
   try {
     const results = await ensureEmailAccountsWatched({ userIds: null, logger });
+
+    // Runs after the renewal pass so only watches still failing renewal count
+    // as lapsed.
+    try {
+      await notifyLapsedWatches({ logger });
+    } catch (error) {
+      logger.error("Failed to notify lapsed watches", { error });
+      captureException(error);
+    }
+
     return NextResponse.json({ success: true, results });
   } catch (error) {
     logger.error("Failed to watch all emails", { error });

--- a/apps/web/utils/email/notify-lapsed-watches.test.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.test.ts
@@ -124,4 +124,42 @@ describe("notifyLapsedWatches", () => {
       expect.objectContaining({ emailAccountId: "email-account-1" }),
     );
   });
+
+  it("queries oldest-expired-first and requests one extra row to detect truncation", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([]);
+
+    await notifyLapsedWatches({ logger });
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { watchEmailsExpirationDate: "asc" },
+        take: 501,
+      }),
+    );
+  });
+
+  it("processes all 500 accounts when the match count exactly equals the cap", async () => {
+    const exactlyCapped = Array.from({ length: 500 }, (_, i) =>
+      getLapsedEmailAccount({ id: `email-account-${i}`, userId: `user-${i}` }),
+    );
+    prisma.emailAccount.findMany.mockResolvedValue(exactlyCapped as any);
+
+    const result = await notifyLapsedWatches({ logger });
+
+    expect(result).toEqual({ notified: 500 });
+  });
+
+  it("drops the extra row fetched to detect truncation instead of processing it", async () => {
+    const overCapped = Array.from({ length: 501 }, (_, i) =>
+      getLapsedEmailAccount({ id: `email-account-${i}`, userId: `user-${i}` }),
+    );
+    prisma.emailAccount.findMany.mockResolvedValue(overCapped as any);
+
+    const result = await notifyLapsedWatches({ logger });
+
+    expect(result).toEqual({ notified: 500 });
+    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ emailAccountId: "email-account-500" }),
+    );
+  });
 });

--- a/apps/web/utils/email/notify-lapsed-watches.test.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.test.ts
@@ -19,6 +19,8 @@ vi.mock("@/utils/premium", () => ({
 vi.mock("@/utils/error-messages", () => ({
   ErrorType: { EMAIL_WATCH_LAPSED: "Email automation stopped" },
   addUserErrorMessageWithNotification: vi.fn(),
+  watchLapsedErrorKey: (emailAccountId: string) =>
+    `Email automation stopped:${emailAccountId}`,
 }));
 
 const logger = createTestLogger();
@@ -90,6 +92,7 @@ describe("notifyLapsedWatches", () => {
         userEmail: "user@example.com",
         emailAccountId: "email-account-1",
         errorType: "Email automation stopped",
+        storageKey: "Email automation stopped:email-account-1",
       }),
     );
     expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
@@ -97,6 +100,7 @@ describe("notifyLapsedWatches", () => {
         userId: "user-2",
         userEmail: "other@example.com",
         emailAccountId: "email-account-2",
+        storageKey: "Email automation stopped:email-account-2",
       }),
     );
   });

--- a/apps/web/utils/email/notify-lapsed-watches.test.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { createTestLogger } from "@/__tests__/helpers";
+import { hasAiAccess } from "@/utils/premium";
+import { addUserErrorMessageWithNotification } from "@/utils/error-messages";
+import { notifyLapsedWatches } from "./notify-lapsed-watches";
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/premium", () => ({
+  getPremiumUserFilter: vi.fn(() => ({
+    user: { premium: { tier: { not: null } } },
+  })),
+  getUserTier: vi.fn(() => "STARTER_MONTHLY"),
+  hasAiAccess: vi.fn(() => true),
+  premiumEntitlementSelect: {},
+}));
+
+vi.mock("@/utils/error-messages", () => ({
+  ErrorType: { EMAIL_WATCH_LAPSED: "Email automation stopped" },
+  addUserErrorMessageWithNotification: vi.fn(),
+}));
+
+const logger = createTestLogger();
+
+const NOW = new Date("2026-07-07T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function getLapsedEmailAccount(overrides?: {
+  id?: string;
+  email?: string;
+  userId?: string;
+}) {
+  return {
+    id: "email-account-1",
+    email: "user@example.com",
+    userId: "user-1",
+    user: { aiApiKey: null, premium: {} },
+    ...overrides,
+  };
+}
+
+describe("notifyLapsedWatches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ now: NOW });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("only targets connected premium accounts that lapsed between 1 and 7 days ago", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([]);
+
+    await notifyLapsedWatches({ logger });
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          user: { premium: { tier: { not: null } } },
+          account: { disconnectedAt: null },
+          watchEmailsExpirationDate: {
+            gte: new Date(NOW.getTime() - 7 * DAY_MS),
+            lt: new Date(NOW.getTime() - DAY_MS),
+          },
+        }),
+      }),
+    );
+    expect(addUserErrorMessageWithNotification).not.toHaveBeenCalled();
+  });
+
+  it("notifies each recently lapsed account", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      getLapsedEmailAccount(),
+      getLapsedEmailAccount({
+        id: "email-account-2",
+        email: "other@example.com",
+        userId: "user-2",
+      }),
+    ] as any);
+
+    const result = await notifyLapsedWatches({ logger });
+
+    expect(result).toEqual({ notified: 2 });
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledTimes(2);
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        userEmail: "user@example.com",
+        emailAccountId: "email-account-1",
+        errorType: "Email automation stopped",
+      }),
+    );
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-2",
+        userEmail: "other@example.com",
+        emailAccountId: "email-account-2",
+      }),
+    );
+  });
+
+  it("skips accounts without AI access", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      getLapsedEmailAccount(),
+      getLapsedEmailAccount({
+        id: "email-account-2",
+        email: "no-ai@example.com",
+        userId: "user-2",
+      }),
+    ] as any);
+    vi.mocked(hasAiAccess).mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const result = await notifyLapsedWatches({ logger });
+
+    expect(result).toEqual({ notified: 1 });
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledTimes(1);
+    expect(addUserErrorMessageWithNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ emailAccountId: "email-account-1" }),
+    );
+  });
+});

--- a/apps/web/utils/email/notify-lapsed-watches.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.ts
@@ -9,6 +9,7 @@ import {
 import {
   addUserErrorMessageWithNotification,
   ErrorType,
+  watchLapsedErrorKey,
 } from "@/utils/error-messages";
 
 // Grace period so a few missed or failed cron runs don't trigger a notification.
@@ -16,15 +17,22 @@ const MIN_LAPSE_MS = 24 * 60 * 60 * 1000;
 // Only notify recent lapses. This is not a backfill: accounts that lapsed long
 // ago must never receive this email.
 const MAX_LAPSE_MS = 7 * 24 * 60 * 60 * 1000;
+// Safety cap so a large backlog can't blow up a single cron run.
+const MAX_ACCOUNTS_PER_RUN = 500;
+// Notifications hit the DB and an email API, so process them in small
+// concurrent batches rather than unboundedly or fully serially.
+const NOTIFY_CONCURRENCY = 10;
 
 /**
  * State-based detection of email accounts whose watch/subscription silently
  * stopped renewing. Runs after the watch renewal pass, so anything still
  * expired here has been failing renewal despite the cron.
  *
- * Notification is once per lapse: `addUserErrorMessageWithNotification`
- * only emails while no `emailSentAt` is recorded for the error type, and the
- * error is cleared when a lapsed watch is successfully re-established.
+ * Notification is once per lapse, per account: `addUserErrorMessageWithNotification`
+ * only emails while no `emailSentAt` is recorded for that account's entry,
+ * and it's a no-op write once an account has already been notified with the
+ * same message. The error is cleared when that specific account's watch is
+ * successfully re-established.
  */
 export async function notifyLapsedWatches({ logger }: { logger: Logger }) {
   const emailAccounts = await getRecentlyLapsedEmailAccounts();
@@ -33,34 +41,49 @@ export async function notifyLapsedWatches({ logger }: { logger: Logger }) {
 
   logger.info("Found recently lapsed watch accounts", {
     count: emailAccounts.length,
+    truncated: emailAccounts.length === MAX_ACCOUNTS_PER_RUN,
   });
 
   let notified = 0;
 
-  for (const emailAccount of emailAccounts) {
-    const { user } = emailAccount;
-
-    const userHasAiAccess = hasAiAccess(
-      getUserTier(user.premium),
-      !!user.aiApiKey,
+  for (let i = 0; i < emailAccounts.length; i += NOTIFY_CONCURRENCY) {
+    const batch = emailAccounts.slice(i, i + NOTIFY_CONCURRENCY);
+    const results = await Promise.all(
+      batch.map((emailAccount) => notifyIfEligible(emailAccount, logger)),
     );
-    if (!userHasAiAccess) continue;
-
-    await addUserErrorMessageWithNotification({
-      userId: emailAccount.userId,
-      userEmail: emailAccount.email,
-      emailAccountId: emailAccount.id,
-      errorType: ErrorType.EMAIL_WATCH_LAPSED,
-      errorMessage: `Email automation for ${emailAccount.email} has stopped. Please reconnect your account to resume automation.`,
-      logger: logger.with({ emailAccountId: emailAccount.id }),
-    });
-
-    notified++;
+    notified += results.filter(Boolean).length;
   }
 
   logger.info("Processed lapsed watch notifications", { notified });
 
   return { notified };
+}
+
+async function notifyIfEligible(
+  emailAccount: Awaited<
+    ReturnType<typeof getRecentlyLapsedEmailAccounts>
+  >[number],
+  logger: Logger,
+): Promise<boolean> {
+  const { user } = emailAccount;
+
+  const userHasAiAccess = hasAiAccess(
+    getUserTier(user.premium),
+    !!user.aiApiKey,
+  );
+  if (!userHasAiAccess) return false;
+
+  await addUserErrorMessageWithNotification({
+    userId: emailAccount.userId,
+    userEmail: emailAccount.email,
+    emailAccountId: emailAccount.id,
+    errorType: ErrorType.EMAIL_WATCH_LAPSED,
+    storageKey: watchLapsedErrorKey(emailAccount.id),
+    errorMessage: `Email automation for ${emailAccount.email} has stopped. Please reconnect your account to resume automation.`,
+    logger: logger.with({ emailAccountId: emailAccount.id }),
+  });
+
+  return true;
 }
 
 async function getRecentlyLapsedEmailAccounts() {
@@ -86,5 +109,6 @@ async function getRecentlyLapsedEmailAccounts() {
         },
       },
     },
+    take: MAX_ACCOUNTS_PER_RUN,
   });
 }

--- a/apps/web/utils/email/notify-lapsed-watches.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.ts
@@ -20,13 +20,18 @@ const MAX_ACCOUNTS_PER_RUN = 500;
 const NOTIFY_CONCURRENCY = 10;
 
 export async function notifyLapsedWatches({ logger }: { logger: Logger }) {
-  const emailAccounts = await getRecentlyLapsedEmailAccounts();
+  const fetched = await getRecentlyLapsedEmailAccounts();
 
-  if (!emailAccounts.length) return { notified: 0 };
+  if (!fetched.length) return { notified: 0 };
+
+  const truncated = fetched.length > MAX_ACCOUNTS_PER_RUN;
+  const emailAccounts = truncated
+    ? fetched.slice(0, MAX_ACCOUNTS_PER_RUN)
+    : fetched;
 
   logger.info("Found recently lapsed watch accounts", {
     count: emailAccounts.length,
-    truncated: emailAccounts.length === MAX_ACCOUNTS_PER_RUN,
+    truncated,
   });
 
   let notified = 0;
@@ -94,6 +99,9 @@ async function getRecentlyLapsedEmailAccounts() {
         },
       },
     },
-    take: MAX_ACCOUNTS_PER_RUN,
+    // Oldest expirations first, so a batch capped below the true match count
+    // still notifies the accounts closest to aging out of the window.
+    orderBy: { watchEmailsExpirationDate: "asc" },
+    take: MAX_ACCOUNTS_PER_RUN + 1,
   });
 }

--- a/apps/web/utils/email/notify-lapsed-watches.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.ts
@@ -12,28 +12,13 @@ import {
   watchLapsedErrorKey,
 } from "@/utils/error-messages";
 
-// Grace period so a few missed or failed cron runs don't trigger a notification.
+// A few missed or failed cron runs shouldn't trigger a notification.
 const MIN_LAPSE_MS = 24 * 60 * 60 * 1000;
-// Only notify recent lapses. This is not a backfill: accounts that lapsed long
-// ago must never receive this email.
+// Not a backfill: accounts that lapsed long ago must never receive this email.
 const MAX_LAPSE_MS = 7 * 24 * 60 * 60 * 1000;
-// Safety cap so a large backlog can't blow up a single cron run.
 const MAX_ACCOUNTS_PER_RUN = 500;
-// Notifications hit the DB and an email API, so process them in small
-// concurrent batches rather than unboundedly or fully serially.
 const NOTIFY_CONCURRENCY = 10;
 
-/**
- * State-based detection of email accounts whose watch/subscription silently
- * stopped renewing. Runs after the watch renewal pass, so anything still
- * expired here has been failing renewal despite the cron.
- *
- * Notification is once per lapse, per account: `addUserErrorMessageWithNotification`
- * only emails while no `emailSentAt` is recorded for that account's entry,
- * and it's a no-op write once an account has already been notified with the
- * same message. The error is cleared when that specific account's watch is
- * successfully re-established.
- */
 export async function notifyLapsedWatches({ logger }: { logger: Logger }) {
   const emailAccounts = await getRecentlyLapsedEmailAccounts();
 

--- a/apps/web/utils/email/notify-lapsed-watches.ts
+++ b/apps/web/utils/email/notify-lapsed-watches.ts
@@ -1,0 +1,90 @@
+import prisma from "@/utils/prisma";
+import type { Logger } from "@/utils/logger";
+import {
+  getPremiumUserFilter,
+  getUserTier,
+  hasAiAccess,
+  premiumEntitlementSelect,
+} from "@/utils/premium";
+import {
+  addUserErrorMessageWithNotification,
+  ErrorType,
+} from "@/utils/error-messages";
+
+// Grace period so a few missed or failed cron runs don't trigger a notification.
+const MIN_LAPSE_MS = 24 * 60 * 60 * 1000;
+// Only notify recent lapses. This is not a backfill: accounts that lapsed long
+// ago must never receive this email.
+const MAX_LAPSE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * State-based detection of email accounts whose watch/subscription silently
+ * stopped renewing. Runs after the watch renewal pass, so anything still
+ * expired here has been failing renewal despite the cron.
+ *
+ * Notification is once per lapse: `addUserErrorMessageWithNotification`
+ * only emails while no `emailSentAt` is recorded for the error type, and the
+ * error is cleared when a lapsed watch is successfully re-established.
+ */
+export async function notifyLapsedWatches({ logger }: { logger: Logger }) {
+  const emailAccounts = await getRecentlyLapsedEmailAccounts();
+
+  if (!emailAccounts.length) return { notified: 0 };
+
+  logger.info("Found recently lapsed watch accounts", {
+    count: emailAccounts.length,
+  });
+
+  let notified = 0;
+
+  for (const emailAccount of emailAccounts) {
+    const { user } = emailAccount;
+
+    const userHasAiAccess = hasAiAccess(
+      getUserTier(user.premium),
+      !!user.aiApiKey,
+    );
+    if (!userHasAiAccess) continue;
+
+    await addUserErrorMessageWithNotification({
+      userId: emailAccount.userId,
+      userEmail: emailAccount.email,
+      emailAccountId: emailAccount.id,
+      errorType: ErrorType.EMAIL_WATCH_LAPSED,
+      errorMessage: `Email automation for ${emailAccount.email} has stopped. Please reconnect your account to resume automation.`,
+      logger: logger.with({ emailAccountId: emailAccount.id }),
+    });
+
+    notified++;
+  }
+
+  logger.info("Processed lapsed watch notifications", { notified });
+
+  return { notified };
+}
+
+async function getRecentlyLapsedEmailAccounts() {
+  const now = Date.now();
+
+  return prisma.emailAccount.findMany({
+    where: {
+      ...getPremiumUserFilter(),
+      account: { disconnectedAt: null },
+      watchEmailsExpirationDate: {
+        gte: new Date(now - MAX_LAPSE_MS),
+        lt: new Date(now - MIN_LAPSE_MS),
+      },
+    },
+    select: {
+      id: true,
+      email: true,
+      userId: true,
+      user: {
+        select: {
+          aiApiKey: true,
+          premium: { select: premiumEntitlementSelect },
+        },
+      },
+    },
+  });
+}

--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -125,7 +125,10 @@ describe("ensureEmailAccountsWatched", () => {
       }),
     ]);
     expect(clearWatchLapsedErrorIfResolved).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: "user-id" }),
+      expect.objectContaining({
+        userId: "user-id",
+        emailAccountId: "email-account-id",
+      }),
     );
   });
 

--- a/apps/web/utils/email/watch-manager.test.ts
+++ b/apps/web/utils/email/watch-manager.test.ts
@@ -4,9 +4,14 @@ import prisma from "@/utils/__mocks__/prisma";
 import { cleanupInvalidTokens } from "@/utils/auth/cleanup-invalid-tokens";
 import { createEmailProvider } from "@/utils/email/provider";
 import { captureException } from "@/utils/error";
+import { clearWatchLapsedErrorIfResolved } from "@/utils/error-messages";
 import { ensureEmailAccountsWatched } from "./watch-manager";
 
 vi.mock("@/utils/prisma");
+
+vi.mock("@/utils/error-messages", () => ({
+  clearWatchLapsedErrorIfResolved: vi.fn(),
+}));
 
 vi.mock("@/utils/auth/cleanup-invalid-tokens", () => ({
   cleanupInvalidTokens: vi.fn(),
@@ -93,4 +98,78 @@ describe("ensureEmailAccountsWatched", () => {
       },
     ]);
   });
+
+  it("clears the watch lapsed error after re-establishing a lapsed watch", async () => {
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      getWatchedEmailAccount({
+        watchEmailsExpirationDate: new Date(Date.now() - 3_600_000),
+      }),
+    ] as any);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      name: "google",
+      watchEmails: vi.fn().mockResolvedValue({
+        expirationDate: new Date(Date.now() + 3_600_000),
+      }),
+    } as any);
+
+    const results = await ensureEmailAccountsWatched({
+      userIds: null,
+      logger,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        emailAccountId: "email-account-id",
+        status: "success",
+      }),
+    ]);
+    expect(clearWatchLapsedErrorIfResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-id" }),
+    );
+  });
+
+  it("does not touch the watch lapsed error when the watch was already healthy", async () => {
+    vi.mocked(prisma.emailAccount.findMany).mockResolvedValue([
+      getWatchedEmailAccount({
+        watchEmailsExpirationDate: new Date(Date.now() + 3_600_000),
+      }),
+    ] as any);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      name: "google",
+      watchEmails: vi.fn().mockResolvedValue({
+        expirationDate: new Date(Date.now() + 3_600_000),
+      }),
+    } as any);
+
+    await ensureEmailAccountsWatched({ userIds: null, logger });
+
+    expect(clearWatchLapsedErrorIfResolved).not.toHaveBeenCalled();
+  });
 });
+
+function getWatchedEmailAccount({
+  watchEmailsExpirationDate,
+}: {
+  watchEmailsExpirationDate: Date;
+}) {
+  return {
+    id: "email-account-id",
+    email: "account@example.com",
+    watchEmailsExpirationDate,
+    watchEmailsSubscriptionId: null,
+    account: {
+      provider: "google",
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_at: Date.now() + 3_600_000,
+      disconnectedAt: null,
+    },
+    user: {
+      id: "user-id",
+      aiApiKey: null,
+      premium: null,
+    },
+  };
+}

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -215,7 +215,11 @@ async function watchEmailAccount(
   if (wasLapsed) {
     // The watch is healthy again, so clear the lapse error. This lets us
     // notify again if the account lapses in the future.
-    await clearWatchLapsedErrorIfResolved({ userId: user.id, logger });
+    await clearWatchLapsedErrorIfResolved({
+      userId: user.id,
+      emailAccountId: emailAccount.id,
+      logger,
+    });
   }
 
   return {

--- a/apps/web/utils/email/watch-manager.ts
+++ b/apps/web/utils/email/watch-manager.ts
@@ -13,6 +13,7 @@ import type { EmailProvider } from "@/utils/email/types";
 import { createManagedOutlookSubscription } from "@/utils/outlook/subscription-manager";
 import { isMicrosoftProvider } from "@/utils/email/provider-types";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
+import { clearWatchLapsedErrorIfResolved } from "@/utils/error-messages";
 
 export type WatchEmailAccountResult =
   | {
@@ -205,6 +206,16 @@ async function watchEmailAccount(
           ? result.error.message
           : String(result.error),
     };
+  }
+
+  const wasLapsed =
+    !watchEmailsExpirationDate ||
+    new Date(watchEmailsExpirationDate) < new Date();
+
+  if (wasLapsed) {
+    // The watch is healthy again, so clear the lapse error. This lets us
+    // notify again if the account lapses in the future.
+    await clearWatchLapsedErrorIfResolved({ userId: user.id, logger });
   }
 
   return {

--- a/apps/web/utils/error-messages/index.test.ts
+++ b/apps/web/utils/error-messages/index.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
+import { sendActionRequiredEmail } from "@inboxzero/resend";
 import {
+  addUserErrorMessageWithNotification,
   clearAccountDisconnectedErrorIfResolved,
+  clearWatchLapsedErrorIfResolved,
   ErrorType,
   getUserErrorMessages,
 } from "@/utils/error-messages";
@@ -142,6 +145,127 @@ describe("clearAccountDisconnectedErrorIfResolved", () => {
             message: "Invalid model",
             timestamp: "2026-06-24T04:00:40.506Z",
           },
+        },
+      },
+    });
+  });
+});
+
+describe("clearWatchLapsedErrorIfResolved", () => {
+  const logger = createTestLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the lapse error while a connected account still has an expired watch", async () => {
+    prisma.emailAccount.count.mockResolvedValue(1);
+
+    await clearWatchLapsedErrorIfResolved({ userId: "user-1", logger });
+
+    expect(prisma.emailAccount.count).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        account: { disconnectedAt: null },
+        watchEmailsExpirationDate: { lt: expect.any(Date) },
+      },
+    });
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("clears only the lapse error when no lapsed watches remain", async () => {
+    prisma.emailAccount.count.mockResolvedValue(0);
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.EMAIL_WATCH_LAPSED]: {
+          message: "Automation stopped",
+          timestamp: "2026-07-01T04:00:40.506Z",
+          emailSentAt: "2026-07-01T04:00:40.506Z",
+        },
+        [ErrorType.INVALID_AI_MODEL]: {
+          message: "Invalid model",
+          timestamp: "2026-06-24T04:00:40.506Z",
+        },
+      },
+    } as any);
+
+    await clearWatchLapsedErrorIfResolved({ userId: "user-1", logger });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        errorMessages: {
+          [ErrorType.INVALID_AI_MODEL]: {
+            message: "Invalid model",
+            timestamp: "2026-06-24T04:00:40.506Z",
+          },
+        },
+      },
+    });
+  });
+});
+
+describe("addUserErrorMessageWithNotification", () => {
+  const logger = createTestLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the notification email on the first occurrence and records emailSentAt", async () => {
+    prisma.user.findUnique.mockResolvedValue({ errorMessages: {} } as any);
+
+    await addUserErrorMessageWithNotification({
+      userId: "user-1",
+      userEmail: "user@example.com",
+      emailAccountId: "email-account-1",
+      errorType: ErrorType.EMAIL_WATCH_LAPSED,
+      errorMessage: "Automation stopped",
+      logger,
+    });
+
+    expect(sendActionRequiredEmail).toHaveBeenCalledTimes(1);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        errorMessages: {
+          [ErrorType.EMAIL_WATCH_LAPSED]: expect.objectContaining({
+            message: "Automation stopped",
+            emailSentAt: expect.any(String),
+          }),
+        },
+      },
+    });
+  });
+
+  it("does not send another email while the error is still active", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.EMAIL_WATCH_LAPSED]: {
+          message: "Automation stopped",
+          timestamp: "2026-07-01T04:00:40.506Z",
+          emailSentAt: "2026-07-01T04:00:40.506Z",
+        },
+      },
+    } as any);
+
+    await addUserErrorMessageWithNotification({
+      userId: "user-1",
+      userEmail: "user@example.com",
+      emailAccountId: "email-account-1",
+      errorType: ErrorType.EMAIL_WATCH_LAPSED,
+      errorMessage: "Automation stopped",
+      logger,
+    });
+
+    expect(sendActionRequiredEmail).not.toHaveBeenCalled();
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        errorMessages: {
+          [ErrorType.EMAIL_WATCH_LAPSED]: expect.objectContaining({
+            emailSentAt: "2026-07-01T04:00:40.506Z",
+          }),
         },
       },
     });

--- a/apps/web/utils/error-messages/index.test.ts
+++ b/apps/web/utils/error-messages/index.test.ts
@@ -7,6 +7,7 @@ import {
   clearWatchLapsedErrorIfResolved,
   ErrorType,
   getUserErrorMessages,
+  watchLapsedErrorKey,
 } from "@/utils/error-messages";
 import { createTestLogger } from "@/__tests__/helpers";
 
@@ -158,27 +159,16 @@ describe("clearWatchLapsedErrorIfResolved", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps the lapse error while a connected account still has an expired watch", async () => {
-    prisma.emailAccount.count.mockResolvedValue(1);
-
-    await clearWatchLapsedErrorIfResolved({ userId: "user-1", logger });
-
-    expect(prisma.emailAccount.count).toHaveBeenCalledWith({
-      where: {
-        userId: "user-1",
-        account: { disconnectedAt: null },
-        watchEmailsExpirationDate: { lt: expect.any(Date) },
-      },
-    });
-    expect(prisma.user.update).not.toHaveBeenCalled();
-  });
-
-  it("clears only the lapse error when no lapsed watches remain", async () => {
-    prisma.emailAccount.count.mockResolvedValue(0);
+  it("clears only the recovered account's lapse entry, leaving other accounts' entries intact", async () => {
     prisma.user.findUnique.mockResolvedValue({
       errorMessages: {
-        [ErrorType.EMAIL_WATCH_LAPSED]: {
-          message: "Automation stopped",
+        [watchLapsedErrorKey("email-account-1")]: {
+          message: "Automation stopped for account 1",
+          timestamp: "2026-07-01T04:00:40.506Z",
+          emailSentAt: "2026-07-01T04:00:40.506Z",
+        },
+        [watchLapsedErrorKey("email-account-2")]: {
+          message: "Automation stopped for account 2",
           timestamp: "2026-07-01T04:00:40.506Z",
           emailSentAt: "2026-07-01T04:00:40.506Z",
         },
@@ -189,12 +179,22 @@ describe("clearWatchLapsedErrorIfResolved", () => {
       },
     } as any);
 
-    await clearWatchLapsedErrorIfResolved({ userId: "user-1", logger });
+    await clearWatchLapsedErrorIfResolved({
+      userId: "user-1",
+      emailAccountId: "email-account-1",
+      logger,
+    });
 
+    expect(prisma.emailAccount.count).not.toHaveBeenCalled();
     expect(prisma.user.update).toHaveBeenCalledWith({
       where: { id: "user-1" },
       data: {
         errorMessages: {
+          [watchLapsedErrorKey("email-account-2")]: {
+            message: "Automation stopped for account 2",
+            timestamp: "2026-07-01T04:00:40.506Z",
+            emailSentAt: "2026-07-01T04:00:40.506Z",
+          },
           [ErrorType.INVALID_AI_MODEL]: {
             message: "Invalid model",
             timestamp: "2026-06-24T04:00:40.506Z",
@@ -238,7 +238,7 @@ describe("addUserErrorMessageWithNotification", () => {
     });
   });
 
-  it("does not send another email while the error is still active", async () => {
+  it("skips the write entirely once already notified with the same message", async () => {
     prisma.user.findUnique.mockResolvedValue({
       errorMessages: {
         [ErrorType.EMAIL_WATCH_LAPSED]: {
@@ -259,12 +259,77 @@ describe("addUserErrorMessageWithNotification", () => {
     });
 
     expect(sendActionRequiredEmail).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("updates the stored message without re-sending when the message text changes", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [ErrorType.EMAIL_WATCH_LAPSED]: {
+          message: "Automation stopped",
+          timestamp: "2026-07-01T04:00:40.506Z",
+          emailSentAt: "2026-07-01T04:00:40.506Z",
+        },
+      },
+    } as any);
+
+    await addUserErrorMessageWithNotification({
+      userId: "user-1",
+      userEmail: "user@example.com",
+      emailAccountId: "email-account-1",
+      errorType: ErrorType.EMAIL_WATCH_LAPSED,
+      errorMessage: "Automation stopped again",
+      logger,
+    });
+
+    expect(sendActionRequiredEmail).not.toHaveBeenCalled();
     expect(prisma.user.update).toHaveBeenCalledWith({
       where: { id: "user-1" },
       data: {
         errorMessages: {
           [ErrorType.EMAIL_WATCH_LAPSED]: expect.objectContaining({
+            message: "Automation stopped again",
             emailSentAt: "2026-07-01T04:00:40.506Z",
+          }),
+        },
+      },
+    });
+  });
+
+  it("stores and dedupes per storageKey when accounts lapse independently", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      errorMessages: {
+        [watchLapsedErrorKey("email-account-1")]: {
+          message: "Automation stopped for account 1",
+          timestamp: "2026-07-01T04:00:40.506Z",
+          emailSentAt: "2026-07-01T04:00:40.506Z",
+        },
+      },
+    } as any);
+
+    await addUserErrorMessageWithNotification({
+      userId: "user-1",
+      userEmail: "user@example.com",
+      emailAccountId: "email-account-2",
+      errorType: ErrorType.EMAIL_WATCH_LAPSED,
+      storageKey: watchLapsedErrorKey("email-account-2"),
+      errorMessage: "Automation stopped for account 2",
+      logger,
+    });
+
+    expect(sendActionRequiredEmail).toHaveBeenCalledTimes(1);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        errorMessages: {
+          [watchLapsedErrorKey("email-account-1")]: {
+            message: "Automation stopped for account 1",
+            timestamp: "2026-07-01T04:00:40.506Z",
+            emailSentAt: "2026-07-01T04:00:40.506Z",
+          },
+          [watchLapsedErrorKey("email-account-2")]: expect.objectContaining({
+            message: "Automation stopped for account 2",
+            emailSentAt: expect.any(String),
           }),
         },
       },

--- a/apps/web/utils/error-messages/index.ts
+++ b/apps/web/utils/error-messages/index.ts
@@ -35,6 +35,12 @@ export type PersistedErrorType = Exclude<
   typeof ErrorType.TRIAL_AI_LIMIT_REACHED
 >;
 
+// EMAIL_WATCH_LAPSED is stored per email account (a user can have several),
+// so each account's lapse is notified and cleared independently.
+export function watchLapsedErrorKey(emailAccountId: string): string {
+  return `${ErrorType.EMAIL_WATCH_LAPSED}:${emailAccountId}`;
+}
+
 export async function getUserErrorMessages(
   userId: string,
 ): Promise<ErrorMessages | null> {
@@ -113,7 +119,9 @@ export async function clearSpecificErrorMessages({
   logger,
 }: {
   userId: string;
-  errorTypes: ErrorTypeValue[];
+  // Accepts raw storage keys, not just canonical ErrorType values, since some
+  // error types (e.g. EMAIL_WATCH_LAPSED) are stored per email account.
+  errorTypes: string[];
   logger: Logger;
 }): Promise<void> {
   try {
@@ -178,33 +186,23 @@ export async function clearAccountDisconnectedErrorIfResolved({
   });
 }
 
+// Called right after a specific account's watch is successfully
+// (re-)established, so the caller has already confirmed that account is no
+// longer lapsed. Only that account's entry is cleared, so an unrelated
+// lapsed/disconnected account belonging to the same user can't block this or
+// suppress future notifications.
 export async function clearWatchLapsedErrorIfResolved({
   userId,
+  emailAccountId,
   logger,
 }: {
   userId: string;
+  emailAccountId: string;
   logger: Logger;
 }): Promise<void> {
-  let lapsedAccounts: number;
-  try {
-    lapsedAccounts = await prisma.emailAccount.count({
-      where: {
-        userId,
-        account: { disconnectedAt: null },
-        watchEmailsExpirationDate: { lt: new Date() },
-      },
-    });
-  } catch (error) {
-    logger.error("Error checking watch lapsed errors:", { userId, error });
-    captureException(error, { extra: { userId } });
-    return;
-  }
-
-  if (lapsedAccounts > 0) return;
-
   await clearSpecificErrorMessages({
     userId,
-    errorTypes: [ErrorType.EMAIL_WATCH_LAPSED],
+    errorTypes: [watchLapsedErrorKey(emailAccountId)],
     logger,
   });
 }
@@ -272,6 +270,7 @@ export async function addUserErrorMessageWithNotification({
   emailAccountId,
   errorType,
   errorMessage,
+  storageKey = errorType,
   logger,
 }: {
   userId: string;
@@ -279,6 +278,10 @@ export async function addUserErrorMessageWithNotification({
   emailAccountId: string;
   errorType: PersistedErrorType;
   errorMessage: string;
+  // Key used to store/dedupe the entry in errorMessages, if different from
+  // errorType (e.g. a per-account key for error types that can recur
+  // independently across a user's email accounts).
+  storageKey?: string;
   logger: Logger;
 }): Promise<void> {
   try {
@@ -293,8 +296,14 @@ export async function addUserErrorMessageWithNotification({
     }
 
     const currentErrorMessages = (user.errorMessages as ErrorMessages) || {};
-    const existingEntry = currentErrorMessages[errorType];
+    const existingEntry = currentErrorMessages[storageKey];
     const shouldSendEmail = !existingEntry?.emailSentAt;
+
+    if (!shouldSendEmail && existingEntry?.message === errorMessage) {
+      // Already notified and nothing has changed - skip the write so
+      // repeatedly-checked, already-notified accounts don't churn the row.
+      return;
+    }
 
     const newEntry: ErrorMessageEntry = {
       message: errorMessage,
@@ -335,7 +344,7 @@ export async function addUserErrorMessageWithNotification({
 
     const newErrorMessages = {
       ...currentErrorMessages,
-      [errorType]: newEntry,
+      [storageKey]: newEntry,
     };
 
     await prisma.user.update({

--- a/apps/web/utils/error-messages/index.ts
+++ b/apps/web/utils/error-messages/index.ts
@@ -15,6 +15,7 @@ export const ErrorType = {
   INSUFFICIENT_CREDITS: "Insufficient AI credits",
   TRIAL_AI_LIMIT_REACHED: "Trial AI limit reached",
   ACCOUNT_DISCONNECTED: "Account disconnected",
+  EMAIL_WATCH_LAPSED: "Email automation stopped",
   // Legacy keys kept for clearing old stored errors
   INCORRECT_OPENAI_API_KEY: "Incorrect OpenAI API key",
   OPENAI_API_KEY_DEACTIVATED: "OpenAI API key deactivated",
@@ -177,6 +178,37 @@ export async function clearAccountDisconnectedErrorIfResolved({
   });
 }
 
+export async function clearWatchLapsedErrorIfResolved({
+  userId,
+  logger,
+}: {
+  userId: string;
+  logger: Logger;
+}): Promise<void> {
+  let lapsedAccounts: number;
+  try {
+    lapsedAccounts = await prisma.emailAccount.count({
+      where: {
+        userId,
+        account: { disconnectedAt: null },
+        watchEmailsExpirationDate: { lt: new Date() },
+      },
+    });
+  } catch (error) {
+    logger.error("Error checking watch lapsed errors:", { userId, error });
+    captureException(error, { extra: { userId } });
+    return;
+  }
+
+  if (lapsedAccounts > 0) return;
+
+  await clearSpecificErrorMessages({
+    userId,
+    errorTypes: [ErrorType.EMAIL_WATCH_LAPSED],
+    logger,
+  });
+}
+
 const errorTypeConfig: Record<
   PersistedErrorType,
   { label: string; actionUrl: string; actionLabel: string }
@@ -208,6 +240,11 @@ const errorTypeConfig: Record<
   },
   [ErrorType.ACCOUNT_DISCONNECTED]: {
     label: "Account Disconnected",
+    actionUrl: "/accounts",
+    actionLabel: "Reconnect Account",
+  },
+  [ErrorType.EMAIL_WATCH_LAPSED]: {
+    label: "Email Automation Stopped",
     actionUrl: "/accounts",
     actionLabel: "Reconnect Account",
   },

--- a/apps/web/utils/error-messages/index.ts
+++ b/apps/web/utils/error-messages/index.ts
@@ -35,8 +35,8 @@ export type PersistedErrorType = Exclude<
   typeof ErrorType.TRIAL_AI_LIMIT_REACHED
 >;
 
-// EMAIL_WATCH_LAPSED is stored per email account (a user can have several),
-// so each account's lapse is notified and cleared independently.
+// A user can have several accounts, so EMAIL_WATCH_LAPSED is keyed per account
+// rather than per errorType.
 export function watchLapsedErrorKey(emailAccountId: string): string {
   return `${ErrorType.EMAIL_WATCH_LAPSED}:${emailAccountId}`;
 }
@@ -119,8 +119,6 @@ export async function clearSpecificErrorMessages({
   logger,
 }: {
   userId: string;
-  // Accepts raw storage keys, not just canonical ErrorType values, since some
-  // error types (e.g. EMAIL_WATCH_LAPSED) are stored per email account.
   errorTypes: string[];
   logger: Logger;
 }): Promise<void> {
@@ -186,11 +184,7 @@ export async function clearAccountDisconnectedErrorIfResolved({
   });
 }
 
-// Called right after a specific account's watch is successfully
-// (re-)established, so the caller has already confirmed that account is no
-// longer lapsed. Only that account's entry is cleared, so an unrelated
-// lapsed/disconnected account belonging to the same user can't block this or
-// suppress future notifications.
+// Callers must confirm the account's watch is healthy before calling this.
 export async function clearWatchLapsedErrorIfResolved({
   userId,
   emailAccountId,
@@ -278,9 +272,6 @@ export async function addUserErrorMessageWithNotification({
   emailAccountId: string;
   errorType: PersistedErrorType;
   errorMessage: string;
-  // Key used to store/dedupe the entry in errorMessages, if different from
-  // errorType (e.g. a per-account key for error types that can recur
-  // independently across a user's email accounts).
   storageKey?: string;
   logger: Logger;
 }): Promise<void> {
@@ -299,11 +290,8 @@ export async function addUserErrorMessageWithNotification({
     const existingEntry = currentErrorMessages[storageKey];
     const shouldSendEmail = !existingEntry?.emailSentAt;
 
-    if (!shouldSendEmail && existingEntry?.message === errorMessage) {
-      // Already notified and nothing has changed - skip the write so
-      // repeatedly-checked, already-notified accounts don't churn the row.
-      return;
-    }
+    // Nothing changed since the last write - skip it.
+    if (!shouldSendEmail && existingEntry?.message === errorMessage) return;
 
     const newEntry: ErrorMessageEntry = {
       message: errorMessage,


### PR DESCRIPTION
## Summary

Email watches (Gmail watch / Outlook subscription) can stop renewing without a hard auth failure. Hard failures like `invalid_grant` already mark the account disconnected and notify the user, but watches that just keep failing renewal lapse silently: automation stops and the user is never told.

This adds state-based detection of lapsed watches to the existing `/api/watch/all` cron flow, plus a one-time notification email with a reconnect link.

## How it works

- After the watch renewal pass, `notifyLapsedWatches` finds email accounts that are premium-entitled (with AI access), still connected (`disconnectedAt: null`), and whose `watchEmailsExpirationDate` lapsed more than 1 day but less than 7 days ago.
  - The 1-day grace period means a few missed or failed cron runs never trigger it (the cron runs hourly).
  - The 7-day cap means accounts that lapsed long ago are never backfilled with emails.
- Notification reuses the existing user error message mechanism (`addUserErrorMessageWithNotification`) with a new `EMAIL_WATCH_LAPSED` error type:
  - Sends the existing action required email (with unsubscribe token) linking to `/accounts` to reconnect.
  - `emailSentAt` on the stored error ensures at most one email per lapse.
  - The error also surfaces in the app UI like other action required errors.
- When a lapsed watch is successfully re-established, the error is cleared (`clearWatchLapsedErrorIfResolved`), so a user who reconnects and lapses again later gets notified again. The check only runs when a watch transitions from lapsed to healthy, so healthy accounts add no extra queries.

## Tests

- `notify-lapsed-watches.test.ts`: detection window and filters, per-account notification, AI access skip.
- `error-messages/index.test.ts`: clear-when-resolved semantics and once-only email behavior.
- `watch-manager.test.ts`: clears the lapse error only when a lapsed watch recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

