### PR TITLE
Accessibility: Respect reduced motion preferences

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -106,6 +106,17 @@
   font-variant-ligatures: none;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* Bulk unsubscribe table → card layout on mobile */
 @media (max-width: 640px) {
   /* Constrain the wrapper div that the Table component adds */


### PR DESCRIPTION
Honor the operating-system reduced-motion preference across the application. Normal animations remain unchanged, while opted-in users get immediate transitions and non-smooth scrolling.

- add a global `prefers-reduced-motion: reduce` media query
- shorten CSS animations and transitions to a single near-instant iteration
- disable smooth scrolling for reduced-motion users

Validation:
- `pnpm check` (passes with existing Biome schema and dev env warnings)
- `pnpm dlx react-doctor@latest apps/web --verbose --scope changed` (no changed-file issues)
- full React Doctor JSON scan confirms `require-reduced-motion` has zero findings

No unit test was added because this is stylesheet behavior, which repository testing guidance excludes from unit coverage.

Performance: no JavaScript, network, or database work is added. The CSS media query is inactive for normal users and removes animation work for reduced-motion users.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

