### PR TITLE
fix(api): strip quoted replies from thread previews

### DIFF
--- a/apps/web/app/api/messages/batch/route.ts
+++ b/apps/web/app/api/messages/batch/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
 import { messagesBatchQuery } from "@/app/api/messages/validation";
-import { convertEmailHtmlToText, parseReply } from "@/utils/mail";
 import type { EmailProvider } from "@/utils/email/types";
-import { stripQuotedHtmlContent } from "@/utils/ai/choose-rule/draft-management";
+import { parseMessageReply } from "@/utils/email/parse-message-reply";
 
 export type MessagesBatchResponse = {
   messages: Awaited<ReturnType<typeof getMessagesBatch>>;
@@ -21,23 +20,7 @@ async function getMessagesBatch({
   const messages = await emailProvider.getMessagesBatch(messageIds);
 
   if (parseReplies) {
-    return messages.map((message) => {
-      const parsedTextPlain = parseReply(message.textPlain || "").trim();
-      const parsedTextHtml = message.textHtml
-        ? parseReply(
-            convertEmailHtmlToText({
-              htmlText: stripQuotedHtmlContent(message.textHtml),
-              includeLinks: false,
-            }),
-          ).trim()
-        : "";
-
-      return {
-        ...message,
-        textPlain: parsedTextPlain || parsedTextHtml,
-        textHtml: parsedTextHtml,
-      };
-    });
+    return messages.map(parseMessageReply);
   }
 
   return messages;

--- a/apps/web/app/api/threads/[id]/route.ts
+++ b/apps/web/app/api/threads/[id]/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
 import type { EmailProvider } from "@/utils/email/types";
+import { parseMessageReply } from "@/utils/email/parse-message-reply";
 
 const threadQuery = z.object({ id: z.string() });
 export type ThreadQuery = z.infer<typeof threadQuery>;
@@ -10,13 +11,18 @@ export type ThreadResponse = Awaited<ReturnType<typeof getThread>>;
 async function getThread(
   id: string,
   includeDrafts: boolean,
+  parseReplies: boolean,
   emailProvider: EmailProvider,
 ) {
   const thread = await emailProvider.getThread(id);
 
-  const filteredMessages = includeDrafts
+  let filteredMessages = includeDrafts
     ? thread.messages
     : thread.messages.filter((msg) => !msg.labelIds?.includes("DRAFT"));
+
+  if (parseReplies) {
+    filteredMessages = filteredMessages.map(parseMessageReply);
+  }
 
   return {
     thread: {
@@ -39,9 +45,15 @@ export const GET = withEmailProvider(
 
     const { searchParams } = new URL(request.url);
     const includeDrafts = searchParams.get("includeDrafts") === "true";
+    const parseReplies = searchParams.get("parseReplies") === "true";
 
     try {
-      const thread = await getThread(id, includeDrafts, emailProvider);
+      const thread = await getThread(
+        id,
+        includeDrafts,
+        parseReplies,
+        emailProvider,
+      );
       return NextResponse.json(thread);
     } catch (error) {
       request.logger.error("Error fetching thread", {

--- a/apps/web/utils/ai/choose-rule/draft-management.test.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.test.ts
@@ -3,9 +3,9 @@ import {
   handlePreviousDraftDeletion,
   extractDraftPlainText,
   stripQuotedContent,
-  stripQuotedHtmlContent,
   isDraftUnmodified,
 } from "@/utils/ai/choose-rule/draft-management";
+import { stripQuotedHtmlContent } from "@/utils/email/parse-message-reply";
 import prisma from "@/utils/prisma";
 import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { ParsedMessage } from "@/utils/types";

--- a/apps/web/utils/ai/choose-rule/draft-management.ts
+++ b/apps/web/utils/ai/choose-rule/draft-management.ts
@@ -1,4 +1,3 @@
-import { load } from "cheerio";
 import prisma from "@/utils/prisma";
 import { ActionType, DraftEmailStatus } from "@/generated/prisma/enums";
 import type { ExecutedRule } from "@/generated/prisma/client";
@@ -6,6 +5,7 @@ import type { Logger } from "@/utils/logger";
 import type { EmailProvider } from "@/utils/email/types";
 import { convertEmailHtmlToText } from "@/utils/mail";
 import type { ParsedMessage } from "@/utils/types";
+import { stripQuotedHtmlContent } from "@/utils/email/parse-message-reply";
 
 export type PreviousDraftHandlingResult =
   | {
@@ -175,21 +175,6 @@ export function extractDraftPlainText(draft: ParsedMessage): string {
       : "";
   }
   return draft.textPlain || "";
-}
-
-export function stripQuotedHtmlContent(html: string): string {
-  const $ = load(html, null, false);
-
-  $(
-    [
-      ".gmail_quote_container",
-      ".gmail_quote",
-      ".gmail_attr",
-      "blockquote[type='cite']",
-    ].join(", "),
-  ).remove();
-
-  return $.root().html() || html;
 }
 
 /**

--- a/apps/web/utils/email/parse-message-reply.test.ts
+++ b/apps/web/utils/email/parse-message-reply.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ParsedMessage } from "@/utils/types";
+import { parseMessageReply } from "./parse-message-reply";
+
+vi.mock("server-only", () => ({}));
+
+describe("parseMessageReply", () => {
+  it("removes quoted replies from plain text messages", () => {
+    const message = createMessage({
+      textPlain:
+        "Fresh reply\n\nOn Tue, Apr 28, 2026 at 1:10 PM, Sender <sender@example.com> wrote:\n\n> Older quoted line",
+    });
+
+    expect(parseMessageReply(message).textPlain).toBe("Fresh reply");
+  });
+
+  it("removes Gmail quote containers before converting HTML", () => {
+    const message = createMessage({
+      textPlain: "",
+      textHtml:
+        '<div>Fresh reply</div><div class="gmail_quote gmail_quote_container"><div class="gmail_attr">Le lun. 27 avr. 2026, Sender a écrit:</div><blockquote class="gmail_quote"><div>Older quoted line</div></blockquote></div>',
+    });
+
+    expect(parseMessageReply(message)).toMatchObject({
+      textPlain: "Fresh reply",
+      textHtml: "Fresh reply",
+    });
+  });
+});
+
+function createMessage(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
+  return {
+    date: "2026-04-28T13:10:00.000Z",
+    headers: {
+      date: "2026-04-28T13:10:00.000Z",
+      from: "sender@example.com",
+      subject: "Re: Update",
+      to: "me@example.com",
+    },
+    historyId: "history-1",
+    id: "message-1",
+    inline: [],
+    snippet: "Fresh reply",
+    subject: "Re: Update",
+    threadId: "thread-1",
+    ...overrides,
+  };
+}

--- a/apps/web/utils/email/parse-message-reply.ts
+++ b/apps/web/utils/email/parse-message-reply.ts
@@ -1,0 +1,36 @@
+import { load } from "cheerio";
+import type { ParsedMessage } from "@/utils/types";
+import { convertEmailHtmlToText, parseReply } from "@/utils/mail";
+
+export function parseMessageReply(message: ParsedMessage): ParsedMessage {
+  const parsedTextPlain = parseReply(message.textPlain || "").trim();
+  const parsedTextHtml = message.textHtml
+    ? parseReply(
+        convertEmailHtmlToText({
+          htmlText: stripQuotedHtmlContent(message.textHtml),
+          includeLinks: false,
+        }),
+      ).trim()
+    : "";
+
+  return {
+    ...message,
+    textPlain: parsedTextPlain || parsedTextHtml,
+    textHtml: parsedTextHtml,
+  };
+}
+
+export function stripQuotedHtmlContent(html: string): string {
+  const $ = load(html, null, false);
+
+  $(
+    [
+      ".gmail_quote_container",
+      ".gmail_quote",
+      ".gmail_attr",
+      "blockquote[type='cite']",
+    ].join(", "),
+  ).remove();
+
+  return $.root().html() || html;
+}

--- a/apps/web/utils/similarity-score.ts
+++ b/apps/web/utils/similarity-score.ts
@@ -5,10 +5,8 @@ import {
   parseReply,
   stripForwardedContent,
 } from "@/utils/mail";
-import {
-  stripQuotedContent,
-  stripQuotedHtmlContent,
-} from "@/utils/ai/choose-rule/draft-management";
+import { stripQuotedContent } from "@/utils/ai/choose-rule/draft-management";
+import { stripQuotedHtmlContent } from "@/utils/email/parse-message-reply";
 import {
   stripPlainTextSignature,
   stripProviderSignatureHtml,


### PR DESCRIPTION
## Summary
- reuse the existing reply parser for thread-detail responses
- strip Gmail and cited HTML quote containers before returning preview text
- request parsed replies from the mobile thread and inline-preview clients

## Tests
- pnpm test utils/email/parse-message-reply.test.ts utils/ai/choose-rule/draft-management.test.ts utils/similarity-score.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

