### PR TITLE
assistant: Improve multi-batch cleanup execution

### DIFF
--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -213,6 +213,43 @@ describe("aiProcessAssistantChat", () => {
     expect(args.tools.forwardEmail).toBeDefined();
   }, 30_000);
 
+  it("continues tool calls without a step cap and reserves time for a final response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    try {
+      const { aiProcessAssistantChat } = await loadAssistantChatModule({
+        emailSend: true,
+      });
+
+      mockToolCallAgentStream.mockResolvedValue({
+        toUIMessageStreamResponse: vi.fn(),
+      });
+
+      await aiProcessAssistantChat({
+        messages: baseMessages,
+        emailAccountId: "email-account-id",
+        user: getEmailAccount(),
+        logger,
+      });
+
+      const args = mockToolCallAgentStream.mock.lastCall?.[0];
+
+      expect(args.maxSteps).toBeUndefined();
+      expect(args.stopWhen()).toBe(false);
+      expect(await args.prepareStep()).toBeUndefined();
+
+      vi.advanceTimersByTime(240_000);
+
+      expect(await args.prepareStep()).toEqual({
+        activeTools: [],
+        toolChoice: "none",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 30_000);
+
   it.each([
     ["slack"],
     ["teams"],

--- a/apps/web/__tests__/ai-assistant-chat.test.ts
+++ b/apps/web/__tests__/ai-assistant-chat.test.ts
@@ -213,42 +213,51 @@ describe("aiProcessAssistantChat", () => {
     expect(args.tools.forwardEmail).toBeDefined();
   }, 30_000);
 
-  it("continues tool calls without a step cap and reserves time for a final response", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  it.each([
+    ["web", 240_000],
+    ["messaging", 60_000],
+  ] as const)(
+    "continues %s tool calls without a step cap and reserves time for a final response",
+    async (responseSurface, toolBudgetMs) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
 
-    try {
-      const { aiProcessAssistantChat } = await loadAssistantChatModule({
-        emailSend: true,
-      });
+      try {
+        const { aiProcessAssistantChat } = await loadAssistantChatModule({
+          emailSend: true,
+        });
 
-      mockToolCallAgentStream.mockResolvedValue({
-        toUIMessageStreamResponse: vi.fn(),
-      });
+        mockToolCallAgentStream.mockResolvedValue({
+          toUIMessageStreamResponse: vi.fn(),
+        });
 
-      await aiProcessAssistantChat({
-        messages: baseMessages,
-        emailAccountId: "email-account-id",
-        user: getEmailAccount(),
-        logger,
-      });
+        await aiProcessAssistantChat({
+          messages: baseMessages,
+          emailAccountId: "email-account-id",
+          user: getEmailAccount(),
+          responseSurface,
+          logger,
+        });
 
-      const args = mockToolCallAgentStream.mock.lastCall?.[0];
+        const args = mockToolCallAgentStream.mock.lastCall?.[0];
 
-      expect(args.maxSteps).toBeUndefined();
-      expect(args.stopWhen()).toBe(false);
-      expect(await args.prepareStep()).toBeUndefined();
+        expect(args.maxSteps).toBeUndefined();
+        expect(args.stopWhen()).toBe(false);
 
-      vi.advanceTimersByTime(240_000);
+        vi.advanceTimersByTime(toolBudgetMs - 1);
+        expect(await args.prepareStep()).toBeUndefined();
 
-      expect(await args.prepareStep()).toEqual({
-        activeTools: [],
-        toolChoice: "none",
-      });
-    } finally {
-      vi.useRealTimers();
-    }
-  }, 30_000);
+        vi.advanceTimersByTime(1);
+        expect(await args.prepareStep()).toEqual({
+          activeTools: [],
+          toolChoice: "none",
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+    30_000,
+  );
 
   it.each([
     ["slack"],

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -49,7 +49,10 @@ import { getAssistantChatProvider } from "./chat-provider-shared";
 import { LlmUseCase } from "@/utils/llms/use-cases";
 
 export const maxDuration = 300;
-const ASSISTANT_CHAT_TOOL_BUDGET_MS = 240_000;
+const ASSISTANT_CHAT_TOOL_BUDGET_MS = {
+  web: 240_000,
+  messaging: 60_000,
+} satisfies Record<"web" | "messaging", number>;
 const ASSISTANT_CHAT_REASONING_MAX_TOKENS = 100;
 
 type AssistantChatOnStepFinish = NonNullable<
@@ -326,7 +329,11 @@ export async function aiProcessAssistantChat({
     },
     stopWhen: () => false,
     prepareStep: () => {
-      if (Date.now() - startedAt < ASSISTANT_CHAT_TOOL_BUDGET_MS) return;
+      if (
+        Date.now() - startedAt <
+        ASSISTANT_CHAT_TOOL_BUDGET_MS[responseSurface]
+      )
+        return;
 
       return {
         activeTools: [],

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -49,7 +49,7 @@ import { getAssistantChatProvider } from "./chat-provider-shared";
 import { LlmUseCase } from "@/utils/llms/use-cases";
 
 export const maxDuration = 300;
-const ASSISTANT_CHAT_MAX_STEPS = 25;
+const ASSISTANT_CHAT_TOOL_BUDGET_MS = 240_000;
 const ASSISTANT_CHAT_REASONING_MAX_TOKENS = 100;
 
 type AssistantChatOnStepFinish = NonNullable<
@@ -94,6 +94,8 @@ export async function aiProcessAssistantChat({
   onModelResolved?: AssistantChatOnModelResolved;
   logger: Logger;
 }) {
+  const startedAt = Date.now();
+
   if (chatLastSeenRulesRevision !== undefined && chatHasHistory === undefined) {
     throw new Error(
       "chatHasHistory must be provided when chatLastSeenRulesRevision is set",
@@ -322,7 +324,15 @@ export async function aiProcessAssistantChat({
       });
       onModelResolved?.(resolvedModel);
     },
-    maxSteps: ASSISTANT_CHAT_MAX_STEPS,
+    stopWhen: () => false,
+    prepareStep: () => {
+      if (Date.now() - startedAt < ASSISTANT_CHAT_TOOL_BUDGET_MS) return;
+
+      return {
+        activeTools: [],
+        toolChoice: "none",
+      };
+    },
     tools: allTools,
   });
 

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -738,7 +738,7 @@ export function buildResolvedSystemPrompt({
 - For low-priority repeated senders, you may suggest bulk archive by sender as an option, but default to archiving the specific threads shown.
 - For all-matching cleanup, paginate searchInbox until hasMore=false, collect matching threadIds across pages, then write in batches.
 - Do not turn one-time cleanup into a recurring rule unless the user asks for automation.
-- For ongoing sender-level batch cleanup, once the user confirms the category, continue subsequent batches without re-asking.
+- For confirmed multi-batch cleanup, continue search and action batches within the current response until the requested scope is complete. Do not pause merely to provide progress updates or ask the user to trigger the next batch, and never claim work will continue after the response ends.
 - Never claim or report that the inbox is empty, fully caught up, or has no unread emails without first running searchInbox in this turn to confirm — the initial inbox snapshot and prior-turn results can be stale, and earlier search pages or filters may not cover the whole mailbox. Treat zero results from a single narrow query as inconclusive: broaden or re-run searchInbox before asserting absence. If the user signals doubt about a prior conclusion or asks you to re-check, re-run searchInbox with fresh (and broader, if the prior call was narrow) parameters and report the new results rather than rephrasing the prior conclusion.`,
     providerPolicy.ruleSuggestionPolicy,
     `Rules and automation:

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -18,6 +18,7 @@ import {
   type StreamTextOnFinishCallback,
   type StreamTextOnStepFinishCallback,
   type PrepareStepFunction,
+  type StopCondition,
   NoObjectGeneratedError,
   TypeValidationError,
 } from "ai";
@@ -233,6 +234,7 @@ type ToolCallAgentStreamOptions = BaseStreamOptions & {
   tools?: Record<string, Tool>;
   activeTools?: Array<string>;
   prepareStep?: PrepareStepFunction<Record<string, Tool>>;
+  stopWhen?: StopCondition<Record<string, Tool>>;
   onFinish?: StreamTextOnFinishCallback<Record<string, Tool>>;
   onStepFinish?: StreamTextOnStepFinishCallback<Record<string, Tool>>;
   onModelResolved?: (resolvedModel: ToolCallAgentResolvedModel) => void;
@@ -790,6 +792,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
     tools,
     activeTools,
     prepareStep,
+    stopWhen,
     maxSteps,
     userId,
     emailAccountId,
@@ -893,7 +896,7 @@ export async function toolCallAgentStream(options: ToolCallAgentStreamOptions) {
         ? undefined
         : (activeTools as Array<keyof typeof candidateTools> | undefined),
       prepareStep,
-      stopWhen: maxSteps ? stepCountIs(maxSteps) : undefined,
+      stopWhen: stopWhen ?? (maxSteps ? stepCountIs(maxSteps) : undefined),
       temperature,
       ...commonOptions,
       providerOptions,


### PR DESCRIPTION
Allows confirmed multi-batch work to continue within the active response without a fixed step-count ceiling.

- Continue search and action batches without progress-only pauses
- Replace the fixed assistant step limit with per-surface time-aware finalization
- Reserve response time for a clear completion summary across web and messaging surfaces

Validation:
- Focused assistant chat tests
- Inbox workflow action evals
- Repository checks