### PR TITLE
ai: Extend model evaluation coverage

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-attachments.test.ts
@@ -13,10 +13,10 @@ import {
   captureAssistantChatToolCalls,
   getFirstMatchingToolCall,
   getLastMatchingToolCall,
-  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
 import { getMockMessage } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";

--- a/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-email-actions.test.ts
@@ -13,10 +13,10 @@ import {
   captureAssistantChatTrace,
   getFirstMatchingToolCall,
   getLastMatchingToolCall,
-  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
 import { getMockMessage } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";

--- a/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-eval-utils.ts
@@ -277,39 +277,6 @@ export function getLastRuleConditionUpdate(toolCalls: RecordedToolCall[]) {
   return null;
 }
 
-export function getStableMessageCacheKey(
-  messages:
-    | Array<{
-        attachments?: unknown;
-        headers?: {
-          from?: unknown;
-          subject?: unknown;
-          to?: unknown;
-        };
-        id?: unknown;
-        labelIds?: unknown;
-        snippet?: unknown;
-        subject?: unknown;
-        textHtml?: unknown;
-        textPlain?: unknown;
-        threadId?: unknown;
-      }>
-    | undefined,
-) {
-  return messages?.map((message) => ({
-    id: message.id,
-    threadId: message.threadId,
-    from: message.headers?.from,
-    to: message.headers?.to,
-    subject: message.headers?.subject ?? message.subject,
-    snippet: message.snippet,
-    textPlain: message.textPlain,
-    textHtml: message.textHtml,
-    labelIds: message.labelIds,
-    attachments: message.attachments,
-  }));
-}
-
 export type UpdateRuleConditionsInput = {
   ruleName: string;
   condition: {

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-actions.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-actions.test.ts
@@ -52,7 +52,7 @@ describe.runIf(shouldRunEval)(
           },
         ])(
           "continues Outlook mark-read cleanup through empty filtered pages [$name]",
-          async ({ prompt, categoryName }) => {
+          async ({ name, prompt, categoryName }) => {
             mockSearchMessages.mockImplementation(
               async (input: ProviderSearchInput) => {
                 if (
@@ -131,8 +131,7 @@ describe.runIf(shouldRunEval)(
               );
 
             evalReporter.record({
-              testName:
-                "outlook scoped mark read paginates empty filtered page",
+              testName: `outlook scoped mark read paginates empty filtered page (${name})`,
               model: model.label,
               pass,
               actual: `${actual} | providerSearch=${summarizeProviderSearchCalls(providerSearchCalls)}`,

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-search.test.ts
@@ -1,9 +1,3 @@
-import { afterAll, describe, expect, test } from "vitest";
-import { describeEvalMatrix } from "@/__tests__/eval/models";
-import { createEvalReporter } from "@/__tests__/eval/reporter";
-import { formatSemanticJudgeActual } from "@/__tests__/eval/semantic-judge";
-import { getMockMessage } from "@/__tests__/helpers";
-import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -20,6 +14,12 @@ import {
   shouldRunEval,
   TIMEOUT,
 } from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+import { afterAll, describe, expect, test } from "vitest";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
+import { describeEvalMatrix } from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { formatSemanticJudgeActual } from "@/__tests__/eval/semantic-judge";
+import { getMockMessage } from "@/__tests__/helpers";
 
 // pnpm test-ai eval/assistant-chat-inbox-workflows
 // Multi-model: EVAL_MODELS=all pnpm test-ai eval/assistant-chat-inbox-workflows

--- a/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-inbox-workflows-triage.test.ts
@@ -1,7 +1,3 @@
-// Import test-utils first: it declares the vi.mock for the email provider and
-// prisma. Importing a module that pulls the real app graph (e.g.
-// assistant-chat-eval-utils) before this would bind the unmocked
-// createEmailProvider, so searchInbox would hit a real DB and return no content.
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -20,7 +16,7 @@ import { afterAll, describe, expect, test } from "vitest";
 import { describeEvalMatrix } from "@/__tests__/eval/models";
 import { createEvalReporter } from "@/__tests__/eval/reporter";
 import { getMockMessage } from "@/__tests__/helpers";
-import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
 import {
   formatSemanticJudgeActual,
   judgeEvalOutput,

--- a/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-outlook-folders.test.ts
@@ -1,12 +1,3 @@
-import { afterAll, describe, expect, test } from "vitest";
-import {
-  describeEvalMatrix,
-  shouldRunEvalTests,
-} from "@/__tests__/eval/models";
-import { createEvalReporter } from "@/__tests__/eval/reporter";
-import { getMockMessage } from "@/__tests__/helpers";
-import { getStableMessageCacheKey } from "@/__tests__/eval/assistant-chat-eval-utils";
-import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 import {
   cloneEmailAccountForProvider,
   getLastMatchingToolCall,
@@ -17,6 +8,15 @@ import {
   setupInboxWorkflowEval,
   TIMEOUT,
 } from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+import { afterAll, describe, expect, test } from "vitest";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
+import {
+  describeEvalMatrix,
+  shouldRunEvalTests,
+} from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { getMockMessage } from "@/__tests__/helpers";
+import { FOLDER_SEPARATOR } from "@/utils/outlook/folders";
 
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-outlook-folders.test.ts
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-outlook-folders.test.ts

--- a/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-sender-category-cleanup.test.ts
@@ -1,11 +1,3 @@
-import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
-import { describeEvalMatrix } from "@/__tests__/eval/models";
-import { createEvalReporter } from "@/__tests__/eval/reporter";
-import { getMockMessage } from "@/__tests__/helpers";
-import {
-  getStableMessageCacheKey,
-  type RecordedToolCall,
-} from "@/__tests__/eval/assistant-chat-eval-utils";
 import {
   cloneEmailAccountForProvider,
   getFirstSearchInboxCall,
@@ -17,6 +9,12 @@ import {
   shouldRunEval,
   TIMEOUT,
 } from "@/__tests__/eval/assistant-chat-inbox-workflows-test-utils";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import type { RecordedToolCall } from "@/__tests__/eval/assistant-chat-eval-utils";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
+import { describeEvalMatrix } from "@/__tests__/eval/models";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { getMockMessage } from "@/__tests__/helpers";
 
 // pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts
 // Multi-model: EVAL_MODELS=all pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-sender-category-cleanup.test.ts

--- a/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-trash-delete.test.ts
@@ -12,10 +12,10 @@ import {
 import {
   captureAssistantChatToolCalls,
   getLastMatchingToolCall,
-  getStableMessageCacheKey,
   summarizeRecordedToolCalls,
   type RecordedToolCall,
 } from "@/__tests__/eval/assistant-chat-eval-utils";
+import { getStableMessageCacheKey } from "@/__tests__/eval/message-cache-key";
 import { getMockMessage } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
 import { createScopedLogger } from "@/utils/logger";

--- a/apps/web/__tests__/eval/choose-rule.test.ts
+++ b/apps/web/__tests__/eval/choose-rule.test.ts
@@ -686,8 +686,9 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
       const expectedLabel = Array.isArray(tc.expectedRule)
         ? tc.expectedRule.join(" | ")
         : (tc.expectedRule ?? "no match");
+      const testName = `${tc.email.from} / ${tc.email.subject} → ${expectedLabel}`;
       test(
-        `${tc.email.from} → ${expectedLabel}`,
+        testName,
         async () => {
           const result = await aiChooseRule({
             email: tc.email,
@@ -705,7 +706,7 @@ describe.runIf(shouldRunEval)("Eval: Choose Rule", () => {
           const pass = acceptable.includes(actual);
 
           evalReporter.record({
-            testName: `${tc.email.from} → ${expectedLabel}`,
+            testName,
             model: model.label,
             pass,
             expected: expectedLabel,

--- a/apps/web/__tests__/eval/message-cache-key.ts
+++ b/apps/web/__tests__/eval/message-cache-key.ts
@@ -1,0 +1,32 @@
+export function getStableMessageCacheKey(
+  messages:
+    | Array<{
+        attachments?: unknown;
+        headers?: {
+          from?: unknown;
+          subject?: unknown;
+          to?: unknown;
+        };
+        id?: unknown;
+        labelIds?: unknown;
+        snippet?: unknown;
+        subject?: unknown;
+        textHtml?: unknown;
+        textPlain?: unknown;
+        threadId?: unknown;
+      }>
+    | undefined,
+) {
+  return messages?.map((message) => ({
+    id: message.id,
+    threadId: message.threadId,
+    from: message.headers?.from,
+    to: message.headers?.to,
+    subject: message.headers?.subject ?? message.subject,
+    snippet: message.snippet,
+    textPlain: message.textPlain,
+    textHtml: message.textHtml,
+    labelIds: message.labelIds,
+    attachments: message.attachments,
+  }));
+}

--- a/apps/web/__tests__/eval/models.test.ts
+++ b/apps/web/__tests__/eval/models.test.ts
@@ -8,6 +8,41 @@ afterEach(() => {
 });
 
 describe("shouldRunEvalTests", () => {
+  it("exposes Azure GPT-5.6 presets without duplicating them in all-model runs", () => {
+    process.env.EVAL_MODELS = "gpt-5.6-luna-azure,gpt-5.6-terra-azure";
+
+    expect(getEvalModels()).toEqual([
+      {
+        provider: "azure-foundry",
+        model: "gpt-5.6-luna",
+        label: "GPT-5.6 Luna Azure",
+        includeInAll: false,
+      },
+      {
+        provider: "azure-foundry",
+        model: "gpt-5.6-terra",
+        label: "GPT-5.6 Terra Azure",
+        includeInAll: false,
+      },
+    ]);
+
+    process.env.EVAL_MODELS = "all";
+
+    expect(getEvalModels()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ model: "openai/gpt-5.6-luna" }),
+        expect.objectContaining({ model: "openai/gpt-5.6-terra" }),
+      ]),
+    );
+    expect(
+      getEvalModels().some(
+        (model) =>
+          model.provider === "azure-foundry" &&
+          model.model.startsWith("gpt-5.6-"),
+      ),
+    ).toBe(false);
+  });
+
   it("exposes Azure DeepSeek presets without including them in all-model runs", () => {
     process.env.EVAL_MODELS = "deepseek-v4-pro-azure";
 

--- a/apps/web/__tests__/eval/models.ts
+++ b/apps/web/__tests__/eval/models.ts
@@ -36,6 +36,28 @@ const EVAL_MODEL_CATALOG: Record<string, EvalModel> = {
     model: "openai/gpt-5.4-mini",
     label: "GPT-5.4 Mini",
   },
+  "gpt-5.6-luna": {
+    provider: "openrouter",
+    model: "openai/gpt-5.6-luna",
+    label: "GPT-5.6 Luna",
+  },
+  "gpt-5.6-terra": {
+    provider: "openrouter",
+    model: "openai/gpt-5.6-terra",
+    label: "GPT-5.6 Terra",
+  },
+  "gpt-5.6-luna-azure": {
+    provider: "azure-foundry",
+    model: "gpt-5.6-luna",
+    label: "GPT-5.6 Luna Azure",
+    includeInAll: false,
+  },
+  "gpt-5.6-terra-azure": {
+    provider: "azure-foundry",
+    model: "gpt-5.6-terra",
+    label: "GPT-5.6 Terra Azure",
+    includeInAll: false,
+  },
   "deepseek-v4-pro-azure": {
     provider: "azure-foundry",
     model: "DeepSeek-V4-Pro",

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -238,6 +238,32 @@ describe("eval reporter", () => {
     expect(markdown).toContain("## Eval Cache");
     expect(markdown).toContain("Cached records: 1/1");
   });
+
+  it("reuses an identical cached scenario on the same reporter", async () => {
+    const { packageDir } = createTempWorkspace();
+    process.chdir(packageDir);
+    process.env.EVAL_RESULT_CACHE = "readwrite";
+    process.env.EVAL_RESULT_CACHE_DIR = ".context/cache";
+
+    const firstRun = vi.fn().mockResolvedValue({
+      pass: true,
+      actual: "live result",
+    });
+    const secondRun = vi.fn();
+    const options = {
+      testName: "example case",
+      model: "Example Model",
+      cacheKeyParts: [{ input: "hello" }],
+    };
+    const reporter = createEvalReporter({ evalName: "example eval" });
+
+    const firstRecord = await reporter.recordCached(options, firstRun);
+    const secondRecord = await reporter.recordCached(options, secondRun);
+
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(secondRun).not.toHaveBeenCalled();
+    expect(secondRecord).toBe(firstRecord);
+  });
 });
 
 function createTempWorkspace(): {

--- a/apps/web/__tests__/eval/reporter.test.ts
+++ b/apps/web/__tests__/eval/reporter.test.ts
@@ -163,6 +163,25 @@ describe("eval reporter", () => {
     });
   });
 
+  it("rejects duplicate test records for the same model", () => {
+    const reporter = createEvalReporter({ evalName: "example eval" });
+    reporter.record({
+      testName: "example case",
+      model: "Example Model",
+      pass: true,
+    });
+
+    expect(() =>
+      reporter.record({
+        testName: "example case",
+        model: "Example Model",
+        pass: false,
+      }),
+    ).toThrowError(
+      'Duplicate eval record for "example case" using "Example Model"',
+    );
+  });
+
   it("reuses cached eval records in readwrite mode", async () => {
     const { workspaceRoot, packageDir } = createTempWorkspace();
     process.chdir(packageDir);

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -86,6 +86,11 @@ class EvalReporter {
       model: options.model,
       testName: options.testName,
     });
+    const existingRecord = this.records.find(
+      (record) => record.cacheKey === cacheKey,
+    );
+    if (existingRecord) return existingRecord;
+
     const cachePath = getEvalResultCachePath(cacheKey);
 
     if (cacheMode !== "off" && cacheMode !== "refresh") {

--- a/apps/web/__tests__/eval/reporter.ts
+++ b/apps/web/__tests__/eval/reporter.ts
@@ -60,6 +60,17 @@ class EvalReporter {
   }
 
   record(result: EvalRecord): void {
+    if (
+      this.records.some(
+        (record) =>
+          record.testName === result.testName && record.model === result.model,
+      )
+    ) {
+      throw new Error(
+        `Duplicate eval record for "${result.testName}" using "${result.model}"`,
+      );
+    }
+
     this.records.push(result);
   }
 

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-senders.ts
@@ -6,6 +6,7 @@ import { formatCategoriesForPrompt } from "@/utils/ai/categorize-sender/format-c
 import { extractEmailAddress } from "@/utils/email";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createGenerateObject } from "@/utils/llms";
+import { strictOptional } from "@/utils/llms/strict-optional";
 
 export const REQUEST_MORE_INFORMATION_CATEGORY = "RequestMoreInformation";
 export const UNKNOWN_CATEGORY = "Other";
@@ -13,8 +14,7 @@ export const UNKNOWN_CATEGORY = "Other";
 const categorizeSendersSchema = z.object({
   senders: z.array(
     z.object({
-      // reasoning models often omit this; a missing rationale shouldn't fail categorization
-      rationale: z.string().nullish().describe("Keep it short."),
+      rationale: strictOptional(z.string()).describe("Keep it short."),
       sender: z.string(),
       category: z.string(), // not using enum, because sometimes the ai creates new categories, which throws an error. we prefer to handle this ourselves
     }),

--- a/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
+++ b/apps/web/utils/ai/categorize-sender/ai-categorize-single-sender.ts
@@ -4,6 +4,7 @@ import type { Category } from "@/generated/prisma/client";
 import { formatCategoriesForPrompt } from "@/utils/ai/categorize-sender/format-categories";
 import { getModelForUseCase, LlmUseCase } from "@/utils/llms/use-cases";
 import { createGenerateObject } from "@/utils/llms";
+import { strictOptional } from "@/utils/llms/strict-optional";
 
 export async function aiCategorizeSender({
   emailAccount,
@@ -63,11 +64,9 @@ ${formatCategoriesForPrompt(categories)}
     system,
     prompt,
     schema: z.object({
-      // reasoning models often omit this; a missing rationale shouldn't fail categorization
-      rationale: z
-        .string()
-        .nullish()
-        .describe("Keep it short. 1-2 sentences max."),
+      rationale: strictOptional(z.string()).describe(
+        "Keep it short. 1-2 sentences max.",
+      ),
       category: z.string(),
     }),
   });

--- a/apps/web/utils/llms/pricing.generated.ts
+++ b/apps/web/utils/llms/pricing.generated.ts
@@ -115,9 +115,9 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     cachedInput: 1.65e-7,
   },
   "deepseek/deepseek-v4-flash": {
-    input: 9e-8,
-    output: 1.8e-7,
-    cachedInput: 2e-8,
+    input: 7.7e-8,
+    output: 1.54e-7,
+    cachedInput: 1.54e-8,
   },
   "eu.anthropic.claude-sonnet-4-6": {
     input: 0.000_003,
@@ -284,15 +284,25 @@ export const OPENROUTER_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 0.000_001_25,
     cachedInput: 2e-8,
   },
+  "gpt-5.6-luna": {
+    input: 0.000_001,
+    output: 0.000_006,
+    cachedInput: 1e-7,
+  },
+  "gpt-5.6-terra": {
+    input: 0.000_002_5,
+    output: 0.000_015,
+    cachedInput: 2.5e-7,
+  },
   "llama-3.3-70b-versatile": {
     input: 5.9e-7,
     output: 7.900_000_000_000_001e-7,
     cachedInput: 5.9e-7,
   },
   "meta-llama/llama-4-maverick": {
-    input: 1.5e-7,
-    output: 6e-7,
-    cachedInput: 1.5e-7,
+    input: 2e-7,
+    output: 8e-7,
+    cachedInput: 2e-7,
   },
   "moonshotai/kimi-k2": {
     input: 5.7e-7,

--- a/apps/web/utils/llms/strict-optional.test.ts
+++ b/apps/web/utils/llms/strict-optional.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { strictOptional } from "@/utils/llms/strict-optional";
+
+describe("strictOptional", () => {
+  it("accepts omitted values while generating a required nullable property", () => {
+    const schema = z.object({
+      rationale: strictOptional(z.string()),
+      category: z.string(),
+    });
+
+    expect(schema.parse({ category: "Newsletter" })).toEqual({
+      rationale: null,
+      category: "Newsletter",
+    });
+    expect(z.toJSONSchema(schema)).toMatchObject({
+      properties: {
+        rationale: {
+          anyOf: [{ type: "string" }, { type: "null" }],
+        },
+      },
+      required: ["rationale", "category"],
+    });
+  });
+});

--- a/apps/web/utils/llms/strict-optional.ts
+++ b/apps/web/utils/llms/strict-optional.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export function strictOptional<T extends z.ZodType>(schema: T) {
+  return z.preprocess((value) => value ?? null, schema.nullable());
+}

--- a/apps/web/utils/llms/supported-model-pricing.ts
+++ b/apps/web/utils/llms/supported-model-pricing.ts
@@ -70,6 +70,16 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 1.25 / 1_000_000,
     cachedInput: 0.02 / 1_000_000,
   },
+  "gpt-5.6-luna": {
+    input: 1 / 1_000_000,
+    output: 6 / 1_000_000,
+    cachedInput: 0.1 / 1_000_000,
+  },
+  "gpt-5.6-terra": {
+    input: 2.5 / 1_000_000,
+    output: 15 / 1_000_000,
+    cachedInput: 0.25 / 1_000_000,
+  },
   "gpt-5-mini": {
     input: 0.25 / 1_000_000,
     output: 2 / 1_000_000,
@@ -183,6 +193,8 @@ export const OPENROUTER_MODEL_ID_BY_SUPPORTED_MODEL: Partial<
   "gpt-5.4": "openai/gpt-5.4",
   "gpt-5.4-mini": "openai/gpt-5.4-mini",
   "gpt-5.4-nano": "openai/gpt-5.4-nano",
+  "gpt-5.6-luna": "openai/gpt-5.6-luna",
+  "gpt-5.6-terra": "openai/gpt-5.6-terra",
   "gpt-5-mini": "openai/gpt-5-mini",
   "gpt-5.1": "openai/gpt-5.1",
   "claude-3-5-sonnet-20240620": "anthropic/claude-3.5-sonnet",


### PR DESCRIPTION
Adds support for evaluating additional models while keeping structured outputs compatible across providers.

- Refreshes model pricing metadata and evaluation presets.
- Preserves optional structured-output behavior under strict schemas.
- Hardens evaluation mocks, cache helpers, and duplicate reporting.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

