### PR TITLE
outlook: Preserve HTML signature structure

### DIFF
--- a/apps/web/utils/outlook/reply.test.ts
+++ b/apps/web/utils/outlook/reply.test.ts
@@ -83,6 +83,48 @@ describe("Outlook email formatting", () => {
     );
   });
 
+  it("preserves source newlines inside an HTML signature", () => {
+    const textContent = `Thanks for your email.
+
+<table cellspacing="0" cellpadding="0">
+  <tr>
+    <td>
+      <img src="https://example.com/logo.jpg" width="262" height="109" alt="Company logo" />
+    </td>
+    <td>
+      <div>Employee Name</div>
+      <div>Job Title</div>
+    </td>
+  </tr>
+</table>`;
+    const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {
+      headers: {
+        date: "Thu, 6 Feb 2025 23:23:47 +0200",
+        from: "John Doe <john@example.com>",
+        subject: "Test Email",
+        to: "jane@example.com",
+        "message-id": "<123@example.com>",
+      },
+      textPlain: "Original message content",
+      textHtml: "<div>Original message content</div>",
+    };
+
+    const { html } = createOutlookReplyContent({
+      textContent,
+      message,
+    });
+
+    expect(html).toContain(
+      'Thanks for your email.<br><br><table cellspacing="0" cellpadding="0">',
+    );
+    expect(html).toContain(
+      '<img src="https://example.com/logo.jpg" width="262" height="109" alt="Company logo">',
+    );
+    expect(html).not.toMatch(/<table[^>]*><br>/);
+    expect(html).not.toMatch(/<tr><br>/);
+    expect(html).not.toMatch(/<td><br>/);
+  });
+
   it("formats reply email correctly for RTL content with Outlook styling", () => {
     const textContent = "שלום, מה שלומך?"; // "Hello, how are you?" in Hebrew
     const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {

--- a/apps/web/utils/outlook/reply.test.ts
+++ b/apps/web/utils/outlook/reply.test.ts
@@ -125,6 +125,31 @@ describe("Outlook email formatting", () => {
     expect(html).not.toMatch(/<td><br>/);
   });
 
+  it("keeps escaped markup in text content escaped", () => {
+    const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {
+      headers: {
+        date: "Thu, 6 Feb 2025 23:23:47 +0200",
+        from: "John Doe <john@example.com>",
+        subject: "Test Email",
+        to: "jane@example.com",
+        "message-id": "<123@example.com>",
+      },
+      textPlain: "Original message content",
+      textHtml: "<div>Original message content</div>",
+    };
+
+    const { html } = createOutlookReplyContent({
+      textContent:
+        'Use &lt;script&gt;alert("unsafe")&lt;/script&gt;\nNext line',
+      message,
+    });
+
+    expect(html).toContain(
+      'Use &lt;script&gt;alert("unsafe")&lt;/script&gt;<br>Next line',
+    );
+    expect(html).not.toContain("<script>");
+  });
+
   it("formats reply email correctly for RTL content with Outlook styling", () => {
     const textContent = "שלום, מה שלומך?"; // "Hello, how are you?" in Hebrew
     const message: Pick<ParsedMessage, "headers" | "textPlain" | "textHtml"> = {

--- a/apps/web/utils/outlook/reply.ts
+++ b/apps/web/utils/outlook/reply.ts
@@ -76,7 +76,7 @@ function renderMixedContentAsHtml(content: string): string {
     .each((_index, node) => {
       if (node.type !== "text") return;
 
-      $(node).replaceWith(convertNewlinesToBr(node.data));
+      $(node).replaceWith(convertNewlinesToBr(escapeHtml(node.data)));
     });
 
   return $.root().html() ?? "";

--- a/apps/web/utils/outlook/reply.ts
+++ b/apps/web/utils/outlook/reply.ts
@@ -1,3 +1,4 @@
+import { load } from "cheerio";
 import type { ParsedMessage } from "@/utils/types";
 import {
   buildQuotedPlainText,
@@ -37,7 +38,7 @@ export const createOutlookReplyContent = ({
     (message.textPlain ? convertNewlinesToBr(message.textPlain) : "");
 
   const contentHtml =
-    htmlContent || (textContent ? convertNewlinesToBr(textContent) : "");
+    htmlContent || (textContent ? renderMixedContentAsHtml(textContent) : "");
 
   // Outlook-specific font styling with Aptos as default
   const outlookFontStyle =
@@ -65,6 +66,20 @@ function detectTextDirection(text: string): "ltr" | "rtl" {
   const rtlRegex =
     /[\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]/;
   return rtlRegex.test(text.trim().charAt(0)) ? "rtl" : "ltr";
+}
+
+function renderMixedContentAsHtml(content: string): string {
+  const $ = load(content, null, false);
+
+  $.root()
+    .contents()
+    .each((_index, node) => {
+      if (node.type !== "text") return;
+
+      $(node).replaceWith(convertNewlinesToBr(node.data));
+    });
+
+  return $.root().html() ?? "";
 }
 
 export function formatEmailDate(date: Date): string {


### PR DESCRIPTION
Prevent Outlook draft formatting from inserting line breaks inside structured HTML signatures.

- Convert newlines only in top-level reply text while preserving nested HTML markup.
- Add regression coverage for table-based signatures containing an image.
- Validate with the Outlook reply and mail unit-test suites.

Performance: Parses each Outlook reply fragment once in memory; adds no database or network calls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

