### PR TITLE
assistant: Restore rule list ordering

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -10,9 +10,8 @@ import {
   Trash2Icon,
   SparklesIcon,
   CopyIcon,
-  SearchIcon,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { LoadingContent } from "@/components/LoadingContent";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader } from "@/components/ui/card";
@@ -32,7 +31,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Switch } from "@/components/ui/switch";
-import { Input } from "@/components/ui/input";
 import { deleteRuleAction, toggleRuleAction } from "@/utils/actions/rule";
 import { setMemberOrganizationRuleEnabledAction } from "@/utils/actions/organization-rule";
 import { Badge } from "@/components/Badge";
@@ -63,6 +61,7 @@ import {
   SYSTEM_RULE_ORDER,
   getDefaultActions,
 } from "@/utils/rule/consts";
+import { sortRulesForAutomation } from "@/utils/rule/sort";
 import {
   STEP_KEYS,
   getOnboardingStepHref,
@@ -176,41 +175,13 @@ export function Rules({
 
     const userRules = existingRules.filter((rule) => !rule.systemType);
 
-    const sortedUserRules = userRules.sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
-    );
-
-    return [...systemRulePlaceholders, ...sortedUserRules];
+    return sortRulesForAutomation([...systemRulePlaceholders, ...userRules]);
   }, [data, emailAccountId, provider]);
-
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const filteredRules = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return rules;
-    return rules.filter(
-      (rule) =>
-        rule.name.toLowerCase().includes(query) ||
-        conditionsToString(rule).toLowerCase().includes(query),
-    );
-  }, [rules, searchQuery]);
 
   const hasRules = !!rules?.length;
 
   return (
     <div className="space-y-6">
-      {hasRules && (
-        <div className="relative max-w-xs">
-          <SearchIcon className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search rules..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-8"
-          />
-        </div>
-      )}
       <Card>
         <LoadingContent loading={isLoading} error={error}>
           {hasRules ? (
@@ -238,17 +209,7 @@ export function Rules({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredRules.length === 0 && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={5}
-                      className="py-8 text-center text-muted-foreground"
-                    >
-                      No rules match "{searchQuery}".
-                    </TableCell>
-                  </TableRow>
-                )}
-                {filteredRules.map((rule) => {
+                {rules.map((rule) => {
                   const isPlaceholder = rule.id.startsWith("placeholder-");
                   const isOrgManaged = !!rule.organizationRuleId;
                   const isDisabledByOrg =

--- a/apps/web/utils/rule/sort.test.ts
+++ b/apps/web/utils/rule/sort.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { SystemType } from "@/generated/prisma/enums";
+import { sortRulesForAutomation } from "./sort";
+
+describe("sortRulesForAutomation", () => {
+  it("puts disabled rules after enabled rules and sorts each group by name", () => {
+    const rules = [
+      { name: "Zulu", enabled: true },
+      { name: "Alpha", enabled: false },
+      { name: "Bravo", enabled: true },
+      { name: "Charlie", enabled: false },
+    ];
+
+    expect(sortRulesForAutomation(rules).map((rule) => rule.name)).toEqual([
+      "Bravo",
+      "Zulu",
+      "Alpha",
+      "Charlie",
+    ]);
+  });
+
+  it("keeps system rules in their canonical order within a status group", () => {
+    const rules = [
+      {
+        name: "Newsletter",
+        enabled: true,
+        systemType: SystemType.NEWSLETTER,
+      },
+      {
+        name: "Cold Email",
+        enabled: true,
+        systemType: SystemType.COLD_EMAIL,
+      },
+      { name: "Alpha", enabled: true },
+    ];
+
+    expect(sortRulesForAutomation(rules).map((rule) => rule.name)).toEqual([
+      "Newsletter",
+      "Cold Email",
+      "Alpha",
+    ]);
+  });
+});


### PR DESCRIPTION
Restores a quieter rules table and predictable status-aware ordering.

- Removes the persistent inline search field.
- Keeps enabled rules first and disabled rules last, with canonical and alphabetical ordering within groups.
- Adds focused ordering regression tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

