### PR TITLE
api: Preserve request APIs through middleware

### DIFF
--- a/apps/web/utils/middleware.test.ts
+++ b/apps/web/utils/middleware.test.ts
@@ -8,6 +8,8 @@ import {
   withEmailAccount,
   withEmailProvider,
   type RequestWithAuth,
+  type RequestWithEmailAccount,
+  type RequestWithEmailProvider,
   type NextHandler,
 } from "./middleware";
 import { EMAIL_ACCOUNT_HEADER } from "@/utils/config";
@@ -286,6 +288,28 @@ describe("Middleware", () => {
       );
     });
 
+    it("preserves NextRequest APIs when adding auth info", async () => {
+      mockReq = createMockRequest("GET", "http://localhost/test?view=all", {
+        cookie: "display=compact",
+      });
+      mockAuth.mockResolvedValue({ user: { id: mockUserId } } as any);
+      const handler = vi.fn(async (request: RequestWithAuth) =>
+        NextResponse.json({
+          pathname: request.nextUrl.pathname,
+          view: request.nextUrl.searchParams.get("view"),
+          display: request.cookies.get("display")?.value,
+        }),
+      );
+
+      const response = await withAuth(handler)(mockReq, mockContext);
+
+      await expect(response.json()).resolves.toEqual({
+        pathname: "/test",
+        view: "all",
+        display: "compact",
+      });
+    });
+
     it("should return 401 if session does not exist", async () => {
       mockAuth.mockResolvedValue(null as any);
       const handler: NextHandler<RequestWithAuth> = vi.fn();
@@ -434,6 +458,29 @@ describe("Middleware", () => {
       );
     });
 
+    it("preserves NextRequest APIs when adding email account info", async () => {
+      mockReq = createMockRequest("GET", "http://localhost/api/test?view=all", {
+        [EMAIL_ACCOUNT_HEADER]: mockAccountId,
+        cookie: "display=compact",
+      });
+      mockGetEmailAccount.mockResolvedValue(mockEmail);
+      const handler = vi.fn(async (request: RequestWithEmailAccount) =>
+        NextResponse.json({
+          pathname: request.nextUrl.pathname,
+          view: request.nextUrl.searchParams.get("view"),
+          display: request.cookies.get("display")?.value,
+        }),
+      );
+
+      const response = await withEmailAccount(handler)(mockReq, mockContext);
+
+      await expect(response.json()).resolves.toEqual({
+        pathname: "/api/test",
+        view: "all",
+        display: "compact",
+      });
+    });
+
     it("should return 403 if email account header is missing", async () => {
       const handler = createEmailAccountHandler();
       const wrappedHandler = withEmailAccount(handler);
@@ -484,6 +531,41 @@ describe("Middleware", () => {
 
     beforeEach(() => {
       mockAuth.mockResolvedValue({ user: { id: mockUserId } } as any);
+    });
+
+    it("preserves NextRequest APIs when adding an email provider", async () => {
+      mockReq = createMockRequest(
+        "GET",
+        "http://localhost/api/labels?view=all",
+        {
+          [EMAIL_ACCOUNT_HEADER]: mockAccountId,
+          cookie: "display=compact",
+        },
+      );
+      mockGetEmailAccount.mockResolvedValue(mockEmail);
+      mockPrismaEmailAccountFindUnique.mockResolvedValue({
+        id: mockAccountId,
+        account: { provider: "google" },
+      } as any);
+      const emailProvider = { name: "provider" };
+      mockCreateEmailProvider.mockResolvedValue(emailProvider as any);
+      const handler = vi.fn(async (request: RequestWithEmailProvider) =>
+        NextResponse.json({
+          pathname: request.nextUrl.pathname,
+          view: request.nextUrl.searchParams.get("view"),
+          display: request.cookies.get("display")?.value,
+          hasEmailProvider: request.emailProvider === emailProvider,
+        }),
+      );
+
+      const response = await withEmailProvider(handler)(mockReq, mockContext);
+
+      await expect(response.json()).resolves.toEqual({
+        pathname: "/api/labels",
+        view: "all",
+        display: "compact",
+        hasEmailProvider: true,
+      });
     });
 
     it.each([
@@ -560,7 +642,6 @@ function createMockRequest(
     method,
     headers: new Headers(headers),
   });
-  request.clone = vi.fn(() => request) as any;
   return request;
 }
 

--- a/apps/web/utils/middleware.ts
+++ b/apps/web/utils/middleware.ts
@@ -284,7 +284,7 @@ async function authMiddleware(
     );
   }
 
-  const authReq = req.clone() as RequestWithAuth;
+  const authReq = req as RequestWithAuth;
   authReq.auth = { userId: session.user.id };
 
   authReq.logger = baseLogger.with({ userId: session.user.id });
@@ -398,7 +398,7 @@ async function emailAccountMiddleware(
           userId,
         });
 
-        const emailAccountReq = req.clone() as RequestWithEmailAccount;
+        const emailAccountReq = authReq as RequestWithEmailAccount;
         emailAccountReq.auth = {
           userId,
           emailAccountId,
@@ -428,8 +428,7 @@ async function emailAccountMiddleware(
       userId,
     });
 
-    // Create a new request with email account info
-    const emailAccountReq = req.clone() as RequestWithEmailAccount;
+    const emailAccountReq = authReq as RequestWithEmailAccount;
     emailAccountReq.auth = { userId, emailAccountId, email };
     emailAccountReq.logger = emailAccountLogger;
 
@@ -451,9 +450,6 @@ async function emailProviderMiddleware(
   if (emailAccountReq instanceof Response) return emailAccountReq;
 
   const { userId, emailAccountId } = emailAccountReq.auth;
-  const reqWithAuth = req as RequestWithEmailAccount;
-  reqWithAuth.auth = emailAccountReq.auth;
-  reqWithAuth.logger = emailAccountReq.logger;
   const middlewareStartTime = Date.now();
 
   try {
@@ -494,7 +490,7 @@ async function emailProviderMiddleware(
         }),
     });
 
-    const providerReq = emailAccountReq.clone() as RequestWithEmailProvider;
+    const providerReq = emailAccountReq as RequestWithEmailProvider;
     providerReq.auth = emailAccountReq.auth;
     providerReq.emailProvider = provider;
     providerReq.logger = emailAccountReq.logger;


### PR DESCRIPTION
Keep framework request capabilities intact while authentication and account middleware attach scoped context.

- Enrich the original request instead of replacing it with native clones
- Preserve URL and cookie APIs through auth, account, and provider middleware
- Remove a test stub that masked framework behavior
- Add regression coverage for every enrichment layer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

