### PR TITLE
Bake Node 24 into Cloud Agent environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,48 @@
+# Cloud Agent base image for inbox-zero.
+# Do not COPY the project — Cursor checks out the workspace separately.
+FROM node:24-bookworm
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    openssl \
+    sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+# Match root package.json packageManager
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
+
+# Docker-in-Docker for postgres/redis via docker-compose.dev.yml
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/debian/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+    > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-ce \
+    docker-ce-cli \
+    docker-compose-plugin \
+    fuse-overlayfs \
+    iptables \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /etc/docker \
+  && printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' > /etc/docker/daemon.json \
+  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Non-root user with passwordless sudo (required by Cloud Agents)
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
+  && groupadd -f docker \
+  && usermod -aG docker ubuntu \
+  && usermod -aG sudo ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+
+USER ubuntu
+WORKDIR /home/ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,5 +4,5 @@
     "context": ".."
   },
   "install": "pnpm install",
-  "start": "sudo dockerd &>/dev/null &"
+  "start": "sudo dockerd >/dev/null 2>&1 &"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "pnpm install",
+  "start": "sudo dockerd &>/dev/null &"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cloud Agent startup was failing because the dashboard install script tried to install Node 24 with `apt` as a non-root user (no `sudo`), and also pinned the wrong pnpm (`10.33.0` vs repo `11.9.0`).

## Long-term fix
Commit an in-repo Cloud Agent environment (highest priority over dashboard config):

- **`.cursor/Dockerfile`** — `node:24-bookworm` with git/sudo, `pnpm@11.9.0` via corepack, and Docker + fuse-overlayfs for `docker-compose.dev.yml`
- **`.cursor/environment.json`** — build from that Dockerfile; `install` is just `pnpm install`; `start` brings up `dockerd` with a POSIX redirect

This removes the nodesource/`apt` install branch entirely. Future agents get Node 24 baked into the image.

## How to verify
Start a new Cloud Agent from this branch and confirm setup succeeds with Node 24 + `pnpm install` (no apt permission errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f70cd-0051-7f96-9dd5-7be8bd2a5ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f70cd-0051-7f96-9dd5-7be8bd2a5ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

