### PR TITLE
UI lifecycle: Cancel delayed scroll work

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepWho.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepWho.tsx
@@ -67,28 +67,30 @@ export function StepWho({
 
   // Scroll to selected role on mount
   useEffect(() => {
-    if (defaultRole && scrollContainerRef.current) {
-      // Find the button with the selected role
-      // biome-ignore lint/complexity/useIndexOf: indexOf requires exact type match but defaultRole is `string` while array has a narrower union type
-      const selectedIndex = displayedRoleValues.findIndex(
-        (role) => role === defaultRole,
-      );
-      if (selectedIndex !== -1) {
-        const buttons = scrollContainerRef.current.querySelectorAll(
-          'button[type="button"]',
-        );
-        const selectedButton = buttons[selectedIndex];
-        if (selectedButton) {
-          // Use setTimeout to ensure the DOM is ready
-          setTimeout(() => {
-            selectedButton.scrollIntoView({
-              behavior: "smooth",
-              block: "center",
-            });
-          }, 100);
-        }
-      }
-    }
+    if (!defaultRole || !scrollContainerRef.current) return;
+
+    // Find the button with the selected role
+    // biome-ignore lint/complexity/useIndexOf: indexOf requires exact type match but defaultRole is `string` while array has a narrower union type
+    const selectedIndex = displayedRoleValues.findIndex(
+      (role) => role === defaultRole,
+    );
+    if (selectedIndex === -1) return;
+
+    const buttons = scrollContainerRef.current.querySelectorAll(
+      'button[type="button"]',
+    );
+    const selectedButton = buttons[selectedIndex];
+    if (!selectedButton) return;
+
+    // Use setTimeout to ensure the DOM is ready
+    const scrollTimeout = setTimeout(() => {
+      selectedButton.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }, 100);
+
+    return () => clearTimeout(scrollTimeout);
   }, [defaultRole, displayedRoleValues]);
 
   return (

--- a/apps/web/components/email-list/EmailMessage.tsx
+++ b/apps/web/components/email-list/EmailMessage.tsx
@@ -213,12 +213,14 @@ function ReplyPanel({
   const [reply, setReply] = useState<string | null>(null);
   // scroll to the reply panel when it first opens
   useEffect(() => {
-    if (defaultShowReply && replyRef.current) {
-      // hacky using setTimeout
-      setTimeout(() => {
-        replyRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-      }, 500);
-    }
+    if (!defaultShowReply || !replyRef.current) return;
+
+    // Wait for the reply panel layout before scrolling.
+    const scrollTimeout = setTimeout(() => {
+      replyRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    }, 500);
+
+    return () => clearTimeout(scrollTimeout);
   }, [defaultShowReply]);
 
   useEffect(() => {


### PR DESCRIPTION
Cancel deferred scrolling when the owning component unmounts or its inputs change. This prevents stale DOM work in the email reply panel and onboarding role picker while preserving the existing scroll timing.

- clear the delayed reply-panel scroll during effect cleanup
- clear the delayed onboarding selection scroll during effect cleanup
- simplify the onboarding effect with explicit early exits

Validation:
- `pnpm check` (passes with existing Biome schema and dev env warnings)
- `pnpm dlx react-doctor@latest apps/web --verbose --scope changed` (no issues)

No component-rendering tests were added per repository testing guidance; the behavior change is limited to effect cleanup.

Performance: no added network or database work; only constant-time timeout cancellation during lifecycle cleanup, outside rendering hot paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

