### PR TITLE
Support multi-label thread queries

### DIFF
--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -59,4 +59,21 @@ describe("GET /api/threads", () => {
       pageToken: undefined,
     });
   });
+
+  it("trims comma-separated and repeated label IDs", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads?labelIds=Label_123%2C%20INBOX&labelIds=%20STARRED%20&labelIds=%20",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetThreadsWithQuery).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        labelIds: ["Label_123", "INBOX", "STARRED"],
+      }),
+      maxResults: 50,
+      pageToken: undefined,
+    });
+  });
 });

--- a/apps/web/app/api/threads/route.test.ts
+++ b/apps/web/app/api/threads/route.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFindMany, mockGetThreadsWithQuery } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockGetThreadsWithQuery: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    executedRule: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+}));
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailProvider:
+    (
+      _name: string,
+      handler: (
+        request: NextRequest & Record<string, unknown>,
+      ) => Promise<Response>,
+    ) =>
+    (request: NextRequest) =>
+      handler(
+        Object.assign(request, {
+          auth: { emailAccountId: "email-account-id" },
+          emailProvider: { getThreadsWithQuery: mockGetThreadsWithQuery },
+          logger: { error: vi.fn() },
+        }),
+      ),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/threads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockGetThreadsWithQuery.mockResolvedValue({ threads: [] });
+  });
+
+  it("passes multiple label IDs to the email provider", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads?labelId=Label_123&labelIds=Label_123%2CINBOX&limit=100",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetThreadsWithQuery).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        labelId: "Label_123",
+        labelIds: ["Label_123", "INBOX"],
+        limit: 100,
+      }),
+      maxResults: 100,
+      pageToken: undefined,
+    });
+  });
+});

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -24,6 +24,7 @@ export const GET = withEmailProvider(
     const labelIds = searchParams
       .getAll("labelIds")
       .flatMap((value) => value.split(","))
+      .map((labelId) => labelId.trim())
       .filter(Boolean);
     const after = searchParams.get("after");
     const before = searchParams.get("before");

--- a/apps/web/app/api/threads/route.ts
+++ b/apps/web/app/api/threads/route.ts
@@ -21,6 +21,10 @@ export const GET = withEmailProvider(
     const nextPageToken = searchParams.get("nextPageToken");
     const q = searchParams.get("q");
     const labelId = searchParams.get("labelId");
+    const labelIds = searchParams
+      .getAll("labelIds")
+      .flatMap((value) => value.split(","))
+      .filter(Boolean);
     const after = searchParams.get("after");
     const before = searchParams.get("before");
     const isUnread = searchParams.get("isUnread");
@@ -32,6 +36,7 @@ export const GET = withEmailProvider(
       nextPageToken,
       q,
       labelId,
+      labelIds: labelIds.length ? labelIds : undefined,
       after,
       before,
       isUnread,

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -3,6 +3,7 @@ import type { EmailThread } from "@/utils/email/types";
 import type { ParsedMessage } from "@/utils/types";
 import { GmailLabel } from "@/utils/gmail/label";
 import * as gmailLabelModule from "@/utils/gmail/label";
+import * as gmailThreadModule from "@/utils/gmail/thread";
 import { GmailProvider } from "./google";
 
 const { envMock, gmailMailMock, gmailDraftMock, gmailSignatureMock } =
@@ -197,6 +198,35 @@ describe("GmailProvider.getSentMessageIds", () => {
       pageToken: undefined,
       labelIds: [GmailLabel.SENT],
     });
+  });
+});
+
+describe("GmailProvider.getThreadsWithQuery", () => {
+  it("uses multiple label IDs in preference to the legacy single label", async () => {
+    const getThreadsWithNextPageToken = vi
+      .spyOn(gmailThreadModule, "getThreadsWithNextPageToken")
+      .mockResolvedValue({ threads: [], nextPageToken: undefined });
+    vi.spyOn(gmailThreadModule, "getThreadsBatch").mockResolvedValue([]);
+    const provider = new GmailProvider({
+      context: {
+        _options: {
+          auth: { credentials: { access_token: "access-token" } },
+        },
+      },
+    } as any);
+
+    await provider.getThreadsWithQuery({
+      query: {
+        labelId: "Label_123",
+        labelIds: ["Label_123", GmailLabel.INBOX],
+      },
+    });
+
+    expect(getThreadsWithNextPageToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labelIds: ["Label_123", GmailLabel.INBOX],
+      }),
+    );
   });
 });
 

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1415,9 +1415,10 @@ export class GmailProvider implements EmailProvider {
       }
 
       function getLabelIds(type?: string | null) {
-        if (labelIds) {
+        if (labelIds?.length) {
           return labelIds;
         }
+        if (labelId) return [labelId];
 
         switch (type) {
           case "inbox":
@@ -1451,7 +1452,7 @@ export class GmailProvider implements EmailProvider {
         await getThreadsWithNextPageToken({
           gmail: this.client,
           q: getQuery(),
-          labelIds: labelId ? [labelId] : getLabelIds(type) || [],
+          labelIds: getLabelIds(type) || [],
           maxResults: options.maxResults || 50,
           pageToken: options.pageToken || undefined,
           logger: this.logger,

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -223,31 +223,31 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     vi.spyOn(outlookMessageModule, "getCategoryMap").mockResolvedValue(
       new Map([["To Reply", "label-to-reply"]]),
     );
-    const provider = new OutlookProvider(
-      createMockOutlookClient([
-        createMessage({
-          id: "inbox-message",
-          conversationId: "inbox-thread",
-          categories: ["To Reply"],
-          parentFolderId: "folder-inbox",
-        }),
-        createMessage({
-          id: "archived-message",
-          conversationId: "archived-thread",
-          categories: ["To Reply"],
-          parentFolderId: "folder-archive",
-        }),
-      ]),
-    );
+    const client = createMockOutlookClient([
+      createMessage({
+        id: "inbox-message",
+        conversationId: "inbox-thread",
+        categories: ["To Reply"],
+        parentFolderId: "folder-inbox",
+      }),
+      createMessage({
+        id: "archived-message",
+        conversationId: "archived-thread",
+        categories: ["To Reply"],
+        parentFolderId: "folder-archive",
+      }),
+    ]);
+    const provider = new OutlookProvider(client);
 
     const result = await provider.getThreadsWithQuery({
       query: {
-        labelId: "label-to-reply",
+        labelId: "ARCHIVE",
         labelIds: ["label-to-reply", "INBOX"],
       },
     });
 
     expect(result.threads.map((thread) => thread.id)).toEqual(["inbox-thread"]);
+    expect(client.getRequestLog()[0]?.filter).toBeUndefined();
   });
 
   it("keeps paging until explicit labelIds produce enough matching threads", async () => {

--- a/apps/web/utils/email/microsoft.test.ts
+++ b/apps/web/utils/email/microsoft.test.ts
@@ -211,6 +211,45 @@ describe("OutlookProvider.getThreadsWithQuery", () => {
     ]);
   });
 
+  it("uses multiple label IDs in preference to the legacy single label", async () => {
+    getFolderIdsMock.mockResolvedValue({
+      inbox: "folder-inbox",
+      archive: "folder-archive",
+      drafts: "folder-drafts",
+      deleteditems: "folder-trash",
+      junkemail: "folder-spam",
+      sentitems: "folder-sent",
+    });
+    vi.spyOn(outlookMessageModule, "getCategoryMap").mockResolvedValue(
+      new Map([["To Reply", "label-to-reply"]]),
+    );
+    const provider = new OutlookProvider(
+      createMockOutlookClient([
+        createMessage({
+          id: "inbox-message",
+          conversationId: "inbox-thread",
+          categories: ["To Reply"],
+          parentFolderId: "folder-inbox",
+        }),
+        createMessage({
+          id: "archived-message",
+          conversationId: "archived-thread",
+          categories: ["To Reply"],
+          parentFolderId: "folder-archive",
+        }),
+      ]),
+    );
+
+    const result = await provider.getThreadsWithQuery({
+      query: {
+        labelId: "label-to-reply",
+        labelIds: ["label-to-reply", "INBOX"],
+      },
+    });
+
+    expect(result.threads.map((thread) => thread.id)).toEqual(["inbox-thread"]);
+  });
+
   it("keeps paging until explicit labelIds produce enough matching threads", async () => {
     getFolderIdsMock.mockResolvedValue({
       inbox: "folder-inbox",

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -2081,8 +2081,8 @@ function getRequiredOutlookThreadLabelIds({
   labelIds,
   type,
 }: Pick<ThreadsQuery, "labelId" | "labelIds" | "type">): string[] | undefined {
-  if (labelId) return [labelId];
   if (labelIds?.length) return labelIds;
+  if (labelId) return [labelId];
 
   switch (type) {
     case "all":

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -1546,7 +1546,7 @@ export class OutlookProvider implements EmailProvider {
       if (type === "sent" && !hasExplicitLabelFilters) {
         endpoint = "/me/mailFolders('sentitems')/messages";
       } else {
-        if (labelId) {
+        if (labelId && !labelIds?.length) {
           const labelFilter = await resolveOutlookThreadQueryFilter({
             client: this.client,
             folderIds: resolvedFolderIds,


### PR DESCRIPTION
## Summary

- accept comma-separated or repeated labelIds on the threads API
- prefer multi-label intersections over the legacy single label for Gmail and Outlook
- preserve labelId compatibility for older mobile clients

This lets cleanup request a category label together with INBOX, so archived threads do not consume the first result page and hide older inbox matches.

## Testing

- pnpm test app/api/threads/route.test.ts utils/email/google.test.ts utils/email/microsoft.test.ts
- pnpm exec ultracite check on all changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

