### PR TITLE
Fix cramped mobile header by hiding redundant Log in button

### DIFF
--- a/apps/web/components/new-landing/sections/Header.tsx
+++ b/apps/web/components/new-landing/sections/Header.tsx
@@ -30,14 +30,16 @@ export function Header({ className }: HeaderProps) {
       </div>
       <HeaderLinks />
       <div className="flex items-center gap-3">
-        <Button variant="secondary" asChild>
-          <Link
-            href="/login"
-            onClick={() => landingPageAnalytics.logInClicked(posthog)}
-          >
-            Log in
-          </Link>
-        </Button>
+        <div className="hidden md:block">
+          <Button variant="secondary" asChild>
+            <Link
+              href="/login"
+              onClick={() => landingPageAnalytics.logInClicked(posthog)}
+            >
+              Log in
+            </Link>
+          </Button>
+        </div>
         <Button asChild>
           <Link
             href="/login"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On mobile, the landing header showed both **Log in** and **Get started free**, which crowded the bar and wrapped "Log in" onto two lines. Both links already go to `/login`.

## Change
Hide the secondary **Log in** button below the `md` breakpoint so mobile only shows **Get started free**. Desktop still shows both.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f70cd-0051-7f96-9dd5-7be8bd2a5ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f70cd-0051-7f96-9dd5-7be8bd2a5ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

