### PR TITLE
api: support incremental all-inboxes loading

### DIFF
--- a/apps/web/app/api/mobile/all-inboxes/route.test.ts
+++ b/apps/web/app/api/mobile/all-inboxes/route.test.ts
@@ -79,4 +79,40 @@ describe("GET /api/mobile/all-inboxes", () => {
       failedAccountIds: [],
     });
   });
+
+  it("can scope the summary to one owned account", async () => {
+    prisma.emailAccount.findMany.mockResolvedValue([
+      {
+        id: "account-2",
+        email: "two@example.com",
+        account: { provider: "microsoft" },
+      },
+    ] as never);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/mobile/all-inboxes?accountId=account-2&after=2026-07-23T00%3A00%3A00.000Z",
+      ),
+      {} as never,
+    );
+
+    expect(prisma.emailAccount.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "account-2",
+          userId: "user-1",
+          account: { disconnectedAt: null },
+        },
+      }),
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      accounts: [
+        {
+          accountId: "account-2",
+          email: "two@example.com",
+          status: "ok",
+        },
+      ],
+    });
+  });
 });

--- a/apps/web/app/api/mobile/all-inboxes/route.ts
+++ b/apps/web/app/api/mobile/all-inboxes/route.ts
@@ -8,6 +8,7 @@ import { loadAllInboxesSummary } from "./summary";
 export const maxDuration = 30;
 
 const querySchema = z.object({
+  accountId: z.string().min(1).optional(),
   after: z.coerce.date(),
 });
 
@@ -16,11 +17,12 @@ export type GetAllInboxesResponse = Awaited<
 >;
 
 export const GET = withAuth("mobile/all-inboxes", async (request) => {
-  const { after } = querySchema.parse(
+  const { accountId, after } = querySchema.parse(
     Object.fromEntries(new URL(request.url).searchParams),
   );
   const accounts = await prisma.emailAccount.findMany({
     where: {
+      ...(accountId ? { id: accountId } : {}),
       userId: request.auth.userId,
       account: { disconnectedAt: null },
     },


### PR DESCRIPTION
## Summary
- allow the mobile inbox summary endpoint to scope work to one owned account
- preserve the existing all-account behavior for backwards compatibility
- enable mobile to request account summaries in parallel and render each result as it arrives

## Test plan
- corepack pnpm test app/api/mobile/all-inboxes/route.test.ts app/api/mobile/all-inboxes/summary.test.ts app/api/mobile/all-inboxes/archive/route.test.ts
- Biome check for the changed route and test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

