### PR TITLE
queue: Normalize QStash delivery headers

### DIFF
--- a/apps/web/utils/upstash/index.test.ts
+++ b/apps/web/utils/upstash/index.test.ts
@@ -103,6 +103,24 @@ describe("publishToQstash", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("forwards iterable delivery headers", async () => {
+    const fetchMock = setupFetchMock();
+    const upstash = await loadUpstashModule({ qstashToken: "token" });
+
+    await upstash.publishToQstash(
+      "/api/process",
+      { id: 1 },
+      undefined,
+      new Map([["x-delivery-secret", "secret_test"]]).entries(),
+    );
+
+    expect(mockPublishJSON).toHaveBeenCalledOnce();
+    const request = mockPublishJSON.mock.calls[0]?.[0];
+    expect(request?.headers.get("x-delivery-secret")).toBe("secret_test");
+    expect(request?.headers.get("Retry-After")).toBe("10");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to internal URL when QStash client is unavailable", async () => {
     const fetchMock = setupFetchMock();
     const upstash = await loadUpstashModule({ qstashToken: undefined });

--- a/apps/web/utils/upstash/index.ts
+++ b/apps/web/utils/upstash/index.ts
@@ -27,7 +27,7 @@ export async function publishToQstash<T>(
   flowControl?: FlowControl,
   headers?: HeadersInit,
 ) {
-  const requestHeaders = new Headers(headers);
+  const requestHeaders = createHeaders(headers);
   requestHeaders.set("Retry-After", "10");
 
   const client = getQstashClient();
@@ -136,15 +136,7 @@ async function fallbackPublishToQstash<T>(
 ) {
   logger.warn("Qstash client not found");
 
-  const internalHeaders = new Headers(
-    headers instanceof Headers
-      ? headers
-      : Array.isArray(headers)
-        ? headers
-        : headers && typeof headers === "object" && Symbol.iterator in headers
-          ? Array.from(headers as Iterable<[string, string]>)
-          : headers,
-  );
+  const internalHeaders = createHeaders(headers);
   internalHeaders.set("Content-Type", "application/json");
   for (const [key, value] of Object.entries(getInternalApiHeaders())) {
     internalHeaders.set(key, value);
@@ -196,4 +188,12 @@ function getQstashCallbackBaseUrl() {
   if (safeExternalUrl) return normalizeBaseUrl(safeExternalUrl);
 
   return normalizeBaseUrl(getInternalApiUrl());
+}
+
+function createHeaders(headers?: HeadersInit) {
+  if (headers && Symbol.iterator in headers) {
+    return new Headers(Array.from(headers));
+  }
+
+  return new Headers(headers);
 }


### PR DESCRIPTION
Normalizes SDK header inputs before constructing web Headers, resolving the Node 24 type check while retaining custom delivery headers.

- Converts iterable SDK headers to tuple arrays and reuses the helper for fallback publishing
- Adds regression coverage for iterator-based headers
- Validation: focused unit suite (13 tests) and targeted TypeScript diagnostics passed
- Note: the repository check could not load the shared formatter config through the VM dependency symlinks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

