### PR TITLE
fix: writing-style sample population + comment cleanup

### DIFF
--- a/apps/web/utils/actions/assess.test.ts
+++ b/apps/web/utils/actions/assess.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { ParsedMessage } from "@/utils/types";
+import { selectWritingStyleSampleMessages } from "./assess";
+
+describe("selectWritingStyleSampleMessages", () => {
+  it("keeps only in-thread replies when there are enough of them", () => {
+    const replies = Array.from({ length: 6 }, (_, i) => replyMessage(`r${i}`));
+    const composed = Array.from({ length: 3 }, (_, i) =>
+      composedMessage(`c${i}`),
+    );
+
+    const result = selectWritingStyleSampleMessages([...replies, ...composed]);
+
+    expect(result.map((m) => m.id).sort()).toEqual(
+      replies.map((m) => m.id).sort(),
+    );
+  });
+
+  it("falls back to the full pool when too few replies are found", () => {
+    const replies = [replyMessage("r0"), replyMessage("r1")];
+    const composed = [composedMessage("c0"), composedMessage("c1")];
+    const messages = [...replies, ...composed];
+
+    const result = selectWritingStyleSampleMessages(messages);
+
+    expect(result).toHaveLength(messages.length);
+  });
+});
+
+function replyMessage(id: string): ParsedMessage {
+  return baseMessage(
+    id,
+    `Sounds good.
+
+On Jan 1, 2024, someone@example.com wrote:
+> Does tomorrow work?`,
+  );
+}
+
+function composedMessage(id: string): ParsedMessage {
+  return baseMessage(id, "Hey team, just wanted to check in on the project.");
+}
+
+function baseMessage(id: string, textPlain: string): ParsedMessage {
+  return {
+    id,
+    threadId: id,
+    historyId: id,
+    date: "2024-01-01T00:00:00Z",
+    snippet: textPlain.slice(0, 50),
+    subject: "Test",
+    textPlain,
+    inline: [],
+    headers: {
+      date: "2024-01-01T00:00:00Z",
+      from: "user@example.com",
+      to: "recipient@example.com",
+      subject: "Test",
+    },
+  };
+}

--- a/apps/web/utils/actions/assess.ts
+++ b/apps/web/utils/actions/assess.ts
@@ -8,6 +8,16 @@ import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { actionClient } from "@/utils/actions/safe-action";
 import { createEmailProvider } from "@/utils/email/provider";
 import { SafeError } from "@/utils/error";
+import { emailToContent, hasQuotedReplyContent } from "@/utils/mail";
+import type { ParsedMessage } from "@/utils/types";
+
+// Sampling a larger pool and filtering to in-thread replies keeps the style
+// analysis representative of the quick replies drafts are generated for,
+// rather than being skewed long by cold outreach, forwards, and intros
+// mixed into "sent mail".
+const SENT_MESSAGE_SAMPLE_POOL_SIZE = 60;
+const STYLE_SAMPLE_SIZE = 20;
+const MIN_REPLY_SAMPLES_FOR_STYLE = 5;
 
 // to help with onboarding and provide the best flow to new users
 export const assessAction = actionClient
@@ -58,17 +68,21 @@ export const analyzeWritingStyleAction = actionClient
 
     if (emailAccount?.writingStyle) return { success: true, skipped: true };
 
-    // fetch last 20 sent emails using the provider's getSentMessages method
     const emailProvider = await createEmailProvider({
       emailAccountId,
       provider,
       logger,
     });
-    const sentMessages = await emailProvider.getSentMessages(20);
+    const sentMessages = await emailProvider.getSentMessages(
+      SENT_MESSAGE_SAMPLE_POOL_SIZE,
+    );
+    const styleSourceMessages = selectWritingStyleSampleMessages(
+      sentMessages,
+    ).slice(0, STYLE_SAMPLE_SIZE);
 
     // analyze writing style
     const style = await aiAnalyzeWritingStyle({
-      emails: sentMessages.map((email) =>
+      emails: styleSourceMessages.map((email) =>
         getEmailForLLM(email, { extractReply: true }),
       ),
       emailAccount: { ...emailAccount, account: { provider } },
@@ -98,3 +112,18 @@ export const analyzeWritingStyleAction = actionClient
 
     return { success: true };
   });
+
+// Prefers in-thread replies (what draft generation writes) over composed-
+// from-scratch sent mail, which trends longer and skews the style analysis.
+// Falls back to the full pool when too few replies are available.
+export function selectWritingStyleSampleMessages(
+  sentMessages: ParsedMessage[],
+) {
+  const replyMessages = sentMessages.filter((message) =>
+    hasQuotedReplyContent(emailToContent(message, { maxLength: 0 })),
+  );
+
+  return replyMessages.length >= MIN_REPLY_SAMPLES_FOR_STYLE
+    ? replyMessages
+    : sentMessages;
+}

--- a/apps/web/utils/actions/assess.ts
+++ b/apps/web/utils/actions/assess.ts
@@ -11,10 +11,6 @@ import { SafeError } from "@/utils/error";
 import { emailToContent, hasQuotedReplyContent } from "@/utils/mail";
 import type { ParsedMessage } from "@/utils/types";
 
-// Sampling a larger pool and filtering to in-thread replies keeps the style
-// analysis representative of the quick replies drafts are generated for,
-// rather than being skewed long by cold outreach, forwards, and intros
-// mixed into "sent mail".
 const SENT_MESSAGE_SAMPLE_POOL_SIZE = 60;
 const STYLE_SAMPLE_SIZE = 20;
 const MIN_REPLY_SAMPLES_FOR_STYLE = 5;
@@ -113,9 +109,6 @@ export const analyzeWritingStyleAction = actionClient
     return { success: true };
   });
 
-// Prefers in-thread replies (what draft generation writes) over composed-
-// from-scratch sent mail, which trends longer and skews the style analysis.
-// Falls back to the full pool when too few replies are available.
 export function selectWritingStyleSampleMessages(
   sentMessages: ParsedMessage[],
 ) {

--- a/apps/web/utils/actions/assess.ts
+++ b/apps/web/utils/actions/assess.ts
@@ -3,17 +3,15 @@
 import prisma from "@/utils/prisma";
 import { assessUser } from "@/utils/assess";
 import { aiAnalyzeWritingStyle } from "@/utils/ai/knowledge/writing-style";
+import { selectWritingStyleSampleMessages } from "@/utils/ai/knowledge/select-writing-style-samples";
 import { formatBulletList } from "@/utils/string";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { actionClient } from "@/utils/actions/safe-action";
 import { createEmailProvider } from "@/utils/email/provider";
 import { SafeError } from "@/utils/error";
-import { emailToContent, hasQuotedReplyContent } from "@/utils/mail";
-import type { ParsedMessage } from "@/utils/types";
 
 const SENT_MESSAGE_SAMPLE_POOL_SIZE = 60;
 const STYLE_SAMPLE_SIZE = 20;
-const MIN_REPLY_SAMPLES_FOR_STYLE = 5;
 
 // to help with onboarding and provide the best flow to new users
 export const assessAction = actionClient
@@ -108,15 +106,3 @@ export const analyzeWritingStyleAction = actionClient
 
     return { success: true };
   });
-
-export function selectWritingStyleSampleMessages(
-  sentMessages: ParsedMessage[],
-) {
-  const replyMessages = sentMessages.filter((message) =>
-    hasQuotedReplyContent(emailToContent(message, { maxLength: 0 })),
-  );
-
-  return replyMessages.length >= MIN_REPLY_SAMPLES_FOR_STYLE
-    ? replyMessages
-    : sentMessages;
-}

--- a/apps/web/utils/ai/knowledge/select-writing-style-samples.test.ts
+++ b/apps/web/utils/ai/knowledge/select-writing-style-samples.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ParsedMessage } from "@/utils/types";
-import { selectWritingStyleSampleMessages } from "./assess";
+import { selectWritingStyleSampleMessages } from "./select-writing-style-samples";
 
 describe("selectWritingStyleSampleMessages", () => {
   it("keeps only in-thread replies when there are enough of them", () => {

--- a/apps/web/utils/ai/knowledge/select-writing-style-samples.ts
+++ b/apps/web/utils/ai/knowledge/select-writing-style-samples.ts
@@ -1,0 +1,16 @@
+import type { ParsedMessage } from "@/utils/types";
+import { emailToContent, hasQuotedReplyContent } from "@/utils/mail";
+
+const MIN_REPLY_SAMPLES_FOR_STYLE = 5;
+
+export function selectWritingStyleSampleMessages(
+  sentMessages: ParsedMessage[],
+) {
+  const replyMessages = sentMessages.filter((message) =>
+    hasQuotedReplyContent(emailToContent(message, { maxLength: 0 })),
+  );
+
+  return replyMessages.length >= MIN_REPLY_SAMPLES_FOR_STYLE
+    ? replyMessages
+    : sentMessages;
+}

--- a/apps/web/utils/ai/reply/reply-memory.ts
+++ b/apps/web/utils/ai/reply/reply-memory.ts
@@ -227,7 +227,7 @@ export async function getReplyMemoriesForPrompt({
     );
 
     const selected = await selectReplyMemoriesForEmail({
-      candidates,
+      prioritizedCandidates: candidates,
       emailContent,
       emailAccount,
       logger,

--- a/apps/web/utils/ai/reply/select-reply-memories.ts
+++ b/apps/web/utils/ai/reply/select-reply-memories.ts
@@ -38,52 +38,45 @@ const selectionSchema = z.object({
     ),
 });
 
-/**
- * Narrows a candidate pool (pre-sorted by scope priority) down to the
- * memories worth injecting into the draft prompt. Falls back to the
- * scope-priority order when AI selection fails.
- */
 export async function selectReplyMemoriesForEmail<
   T extends ReplyMemoryCandidate,
 >({
-  candidates,
+  prioritizedCandidates,
   emailContent,
   emailAccount,
   logger,
 }: {
-  candidates: T[];
+  prioritizedCandidates: T[];
   emailContent: string;
   emailAccount: EmailAccountWithAI;
   logger: Logger;
 }): Promise<T[]> {
-  if (candidates.length <= MAX_SELECTED_REPLY_MEMORIES) return candidates;
+  if (prioritizedCandidates.length <= MAX_SELECTED_REPLY_MEMORIES) {
+    return prioritizedCandidates;
+  }
 
   const selectedIds = await aiSelectRelevantReplyMemories({
-    candidates,
+    candidates: prioritizedCandidates,
     emailContent,
     emailAccount,
     logger,
   });
 
-  // Selection failed; fall back to scope-priority + recency.
   if (selectedIds === null) {
-    return candidates.slice(0, MAX_SELECTED_REPLY_MEMORIES);
+    return prioritizedCandidates.slice(0, MAX_SELECTED_REPLY_MEMORIES);
   }
 
   const candidatesById = new Map(
-    candidates.map((memory) => [memory.id, memory]),
+    prioritizedCandidates.map((memory) => [memory.id, memory]),
   );
 
-  // Keep the model's most-relevant-first ordering.
+  // Keep the model's most-relevant-first ordering rather than reverting to
+  // prioritizedCandidates' scope-priority order.
   return selectedIds
     .map((id) => candidatesById.get(id))
     .filter((memory): memory is T => memory !== undefined);
 }
 
-/**
- * Returns the selected memory ids, or null on failure so callers can fall
- * back to heuristic selection.
- */
 export async function aiSelectRelevantReplyMemories({
   candidates,
   emailContent,

--- a/apps/web/utils/mail.test.ts
+++ b/apps/web/utils/mail.test.ts
@@ -4,6 +4,7 @@ import {
   emailToContent,
   convertEmailHtmlToText,
   parseReply,
+  hasQuotedReplyContent,
 } from "./mail";
 
 describe("emailToContent", () => {
@@ -291,6 +292,22 @@ On Jan 1, 2024, someone@example.com wrote:
     const plainText = "Simple message without any quotes";
     const result = parseReply(plainText);
     expect(result).toBe("Simple message without any quotes");
+  });
+});
+
+describe("hasQuotedReplyContent", () => {
+  it("returns true for a reply quoting an earlier message", () => {
+    const plainText = `Thanks, that works for me.
+
+On Jan 1, 2024, someone@example.com wrote:
+> Does tomorrow work?`;
+
+    expect(hasQuotedReplyContent(plainText)).toBe(true);
+  });
+
+  it("returns false for a freshly composed message", () => {
+    const plainText = "Hey team, just wanted to check in on the project.";
+    expect(hasQuotedReplyContent(plainText)).toBe(false);
   });
 });
 

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -12,8 +12,6 @@ export function parseReply(plainText: string) {
   return result;
 }
 
-// True when the message quotes an earlier message in the thread (a reply),
-// as opposed to a freshly composed email, forward, or newsletter reply.
 export function hasQuotedReplyContent(plainText: string): boolean {
   return new EmailReplyParser().read(plainText).getQuotedText().length > 0;
 }

--- a/apps/web/utils/mail.ts
+++ b/apps/web/utils/mail.ts
@@ -12,6 +12,12 @@ export function parseReply(plainText: string) {
   return result;
 }
 
+// True when the message quotes an earlier message in the thread (a reply),
+// as opposed to a freshly composed email, forward, or newsletter reply.
+export function hasQuotedReplyContent(plainText: string): boolean {
+  return new EmailReplyParser().read(plainText).getQuotedText().length > 0;
+}
+
 const IMAGE_ALT_MAX_LENGTH = 160;
 const IMAGE_PLACEHOLDER = "[image]";
 const GENERIC_IMAGE_ALT_TEXT_PATTERN =


### PR DESCRIPTION
## Summary

Follow-up to #2987. Two changes:

1. **Fixes the writing-style sampling population mismatch.** Onboarding writing-style analysis (`utils/actions/assess.ts`) summarized the last 20 sent messages unfiltered — mixing quick replies with cold outreach, forwards, and from-scratch compositions. The resulting "typical length" guidance skewed long (e.g. "varies... single-sentence to 3-4 paragraphs") and then overrode the default brevity instruction used when drafting replies, even though replies to inbound email are a much shorter, distinct population from sent mail overall.

   Now samples a wider pool (60) and prefers messages that quote an earlier message in the thread — true in-thread replies, detected via the same `email-reply-parser` library already used for `parseReply` — falling back to the unfiltered pool when too few qualify (<5).

2. **Removes comments that restated clear names/behavior**, in both the new code and in the already-merged `select-reply-memories.ts` from #2987, per repo preference for self-documenting code. One parameter was renamed (`candidates` → `prioritizedCandidates`) so a previously-implicit precondition is now conveyed by the name instead of a comment.

## Changes

- `utils/mail.ts`: new `hasQuotedReplyContent` helper
- `utils/actions/assess.ts`: wider sample pool + reply-filtering with fallback
- `utils/ai/reply/select-reply-memories.ts`, `utils/ai/reply/reply-memory.ts`: comment cleanup, parameter rename
- New tests: `utils/mail.test.ts`, `utils/actions/assess.test.ts`

## Testing

- Full repo suite passing: 456 test files, 4172 tests
- New/updated unit tests for the quote-detection helper and sampling/fallback logic

## Follow-ups (not in this PR)

- Backfill existing accounts whose `writingStyle` was generated with the old unfiltered sampling (planned as a separate script after this merges)
- `learnedWritingStyle` (evidence-based, refreshed from real draft edits) is currently always subordinate to the static onboarding `writingStyle` once the latter is set — worth revisiting separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

