### PR TITLE
Fix mobile onboarding layout so the primary CTA stays on screen

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingWrapper.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/OnboardingWrapper.tsx
@@ -10,7 +10,7 @@ export function OnboardingWrapper({
   return (
     <div
       className={cn(
-        "flex flex-col justify-center sm:px-6 sm:py-20 text-gray-900 bg-slate-50 min-h-screen",
+        "flex flex-col justify-center sm:px-6 sm:py-20 text-gray-900 bg-slate-50 min-h-svh",
         className,
       )}
     >

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -211,7 +211,7 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
   const hasMore = suggestions.length > previewSenders.length;
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4 py-10">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-10">
       <div className="w-full max-w-xl">
         <div className="mb-6 text-center">
           <PageHeading className="mb-3">
@@ -286,7 +286,7 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
 
 function StaticBulkUnsubscribeStep({ onNext }: { onNext: () => void }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-8">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
           <BulkUnsubscribeIllustration />

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepChat.tsx
@@ -7,7 +7,7 @@ import { ChatIllustration } from "@/app/(app)/[emailAccountId]/onboarding/illust
 
 export function StepChat({ onNext }: { onNext: () => void }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-8">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
           <ChatIllustration />

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepDraftReplies.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepDraftReplies.tsx
@@ -7,7 +7,7 @@ import { DraftRepliesIllustration } from "@/app/(app)/[emailAccountId]/onboardin
 
 export function StepDraftReplies({ onNext }: { onNext: () => void }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-8">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
           <DraftRepliesIllustration />

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepEmailsSorted.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepEmailsSorted.tsx
@@ -7,7 +7,7 @@ import { EmailsSortedIllustration } from "@/app/(app)/[emailAccountId]/onboardin
 
 export function StepEmailsSorted({ onNext }: { onNext: () => void }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-8">
       <div className="flex flex-col items-center text-center max-w-md">
         <div className="mb-6 h-[240px] flex items-end justify-center">
           <EmailsSortedIllustration />

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepInboxProcessed.tsx
@@ -62,7 +62,7 @@ export function StepInboxProcessed({ onNext }: { onNext: () => void }) {
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-4 py-10">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-slate-50 px-4 py-10">
       <StepInboxProcessedView
         data={data}
         isLoading={isLoading}

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepWho.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepWho.tsx
@@ -175,7 +175,7 @@ export function StepWho({
               ref={scrollContainerRef}
               className="grid gap-2 px-1 pt-6 pb-6"
               fadeFromClass="from-slate-50"
-              height="h-[576px]"
+              height="h-[48svh] sm:h-[576px]"
             >
               {displayedRoles.map(({ value: roleName }) => {
                 const role = usersRolesInfo[roleName];

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/BulkUnsubscribeIllustration.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/illustrations/BulkUnsubscribeIllustration.tsx
@@ -83,7 +83,7 @@ export function BulkUnsubscribeIllustration() {
     .reduce((sum, sender) => sum + sender.emailCount, 0);
 
   return (
-    <div className="relative flex h-[200px] w-[420px] items-center justify-center gap-6">
+    <div className="relative flex h-[200px] w-full max-w-[420px] items-center justify-center gap-4 sm:gap-6">
       <div className="relative z-10 flex h-[160px] w-[150px] flex-col rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-slate-800">
         <div className="border-b border-gray-100 px-3 py-2 dark:border-gray-700">
           <div className="text-[10px] font-medium text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
## Summary

Onboarding completion is significantly lower on mobile than desktop. Analytics show mobile users disproportionately drop on the vertically centered "Continue" steps early in the flow and on the role-selection step, while desktop users complete those same steps at very high rates. A responsive audit (plus rendering the steps at 375-390px-wide viewports) found layout bugs that push or clip the primary CTA on phones:

- **`min-h-screen` + `justify-center`**: `100vh` refers to the large viewport on mobile browsers, so with dynamic browser toolbars the centered content (and the Continue button at the bottom of it) can sit below the visible fold, with no scroll cue on the uniform background.
- **Role-selection step**: the scrollable role list had a fixed `576px` height, pushing the Continue button entirely off screen on phones.
- **Bulk unsubscribe illustration**: fixed `420px` width overflowed narrow viewports, stretching the step column and clipping the step copy at both edges.

## Changes

- Replace `min-h-screen` with `min-h-svh` on all vertically centered onboarding steps (`StepEmailsSorted`, `StepChat`, `StepDraftReplies`, `StepBulkUnsubscribe`, `StepInboxProcessed`, `OnboardingWrapper`) so content centers within the small (always-visible) viewport.
- Add `py-8` to centered illustration steps so content isn't flush with viewport edges on short screens.
- Cap the role list height at `48svh` on mobile (`sm:` keeps the existing `576px` on larger screens) in `StepWho`, keeping the Continue button on screen.
- Make `BulkUnsubscribeIllustration` fluid width (`w-full max-w-[420px]`, tighter gap on mobile) so it no longer overflows narrow screens.

No onboarding logic, step order, or analytics changes. Desktop rendering is unchanged (`svh == vh` on desktop; `sm:` breakpoints preserve prior sizes).

## Verification

- Rendered the affected steps locally at 390x844, 375x667, and 1440x900 and confirmed via screenshots: Continue button fully visible on the role step, no more clipped copy on the bulk unsubscribe step, desktop unchanged.
- `biome check` clean on all changed files.
- `pnpm test app/(app)/[emailAccountId]/onboarding/onboardingFlow.test.ts` passes (14 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

