### PR TITLE
analytics: Set signup-age person property for survey targeting

### DIFF
--- a/apps/web/providers/PostHogProvider.tsx
+++ b/apps/web/providers/PostHogProvider.tsx
@@ -11,6 +11,7 @@ import {
   getAppPageViewProperties,
   PRODUCT_ANALYTICS_EVENTS,
 } from "@/utils/analytics/product";
+import { ONE_DAY_MS } from "@/utils/date";
 
 // based on: https://posthog.com/docs/libraries/next-js
 
@@ -46,11 +47,17 @@ export function PostHogIdentify() {
   const { emailAccount } = useAccount();
 
   useEffect(() => {
-    if (session?.user.email)
-      posthog.identify(session.user.email, {
-        email: session.user.email,
-      });
-  }, [session?.user.email]);
+    const user = session?.user;
+    if (!user?.email) return;
+
+    const signedUpOverOneDayAgo =
+      Date.now() - new Date(user.createdAt).getTime() > ONE_DAY_MS;
+
+    posthog.identify(user.email, {
+      email: user.email,
+      ...(signedUpOverOneDayAgo && { signed_up_over_1_day: true }),
+    });
+  }, [session?.user.createdAt, session?.user.email]);
 
   useEffect(() => {
     // Set super properties that will be included with all events


### PR DESCRIPTION
Sets a `signed_up_over_1_day` PostHog person property at identify time so surveys can target users who signed up more than a day ago (PostHog survey display conditions don't support relative date comparisons).

- Compute the flag client-side from the session user's creation date during `posthog.identify`
- Only set the property once the user is past the one-day mark; newer users pick it up on a later visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

