### PR TITLE
Forward trial starts to conversion analytics

### DIFF
--- a/apps/web/app/api/stripe/webhook/controller.ts
+++ b/apps/web/app/api/stripe/webhook/controller.ts
@@ -69,6 +69,7 @@ export async function processEvent(event: Stripe.Event, logger: Logger) {
     trackEvent(email, event),
     trackBillingMilestones(email, event, customerId),
     handleReferralCompletion(customerId, event, logger),
+    trackTrialStartedConversion(event, logger),
     trackPaidSubscriptionConversion(event, logger),
     recordCancellationInitiated(customerId, event, logger),
   ];
@@ -181,6 +182,24 @@ async function trackPaidSubscriptionConversion(
     name: "subscription_created",
     id: event.id,
     timestamp: trialConvertedAt,
+    ...getStripeSubscriptionConversionProperties(subscription),
+    logger,
+  });
+}
+
+async function trackTrialStartedConversion(
+  event: Stripe.Event,
+  logger: Logger,
+) {
+  if (event.type !== "customer.subscription.created") return;
+
+  const subscription = event.data.object as Stripe.Subscription;
+  if (subscription.status !== "trialing" || !subscription.trial_start) return;
+
+  await trackServerConversionEvent({
+    name: "trial_started",
+    id: `${event.id}:trial_started`,
+    timestamp: new Date(subscription.trial_start * 1000),
     ...getStripeSubscriptionConversionProperties(subscription),
     logger,
   });

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -231,6 +231,54 @@ describe("processEvent", () => {
     });
   });
 
+  it("tracks a trial-start conversion from a new trialing subscription", async () => {
+    mockSyncStripeDataToDb.mockResolvedValue(undefined);
+
+    await processEvent(
+      subscriptionEvent({
+        id: "evt_trial_started",
+        type: "customer.subscription.created",
+        data: {
+          object: {
+            id: "sub_test",
+            customer: "cus_test",
+            status: "trialing",
+            trial_start: 1_700_000_000,
+            metadata: {
+              conversionAttributionId: "attr_test",
+            },
+            items: {
+              data: [
+                {
+                  quantity: 1,
+                  price: {
+                    id: "price_test",
+                    unit_amount: 2000,
+                    currency: "usd",
+                  },
+                },
+              ],
+            },
+          },
+        } as Stripe.Event.Data,
+      }),
+      logger,
+    );
+
+    expect(mockTrackServerConversionEvent).toHaveBeenCalledWith({
+      name: "trial_started",
+      id: "evt_trial_started:trial_started",
+      timestamp: new Date("2023-11-14T22:13:20.000Z"),
+      attributionId: "attr_test",
+      properties: {
+        planId: "price_test",
+        amount: 2000,
+        currency: "USD",
+      },
+      logger,
+    });
+  });
+
   it("does not track paid subscription conversions for non-conversion updates", async () => {
     mockSyncStripeDataToDb.mockResolvedValue(undefined);
 

--- a/apps/web/utils/analytics/server-conversion-events.test.ts
+++ b/apps/web/utils/analytics/server-conversion-events.test.ts
@@ -96,6 +96,26 @@ describe("trackServerConversionEvent", () => {
     });
   });
 
+  it("posts trial-start conversion events to the configured private endpoint", async () => {
+    await trackServerConversionEvent({
+      name: "trial_started",
+      id: "evt_trial:trial_started",
+      timestamp: new Date("2026-07-13T00:00:00.000Z"),
+      clickIds: { gclid: "test-gclid" },
+      properties: { planId: "price_test" },
+      logger,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body);
+    expect(body).toEqual(
+      expect.objectContaining({
+        name: "trial_started",
+        id: "evt_trial:trial_started",
+        clickIds: { gclid: "test-gclid" },
+      }),
+    );
+  });
+
   it("sends the shared secret header when configured", async () => {
     envMock.CONVERSION_ANALYTICS_SERVER_SECRET = "secret_test";
 

--- a/apps/web/utils/analytics/server-conversion-events.test.ts
+++ b/apps/web/utils/analytics/server-conversion-events.test.ts
@@ -106,14 +106,23 @@ describe("trackServerConversionEvent", () => {
       logger,
     });
 
-    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body);
-    expect(body).toEqual(
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("https://example.com/rill"),
       expect.objectContaining({
-        name: "trial_started",
-        id: "evt_trial:trial_started",
-        clickIds: { gclid: "test-gclid" },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
       }),
     );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body);
+    expect(body).toEqual({
+      name: "trial_started",
+      id: "evt_trial:trial_started",
+      timestamp: "2026-07-13T00:00:00.000Z",
+      clickIds: { gclid: "test-gclid" },
+      properties: { planId: "price_test" },
+      sourceUrl: "https://example.com",
+    });
   });
 
   it("sends the shared secret header when configured", async () => {

--- a/apps/web/utils/analytics/server-conversion-events.ts
+++ b/apps/web/utils/analytics/server-conversion-events.ts
@@ -16,7 +16,7 @@ type ConversionClickIds = {
 };
 
 type ServerConversionEvent = {
-  name: "subscription_created";
+  name: "subscription_created" | "trial_started";
   id: string;
   timestamp: Date;
   attributionId?: string;


### PR DESCRIPTION
## Summary
- emit a server-side `trial_started` event when Stripe creates a trialing subscription
- preserve the stored Google click IDs and attribution metadata
- keep paid-subscription tracking unchanged
- add focused tests for trial event forwarding

## Validation
- `pnpm --dir apps/web test --run app/api/stripe/webhook/route.test.ts utils/analytics/server-conversion-events.test.ts` (26 tests passed)
- Biome check passed on the changed files

## Context
This gives Google Ads a higher-volume trial-start signal for the new non-brand campaigns while paid subscriptions remain the final business metric. The private uploader change is inbox-zero/marketing#28.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

