### PR TITLE
api: Add REST endpoint for sending email

### DIFF
--- a/apps/web/app/api/messages/send/route.ts
+++ b/apps/web/app/api/messages/send/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withEmailProvider } from "@/utils/middleware";
+import { sendEmailBody } from "@/utils/gmail/mail";
+
+export type SendMessageResponse = {
+  success: true;
+  messageId: string;
+  threadId: string;
+};
+
+/**
+ * REST equivalent of `sendEmailAction` for clients that cannot call server
+ * actions (e.g. the mobile app). Accepts the same `sendEmailBody` payload:
+ * pass `replyToEmail` (threadId + headerMessageId + references) to reply on
+ * an existing thread, or omit it to send a new email.
+ */
+export const POST = withEmailProvider("messages/send", async (request) => {
+  const body = sendEmailBody.parse(await request.json());
+
+  try {
+    const result = await request.emailProvider.sendEmailWithHtml(body);
+
+    return NextResponse.json({
+      success: true,
+      messageId: result.messageId,
+      threadId: result.threadId,
+    } satisfies SendMessageResponse);
+  } catch (error) {
+    request.logger.error("Failed to send email", {
+      error,
+      threadId: body.replyToEmail?.threadId,
+      emailAccountId: request.auth.emailAccountId,
+    });
+    return NextResponse.json(
+      { error: "Failed to send email" },
+      { status: 500 },
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Sending email currently exists only as the `sendEmailAction` server action, which native clients cannot call. This adds `POST /api/messages/send` exposing the same logic over REST:

- Same input contract: the existing `sendEmailBody` zod schema from `utils/gmail/mail` (including `replyToEmail` threading fields, cc/bcc, and `attachments`)
- Same execution: `emailProvider.sendEmailWithHtml(...)`, identical to the server action
- Same auth as the other message/thread routes: `withEmailProvider` (session + `X-Email-Account-ID` header)

## Why

The Inbox Zero mobile app's new Today/thread screens let users review the AI-drafted reply and send it. Every read the mobile app needs is already available over REST; sending was the one gap. A REST route also benefits any other non-Next client.

## Testing

- Route mirrors the structure of `app/api/threads/[id]/archive/route.ts` and reuses the schema/provider call verbatim; no logic is duplicated.
- Verified the mobile app against this endpoint (reply payload built from the thread's `message-id`/`references` headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERAHbxc2jnXFs6HzU4RPM9

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

