### PR TITLE
assistant: Validate sender categorization access

### DIFF
--- a/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.test.ts
@@ -3,6 +3,7 @@ import type { ParsedMessage } from "@/utils/types";
 import prisma from "@/utils/__mocks__/prisma";
 import { createTestLogger } from "@/__tests__/helpers";
 import { createEmailProvider } from "@/utils/email/provider";
+import { SafeError } from "@/utils/error";
 import {
   forwardEmailTool,
   getAccountOverviewTool,
@@ -28,12 +29,14 @@ const {
   mockStartBulkCategorization,
   mockGetCategorizationProgress,
   mockGetCategorizationStatusSnapshot,
+  mockValidateUserAndAiAccess,
 } = vi.hoisted(() => ({
   mockArchiveCategory: vi.fn(),
   mockGetCategoryOverview: vi.fn(),
   mockStartBulkCategorization: vi.fn(),
   mockGetCategorizationProgress: vi.fn(),
   mockGetCategorizationStatusSnapshot: vi.fn(),
+  mockValidateUserAndAiAccess: vi.fn(),
 }));
 
 vi.mock("@/utils/categorize/senders/archive-category", () => ({
@@ -59,6 +62,12 @@ vi.mock("@/utils/redis/categorization-progress", () => ({
   getCategorizationStatusSnapshot: (
     ...args: Parameters<typeof mockGetCategorizationStatusSnapshot>
   ) => mockGetCategorizationStatusSnapshot(...args),
+}));
+
+vi.mock("@/utils/user/validate", () => ({
+  validateUserAndAiAccess: (
+    ...args: Parameters<typeof mockValidateUserAndAiAccess>
+  ) => mockValidateUserAndAiAccess(...args),
 }));
 
 const TEST_EMAIL = "user@test.com";
@@ -1537,6 +1546,7 @@ describe("chat inbox tools - bulk pagination guidance (INB-134)", () => {
 describe("chat inbox tools - sender categories", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockValidateUserAndAiAccess.mockResolvedValue(undefined);
   });
 
   it("getSenderCategoryOverview returns the shared overview payload", async () => {
@@ -1596,6 +1606,9 @@ describe("chat inbox tools - sender categories", () => {
 
     const result = await (toolInstance.execute as any)({});
 
+    expect(mockValidateUserAndAiAccess).toHaveBeenCalledWith({
+      emailAccountId: "email-account-1",
+    });
     expect(createEmailProvider).toHaveBeenCalledWith({
       emailAccountId: "email-account-1",
       provider: "google",
@@ -1607,6 +1620,25 @@ describe("chat inbox tools - sender categories", () => {
       logger,
     });
     expect(result.totalQueuedSenders).toBe(8);
+  });
+
+  it("startSenderCategorization reports an AI access error before queuing work", async () => {
+    mockValidateUserAndAiAccess.mockRejectedValue(
+      new SafeError("Please upgrade for AI access"),
+    );
+
+    const toolInstance = startSenderCategorizationTool({
+      email: TEST_EMAIL,
+      emailAccountId: "email-account-1",
+      provider: "google",
+      logger,
+    });
+
+    const result = await (toolInstance.execute as any)({});
+
+    expect(result).toEqual({ error: "Please upgrade for AI access" });
+    expect(createEmailProvider).not.toHaveBeenCalled();
+    expect(mockStartBulkCategorization).not.toHaveBeenCalled();
   });
 
   it("getSenderCategorizationStatus waits briefly before reading progress", async () => {

--- a/apps/web/utils/ai/assistant/chat-inbox-tools.ts
+++ b/apps/web/utils/ai/assistant/chat-inbox-tools.ts
@@ -54,6 +54,8 @@ import {
   isRetryableError as isGmailRetryableError,
 } from "@/utils/gmail/retry";
 import { microsoftGraphPageTokenSchema } from "@/utils/outlook/page-token";
+import { validateUserAndAiAccess } from "@/utils/user/validate";
+import { SafeError } from "@/utils/error";
 
 const SEARCH_INBOX_MAX_RESULTS = 20;
 const OUTLOOK_EMPTY_PAGE_AUTOPAGINATION_LIMIT = 5;
@@ -376,6 +378,8 @@ export const startSenderCategorizationTool = ({
       trackToolCall({ tool: "start_sender_categorization", email, logger });
 
       try {
+        await validateUserAndAiAccess({ emailAccountId });
+
         const emailProvider = await createEmailProvider({
           emailAccountId,
           provider,
@@ -388,6 +392,11 @@ export const startSenderCategorizationTool = ({
           logger,
         });
       } catch (error) {
+        if (error instanceof SafeError) {
+          logger.warn("Unable to start sender categorization", { error });
+          return { error: error.message };
+        }
+
         logger.error("Failed to start sender categorization", { error });
         return {
           error: "Failed to start sender categorization",


### PR DESCRIPTION
Prevents sender categorization from being queued when an account cannot use AI. Returns a safe, actionable error instead of reporting a job that cannot run.

- Validate AI access before provider setup and queue publication
- Preserve generic handling for unexpected failures
- Add regression coverage for allowed and denied access paths

Performance impact: Adds one existing entitlement lookup before manually starting categorization. No hot-path impact; avoids unnecessary provider and queue network calls for ineligible accounts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

