### PR TITLE
Fix assistant chat stale rule state rejections

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -1227,28 +1227,24 @@ describe("aiProcessAssistantChat", () => {
     mockToolCallAgentStream.mockResolvedValue({
       toUIMessageStreamResponse: vi.fn(),
     });
-    mockPrisma.emailAccount.findUnique
-      .mockResolvedValueOnce({
-        rulesRevision: 2,
-      })
-      .mockResolvedValueOnce({
-        about: "About",
-        rulesRevision: 2,
-        rules: [
-          {
-            name: "To Reply",
-            instructions: "Emails I need to respond to",
-            updatedAt: new Date("2026-02-13T10:00:00.000Z"),
-            from: null,
-            to: null,
-            subject: null,
-            conditionalOperator: null,
-            enabled: true,
-            runOnThreads: true,
-            actions: [],
-          },
-        ],
-      });
+    mockPrisma.emailAccount.findUnique.mockResolvedValueOnce({
+      about: "About",
+      rulesRevision: 2,
+      rules: [
+        {
+          name: "To Reply",
+          instructions: "Emails I need to respond to",
+          updatedAt: new Date("2026-02-13T10:00:00.000Z"),
+          from: null,
+          to: null,
+          subject: null,
+          conditionalOperator: null,
+          enabled: true,
+          runOnThreads: true,
+          actions: [],
+        },
+      ],
+    });
     mockPrisma.rule.findUnique.mockResolvedValue({
       id: "rule-1",
       name: "To Reply",
@@ -1319,6 +1315,93 @@ describe("aiProcessAssistantChat", () => {
     );
   });
 
+  it("hydrates rule read state without reinjecting rules when the revision is unchanged", async () => {
+    const { aiProcessAssistantChat } = await loadAssistantChatModule({
+      emailSend: true,
+    });
+    const onRulesStateExposed = vi.fn();
+
+    mockToolCallAgentStream.mockResolvedValue({
+      toUIMessageStreamResponse: vi.fn(),
+    });
+    mockPrisma.emailAccount.findUnique.mockResolvedValue({
+      about: "About",
+      rulesRevision: 2,
+      rules: [
+        {
+          name: "To Reply",
+          instructions: "Emails I need to respond to",
+          updatedAt: new Date("2026-02-13T10:00:00.000Z"),
+          from: null,
+          to: null,
+          subject: null,
+          conditionalOperator: null,
+          enabled: true,
+          runOnThreads: true,
+          actions: [],
+        },
+      ],
+    });
+    mockPrisma.rule.findUnique.mockResolvedValue({
+      id: "rule-1",
+      name: "To Reply",
+      updatedAt: new Date("2026-02-13T10:00:00.000Z"),
+      enabled: true,
+      emailAccount: {
+        rulesRevision: 2,
+      },
+      instructions: "Emails I need to respond to",
+      from: null,
+      to: null,
+      subject: null,
+      conditionalOperator: "AND",
+      actions: [],
+    });
+    mockPrisma.rule.update.mockResolvedValue({
+      id: "rule-1",
+      actions: [],
+      group: null,
+    });
+
+    await aiProcessAssistantChat({
+      messages: baseMessages,
+      emailAccountId: "email-account-id",
+      user: getEmailAccount(),
+      chatLastSeenRulesRevision: 2,
+      chatHasHistory: true,
+      onRulesStateExposed,
+      logger,
+    });
+
+    const args = mockToolCallAgentStream.mock.calls[0][0];
+    const freshRuleContext = args.messages.find(
+      (message: { role: string; content: string }) =>
+        message.role === "user" &&
+        message.content.includes("[Fresh rule state update"),
+    );
+
+    expect(freshRuleContext).toBeUndefined();
+    expect(onRulesStateExposed).not.toHaveBeenCalled();
+
+    // The chat already saw this revision, so a rule write must succeed without
+    // requiring another getUserRulesAndSettings round trip first.
+    const result = await args.tools.updateRule.execute({
+      ruleName: "To Reply",
+      updates: {
+        condition: {
+          aiInstructions: "Updated instructions",
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        ruleId: "rule-1",
+      }),
+    );
+  });
+
   it("injects fresh rule state for legacy chats with history but no cursor", async () => {
     const { aiProcessAssistantChat } = await loadAssistantChatModule({
       emailSend: true,
@@ -1328,28 +1411,24 @@ describe("aiProcessAssistantChat", () => {
     mockToolCallAgentStream.mockResolvedValue({
       toUIMessageStreamResponse: vi.fn(),
     });
-    mockPrisma.emailAccount.findUnique
-      .mockResolvedValueOnce({
-        rulesRevision: 0,
-      })
-      .mockResolvedValueOnce({
-        about: "About",
-        rulesRevision: 0,
-        rules: [
-          {
-            name: "Newsletter",
-            instructions: "Archive newsletters",
-            updatedAt: new Date("2026-02-13T10:00:00.000Z"),
-            from: null,
-            to: null,
-            subject: null,
-            conditionalOperator: null,
-            enabled: true,
-            runOnThreads: true,
-            actions: [],
-          },
-        ],
-      });
+    mockPrisma.emailAccount.findUnique.mockResolvedValueOnce({
+      about: "About",
+      rulesRevision: 0,
+      rules: [
+        {
+          name: "Newsletter",
+          instructions: "Archive newsletters",
+          updatedAt: new Date("2026-02-13T10:00:00.000Z"),
+          from: null,
+          to: null,
+          subject: null,
+          conditionalOperator: null,
+          enabled: true,
+          runOnThreads: true,
+          actions: [],
+        },
+      ],
+    });
 
     await aiProcessAssistantChat({
       messages: baseMessages,

--- a/apps/web/prisma/migrations/20260707120000_rules_revision_ignore_learned_patterns/migration.sql
+++ b/apps/web/prisma/migrations/20260707120000_rules_revision_ignore_learned_patterns/migration.sql
@@ -1,0 +1,12 @@
+-- Learned patterns (Group/GroupItem) are written constantly by background
+-- email processing, and they are not part of the rule snapshot the assistant
+-- chat reads. Bumping rulesRevision for them invalidated chat rule state
+-- mid-conversation and forced fresh rule context reinjection on every turn.
+-- Keep the Rule/Action triggers: they cover everything the snapshot exposes.
+
+DROP TRIGGER IF EXISTS bump_rules_revision_from_group_item ON "GroupItem";
+DROP TRIGGER IF EXISTS bump_rules_revision_from_group ON "Group";
+
+DROP FUNCTION IF EXISTS trg_bump_rules_revision_from_group_item();
+DROP FUNCTION IF EXISTS trg_bump_rules_revision_from_group();
+DROP FUNCTION IF EXISTS bump_rules_revision_for_group(TEXT);

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -797,6 +797,50 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     });
   });
 
+  it("searchInbox clamps out-of-range limits instead of rejecting them", async () => {
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const schema = toolInstance.inputSchema as any;
+
+    expect(schema.parse({ query: "is:unread", limit: 100 }).limit).toBe(20);
+    expect(schema.parse({ query: "is:unread", limit: 0 }).limit).toBe(1);
+    expect(schema.parse({ query: "is:unread" }).limit).toBe(20);
+  });
+
+  it("searchInbox returns provider failure feedback the model can act on", async () => {
+    (createEmailProvider as any).mockResolvedValue({
+      searchMessages: vi.fn().mockRejectedValue({
+        status: 429,
+        message: "Rate limit exceeded",
+      }),
+      getLabels: vi.fn().mockResolvedValue([]),
+    });
+
+    const toolInstance = searchInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result: any = await (toolInstance.execute as any)({
+      query: "is:unread",
+      limit: 20,
+    });
+
+    expect(result.error).toBe("Failed to search inbox");
+    expect(result.searchFeedback).toMatchObject({
+      status: 429,
+      message: "Rate limit exceeded",
+      retryable: true,
+    });
+  });
+
   it("searchInbox result reports hasMore=false when no more pages", async () => {
     (createEmailProvider as any).mockResolvedValue({
       searchMessages: vi.fn().mockResolvedValue({
@@ -1369,7 +1413,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
     );
   });
 
-  it("searchInbox keeps the generic Google failure payload unchanged", async () => {
+  it("searchInbox reports non-retryable Google failures with the failure detail", async () => {
     const searchMessages = vi
       .fn()
       .mockRejectedValue(new Error("Search syntax failed"));
@@ -1391,9 +1435,11 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
       limit: 20,
     });
 
-    expect(result).toEqual({
-      queryUsed: "from:sender@example.com",
-      error: "Failed to search inbox",
+    expect(result.queryUsed).toBe("from:sender@example.com");
+    expect(result.error).toBe("Failed to search inbox");
+    expect(result.searchFeedback).toMatchObject({
+      message: "Search syntax failed",
+      retryable: false,
     });
     expect(searchMessages).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -46,6 +46,10 @@ import {
   getCategorizationStatusSnapshot,
 } from "@/utils/redis/categorization-progress";
 import { extractErrorInfo, isRetryableError } from "@/utils/outlook/retry";
+import {
+  extractErrorInfo as extractGmailErrorInfo,
+  isRetryableError as isGmailRetryableError,
+} from "@/utils/gmail/retry";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
 
 const SEARCH_INBOX_MAX_RESULTS = 20;
@@ -487,10 +491,13 @@ const searchInboxBaseFields = {
   limit: z
     .number()
     .int()
-    .min(1)
-    .max(SEARCH_INBOX_MAX_RESULTS)
     .default(SEARCH_INBOX_MAX_RESULTS)
-    .describe("Maximum number of messages to return."),
+    .transform((value) =>
+      Math.min(Math.max(value, 1), SEARCH_INBOX_MAX_RESULTS),
+    )
+    .describe(
+      `Maximum number of messages to return, up to ${SEARCH_INBOX_MAX_RESULTS}. Larger values are clamped; use pagination for more results.`,
+    ),
   pageToken: microsoftGraphPageTokenSchema.describe(
     "Use the page token returned from a prior search to paginate.",
   ),
@@ -549,7 +556,7 @@ const gmailSearchInboxTool = ({
 }: InboxToolOptions) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. totalReturned is only the number of messages returned by this call, so do not present it or a single search page as an exact mailbox, folder, or label count. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
+      "Search inbox messages and return concise message metadata. Returns at most 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion. totalReturned is only the number of messages returned by this call, so do not present it or a single search page as an exact mailbox, folder, or label count. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
     inputSchema: gmailSearchInboxInputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "search_inbox", email, logger });
@@ -578,9 +585,21 @@ const gmailSearchInboxTool = ({
           labels,
           taxonomyNamesKey: "labelNames",
         });
-      } catch {
+      } catch (error) {
         // Provider failures are logged and flushed at the provider boundary.
-        return { queryUsed: query, error: "Failed to search inbox" };
+        const errorInfo = extractGmailErrorInfo(error);
+        const { retryable } = isGmailRetryableError(errorInfo);
+        return {
+          queryUsed: query,
+          error: "Failed to search inbox",
+          searchFeedback: {
+            status: errorInfo.status,
+            message: (
+              errorInfo.errorMessage || "Gmail search request failed"
+            ).slice(0, 300),
+            retryable,
+          },
+        };
       }
     },
   });
@@ -593,7 +612,7 @@ const outlookSearchInboxTool = ({
 }: InboxToolOptions) =>
   tool({
     description:
-      "Search inbox messages and return concise message metadata. Limit must be between 1 and 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion, even when the current page has zero messages. Outlook filtered searches can return an empty page before later matching pages. totalReturned is only the number of messages returned by this call, so do not present it or a single search page as an exact mailbox, folder, or category count. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
+      "Search inbox messages and return concise message metadata. Returns at most 20 messages per call. If hasMore=true, more matches remain; for bulk or all-matching requests, keep calling searchInbox with nextPageToken until hasMore=false before reporting completion, even when the current page has zero messages. Outlook filtered searches can return an empty page before later matching pages. totalReturned is only the number of messages returned by this call, so do not present it or a single search page as an exact mailbox, folder, or category count. If the tool returns an error or provider search feedback instead of messages, treat the lookup as inconclusive rather than evidence that the email is absent.",
     inputSchema: outlookSearchInboxInputSchema,
     execute: async (input) => {
       trackToolCall({ tool: "search_inbox", email, logger });

--- a/apps/web/utils/ai/assistant/chat-rule-state.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-state.ts
@@ -156,19 +156,6 @@ export async function loadAssistantRuleSnapshot({
   };
 }
 
-export async function loadCurrentRulesRevision({
-  emailAccountId,
-}: {
-  emailAccountId: string;
-}) {
-  const emailAccount = await prisma.emailAccount.findUnique({
-    where: { id: emailAccountId },
-    select: { rulesRevision: true },
-  });
-
-  return emailAccount?.rulesRevision ?? 0;
-}
-
 export function buildRuleReadState(
   snapshot: AssistantRuleSnapshot,
 ): RuleReadState {

--- a/apps/web/utils/ai/assistant/chat.test.ts
+++ b/apps/web/utils/ai/assistant/chat.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
 import {
   buildInboxSnapshotMessage,
   buildResolvedSystemPrompt,
+  loadFreshRuleContext,
 } from "@/utils/ai/assistant/chat";
 
 vi.mock("server-only", () => ({}));
+vi.mock("@/utils/prisma");
 
 describe("buildResolvedSystemPrompt", () => {
   it("uses Outlook category wording instead of label wording", () => {
@@ -37,5 +40,86 @@ describe("buildInboxSnapshotMessage", () => {
   it("returns null when no inboxStats are available", () => {
     expect(buildInboxSnapshotMessage(null)).toBeNull();
     expect(buildInboxSnapshotMessage(undefined)).toBeNull();
+  });
+});
+
+describe("loadFreshRuleContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockRuleSnapshot({ rulesRevision }: { rulesRevision: number }) {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      about: "Prefers short replies",
+      rulesRevision,
+      rules: [
+        {
+          name: "Newsletters",
+          instructions: "Newsletters and digests",
+          updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+          from: null,
+          to: null,
+          subject: null,
+          conditionalOperator: "AND",
+          enabled: true,
+          runOnThreads: true,
+          actions: [],
+        },
+      ],
+      messagingChannels: [],
+    } as any);
+  }
+
+  it("returns null for a brand-new chat that has never seen rules", async () => {
+    const result = await loadFreshRuleContext({
+      emailAccountId: "account-1",
+      chatLastSeenRulesRevision: null,
+      chatHasHistory: false,
+    });
+
+    expect(result).toBeNull();
+    expect(prisma.emailAccount.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("hydrates read state without new rule state when the revision is unchanged", async () => {
+    mockRuleSnapshot({ rulesRevision: 5 });
+
+    const result = await loadFreshRuleContext({
+      emailAccountId: "account-1",
+      chatLastSeenRulesRevision: 5,
+      chatHasHistory: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.hasNewRuleState).toBe(false);
+    expect(result?.ruleReadState.rulesRevision).toBe(5);
+    expect(result?.ruleReadState.ruleUpdatedAtByName.get("Newsletters")).toBe(
+      "2026-07-01T00:00:00.000Z",
+    );
+  });
+
+  it("marks new rule state when the revision advanced since the chat last saw it", async () => {
+    mockRuleSnapshot({ rulesRevision: 6 });
+
+    const result = await loadFreshRuleContext({
+      emailAccountId: "account-1",
+      chatLastSeenRulesRevision: 5,
+      chatHasHistory: true,
+    });
+
+    expect(result?.hasNewRuleState).toBe(true);
+    expect(result?.ruleReadState.rulesRevision).toBe(6);
+  });
+
+  it("marks new rule state for a chat with history that never saw a revision", async () => {
+    mockRuleSnapshot({ rulesRevision: 0 });
+
+    const result = await loadFreshRuleContext({
+      emailAccountId: "account-1",
+      chatLastSeenRulesRevision: null,
+      chatHasHistory: true,
+    });
+
+    expect(result?.hasNewRuleState).toBe(true);
   });
 });

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -42,7 +42,6 @@ import type { SerializedMatchReason } from "@/utils/ai/choose-rule/types";
 import {
   buildFreshRuleContextMessage,
   buildRuleReadState,
-  loadCurrentRulesRevision,
   loadAssistantRuleSnapshot,
   type RuleReadState,
 } from "./chat-rule-state";
@@ -150,10 +149,12 @@ export async function aiProcessAssistantChat({
 
     if (freshRuleState) {
       ruleReadState = freshRuleState.ruleReadState;
-      onRulesStateExposed?.(freshRuleState.snapshot.rulesRevision);
-      freshRuleContextMessage = [
-        buildFreshRuleContextMessage(freshRuleState.snapshot),
-      ];
+      if (freshRuleState.hasNewRuleState) {
+        onRulesStateExposed?.(freshRuleState.snapshot.rulesRevision);
+        freshRuleContextMessage = [
+          buildFreshRuleContextMessage(freshRuleState.snapshot),
+        ];
+      }
     }
   } catch (error) {
     logger.warn("Failed to load fresh rule state for chat", { error });
@@ -328,7 +329,7 @@ export async function aiProcessAssistantChat({
   return result;
 }
 
-async function loadFreshRuleContext({
+export async function loadFreshRuleContext({
   emailAccountId,
   chatLastSeenRulesRevision,
   chatHasHistory,
@@ -341,19 +342,15 @@ async function loadFreshRuleContext({
 
   const knownRulesRevision = chatLastSeenRulesRevision ?? -1;
 
-  const currentRulesRevision = await loadCurrentRulesRevision({
-    emailAccountId,
-  });
-
-  if (currentRulesRevision <= knownRulesRevision) return null;
-
   const snapshot = await loadAssistantRuleSnapshot({ emailAccountId });
 
-  if (snapshot.rulesRevision <= knownRulesRevision) return null;
-
+  // Rule-write tools reject writes without a recent read. The chat already saw
+  // this exact revision, so hydrate the read state even when nothing changed;
+  // only inject the fresh-context message when the revision advanced.
   return {
     snapshot,
     ruleReadState: buildRuleReadState(snapshot),
+    hasNewRuleState: snapshot.rulesRevision > knownRulesRevision,
   };
 }
 


### PR DESCRIPTION
## Problem

Production chat telemetry (aggregate tool-call outcomes, no message content) showed the assistant chat's rule-write tools failing at a high rate:

- Roughly half of recent rule-write rejections were "Call getUserRulesAndSettings immediately before updating this rule", returned on the first write of a turn even though the chat had already seen the current rules. The rule read state was only hydrated at request start when the rules revision had changed, so the model paid a wasted round trip (or failed) on every rule edit in an ongoing chat.
- The rules revision was bumped by DB triggers on every learned-pattern write. Learned patterns are written constantly by background email processing and are not part of the rule snapshot the chat reads, so background activity invalidated chat rule state mid-conversation and forced fresh rule-context reinjection (extra tokens + prompt cache churn) on every turn for active accounts.
- Gmail inbox search failures returned a bare "Failed to search inbox" with no detail, giving the model nothing to decide between retrying and reporting. The search limit also hard-rejected values above the cap, which caused repeated failed calls in bulk-cleanup sessions.

## Changes

- `loadFreshRuleContext` now always hydrates the rule read state for chats that have seen rules, and only injects the fresh rule-context message when the revision actually advanced.
- New migration drops the `Group`/`GroupItem` rules-revision triggers. The `Rule`/`Action` triggers remain and cover everything the assistant rule snapshot exposes, so the per-rule staleness guard is unchanged.
- Gmail `searchInbox` failures now include status, a truncated provider message, and a retryable flag. The `limit` input is clamped to the supported range instead of rejected, and tool descriptions were updated to match.

## Testing

- Unit: full suite passes (455 files). New tests cover read-state hydration with unchanged/advanced revisions, a rule write succeeding without a redundant re-read, limit clamping, and search failure feedback.
- Evals: `assistant-chat-rule-editing-action-updates` passes. `assistant-chat-inbox-workflows-search` has 2 pre-existing failures that reproduce identically on a clean tree (verified) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

