### PR TITLE
drafts: Normalize tracked reply body lengths

### DIFF
--- a/apps/web/utils/reply-tracker/draft-similarity.test.ts
+++ b/apps/web/utils/reply-tracker/draft-similarity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { ParsedMessage } from "@/utils/types";
+import { getDraftSendLogSimilarityFields } from "./draft-similarity";
+
+describe("getDraftSendLogSimilarityFields", () => {
+  it("records normalized reply lengths without signatures or quoted content", () => {
+    const accountSignature = [
+      "Sender Name",
+      "Company Name",
+      "555-0100",
+      "A long confidentiality disclaimer that is not authored reply content.",
+    ].join("\n");
+    const quotedThread = `On Mon, Jan 1, 2024 at 10:00 AM Sender <sender@example.com> wrote:
+> A previous message with a lot of unrelated detail.`;
+    const draftReply = "Short draft reply.";
+    const sentReply = "Short sent reply.";
+    const draftText = `${draftReply}\n\n${accountSignature}\n\n${quotedThread}`;
+    const sentText = `${sentReply}\n\n${accountSignature}\n\n${quotedThread}`;
+
+    const fields = getDraftSendLogSimilarityFields({
+      draftText,
+      sentMessage: createParsedMessage(sentText),
+      sentText,
+      accountSignature,
+      draftExists: false,
+      sentMessageRepliesToSource: true,
+    });
+
+    expect(fields.similarityMetadata).toMatchObject({
+      version: 2,
+      draft: {
+        length: draftText.length,
+        comparableBodyLength: draftReply.length,
+      },
+      sent: {
+        extractedReplyLength: sentText.length,
+        comparableBodyLength: sentReply.length,
+      },
+    });
+  });
+});
+
+function createParsedMessage(textPlain: string): ParsedMessage {
+  return {
+    id: "sent-message-1",
+    threadId: "thread-1",
+    textPlain,
+    textHtml: undefined,
+    subject: "Test subject",
+    date: new Date().toISOString(),
+    snippet: textPlain,
+    historyId: "history-1",
+    internalDate: "1",
+    headers: {
+      from: "sender@example.com",
+      to: "recipient@example.com",
+      subject: "Test subject",
+      date: "Mon, 1 Jan 2024 10:00:00 +0000",
+    },
+    labelIds: [],
+    inline: [],
+    bodyContentType: "text",
+  };
+}

--- a/apps/web/utils/reply-tracker/draft-similarity.ts
+++ b/apps/web/utils/reply-tracker/draft-similarity.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@/generated/prisma/client";
 import type { ParsedMessage } from "@/utils/types";
 import { stripReferralSignature } from "@/utils/referral/signature";
-import { calculateSimilarity } from "@/utils/similarity-score";
+import { calculateSimilarityDetails } from "@/utils/similarity-score";
 
 const BODY_SIMILARITY_STATUS = {
   SCORED: "scored",
@@ -40,7 +40,7 @@ export function getDraftSendLogSimilarityFields({
     bodySimilarityScore: bodySimilarity.score,
     bodySimilarityStatus: bodySimilarity.status,
     similarityMetadata: {
-      version: 1,
+      version: 2,
       draft: {
         length: draftText?.length ?? 0,
         comparableBodyLength: bodySimilarity.comparableDraftLength,
@@ -99,11 +99,19 @@ function getBodySimilarityResult({
     return { ...base, score: null, status: unscoredStatus };
   }
 
+  const similarity = calculateSimilarityDetails(
+    comparableDraftText,
+    comparableSentText,
+    {
+      excludedSignatures: accountSignature ? [accountSignature] : [],
+    },
+  );
+
   return {
     ...base,
-    score: calculateSimilarity(comparableDraftText, comparableSentText, {
-      excludedSignatures: accountSignature ? [accountSignature] : [],
-    }),
+    comparableDraftLength: similarity.normalizedStoredContentLength,
+    comparableSentLength: similarity.normalizedProviderMessageLength,
+    score: similarity.score,
     status: BODY_SIMILARITY_STATUS.SCORED,
   };
 }

--- a/apps/web/utils/reply-tracker/draft-tracking.test.ts
+++ b/apps/web/utils/reply-tracker/draft-tracking.test.ts
@@ -5,13 +5,16 @@ import { createTestLogger } from "@/__tests__/helpers";
 import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import { cleanupThreadAIDrafts, trackSentDraftStatus } from "./draft-tracking";
 
+const similarityMocks = vi.hoisted(() => ({
+  calculateSimilarity: vi.fn(),
+  calculateSimilarityDetails: vi.fn(),
+}));
+
 vi.mock("@/utils/prisma");
 vi.mock("@/utils/prisma-retry", () => ({
   withPrismaRetry: vi.fn().mockImplementation((fn) => fn()),
 }));
-vi.mock("@/utils/similarity-score", () => ({
-  calculateSimilarity: vi.fn(),
-}));
+vi.mock("@/utils/similarity-score", () => similarityMocks);
 vi.mock("@/utils/ai/choose-rule/draft-management", () => ({
   isDraftUnmodified: vi.fn(),
 }));
@@ -29,7 +32,10 @@ vi.mock("@/utils/messaging/rule-notifications", () => ({
     .mockResolvedValue(undefined),
 }));
 
-import { calculateSimilarity } from "@/utils/similarity-score";
+import {
+  calculateSimilarity,
+  calculateSimilarityDetails,
+} from "@/utils/similarity-score";
 import { isDraftUnmodified } from "@/utils/ai/choose-rule/draft-management";
 import {
   isMeaningfulDraftEdit,
@@ -46,6 +52,14 @@ const logger = createTestLogger();
 describe("trackSentDraftStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(calculateSimilarityDetails).mockImplementation(
+      (storedContent, providerMessage, options) => ({
+        score: calculateSimilarity(storedContent, providerMessage, options),
+        normalizedStoredContentLength: storedContent?.length ?? 0,
+        normalizedProviderMessageLength:
+          typeof providerMessage === "string" ? providerMessage.length : 0,
+      }),
+    );
     vi.mocked(prisma.draftSendLog.create).mockResolvedValue({
       id: "draft-send-log-1",
     } as any);

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -119,30 +119,53 @@ export function calculateSimilarity(
   providerMessage?: string | ParsedMessage | null,
   options: { excludedSignatures?: string[] } = {},
 ): number {
+  return calculateSimilarityDetails(storedContent, providerMessage, options)
+    .score;
+}
+
+export function calculateSimilarityDetails(
+  storedContent?: string | null,
+  providerMessage?: string | ParsedMessage | null,
+  options: { excludedSignatures?: string[] } = {},
+): {
+  score: number;
+  normalizedStoredContentLength: number;
+  normalizedProviderMessageLength: number;
+} {
   if (!storedContent || !providerMessage) {
-    return 0.0;
+    return {
+      score: 0.0,
+      normalizedStoredContentLength: 0,
+      normalizedProviderMessageLength: 0,
+    };
   }
 
-  const [normalized1, normalized2] = normalizePair({
+  const baselinePair = normalizePair({
     storedContent,
     providerMessage,
     stripSignature: false,
     excludedSignatures: options.excludedSignatures,
   });
-  const baselineScore = compareNormalizedStrings(normalized1, normalized2);
+  const baselineScore = compareNormalizedStrings(...baselinePair);
 
-  const [signatureStripped1, signatureStripped2] = normalizePair({
+  const signatureStrippedPair = normalizePair({
     storedContent,
     providerMessage,
     stripSignature: true,
     excludedSignatures: options.excludedSignatures,
   });
   const signatureStrippedScore = compareNormalizedStrings(
-    signatureStripped1,
-    signatureStripped2,
+    ...signatureStrippedPair,
   );
+  const useSignatureStrippedPair = signatureStrippedScore >= baselineScore;
+  const [normalizedStoredContent, normalizedProviderMessage] =
+    useSignatureStrippedPair ? signatureStrippedPair : baselinePair;
 
-  return Math.max(baselineScore, signatureStrippedScore);
+  return {
+    score: Math.max(baselineScore, signatureStrippedScore),
+    normalizedStoredContentLength: normalizedStoredContent.length,
+    normalizedProviderMessageLength: normalizedProviderMessage.length,
+  };
 }
 
 function normalizePair({


### PR DESCRIPTION
Future draft-send metadata records comparable body lengths from the same normalized text used by similarity scoring, avoiding inflation from signatures and quoted threads.

- add normalized length details without changing similarity scores
- bump similarity metadata to version 2 for clean historical separation
- cover signatures and quoted content with a focused regression test

Performance: no new database or network calls; the normalized strings are reused from existing scoring work.

Tests:
- pnpm test utils/similarity-score.test.ts utils/reply-tracker/draft-similarity.test.ts utils/reply-tracker/draft-tracking.test.ts
- pnpm exec ultracite check apps/web/utils/similarity-score.ts apps/web/utils/reply-tracker/draft-similarity.ts apps/web/utils/reply-tracker/draft-similarity.test.ts apps/web/utils/reply-tracker/draft-tracking.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

