### PR TITLE
security: Prevent chart style injection

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/stats/RuleStatsChart.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/stats/RuleStatsChart.tsx
@@ -79,6 +79,7 @@ export function RuleStatsChart({ dateRange, title }: RuleStatsChartProps) {
       return { pieChartData: [], chartConfig: {}, barChartConfig: {} };
 
     const pieData = data.ruleStats.map((rule, index) => ({
+      configKey: `rule-${index}`,
       name: rule.ruleName,
       value: rule.executedCount,
       fill: CHART_COLORS[index % CHART_COLORS.length],
@@ -90,7 +91,7 @@ export function RuleStatsChart({ dateRange, title }: RuleStatsChartProps) {
       },
       ...fromPairs(
         data.ruleStats.map((rule, index) => [
-          rule.ruleName,
+          `rule-${index}`,
           {
             label: rule.ruleName,
             color: CHART_COLORS[index % CHART_COLORS.length],
@@ -152,7 +153,7 @@ export function RuleStatsChart({ dateRange, title }: RuleStatsChartProps) {
                     <ChartPieChart>
                       <ChartTooltipComponent
                         content={
-                          <ChartTooltipContent nameKey="value" hideLabel />
+                          <ChartTooltipContent nameKey="configKey" hideLabel />
                         }
                       />
                       <ChartPie data={pieChartData} dataKey="value">

--- a/apps/web/components/ui/chart.test.ts
+++ b/apps/web/components/ui/chart.test.ts
@@ -1,0 +1,20 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ChartStyle } from "./chart";
+
+describe("ChartStyle", () => {
+  it("does not allow chart config keys to escape the style element", () => {
+    const hostileKey = "rule</style><script>alert('xss')</script><style>";
+
+    const html = renderToStaticMarkup(
+      createElement(ChartStyle, {
+        id: "rule-stats",
+        config: { [hostileKey]: { color: "red" } },
+      }),
+    );
+
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("</style><script>");
+  });
+});

--- a/apps/web/components/ui/chart.tsx
+++ b/apps/web/components/ui/chart.tsx
@@ -45,7 +45,7 @@ const ChartContainer = React.forwardRef<
   }
 >(({ id, className, children, config, ...props }, ref) => {
   const uniqueId = React.useId();
-  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
+  const chartId = `chart-${sanitizeCssIdentifier(id || uniqueId)}`;
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -78,27 +78,24 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   }
 
   return (
-    <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: chart colors are generated from typed config
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
+    <style>
+      {Object.entries(THEMES)
+        .map(
+          ([theme, prefix]) => `
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color;
-    return color ? `  --color-${key}: ${color};` : null;
+    return color ? `  --color-${sanitizeCssIdentifier(key)}: ${color};` : null;
   })
   .join("\n")}
 }
 `,
-          )
-          .join("\n"),
-      }}
-    />
+        )
+        .join("\n")}
+    </style>
   );
 };
 
@@ -361,6 +358,10 @@ function getPayloadConfigFromPayload(
   return configLabelKey in config
     ? config[configLabelKey]
     : config[key as keyof typeof config];
+}
+
+function sanitizeCssIdentifier(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 export {


### PR DESCRIPTION
Prevents database-backed rule names from escaping the server-rendered chart style element. Chart labels remain unchanged while stylesheet identifiers are generated and normalized separately.

- render chart CSS through React-escaped style content instead of raw HTML
- normalize chart IDs and CSS custom-property keys to a strict safe alphabet
- use generated rule keys while preserving rule names only as display labels
- add an SSR regression test with a hostile closing-style and script payload

Tests:
- `pnpm test components/ui/chart.test.ts`
- `pnpm check`
- `npx react-doctor@latest --scope changed --no-score`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

