### PR TITLE
document filing: Ignore inline email assets

### DIFF
--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -540,6 +540,34 @@ describe("processAttachment", () => {
 });
 
 describe("getFilableAttachments", () => {
+  it("excludes inline images embedded in the email body", () => {
+    const documentAttachment = createAttachment({
+      attachmentId: "attachment-1",
+      filename: "receipt.pdf",
+      mimeType: "application/pdf",
+    });
+    const inlineImage = {
+      ...createAttachment({
+        attachmentId: "attachment-2",
+        filename: "signature-logo.png",
+        mimeType: "image/png",
+      }),
+      headers: {
+        "content-description": "",
+        "content-disposition": 'inline; filename="signature-logo.png"',
+        "content-id": "<signature-logo>",
+        "content-transfer-encoding": "base64",
+        "content-type": 'image/png; name="signature-logo.png"',
+      },
+    };
+
+    const message = getMockParsedMessage({
+      attachments: [documentAttachment, inlineImage],
+    });
+
+    expect(getFilableAttachments(message)).toEqual([documentAttachment]);
+  });
+
   it("excludes calendar invite attachments", () => {
     const documentAttachment = createAttachment({
       attachmentId: "attachment-1",

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -384,15 +384,22 @@ export async function processAttachment({
 
 /**
  * Get all filable attachments from a message.
- * All attachment types are supported - text-extractable files (PDF, DOCX, TXT)
- * get full content analysis, while other types (images, spreadsheets, etc.)
- * are filed based on filename and email metadata. Calendar invite artifacts are
- * excluded because they describe the email event rather than a user document.
+ * All user attachment types are supported - text-extractable files (PDF, DOCX,
+ * TXT) get full content analysis, while other types (images, spreadsheets,
+ * etc.) are filed based on filename and email metadata. Inline email assets and
+ * calendar invite artifacts are excluded because they are part of the message
+ * itself rather than user documents.
  */
 export function getFilableAttachments(message: ParsedMessage): Attachment[] {
-  return (message.attachments || []).filter(
-    (attachment) => !isCalendarInviteAttachment(attachment),
-  );
+  return (message.attachments || []).filter((attachment) => {
+    const contentDisposition =
+      attachment.headers?.["content-disposition"]?.toLowerCase();
+
+    return (
+      !contentDisposition?.includes("inline") &&
+      !isCalendarInviteAttachment(attachment)
+    );
+  });
 }
 
 // ============================================================================

--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -15,6 +15,38 @@ import {
 import type { OutlookClient } from "@/utils/outlook/client";
 
 describe("convertMessage", () => {
+  it("excludes inline images embedded in the email body from attachments", () => {
+    const message: Message = {
+      id: "msg-123",
+      conversationId: "thread-456",
+      attachments: [
+        {
+          id: "inline-attachment",
+          name: "signature-logo.png",
+          contentType: "image/png",
+          size: 128,
+          isInline: true,
+        },
+        {
+          id: "document-attachment",
+          name: "receipt.pdf",
+          contentType: "application/pdf",
+          size: 1024,
+          isInline: false,
+        },
+      ],
+    };
+
+    const result = convertMessage(message, {});
+
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        attachmentId: "document-attachment",
+        filename: "receipt.pdf",
+      }),
+    ]);
+  });
+
   describe("category ID mapping", () => {
     it("should return category IDs when categoryMap is provided", () => {
       const message: Message = {

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -19,7 +19,7 @@ export const MESSAGE_SELECT_FIELDS =
 
 // Expand attachments to get metadata (name, type, size) without fetching content
 export const MESSAGE_EXPAND_ATTACHMENTS =
-  "attachments($select=id,name,contentType,size)";
+  "attachments($select=id,name,contentType,size,isInline)";
 
 export async function getFolderIds(
   client: OutlookClient,
@@ -995,18 +995,20 @@ function convertAttachments(
     return;
   }
 
-  return graphAttachments.map((attachment) => ({
-    filename: attachment.name || "",
-    mimeType: attachment.contentType || "application/octet-stream",
-    size: attachment.size || 0,
-    attachmentId: attachment.id || "",
-    headers: {
-      "content-type": attachment.contentType || "",
-      "content-description": "",
-      "content-transfer-encoding": "",
-      "content-id": "",
-    },
-  }));
+  return graphAttachments
+    .filter((attachment) => !attachment.isInline)
+    .map((attachment) => ({
+      filename: attachment.name || "",
+      mimeType: attachment.contentType || "application/octet-stream",
+      size: attachment.size || 0,
+      attachmentId: attachment.id || "",
+      headers: {
+        "content-type": attachment.contentType || "",
+        "content-description": "",
+        "content-transfer-encoding": "",
+        "content-id": "",
+      },
+    }));
 }
 
 function logWellKnownFolderFetchError(

--- a/apps/web/utils/types.ts
+++ b/apps/web/utils/types.ts
@@ -85,6 +85,7 @@ export interface Attachment {
 
 interface Headers {
   "content-description": string;
+  "content-disposition"?: string;
   "content-id": string;
   "content-transfer-encoding": string;
   "content-type": string;


### PR DESCRIPTION
Prevents embedded email assets from being processed as user attachments. Normal document attachments continue through the existing filing flow.

- filter inline MIME assets before document filing
- preserve inline metadata handling across email providers
- add regression coverage for inline and regular attachments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

