### PR TITLE
Scope account providers to authenticated routes

### DIFF
--- a/apps/web/app/(landing)/components/tools/page.tsx
+++ b/apps/web/app/(landing)/components/tools/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/assistant-chat/tools";
 import { ActionType } from "@/generated/prisma/enums";
 import { ChatProvider } from "@/providers/ChatProvider";
+import { EmailAccountPreviewProvider } from "@/providers/EmailAccountProvider";
 
 export default function ToolsPage() {
   const assistantToolThreadLookup = getAssistantToolThreadLookup();
@@ -314,9 +315,11 @@ export default function ToolsPage() {
           <Suspense
             fallback={<BasicToolInfo text="Loading email action states..." />}
           >
-            <ChatProvider>
-              <AssistantEmailActionStates />
-            </ChatProvider>
+            <EmailAccountPreviewProvider>
+              <ChatProvider>
+                <AssistantEmailActionStates />
+              </ChatProvider>
+            </EmailAccountPreviewProvider>
           </Suspense>
         </section>
 

--- a/apps/web/providers/AppProviders.tsx
+++ b/apps/web/providers/AppProviders.tsx
@@ -6,14 +6,23 @@ import { ComposeModalProvider } from "@/providers/ComposeModalProvider";
 import { jotaiStore } from "@/store";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ChatProvider } from "@/providers/ChatProvider";
+import { EmailAccountProvider } from "@/providers/EmailAccountProvider";
+import { StatLoaderProvider } from "@/providers/StatLoaderProvider";
+import { SWRProvider } from "@/providers/SWRProvider";
 
 export function AppProviders(props: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="light">
       <Provider store={jotaiStore}>
-        <ChatProvider>
-          <ComposeModalProvider>{props.children}</ComposeModalProvider>
-        </ChatProvider>
+        <EmailAccountProvider>
+          <SWRProvider>
+            <StatLoaderProvider>
+              <ChatProvider>
+                <ComposeModalProvider>{props.children}</ComposeModalProvider>
+              </ChatProvider>
+            </StatLoaderProvider>
+          </SWRProvider>
+        </EmailAccountProvider>
       </Provider>
     </ThemeProvider>
   );

--- a/apps/web/providers/EmailAccountProvider.test.tsx
+++ b/apps/web/providers/EmailAccountProvider.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EmailAccountPreviewProvider,
+  useAccount,
+} from "./EmailAccountProvider";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+}));
+
+vi.mock("@/utils/actions/email-account-cookie", () => ({
+  setLastEmailAccountAction: vi.fn(),
+}));
+
+describe("EmailAccountProvider", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("supports account-free previews without requesting user accounts", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <EmailAccountPreviewProvider>
+        <AccountState />
+      </EmailAccountPreviewProvider>,
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByText("ready without an account")).toBeTruthy();
+  });
+});
+
+function AccountState() {
+  const { emailAccountId, isLoading } = useAccount();
+
+  return (
+    <span>
+      {isLoading
+        ? "loading"
+        : `ready ${emailAccountId ? "with" : "without"} an account`}
+    </span>
+  );
+}

--- a/apps/web/providers/EmailAccountProvider.tsx
+++ b/apps/web/providers/EmailAccountProvider.tsx
@@ -18,6 +18,15 @@ type Context = {
 
 const EmailAccountContext = createContext<Context | undefined>(undefined);
 
+const previewContextValue: Context = {
+  emailAccount: undefined,
+  emailAccountId: "",
+  userEmail: "",
+  isLoading: false,
+  provider: "",
+  providerRateLimit: null,
+};
+
 export function EmailAccountProvider({
   children,
 }: {
@@ -81,6 +90,18 @@ export function EmailAccountProvider({
         providerRateLimit: emailAccount?.providerRateLimit ?? null,
       }}
     >
+      {children}
+    </EmailAccountContext.Provider>
+  );
+}
+
+export function EmailAccountPreviewProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <EmailAccountContext.Provider value={previewContextValue}>
       {children}
     </EmailAccountContext.Provider>
   );

--- a/apps/web/providers/GlobalProviders.tsx
+++ b/apps/web/providers/GlobalProviders.tsx
@@ -1,10 +1,6 @@
 import type React from "react";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { SerwistProvider } from "@serwist/next/react";
-import { SWRProvider } from "@/providers/SWRProvider";
-import { StatLoaderProvider } from "@/providers/StatLoaderProvider";
-import { ComposeModalProvider } from "@/providers/ComposeModalProvider";
-import { EmailAccountProvider } from "@/providers/EmailAccountProvider";
 
 export function GlobalProviders(props: { children: React.ReactNode }) {
   return (
@@ -16,15 +12,7 @@ export function GlobalProviders(props: { children: React.ReactNode }) {
       cacheOnNavigation={false}
       disable={process.env.NODE_ENV !== "production"}
     >
-      <NuqsAdapter>
-        <EmailAccountProvider>
-          <SWRProvider>
-            <StatLoaderProvider>
-              <ComposeModalProvider>{props.children}</ComposeModalProvider>
-            </StatLoaderProvider>
-          </SWRProvider>
-        </EmailAccountProvider>
-      </NuqsAdapter>
+      <NuqsAdapter>{props.children}</NuqsAdapter>
     </SerwistProvider>
   );
 }


### PR DESCRIPTION
## Summary

- keep the root provider tree limited to truly global service-worker and URL-state infrastructure
- mount email-account, account-aware SWR, stats, chat, and compose providers only for authenticated app routes
- preserve the component showcase with a no-fetch account preview provider and a regression test

## Why

Public pages were mounting `EmailAccountProvider`, which requested the authenticated `/api/user/email-accounts` endpoint on every visit. They also mounted stats and compose infrastructure they do not use, while authenticated pages mounted a second compose provider. Scoping these providers removes that unnecessary public-page work and keeps account-dependent providers together.

## Validation

- `pnpm test providers/EmailAccountProvider.test.tsx providers/ChatProvider.test.tsx`
- `pnpm check` (passes; reports existing Biome schema and undeclared dev env warnings)
- `pnpm dlx react-doctor@latest apps/web --verbose --scope changed` (no issues)

## Performance

Public routes no longer initialize account state, call the email-accounts endpoint, mount the stats loader, or mount compose UI. Authenticated routes also avoid the previous duplicate compose provider.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

