### PR TITLE
billing: Add opt-in Stripe invoice emails

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/BillingSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useAction } from "next-safe-action/hooks";
 import { usePremium } from "@/hooks/usePremium";
 import {
   ManageSubscription,
@@ -8,27 +9,60 @@ import {
 } from "@/app/(app)/premium/ManageSubscription";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { toastError } from "@/components/Toast";
 import {
   Item,
   ItemContent,
   ItemTitle,
   ItemDescription,
   ItemActions,
+  ItemSeparator,
 } from "@/components/ui/item";
 import {
   getPremiumTierName,
   shouldShowLegacyStripePricingNotice,
 } from "@/app/(app)/premium/config";
 import { hasActiveAppleSubscription } from "@/utils/premium";
+import { getActionErrorMessage } from "@/utils/error";
+import { updateStripeInvoiceEmailsAction } from "@/utils/actions/premium";
 
 export function BillingSection() {
-  const { premium, isPremium, isLoading, tier } = usePremium();
+  const { data, premium, isPremium, isLoading, tier, mutate } = usePremium();
   const isLegacyStripePlan = shouldShowLegacyStripePricingNotice(premium);
   const hasAppleSubscription = hasActiveAppleSubscription(
     premium?.appleExpiresAt || null,
     premium?.appleRevokedAt || null,
     premium?.appleSubscriptionStatus || null,
   );
+  const { execute, isExecuting } = useAction(updateStripeInvoiceEmailsAction, {
+    onError: (error) => {
+      toastError({
+        description: getActionErrorMessage(error.error, {
+          prefix: "Failed to update invoice emails",
+        }),
+      });
+    },
+    onSettled: () => {
+      mutate();
+    },
+  });
+
+  const handleInvoiceEmailToggle = (enabled: boolean) => {
+    if (!data?.premium) return;
+
+    mutate(
+      {
+        ...data,
+        premium: {
+          ...data.premium,
+          stripeInvoiceEmailsEnabled: enabled,
+        },
+      },
+      false,
+    );
+    execute({ enabled });
+  };
 
   return (
     <LoadingContent loading={isLoading}>
@@ -70,6 +104,28 @@ export function BillingSection() {
             </Button>
           </ItemActions>
         </Item>
+      )}
+
+      {premium?.stripeCustomerId && premium.isAdmin && (
+        <>
+          <ItemSeparator />
+          <Item size="sm">
+            <ItemContent>
+              <ItemTitle>Email paid invoices</ItemTitle>
+              <ItemDescription>
+                Automatically send each Stripe invoice to the billing email.
+              </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+              <Switch
+                aria-label="Email paid Stripe invoices"
+                checked={premium.stripeInvoiceEmailsEnabled}
+                disabled={isExecuting}
+                onCheckedChange={handleInvoiceEmailToggle}
+              />
+            </ItemActions>
+          </Item>
+        </>
       )}
     </LoadingContent>
   );

--- a/apps/web/app/api/stripe/invoice-email/queue/route.ts
+++ b/apps/web/app/api/stripe/invoice-email/queue/route.ts
@@ -1,0 +1,13 @@
+import { stripeInvoiceEmailBody } from "@/ee/billing/stripe/invoice-email";
+import { createForwardingQueueHandler } from "@/utils/queue/create-forwarding-queue-handler";
+
+export const maxDuration = 60;
+
+export const POST = createForwardingQueueHandler({
+  loggerScope: "stripe/invoice-email/queue",
+  schema: stripeInvoiceEmailBody,
+  path: "/api/stripe/invoice-email",
+  invalidPayloadMessage: "Invalid Stripe invoice email queue payload",
+  visibilityTimeoutSeconds: 55,
+  getLoggerContext: ({ invoiceId }) => ({ invoiceId }),
+});

--- a/apps/web/app/api/stripe/invoice-email/route.ts
+++ b/apps/web/app/api/stripe/invoice-email/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import {
+  sendStripeInvoiceEmail,
+  stripeInvoiceEmailBody,
+} from "@/ee/billing/stripe/invoice-email";
+import { withError } from "@/utils/middleware";
+import { withQstashOrInternal } from "@/utils/qstash";
+
+export const POST = withError(
+  "stripe/invoice-email",
+  withQstashOrInternal(async (request) => {
+    const validation = stripeInvoiceEmailBody.safeParse(await request.json());
+
+    if (!validation.success) {
+      request.logger.error("Invalid Stripe invoice email payload", {
+        errors: validation.error.issues,
+      });
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    await sendStripeInvoiceEmail({
+      invoiceId: validation.data.invoiceId,
+      logger: request.logger,
+    });
+
+    return NextResponse.json({ success: true });
+  }),
+);

--- a/apps/web/app/api/stripe/webhook/controller.ts
+++ b/apps/web/app/api/stripe/webhook/controller.ts
@@ -6,6 +6,7 @@ import {
 } from "@/ee/billing/stripe/refunds";
 import { syncAiGenerationOverageForUpcomingInvoice } from "@/ee/billing/stripe/ai-overage";
 import { syncStripeInvoicePayment } from "@/ee/billing/stripe/payments";
+import { sendStripeInvoiceEmail } from "@/ee/billing/stripe/invoice-email";
 import { getStripeTrialStartedProperties } from "@/ee/billing/stripe/posthog-events";
 import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
 import { env } from "@/env";
@@ -78,7 +79,11 @@ export async function processEvent(event: Stripe.Event, logger: Logger) {
   ];
 
   if (stripeSync.status === "fulfilled") {
-    tasks.push(syncStripeInvoicePayment({ event, logger }));
+    tasks.push(
+      syncStripeInvoicePayment({ event, logger }).then(() =>
+        sendStripeInvoiceEmail({ event, logger }),
+      ),
+    );
     tasks.push(syncAiGenerationOverageForUpcomingInvoice({ event, logger }));
   } else {
     logger.error(

--- a/apps/web/app/api/stripe/webhook/controller.ts
+++ b/apps/web/app/api/stripe/webhook/controller.ts
@@ -6,7 +6,7 @@ import {
 } from "@/ee/billing/stripe/refunds";
 import { syncAiGenerationOverageForUpcomingInvoice } from "@/ee/billing/stripe/ai-overage";
 import { syncStripeInvoicePayment } from "@/ee/billing/stripe/payments";
-import { sendStripeInvoiceEmail } from "@/ee/billing/stripe/invoice-email";
+import { enqueueStripeInvoiceEmail } from "@/ee/billing/stripe/invoice-email";
 import { getStripeTrialStartedProperties } from "@/ee/billing/stripe/posthog-events";
 import { syncStripeDataToDb } from "@/ee/billing/stripe/sync-stripe";
 import { env } from "@/env";
@@ -81,7 +81,7 @@ export async function processEvent(event: Stripe.Event, logger: Logger) {
   if (stripeSync.status === "fulfilled") {
     tasks.push(
       syncStripeInvoicePayment({ event, logger }).then(() =>
-        sendStripeInvoiceEmail({ event, logger }),
+        enqueueStripeInvoiceEmail({ event, logger }),
       ),
     );
     tasks.push(syncAiGenerationOverageForUpcomingInvoice({ event, logger }));

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -8,6 +8,7 @@ import { getStripeTrialConvertedAt } from "./trial-conversion";
 const {
   mockSyncStripeDataToDb,
   mockSyncStripeInvoicePayment,
+  mockSendStripeInvoiceEmail,
   mockSyncAiGenerationOverageForUpcomingInvoice,
   mockTrackStripeEvent,
   mockTrackBillingTrialStarted,
@@ -22,6 +23,7 @@ const {
 } = vi.hoisted(() => ({
   mockSyncStripeDataToDb: vi.fn(),
   mockSyncStripeInvoicePayment: vi.fn(),
+  mockSendStripeInvoiceEmail: vi.fn(),
   mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
   mockTrackStripeEvent: vi.fn(),
   mockTrackBillingTrialStarted: vi.fn(),
@@ -57,6 +59,10 @@ vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
 
 vi.mock("@/ee/billing/stripe/payments", () => ({
   syncStripeInvoicePayment: mockSyncStripeInvoicePayment,
+}));
+
+vi.mock("@/ee/billing/stripe/invoice-email", () => ({
+  sendStripeInvoiceEmail: mockSendStripeInvoiceEmail,
 }));
 
 vi.mock("@/ee/billing/stripe/ai-overage", () => ({
@@ -124,6 +130,7 @@ describe("processEvent", () => {
     mockFindUnique.mockResolvedValue(null);
     mockUpdateMany.mockResolvedValue({ count: 0 });
     mockSyncStripeInvoicePayment.mockResolvedValue(undefined);
+    mockSendStripeInvoiceEmail.mockResolvedValue(undefined);
     mockSyncAiGenerationOverageForUpcomingInvoice.mockResolvedValue(undefined);
     mockTrackStripeEvent.mockResolvedValue(undefined);
     mockTrackBillingTrialStarted.mockResolvedValue(undefined);
@@ -144,6 +151,10 @@ describe("processEvent", () => {
       logger,
     });
     expect(mockSyncStripeInvoicePayment).toHaveBeenCalledWith({
+      event: expect.objectContaining({ type: "invoice.paid" }),
+      logger,
+    });
+    expect(mockSendStripeInvoiceEmail).toHaveBeenCalledWith({
       event: expect.objectContaining({ type: "invoice.paid" }),
       logger,
     });
@@ -186,6 +197,7 @@ describe("processEvent", () => {
       logger,
     });
     expect(mockSyncStripeInvoicePayment).not.toHaveBeenCalled();
+    expect(mockSendStripeInvoiceEmail).not.toHaveBeenCalled();
     expect(
       mockSyncAiGenerationOverageForUpcomingInvoice,
     ).not.toHaveBeenCalled();

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -8,7 +8,7 @@ import { getStripeTrialConvertedAt } from "./trial-conversion";
 const {
   mockSyncStripeDataToDb,
   mockSyncStripeInvoicePayment,
-  mockSendStripeInvoiceEmail,
+  mockEnqueueStripeInvoiceEmail,
   mockSyncAiGenerationOverageForUpcomingInvoice,
   mockTrackStripeEvent,
   mockTrackBillingTrialStarted,
@@ -23,7 +23,7 @@ const {
 } = vi.hoisted(() => ({
   mockSyncStripeDataToDb: vi.fn(),
   mockSyncStripeInvoicePayment: vi.fn(),
-  mockSendStripeInvoiceEmail: vi.fn(),
+  mockEnqueueStripeInvoiceEmail: vi.fn(),
   mockSyncAiGenerationOverageForUpcomingInvoice: vi.fn(),
   mockTrackStripeEvent: vi.fn(),
   mockTrackBillingTrialStarted: vi.fn(),
@@ -62,7 +62,7 @@ vi.mock("@/ee/billing/stripe/payments", () => ({
 }));
 
 vi.mock("@/ee/billing/stripe/invoice-email", () => ({
-  sendStripeInvoiceEmail: mockSendStripeInvoiceEmail,
+  enqueueStripeInvoiceEmail: mockEnqueueStripeInvoiceEmail,
 }));
 
 vi.mock("@/ee/billing/stripe/ai-overage", () => ({
@@ -130,7 +130,7 @@ describe("processEvent", () => {
     mockFindUnique.mockResolvedValue(null);
     mockUpdateMany.mockResolvedValue({ count: 0 });
     mockSyncStripeInvoicePayment.mockResolvedValue(undefined);
-    mockSendStripeInvoiceEmail.mockResolvedValue(undefined);
+    mockEnqueueStripeInvoiceEmail.mockResolvedValue(undefined);
     mockSyncAiGenerationOverageForUpcomingInvoice.mockResolvedValue(undefined);
     mockTrackStripeEvent.mockResolvedValue(undefined);
     mockTrackBillingTrialStarted.mockResolvedValue(undefined);
@@ -154,7 +154,7 @@ describe("processEvent", () => {
       event: expect.objectContaining({ type: "invoice.paid" }),
       logger,
     });
-    expect(mockSendStripeInvoiceEmail).toHaveBeenCalledWith({
+    expect(mockEnqueueStripeInvoiceEmail).toHaveBeenCalledWith({
       event: expect.objectContaining({ type: "invoice.paid" }),
       logger,
     });
@@ -197,7 +197,7 @@ describe("processEvent", () => {
       logger,
     });
     expect(mockSyncStripeInvoicePayment).not.toHaveBeenCalled();
-    expect(mockSendStripeInvoiceEmail).not.toHaveBeenCalled();
+    expect(mockEnqueueStripeInvoiceEmail).not.toHaveBeenCalled();
     expect(
       mockSyncAiGenerationOverageForUpcomingInvoice,
     ).not.toHaveBeenCalled();

--- a/apps/web/app/api/user/me/route.test.ts
+++ b/apps/web/app/api/user/me/route.test.ts
@@ -124,11 +124,13 @@ describe("user/me route", () => {
         stripePriceId: null,
         stripeSubscriptionId: null,
         stripeSubscriptionStatus: null,
+        stripeInvoiceEmailsEnabled: false,
         unsubscribeCredits: 0,
         tier: null,
         emailAccountsAccess: 0,
         lemonLicenseKey: null,
         pendingInvites: [],
+        admins: [{ id: "user-1" }],
       },
       emailAccounts: [],
     } as unknown as Awaited<ReturnType<typeof prisma.user.findUnique>>);
@@ -144,7 +146,9 @@ describe("user/me route", () => {
       appleExpiresAt: "2026-02-01T00:00:00.000Z",
       appleRevokedAt: null,
       appleSubscriptionStatus: "ACTIVE",
+      isAdmin: true,
     });
+    expect(body.premium.admins).toBeUndefined();
     expect(body.premium.appleAppAccountToken).toBeUndefined();
     expect(body.premium.appleEnvironment).toBeUndefined();
     expect(body.premium.appleLatestTransactionId).toBeUndefined();

--- a/apps/web/app/api/user/me/route.ts
+++ b/apps/web/app/api/user/me/route.ts
@@ -3,7 +3,7 @@ import prisma from "@/utils/prisma";
 import { withError } from "@/utils/middleware";
 import { SafeError } from "@/utils/error";
 import { auth } from "@/utils/auth";
-import { premiumEntitlementSelect } from "@/utils/premium";
+import { isAdminForPremium, premiumEntitlementSelect } from "@/utils/premium";
 
 export type UserResponse = Awaited<ReturnType<typeof getUser>> | null;
 
@@ -33,10 +33,12 @@ async function getUser({
           stripeCustomerId: true,
           stripePriceId: true,
           stripeSubscriptionId: true,
+          stripeInvoiceEmailsEnabled: true,
           unsubscribeCredits: true,
           emailAccountsAccess: true,
           lemonLicenseKey: true,
           pendingInvites: true,
+          admins: { select: { id: true } },
         },
       },
       emailAccounts: {
@@ -71,6 +73,14 @@ async function getUser({
   );
 
   const { aiApiKey, webhookSecret, emailAccounts } = user;
+  let premium = null;
+  if (user.premium) {
+    const { admins, ...premiumData } = user.premium;
+    premium = {
+      ...premiumData,
+      isAdmin: isAdminForPremium(admins, user.id),
+    };
+  }
 
   return {
     id: user.id,
@@ -79,7 +89,7 @@ async function getUser({
     aiModel: user.aiModel,
     announcementDismissedAt: user.announcementDismissedAt,
     dismissedHints: user.dismissedHints,
-    premium: user.premium,
+    premium,
     emailAccounts: emailAccounts.map(({ members: _members, ...account }) => ({
       ...account,
     })),

--- a/apps/web/ee/billing/stripe/invoice-email.test.ts
+++ b/apps/web/ee/billing/stripe/invoice-email.test.ts
@@ -2,13 +2,27 @@ import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestLogger } from "@/__tests__/helpers";
 import prisma from "@/utils/__mocks__/prisma";
-import { sendStripeInvoiceEmail } from "./invoice-email";
+import {
+  enqueueStripeInvoiceEmail,
+  sendStripeInvoiceEmail,
+} from "./invoice-email";
 
-const { mockSendInvoiceEmail } = vi.hoisted(() => ({
-  mockSendInvoiceEmail: vi.fn(),
-}));
+const { mockEnqueueBackgroundJob, mockRetrieveInvoice, mockSendInvoiceEmail } =
+  vi.hoisted(() => ({
+    mockEnqueueBackgroundJob: vi.fn(),
+    mockRetrieveInvoice: vi.fn(),
+    mockSendInvoiceEmail: vi.fn(),
+  }));
 
 vi.mock("@/utils/prisma");
+vi.mock("@/utils/queue/dispatch", () => ({
+  enqueueBackgroundJob: mockEnqueueBackgroundJob,
+}));
+vi.mock("@/ee/billing/stripe", () => ({
+  getStripe: () => ({
+    invoices: { retrieve: mockRetrieveInvoice },
+  }),
+}));
 vi.mock("@inboxzero/resend", () => ({
   sendInvoiceEmail: mockSendInvoiceEmail,
 }));
@@ -21,52 +35,86 @@ vi.mock("@/env", () => ({
 
 const logger = createTestLogger();
 
+describe("enqueueStripeInvoiceEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnqueueBackgroundJob.mockResolvedValue("qstash");
+  });
+
+  it("queues a positive paid invoice", async () => {
+    await enqueueStripeInvoiceEmail({ event: invoiceEvent(), logger });
+
+    expect(mockEnqueueBackgroundJob).toHaveBeenCalledWith({
+      topic: "stripe-invoice-email",
+      body: { invoiceId: "in_test" },
+      qstash: {
+        queueName: "stripe-invoice-email",
+        parallelism: 3,
+        path: "/api/stripe/invoice-email",
+      },
+      logger,
+    });
+  });
+
+  it("ignores invoices without a positive paid amount", async () => {
+    await enqueueStripeInvoiceEmail({
+      event: invoiceEvent({ total: 0 }),
+      logger,
+    });
+
+    expect(mockEnqueueBackgroundJob).not.toHaveBeenCalled();
+  });
+});
+
 describe("sendStripeInvoiceEmail", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prisma.payment.findFirst.mockResolvedValue({ id: "payment-1" });
     prisma.payment.updateMany.mockResolvedValue({ count: 1 });
+    mockRetrieveInvoice.mockResolvedValue(invoice());
     mockSendInvoiceEmail.mockResolvedValue(undefined);
   });
 
-  it("emails a paid invoice after claiming its payment record", async () => {
-    await sendStripeInvoiceEmail({ event: invoiceEvent(), logger });
+  it("emails an eligible invoice idempotently and marks it sent", async () => {
+    await sendStripeInvoiceEmail({ invoiceId: "in_test", logger });
 
-    expect(prisma.payment.updateMany).toHaveBeenCalledWith({
-      where: {
-        processorId: "in_test",
-        processorType: "STRIPE",
-        invoiceEmailSentAt: null,
-        premium: { stripeInvoiceEmailsEnabled: true },
-      },
-      data: { invoiceEmailSentAt: expect.any(Date) },
-    });
     expect(mockSendInvoiceEmail).toHaveBeenCalledWith({
       from: "Inbox Zero <billing@example.com>",
       to: "billing@example.com",
       attachmentUrl: "https://stripe.example.com/invoice.pdf",
+      idempotencyKey: "stripe-invoice-email/in_test",
       emailProps: {
         baseUrl: "https://example.com",
         invoiceUrl: "https://stripe.example.com/invoice.pdf",
       },
     });
+    expect(prisma.payment.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "payment-1",
+        invoiceEmailSentAt: null,
+      },
+      data: { invoiceEmailSentAt: expect.any(Date) },
+    });
   });
 
-  it("does not email when the preference is disabled or already sent", async () => {
-    prisma.payment.updateMany.mockResolvedValue({ count: 0 });
+  it("does not retrieve or email an invoice that is disabled or already sent", async () => {
+    prisma.payment.findFirst.mockResolvedValue(null);
 
-    await sendStripeInvoiceEmail({ event: invoiceEvent(), logger });
+    await sendStripeInvoiceEmail({ invoiceId: "in_test", logger });
 
+    expect(mockRetrieveInvoice).not.toHaveBeenCalled();
     expect(mockSendInvoiceEmail).not.toHaveBeenCalled();
   });
 
   it("uses the hosted invoice when the PDF URL is unavailable", async () => {
-    await sendStripeInvoiceEmail({
-      event: invoiceEvent({
+    mockRetrieveInvoice.mockResolvedValue(
+      invoice({
         invoice_pdf: null,
         hosted_invoice_url: "https://stripe.example.com/hosted-invoice",
       }),
-      logger,
-    });
+    );
+
+    await sendStripeInvoiceEmail({ invoiceId: "in_test", logger });
 
     expect(mockSendInvoiceEmail).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -78,34 +126,31 @@ describe("sendStripeInvoiceEmail", () => {
     );
   });
 
-  it("releases the payment record when sending fails", async () => {
+  it("leaves the payment unsent when delivery fails", async () => {
     mockSendInvoiceEmail.mockRejectedValue(new Error("send failed"));
 
     await expect(
-      sendStripeInvoiceEmail({ event: invoiceEvent(), logger }),
+      sendStripeInvoiceEmail({ invoiceId: "in_test", logger }),
     ).rejects.toThrow("send failed");
 
-    const claimedAt = prisma.payment.updateMany.mock.calls[0]?.[0].data
-      .invoiceEmailSentAt as Date;
-    expect(prisma.payment.updateMany).toHaveBeenLastCalledWith({
-      where: {
-        processorId: "in_test",
-        invoiceEmailSentAt: claimedAt,
-      },
-      data: { invoiceEmailSentAt: null },
-    });
-  });
-
-  it("ignores invoices without a positive paid amount", async () => {
-    await sendStripeInvoiceEmail({
-      event: invoiceEvent({ total: 0 }),
-      logger,
-    });
-
     expect(prisma.payment.updateMany).not.toHaveBeenCalled();
-    expect(mockSendInvoiceEmail).not.toHaveBeenCalled();
   });
 });
+
+function invoice(overrides: Partial<Stripe.Invoice> = {}): Stripe.Invoice {
+  return {
+    id: "in_test",
+    customer: "cus_test",
+    customer_email: "billing@example.com",
+    created: 1_700_000_000,
+    currency: "usd",
+    total: 1000,
+    status: "paid",
+    invoice_pdf: "https://stripe.example.com/invoice.pdf",
+    hosted_invoice_url: "https://stripe.example.com/hosted-invoice",
+    ...overrides,
+  } as Stripe.Invoice;
+}
 
 function invoiceEvent(
   invoiceOverrides: Partial<Stripe.Invoice> = {},
@@ -120,18 +165,7 @@ function invoiceEvent(
     pending_webhooks: 0,
     request: { id: null, idempotency_key: null },
     data: {
-      object: {
-        id: "in_test",
-        customer: "cus_test",
-        customer_email: "billing@example.com",
-        created: 1_700_000_000,
-        currency: "usd",
-        total: 1000,
-        status: "paid",
-        invoice_pdf: "https://stripe.example.com/invoice.pdf",
-        hosted_invoice_url: "https://stripe.example.com/hosted-invoice",
-        ...invoiceOverrides,
-      } as Stripe.Invoice,
+      object: invoice(invoiceOverrides),
     },
   } as Stripe.Event;
 }

--- a/apps/web/ee/billing/stripe/invoice-email.test.ts
+++ b/apps/web/ee/billing/stripe/invoice-email.test.ts
@@ -1,0 +1,137 @@
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import prisma from "@/utils/__mocks__/prisma";
+import { sendStripeInvoiceEmail } from "./invoice-email";
+
+const { mockSendInvoiceEmail } = vi.hoisted(() => ({
+  mockSendInvoiceEmail: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+vi.mock("@inboxzero/resend", () => ({
+  sendInvoiceEmail: mockSendInvoiceEmail,
+}));
+vi.mock("@/env", () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: "https://example.com",
+    RESEND_FROM_EMAIL: "Inbox Zero <billing@example.com>",
+  },
+}));
+
+const logger = createTestLogger();
+
+describe("sendStripeInvoiceEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.payment.updateMany.mockResolvedValue({ count: 1 });
+    mockSendInvoiceEmail.mockResolvedValue(undefined);
+  });
+
+  it("emails a paid invoice after claiming its payment record", async () => {
+    await sendStripeInvoiceEmail({ event: invoiceEvent(), logger });
+
+    expect(prisma.payment.updateMany).toHaveBeenCalledWith({
+      where: {
+        processorId: "in_test",
+        processorType: "STRIPE",
+        invoiceEmailSentAt: null,
+        premium: { stripeInvoiceEmailsEnabled: true },
+      },
+      data: { invoiceEmailSentAt: expect.any(Date) },
+    });
+    expect(mockSendInvoiceEmail).toHaveBeenCalledWith({
+      from: "Inbox Zero <billing@example.com>",
+      to: "billing@example.com",
+      attachmentUrl: "https://stripe.example.com/invoice.pdf",
+      emailProps: {
+        baseUrl: "https://example.com",
+        invoiceUrl: "https://stripe.example.com/invoice.pdf",
+      },
+    });
+  });
+
+  it("does not email when the preference is disabled or already sent", async () => {
+    prisma.payment.updateMany.mockResolvedValue({ count: 0 });
+
+    await sendStripeInvoiceEmail({ event: invoiceEvent(), logger });
+
+    expect(mockSendInvoiceEmail).not.toHaveBeenCalled();
+  });
+
+  it("uses the hosted invoice when the PDF URL is unavailable", async () => {
+    await sendStripeInvoiceEmail({
+      event: invoiceEvent({
+        invoice_pdf: null,
+        hosted_invoice_url: "https://stripe.example.com/hosted-invoice",
+      }),
+      logger,
+    });
+
+    expect(mockSendInvoiceEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachmentUrl: undefined,
+        emailProps: expect.objectContaining({
+          invoiceUrl: "https://stripe.example.com/hosted-invoice",
+        }),
+      }),
+    );
+  });
+
+  it("releases the payment record when sending fails", async () => {
+    mockSendInvoiceEmail.mockRejectedValue(new Error("send failed"));
+
+    await expect(
+      sendStripeInvoiceEmail({ event: invoiceEvent(), logger }),
+    ).rejects.toThrow("send failed");
+
+    const claimedAt = prisma.payment.updateMany.mock.calls[0]?.[0].data
+      .invoiceEmailSentAt as Date;
+    expect(prisma.payment.updateMany).toHaveBeenLastCalledWith({
+      where: {
+        processorId: "in_test",
+        invoiceEmailSentAt: claimedAt,
+      },
+      data: { invoiceEmailSentAt: null },
+    });
+  });
+
+  it("ignores invoices without a positive paid amount", async () => {
+    await sendStripeInvoiceEmail({
+      event: invoiceEvent({ total: 0 }),
+      logger,
+    });
+
+    expect(prisma.payment.updateMany).not.toHaveBeenCalled();
+    expect(mockSendInvoiceEmail).not.toHaveBeenCalled();
+  });
+});
+
+function invoiceEvent(
+  invoiceOverrides: Partial<Stripe.Invoice> = {},
+): Stripe.Event {
+  return {
+    id: "evt_test",
+    type: "invoice.paid",
+    object: "event",
+    api_version: "2025-03-31.basil",
+    created: 1,
+    livemode: false,
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    data: {
+      object: {
+        id: "in_test",
+        customer: "cus_test",
+        customer_email: "billing@example.com",
+        created: 1_700_000_000,
+        currency: "usd",
+        total: 1000,
+        status: "paid",
+        invoice_pdf: "https://stripe.example.com/invoice.pdf",
+        hosted_invoice_url: "https://stripe.example.com/hosted-invoice",
+        ...invoiceOverrides,
+      } as Stripe.Invoice,
+    },
+  } as Stripe.Event;
+}

--- a/apps/web/ee/billing/stripe/invoice-email.ts
+++ b/apps/web/ee/billing/stripe/invoice-email.ts
@@ -1,16 +1,23 @@
-import type Stripe from "stripe";
 import { sendInvoiceEmail } from "@inboxzero/resend";
+import type Stripe from "stripe";
+import { z } from "zod";
+import { getStripe } from "@/ee/billing/stripe";
 import { env } from "@/env";
 import { ProcessorType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
+import { enqueueBackgroundJob } from "@/utils/queue/dispatch";
 
 const successfulInvoiceEvents = new Set<Stripe.Event.Type>([
   "invoice.paid",
   "invoice.payment_succeeded",
 ]);
 
-export async function sendStripeInvoiceEmail({
+export const stripeInvoiceEmailBody = z.object({
+  invoiceId: z.string().min(1),
+});
+
+export async function enqueueStripeInvoiceEmail({
   event,
   logger,
 }: {
@@ -20,10 +27,43 @@ export async function sendStripeInvoiceEmail({
   if (!successfulInvoiceEvents.has(event.type)) return;
 
   const invoice = event.data.object as Stripe.Invoice;
+  if (!invoice.id || invoice.status !== "paid" || invoice.total <= 0) return;
+
+  await enqueueBackgroundJob({
+    topic: "stripe-invoice-email",
+    body: { invoiceId: invoice.id },
+    qstash: {
+      queueName: "stripe-invoice-email",
+      parallelism: 3,
+      path: "/api/stripe/invoice-email",
+    },
+    logger,
+  });
+}
+
+export async function sendStripeInvoiceEmail({
+  invoiceId,
+  logger,
+}: {
+  invoiceId: string;
+  logger: Logger;
+}) {
+  const payment = await prisma.payment.findFirst({
+    where: {
+      processorId: invoiceId,
+      processorType: ProcessorType.STRIPE,
+      invoiceEmailSentAt: null,
+      premium: { stripeInvoiceEmailsEnabled: true },
+    },
+    select: { id: true },
+  });
+
+  if (!payment) return;
+
+  const invoice = await getStripe().invoices.retrieve(invoiceId);
   const invoiceUrl = invoice.invoice_pdf || invoice.hosted_invoice_url;
 
   if (
-    !invoice.id ||
     invoice.status !== "paid" ||
     invoice.total <= 0 ||
     !invoice.customer_email ||
@@ -32,38 +72,20 @@ export async function sendStripeInvoiceEmail({
     return;
   }
 
-  const claimedAt = new Date();
-  const claim = await prisma.payment.updateMany({
-    where: {
-      processorId: invoice.id,
-      processorType: ProcessorType.STRIPE,
-      invoiceEmailSentAt: null,
-      premium: { stripeInvoiceEmailsEnabled: true },
+  await sendInvoiceEmail({
+    from: env.RESEND_FROM_EMAIL,
+    to: invoice.customer_email,
+    attachmentUrl: invoice.invoice_pdf || undefined,
+    idempotencyKey: `stripe-invoice-email/${invoice.id}`,
+    emailProps: {
+      baseUrl: env.NEXT_PUBLIC_BASE_URL,
+      invoiceUrl,
     },
-    data: { invoiceEmailSentAt: claimedAt },
   });
 
-  if (claim.count === 0) return;
-
-  try {
-    await sendInvoiceEmail({
-      from: env.RESEND_FROM_EMAIL,
-      to: invoice.customer_email,
-      attachmentUrl: invoice.invoice_pdf || undefined,
-      emailProps: {
-        baseUrl: env.NEXT_PUBLIC_BASE_URL,
-        invoiceUrl,
-      },
-    });
-    logger.info("Sent Stripe invoice email", { invoiceId: invoice.id });
-  } catch (error) {
-    await prisma.payment.updateMany({
-      where: {
-        processorId: invoice.id,
-        invoiceEmailSentAt: claimedAt,
-      },
-      data: { invoiceEmailSentAt: null },
-    });
-    throw error;
-  }
+  await prisma.payment.updateMany({
+    where: { id: payment.id, invoiceEmailSentAt: null },
+    data: { invoiceEmailSentAt: new Date() },
+  });
+  logger.info("Sent Stripe invoice email", { invoiceId });
 }

--- a/apps/web/ee/billing/stripe/invoice-email.ts
+++ b/apps/web/ee/billing/stripe/invoice-email.ts
@@ -1,0 +1,69 @@
+import type Stripe from "stripe";
+import { sendInvoiceEmail } from "@inboxzero/resend";
+import { env } from "@/env";
+import { ProcessorType } from "@/generated/prisma/enums";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+const successfulInvoiceEvents = new Set<Stripe.Event.Type>([
+  "invoice.paid",
+  "invoice.payment_succeeded",
+]);
+
+export async function sendStripeInvoiceEmail({
+  event,
+  logger,
+}: {
+  event: Stripe.Event;
+  logger: Logger;
+}) {
+  if (!successfulInvoiceEvents.has(event.type)) return;
+
+  const invoice = event.data.object as Stripe.Invoice;
+  const invoiceUrl = invoice.invoice_pdf || invoice.hosted_invoice_url;
+
+  if (
+    !invoice.id ||
+    invoice.status !== "paid" ||
+    invoice.total <= 0 ||
+    !invoice.customer_email ||
+    !invoiceUrl
+  ) {
+    return;
+  }
+
+  const claimedAt = new Date();
+  const claim = await prisma.payment.updateMany({
+    where: {
+      processorId: invoice.id,
+      processorType: ProcessorType.STRIPE,
+      invoiceEmailSentAt: null,
+      premium: { stripeInvoiceEmailsEnabled: true },
+    },
+    data: { invoiceEmailSentAt: claimedAt },
+  });
+
+  if (claim.count === 0) return;
+
+  try {
+    await sendInvoiceEmail({
+      from: env.RESEND_FROM_EMAIL,
+      to: invoice.customer_email,
+      attachmentUrl: invoice.invoice_pdf || undefined,
+      emailProps: {
+        baseUrl: env.NEXT_PUBLIC_BASE_URL,
+        invoiceUrl,
+      },
+    });
+    logger.info("Sent Stripe invoice email", { invoiceId: invoice.id });
+  } catch (error) {
+    await prisma.payment.updateMany({
+      where: {
+        processorId: invoice.id,
+        invoiceEmailSentAt: claimedAt,
+      },
+      data: { invoiceEmailSentAt: null },
+    });
+    throw error;
+  }
+}

--- a/apps/web/prisma/migrations/20260714120000_add_stripe_invoice_emails/migration.sql
+++ b/apps/web/prisma/migrations/20260714120000_add_stripe_invoice_emails/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Premium"
+ADD COLUMN "stripeInvoiceEmailsEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "Payment"
+ADD COLUMN "invoiceEmailSentAt" TIMESTAMP(3);

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -462,6 +462,7 @@ model Premium {
   stripeAiOverageLastInvoiceId  String?
   stripeAiOverageLastPeriodEnd  DateTime?
   stripeAiOverageLastUnits      Int?
+  stripeInvoiceEmailsEnabled    Boolean   @default(false)
 
   // apple app store
   appleOriginalTransactionId       String?   @unique
@@ -1106,6 +1107,7 @@ model Payment {
 
   // Metadata
   billingReason String? // initial, renewal, update, etc.
+  invoiceEmailSentAt DateTime?
 
   @@index([premiumId, createdAt])
 }

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+import { updateStripeInvoiceEmailsAction } from "./premium";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/auth", () => ({
+  auth: vi.fn(async () => ({
+    user: { id: "user-1", email: "user@example.com" },
+  })),
+}));
+
+describe("updateStripeInvoiceEmailsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        admins: [{ id: "user-1" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+  });
+
+  it("updates the Stripe invoice email preference for an admin", async () => {
+    const result = await updateStripeInvoiceEmailsAction({ enabled: true });
+
+    expect(prisma.premium.update).toHaveBeenCalledWith({
+      where: { id: "premium-1" },
+      data: { stripeInvoiceEmailsEnabled: true },
+    });
+    expect(result?.data).toEqual({ enabled: true });
+  });
+
+  it("rejects a non-admin user", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: "cus_test",
+        admins: [{ id: "another-user" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await updateStripeInvoiceEmailsAction({ enabled: true });
+
+    expect(result?.serverError).toBe("Not admin");
+    expect(prisma.premium.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/actions/premium.test.ts
+++ b/apps/web/utils/actions/premium.test.ts
@@ -21,14 +21,17 @@ describe("updateStripeInvoiceEmailsAction", () => {
     } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
   });
 
-  it("updates the Stripe invoice email preference for an admin", async () => {
-    const result = await updateStripeInvoiceEmailsAction({ enabled: true });
+  it.each([
+    true,
+    false,
+  ])("sets the Stripe invoice email preference to %s for an admin", async (enabled) => {
+    const result = await updateStripeInvoiceEmailsAction({ enabled });
 
     expect(prisma.premium.update).toHaveBeenCalledWith({
       where: { id: "premium-1" },
-      data: { stripeInvoiceEmailsEnabled: true },
+      data: { stripeInvoiceEmailsEnabled: enabled },
     });
-    expect(result?.data).toEqual({ enabled: true });
+    expect(result?.data).toEqual({ enabled });
   });
 
   it("rejects a non-admin user", async () => {
@@ -43,6 +46,21 @@ describe("updateStripeInvoiceEmailsAction", () => {
     const result = await updateStripeInvoiceEmailsAction({ enabled: true });
 
     expect(result?.serverError).toBe("Not admin");
+    expect(prisma.premium.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a user without a Stripe billing account", async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      premium: {
+        id: "premium-1",
+        stripeCustomerId: null,
+        admins: [{ id: "user-1" }],
+      },
+    } as Awaited<ReturnType<typeof prisma.user.findUnique>>);
+
+    const result = await updateStripeInvoiceEmailsAction({ enabled: true });
+
+    expect(result?.serverError).toBe("Stripe billing account not found");
     expect(prisma.premium.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/utils/actions/premium.ts
+++ b/apps/web/utils/actions/premium.ts
@@ -364,6 +364,38 @@ export const claimPremiumAdminAction = actionClientUser
     });
   });
 
+export const updateStripeInvoiceEmailsAction = actionClientUser
+  .metadata({ name: "updateStripeInvoiceEmails" })
+  .inputSchema(z.object({ enabled: z.boolean() }))
+  .action(async ({ ctx: { userId }, parsedInput: { enabled } }) => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        premium: {
+          select: {
+            id: true,
+            stripeCustomerId: true,
+            admins: { select: { id: true } },
+          },
+        },
+      },
+    });
+
+    if (!user?.premium?.stripeCustomerId) {
+      throw new SafeError("Stripe billing account not found");
+    }
+    if (!isAdminForPremium(user.premium.admins, userId)) {
+      throw new SafeError("Not admin");
+    }
+
+    await prisma.premium.update({
+      where: { id: user.premium.id },
+      data: { stripeInvoiceEmailsEnabled: enabled },
+    });
+
+    return { enabled };
+  });
+
 export const getBillingPortalUrlAction = actionClientUser
   .metadata({ name: "getBillingPortalUrl" })
   .inputSchema(z.object({ tier: z.nativeEnum(PremiumTier).optional() }))

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -47,6 +47,15 @@
           "retryAfterSeconds": 60
         }
       ]
+    },
+    "app/api/stripe/invoice-email/queue/route.ts": {
+      "experimentalTriggers": [
+        {
+          "type": "queue/v2beta",
+          "topic": "stripe-invoice-email",
+          "retryAfterSeconds": 60
+        }
+      ]
     }
   },
   "rewrites": [

--- a/packages/resend/emails/invoice.tsx
+++ b/packages/resend/emails/invoice.tsx
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Html,
+  Link,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+import { InboxZeroFooter } from "./components/inbox-zero-footer";
+
+export type InvoiceEmailProps = {
+  baseUrl: string;
+  invoiceUrl: string;
+};
+
+export default function InvoiceEmail({
+  baseUrl,
+  invoiceUrl,
+}: InvoiceEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Tailwind>
+        <Body className="bg-white font-sans">
+          <Container className="mx-auto w-full max-w-[600px] p-0">
+            <Section className="px-8 py-10">
+              <Text className="m-0 text-2xl font-semibold text-gray-900">
+                Your Inbox Zero invoice is ready
+              </Text>
+              <Text className="mb-6 mt-4 text-[15px] leading-6 text-gray-600">
+                Your Stripe payment was successful. You can download the paid
+                invoice below.
+              </Text>
+              <Button
+                href={invoiceUrl}
+                className="box-border rounded-lg bg-blue-600 px-5 py-3 text-[15px] font-semibold text-white no-underline"
+              >
+                Download invoice
+              </Button>
+              <Text className="mb-0 mt-8 text-[13px] leading-5 text-gray-500">
+                You can turn off automatic invoice emails in your{" "}
+                <Link href={`${baseUrl}/settings`} className="text-blue-600">
+                  billing settings
+                </Link>
+                .
+              </Text>
+            </Section>
+            <InboxZeroFooter />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}
+
+InvoiceEmail.PreviewProps = {
+  baseUrl: "https://www.getinboxzero.com",
+  invoiceUrl: "https://example.com/invoice.pdf",
+} satisfies InvoiceEmailProps;

--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -103,6 +103,7 @@ const sendTransactionalEmail = async ({
   test,
   tags,
   attachments,
+  idempotencyKey,
 }: {
   from: string;
   to: string;
@@ -111,6 +112,7 @@ const sendTransactionalEmail = async ({
   test?: boolean;
   tags?: { name: string; value: string }[];
   attachments?: Attachment[];
+  idempotencyKey?: string;
 }) => {
   if (!resend) {
     console.log(RESEND_NOT_CONFIGURED_MESSAGE);
@@ -119,18 +121,21 @@ const sendTransactionalEmail = async ({
 
   const text = await render(react, { plainText: true });
 
-  const result = await resend.emails.send({
-    from,
-    to: test ? "delivered@resend.dev" : to,
-    subject,
-    react,
-    text,
-    attachments,
-    headers: {
-      "X-Entity-Ref-ID": nanoid(),
+  const result = await resend.emails.send(
+    {
+      from,
+      to: test ? "delivered@resend.dev" : to,
+      subject,
+      react,
+      text,
+      attachments,
+      headers: {
+        "X-Entity-Ref-ID": nanoid(),
+      },
+      tags,
     },
-    tags,
-  });
+    idempotencyKey ? { idempotencyKey } : undefined,
+  );
 
   if (result.error) {
     console.error("Error sending email", result.error);
@@ -490,12 +495,14 @@ export const sendInvoiceEmail = async ({
   test,
   emailProps,
   attachmentUrl,
+  idempotencyKey,
 }: {
   from: string;
   to: string;
   test?: boolean;
   emailProps: InvoiceEmailProps;
   attachmentUrl?: string;
+  idempotencyKey: string;
 }) =>
   sendTransactionalEmail({
     from,
@@ -506,5 +513,6 @@ export const sendInvoiceEmail = async ({
     attachments: attachmentUrl
       ? [{ filename: "invoice.pdf", path: attachmentUrl }]
       : undefined,
+    idempotencyKey,
     tags: [{ name: "category", value: "invoice" }],
   });

--- a/packages/resend/src/send.tsx
+++ b/packages/resend/src/send.tsx
@@ -2,6 +2,7 @@ import { render } from "@react-email/render";
 import { nanoid } from "nanoid";
 import { resend } from "./client";
 import type { ReactElement } from "react";
+import type { Attachment } from "resend";
 import SummaryEmail, { type SummaryEmailProps } from "../emails/summary";
 import DigestEmail, {
   type DigestEmailProps,
@@ -38,6 +39,7 @@ import GuestBookingRescheduledEmail, {
 import HostBookingRescheduledEmail, {
   type HostBookingRescheduledEmailProps,
 } from "../emails/host-booking-rescheduled";
+import InvoiceEmail, { type InvoiceEmailProps } from "../emails/invoice";
 
 const RESEND_NOT_CONFIGURED_MESSAGE =
   "Resend is not configured. You need to add a RESEND_API_KEY in your .env file for emails to work.";
@@ -100,6 +102,7 @@ const sendTransactionalEmail = async ({
   react,
   test,
   tags,
+  attachments,
 }: {
   from: string;
   to: string;
@@ -107,6 +110,7 @@ const sendTransactionalEmail = async ({
   react: ReactElement;
   test?: boolean;
   tags?: { name: string; value: string }[];
+  attachments?: Attachment[];
 }) => {
   if (!resend) {
     console.log(RESEND_NOT_CONFIGURED_MESSAGE);
@@ -121,6 +125,7 @@ const sendTransactionalEmail = async ({
     subject,
     react,
     text,
+    attachments,
     headers: {
       "X-Entity-Ref-ID": nanoid(),
     },
@@ -477,4 +482,29 @@ export const sendHostBookingRescheduledEmail = async ({
     react: <HostBookingRescheduledEmail {...emailProps} />,
     test,
     tags: [{ name: "category", value: "booking-rescheduled" }],
+  });
+
+export const sendInvoiceEmail = async ({
+  from,
+  to,
+  test,
+  emailProps,
+  attachmentUrl,
+}: {
+  from: string;
+  to: string;
+  test?: boolean;
+  emailProps: InvoiceEmailProps;
+  attachmentUrl?: string;
+}) =>
+  sendTransactionalEmail({
+    from,
+    to,
+    subject: "Your Inbox Zero invoice",
+    react: <InvoiceEmail {...emailProps} />,
+    test,
+    attachments: attachmentUrl
+      ? [{ filename: "invoice.pdf", path: attachmentUrl }]
+      : undefined,
+    tags: [{ name: "category", value: "invoice" }],
   });


### PR DESCRIPTION
Adds an optional billing preference for automatic Stripe invoice delivery. The preference is disabled by default.

- Add an admin-only billing toggle for Stripe customers
- Email the paid invoice PDF and download link after successful payment
- Prevent duplicate delivery across webhook events
- Add focused tests for authorization, delivery, fallback, and retry behavior

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

