### PR TITLE
fix: harden React bulk workflows

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithAccount } from "@/utils/fetch";
+import { runAiRules } from "@/utils/queue/email-actions";
+import { onRun } from "./bulk-run";
+
+vi.mock("@/utils/fetch", () => ({ fetchWithAccount: vi.fn() }));
+vi.mock("@/utils/queue/email-actions", () => ({ runAiRules: vi.fn() }));
+vi.mock("@/utils/sleep", () => ({ sleep: vi.fn() }));
+
+describe("onRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not queue a fetched batch after cancellation", async () => {
+    vi.mocked(fetchWithAccount).mockImplementation(
+      ({ init }) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    const onThreadsQueued = vi.fn();
+    const onComplete = vi.fn();
+
+    const abort = await onRun(
+      "account-id",
+      { startDate: new Date("2026-01-01T00:00:00.000Z") },
+      onThreadsQueued,
+      onComplete,
+    );
+    abort();
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith("cancelled", 0);
+    });
+    expect(onThreadsQueued).not.toHaveBeenCalled();
+    expect(runAiRules).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
@@ -40,4 +40,32 @@ describe("onRun", () => {
     expect(onThreadsQueued).not.toHaveBeenCalled();
     expect(runAiRules).not.toHaveBeenCalled();
   });
+
+  it("continues fetching while another page is available", async () => {
+    let page = 0;
+    vi.mocked(fetchWithAccount).mockImplementation(async () => {
+      page += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          threads: [{ id: `thread-${page}`, messages: [{ id: "message-id" }] }],
+          nextPageToken: page <= 100 ? `page-${page + 1}` : undefined,
+        }),
+      } as Response;
+    });
+    const onComplete = vi.fn();
+
+    await onRun(
+      "account-id",
+      { startDate: new Date("2026-01-01T00:00:00.000Z") },
+      vi.fn(),
+      onComplete,
+    );
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith("success", 101);
+    });
+    expect(fetchWithAccount).toHaveBeenCalledTimes(101);
+    expect(runAiRules).toHaveBeenCalledTimes(101);
+  });
 });

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -4,16 +4,12 @@ import { useReducer, useRef, useState } from "react";
 import { PauseIcon, PlayIcon, SquareIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SectionDescription } from "@/components/Typography";
-import type { ThreadsResponse } from "@/app/api/threads/route";
-import type { ThreadsQuery } from "@/utils/threads/validation";
 import { LoadingContent } from "@/components/LoadingContent";
-import { runAiRules } from "@/utils/queue/email-actions";
 import {
   pauseAiQueue,
   resumeAiQueue,
   clearAiQueue,
 } from "@/utils/queue/ai-queue";
-import { sleep } from "@/utils/sleep";
 import { toastError } from "@/components/Toast";
 import { PremiumAlertWithData } from "@/components/PremiumAlert";
 import { usePremium } from "@/hooks/usePremium";
@@ -29,10 +25,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useAccount } from "@/providers/EmailAccountProvider";
-import { fetchWithAccount } from "@/utils/fetch";
 import { Toggle } from "@/components/Toggle";
 import { hasTierAccess } from "@/utils/premium";
-import { createSearchParams } from "@/utils/url";
 import { BulkProcessActivityLog } from "@/app/(app)/[emailAccountId]/assistant/BulkProcessActivityLog";
 import {
   bulkRunReducer,
@@ -40,6 +34,7 @@ import {
   initialBulkRunState,
 } from "@/app/(app)/[emailAccountId]/assistant/bulk-run-rules-reducer";
 import { useEndStripeTrial } from "@/hooks/useEndStripeTrial";
+import { onRun } from "@/app/(app)/[emailAccountId]/assistant/bulk-run";
 
 const TRIAL_BULK_PROCESS_EMAIL_LIMIT = 200;
 
@@ -285,115 +280,4 @@ export function BulkRunRules() {
       </Dialog>
     </div>
   );
-}
-
-// fetch batches of messages and add them to the ai queue
-async function onRun(
-  emailAccountId: string,
-  {
-    startDate,
-    endDate,
-    includeRead,
-    maxEmails,
-  }: {
-    startDate: Date;
-    endDate?: Date;
-    includeRead?: boolean;
-    maxEmails?: number;
-  },
-  onThreadsQueued: (threads: ThreadsResponse["threads"]) => void,
-  onComplete: (
-    status: "success" | "error" | "cancelled",
-    count: number,
-  ) => void,
-) {
-  let nextPageToken = "";
-  const LIMIT = 25;
-  let totalProcessed = 0;
-
-  let aborted = false;
-
-  function abort() {
-    aborted = true;
-  }
-
-  async function run() {
-    for (let i = 0; i < 100; i++) {
-      const query: ThreadsQuery = {
-        type: "inbox",
-        limit: LIMIT,
-        after: startDate,
-        ...(endDate ? { before: endDate } : {}),
-        ...(!includeRead ? { isUnread: true } : {}),
-        ...(nextPageToken ? { nextPageToken } : {}),
-      };
-
-      const res = await fetchWithAccount({
-        url: `/api/threads?${createSearchParams(query).toString()}`,
-        emailAccountId,
-      });
-
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        console.error("Failed to fetch threads:", res.status, errorData);
-        toastError({
-          title: "Failed to fetch emails",
-          description:
-            typeof errorData.error === "string"
-              ? errorData.error
-              : `Error: ${res.status}`,
-        });
-        onComplete("error", totalProcessed);
-        return;
-      }
-
-      const data: ThreadsResponse = await res.json();
-
-      if (!data.threads) {
-        console.error("Invalid response: missing threads", data);
-        toastError({
-          title: "Invalid response",
-          description: "Failed to process emails. Please try again.",
-        });
-        onComplete("error", totalProcessed);
-        return;
-      }
-
-      nextPageToken = data.nextPageToken || "";
-
-      const threadsWithoutPlan = data.threads.filter((t) => !t.plan);
-      const remainingEmails =
-        maxEmails === undefined ? undefined : maxEmails - totalProcessed;
-      if (remainingEmails !== undefined && remainingEmails <= 0) break;
-
-      const threadsToQueue =
-        remainingEmails === undefined
-          ? threadsWithoutPlan
-          : threadsWithoutPlan.slice(0, remainingEmails);
-
-      onThreadsQueued(threadsToQueue);
-      totalProcessed += threadsToQueue.length;
-
-      runAiRules(emailAccountId, threadsToQueue, false);
-
-      if (aborted) {
-        onComplete("cancelled", totalProcessed);
-        return;
-      }
-
-      if (maxEmails !== undefined && totalProcessed >= maxEmails) break;
-
-      if (!nextPageToken) break;
-
-      // avoid gmail api rate limits
-      // ai takes longer anyway
-      await sleep(threadsToQueue.length ? 5000 : 2000);
-    }
-
-    onComplete("success", totalProcessed);
-  }
-
-  run();
-
-  return abort;
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
@@ -39,7 +39,7 @@ export async function onRun(
   }
 
   async function run() {
-    for (let i = 0; i < 100; i++) {
+    while (true) {
       if (completeIfCancelled()) return;
 
       const query: ThreadsQuery = {

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
@@ -1,0 +1,136 @@
+import type { ThreadsResponse } from "@/app/api/threads/route";
+import type { ThreadsQuery } from "@/utils/threads/validation";
+import { runAiRules } from "@/utils/queue/email-actions";
+import { sleep } from "@/utils/sleep";
+import { toastError } from "@/components/Toast";
+import { captureException } from "@/utils/error";
+import { fetchWithAccount } from "@/utils/fetch";
+import { createSearchParams } from "@/utils/url";
+
+const BATCH_SIZE = 25;
+
+export async function onRun(
+  emailAccountId: string,
+  {
+    startDate,
+    endDate,
+    includeRead,
+    maxEmails,
+  }: {
+    startDate: Date;
+    endDate?: Date;
+    includeRead?: boolean;
+    maxEmails?: number;
+  },
+  onThreadsQueued: (threads: ThreadsResponse["threads"]) => void,
+  onComplete: (
+    status: "success" | "error" | "cancelled",
+    count: number,
+  ) => void,
+) {
+  let nextPageToken = "";
+  let totalProcessed = 0;
+  let aborted = false;
+  const abortController = new AbortController();
+
+  function abort() {
+    aborted = true;
+    abortController.abort();
+  }
+
+  async function run() {
+    for (let i = 0; i < 100; i++) {
+      if (completeIfCancelled()) return;
+
+      const query: ThreadsQuery = {
+        type: "inbox",
+        limit: BATCH_SIZE,
+        after: startDate,
+        ...(endDate ? { before: endDate } : {}),
+        ...(!includeRead ? { isUnread: true } : {}),
+        ...(nextPageToken ? { nextPageToken } : {}),
+      };
+
+      let response: Response;
+      try {
+        response = await fetchWithAccount({
+          url: `/api/threads?${createSearchParams(query).toString()}`,
+          emailAccountId,
+          init: { signal: abortController.signal },
+        });
+      } catch (error) {
+        if (completeIfCancelled()) return;
+        throw error;
+      }
+
+      if (completeIfCancelled()) return;
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        toastError({
+          title: "Failed to fetch emails",
+          description:
+            typeof errorData.error === "string"
+              ? errorData.error
+              : `Error: ${response.status}`,
+        });
+        onComplete("error", totalProcessed);
+        return;
+      }
+
+      const data: ThreadsResponse = await response.json();
+      if (completeIfCancelled()) return;
+
+      if (!data.threads) {
+        toastError({
+          title: "Invalid response",
+          description: "Failed to process emails. Please try again.",
+        });
+        onComplete("error", totalProcessed);
+        return;
+      }
+
+      nextPageToken = data.nextPageToken || "";
+
+      const threadsWithoutPlan = data.threads.filter((thread) => !thread.plan);
+      const remainingEmails =
+        maxEmails === undefined ? undefined : maxEmails - totalProcessed;
+      if (remainingEmails !== undefined && remainingEmails <= 0) break;
+
+      const threadsToQueue =
+        remainingEmails === undefined
+          ? threadsWithoutPlan
+          : threadsWithoutPlan.slice(0, remainingEmails);
+
+      if (completeIfCancelled()) return;
+
+      onThreadsQueued(threadsToQueue);
+      totalProcessed += threadsToQueue.length;
+      runAiRules(emailAccountId, threadsToQueue, false);
+
+      if (maxEmails !== undefined && totalProcessed >= maxEmails) break;
+      if (!nextPageToken) break;
+
+      await sleep(threadsToQueue.length ? 5000 : 2000);
+    }
+
+    onComplete("success", totalProcessed);
+  }
+
+  function completeIfCancelled() {
+    if (!aborted) return false;
+    onComplete("cancelled", totalProcessed);
+    return true;
+  }
+
+  run().catch((error) => {
+    captureException(error);
+    toastError({
+      title: "Failed to process emails",
+      description: "Please try again.",
+    });
+    onComplete("error", totalProcessed);
+  });
+
+  return abort;
+}

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/BulkUnsubscribeDesktop.tsx
@@ -45,6 +45,9 @@ export function BulkUnsubscribeDesktop({
         <TableRow>
           <TableHead className="w-10 pr-0">
             <ButtonCheckbox
+              label={
+                isAllSelected ? "Deselect all senders" : "Select all senders"
+              }
               checked={isAllSelected}
               indeterminate={isSomeSelected && !isAllSelected}
               onChange={() => onToggleSelectAll()}
@@ -115,6 +118,7 @@ export function BulkUnsubscribeRowDesktop({
     >
       <TableCell className="w-10 pr-0" data-cell="checkbox">
         <ButtonCheckbox
+          label={`Select ${item.fromName || item.name}`}
           checked={checked}
           onChange={(shiftKey) => onToggleSelect?.(item.name, shiftKey)}
         />

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -516,19 +516,24 @@ export function useAutoArchive<T extends Row>({
 
     setAutoArchiveLoading(true);
 
-    await autoArchive({
-      name: item.name,
-      labelId: undefined,
-      labelName: undefined,
-      mutate,
-      refetchPremium,
-      emailAccountId,
-      queueArchiveSenders,
-    });
+    try {
+      await autoArchive({
+        name: item.name,
+        labelId: undefined,
+        labelName: undefined,
+        mutate,
+        refetchPremium,
+        emailAccountId,
+        queueArchiveSenders,
+      });
 
-    posthog.capture("Clicked Auto Archive");
-
-    setAutoArchiveLoading(false);
+      posthog.capture("Clicked Auto Archive");
+    } catch (error) {
+      captureException(error);
+      toast.error("Failed to enable auto archive");
+    } finally {
+      setAutoArchiveLoading(false);
+    }
   }, [
     item.name,
     mutate,
@@ -542,20 +547,25 @@ export function useAutoArchive<T extends Row>({
   const onDisableAutoArchive = useCallback(async () => {
     setAutoArchiveLoading(true);
 
-    if (item.autoArchived?.id) {
-      await onDeleteFilter({
-        emailAccountId,
-        filterId: item.autoArchived.id,
+    try {
+      if (item.autoArchived?.id) {
+        await onDeleteFilter({
+          emailAccountId,
+          filterId: item.autoArchived.id,
+        });
+      }
+      const statusResult = await setNewsletterStatusAction(emailAccountId, {
+        newsletterEmail: item.name,
+        status: null,
       });
+      assertActionSucceeded(statusResult);
+      await mutate();
+    } catch (error) {
+      captureException(error);
+      toast.error("Failed to disable auto archive");
+    } finally {
+      setAutoArchiveLoading(false);
     }
-    const statusResult = await setNewsletterStatusAction(emailAccountId, {
-      newsletterEmail: item.name,
-      status: null,
-    });
-    assertActionSucceeded(statusResult);
-    await mutate();
-
-    setAutoArchiveLoading(false);
   }, [item.name, item.autoArchived?.id, mutate, emailAccountId]);
 
   const onAutoArchiveAndLabel = useCallback(
@@ -564,17 +574,22 @@ export function useAutoArchive<T extends Row>({
 
       setAutoArchiveLoading(true);
 
-      await autoArchive({
-        name: item.name,
-        labelId,
-        labelName,
-        mutate,
-        refetchPremium,
-        emailAccountId,
-        queueArchiveSenders,
-      });
-
-      setAutoArchiveLoading(false);
+      try {
+        await autoArchive({
+          name: item.name,
+          labelId,
+          labelName,
+          mutate,
+          refetchPremium,
+          emailAccountId,
+          queueArchiveSenders,
+        });
+      } catch (error) {
+        captureException(error);
+        toast.error("Failed to enable auto archive");
+      } finally {
+        setAutoArchiveLoading(false);
+      }
     },
     [
       item.name,

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -12,7 +12,7 @@ import {
 } from "@/utils/actions/unsubscriber";
 import { decrementUnsubscribeCreditAction } from "@/utils/actions/premium";
 import { NewsletterStatus } from "@/generated/prisma/enums";
-import { captureException } from "@/utils/error";
+import { assertActionSucceeded, captureException } from "@/utils/error";
 import {
   addToArchiveSenderThreadQueue,
   useArchiveSenderQueueActions,
@@ -224,16 +224,19 @@ async function blockSender({
   labelName?: string;
   queueArchiveSenders: QueueArchiveSendersFn;
 }): Promise<boolean> {
-  const ok = await onAutoArchive({
-    emailAccountId,
-    from: sender,
-    gmailLabelId: labelId,
-    labelName,
-  });
-  await setNewsletterStatusAction(emailAccountId, {
-    newsletterEmail: sender,
-    status: NewsletterStatus.AUTO_ARCHIVED,
-  });
+  const [ok, statusResult] = await Promise.all([
+    onAutoArchive({
+      emailAccountId,
+      from: sender,
+      gmailLabelId: labelId,
+      labelName,
+    }),
+    setNewsletterStatusAction(emailAccountId, {
+      newsletterEmail: sender,
+      status: NewsletterStatus.AUTO_ARCHIVED,
+    }),
+  ]);
+  assertActionSucceeded(statusResult);
   await decrementUnsubscribeCreditAction();
 
   if (labelId) {
@@ -288,10 +291,11 @@ export function useUnsubscribe<T extends Row>({
       });
 
       if (item.status === NewsletterStatus.UNSUBSCRIBED) {
-        await setNewsletterStatusAction(emailAccountId, {
+        const statusResult = await setNewsletterStatusAction(emailAccountId, {
           newsletterEmail: item.name,
           status: null,
         });
+        assertActionSucceeded(statusResult);
         await mutate();
       } else {
         if (!userFacingUnsubscribeLink) {
@@ -544,10 +548,11 @@ export function useAutoArchive<T extends Row>({
         filterId: item.autoArchived.id,
       });
     }
-    await setNewsletterStatusAction(emailAccountId, {
+    const statusResult = await setNewsletterStatusAction(emailAccountId, {
       newsletterEmail: item.name,
       status: null,
     });
+    assertActionSucceeded(statusResult);
     await mutate();
 
     setAutoArchiveLoading(false);
@@ -726,10 +731,11 @@ export function useApproveButton<T extends Row>({
         });
       }
       // Set the new status
-      await setNewsletterStatusAction(emailAccountId, {
+      const result = await setNewsletterStatusAction(emailAccountId, {
         newsletterEmail: item.name,
         status: newStatus,
       });
+      assertActionSucceeded(result);
       // Don't revalidate - the optimistic update is correct
     } catch (error) {
       // Revert on error by revalidating
@@ -782,10 +788,11 @@ export function useBulkApprove<T extends Row>({
       successMessage: actionPast,
       errorMessage: `Failed to ${unapprove ? "unapprove" : "approve"}`,
       processItem: async (item) => {
-        await setNewsletterStatusAction(emailAccountId, {
+        const result = await setNewsletterStatusAction(emailAccountId, {
           newsletterEmail: item.name,
           status: newStatus,
         });
+        assertActionSucceeded(result);
       },
     });
   };
@@ -1012,10 +1019,11 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
           }).then((ok) => {
             if (ok) toastSuccess({ description: "Auto archive enabled!" });
           });
-          await setNewsletterStatusAction(emailAccountId, {
+          const statusResult = await setNewsletterStatusAction(emailAccountId, {
             newsletterEmail: item.name,
             status: NewsletterStatus.AUTO_ARCHIVED,
           });
+          assertActionSucceeded(statusResult);
           await mutate();
           await decrementUnsubscribeCreditAction();
           await refetchPremium();
@@ -1070,10 +1078,11 @@ export function useBulkUnsubscribeShortcuts<T extends Row>({
         if (e.key === "a") {
           // approve
           e.preventDefault();
-          await setNewsletterStatusAction(emailAccountId, {
+          const statusResult = await setNewsletterStatusAction(emailAccountId, {
             newsletterEmail: item.name,
             status: NewsletterStatus.APPROVED,
           });
+          assertActionSucceeded(statusResult);
           await mutate();
           return;
         }

--- a/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.test.ts
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { addThreadToEmailState, useEmailStream } from "./useEmailStream";
+import type { CleanThread } from "@/utils/redis/clean.types";
+
+describe("useEmailStream", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the existing connection when a thread arrives", () => {
+    renderHook(() => useEmailStream("account-id"));
+
+    act(() => {
+      MockEventSource.instances[0].emitThread(createThread("thread-1"));
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it("does not reconnect after unmounting during a retry delay", () => {
+    const { unmount } = renderHook(() => useEmailStream("account-id"));
+
+    act(() => {
+      MockEventSource.instances[0].emitError();
+    });
+    unmount();
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it("ignores errors from a connection after it has been replaced", () => {
+    const { rerender } = renderHook(
+      ({ emailAccountId }) => useEmailStream(emailAccountId),
+      { initialProps: { emailAccountId: "first-account" } },
+    );
+    const firstConnection = MockEventSource.instances[0];
+
+    rerender({ emailAccountId: "second-account" });
+    firstConnection.emitError();
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(MockEventSource.instances).toHaveLength(2);
+  });
+});
+
+describe("addThreadToEmailState", () => {
+  it("evicts the oldest thread from both the map and order", () => {
+    const first = createThread("first");
+    const second = createThread("second");
+    const third = createThread("third");
+
+    const result = addThreadToEmailState(
+      {
+        emailsMap: { first, second },
+        emailOrder: ["first", "second"],
+      },
+      third,
+      2,
+    );
+
+    expect(result.emailOrder).toEqual(["second", "third"]);
+    expect(result.emailsMap).toEqual({ second, third });
+  });
+});
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onerror: ((event: Event) => void) | null = null;
+  private threadListener?: (event: MessageEvent<string>) => void;
+
+  constructor() {
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    if (type === "thread" && typeof listener === "function") {
+      this.threadListener = listener as (event: MessageEvent<string>) => void;
+    }
+  }
+
+  close() {}
+
+  emitThread(thread: CleanThread) {
+    this.threadListener?.(
+      new MessageEvent("thread", { data: JSON.stringify(thread) }),
+    );
+  }
+
+  emitError() {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+function createThread(threadId: string): CleanThread {
+  return {
+    threadId,
+    date: new Date("2026-01-01T00:00:00.000Z"),
+  } as CleanThread;
+}

--- a/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.ts
+++ b/apps/web/app/(app)/[emailAccountId]/clean/useEmailStream.ts
@@ -5,6 +5,13 @@ import keyBy from "lodash/keyBy";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { CleanThread } from "@/utils/redis/clean.types";
 
+const MAX_EMAILS = 1000;
+
+type EmailStreamState = {
+  emailsMap: Record<string, CleanThread>;
+  emailOrder: string[];
+};
+
 export function useEmailStream(
   emailAccountId: string,
   initialPaused = false,
@@ -12,18 +19,18 @@ export function useEmailStream(
   filter?: string | null,
 ) {
   // Initialize emailsMap with sorted threads and proper dates
-  const [emailsMap, setEmailsMap] = useState<Record<string, CleanThread>>(() =>
-    createEmailMap(initialThreads),
-  );
-
-  // Initialize emailOrder sorted by date (newest first)
-  const [emailOrder, setEmailOrder] = useState<string[]>(() =>
-    getSortedThreadIds(initialThreads),
+  const [{ emailsMap, emailOrder }, setEmailState] = useState<EmailStreamState>(
+    () => ({
+      emailsMap: createEmailMap(initialThreads),
+      emailOrder: getSortedThreadIds(initialThreads),
+    }),
   );
 
   const [isPaused, setIsPaused] = useState(initialPaused);
   const eventSourceRef = useRef<EventSource | null>(null);
-  const maxEmails = 1000; // Maximum emails to keep in the buffer
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const connectToSSE = useCallback(() => {
     try {
@@ -58,32 +65,9 @@ export function useEmailStream(
             date: new Date(threadData.date),
           };
 
-          setEmailsMap((prev) => {
-            // If we're at the limit and this is a new email, remove the oldest one
-            if (
-              Object.keys(prev).length >= maxEmails &&
-              !prev[thread.threadId]
-            ) {
-              const newMap = { ...prev };
-              delete newMap[emailOrder[emailOrder.length - 1]];
-              return {
-                ...newMap,
-                [thread.threadId]: thread,
-              };
-            }
-            return {
-              ...prev,
-              [thread.threadId]: thread,
-            };
-          });
-
-          // Update order - add to end if new
-          setEmailOrder((prev) => {
-            if (!prev.includes(thread.threadId)) {
-              return [...prev, thread.threadId];
-            }
-            return prev;
-          });
+          setEmailState((current) =>
+            addThreadToEmailState(current, thread, MAX_EMAILS),
+          );
         } catch (error) {
           console.error("Error processing thread:", error);
         }
@@ -91,36 +75,43 @@ export function useEmailStream(
 
       eventSource.onerror = (error) => {
         console.error("SSE connection error:", error);
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close();
-          eventSourceRef.current = null;
-        }
+        if (eventSourceRef.current !== eventSource) return;
+
+        eventSource.close();
+        eventSourceRef.current = null;
 
         // Attempt to reconnect after a short delay if not paused
-        if (!isPaused) {
+        if (!isPaused && reconnectTimeoutRef.current === null) {
           console.log("Attempting to reconnect in 2 seconds...");
-          setTimeout(connectToSSE, 2000);
+          reconnectTimeoutRef.current = setTimeout(() => {
+            reconnectTimeoutRef.current = null;
+            connectToSSE();
+          }, 2000);
         }
       };
     } catch (error) {
       console.error("Error establishing SSE connection:", error);
     }
-  }, [isPaused, emailOrder, emailAccountId]);
+  }, [isPaused, emailAccountId]);
 
   // Connect or disconnect based on pause state
   useEffect(() => {
-    console.log("SSE effect triggered, isPaused:", isPaused);
     connectToSSE();
 
     // Cleanup
     return () => {
       console.log("Cleaning up SSE connection");
+      if (reconnectTimeoutRef.current !== null) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
       if (eventSourceRef.current) {
+        eventSourceRef.current.onerror = null;
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
     };
-  }, [connectToSSE, isPaused]);
+  }, [connectToSSE]);
 
   const togglePause = useCallback(() => {
     setIsPaused((prev) => !prev);
@@ -172,4 +163,26 @@ function getSortedThreadIds(threads: CleanThread[]): string[] {
     .slice()
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((thread) => thread.threadId);
+}
+
+export function addThreadToEmailState(
+  current: EmailStreamState,
+  thread: CleanThread,
+  maxEmails: number,
+): EmailStreamState {
+  const isNewThread = !current.emailsMap[thread.threadId];
+  const emailsMap = {
+    ...current.emailsMap,
+    [thread.threadId]: thread,
+  };
+
+  if (!isNewThread) return { ...current, emailsMap };
+
+  const emailOrder = [...current.emailOrder, thread.threadId];
+  if (emailOrder.length <= maxEmails) return { emailsMap, emailOrder };
+
+  const [oldestThreadId, ...remainingEmailOrder] = emailOrder;
+  delete emailsMap[oldestThreadId];
+
+  return { emailsMap, emailOrder: remainingEmailOrder };
 }

--- a/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/ColdEmailList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/cold-email-blocker/ColdEmailList.tsx
@@ -88,6 +88,11 @@ export function ColdEmailList() {
               <TableRow>
                 <TableHead className="text-center">
                   <Checkbox
+                    label={
+                      isAllSelected
+                        ? "Deselect all cold emails"
+                        : "Select all cold emails"
+                    }
                     checked={isAllSelected}
                     onChange={onToggleSelectAll}
                   />
@@ -146,6 +151,7 @@ function Row({
     <TableRow key={row.id}>
       <TableCell className="text-center">
         <Checkbox
+          label={`Select ${row.fromEmail}`}
           checked={selected.get(row.id) || false}
           onChange={() => onToggleSelect(row.id)}
         />

--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -325,7 +325,11 @@ function SuggestionRow({
 
   return (
     <li className="flex items-center gap-3 px-4 py-2.5">
-      <ButtonCheckbox checked={checked} onChange={onToggle} />
+      <ButtonCheckbox
+        label={`Select ${item.fromName || item.name}`}
+        checked={checked}
+        onChange={onToggle}
+      />
 
       <DomainIcon domain={domain} size={32} variant="circular" />
 

--- a/apps/web/components/BulkArchiveCards.tsx
+++ b/apps/web/components/BulkArchiveCards.tsx
@@ -398,6 +398,7 @@ export function BulkArchiveCards({
                       {/* Select all row */}
                       <div className="flex items-center gap-3 bg-muted/30 px-4 py-3">
                         <ButtonCheckbox
+                          label={`Select all senders in ${categoryName}`}
                           checked={areAllSelectedInCategory(categoryName)}
                           indeterminate={areSomeSelectedInCategory(
                             categoryName,
@@ -487,6 +488,7 @@ function SenderRow({
         tabIndex={0}
       >
         <ButtonCheckbox
+          label={`Select ${sender.name || sender.address}`}
           checked={isSelected}
           onChange={() => onToggleSelection()}
         />

--- a/apps/web/components/ButtonCheckbox.tsx
+++ b/apps/web/components/ButtonCheckbox.tsx
@@ -2,10 +2,12 @@ import { Check, Minus } from "lucide-react";
 import { cn } from "@/utils";
 
 export function ButtonCheckbox({
+  label,
   checked,
   indeterminate,
   onChange,
 }: {
+  label: string;
   checked: boolean;
   indeterminate?: boolean;
   onChange: (shiftKey: boolean) => void;
@@ -14,6 +16,7 @@ export function ButtonCheckbox({
     <button
       type="button"
       role="checkbox"
+      aria-label={label}
       aria-checked={indeterminate ? "mixed" : checked}
       onClick={(e) => {
         e.stopPropagation();

--- a/apps/web/components/ButtonGroup.tsx
+++ b/apps/web/components/ButtonGroup.tsx
@@ -6,7 +6,7 @@ export function ButtonGroup(props: {
   buttons: {
     text?: string;
     icon?: React.ReactNode;
-    tooltip?: string;
+    tooltip: string;
     onClick: () => void;
   }[];
   shadow?: boolean;
@@ -19,7 +19,12 @@ export function ButtonGroup(props: {
     >
       {props.buttons.map((button) => (
         <Tooltip key={button.text || button.tooltip} content={button.tooltip}>
-          <Button onClick={button.onClick} size="icon" variant="ghost">
+          <Button
+            aria-label={button.text ? undefined : button.tooltip}
+            onClick={button.onClick}
+            size="icon"
+            variant="ghost"
+          >
             {button.icon}
             {button.text}
           </Button>

--- a/apps/web/components/Checkbox.tsx
+++ b/apps/web/components/Checkbox.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from "react";
 export const Checkbox = forwardRef(
   (
     props: {
+      label: string;
       checked: boolean;
       onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     },
@@ -10,6 +11,7 @@ export const Checkbox = forwardRef(
   ) => (
     <input
       type="checkbox"
+      aria-label={props.label}
       className="h-4 w-4 cursor-pointer rounded border-gray-300 text-black focus:ring-black"
       ref={ref}
       checked={props.checked}

--- a/apps/web/components/SidebarRight.tsx
+++ b/apps/web/components/SidebarRight.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useCallback, useEffect } from "react";
 import { useSidebar } from "@/components/ui/sidebar";
-import { Chat } from "@/components/assistant-chat/chat";
 import { cn } from "@/utils";
+
+const Chat = dynamic(
+  () => import("@/components/assistant-chat/chat").then((mod) => mod.Chat),
+  { ssr: false },
+);
 
 export function SidebarRight({
   name,
@@ -24,7 +29,7 @@ export function SidebarRight({
       )}
     >
       <div className="flex h-full w-full flex-col overflow-hidden">
-        <Chat open={isOpen} onClose={close} />
+        {isOpen ? <Chat open onClose={close} /> : null}
       </div>
     </div>
   );

--- a/apps/web/components/email-list/EmailList.tsx
+++ b/apps/web/components/email-list/EmailList.tsx
@@ -358,7 +358,13 @@ export function EmailList({
       {!(isEmpty && hideActionBarWhenEmpty) && (
         <div className="flex items-center border-b border-l-4 border-border bg-background px-4 py-1">
           <div className="pl-1">
-            <Checkbox checked={isAllSelected} onChange={onToggleSelectAll} />
+            <Checkbox
+              label={
+                isAllSelected ? "Deselect all emails" : "Select all emails"
+              }
+              checked={isAllSelected}
+              onChange={onToggleSelectAll}
+            />
           </div>
           <div className="ml-2">
             <ActionButtonsBulk

--- a/apps/web/components/email-list/EmailListItem.tsx
+++ b/apps/web/components/email-list/EmailListItem.tsx
@@ -103,6 +103,7 @@ export const EmailListItem = forwardRef(
                   onKeyDown={preventPropagation}
                 >
                   <Checkbox
+                    label={`Select email: ${lastMessage.headers.subject || "No subject"}`}
                     checked={!!props.selected}
                     onChange={onRowSelected}
                   />

--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -13,6 +13,7 @@ vi.mock("@sentry/nextjs", () => ({
 }));
 
 import {
+  assertActionSucceeded,
   attachLlmRepairMetadata,
   captureException,
   checkCommonErrors,
@@ -28,6 +29,29 @@ import {
   isOutlookThrottlingError,
   markAsHandledUserKeyError,
 } from "./error";
+
+describe("assertActionSucceeded", () => {
+  it("does not throw for a successful action result", () => {
+    expect(() => assertActionSucceeded({})).not.toThrow();
+  });
+
+  it("throws the server error from a failed action result", () => {
+    expect(() =>
+      assertActionSucceeded({ serverError: "Unable to update sender" }),
+    ).toThrow("Unable to update sender");
+  });
+
+  it("throws flattened validation errors", () => {
+    expect(() =>
+      assertActionSucceeded({
+        validationErrors: {
+          formErrors: ["Invalid request"],
+          fieldErrors: {},
+        },
+      }),
+    ).toThrow("Invalid request");
+  });
+});
 
 describe("getUserFacingErrorMessage", () => {
   it.each([

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -534,6 +534,15 @@ export function getActionErrorMessage(
   return message || fallback;
 }
 
+export function assertActionSucceeded(
+  result: SafeActionError | undefined,
+): void {
+  if (!result) return;
+
+  const message = extractActionErrorMessage(result);
+  if (message) throw new Error(message);
+}
+
 function extractActionErrorMessage(error: SafeActionError): string | null {
   if (error.serverError) {
     return error.serverError;

--- a/apps/web/utils/parse/parseHtml.client.test.ts
+++ b/apps/web/utils/parse/parseHtml.client.test.ts
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import { findCtaLink } from "./parseHtml.client";
+
+describe("findCtaLink", () => {
+  it("returns the first CTA with a safe link", () => {
+    expect(
+      findCtaLink(
+        '<p><a href="https://example.com/message">view message</a></p>',
+      ),
+    ).toEqual({
+      ctaText: "View message",
+      ctaLink: "https://example.com/message",
+    });
+  });
+
+  it("normalizes links without a protocol", () => {
+    expect(findCtaLink('<a href="example.com/reply">reply</a>')).toEqual({
+      ctaText: "Reply",
+      ctaLink: "https://example.com/reply",
+    });
+  });
+
+  it("skips unsafe CTA links", () => {
+    expect(
+      findCtaLink(
+        '<a href="javascript:alert(1)">view message</a><a href="https://example.com/reply">reply</a>',
+      ),
+    ).toEqual({
+      ctaText: "Reply",
+      ctaLink: "https://example.com/reply",
+    });
+  });
+});

--- a/apps/web/utils/parse/parseHtml.client.ts
+++ b/apps/web/utils/parse/parseHtml.client.ts
@@ -8,24 +8,36 @@ export function findCtaLink(
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
-  let ctaText: string | undefined;
-  let ctaLink: string | undefined;
-
   const links = doc.querySelectorAll("a");
   for (const element of links) {
     if (!element.textContent) continue;
     if (containsCtaKeyword(element.textContent.toLowerCase())) {
-      // capitalise first letter
-      ctaText =
+      const ctaLink = normalizeCtaLink(element.getAttribute("href"));
+      if (!ctaLink) continue;
+
+      const ctaText =
         element.textContent.charAt(0).toUpperCase() +
         element.textContent.slice(1);
-      ctaLink = element.getAttribute("href") ?? undefined;
-      return;
+      return { ctaText, ctaLink };
     }
   }
+}
 
-  if (ctaLink && !ctaLink.startsWith("http") && !ctaLink.startsWith("mailto:"))
-    ctaLink = `https://${ctaLink}`;
+function normalizeCtaLink(link: string | null): string | undefined {
+  const trimmedLink = link?.trim();
+  if (!trimmedLink || trimmedLink.startsWith("/")) return;
 
-  return ctaText && ctaLink ? { ctaText, ctaLink } : undefined;
+  const normalizedLink = /^[a-z][a-z\d+.-]*:/i.test(trimmedLink)
+    ? trimmedLink
+    : `https://${trimmedLink}`;
+
+  try {
+    const protocol = new URL(normalizedLink).protocol;
+    if (protocol !== "http:" && protocol !== "https:" && protocol !== "mailto:")
+      return;
+  } catch {
+    return;
+  }
+
+  return normalizedLink;
 }

--- a/apps/web/utils/queue/email-actions.test.ts
+++ b/apps/web/utils/queue/email-actions.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runAiRules } from "./email-actions";
+import { runRulesAction } from "@/utils/actions/ai-rule";
+import { pushToAiQueueAtom, removeFromAiQueueAtom } from "@/store/ai-queue";
+import { aiQueue } from "@/utils/queue/ai-queue";
+
+vi.mock("@/utils/actions/ai-rule", () => ({ runRulesAction: vi.fn() }));
+vi.mock("@/store/ai-queue", () => ({
+  pushToAiQueueAtom: vi.fn(),
+  removeFromAiQueueAtom: vi.fn(),
+}));
+vi.mock("@/utils/queue/ai-queue", () => ({
+  aiQueue: { addAll: vi.fn() },
+}));
+
+describe("runAiRules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes a thread without messages from the visible queue", async () => {
+    await runAiRules(
+      "account-id",
+      [{ id: "thread-id", messages: [] } as never],
+      false,
+    );
+
+    await runQueuedTask();
+
+    expect(pushToAiQueueAtom).toHaveBeenCalledWith(["thread-id"]);
+    expect(runRulesAction).not.toHaveBeenCalled();
+    expect(removeFromAiQueueAtom).toHaveBeenCalledWith("thread-id");
+  });
+
+  it("removes a thread when rule processing fails", async () => {
+    vi.mocked(runRulesAction).mockRejectedValue(new Error("Failed"));
+    await runAiRules(
+      "account-id",
+      [{ id: "thread-id", messages: [{ id: "message-id" }] } as never],
+      false,
+    );
+
+    await expect(runQueuedTask()).rejects.toThrow("Failed");
+
+    expect(removeFromAiQueueAtom).toHaveBeenCalledWith("thread-id");
+  });
+});
+
+async function runQueuedTask() {
+  const tasks = vi.mocked(aiQueue.addAll).mock.calls[0][0];
+  return tasks[0]();
+}

--- a/apps/web/utils/queue/email-actions.ts
+++ b/apps/web/utils/queue/email-actions.ts
@@ -17,15 +17,19 @@ export const runAiRules = async (
 
   aiQueue.addAll(
     threads.map((thread) => async () => {
-      const message = thread.messages?.[thread.messages.length - 1];
-      if (!message) return;
-      await runRulesAction(emailAccountId, {
-        messageId: message.id,
-        threadId: thread.id,
-        rerun,
-        isTest: false,
-      });
-      removeFromAiQueueAtom(thread.id);
+      try {
+        const message = thread.messages?.[thread.messages.length - 1];
+        if (!message) return;
+
+        await runRulesAction(emailAccountId, {
+          messageId: message.id,
+          threadId: thread.id,
+          rerun,
+          isTest: false,
+        });
+      } finally {
+        removeFromAiQueueAtom(thread.id);
+      }
     }),
   );
 };


### PR DESCRIPTION
## Summary

- abort in-flight bulk rule requests before cancelled batches can be queued, and report unexpected background failures
- propagate safe-action failures in bulk unsubscribe flows and parallelize independent sender updates
- keep SSE state consistent, prevent stale reconnects, restore safe CTA parsing, and lazy-load chat only when opened
- add accessible names to shared icon actions and selection controls

## Tests

- `pnpm test utils/parse/parseHtml.client.test.ts app/(app)/[emailAccountId]/clean/useEmailStream.test.ts app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts utils/error.test.ts` (71 tests)
- `pnpm check`
- `npx react-doctor@latest --scope changed --no-score` (0 diagnostics; 2 baseline findings fixed)

## Performance

- the assistant chat code and component are no longer loaded or mounted while the right sidebar is closed
- independent auto-archive and newsletter-status actions now run concurrently
- SSE thread arrivals no longer recreate the connection, and cancelled bulk runs abort their active fetch

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

