### PR TITLE
onboarding: Recognize mobile premium on web login

### DIFF
--- a/apps/web/app/(landing)/welcome-redirect/page.test.ts
+++ b/apps/web/app/(landing)/welcome-redirect/page.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  findUser: vi.fn(),
+  findPremium: vi.fn(),
+  redirectToEmailAccountPath: vi.fn((path: string) => {
+    throw new Error(`account-redirect:${path}`);
+  }),
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+  env: {
+    NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS: false,
+  },
+}));
+
+vi.mock("@/utils/auth", () => ({
+  auth: () => mocks.auth(),
+}));
+
+vi.mock("@/utils/prisma", () => ({
+  default: {
+    user: {
+      findUnique: (...args: Parameters<typeof mocks.findUser>) =>
+        mocks.findUser(...args),
+    },
+    premium: {
+      findUnique: (...args: Parameters<typeof mocks.findPremium>) =>
+        mocks.findPremium(...args),
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mocks.redirect(url),
+}));
+
+vi.mock("@/utils/account", () => ({
+  redirectToEmailAccountPath: (path: string) =>
+    mocks.redirectToEmailAccountPath(path),
+}));
+
+vi.mock("@/env", () => ({
+  env: mocks.env,
+}));
+
+import { premiumEntitlementSelect } from "@/utils/premium";
+import WelcomeRedirectPage from "./page";
+
+describe("WelcomeRedirectPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ user: { id: "user-1" } });
+  });
+
+  it("sends completed web users to automation without loading premium", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: new Date("2026-01-01T00:00:00.000Z"),
+      premiumId: "premium-1",
+    });
+
+    await expect(
+      WelcomeRedirectPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("account-redirect:/automation");
+
+    expect(mocks.findPremium).not.toHaveBeenCalled();
+  });
+
+  it("sends mobile-paid users with active Apple premium to setup", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: null,
+      premiumId: "premium-1",
+    });
+    mocks.findPremium.mockResolvedValue({
+      appleExpiresAt: new Date("2099-07-01T00:00:00.000Z"),
+      appleRevokedAt: null,
+      appleSubscriptionStatus: "ACTIVE",
+      lemonSqueezyRenewsAt: null,
+      stripeSubscriptionStatus: null,
+      tier: "STARTER_MONTHLY",
+    });
+
+    await expect(
+      WelcomeRedirectPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("account-redirect:/setup");
+
+    expect(mocks.findUser).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: {
+        completedOnboardingAt: true,
+        premiumId: true,
+      },
+    });
+    expect(mocks.findPremium).toHaveBeenCalledWith({
+      where: { id: "premium-1" },
+      select: premiumEntitlementSelect,
+    });
+    expect(mocks.redirectToEmailAccountPath).toHaveBeenCalledWith("/setup");
+  });
+
+  it("keeps incomplete users without premium in onboarding", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: null,
+      premiumId: null,
+    });
+
+    await expect(
+      WelcomeRedirectPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("redirect:/onboarding");
+
+    expect(mocks.findPremium).not.toHaveBeenCalled();
+  });
+
+  it("keeps incomplete users with expired premium in onboarding", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: null,
+      premiumId: "premium-1",
+    });
+    mocks.findPremium.mockResolvedValue({
+      appleExpiresAt: new Date("2020-07-01T00:00:00.000Z"),
+      appleRevokedAt: null,
+      appleSubscriptionStatus: "EXPIRED",
+      lemonSqueezyRenewsAt: null,
+      stripeSubscriptionStatus: null,
+      tier: "STARTER_MONTHLY",
+    });
+
+    await expect(
+      WelcomeRedirectPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("redirect:/onboarding");
+  });
+
+  it("honors forced onboarding for premium users", async () => {
+    mocks.findUser.mockResolvedValue({
+      completedOnboardingAt: null,
+      premiumId: "premium-1",
+    });
+
+    await expect(
+      WelcomeRedirectPage({
+        searchParams: Promise.resolve({ force: true }),
+      }),
+    ).rejects.toThrow("redirect:/onboarding");
+
+    expect(mocks.findPremium).not.toHaveBeenCalled();
+    expect(mocks.redirectToEmailAccountPath).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(landing)/welcome-redirect/page.tsx
+++ b/apps/web/app/(landing)/welcome-redirect/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@/utils/auth";
 import prisma from "@/utils/prisma";
 import { redirectToEmailAccountPath } from "@/utils/account";
+import { isPremiumRecord, premiumEntitlementSelect } from "@/utils/premium";
 
 export default async function WelcomeRedirectPage(props: {
   searchParams: Promise<{ force?: boolean }>;
@@ -13,7 +14,10 @@ export default async function WelcomeRedirectPage(props: {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    select: { completedOnboardingAt: true },
+    select: {
+      completedOnboardingAt: true,
+      premiumId: true,
+    },
   });
 
   // Session exists but user doesn't - invalid state, log out
@@ -22,5 +26,17 @@ export default async function WelcomeRedirectPage(props: {
   if (user.completedOnboardingAt) {
     await redirectToEmailAccountPath("/automation");
   }
+
+  if (user.premiumId) {
+    const premium = await prisma.premium.findUnique({
+      where: { id: user.premiumId },
+      select: premiumEntitlementSelect,
+    });
+
+    if (isPremiumRecord(premium)) {
+      await redirectToEmailAccountPath("/setup");
+    }
+  }
+
   redirect("/onboarding");
 }


### PR DESCRIPTION
Mobile-first paid users can now enter the web app without repeating web onboarding. The compatibility check keeps the normal completed-user login path narrow and only reads the Premium row for incomplete users who have a premium record.

- Query only completedOnboardingAt and premiumId on the common welcome path
- Keep completed web users on the account-aware /automation redirect without loading Premium
- Send active incomplete premium users to /setup, avoiding the automation page no-rule onboarding redirect
- Preserve free, expired, and forced-onboarding behavior
- Add focused coverage for destinations and premium-query avoidance

Linear: https://linear.app/issue/INB-183