### PR TITLE
auth: Prevent duplicate OAuth callback processing

### DIFF
--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from "@/utils/logger";
 const logger = createScopedLogger("auth/oauth-callback");
 const handlers = toNextJsHandler(betterAuthConfig);
 
+export const maxDuration = 300;
 export const { POST, PUT, PATCH, DELETE } = handlers;
 
 export const GET: typeof handlers.GET = async (...args) => {

--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,5 +1,19 @@
 import { betterAuthConfig } from "@/utils/auth";
 import { toNextJsHandler } from "better-auth/next-js";
+import { deduplicateOAuthCallback } from "@/utils/oauth/auth-callback-deduplication";
+import { createScopedLogger } from "@/utils/logger";
 
-export const { POST, GET, PUT, PATCH, DELETE } =
-  toNextJsHandler(betterAuthConfig);
+const logger = createScopedLogger("auth/oauth-callback");
+const handlers = toNextJsHandler(betterAuthConfig);
+
+export const { POST, PUT, PATCH, DELETE } = handlers;
+
+export const GET: typeof handlers.GET = async (...args) => {
+  const [request] = args;
+
+  return deduplicateOAuthCallback({
+    request,
+    handleRequest: () => handlers.GET(...args),
+    logger,
+  });
+};

--- a/apps/web/utils/oauth/auth-callback-deduplication.test.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.test.ts
@@ -1,5 +1,12 @@
+import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createScopedLogger } from "@/utils/logger";
+
+const OAUTH_STATE_COOKIE =
+  "__Secure-better-auth.oauth_state=encrypted-oauth-state";
+const REQUEST_FINGERPRINT = createHash("sha256")
+  .update("encrypted-oauth-state")
+  .digest("hex");
 
 const {
   mockClaimOAuthCode,
@@ -31,7 +38,7 @@ describe("deduplicateOAuthCallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsOAuthCodeStoreConfigured.mockReturnValue(true);
-    mockClaimOAuthCode.mockResolvedValue("acquired");
+    mockClaimOAuthCode.mockResolvedValue(null);
     mockGetOAuthCodeResult.mockResolvedValue(null);
     mockSetOAuthCodeResult.mockResolvedValue(undefined);
     mockClearOAuthCode.mockResolvedValue(undefined);
@@ -62,10 +69,7 @@ describe("deduplicateOAuthCallback", () => {
 
   it("does not use Redis when the callback store is not configured", async () => {
     mockIsOAuthCodeStoreConfigured.mockReturnValue(false);
-    const response = Response.redirect(
-      "https://example.com/welcome-redirect",
-      302,
-    );
+    const response = createSuccessfulCallbackResponse();
     const handleRequest = vi.fn().mockResolvedValue(response);
 
     await expect(
@@ -80,11 +84,26 @@ describe("deduplicateOAuthCallback", () => {
     expect(mockClaimOAuthCode).not.toHaveBeenCalled();
   });
 
+  it("does not use Redis without Better Auth's OAuth state cookie", async () => {
+    const response = createSuccessfulCallbackResponse();
+    const handleRequest = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      deduplicateOAuthCallback({
+        request: new Request(
+          "https://example.com/api/auth/callback/google?code=oauth-code&state=oauth-state",
+        ),
+        handleRequest,
+        logger,
+      }),
+    ).resolves.toBe(response);
+
+    expect(handleRequest).toHaveBeenCalledOnce();
+    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+  });
+
   it("caches the first successful callback redirect", async () => {
-    const response = Response.redirect(
-      "https://example.com/welcome-redirect",
-      302,
-    );
+    const response = createSuccessfulCallbackResponse();
     const handleRequest = vi.fn().mockResolvedValue(response);
 
     await expect(
@@ -95,19 +114,36 @@ describe("deduplicateOAuthCallback", () => {
       }),
     ).resolves.toBe(response);
 
-    expect(mockClaimOAuthCode).toHaveBeenCalledWith("oauth-code");
-    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("oauth-code", {
-      redirect: "https://example.com/welcome-redirect",
-      status: "302",
-    });
+    expect(mockClaimOAuthCode).toHaveBeenCalledWith(
+      "oauth-code",
+      REQUEST_FINGERPRINT,
+    );
+    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith(
+      "oauth-code",
+      {
+        redirect: "https://example.com/welcome-redirect",
+        setCookies: JSON.stringify([
+          "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+        ]),
+        status: "302",
+      },
+      {
+        requestFingerprint: REQUEST_FINGERPRINT,
+        ttlSeconds: 600,
+      },
+    );
   });
 
   it("reuses a cached callback redirect without exchanging the code again", async () => {
     mockClaimOAuthCode.mockResolvedValue({
       params: {
         redirect: "https://example.com/welcome-redirect",
+        setCookies: JSON.stringify([
+          "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+        ]),
         status: "302",
       },
+      requestFingerprint: REQUEST_FINGERPRINT,
       status: "success",
     });
     const handleRequest = vi.fn();
@@ -122,7 +158,32 @@ describe("deduplicateOAuthCallback", () => {
     expect(response.headers.get("location")).toBe(
       "https://example.com/welcome-redirect",
     );
+    expect(response.headers.get("set-cookie")).toBe(
+      "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+    );
     expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not replay session cookies to a different OAuth state", async () => {
+    mockClaimOAuthCode.mockResolvedValue({
+      params: {
+        redirect: "https://example.com/welcome-redirect",
+        setCookies: JSON.stringify([
+          "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+        ]),
+        status: "302",
+      },
+      requestFingerprint: "different-request",
+      status: "success",
+    });
+
+    const response = await deduplicateOAuthCallback({
+      request: createGoogleCallbackRequest(),
+      handleRequest: vi.fn(),
+      logger,
+    });
+
+    expect(response.headers.get("set-cookie")).toBeNull();
   });
 
   it("waits for an in-flight callback and reuses its redirect", async () => {
@@ -132,9 +193,13 @@ describe("deduplicateOAuthCallback", () => {
         redirect: "https://example.com/welcome-redirect",
         status: "302",
       },
+      requestFingerprint: REQUEST_FINGERPRINT,
       status: "success",
     });
-    mockClaimOAuthCode.mockResolvedValue("processing");
+    mockClaimOAuthCode.mockResolvedValue({
+      requestFingerprint: REQUEST_FINGERPRINT,
+      status: "processing",
+    });
     const handleRequest = vi.fn();
 
     const responsePromise = deduplicateOAuthCallback({
@@ -154,10 +219,7 @@ describe("deduplicateOAuthCallback", () => {
 
   it("falls back to Better Auth when the deduplication store is unavailable", async () => {
     mockClaimOAuthCode.mockRejectedValue(new Error("Redis unavailable"));
-    const response = Response.redirect(
-      "https://example.com/welcome-redirect",
-      302,
-    );
+    const response = createSuccessfulCallbackResponse();
     const handleRequest = vi.fn().mockResolvedValue(response);
 
     await expect(
@@ -190,5 +252,19 @@ describe("deduplicateOAuthCallback", () => {
 function createGoogleCallbackRequest() {
   return new Request(
     "https://example.com/api/auth/callback/google?code=oauth-code&state=oauth-state",
+    { headers: { cookie: OAUTH_STATE_COOKIE } },
   );
+}
+
+function createSuccessfulCallbackResponse() {
+  return new Response(null, {
+    headers: [
+      ["location", "https://example.com/welcome-redirect"],
+      [
+        "set-cookie",
+        "better-auth.session_token=session-token; Path=/; HttpOnly; Secure",
+      ],
+    ],
+    status: 302,
+  });
 }

--- a/apps/web/utils/oauth/auth-callback-deduplication.test.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createScopedLogger } from "@/utils/logger";
+
+const {
+  mockClaimOAuthCode,
+  mockClearOAuthCode,
+  mockGetOAuthCodeResult,
+  mockIsOAuthCodeStoreConfigured,
+  mockSetOAuthCodeResult,
+} = vi.hoisted(() => ({
+  mockClaimOAuthCode: vi.fn(),
+  mockClearOAuthCode: vi.fn(),
+  mockGetOAuthCodeResult: vi.fn(),
+  mockIsOAuthCodeStoreConfigured: vi.fn(),
+  mockSetOAuthCodeResult: vi.fn(),
+}));
+
+vi.mock("@/utils/redis/oauth-code", () => ({
+  claimOAuthCode: mockClaimOAuthCode,
+  clearOAuthCode: mockClearOAuthCode,
+  getOAuthCodeResult: mockGetOAuthCodeResult,
+  isOAuthCodeStoreConfigured: mockIsOAuthCodeStoreConfigured,
+  setOAuthCodeResult: mockSetOAuthCodeResult,
+}));
+
+import { deduplicateOAuthCallback } from "./auth-callback-deduplication";
+
+const logger = createScopedLogger("test/auth-callback-deduplication");
+
+describe("deduplicateOAuthCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsOAuthCodeStoreConfigured.mockReturnValue(true);
+    mockClaimOAuthCode.mockResolvedValue("acquired");
+    mockGetOAuthCodeResult.mockResolvedValue(null);
+    mockSetOAuthCodeResult.mockResolvedValue(undefined);
+    mockClearOAuthCode.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("passes non-callback requests directly to Better Auth", async () => {
+    const handleRequest = vi
+      .fn()
+      .mockResolvedValue(Response.json({ providers: ["google"] }));
+
+    const response = await deduplicateOAuthCallback({
+      request: new Request(
+        "https://example.com/api/auth/sign-in/social?code=not-a-callback",
+      ),
+      handleRequest,
+      logger,
+    });
+
+    expect(response.status).toBe(200);
+    expect(handleRequest).toHaveBeenCalledOnce();
+    expect(mockIsOAuthCodeStoreConfigured).not.toHaveBeenCalled();
+    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it("does not use Redis when the callback store is not configured", async () => {
+    mockIsOAuthCodeStoreConfigured.mockReturnValue(false);
+    const response = Response.redirect(
+      "https://example.com/welcome-redirect",
+      302,
+    );
+    const handleRequest = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      deduplicateOAuthCallback({
+        request: createGoogleCallbackRequest(),
+        handleRequest,
+        logger,
+      }),
+    ).resolves.toBe(response);
+
+    expect(handleRequest).toHaveBeenCalledOnce();
+    expect(mockClaimOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it("caches the first successful callback redirect", async () => {
+    const response = Response.redirect(
+      "https://example.com/welcome-redirect",
+      302,
+    );
+    const handleRequest = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      deduplicateOAuthCallback({
+        request: createGoogleCallbackRequest(),
+        handleRequest,
+        logger,
+      }),
+    ).resolves.toBe(response);
+
+    expect(mockClaimOAuthCode).toHaveBeenCalledWith("oauth-code");
+    expect(mockSetOAuthCodeResult).toHaveBeenCalledWith("oauth-code", {
+      redirect: "https://example.com/welcome-redirect",
+      status: "302",
+    });
+  });
+
+  it("reuses a cached callback redirect without exchanging the code again", async () => {
+    mockClaimOAuthCode.mockResolvedValue({
+      params: {
+        redirect: "https://example.com/welcome-redirect",
+        status: "302",
+      },
+      status: "success",
+    });
+    const handleRequest = vi.fn();
+
+    const response = await deduplicateOAuthCallback({
+      request: createGoogleCallbackRequest(),
+      handleRequest,
+      logger,
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/welcome-redirect",
+    );
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it("waits for an in-flight callback and reuses its redirect", async () => {
+    vi.useFakeTimers();
+    mockGetOAuthCodeResult.mockResolvedValueOnce({
+      params: {
+        redirect: "https://example.com/welcome-redirect",
+        status: "302",
+      },
+      status: "success",
+    });
+    mockClaimOAuthCode.mockResolvedValue("processing");
+    const handleRequest = vi.fn();
+
+    const responsePromise = deduplicateOAuthCallback({
+      request: createGoogleCallbackRequest(),
+      handleRequest,
+      logger,
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/welcome-redirect",
+    );
+    expect(handleRequest).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Better Auth when the deduplication store is unavailable", async () => {
+    mockClaimOAuthCode.mockRejectedValue(new Error("Redis unavailable"));
+    const response = Response.redirect(
+      "https://example.com/welcome-redirect",
+      302,
+    );
+    const handleRequest = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      deduplicateOAuthCallback({
+        request: createGoogleCallbackRequest(),
+        handleRequest,
+        logger,
+      }),
+    ).resolves.toBe(response);
+
+    expect(handleRequest).toHaveBeenCalledOnce();
+  });
+
+  it("releases the callback lock when Better Auth throws", async () => {
+    const error = new Error("Callback failed");
+    const handleRequest = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      deduplicateOAuthCallback({
+        request: createGoogleCallbackRequest(),
+        handleRequest,
+        logger,
+      }),
+    ).rejects.toBe(error);
+
+    expect(mockClearOAuthCode).toHaveBeenCalledWith("oauth-code");
+  });
+});
+
+function createGoogleCallbackRequest() {
+  return new Request(
+    "https://example.com/api/auth/callback/google?code=oauth-code&state=oauth-state",
+  );
+}

--- a/apps/web/utils/oauth/auth-callback-deduplication.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.ts
@@ -1,9 +1,11 @@
+import { createHash } from "node:crypto";
 import type { Logger } from "@/utils/logger";
 import {
   claimOAuthCode,
   clearOAuthCode,
   getOAuthCodeResult,
   isOAuthCodeStoreConfigured,
+  type OAuthCodeResult,
   setOAuthCodeResult,
 } from "@/utils/redis/oauth-code";
 import { WELCOME_PATH } from "@/utils/config";
@@ -11,7 +13,12 @@ import { WELCOME_PATH } from "@/utils/config";
 const CALLBACK_PATH_REGEX = /\/api\/auth\/(?:oauth2\/)?callback\/([^/]+)\/?$/;
 const CALLBACK_RESULT_POLL_INTERVAL_MS = 250;
 const CALLBACK_RESULT_WAIT_MS = 15_000;
+const CALLBACK_RESULT_TTL_SECONDS = 600;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const OAUTH_STATE_COOKIE_NAMES = new Set([
+  "__Secure-better-auth.oauth_state",
+  "better-auth.oauth_state",
+]);
 
 export async function deduplicateOAuthCallback({
   request,
@@ -26,10 +33,13 @@ export async function deduplicateOAuthCallback({
   if (!callback || !isOAuthCodeStoreConfigured()) return handleRequest();
 
   const { code, provider } = callback;
+  const requestFingerprint = getOAuthStateFingerprint(request);
+  if (!requestFingerprint) return handleRequest();
+
   let claim: Awaited<ReturnType<typeof claimOAuthCode>>;
 
   try {
-    claim = await claimOAuthCode(code);
+    claim = await claimOAuthCode(code, requestFingerprint);
   } catch (error) {
     logger.warn("OAuth callback deduplication unavailable", {
       error,
@@ -38,12 +48,12 @@ export async function deduplicateOAuthCallback({
     return handleRequest();
   }
 
-  if (typeof claim === "object") {
+  if (claim?.status === "success") {
     logger.info("Reusing completed OAuth callback", { provider });
-    return createCachedRedirect(request, claim.params);
+    return createCachedRedirect({ request, requestFingerprint, result: claim });
   }
 
-  if (claim === "processing") {
+  if (claim?.status === "processing") {
     logger.info("Waiting for in-flight OAuth callback", { provider });
     const inFlightResult = await waitForOAuthCodeResult({
       code,
@@ -53,7 +63,11 @@ export async function deduplicateOAuthCallback({
 
     if (inFlightResult) {
       logger.info("Reusing in-flight OAuth callback result", { provider });
-      return createCachedRedirect(request, inFlightResult.params);
+      return createCachedRedirect({
+        request,
+        requestFingerprint,
+        result: inFlightResult,
+      });
     }
 
     logger.warn("OAuth callback wait timed out", { provider });
@@ -66,9 +80,18 @@ export async function deduplicateOAuthCallback({
 
     if (location && REDIRECT_STATUSES.has(response.status)) {
       try {
-        await setOAuthCodeResult(code, {
+        const params: Record<string, string> = {
           redirect: location,
           status: response.status.toString(),
+        };
+        const setCookies = getSetCookieHeaders(response.headers);
+        if (setCookies.length > 0) {
+          params.setCookies = JSON.stringify(setCookies);
+        }
+
+        await setOAuthCodeResult(code, params, {
+          requestFingerprint,
+          ttlSeconds: CALLBACK_RESULT_TTL_SECONDS,
         });
       } catch (error) {
         logger.warn("Failed to cache OAuth callback result", {
@@ -137,10 +160,16 @@ async function waitForOAuthCodeResult({
   return null;
 }
 
-function createCachedRedirect(
-  request: Request,
-  params: Record<string, string>,
-) {
+function createCachedRedirect({
+  request,
+  requestFingerprint,
+  result,
+}: {
+  request: Request;
+  requestFingerprint?: string;
+  result: OAuthCodeResult;
+}) {
+  const { params } = result;
   const redirect = params.redirect;
   const status = Number(params.status);
 
@@ -150,5 +179,54 @@ function createCachedRedirect(
 
   const redirectUrl = new URL(redirect, request.url);
   const redirectStatus = REDIRECT_STATUSES.has(status) ? status : 302;
-  return Response.redirect(redirectUrl, redirectStatus);
+  const headers = new Headers({ location: redirectUrl.toString() });
+
+  if (
+    requestFingerprint &&
+    requestFingerprint === result.requestFingerprint &&
+    params.setCookies
+  ) {
+    for (const cookie of parseSetCookies(params.setCookies)) {
+      headers.append("set-cookie", cookie);
+    }
+  }
+
+  return new Response(null, { headers, status: redirectStatus });
+}
+
+function getSetCookieHeaders(headers: Headers) {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie;
+
+  return getSetCookie?.call(headers) ?? [];
+}
+
+function getOAuthStateFingerprint(request: Request) {
+  const cookieHeader = request.headers.get("cookie");
+  if (!cookieHeader) return;
+
+  for (const cookie of cookieHeader.split(";")) {
+    const separator = cookie.indexOf("=");
+    if (separator === -1) continue;
+
+    const name = cookie.slice(0, separator).trim();
+    if (!OAUTH_STATE_COOKIE_NAMES.has(name)) continue;
+
+    const value = cookie.slice(separator + 1);
+    if (!value) return;
+
+    return createHash("sha256").update(value).digest("hex");
+  }
+}
+
+function parseSetCookies(value: string) {
+  try {
+    const cookies = JSON.parse(value) as unknown;
+    return Array.isArray(cookies) &&
+      cookies.every((cookie) => typeof cookie === "string")
+      ? cookies
+      : [];
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/utils/oauth/auth-callback-deduplication.ts
+++ b/apps/web/utils/oauth/auth-callback-deduplication.ts
@@ -1,0 +1,154 @@
+import type { Logger } from "@/utils/logger";
+import {
+  claimOAuthCode,
+  clearOAuthCode,
+  getOAuthCodeResult,
+  isOAuthCodeStoreConfigured,
+  setOAuthCodeResult,
+} from "@/utils/redis/oauth-code";
+import { WELCOME_PATH } from "@/utils/config";
+
+const CALLBACK_PATH_REGEX = /\/api\/auth\/(?:oauth2\/)?callback\/([^/]+)\/?$/;
+const CALLBACK_RESULT_POLL_INTERVAL_MS = 250;
+const CALLBACK_RESULT_WAIT_MS = 15_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+export async function deduplicateOAuthCallback({
+  request,
+  handleRequest,
+  logger,
+}: {
+  request: Request;
+  handleRequest: () => Promise<Response>;
+  logger: Logger;
+}) {
+  const callback = getOAuthCallback(request);
+  if (!callback || !isOAuthCodeStoreConfigured()) return handleRequest();
+
+  const { code, provider } = callback;
+  let claim: Awaited<ReturnType<typeof claimOAuthCode>>;
+
+  try {
+    claim = await claimOAuthCode(code);
+  } catch (error) {
+    logger.warn("OAuth callback deduplication unavailable", {
+      error,
+      provider,
+    });
+    return handleRequest();
+  }
+
+  if (typeof claim === "object") {
+    logger.info("Reusing completed OAuth callback", { provider });
+    return createCachedRedirect(request, claim.params);
+  }
+
+  if (claim === "processing") {
+    logger.info("Waiting for in-flight OAuth callback", { provider });
+    const inFlightResult = await waitForOAuthCodeResult({
+      code,
+      logger,
+      provider,
+    });
+
+    if (inFlightResult) {
+      logger.info("Reusing in-flight OAuth callback result", { provider });
+      return createCachedRedirect(request, inFlightResult.params);
+    }
+
+    logger.warn("OAuth callback wait timed out", { provider });
+    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+  }
+
+  try {
+    const response = await handleRequest();
+    const location = response.headers.get("location");
+
+    if (location && REDIRECT_STATUSES.has(response.status)) {
+      try {
+        await setOAuthCodeResult(code, {
+          redirect: location,
+          status: response.status.toString(),
+        });
+      } catch (error) {
+        logger.warn("Failed to cache OAuth callback result", {
+          error,
+          provider,
+        });
+      }
+    } else {
+      await clearOAuthCode(code);
+    }
+
+    return response;
+  } catch (error) {
+    await clearOAuthCode(code);
+    throw error;
+  }
+}
+
+function getOAuthCallback(request: Request) {
+  if (request.method !== "GET") return null;
+  if (
+    !request.url.includes("/api/auth/") ||
+    !request.url.includes("/callback/")
+  ) {
+    return null;
+  }
+
+  const url = new URL(request.url);
+  const match = url.pathname.match(CALLBACK_PATH_REGEX);
+  const code = url.searchParams.get("code");
+  const provider = match?.[1];
+
+  if (!code || !provider) return null;
+
+  return { code, provider };
+}
+
+async function waitForOAuthCodeResult({
+  code,
+  logger,
+  provider,
+}: {
+  code: string;
+  logger: Logger;
+  provider: string;
+}) {
+  const attempts = CALLBACK_RESULT_WAIT_MS / CALLBACK_RESULT_POLL_INTERVAL_MS;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, CALLBACK_RESULT_POLL_INTERVAL_MS),
+    );
+
+    try {
+      const result = await getOAuthCodeResult(code);
+      if (result) return result;
+    } catch (error) {
+      logger.warn("Failed while waiting for OAuth callback result", {
+        error,
+        provider,
+      });
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function createCachedRedirect(
+  request: Request,
+  params: Record<string, string>,
+) {
+  const redirect = params.redirect;
+  const status = Number(params.status);
+
+  if (!redirect) {
+    return Response.redirect(new URL(WELCOME_PATH, request.url), 302);
+  }
+
+  const redirectUrl = new URL(redirect, request.url);
+  const redirectStatus = REDIRECT_STATUSES.has(status) ? status : 302;
+  return Response.redirect(redirectUrl, redirectStatus);
+}

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -51,6 +51,14 @@ describe("claimOAuthCode", () => {
     await expect(claimOAuthCode("oauth-code")).resolves.toBe(processing);
   });
 
+  it("normalizes a legacy string lock as an in-flight callback", async () => {
+    vi.mocked(redis.set).mockResolvedValue("processing");
+
+    await expect(claimOAuthCode("oauth-code")).resolves.toEqual({
+      status: "processing",
+    });
+  });
+
   it("returns a completed callback result", async () => {
     const completed = {
       params: { redirect: "https://example.com/welcome-redirect" },

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -23,13 +23,18 @@ describe("claimOAuthCode", () => {
   it("atomically claims an unused code", async () => {
     vi.mocked(redis.set).mockResolvedValue(null);
 
-    await expect(claimOAuthCode("oauth-code")).resolves.toBe("acquired");
+    await expect(
+      claimOAuthCode("oauth-code", "request-fingerprint"),
+    ).resolves.toBeNull();
 
     expect(redis.set).toHaveBeenCalledWith(
       expect.stringMatching(/^oauth-code:/),
-      "processing",
       {
-        ex: 60,
+        requestFingerprint: "request-fingerprint",
+        status: "processing",
+      },
+      {
+        ex: 600,
         get: true,
         nx: true,
       },
@@ -37,9 +42,13 @@ describe("claimOAuthCode", () => {
   });
 
   it("reports an in-flight callback", async () => {
-    vi.mocked(redis.set).mockResolvedValue("processing");
+    const processing = {
+      requestFingerprint: "request-fingerprint",
+      status: "processing" as const,
+    };
+    vi.mocked(redis.set).mockResolvedValue(processing);
 
-    await expect(claimOAuthCode("oauth-code")).resolves.toBe("processing");
+    await expect(claimOAuthCode("oauth-code")).resolves.toBe(processing);
   });
 
   it("returns a completed callback result", async () => {

--- a/apps/web/utils/redis/oauth-code.test.ts
+++ b/apps/web/utils/redis/oauth-code.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import { claimOAuthCode } from "@/utils/redis/oauth-code";
+
+vi.mock("@/env", () => ({
+  env: {
+    UPSTASH_REDIS_TOKEN: "token",
+    UPSTASH_REDIS_URL: "https://redis.example.com",
+  },
+}));
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    set: vi.fn(),
+  },
+}));
+
+describe("claimOAuthCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("atomically claims an unused code", async () => {
+    vi.mocked(redis.set).mockResolvedValue(null);
+
+    await expect(claimOAuthCode("oauth-code")).resolves.toBe("acquired");
+
+    expect(redis.set).toHaveBeenCalledWith(
+      expect.stringMatching(/^oauth-code:/),
+      "processing",
+      {
+        ex: 60,
+        get: true,
+        nx: true,
+      },
+    );
+  });
+
+  it("reports an in-flight callback", async () => {
+    vi.mocked(redis.set).mockResolvedValue("processing");
+
+    await expect(claimOAuthCode("oauth-code")).resolves.toBe("processing");
+  });
+
+  it("returns a completed callback result", async () => {
+    const completed = {
+      params: { redirect: "https://example.com/welcome-redirect" },
+      status: "success" as const,
+    };
+    vi.mocked(redis.set).mockResolvedValue(completed);
+
+    await expect(claimOAuthCode("oauth-code")).resolves.toBe(completed);
+  });
+});

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -42,6 +42,8 @@ export async function claimOAuthCode(
     },
   );
 
+  if (typeof existing === "string") return { status: "processing" };
+
   return existing as OAuthCodeClaim;
 }
 

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -11,35 +11,38 @@ function getCodeKey(code: string) {
   return `oauth-code:${createOAuthCodeCacheKey(code)}`;
 }
 
-interface OAuthCodeResult {
+export interface OAuthCodeResult {
   params: Record<string, string>;
+  requestFingerprint?: string;
   status: "success";
 }
 
-type OAuthCodeClaim = "acquired" | "processing" | OAuthCodeResult;
+interface OAuthCodeProcessing {
+  requestFingerprint?: string;
+  status: "processing";
+}
+
+type OAuthCodeClaim = OAuthCodeProcessing | OAuthCodeResult | null;
 
 export function isOAuthCodeStoreConfigured() {
   return Boolean(env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN);
 }
 
-export async function claimOAuthCode(code: string): Promise<OAuthCodeClaim> {
-  const existing = await redis.set<string | OAuthCodeResult>(
+export async function claimOAuthCode(
+  code: string,
+  requestFingerprint?: string,
+): Promise<OAuthCodeClaim> {
+  const existing = await redis.set<OAuthCodeProcessing | OAuthCodeResult>(
     getCodeKey(code),
-    "processing",
+    { requestFingerprint, status: "processing" },
     {
-      ex: 60,
+      ex: 600,
       get: true,
       nx: true,
     },
   );
 
-  if (!existing || existing === "OK") return "acquired";
-  if (existing === "processing") return existing;
-  if (typeof existing === "object" && existing.status === "success") {
-    return existing;
-  }
-
-  return "processing";
+  return existing as OAuthCodeClaim;
 }
 
 export async function acquireOAuthCodeLock(code: string): Promise<boolean> {
@@ -70,13 +73,20 @@ export async function getOAuthCodeResult(
 export async function setOAuthCodeResult(
   code: string,
   params: Record<string, string>,
+  options?: {
+    requestFingerprint?: string;
+    ttlSeconds?: number;
+  },
 ): Promise<void> {
   const result: OAuthCodeResult = {
     status: "success",
     params,
+    requestFingerprint: options?.requestFingerprint,
   };
 
-  await redis.set(getCodeKey(code), result, { ex: 60 });
+  await redis.set(getCodeKey(code), result, {
+    ex: options?.ttlSeconds ?? 60,
+  });
 }
 
 /**

--- a/apps/web/utils/redis/oauth-code.ts
+++ b/apps/web/utils/redis/oauth-code.ts
@@ -1,5 +1,6 @@
-import { redis } from "@/utils/redis";
 import { createHash } from "node:crypto";
+import { env } from "@/env";
+import { redis } from "@/utils/redis";
 
 // Not password hashing - creating a short cache key for OAuth authorization codes
 function createOAuthCodeCacheKey(code: string): string {
@@ -13,6 +14,32 @@ function getCodeKey(code: string) {
 interface OAuthCodeResult {
   params: Record<string, string>;
   status: "success";
+}
+
+type OAuthCodeClaim = "acquired" | "processing" | OAuthCodeResult;
+
+export function isOAuthCodeStoreConfigured() {
+  return Boolean(env.UPSTASH_REDIS_URL && env.UPSTASH_REDIS_TOKEN);
+}
+
+export async function claimOAuthCode(code: string): Promise<OAuthCodeClaim> {
+  const existing = await redis.set<string | OAuthCodeResult>(
+    getCodeKey(code),
+    "processing",
+    {
+      ex: 60,
+      get: true,
+      nx: true,
+    },
+  );
+
+  if (!existing || existing === "OK") return "acquired";
+  if (existing === "processing") return existing;
+  if (typeof existing === "object" && existing.status === "success") {
+    return existing;
+  }
+
+  return "processing";
 }
 
 export async function acquireOAuthCodeLock(code: string): Promise<boolean> {


### PR DESCRIPTION
Prevents concurrent OAuth callback requests from redeeming the same authorization code more than once.

- Coordinate callback processing with a short-lived shared claim
- Reuse completed redirect results for duplicate requests
- Bypass coordination when the shared store is unavailable
- Add focused regression coverage for callback concurrency and fallbacks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

