### PR TITLE
llms: Log structured fallback outcomes

### DIFF
--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -349,6 +349,43 @@ describe("createGenerateObject repairText", () => {
     expect(mockGenerateObject).toHaveBeenCalledTimes(2);
   });
 
+  it("logs the successful model and sanitized fallback path", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const contentFilterError = mockContentFilterRefusal();
+
+    mockGenerateObject
+      .mockRejectedValueOnce(contentFilterError)
+      .mockResolvedValueOnce({ object: { ok: true }, usage: null });
+
+    const generateObject = await createGenerateObjectWithFallback();
+
+    try {
+      await generateObject({
+        system: "Return JSON.",
+        prompt: "Return JSON.",
+        schema: {} as any,
+      } as any);
+
+      const outcomeLog = logSpy.mock.calls
+        .flat()
+        .find(
+          (value) =>
+            typeof value === "string" &&
+            value.includes("LLM object generation completed"),
+        );
+
+      expect(outcomeLog).toContain('"fallbackDepth": 1');
+      expect(outcomeLog).toContain('"selectedProvider": "anthropic"');
+      expect(outcomeLog).toContain('"selectedModel": "claude-test"');
+      expect(outcomeLog).toContain('"openai:gpt-test"');
+      expect(outcomeLog).toContain('"failureCategories"');
+      expect(outcomeLog).toContain('"content_filter"');
+      expect(outcomeLog).not.toContain(contentFilterError.message);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it("throws content-filter refusal without Sentry noise when no fallback is configured", async () => {
     const contentFilterError = mockContentFilterRefusal();
 

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -174,6 +174,19 @@ type RepairAttemptState = {
   successfulCandidateKind?: RepairCandidateKind;
 };
 
+type LlmFallbackFailureCategory =
+  | "content_filter"
+  | "network"
+  | "rate_limit"
+  | "server_error"
+  | "unknown";
+
+type LlmFallbackFailure = {
+  provider: string;
+  model: string;
+  category: LlmFallbackFailureCategory;
+};
+
 type ProviderCostSource =
   | "openrouter_usage"
   | "openrouter_usage_with_step_fallback"
@@ -457,6 +470,7 @@ export function createGenerateObject({
         label,
       });
     let latestRepairAttempt: RepairAttemptState | undefined;
+    const fallbackFailures: LlmFallbackFailure[] = [];
 
     const generate = async (candidate: ResolvedModel) => {
       const systemText = applyPromptHardeningToSystem({
@@ -576,7 +590,7 @@ export function createGenerateObject({
       latestRepairAttempt = undefined;
 
       try {
-        return await withLLMRetry(
+        const result = await withLLMRetry(
           () =>
             withNetworkRetry(() => generate(candidate), {
               label,
@@ -587,6 +601,24 @@ export function createGenerateObject({
             }),
           { label },
         );
+
+        logger.info("LLM object generation completed", {
+          label,
+          candidateCount: modelCandidates.length,
+          fallbackUsed: index > 0,
+          fallbackDepth: index,
+          selectedProvider: candidate.provider,
+          selectedModel: candidate.modelName,
+          attemptedModels: modelCandidates
+            .slice(0, index + 1)
+            .map(getResolvedModelKey),
+          failedModels: fallbackFailures.map(
+            ({ provider, model }) => `${provider}:${model}`,
+          ),
+          failureCategories: fallbackFailures.map(({ category }) => category),
+        });
+
+        return result;
       } catch (error) {
         if (error instanceof SafeError) throw error;
 
@@ -601,6 +633,11 @@ export function createGenerateObject({
         );
 
         if (nextCandidate && shouldFallbackToNextModel(error)) {
+          fallbackFailures.push({
+            provider: candidate.provider,
+            model: candidate.modelName,
+            category: getLlmFallbackFailureCategory(error),
+          });
           logger.warn("LLM object generation failed, trying fallback model", {
             label,
             provider: candidate.provider,
@@ -1310,6 +1347,28 @@ function getModelCandidates(modelOptions: SelectModel): ResolvedModel[] {
   };
 
   return [primaryModel, ...modelOptions.fallbackModels];
+}
+
+function getResolvedModelKey({ provider, modelName }: ResolvedModel): string {
+  return `${provider}:${modelName}`;
+}
+
+function getLlmFallbackFailureCategory(
+  error: unknown,
+): LlmFallbackFailureCategory {
+  if (isContentFilterRefusal(error)) return "content_filter";
+
+  const errorInfo = extractLLMErrorInfo(error);
+  if (
+    errorInfo.isRateLimit ||
+    (RetryError.isInstance(error) && isAiQuotaExceededError(error))
+  ) {
+    return "rate_limit";
+  }
+  if (isTransientNetworkError(error)) return "network";
+  if (errorInfo.retryable) return "server_error";
+
+  return "unknown";
 }
 
 function shouldFallbackToNextModel(error: unknown): boolean {


### PR DESCRIPTION
Adds a structured completion event for successful object generation so Axiom can measure actual fallback outcomes without reconstructing warning logs.

- record fallback depth, selected provider and model, and attempted and failed model paths
- classify fallback failures into sanitized stable categories without logging raw errors in the completion event
- log primary successes at depth zero to provide the denominator for fallback-rate analysis
- add focused regression coverage for the structured fields and error sanitization

Performance: adds one buffered structured log event and small candidate arrays per successful object-generation call. It adds no database calls, LLM calls, retries, or routing changes; hot-path compute risk is low, with a modest increase in Axiom ingestion volume.

Tests:
- pnpm test utils/llms/fallback.test.ts utils/llms/index.generate-object.test.ts
- pnpm exec ultracite check apps/web/utils/llms/index.ts apps/web/utils/llms/index.generate-object.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

