### PR TITLE
performance: Shorten landing hero render delay

### DIFF
--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -74,13 +74,7 @@ export function Hero({
 
 export function HeroVideoPlayer() {
   return (
-    <BlurFade
-      delay={0.4}
-      variant={{
-        hidden: { y: 6, opacity: 0.75, filter: "blur(4px)" },
-        visible: { y: 0, opacity: 1, filter: "blur(0px)" },
-      }}
-    >
+    <BlurFade delay={0.4}>
       <div className="relative w-full">
         <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
           <HeroVideoDialog />

--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -83,7 +83,7 @@ export function HeroVideoPlayer() {
           width={4600}
           height={2524}
           sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
-          preload
+          loading="eager"
           fetchPriority="high"
           className="h-auto w-full"
         />

--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -74,24 +74,24 @@ export function Hero({
 
 export function HeroVideoPlayer() {
   return (
-    <BlurFade delay={0.4}>
-      <div className="relative w-full">
-        <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
+    <div className="relative w-full">
+      <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
+        <BlurFade delay={0.4} className="absolute inset-0 z-10" duration={0.4}>
           <HeroVideoDialog />
-          <Image
-            src="/images/new-landing/video-thumbnail.png"
-            alt="an organized inbox"
-            width={4600}
-            height={2524}
-            sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
-            loading="eager"
-            fetchPriority="high"
-            className="h-auto w-full"
-          />
-          <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
-        </div>
+        </BlurFade>
+        <Image
+          src="/images/new-landing/video-thumbnail.png"
+          alt="an organized inbox"
+          width={4600}
+          height={2524}
+          sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
+          loading="eager"
+          fetchPriority="high"
+          className="h-auto w-full"
+        />
+        <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
       </div>
-    </BlurFade>
+    </div>
   );
 }
 

--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -74,22 +74,24 @@ export function Hero({
 
 export function HeroVideoPlayer() {
   return (
-    <div className="relative w-full">
-      <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
-        <HeroVideoDialog />
-        <Image
-          src="/images/new-landing/video-thumbnail.png"
-          alt="an organized inbox"
-          width={4600}
-          height={2524}
-          sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
-          loading="eager"
-          fetchPriority="high"
-          className="h-auto w-full"
-        />
-        <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
+    <BlurFade delay={0.4}>
+      <div className="relative w-full">
+        <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
+          <HeroVideoDialog />
+          <Image
+            src="/images/new-landing/video-thumbnail.png"
+            alt="an organized inbox"
+            width={4600}
+            height={2524}
+            sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
+            loading="eager"
+            fetchPriority="high"
+            className="h-auto w-full"
+          />
+          <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
+        </div>
       </div>
-    </div>
+    </BlurFade>
   );
 }
 

--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -74,23 +74,22 @@ export function Hero({
 
 export function HeroVideoPlayer() {
   return (
-    <BlurFade delay={0.125 * 9}>
-      <div className="relative w-full">
-        <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
-          <HeroVideoDialog />
-          <Image
-            src="/images/new-landing/video-thumbnail.png"
-            alt="an organized inbox"
-            width={4600}
-            height={2524}
-            sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
-            preload
-            className="h-auto w-full"
-          />
-          <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
-        </div>
+    <div className="relative w-full">
+      <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
+        <HeroVideoDialog />
+        <Image
+          src="/images/new-landing/video-thumbnail.png"
+          alt="an organized inbox"
+          width={4600}
+          height={2524}
+          sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
+          preload
+          fetchPriority="high"
+          className="h-auto w-full"
+        />
+        <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
       </div>
-    </BlurFade>
+    </div>
   );
 }
 

--- a/apps/web/app/(landing)/home/Hero.tsx
+++ b/apps/web/app/(landing)/home/Hero.tsx
@@ -74,24 +74,30 @@ export function Hero({
 
 export function HeroVideoPlayer() {
   return (
-    <div className="relative w-full">
-      <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
-        <BlurFade delay={0.4} className="absolute inset-0 z-10" duration={0.4}>
+    <BlurFade
+      delay={0.4}
+      variant={{
+        hidden: { y: 6, opacity: 0.75, filter: "blur(4px)" },
+        visible: { y: 0, opacity: 1, filter: "blur(0px)" },
+      }}
+    >
+      <div className="relative w-full">
+        <div className="relative border border-[#EFEFEF] rounded-3xl md:rounded-[43px] overflow-hidden block">
           <HeroVideoDialog />
-        </BlurFade>
-        <Image
-          src="/images/new-landing/video-thumbnail.png"
-          alt="an organized inbox"
-          width={4600}
-          height={2524}
-          sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
-          loading="eager"
-          fetchPriority="high"
-          className="h-auto w-full"
-        />
-        <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
+          <Image
+            src="/images/new-landing/video-thumbnail.png"
+            alt="an organized inbox"
+            width={4600}
+            height={2524}
+            sizes="(min-width: 1280px) 1152px, (min-width: 1024px) calc(100vw - 64px), calc(100vw - 48px)"
+            loading="eager"
+            fetchPriority="high"
+            className="h-auto w-full"
+          />
+          <UnicornScene className="h-[calc(100%+5px)] opacity-30" />
+        </div>
       </div>
-    </div>
+    </BlurFade>
   );
 }
 

--- a/apps/web/components/new-landing/common/BlurFade.tsx
+++ b/apps/web/components/new-landing/common/BlurFade.tsx
@@ -21,10 +21,7 @@ interface BlurFadeProps {
   duration?: number;
   inView?: boolean;
   inViewMargin?: MarginType;
-  variant?: {
-    hidden: { y: number };
-    visible: { y: number };
-  };
+  variant?: Variants;
   yOffset?: number;
 }
 

--- a/apps/web/components/new-landing/common/BlurFade.tsx
+++ b/apps/web/components/new-landing/common/BlurFade.tsx
@@ -21,7 +21,10 @@ interface BlurFadeProps {
   duration?: number;
   inView?: boolean;
   inViewMargin?: MarginType;
-  variant?: Variants;
+  variant?: {
+    hidden: { y: number };
+    visible: { y: number };
+  };
   yOffset?: number;
 }
 


### PR DESCRIPTION
Preserves the landing page’s existing staggered hero reveal while making it begin substantially sooner.

- reduce the whole-hero BlurFade delay from 1.125 seconds to 0.4 seconds
- retain the original 0.6-second blur/fade transition
- preserve responsive Retina sizing
- load the LCP image eagerly at high priority

The hero intentionally remains animation-gated to preserve the designed choreography. This PR improves that tradeoff rather than claiming immediate LCP paint. No API, database, authentication, or analytics behavior changes.