### PR TITLE
Mail: Stabilize beta banner hydration

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/mail/BetaBanner.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/mail/BetaBanner.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useLocalStorage } from "usehooks-ts";
+import { useIsClient, useLocalStorage } from "usehooks-ts";
 import { Banner } from "@/components/Banner";
 
 export function BetaBanner() {
+  const isClient = useIsClient();
   const [bannerVisible] = useLocalStorage<boolean | undefined>(
     "mailBetaBannerVisibile",
     true,
   );
 
-  if (bannerVisible && typeof window !== "undefined")
+  if (isClient && bannerVisible)
     return (
       <Banner title="Beta">
         Mail is currently in beta. It is not intended to be a full replacement


### PR DESCRIPTION
Make the mail beta banner render the same initial branch on the server and client, then apply browser-only persisted visibility after mount. This removes a hydration mismatch without changing dismissal behavior.

- replace the render-time `window` branch with the existing `useIsClient` hook
- continue reading the same local-storage visibility setting
- keep the banner client-only as before

Validation:
- `pnpm check` (passes with existing Biome schema and dev env warnings)
- `pnpm dlx react-doctor@latest apps/web --verbose --scope changed` (no issues)

Performance: one small client-state update when the mail banner mounts; no added network or database calls and no meaningful hot-path risk.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

