### PR TITLE
api: add fast all-inboxes mobile endpoints

### DIFF
--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -106,6 +106,10 @@ export function createMockEmailProvider(
     // Thread/message actions
     archiveThread: vi.fn().mockResolvedValue(undefined),
     archiveThreadWithLabel: vi.fn().mockResolvedValue(undefined),
+    bulkArchiveThreads: vi.fn().mockResolvedValue({
+      succeededThreadIds: [],
+      failedThreadIds: [],
+    }),
     archiveMessage: vi.fn().mockResolvedValue(undefined),
     trashThread: vi.fn().mockResolvedValue(undefined),
     markSpam: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
@@ -105,4 +105,41 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
       failed: [{ accountId: "owned-account", threadId: "thread-2" }],
     });
   });
+
+  it("reports every account thread when provider initialization fails", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "owned-account",
+        email: "owner@example.com",
+        account: { provider: "google" },
+      },
+    ] as never);
+    createEmailProviderMock.mockRejectedValueOnce(
+      new Error("Provider unavailable"),
+    );
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/all-inboxes/archive", {
+        method: "POST",
+        body: JSON.stringify({
+          threads: [
+            { accountId: "owned-account", threadId: "thread-1" },
+            { accountId: "owned-account", threadId: "thread-2" },
+          ],
+        }),
+      }),
+      {} as never,
+    );
+
+    expect(archiveThreadMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      archived: 0,
+      total: 2,
+      succeeded: [],
+      failed: [
+        { accountId: "owned-account", threadId: "thread-1" },
+        { accountId: "owned-account", threadId: "thread-2" },
+      ],
+    });
+  });
 });

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+const { archiveThreadMock, createEmailProviderMock } = vi.hoisted(() => ({
+  archiveThreadMock: vi.fn(),
+  createEmailProviderMock: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: createEmailProviderMock,
+}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAuthTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithAuthTestMiddleware();
+});
+
+import { POST } from "./route";
+
+describe("POST /api/mobile/all-inboxes/archive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createEmailProviderMock.mockResolvedValue({
+      archiveThreadWithLabel: archiveThreadMock,
+    });
+    archiveThreadMock.mockResolvedValue(undefined);
+  });
+
+  it("archives only accounts owned by the authenticated user", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "owned-account",
+        email: "owner@example.com",
+        account: { provider: "google" },
+      },
+    ] as never);
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/all-inboxes/archive", {
+        method: "POST",
+        body: JSON.stringify({
+          threads: [
+            { accountId: "owned-account", threadId: "thread-1" },
+            { accountId: "owned-account", threadId: "thread-1" },
+            { accountId: "other-account", threadId: "thread-2" },
+          ],
+        }),
+      }),
+      {} as never,
+    );
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ["owned-account", "other-account"] },
+          userId: "user-1",
+        }),
+      }),
+    );
+    expect(archiveThreadMock).toHaveBeenCalledTimes(1);
+    expect(archiveThreadMock).toHaveBeenCalledWith(
+      "thread-1",
+      "owner@example.com",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      archived: 1,
+      total: 2,
+      succeeded: [{ accountId: "owned-account", threadId: "thread-1" }],
+      failed: [{ accountId: "other-account", threadId: "thread-2" }],
+    });
+  });
+
+  it("reports individual provider failures without failing the whole request", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "owned-account",
+        email: "owner@example.com",
+        account: { provider: "google" },
+      },
+    ] as never);
+    archiveThreadMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Provider failure"));
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/all-inboxes/archive", {
+        method: "POST",
+        body: JSON.stringify({
+          threads: [
+            { accountId: "owned-account", threadId: "thread-1" },
+            { accountId: "owned-account", threadId: "thread-2" },
+          ],
+        }),
+      }),
+      {} as never,
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      archived: 1,
+      total: 2,
+      failed: [{ accountId: "owned-account", threadId: "thread-2" }],
+    });
+  });
+});

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
@@ -52,17 +52,17 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
             {
               accountId: "owned-account",
               threadId: "thread-1",
-              messageIds: ["message-1"],
+              messageIds: ["message-1", "message-2"],
             },
             {
               accountId: "owned-account",
               threadId: "thread-1",
-              messageIds: ["message-1"],
+              messageIds: ["message-2", "message-3"],
             },
             {
               accountId: "other-account",
               threadId: "thread-2",
-              messageIds: ["message-2"],
+              messageIds: ["message-4"],
             },
           ],
         }),
@@ -80,7 +80,12 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
     );
     expect(bulkArchiveThreadsMock).toHaveBeenCalledTimes(1);
     expect(bulkArchiveThreadsMock).toHaveBeenCalledWith(
-      [{ threadId: "thread-1", messageIds: ["message-1"] }],
+      [
+        {
+          threadId: "thread-1",
+          messageIds: ["message-1", "message-2", "message-3"],
+        },
+      ],
       "owner@example.com",
     );
     await expect(response.json()).resolves.toEqual({

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.test.ts
@@ -2,8 +2,8 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
-const { archiveThreadMock, createEmailProviderMock } = vi.hoisted(() => ({
-  archiveThreadMock: vi.fn(),
+const { bulkArchiveThreadsMock, createEmailProviderMock } = vi.hoisted(() => ({
+  bulkArchiveThreadsMock: vi.fn(),
   createEmailProviderMock: vi.fn(),
 }));
 
@@ -25,9 +25,14 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     createEmailProviderMock.mockResolvedValue({
-      archiveThreadWithLabel: archiveThreadMock,
+      bulkArchiveThreads: bulkArchiveThreadsMock,
     });
-    archiveThreadMock.mockResolvedValue(undefined);
+    bulkArchiveThreadsMock.mockImplementation(async (threads) => ({
+      succeededThreadIds: threads.map(
+        (thread: { threadId: string }) => thread.threadId,
+      ),
+      failedThreadIds: [],
+    }));
   });
 
   it("archives only accounts owned by the authenticated user", async () => {
@@ -44,9 +49,21 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
         method: "POST",
         body: JSON.stringify({
           threads: [
-            { accountId: "owned-account", threadId: "thread-1" },
-            { accountId: "owned-account", threadId: "thread-1" },
-            { accountId: "other-account", threadId: "thread-2" },
+            {
+              accountId: "owned-account",
+              threadId: "thread-1",
+              messageIds: ["message-1"],
+            },
+            {
+              accountId: "owned-account",
+              threadId: "thread-1",
+              messageIds: ["message-1"],
+            },
+            {
+              accountId: "other-account",
+              threadId: "thread-2",
+              messageIds: ["message-2"],
+            },
           ],
         }),
       }),
@@ -61,12 +78,12 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
         }),
       }),
     );
-    expect(archiveThreadMock).toHaveBeenCalledTimes(1);
-    expect(archiveThreadMock).toHaveBeenCalledWith(
-      "thread-1",
+    expect(bulkArchiveThreadsMock).toHaveBeenCalledTimes(1);
+    expect(bulkArchiveThreadsMock).toHaveBeenCalledWith(
+      [{ threadId: "thread-1", messageIds: ["message-1"] }],
       "owner@example.com",
     );
-    await expect(response.json()).resolves.toMatchObject({
+    await expect(response.json()).resolves.toEqual({
       archived: 1,
       total: 2,
       succeeded: [{ accountId: "owned-account", threadId: "thread-1" }],
@@ -74,7 +91,7 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
     });
   });
 
-  it("reports individual provider failures without failing the whole request", async () => {
+  it("reports partial bulk provider failures without failing the whole request", async () => {
     prisma.emailAccount.findMany.mockResolvedValue([
       {
         id: "owned-account",
@@ -82,26 +99,36 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
         account: { provider: "google" },
       },
     ] as never);
-    archiveThreadMock
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("Provider failure"));
+    bulkArchiveThreadsMock.mockResolvedValueOnce({
+      succeededThreadIds: ["thread-1"],
+      failedThreadIds: ["thread-2"],
+    });
 
     const response = await POST(
       new NextRequest("http://localhost:3000/api/mobile/all-inboxes/archive", {
         method: "POST",
         body: JSON.stringify({
           threads: [
-            { accountId: "owned-account", threadId: "thread-1" },
-            { accountId: "owned-account", threadId: "thread-2" },
+            {
+              accountId: "owned-account",
+              threadId: "thread-1",
+              messageIds: ["message-1"],
+            },
+            {
+              accountId: "owned-account",
+              threadId: "thread-2",
+              messageIds: ["message-2"],
+            },
           ],
         }),
       }),
       {} as never,
     );
 
-    await expect(response.json()).resolves.toMatchObject({
+    await expect(response.json()).resolves.toEqual({
       archived: 1,
       total: 2,
+      succeeded: [{ accountId: "owned-account", threadId: "thread-1" }],
       failed: [{ accountId: "owned-account", threadId: "thread-2" }],
     });
   });
@@ -123,15 +150,23 @@ describe("POST /api/mobile/all-inboxes/archive", () => {
         method: "POST",
         body: JSON.stringify({
           threads: [
-            { accountId: "owned-account", threadId: "thread-1" },
-            { accountId: "owned-account", threadId: "thread-2" },
+            {
+              accountId: "owned-account",
+              threadId: "thread-1",
+              messageIds: ["message-1"],
+            },
+            {
+              accountId: "owned-account",
+              threadId: "thread-2",
+              messageIds: ["message-2"],
+            },
           ],
         }),
       }),
       {} as never,
     );
 
-    expect(archiveThreadMock).not.toHaveBeenCalled();
+    expect(bulkArchiveThreadsMock).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({
       archived: 0,
       total: 2,

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.ts
@@ -27,14 +27,29 @@ type ArchiveThreadRef = Pick<ArchiveThread, "accountId" | "threadId">;
 
 export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
   const { threads } = bodySchema.parse(await request.json());
-  const uniqueThreads = [
-    ...new Map(
-      threads.map((thread) => [
-        `${thread.accountId}:${thread.threadId}`,
-        thread,
-      ]),
-    ).values(),
-  ];
+  const threadsByKey = new Map<
+    string,
+    Omit<ArchiveThread, "messageIds"> & { messageIds: Set<string> }
+  >();
+  for (const thread of threads) {
+    const key = `${thread.accountId}:${thread.threadId}`;
+    const existingThread = threadsByKey.get(key);
+    if (existingThread) {
+      for (const messageId of thread.messageIds) {
+        existingThread.messageIds.add(messageId);
+      }
+    } else {
+      threadsByKey.set(key, {
+        accountId: thread.accountId,
+        threadId: thread.threadId,
+        messageIds: new Set(thread.messageIds),
+      });
+    }
+  }
+  const uniqueThreads = [...threadsByKey.values()].map((thread) => ({
+    ...thread,
+    messageIds: [...thread.messageIds],
+  }));
   const accountIds = [
     ...new Set(uniqueThreads.map((thread) => thread.accountId)),
   ];

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.ts
@@ -5,7 +5,6 @@ import { withAuth } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 import { mapWithConcurrency } from "../map-with-concurrency";
 
-const ARCHIVE_CONCURRENCY = 4;
 const ACCOUNT_CONCURRENCY = 4;
 
 export const maxDuration = 300;
@@ -16,11 +15,15 @@ const bodySchema = z.object({
       z.object({
         accountId: z.string().min(1),
         threadId: z.string().min(1),
+        messageIds: z.array(z.string().min(1)).min(1),
       }),
     )
     .min(1)
     .max(500),
 });
+
+type ArchiveThread = z.infer<typeof bodySchema>["threads"][number];
+type ArchiveThreadRef = Pick<ArchiveThread, "accountId" | "threadId">;
 
 export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
   const { threads } = bodySchema.parse(await request.json());
@@ -52,8 +55,8 @@ export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
   const accountsById = new Map(
     accounts.map((account) => [account.id, account]),
   );
-  const succeeded: typeof uniqueThreads = [];
-  const failed: typeof uniqueThreads = [];
+  const succeeded: ArchiveThreadRef[] = [];
+  const failed: ArchiveThreadRef[] = [];
 
   await mapWithConcurrency(
     accountIds,
@@ -64,7 +67,7 @@ export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
       );
       const account = accountsById.get(accountId);
       if (!account) {
-        failed.push(...accountThreads);
+        failed.push(...accountThreads.map(toArchiveThreadRef));
         return;
       }
 
@@ -75,34 +78,32 @@ export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
           provider: account.account.provider,
           logger,
         });
-        await mapWithConcurrency(
-          accountThreads,
-          ARCHIVE_CONCURRENCY,
-          async (thread) => {
-            try {
-              await emailProvider.archiveThreadWithLabel(
-                thread.threadId,
-                account.email,
-              );
-              succeeded.push(thread);
-            } catch (error) {
-              logger.warn("Failed to archive all-inboxes thread", {
-                error,
-                threadId: thread.threadId,
-              });
-              failed.push(thread);
-            }
-          },
+        const result = await emailProvider.bulkArchiveThreads(
+          accountThreads.map(({ threadId, messageIds }) => ({
+            threadId,
+            messageIds,
+          })),
+          account.email,
         );
+        const succeededThreadIds = new Set(result.succeededThreadIds);
+        const failedThreadIds = new Set(result.failedThreadIds);
+
+        for (const thread of accountThreads) {
+          if (
+            succeededThreadIds.has(thread.threadId) &&
+            !failedThreadIds.has(thread.threadId)
+          ) {
+            succeeded.push(toArchiveThreadRef(thread));
+          } else {
+            failed.push(toArchiveThreadRef(thread));
+          }
+        }
       } catch (error) {
-        request.logger.warn(
-          "Failed to initialize all-inboxes archive provider",
-          {
-            error,
-            emailAccountId: account.id,
-          },
-        );
-        failed.push(...accountThreads);
+        request.logger.warn("Failed to archive all-inboxes account threads", {
+          error,
+          emailAccountId: account.id,
+        });
+        failed.push(...accountThreads.map(toArchiveThreadRef));
       }
     },
   );
@@ -114,3 +115,10 @@ export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
     failed,
   });
 });
+
+function toArchiveThreadRef(thread: ArchiveThread): ArchiveThreadRef {
+  return {
+    accountId: thread.accountId,
+    threadId: thread.threadId,
+  };
+}

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createEmailProvider } from "@/utils/email/provider";
+import { withAuth } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { mapWithConcurrency } from "../summary";
+
+const ARCHIVE_CONCURRENCY = 4;
+const ACCOUNT_CONCURRENCY = 4;
+
+const bodySchema = z.object({
+  threads: z
+    .array(
+      z.object({
+        accountId: z.string().min(1),
+        threadId: z.string().min(1),
+      }),
+    )
+    .min(1)
+    .max(500),
+});
+
+export const POST = withAuth("mobile/all-inboxes/archive", async (request) => {
+  const { threads } = bodySchema.parse(await request.json());
+  const uniqueThreads = [
+    ...new Map(
+      threads.map((thread) => [
+        `${thread.accountId}:${thread.threadId}`,
+        thread,
+      ]),
+    ).values(),
+  ];
+  const accountIds = [
+    ...new Set(uniqueThreads.map((thread) => thread.accountId)),
+  ];
+  const accounts = await prisma.emailAccount.findMany({
+    where: {
+      id: { in: accountIds },
+      userId: request.auth.userId,
+      account: { disconnectedAt: null },
+    },
+    select: {
+      id: true,
+      email: true,
+      account: {
+        select: { provider: true },
+      },
+    },
+  });
+  const accountsById = new Map(
+    accounts.map((account) => [account.id, account]),
+  );
+  const succeeded: typeof uniqueThreads = [];
+  const failed: typeof uniqueThreads = [];
+
+  await mapWithConcurrency(
+    accountIds,
+    ACCOUNT_CONCURRENCY,
+    async (accountId) => {
+      const accountThreads = uniqueThreads.filter(
+        (thread) => thread.accountId === accountId,
+      );
+      const account = accountsById.get(accountId);
+      if (!account) {
+        failed.push(...accountThreads);
+        return;
+      }
+
+      try {
+        const logger = request.logger.with({ emailAccountId: account.id });
+        const emailProvider = await createEmailProvider({
+          emailAccountId: account.id,
+          provider: account.account.provider,
+          logger,
+        });
+        await mapWithConcurrency(
+          accountThreads,
+          ARCHIVE_CONCURRENCY,
+          async (thread) => {
+            try {
+              await emailProvider.archiveThreadWithLabel(
+                thread.threadId,
+                account.email,
+              );
+              succeeded.push(thread);
+            } catch (error) {
+              logger.warn("Failed to archive all-inboxes thread", {
+                error,
+                threadId: thread.threadId,
+              });
+              failed.push(thread);
+            }
+          },
+        );
+      } catch (error) {
+        request.logger.warn(
+          "Failed to initialize all-inboxes archive provider",
+          {
+            error,
+            emailAccountId: account.id,
+          },
+        );
+        failed.push(...accountThreads);
+      }
+    },
+  );
+
+  return NextResponse.json({
+    archived: succeeded.length,
+    total: uniqueThreads.length,
+    succeeded,
+    failed,
+  });
+});

--- a/apps/web/app/api/mobile/all-inboxes/archive/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/archive/route.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 import { createEmailProvider } from "@/utils/email/provider";
 import { withAuth } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
-import { mapWithConcurrency } from "../summary";
+import { mapWithConcurrency } from "../map-with-concurrency";
 
 const ARCHIVE_CONCURRENCY = 4;
 const ACCOUNT_CONCURRENCY = 4;
+
+export const maxDuration = 300;
 
 const bodySchema = z.object({
   threads: z

--- a/apps/web/app/api/mobile/all-inboxes/map-with-concurrency.ts
+++ b/apps/web/app/api/mobile/all-inboxes/map-with-concurrency.ts
@@ -1,0 +1,20 @@
+export async function mapWithConcurrency<Input, Output>(
+  values: Input[],
+  concurrency: number,
+  mapper: (value: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const results = new Array<Output>(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(values[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, worker),
+  );
+  return results;
+}

--- a/apps/web/app/api/mobile/all-inboxes/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/route.test.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/utils/__mocks__/prisma";
+
+const { createEmailProviderMock, getThreadsMock } = vi.hoisted(() => ({
+  createEmailProviderMock: vi.fn(),
+  getThreadsMock: vi.fn(),
+}));
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/email/provider", () => ({
+  createEmailProvider: createEmailProviderMock,
+}));
+vi.mock("@/utils/middleware", async () => {
+  const { createWithAuthTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithAuthTestMiddleware();
+});
+
+import { GET } from "./route";
+
+describe("GET /api/mobile/all-inboxes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getThreadsMock.mockResolvedValue({ threads: [] });
+    createEmailProviderMock.mockResolvedValue({
+      getLabels: vi.fn().mockResolvedValue([]),
+      getThreadsWithQuery: getThreadsMock,
+    });
+  });
+
+  it("loads only connected accounts owned by the authenticated user", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "account-1",
+        email: "one@example.com",
+        account: { provider: "google" },
+      },
+    ] as never);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/mobile/all-inboxes?after=2026-07-23T00%3A00%3A00.000Z",
+      ),
+      {} as never,
+    );
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: "user-1",
+          account: { disconnectedAt: null },
+        },
+      }),
+    );
+    expect(createEmailProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAccountId: "account-1",
+        provider: "google",
+      }),
+    );
+    expect(getThreadsMock).toHaveBeenCalledWith({
+      query: {
+        type: "inbox",
+        after: new Date("2026-07-23T00:00:00.000Z"),
+      },
+      maxResults: 100,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      accounts: [
+        {
+          accountId: "account-1",
+          email: "one@example.com",
+          status: "ok",
+        },
+      ],
+      failedAccountIds: [],
+    });
+  });
+});

--- a/apps/web/app/api/mobile/all-inboxes/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/route.test.ts
@@ -66,7 +66,7 @@ describe("GET /api/mobile/all-inboxes", () => {
         type: "inbox",
         after: new Date("2026-07-23T00:00:00.000Z"),
       },
-      maxResults: 100,
+      maxResults: 20,
     });
     await expect(response.json()).resolves.toMatchObject({
       accounts: [

--- a/apps/web/app/api/mobile/all-inboxes/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createEmailProvider } from "@/utils/email/provider";
+import { withAuth } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+import { loadAllInboxesSummary } from "./summary";
+
+export const maxDuration = 30;
+
+const querySchema = z.object({
+  after: z.coerce.date(),
+});
+
+export type GetAllInboxesResponse = Awaited<
+  ReturnType<typeof loadAllInboxesSummary>
+>;
+
+export const GET = withAuth("mobile/all-inboxes", async (request) => {
+  const { after } = querySchema.parse(
+    Object.fromEntries(new URL(request.url).searchParams),
+  );
+  const accounts = await prisma.emailAccount.findMany({
+    where: {
+      userId: request.auth.userId,
+      account: { disconnectedAt: null },
+    },
+    select: {
+      id: true,
+      email: true,
+      account: {
+        select: { provider: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  const normalizedAccounts = accounts.map((account) => ({
+    id: account.id,
+    email: account.email,
+    provider: account.account.provider,
+  }));
+  const result = await loadAllInboxesSummary({
+    accounts: normalizedAccounts,
+    after,
+    logger: request.logger,
+    createProvider: (account) =>
+      createEmailProvider({
+        emailAccountId: account.id,
+        provider: account.provider,
+        logger: request.logger.with({ emailAccountId: account.id }),
+      }),
+  });
+
+  return NextResponse.json(result);
+});

--- a/apps/web/app/api/mobile/all-inboxes/summary.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.test.ts
@@ -107,6 +107,64 @@ describe("loadAllInboxesSummary", () => {
       "error",
     ]);
   });
+
+  it("settles the started inbox request when label loading fails", async () => {
+    let rejectInbox!: (reason?: unknown) => void;
+    const inboxPromise = new Promise<never>((_, reject) => {
+      rejectInbox = reject;
+    });
+    const provider = {
+      getLabels: vi.fn().mockRejectedValue(new Error("Labels unavailable")),
+      getThreadsWithQuery: vi.fn().mockReturnValue(inboxPromise),
+    } as unknown as EmailProvider;
+    let settled = false;
+
+    const resultPromise = loadAllInboxesSummary({
+      accounts: [
+        { id: "account-1", email: "one@example.com", provider: "google" },
+      ],
+      after: new Date("2026-07-23T00:00:00.000Z"),
+      createProvider: vi.fn().mockResolvedValue(provider),
+      logger,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(provider.getLabels).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    rejectInbox(new Error("Inbox unavailable"));
+
+    await expect(resultPromise).resolves.toMatchObject({
+      failedAccountIds: ["account-1"],
+      accounts: [{ accountId: "account-1", status: "error" }],
+    });
+  });
+
+  it("drops threads emptied by ignored-sender filtering", async () => {
+    const provider = createProvider({
+      replies: [
+        thread(
+          "ignored-thread",
+          ["INBOX", "reply-label"],
+          "Reminder <reminder@superhuman.com>",
+        ),
+      ],
+    });
+
+    const result = await loadAllInboxesSummary({
+      accounts: [
+        { id: "account-1", email: "one@example.com", provider: "google" },
+      ],
+      after: new Date("2026-07-23T00:00:00.000Z"),
+      createProvider: vi.fn().mockResolvedValue(provider),
+      logger,
+    });
+
+    expect(result.accounts[0].replies).toEqual([]);
+  });
 });
 
 function createProvider({
@@ -137,7 +195,11 @@ function createProviderResult() {
   return createProvider({});
 }
 
-function thread(id: string, labelIds: string[]): EmailThread {
+function thread(
+  id: string,
+  labelIds: string[],
+  from = "Sender <sender@example.com>",
+): EmailThread {
   return {
     id,
     snippet: id,
@@ -153,7 +215,7 @@ function thread(id: string, labelIds: string[]): EmailThread {
         subject: id,
         headers: {
           date: "2026-07-23T12:00:00.000Z",
-          from: "Sender <sender@example.com>",
+          from,
           subject: id,
           to: "recipient@example.com",
         },

--- a/apps/web/app/api/mobile/all-inboxes/summary.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.test.ts
@@ -32,6 +32,13 @@ describe("loadAllInboxesSummary", () => {
     });
 
     expect(result.failedAccountIds).toEqual([]);
+    expect(accountOneProvider.getThreadsWithQuery).toHaveBeenCalledWith({
+      query: {
+        type: "inbox",
+        after: new Date("2026-07-23T00:00:00.000Z"),
+      },
+      maxResults: 20,
+    });
     expect(
       result.accounts[0].categories[0].threads[0].messages[0],
     ).toMatchObject({

--- a/apps/web/app/api/mobile/all-inboxes/summary.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestLogger } from "@/__tests__/helpers";
+import type { EmailProvider, EmailThread } from "@/utils/email/types";
+import { loadAllInboxesSummary } from "./summary";
+
+const logger = createTestLogger();
+
+describe("loadAllInboxesSummary", () => {
+  it("keeps account results isolated and returns useful partial data", async () => {
+    const accountOneProvider = createProvider({
+      inbox: [
+        thread("newsletter-thread", ["INBOX", "newsletter-label"]),
+        thread("regular-thread", ["INBOX"]),
+      ],
+      replies: [thread("reply-thread", ["INBOX", "reply-label"])],
+    });
+    const accountTwoProvider = createProvider({
+      inboxError: new Error("Inbox unavailable"),
+      replies: [thread("second-reply", ["INBOX", "reply-label"])],
+    });
+
+    const result = await loadAllInboxesSummary({
+      accounts: [
+        { id: "account-1", email: "one@example.com", provider: "google" },
+        { id: "account-2", email: "two@example.com", provider: "microsoft" },
+      ],
+      after: new Date("2026-07-23T00:00:00.000Z"),
+      createProvider: vi.fn(async (account) =>
+        account.id === "account-1" ? accountOneProvider : accountTwoProvider,
+      ),
+      logger,
+    });
+
+    expect(result.failedAccountIds).toEqual([]);
+    expect(
+      result.accounts[0].categories[0].threads[0].messages[0],
+    ).toMatchObject({
+      id: "newsletter-thread-message",
+      textPlain: undefined,
+      attachments: undefined,
+    });
+    expect(result.accounts).toMatchObject([
+      {
+        accountId: "account-1",
+        email: "one@example.com",
+        status: "ok",
+        replies: [{ id: "reply-thread" }],
+        categories: [
+          {
+            name: "Newsletters",
+            threads: [{ id: "newsletter-thread" }],
+          },
+        ],
+      },
+      {
+        accountId: "account-2",
+        email: "two@example.com",
+        status: "partial",
+        replies: [{ id: "second-reply" }],
+      },
+    ]);
+  });
+
+  it("limits provider initialization to four accounts at a time", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const createProvider = vi.fn(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      active--;
+      return createProviderResult();
+    });
+
+    await loadAllInboxesSummary({
+      accounts: Array.from({ length: 7 }, (_, index) => ({
+        id: `account-${index}`,
+        email: `account-${index}@example.com`,
+        provider: "google",
+      })),
+      after: new Date("2026-07-23T00:00:00.000Z"),
+      createProvider,
+      logger,
+    });
+
+    expect(createProvider).toHaveBeenCalledTimes(7);
+    expect(maxActive).toBe(4);
+  });
+
+  it("marks an account failed without dropping successful accounts", async () => {
+    const result = await loadAllInboxesSummary({
+      accounts: [
+        { id: "working", email: "working@example.com", provider: "google" },
+        { id: "failed", email: "failed@example.com", provider: "microsoft" },
+      ],
+      after: new Date("2026-07-23T00:00:00.000Z"),
+      createProvider: vi.fn(async (account) => {
+        if (account.id === "failed") throw new Error("Reconnect required");
+        return createProviderResult();
+      }),
+      logger,
+    });
+
+    expect(result.failedAccountIds).toEqual(["failed"]);
+    expect(result.accounts.map((account) => account.status)).toEqual([
+      "ok",
+      "error",
+    ]);
+  });
+});
+
+function createProvider({
+  inbox = [],
+  replies = [],
+  inboxError,
+}: {
+  inbox?: EmailThread[];
+  replies?: EmailThread[];
+  inboxError?: Error;
+}) {
+  return {
+    getLabels: vi.fn(async () => [
+      { id: "reply-label", name: "To Reply", type: "user" },
+      { id: "newsletter-label", name: "Newsletter", type: "user" },
+    ]),
+    getThreadsWithQuery: vi.fn(async ({ query }) => {
+      if (query?.type === "inbox") {
+        if (inboxError) throw inboxError;
+        return { threads: inbox };
+      }
+      return { threads: replies };
+    }),
+  } as unknown as EmailProvider;
+}
+
+function createProviderResult() {
+  return createProvider({});
+}
+
+function thread(id: string, labelIds: string[]): EmailThread {
+  return {
+    id,
+    snippet: id,
+    messages: [
+      {
+        date: "2026-07-23T12:00:00.000Z",
+        historyId: `${id}-history`,
+        id: `${id}-message`,
+        inline: [],
+        threadId: id,
+        labelIds,
+        snippet: id,
+        subject: id,
+        headers: {
+          date: "2026-07-23T12:00:00.000Z",
+          from: "Sender <sender@example.com>",
+          subject: id,
+          to: "recipient@example.com",
+        },
+        textPlain: "A large email body that should not be in list responses.",
+        attachments: [
+          {
+            attachmentId: "attachment-1",
+            filename: "large.pdf",
+            headers: {
+              "content-description": "",
+              "content-id": "",
+              "content-transfer-encoding": "",
+              "content-type": "application/pdf",
+            },
+            mimeType: "application/pdf",
+            size: 10_000_000,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/app/api/mobile/all-inboxes/summary.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.ts
@@ -53,7 +53,7 @@ export async function loadAllInboxesSummary({
         const [inboxResult, labelsResult] = await Promise.allSettled([
           emailProvider.getThreadsWithQuery({
             query: { type: "inbox", after },
-            maxResults: 100,
+            maxResults: 20,
           }),
           emailProvider.getLabels(),
         ]);

--- a/apps/web/app/api/mobile/all-inboxes/summary.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.ts
@@ -1,6 +1,7 @@
 import type { EmailProvider, EmailThread } from "@/utils/email/types";
 import { isIgnoredSender } from "@/utils/filter-ignored-senders";
 import type { Logger } from "@/utils/logger";
+import { mapWithConcurrency } from "./map-with-concurrency";
 
 const INBOX_LABEL_ID = "INBOX";
 const TO_REPLY_LABEL_NAME = "To Reply";
@@ -49,11 +50,17 @@ export async function loadAllInboxesSummary({
 
       try {
         const emailProvider = await createProvider(account);
-        const inboxPromise = emailProvider.getThreadsWithQuery({
-          query: { type: "inbox", after },
-          maxResults: 100,
-        });
-        const labels = await emailProvider.getLabels();
+        const [inboxResult, labelsResult] = await Promise.allSettled([
+          emailProvider.getThreadsWithQuery({
+            query: { type: "inbox", after },
+            maxResults: 100,
+          }),
+          emailProvider.getLabels(),
+        ]);
+        if (labelsResult.status === "rejected") {
+          throw labelsResult.reason;
+        }
+        const labels = labelsResult.value;
         const toReplyLabel = labels.find(
           (label) =>
             label.name.toLowerCase() === TO_REPLY_LABEL_NAME.toLowerCase(),
@@ -68,17 +75,13 @@ export async function loadAllInboxesSummary({
         const repliesPromise = toReplyLabel
           ? emailProvider.getThreadsWithQuery({
               query: {
-                labelId: toReplyLabel.id,
                 labelIds: [toReplyLabel.id, INBOX_LABEL_ID],
               },
               maxResults: 20,
             })
           : Promise.resolve({ threads: [] as EmailThread[] });
 
-        const [inboxResult, repliesResult] = await Promise.allSettled([
-          inboxPromise,
-          repliesPromise,
-        ]);
+        const [repliesResult] = await Promise.allSettled([repliesPromise]);
         const inboxThreads =
           inboxResult.status === "fulfilled"
             ? normalizeThreads(inboxResult.value.threads)
@@ -150,11 +153,10 @@ export async function loadAllInboxesSummary({
 }
 
 function normalizeThreads(threads: EmailThread[]): EmailThread[] {
-  return threads.map((thread) => ({
-    ...thread,
+  return threads.flatMap((thread) => {
     // List and category screens only need metadata. Full bodies and attachment
     // details are fetched by the existing thread-detail endpoint on demand.
-    messages: thread.messages
+    const messages = thread.messages
       .filter((message) => {
         if (!message.headers?.from) return true;
         return !isIgnoredSender(message.headers.from);
@@ -166,27 +168,8 @@ function normalizeThreads(threads: EmailThread[]): EmailThread[] {
         rawRecipients: undefined,
         textHtml: undefined,
         textPlain: undefined,
-      })),
-  }));
-}
+      }));
 
-export async function mapWithConcurrency<Input, Output>(
-  values: Input[],
-  concurrency: number,
-  mapper: (value: Input) => Promise<Output>,
-): Promise<Output[]> {
-  const results = new Array<Output>(values.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < values.length) {
-      const index = nextIndex++;
-      results[index] = await mapper(values[index]);
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, values.length) }, worker),
-  );
-  return results;
+    return messages.length ? [{ ...thread, messages }] : [];
+  });
 }

--- a/apps/web/app/api/mobile/all-inboxes/summary.ts
+++ b/apps/web/app/api/mobile/all-inboxes/summary.ts
@@ -1,0 +1,192 @@
+import type { EmailProvider, EmailThread } from "@/utils/email/types";
+import { isIgnoredSender } from "@/utils/filter-ignored-senders";
+import type { Logger } from "@/utils/logger";
+
+const INBOX_LABEL_ID = "INBOX";
+const TO_REPLY_LABEL_NAME = "To Reply";
+const CATEGORY_LABELS = [
+  { labelName: "Newsletter", displayName: "Newsletters" },
+  { labelName: "Marketing", displayName: "Promotions" },
+  { labelName: "Notification", displayName: "Notifications" },
+] as const;
+const ACCOUNT_CONCURRENCY = 4;
+
+export type AllInboxesAccount = {
+  id: string;
+  email: string;
+  provider: string;
+};
+
+export type AllInboxesAccountSummary = {
+  accountId: string;
+  email: string;
+  status: "ok" | "partial" | "error";
+  replies: EmailThread[];
+  categories: {
+    key: string;
+    labelId: string;
+    name: string;
+    threads: EmailThread[];
+  }[];
+};
+
+export async function loadAllInboxesSummary({
+  accounts,
+  after,
+  createProvider,
+  logger,
+}: {
+  accounts: AllInboxesAccount[];
+  after: Date;
+  createProvider: (account: AllInboxesAccount) => Promise<EmailProvider>;
+  logger: Logger;
+}) {
+  const summaries = await mapWithConcurrency(
+    accounts,
+    ACCOUNT_CONCURRENCY,
+    async (account): Promise<AllInboxesAccountSummary> => {
+      const accountLogger = logger.with({ emailAccountId: account.id });
+
+      try {
+        const emailProvider = await createProvider(account);
+        const inboxPromise = emailProvider.getThreadsWithQuery({
+          query: { type: "inbox", after },
+          maxResults: 100,
+        });
+        const labels = await emailProvider.getLabels();
+        const toReplyLabel = labels.find(
+          (label) =>
+            label.name.toLowerCase() === TO_REPLY_LABEL_NAME.toLowerCase(),
+        );
+        const categoryLabels = CATEGORY_LABELS.flatMap((category) => {
+          const label = labels.find(
+            (item) =>
+              item.name.toLowerCase() === category.labelName.toLowerCase(),
+          );
+          return label ? [{ ...category, label }] : [];
+        });
+        const repliesPromise = toReplyLabel
+          ? emailProvider.getThreadsWithQuery({
+              query: {
+                labelId: toReplyLabel.id,
+                labelIds: [toReplyLabel.id, INBOX_LABEL_ID],
+              },
+              maxResults: 20,
+            })
+          : Promise.resolve({ threads: [] as EmailThread[] });
+
+        const [inboxResult, repliesResult] = await Promise.allSettled([
+          inboxPromise,
+          repliesPromise,
+        ]);
+        const inboxThreads =
+          inboxResult.status === "fulfilled"
+            ? normalizeThreads(inboxResult.value.threads)
+            : [];
+        const replies =
+          repliesResult.status === "fulfilled"
+            ? normalizeThreads(repliesResult.value.threads)
+            : [];
+
+        if (inboxResult.status === "rejected") {
+          accountLogger.warn("Failed to load all-inboxes categories", {
+            error: inboxResult.reason,
+          });
+        }
+        if (repliesResult.status === "rejected") {
+          accountLogger.warn("Failed to load all-inboxes replies", {
+            error: repliesResult.reason,
+          });
+        }
+
+        let status: AllInboxesAccountSummary["status"] = "partial";
+        if (
+          inboxResult.status === "fulfilled" &&
+          repliesResult.status === "fulfilled"
+        ) {
+          status = "ok";
+        } else if (
+          inboxResult.status === "rejected" &&
+          repliesResult.status === "rejected"
+        ) {
+          status = "error";
+        }
+
+        return {
+          accountId: account.id,
+          email: account.email,
+          status,
+          replies,
+          categories: categoryLabels.map((category) => ({
+            key: `${account.id}:${category.label.id}`,
+            labelId: category.label.id,
+            name: category.displayName,
+            threads: inboxThreads.filter((thread) =>
+              thread.messages.some((message) =>
+                message.labelIds?.includes(category.label.id),
+              ),
+            ),
+          })),
+        };
+      } catch (error) {
+        accountLogger.warn("Failed to load mailbox for all inboxes", { error });
+        return {
+          accountId: account.id,
+          email: account.email,
+          status: "error",
+          replies: [],
+          categories: [],
+        };
+      }
+    },
+  );
+
+  return {
+    accounts: summaries,
+    failedAccountIds: summaries
+      .filter((summary) => summary.status === "error")
+      .map((summary) => summary.accountId),
+  };
+}
+
+function normalizeThreads(threads: EmailThread[]): EmailThread[] {
+  return threads.map((thread) => ({
+    ...thread,
+    // List and category screens only need metadata. Full bodies and attachment
+    // details are fetched by the existing thread-detail endpoint on demand.
+    messages: thread.messages
+      .filter((message) => {
+        if (!message.headers?.from) return true;
+        return !isIgnoredSender(message.headers.from);
+      })
+      .map((message) => ({
+        ...message,
+        attachments: undefined,
+        inline: [],
+        rawRecipients: undefined,
+        textHtml: undefined,
+        textPlain: undefined,
+      })),
+  }));
+}
+
+export async function mapWithConcurrency<Input, Output>(
+  values: Input[],
+  concurrency: number,
+  mapper: (value: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const results = new Array<Output>(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(values[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, worker),
+  );
+  return results;
+}

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -78,6 +78,10 @@ export const createMockEmailProvider = (
   getPreviousConversationMessages: vi.fn().mockResolvedValue([]),
   archiveThread: vi.fn().mockResolvedValue(undefined),
   archiveThreadWithLabel: vi.fn().mockResolvedValue(undefined),
+  bulkArchiveThreads: vi.fn().mockResolvedValue({
+    succeededThreadIds: [],
+    failedThreadIds: [],
+  }),
   archiveMessage: vi.fn().mockResolvedValue(undefined),
   trashThread: vi.fn().mockResolvedValue(undefined),
   bulkArchiveFromSenders: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/email/google.test.ts
+++ b/apps/web/utils/email/google.test.ts
@@ -6,29 +6,38 @@ import * as gmailLabelModule from "@/utils/gmail/label";
 import * as gmailThreadModule from "@/utils/gmail/thread";
 import { GmailProvider } from "./google";
 
-const { envMock, gmailMailMock, gmailDraftMock, gmailSignatureMock } =
-  vi.hoisted(() => ({
-    envMock: {
-      NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
-      EMAIL_ENCRYPT_SECRET: "test-encrypt-secret",
-      EMAIL_ENCRYPT_SALT: "test-encrypt-salt",
-    },
-    gmailMailMock: {
-      draftEmail: vi.fn().mockResolvedValue({ data: { id: "draft-1" } }),
-      forwardEmail: vi.fn(),
-      replyToEmail: vi.fn(),
-      sendEmailWithPlainText: vi.fn(),
-      sendEmailWithHtml: vi.fn(),
-    },
-    gmailDraftMock: {
-      getDraft: vi.fn(),
-      deleteDraft: vi.fn(),
-      sendDraft: vi.fn(),
-    },
-    gmailSignatureMock: {
-      getGmailSignatures: vi.fn().mockResolvedValue([]),
-    },
-  }));
+const {
+  envMock,
+  gmailMailMock,
+  gmailDraftMock,
+  gmailSignatureMock,
+  bulkActionTrackingMock,
+} = vi.hoisted(() => ({
+  envMock: {
+    NEXT_PUBLIC_AUTO_DRAFT_DISABLED: false,
+    EMAIL_ENCRYPT_SECRET: "test-encrypt-secret",
+    EMAIL_ENCRYPT_SALT: "test-encrypt-salt",
+  },
+  gmailMailMock: {
+    draftEmail: vi.fn().mockResolvedValue({ data: { id: "draft-1" } }),
+    forwardEmail: vi.fn(),
+    replyToEmail: vi.fn(),
+    sendEmailWithPlainText: vi.fn(),
+    sendEmailWithHtml: vi.fn(),
+  },
+  gmailDraftMock: {
+    getDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+    sendDraft: vi.fn(),
+  },
+  gmailSignatureMock: {
+    getGmailSignatures: vi.fn().mockResolvedValue([]),
+  },
+  bulkActionTrackingMock: {
+    publishBulkActionToTinybird: vi.fn().mockResolvedValue(undefined),
+    updateEmailMessagesForSender: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 
 vi.mock("@/env", () => ({
   env: envMock,
@@ -42,6 +51,44 @@ vi.mock("@/utils/gmail/mail", async (importOriginal) => {
 vi.mock("@/utils/gmail/draft", () => gmailDraftMock);
 
 vi.mock("@/utils/gmail/signature-settings", () => gmailSignatureMock);
+vi.mock("@/utils/email/bulk-action-tracking", () => bulkActionTrackingMock);
+
+describe("GmailProvider.bulkArchiveThreads", () => {
+  it("archives all supplied messages with one Gmail batch modification", async () => {
+    const batchModify = vi.fn().mockResolvedValue({ data: {} });
+    const provider = new GmailProvider({
+      users: { messages: { batchModify } },
+    } as any);
+
+    const result = await provider.bulkArchiveThreads(
+      [
+        { threadId: "thread-1", messageIds: ["message-1", "message-2"] },
+        { threadId: "thread-2", messageIds: ["message-3"] },
+      ],
+      "owner@example.com",
+    );
+
+    expect(batchModify).toHaveBeenCalledTimes(1);
+    expect(batchModify).toHaveBeenCalledWith({
+      userId: "me",
+      requestBody: {
+        ids: ["message-1", "message-2", "message-3"],
+        removeLabelIds: [GmailLabel.INBOX],
+      },
+    });
+    expect(
+      bulkActionTrackingMock.publishBulkActionToTinybird,
+    ).toHaveBeenCalledWith({
+      threadIds: ["thread-1", "thread-2"],
+      action: "archive",
+      ownerEmail: "owner@example.com",
+    });
+    expect(result).toEqual({
+      succeededThreadIds: ["thread-1", "thread-2"],
+      failedThreadIds: [],
+    });
+  });
+});
 
 describe("GmailProvider.getLatestMessageInThread", () => {
   afterEach(() => {

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -1,4 +1,5 @@
 import type { gmail_v1 } from "@googleapis/gmail";
+import chunk from "lodash/chunk";
 import type { Attachment as MailAttachment } from "nodemailer/lib/mailer";
 import type { MessageWithPayload, ParsedMessage } from "@/utils/types";
 import { parseMessage } from "@/utils/gmail/message";
@@ -59,7 +60,11 @@ import {
 } from "@/utils/gmail/thread";
 import { decodeSnippet } from "@/utils/gmail/decode";
 import { getDraft, deleteDraft, sendDraft } from "@/utils/gmail/draft";
-import { extractErrorInfo, withGmailRetry } from "@/utils/gmail/retry";
+import {
+  extractErrorInfo,
+  isRetryableError,
+  withGmailRetry,
+} from "@/utils/gmail/retry";
 import { getLatestNonDraftMessage } from "@/utils/email/latest-message";
 import { getMessageTimestamp } from "@/utils/email/message-timestamp";
 import {
@@ -76,6 +81,8 @@ import type {
   EmailFilter,
   EmailSignature,
   SentMessagePage,
+  BulkArchiveThread,
+  BulkArchiveResult,
 } from "@/utils/email/types";
 import { createScopedLogger, type Logger } from "@/utils/logger";
 import { getGmailSignatures } from "@/utils/gmail/signature-settings";
@@ -315,6 +322,81 @@ export class GmailProvider implements EmailProvider {
       actionSource: "user",
       labelId,
     });
+  }
+
+  async bulkArchiveThreads(
+    threads: BulkArchiveThread[],
+    ownerEmail: string,
+  ): Promise<BulkArchiveResult> {
+    const threadIdsByMessageId = new Map<string, Set<string>>();
+    const failedThreadIds = new Set<string>();
+
+    for (const thread of threads) {
+      if (thread.messageIds.length === 0) {
+        failedThreadIds.add(thread.threadId);
+      }
+      for (const messageId of thread.messageIds) {
+        const threadIds = threadIdsByMessageId.get(messageId) ?? new Set();
+        threadIds.add(thread.threadId);
+        threadIdsByMessageId.set(messageId, threadIds);
+      }
+    }
+
+    const messageIdChunks = chunk([...threadIdsByMessageId.keys()], 1000);
+    for (let index = 0; index < messageIdChunks.length; index++) {
+      const messageIds = messageIdChunks[index];
+
+      try {
+        await this.withRateLimitTracking("bulk-archive-threads", () =>
+          withGmailRetry(() =>
+            this.client.users.messages.batchModify({
+              userId: "me",
+              requestBody: {
+                ids: messageIds,
+                removeLabelIds: [GmailLabel.INBOX],
+              },
+            }),
+          ),
+        );
+      } catch (error) {
+        for (const messageId of messageIds) {
+          for (const threadId of threadIdsByMessageId.get(messageId) ?? []) {
+            failedThreadIds.add(threadId);
+          }
+        }
+
+        if (isRetryableError(extractErrorInfo(error)).isRateLimit) {
+          for (const remainingMessageIds of messageIdChunks.slice(index + 1)) {
+            for (const messageId of remainingMessageIds) {
+              for (const threadId of threadIdsByMessageId.get(messageId) ??
+                []) {
+                failedThreadIds.add(threadId);
+              }
+            }
+          }
+          break;
+        }
+      }
+    }
+
+    const succeededThreadIds = threads
+      .map((thread) => thread.threadId)
+      .filter((threadId) => !failedThreadIds.has(threadId));
+
+    if (succeededThreadIds.length > 0) {
+      await publishBulkActionToTinybird({
+        threadIds: succeededThreadIds,
+        action: "archive",
+        ownerEmail,
+      });
+    }
+
+    return {
+      succeededThreadIds,
+      failedThreadIds: threads
+        .map((thread) => thread.threadId)
+        .filter((threadId) => failedThreadIds.has(threadId)),
+    };
   }
 
   async archiveMessage(messageId: string): Promise<void> {

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -63,6 +63,8 @@ import type {
   EmailFilter,
   EmailSignature,
   SentMessagePage,
+  BulkArchiveThread,
+  BulkArchiveResult,
 } from "@/utils/email/types";
 import { unwatchOutlook, watchOutlook } from "@/utils/outlook/watch";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
@@ -76,7 +78,10 @@ import {
   getOutlookFolderTree,
 } from "@/utils/outlook/folders";
 import { extractSignatureFromHtml } from "@/utils/email/signature-extraction";
-import { moveMessagesForSenders } from "@/utils/outlook/batch";
+import {
+  moveMessagesForSenders,
+  moveThreadsInBatches,
+} from "@/utils/outlook/batch";
 import {
   extractErrorInfo,
   isRetryableError,
@@ -436,6 +441,19 @@ export class OutlookProvider implements EmailProvider {
       ownerEmail,
       actionSource: "user",
       folderId: "archive",
+      logger: this.logger,
+    });
+  }
+
+  async bulkArchiveThreads(
+    threads: BulkArchiveThread[],
+    ownerEmail: string,
+  ): Promise<BulkArchiveResult> {
+    return moveThreadsInBatches({
+      client: this.client,
+      threads,
+      destinationId: "archive",
+      ownerEmail,
       logger: this.logger,
     });
   }

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -47,6 +47,16 @@ export interface SentMessagePage {
   nextPageToken?: string;
 }
 
+export type BulkArchiveThread = {
+  threadId: string;
+  messageIds: string[];
+};
+
+export type BulkArchiveResult = {
+  succeededThreadIds: string[];
+  failedThreadIds: string[];
+};
+
 export interface EmailProvider {
   archiveMessage(messageId: string): Promise<void>;
   archiveThread(threadId: string, ownerEmail: string): Promise<void>;
@@ -61,6 +71,10 @@ export interface EmailProvider {
     ownerEmail: string,
     emailAccountId: string,
   ): Promise<void>;
+  bulkArchiveThreads(
+    threads: BulkArchiveThread[],
+    ownerEmail: string,
+  ): Promise<BulkArchiveResult>;
   bulkTrashFromSenders(
     fromEmails: string[],
     ownerEmail: string,

--- a/apps/web/utils/outlook/batch.test.ts
+++ b/apps/web/utils/outlook/batch.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OutlookClient } from "@/utils/outlook/client";
 import { createTestLogger } from "@/__tests__/helpers";
-import { moveMessagesForSenders } from "./batch";
+import { moveMessagesForSenders, moveThreadsInBatches } from "./batch";
 
 const mockGetFolderIds = vi.fn();
 const mockUpdateEmailMessagesForSender = vi.fn();
@@ -121,6 +121,85 @@ describe("moveMessagesForSenders", () => {
       messageIds: messages.map((message) => message.id),
       emailAccountId: "account-1",
       action: "trash",
+    });
+  });
+});
+
+describe("moveThreadsInBatches", () => {
+  beforeEach(() => {
+    mockPublishBulkActionToTinybird.mockReset();
+  });
+
+  it("returns thread-level results from Outlook batch responses", async () => {
+    const client = createMockOutlookClient({
+      listMessages: async () => ({ value: [] }),
+      batchPost: async () => ({
+        responses: [
+          { id: "archive-0", status: 201, body: {} },
+          {
+            id: "archive-1",
+            status: 429,
+            body: { error: { message: "Rate limited" } },
+          },
+        ],
+      }),
+    });
+
+    const result = await moveThreadsInBatches({
+      client,
+      threads: [
+        { threadId: "thread-1", messageIds: ["message-1"] },
+        { threadId: "thread-2", messageIds: ["message-2"] },
+      ],
+      destinationId: "archive",
+      ownerEmail: "owner@example.com",
+      logger: createTestLogger(),
+    });
+
+    expect(result).toEqual({
+      succeededThreadIds: ["thread-1"],
+      failedThreadIds: ["thread-2"],
+    });
+    expect(mockPublishBulkActionToTinybird).toHaveBeenCalledWith({
+      threadIds: ["thread-1"],
+      action: "archive",
+      ownerEmail: "owner@example.com",
+    });
+  });
+
+  it("stops sending Outlook batches after a rate-limit response", async () => {
+    const batchPost = vi.fn(
+      async (body: {
+        requests: Array<{ id: string; url: string; method: string }>;
+      }) => ({
+        responses: body.requests.map((request) => ({
+          id: request.id,
+          status: 429,
+          body: { error: { message: "Rate limited" } },
+        })),
+      }),
+    );
+    const client = createMockOutlookClient({
+      listMessages: async () => ({ value: [] }),
+      batchPost,
+    });
+    const threads = Array.from({ length: 5 }, (_, index) => ({
+      threadId: `thread-${index + 1}`,
+      messageIds: [`message-${index + 1}`],
+    }));
+
+    const result = await moveThreadsInBatches({
+      client,
+      threads,
+      destinationId: "archive",
+      ownerEmail: "owner@example.com",
+      logger: createTestLogger(),
+    });
+
+    expect(batchPost).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      succeededThreadIds: [],
+      failedThreadIds: threads.map((thread) => thread.threadId),
     });
   });
 });

--- a/apps/web/utils/outlook/batch.ts
+++ b/apps/web/utils/outlook/batch.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "@/utils/logger";
 import type { OutlookClient } from "@/utils/outlook/client";
+import type { BulkArchiveResult, BulkArchiveThread } from "@/utils/email/types";
 import { escapeODataString } from "@/utils/outlook/odata-escape";
 import { getFolderIds } from "@/utils/outlook/message";
 import {
@@ -39,6 +40,7 @@ async function batch<TRequestBody = unknown, TResponseBody = unknown>({
   requests,
   chunkSize,
   onFailure,
+  shouldStop,
   context,
   logger,
 }: {
@@ -49,6 +51,7 @@ async function batch<TRequestBody = unknown, TResponseBody = unknown>({
     request?: GraphBatchRequestItem<TRequestBody>;
     response: GraphBatchResponseItem<TResponseBody>;
   }) => void;
+  shouldStop?: (responses: GraphBatchResponseItem<TResponseBody>[]) => boolean;
   context?: Record<string, unknown>;
   logger: Logger;
 }): Promise<GraphBatchResponseItem<TResponseBody>[]> {
@@ -83,6 +86,7 @@ async function batch<TRequestBody = unknown, TResponseBody = unknown>({
           });
         }
       });
+      if (shouldStop?.(responses)) break;
     } catch (error) {
       logger.error("Graph batch request failed", {
         ...context,
@@ -165,6 +169,8 @@ async function moveMessagesInBatches({
         logger.error("Failed to move message via batch", context);
       }
     },
+    shouldStop: (responses) =>
+      responses.some((response) => response.status === 429),
   });
 
   const movedMessageIds = responses.flatMap((response) => {
@@ -191,6 +197,55 @@ async function moveMessagesInBatches({
     movedMessageIds,
     hasErrors,
   };
+}
+
+export async function moveThreadsInBatches({
+  client,
+  threads,
+  destinationId,
+  ownerEmail,
+  logger,
+}: {
+  client: OutlookClient;
+  threads: BulkArchiveThread[];
+  destinationId: string;
+  ownerEmail: string;
+  logger: Logger;
+}): Promise<BulkArchiveResult> {
+  const messageIds = [
+    ...new Set(threads.flatMap((thread) => thread.messageIds)),
+  ];
+  const { movedMessageIds } = await moveMessagesInBatches({
+    client,
+    messageIds,
+    destinationId,
+    action: "archive",
+    logger,
+  });
+  const movedMessageIdSet = new Set(movedMessageIds);
+  const succeededThreadIds = threads
+    .filter(
+      (thread) =>
+        thread.messageIds.length > 0 &&
+        thread.messageIds.every((messageId) =>
+          movedMessageIdSet.has(messageId),
+        ),
+    )
+    .map((thread) => thread.threadId);
+  const succeededThreadIdSet = new Set(succeededThreadIds);
+  const failedThreadIds = threads
+    .map((thread) => thread.threadId)
+    .filter((threadId) => !succeededThreadIdSet.has(threadId));
+
+  if (succeededThreadIds.length > 0) {
+    await publishBulkActionToTinybird({
+      threadIds: succeededThreadIds,
+      action: "archive",
+      ownerEmail,
+    });
+  }
+
+  return { succeededThreadIds, failedThreadIds };
 }
 
 export async function moveMessagesForSenders({


### PR DESCRIPTION
## Summary
- add a user-scoped all-inboxes summary endpoint for mobile
- fan out across connected providers with bounded concurrency and partial-failure handling
- return lightweight thread metadata and add an authorized, mailbox-grouped bulk archive endpoint

## Test plan
- corepack pnpm test app/api/mobile/all-inboxes/summary.test.ts app/api/mobile/all-inboxes/route.test.ts app/api/mobile/all-inboxes/archive/route.test.ts
- Biome check for all six changed files

The summary and archive routes validate account ownership and continue returning useful results when an individual provider operation fails.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

