### PR TITLE
Fix email account deletion for admin memberships

### DIFF
--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -276,6 +276,51 @@ describe("deleteEmailAccountAction", () => {
     expect(updateAccountSeats).not.toHaveBeenCalled();
   });
 
+  it("deletes an admin membership before deleting its email account when another owner remains", async () => {
+    prisma.emailAccount.findUnique.mockResolvedValue({
+      email: "admin@example.com",
+      accountId: "account-2",
+      user: { email: "owner@example.com" },
+    } as Awaited<ReturnType<typeof prisma.emailAccount.findUnique>>);
+    prisma.member.findMany.mockResolvedValue([
+      { organizationId: "org-1" },
+    ] as Awaited<ReturnType<typeof prisma.member.findMany>>);
+    prisma.organization.findMany.mockResolvedValue([
+      {
+        id: "org-1",
+        name: "Org",
+        members: [
+          { emailAccountId: "owner-email-account", role: "owner" },
+          { emailAccountId: "admin-email-account", role: "admin" },
+        ],
+      },
+    ] as Awaited<ReturnType<typeof prisma.organization.findMany>>);
+
+    const result = await deleteEmailAccountAction({
+      emailAccountId: "admin-email-account",
+    });
+
+    expect(result?.serverError).toBeUndefined();
+    expect(prisma.member.deleteMany).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "admin-email-account",
+        organizationId: { notIn: [] },
+      },
+    });
+    expect(prisma.member.deleteMany.mock.invocationCallOrder[0]).toBeLessThan(
+      prisma.emailAccount.delete.mock.invocationCallOrder[0],
+    );
+    expect(prisma.emailAccount.delete).toHaveBeenCalledWith({
+      where: {
+        id: "admin-email-account",
+        userId: "user-1",
+        accountId: "account-2",
+        user: { email: "owner@example.com" },
+      },
+    });
+    expect(updateAccountSeats).toHaveBeenCalledWith({ userId: "user-1" });
+  });
+
   it("deletes a solo organization before deleting its only email account", async () => {
     prisma.emailAccount.findMany.mockResolvedValue([
       {

--- a/apps/web/utils/actions/user.test.ts
+++ b/apps/web/utils/actions/user.test.ts
@@ -318,6 +318,9 @@ describe("deleteEmailAccountAction", () => {
         user: { email: "owner@example.com" },
       },
     });
+    expect(prisma.account.delete).toHaveBeenCalledWith({
+      where: { id: "account-2", userId: "user-1" },
+    });
     expect(updateAccountSeats).toHaveBeenCalledWith({ userId: "user-1" });
   });
 

--- a/apps/web/utils/actions/user.ts
+++ b/apps/web/utils/actions/user.ts
@@ -145,6 +145,12 @@ export const deleteEmailAccountAction = actionClientUser
         getDeleteSoloOrganizationsOperation(organizationIdsToDelete, [
           emailAccountId,
         ]);
+      const deleteRemainingMembershipsOperation = prisma.member.deleteMany({
+        where: {
+          emailAccountId,
+          organizationId: { notIn: organizationIdsToDelete },
+        },
+      });
 
       if (isPrimaryAccount) {
         // Check if there are other email accounts
@@ -174,6 +180,7 @@ export const deleteEmailAccountAction = actionClientUser
           userId,
           [
             deleteSoloOrganizationsOperation,
+            deleteRemainingMembershipsOperation,
             prisma.user.update({
               where: {
                 id: userId,
@@ -212,6 +219,7 @@ export const deleteEmailAccountAction = actionClientUser
           userId,
           [
             deleteSoloOrganizationsOperation,
+            deleteRemainingMembershipsOperation,
             prisma.emailAccount.delete({
               where: {
                 id: emailAccountId,


### PR DESCRIPTION
Deleting an email account now removes safe remaining organization memberships before deleting the account. This prevents deletion from being blocked when another owner remains.

- Removes remaining memberships for the deleted email account in organizations that keep an owner.
- Preserves the ownership-transfer guard for organizations that would be left ownerless.
- Tests: `pnpm test utils/actions/user.test.ts`
- Performance: adds one `member.deleteMany` database operation inside the existing deletion transaction; no new network calls; runs only on account deletion, not a hot path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

