### PR TITLE
Fix nested Gmail label resolution in assistant

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-label-management.test.ts
@@ -26,12 +26,16 @@ const evalReporter = createEvalReporter({
 const logger = createScopedLogger("eval-assistant-chat-label-management");
 
 const {
+  mockCreateLabel,
   mockCreateEmailProvider,
+  mockLabelMessage,
   mockPosthogCaptureEvent,
   mockRedis,
   mockUnsubscribeSenderAndMark,
 } = vi.hoisted(() => ({
+  mockCreateLabel: vi.fn(),
   mockCreateEmailProvider: vi.fn(),
+  mockLabelMessage: vi.fn(),
   mockPosthogCaptureEvent: vi.fn(),
   mockRedis: {
     set: vi.fn(),
@@ -83,7 +87,19 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
       { id: "Label_Existing", name: "Existing", type: "user" },
       { id: "Label_Travel", name: "Travel", type: "user" },
       { id: "Label_04_ARCHIVES", name: "04 ARCHIVES", type: "user" },
+      { id: "Label_L3_L4", name: "L3/L4", type: "user" },
     ];
+
+    mockCreateLabel.mockImplementation(async (name: string) => {
+      const createdLabel = {
+        id: `Label_${name.replace(/\s+/g, "_")}`,
+        name,
+        type: "user",
+      };
+      labels = [...labels, createdLabel];
+      return createdLabel;
+    });
+    mockLabelMessage.mockResolvedValue(undefined);
 
     prisma.emailAccount.findUnique.mockResolvedValue({
       about: "I use labels to organize my inbox.",
@@ -100,15 +116,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
         nextPageToken: undefined,
       }),
       getLabels: vi.fn().mockImplementation(async () => labels),
-      createLabel: vi.fn().mockImplementation(async (name: string) => {
-        const createdLabel = {
-          id: `Label_${name.replace(/\s+/g, "_")}`,
-          name,
-          type: "user",
-        };
-        labels = [...labels, createdLabel];
-        return createdLabel;
-      }),
+      createLabel: mockCreateLabel,
       getLabelById: vi
         .fn()
         .mockImplementation(
@@ -125,7 +133,7 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
         .mockImplementation(async (threadId: string) => [
           { id: `${threadId}-message-1`, threadId },
         ]),
-      labelMessage: vi.fn().mockResolvedValue(undefined),
+      labelMessage: mockLabelMessage,
       archiveThreadWithLabel: vi.fn(),
       markReadThread: vi.fn(),
       bulkArchiveFromSenders: vi.fn(),
@@ -341,6 +349,60 @@ describe.runIf(shouldRunEval)("Eval: assistant chat label management", () => {
               return {
                 pass,
                 actual,
+              };
+            },
+          );
+
+          expect(record.pass, record.actual).toBe(true);
+        },
+        TIMEOUT,
+      );
+
+      test(
+        "resolves a unique nested Gmail label from its leaf name",
+        async () => {
+          const testName = "apply unique nested label by leaf name";
+          const messages = [
+            {
+              role: "user" as const,
+              content: "Label thread-1 as L4.",
+            },
+          ];
+
+          const record = await evalReporter.recordCached(
+            {
+              testName,
+              model: model.label,
+              cacheKeyParts: [{ model, messages, existingLabels: ["L3/L4"] }],
+            },
+            async () => {
+              const { toolCalls, actual } = await runAssistantChat({
+                emailAccount,
+                messages,
+              });
+
+              const labelThreadsMatch = getLastMatchingToolCall(
+                toolCalls,
+                "manageInbox",
+                isManageInboxLabelThreadsInput,
+              );
+              const labelThreadsCall = labelThreadsMatch?.input ?? null;
+              const appliedNestedLabel = mockLabelMessage.mock.calls.some(
+                ([input]) =>
+                  input?.labelId === "Label_L3_L4" &&
+                  input?.labelName === "L3/L4",
+              );
+              const pass =
+                !!labelThreadsCall &&
+                labelThreadsCall.threadIds.length === 1 &&
+                labelThreadsCall.threadIds[0] === "thread-1" &&
+                ["L4", "L3/L4"].includes(labelThreadsCall.labelName) &&
+                mockCreateLabel.mock.calls.length === 0 &&
+                appliedNestedLabel;
+
+              return {
+                pass,
+                actual: `${actual}; providerCreateCalls=${mockCreateLabel.mock.calls.length}; appliedNestedLabel=${appliedNestedLabel}`,
               };
             },
           );

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -460,11 +460,13 @@ describe("chat inbox tools", () => {
   it("returns a descriptive error when label_threads receives an unknown labelName", async () => {
     const getThreadMessages = vi.fn();
     const getLabelByName = vi.fn().mockResolvedValue(null);
+    const getLabels = vi.fn().mockResolvedValue([]);
     const labelMessage = vi.fn();
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       getThreadMessages,
       getLabelByName,
+      getLabels,
       labelMessage,
     } as any);
 
@@ -488,6 +490,90 @@ describe("chat inbox tools", () => {
     });
     expect(getLabelByName).toHaveBeenCalledWith("Finance");
     expect(getLabelByName).toHaveBeenCalledTimes(1);
+    expect(getLabels).toHaveBeenCalledWith({ includeHidden: true });
+    expect(getThreadMessages).not.toHaveBeenCalled();
+    expect(labelMessage).not.toHaveBeenCalled();
+  });
+
+  it("applies a unique nested Gmail label when given its leaf name", async () => {
+    const getLabelByName = vi.fn().mockResolvedValue(null);
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "Label_parent", name: "L3", type: "user" },
+      { id: "Label_child", name: "L3/L4", type: "user" },
+    ]);
+    const getThreadMessages = vi
+      .fn()
+      .mockResolvedValue([{ id: "message-1", threadId: "thread-1" }]);
+    const labelMessage = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getLabelByName,
+      getLabels,
+      getThreadMessages,
+      labelMessage,
+    } as any);
+
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      action: "label_threads",
+      labelName: "L4",
+      threadIds: ["thread-1"],
+    });
+
+    expect(getLabelByName).toHaveBeenCalledWith("L4");
+    expect(getLabels).toHaveBeenCalledWith({ includeHidden: true });
+    expect(labelMessage).toHaveBeenCalledWith({
+      messageId: "message-1",
+      labelId: "Label_child",
+      labelName: "L3/L4",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      labelId: "Label_child",
+      labelName: "L3/L4",
+    });
+  });
+
+  it("does not apply an ambiguous nested Gmail leaf name", async () => {
+    const getLabelByName = vi.fn().mockResolvedValue(null);
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "Label_1", name: "L3/L4", type: "user" },
+      { id: "Label_2", name: "Projects/L4", type: "user" },
+    ]);
+    const getThreadMessages = vi.fn();
+    const labelMessage = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue({
+      getLabelByName,
+      getLabels,
+      getThreadMessages,
+      labelMessage,
+    } as any);
+
+    const toolInstance = manageInboxTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({
+      action: "label_threads",
+      labelName: "L4",
+      threadIds: ["thread-1"],
+    });
+
+    expect(result).toEqual({
+      error:
+        'Multiple Gmail labels match "L4": "L3/L4", "Projects/L4". Use the full label path.',
+      toolErrorVisibility: "hidden",
+    });
     expect(getThreadMessages).not.toHaveBeenCalled();
     expect(labelMessage).not.toHaveBeenCalled();
   });
@@ -543,10 +629,12 @@ describe("chat inbox tools", () => {
 
   it("returns a transparent error when removing a label that does not exist", async () => {
     const getLabelByName = vi.fn().mockResolvedValue(null);
+    const getLabels = vi.fn().mockResolvedValue([]);
     const removeThreadLabel = vi.fn();
 
     vi.mocked(createEmailProvider).mockResolvedValue({
       getLabelByName,
+      getLabels,
       removeThreadLabel,
     } as any);
 

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -656,6 +656,7 @@ describe("chat inbox tools", () => {
       toolErrorVisibility: "hidden",
     });
     expect(getLabelByName).toHaveBeenCalledWith("Finance");
+    expect(getLabels).toHaveBeenCalledWith({ includeHidden: true });
     expect(removeThreadLabel).not.toHaveBeenCalled();
   });
 

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -4,6 +4,7 @@ import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { posthogCaptureEvent } from "@/utils/posthog";
 import { createEmailProvider } from "@/utils/email/provider";
+import { isGoogleProvider } from "@/utils/email/provider-types";
 import {
   extractEmailAddress,
   extractUniqueEmailAddresses,
@@ -16,6 +17,8 @@ import type { ParsedMessage } from "@/utils/types";
 import { getEmailForLLM } from "@/utils/get-email-from-message";
 import { getFormattedSenderAddress } from "@/utils/email/get-formatted-sender-address";
 import { runWithBoundedConcurrency } from "@/utils/async";
+import { findNestedLabelMatches } from "@/utils/label/find-nested-label-matches";
+import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import { resolveLabelNameAndId } from "@/utils/label/resolve-label";
 import {
   buildOutlookSearchFallbackQuery,
@@ -1164,6 +1167,7 @@ const buildManageInboxTool = ({
               emailProvider,
               labelName: labelName!,
               action,
+              matchNestedLabels: isGoogleProvider(provider),
               missingLabelError: taxonomy.missingLabelError,
             });
           } catch (error) {
@@ -1981,23 +1985,51 @@ async function resolveThreadLabel({
   emailProvider,
   labelName,
   action,
+  matchNestedLabels,
   missingLabelError,
 }: {
   emailProvider: EmailProvider;
   labelName: string;
   action: ManageInboxAction;
+  matchNestedLabels: boolean;
   missingLabelError: (name: string, action: ManageInboxAction) => string;
 }) {
   const existingLabel = await emailProvider.getLabelByName(labelName);
 
-  if (!existingLabel) {
-    throw new Error(missingLabelError(labelName, action));
+  if (existingLabel) {
+    return {
+      labelId: existingLabel.id,
+      labelName: existingLabel.name,
+    };
   }
 
-  return {
-    labelId: existingLabel.id,
-    labelName: existingLabel.name,
-  };
+  if (matchNestedLabels) {
+    const labels = await emailProvider.getLabels({ includeHidden: true });
+    const nestedMatches = findNestedLabelMatches({
+      labels,
+      name: labelName,
+      getLabelName: (label) => label.name,
+      normalize: normalizeLabelName,
+    });
+
+    if (nestedMatches.length === 1) {
+      return {
+        labelId: nestedMatches[0].id,
+        labelName: nestedMatches[0].name,
+      };
+    }
+
+    if (nestedMatches.length > 1) {
+      const paths = nestedMatches
+        .map((label) => JSON.stringify(label.name))
+        .join(", ");
+      throw new Error(
+        `Multiple Gmail labels match "${labelName}": ${paths}. Use the full label path.`,
+      );
+    }
+  }
+
+  throw new Error(missingLabelError(labelName, action));
 }
 
 async function runSenderUnsubscribeActions({

--- a/apps/web/utils/ai/assistant/chat-label-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.test.ts
@@ -138,6 +138,69 @@ describe("chat label tools", () => {
     expect(getLabels).toHaveBeenCalledWith();
   });
 
+  it("reuses a unique nested Gmail label when given its leaf name", async () => {
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "label-parent", name: "L3", type: "user" },
+      { id: "label-child", name: "L3/L4", type: "user" },
+    ]);
+    const createLabel = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getLabels,
+        createLabel,
+      }),
+    );
+
+    const toolInstance = createOrGetLabelTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({ name: "L4" });
+
+    expect(result).toEqual({
+      created: false,
+      label: { id: "label-child", name: "L3/L4", type: "user" },
+    });
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
+  it("does not create a Gmail label when its leaf name is ambiguous", async () => {
+    const getLabels = vi.fn().mockResolvedValue([
+      { id: "label-1", name: "L3/L4", type: "user" },
+      { id: "label-2", name: "Projects/L4", type: "user" },
+    ]);
+    const createLabel = vi.fn();
+
+    vi.mocked(createEmailProvider).mockResolvedValue(
+      createMockEmailProvider({
+        getLabels,
+        createLabel,
+      }),
+    );
+
+    const toolInstance = createOrGetLabelTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({ name: "L4" });
+
+    expect(result).toEqual({
+      error: 'Multiple Gmail labels match "L4". Use the full label path.',
+      labels: [
+        { id: "label-1", name: "L3/L4", type: "user" },
+        { id: "label-2", name: "Projects/L4", type: "user" },
+      ],
+    });
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
   it("creates a label when no visible or hidden normalized match exists", async () => {
     const getLabels = vi
       .fn()

--- a/apps/web/utils/ai/assistant/chat-label-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-label-tools.ts
@@ -2,6 +2,7 @@ import { type InferUITool, tool } from "ai";
 import { z } from "zod";
 import type { Logger } from "@/utils/logger";
 import { createEmailProvider } from "@/utils/email/provider";
+import { findNestedLabelMatches } from "@/utils/label/find-nested-label-matches";
 import { normalizeLabelName } from "@/utils/label/normalize-label-name";
 import { posthogCaptureEvent } from "@/utils/posthog";
 
@@ -76,14 +77,21 @@ function buildCreateOrGetTool({
       .trim()
       .min(1)
       .max(200)
-      .describe(`Exact ${terms.resource} name to reuse or create.`),
+      .describe(
+        terms.resource === "label"
+          ? "Exact Gmail label path, or a leaf name that uniquely identifies an existing nested label."
+          : `Exact ${terms.resource} name to reuse or create.`,
+      ),
   });
 
   const listToolName =
     terms.resource === "label" ? "listLabels" : "listCategories";
 
   return tool({
-    description: `Reuse an existing ${terms.resource} by exact name or create it if it does not exist yet. Do not call ${listToolName} first — this tool handles the check-and-create in one step.`,
+    description:
+      terms.resource === "label"
+        ? `Reuse an existing Gmail label by exact path. A leaf name also reuses a uniquely matching nested label; if multiple nested labels share that leaf, this returns their full paths instead of creating a root label. Create the label only when no match exists. Do not call ${listToolName} first — this tool handles resolution and creation in one step.`
+        : `Reuse an existing ${terms.resource} by exact name or create it if it does not exist yet. Do not call ${listToolName} first — this tool handles the check-and-create in one step.`,
     inputSchema,
     execute: async (input) => {
       trackToolCall({ tool: terms.createToolName, email, logger });
@@ -115,6 +123,29 @@ function buildCreateOrGetTool({
             created: false,
             [terms.resource]: pickLabelFields(existingHidden),
           };
+        }
+
+        if (terms.resource === "label") {
+          const nestedMatches = findNestedLabelMatches({
+            labels: hiddenAware,
+            name: input.name,
+            getLabelName: (label) => label.name,
+            normalize: normalizeLabelName,
+          });
+
+          if (nestedMatches.length === 1) {
+            return {
+              created: false,
+              label: pickLabelFields(nestedMatches[0]),
+            };
+          }
+
+          if (nestedMatches.length > 1) {
+            return {
+              error: `Multiple Gmail labels match "${input.name}". Use the full label path.`,
+              labels: nestedMatches.map(pickLabelFields),
+            };
+          }
         }
 
         const created = await emailProvider.createLabel(input.name);

--- a/apps/web/utils/label/find-nested-label-matches.ts
+++ b/apps/web/utils/label/find-nested-label-matches.ts
@@ -1,0 +1,23 @@
+export function findNestedLabelMatches<T>({
+  labels,
+  name,
+  getLabelName,
+  normalize,
+}: {
+  labels: T[];
+  name: string;
+  getLabelName: (label: T) => string;
+  normalize: (value: string) => string;
+}) {
+  const normalizedSearch = normalize(name).trim();
+  if (!normalizedSearch || normalizedSearch.includes("/")) return [];
+
+  return labels.filter((label) => {
+    const path = normalize(getLabelName(label))
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    return path.length > 1 && path.at(-1) === normalizedSearch;
+  });
+}


### PR DESCRIPTION
## Summary

- resolve a unique nested Gmail label from its leaf name in assistant label creation/reuse and thread actions
- return full-path ambiguity feedback instead of creating or applying the wrong label when multiple nested labels share a leaf
- add deterministic regression coverage and a live assistant eval for `L4` resolving to `L3/L4` without creating a root label

## Testing

- `pnpm test utils/ai/assistant/chat-label-tools.test.ts utils/ai/assistant/chat-inbox-tools.test.ts` (47 passed)
- `assistant-chat-label-management` live eval with Gemini 3 Flash (7 passed)
- Ultracite formatting/check on all 6 changed files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

