### PR TITLE
UI lifecycle: Cancel stale progress and scroll timers

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ArchiveProgress } from "./ArchiveProgress";
 
 const mockUseArchiveQueueProgress = vi.fn();
@@ -29,6 +29,10 @@ describe("ArchiveProgress", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseArchiveQueueProgress.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("prefers sender archive progress when present", () => {
@@ -62,5 +66,20 @@ describe("ArchiveProgress", () => {
 
     expect(screen.getByText("Archiving emails...")).toBeTruthy();
     expect(screen.getByText("3 of 4 emails processed")).toBeTruthy();
+  });
+
+  it("does not reset archive progress after unmounting", () => {
+    vi.useFakeTimers();
+    mockUseQueueState.mockReturnValue({
+      totalThreads: 1,
+      activeThreads: {},
+    });
+
+    const { unmount } = render(<ArchiveProgress />);
+
+    unmount();
+    vi.runAllTimers();
+
+    expect(mockResetTotalThreads).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.tsx
@@ -19,11 +19,13 @@ export const ArchiveProgress = memo(() => {
   const isLocalCompleted = localProgress === 100;
 
   useEffect(() => {
-    if (isLocalCompleted) {
-      setTimeout(() => {
-        resetTotalThreads();
-      }, 5000);
-    }
+    if (!isLocalCompleted) return;
+
+    const resetTimeout = setTimeout(() => {
+      resetTotalThreads();
+    }, 5000);
+
+    return () => clearTimeout(resetTimeout);
   }, [isLocalCompleted]);
 
   if (hasBackendProgress) {

--- a/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/clean/EmailFirehose.tsx
@@ -74,9 +74,14 @@ export function EmailFirehose({
       virtualizer.scrollToIndex(emails.length - 1, { align: "end" });
 
       // Clear flag after scrolling is likely complete
-      setTimeout(() => {
+      const scrollTimeout = setTimeout(() => {
         isProgrammaticScrollRef.current = false;
       }, 100);
+
+      return () => {
+        clearTimeout(scrollTimeout);
+        isProgrammaticScrollRef.current = false;
+      };
     }
   }, [isPaused, tab, emails.length, virtualizer, userHasScrolled]);
 


### PR DESCRIPTION
Cancel delayed UI work when the owning effect reruns or unmounts. This prevents an old archive completion timer from resetting newer progress and keeps firehose scroll state from remaining stale.

- clear the delayed archive queue reset during effect cleanup
- clear the firehose scroll timer and restore its programmatic-scroll ref
- add a regression test proving unmounted progress cannot reset queue state

Validation:
- `pnpm test "app/(app)/[emailAccountId]/bulk-unsubscribe/ArchiveProgress.test.tsx"`
- `pnpm check` (passes with existing Biome schema and dev env warnings)
- `pnpm dlx react-doctor@latest apps/web --verbose --scope changed` (no issues)

Performance: no added network or database work; only constant-time timer cancellation on effect cleanup, outside rendering hot paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

