### PR TITLE
navigation: Route returning sessions to automation

### DIFF
--- a/apps/web/app/(landing)/welcome-redirect/page.tsx
+++ b/apps/web/app/(landing)/welcome-redirect/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/utils/auth";
 import prisma from "@/utils/prisma";
+import { redirectToEmailAccountPath } from "@/utils/account";
 
 export default async function WelcomeRedirectPage(props: {
   searchParams: Promise<{ force?: boolean }>;
@@ -18,6 +19,8 @@ export default async function WelcomeRedirectPage(props: {
   // Session exists but user doesn't - invalid state, log out
   if (!user) redirect("/logout");
   if (searchParams.force) redirect("/onboarding");
-  if (user.completedOnboardingAt) redirect("/setup");
+  if (user.completedOnboardingAt) {
+    await redirectToEmailAccountPath("/automation");
+  }
   redirect("/onboarding");
 }

--- a/apps/web/components/SideNav.tsx
+++ b/apps/web/components/SideNav.tsx
@@ -172,6 +172,7 @@ export const useNavigation = () => {
   );
 
   return {
+    homeHref: prefixPath(currentEmailAccountId, "/automation"),
     manageItems,
     cleanupItems,
     moreItems,
@@ -263,7 +264,7 @@ export function SideNav({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarHeader className="gap-0 pb-0">
         {state.includes("left-sidebar") ? (
           <div className="flex items-center rounded-md pl-2 pr-0.5 py-3 text-foreground justify-between">
-            <Link href="/setup">
+            <Link href={navigation.homeHref}>
               <Logo className="h-3.5" />
             </Link>
             <SidebarTrigger name="left-sidebar" />


### PR DESCRIPTION
Routes completed onboarding sessions directly to account-specific automation while keeping setup directly accessible.

- Makes the application logo navigate to the current account’s Automation page.
- Avoids the intermediary setup redirect and extra client hop.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

