### PR TITLE
billing: Fix checkout success redirect

### DIFF
--- a/apps/web/app/api/stripe/success/route.test.ts
+++ b/apps/web/app/api/stripe/success/route.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+const { afterMock, redirectMock, syncStripeDataToDbMock } = vi.hoisted(() => ({
+  afterMock: vi.fn(),
+  redirectMock: vi.fn(),
+  syncStripeDataToDbMock: vi.fn(),
+}));
+
+vi.mock("next/server", async (importActual) => ({
+  ...(await importActual<typeof import("next/server")>()),
+  after: afterMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAuthTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+  const { withAuth } = createWithAuthTestMiddleware();
+
+  return {
+    withAuth: (
+      scopeOrHandler: Parameters<typeof withAuth>[0],
+      handler?: Parameters<typeof withAuth>[1],
+    ) => {
+      const wrapped = withAuth(scopeOrHandler, handler);
+      return (request: Request, ...context: unknown[]) =>
+        wrapped(request.clone(), ...context);
+    },
+  };
+});
+
+vi.mock("@/utils/prisma");
+
+vi.mock("@/ee/billing/stripe/sync-stripe", () => ({
+  syncStripeDataToDb: syncStripeDataToDbMock,
+}));
+
+vi.mock("@/utils/posthog", () => ({
+  trackStripeCheckoutCompleted: vi.fn(),
+}));
+
+import { GET } from "./route";
+
+describe("stripe success route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma.user.findUnique.mockResolvedValue({
+      email: "user@example.com",
+      premium: { stripeCustomerId: "stripe-customer-id" },
+    } as never);
+  });
+
+  it("redirects with the checkout session after authenticated request enrichment", async () => {
+    await GET(
+      new Request(
+        "http://localhost:3000/api/stripe/success?session_id=checkout-session-id",
+      ) as never,
+      {} as never,
+    );
+
+    expect(syncStripeDataToDbMock).toHaveBeenCalledWith({
+      customerId: "stripe-customer-id",
+      logger: expect.anything(),
+    });
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/setup?conversion_event=trial_started&conversion_event_id=checkout-session-id",
+    );
+  });
+});

--- a/apps/web/app/api/stripe/success/route.ts
+++ b/apps/web/app/api/stripe/success/route.ts
@@ -34,8 +34,9 @@ export const GET = withAuth("stripe/success", async (request) => {
     logger,
   });
 
-  const stripeCheckoutSessionId =
-    request.nextUrl.searchParams.get("session_id");
+  const stripeCheckoutSessionId = new URL(request.url).searchParams.get(
+    "session_id",
+  );
 
   redirect(
     buildRedirectUrl("/setup", {


### PR DESCRIPTION
Fix the checkout success callback so authenticated request enrichment does not prevent the setup redirect.

- Parse callback query parameters from the standard request URL
- Preserve conversion attribution in the setup redirect
- Add regression coverage for cloned authenticated requests
- Validate with the focused unit test and repository checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

