### PR TITLE
chat: Improve request failure handling

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getEmailAccount } from "@/__tests__/helpers";
+import { ASSISTANT_CHAT_MAX_TEXT_LENGTH } from "@/utils/actions/assistant-chat.validation";
 import prisma from "@/utils/__mocks__/prisma";
 
 const {
@@ -203,6 +204,20 @@ describe("chat route rule freshness persistence", () => {
       error: "Email account not found",
     });
     expect(mockGetInboxStatsForChatContext).not.toHaveBeenCalled();
+    expect(mockAiProcessAssistantChat).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe validation error for oversized messages", async () => {
+    const response = await POST(
+      createRequest("a".repeat(ASSISTANT_CHAT_MAX_TEXT_LENGTH + 1)),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Messages can be up to 20,000 characters.",
+    });
+    expect(prisma.chat.findUnique).not.toHaveBeenCalled();
+    expect(prisma.chatMessage.create).not.toHaveBeenCalled();
     expect(mockAiProcessAssistantChat).not.toHaveBeenCalled();
   });
 
@@ -437,7 +452,7 @@ describe("chat route rule freshness persistence", () => {
   });
 });
 
-function createRequest() {
+function createRequest(text = "Update my rules") {
   return new NextRequest("http://localhost/api/chat", {
     method: "POST",
     headers: {
@@ -448,7 +463,7 @@ function createRequest() {
       message: {
         id: "user-message-1",
         role: "user",
-        parts: [{ type: "text", text: "Update my rules" }],
+        parts: [{ type: "text", text }],
       },
     }),
   });

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -24,6 +24,7 @@ import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stat
 import { formatUtcDate } from "@/utils/date";
 import { mapUiMessagesToChatMessageRows } from "@/app/api/chat/chat-message-persistence";
 import {
+  ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE,
   type AssistantInput,
   assistantInputSchema,
 } from "@/utils/actions/assistant-chat.validation";
@@ -58,7 +59,40 @@ export const POST = withEmailAccount("chat", async (request) => {
   const json = await request.json();
   const { data, error } = assistantInputSchema.safeParse(json);
 
-  if (error) return NextResponse.json({ error: error.issues }, { status: 400 });
+  if (error) {
+    const requestMetadata = getInvalidChatRequestMetadata(json);
+    const messageTooLong = error.issues.some(
+      (issue) =>
+        issue.code === "too_big" &&
+        issue.path.length === 4 &&
+        issue.path[0] === "message" &&
+        issue.path[1] === "parts" &&
+        typeof issue.path[2] === "number" &&
+        issue.path[3] === "text",
+    );
+
+    request.logger.warn("Assistant chat request rejected", {
+      ...requestMetadata,
+      failureCategory: messageTooLong ? "message_too_long" : "validation_error",
+      statusCode: 400,
+      validationIssueCodes: [
+        ...new Set(error.issues.map((issue) => issue.code)),
+      ],
+    });
+    await flushLoggerSafely(request.logger, {
+      action: "assistant-chat",
+      flushReason: "chat-validation-error",
+    });
+
+    return NextResponse.json(
+      {
+        error: messageTooLong
+          ? ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE
+          : "Invalid chat message.",
+      },
+      { status: 400 },
+    );
+  }
 
   const chat =
     (await getChatWithCompactions(data.id)) ||
@@ -442,5 +476,37 @@ function getToolCallIdsFromUiParts(parts: UIMessage["parts"] | undefined) {
   return (
     parts?.flatMap((part) => ("toolCallId" in part ? [part.toolCallId] : [])) ||
     []
+  );
+}
+
+function getInvalidChatRequestMetadata(value: unknown) {
+  if (!value || typeof value !== "object") {
+    return { attachmentCount: 0, textLength: 0 };
+  }
+
+  const message = (value as Record<string, unknown>).message;
+  if (!message || typeof message !== "object") {
+    return { attachmentCount: 0, textLength: 0 };
+  }
+
+  const parts = (message as Record<string, unknown>).parts;
+  if (!Array.isArray(parts)) {
+    return { attachmentCount: 0, textLength: 0 };
+  }
+
+  return parts.reduce(
+    (metadata, part) => {
+      if (!part || typeof part !== "object") return metadata;
+
+      const candidate = part as Record<string, unknown>;
+      if (candidate.type === "text" && typeof candidate.text === "string") {
+        metadata.textLength += candidate.text.length;
+      } else if (candidate.type === "file") {
+        metadata.attachmentCount += 1;
+      }
+
+      return metadata;
+    },
+    { attachmentCount: 0, textLength: 0 },
   );
 }

--- a/apps/web/components/assistant-chat/chat.tsx
+++ b/apps/web/components/assistant-chat/chat.tsx
@@ -191,7 +191,7 @@ export function Chat({
     <PromptInput
       onSubmit={(e) => {
         e.preventDefault();
-        if (hasContent && status === "ready") {
+        if (hasContent && (status === "ready" || status === "error")) {
           analytics.captureAction("chat_message_submitted", {
             has_text: input.trim().length > 0,
             attachment_count: attachments.length,
@@ -199,7 +199,6 @@ export function Chat({
             message_count: messages.length,
           });
           handleSubmit();
-          setLocalStorageInput("");
         }
       }}
       className="relative divide-y-0 rounded-2xl"
@@ -273,7 +272,9 @@ export function Chat({
                 ? "submitted"
                 : "ready"
           }
-          disabled={status === "ready" ? !hasContent : status === "error"}
+          disabled={
+            status === "ready" || status === "error" ? !hasContent : false
+          }
           className="h-9 w-9 rounded-full bg-blue-500 text-white hover:bg-blue-600"
           onClick={(e) => {
             if (status === "streaming" || status === "submitted") {

--- a/apps/web/providers/ChatProvider.test.tsx
+++ b/apps/web/providers/ChatProvider.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ASSISTANT_CHAT_MAX_TEXT_LENGTH } from "@/utils/actions/assistant-chat.validation";
 import { ChatProvider, useChat } from "./ChatProvider";
 
 const {
+  mockClientLoggerError,
+  mockClientLoggerFlush,
+  mockClientLoggerWarn,
   mockSetMessages,
   mockSetQueryState,
+  mockSendMessage,
+  mockToastError,
   mockUseChatMessages,
   mockUseSWRConfig,
   mockConvertToUIMessages,
@@ -15,8 +21,13 @@ const {
   accountState,
   queryState,
 } = vi.hoisted(() => ({
+  mockClientLoggerError: vi.fn(),
+  mockClientLoggerFlush: vi.fn(),
+  mockClientLoggerWarn: vi.fn(),
   mockSetMessages: vi.fn(),
   mockSetQueryState: vi.fn(),
+  mockSendMessage: vi.fn(),
+  mockToastError: vi.fn(),
   mockUseChatMessages: vi.fn(),
   mockUseSWRConfig: vi.fn(),
   mockConvertToUIMessages: vi.fn(),
@@ -30,12 +41,16 @@ const {
 }));
 
 vi.mock("@ai-sdk/react", () => ({
-  useChat: () => ({
+  useChat: (options: { onError?: (error: Error) => void }) => ({
     id: "new-chat-id",
     messages: [],
     status: "ready",
     setMessages: mockSetMessages,
-    sendMessage: vi.fn(),
+    sendMessage: (...args: unknown[]) =>
+      mockSendMessage(...args).catch((error) => {
+        options.onError?.(error);
+        throw error;
+      }),
     stop: vi.fn(),
     regenerate: vi.fn(),
   }),
@@ -88,7 +103,19 @@ vi.mock("@/utils/error", () => ({
   captureException: mockCaptureException,
 }));
 
-describe("ChatProvider account changes", () => {
+vi.mock("@/components/Toast", () => ({
+  toastError: mockToastError,
+}));
+
+vi.mock("@/utils/logger-client", () => ({
+  createClientLogger: () => ({
+    error: mockClientLoggerError,
+    flush: mockClientLoggerFlush,
+    warn: mockClientLoggerWarn,
+  }),
+}));
+
+describe("ChatProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -117,6 +144,8 @@ describe("ChatProvider account changes", () => {
         parts: [{ type: "text", text: "Old chat" }],
       },
     ]);
+    mockClientLoggerFlush.mockResolvedValue(undefined);
+    mockSendMessage.mockResolvedValue(undefined);
   });
 
   it("clears the active chat when the selected email account changes", async () => {
@@ -145,6 +174,93 @@ describe("ChatProvider account changes", () => {
     });
     expect(mockSetQueryState).toHaveBeenCalledWith(null);
     expect(mockSetMessages).toHaveBeenLastCalledWith([]);
+  });
+
+  it("retains the draft and records safe metadata when sending fails", async () => {
+    const draft = "Keep this draft if the request fails";
+    const error = new Error("Network request failed");
+    mockSendMessage.mockRejectedValueOnce(error);
+
+    let latestContext: ReturnType<typeof useChat> | undefined;
+
+    function Consumer() {
+      latestContext = useChat();
+      return null;
+    }
+
+    renderWithProvider(<Consumer />);
+
+    act(() => {
+      latestContext?.setInput(draft);
+    });
+    await waitFor(() => {
+      expect(latestContext?.input).toBe(draft);
+    });
+
+    act(() => {
+      latestContext?.handleSubmit();
+    });
+
+    await waitFor(() => {
+      expect(latestContext?.input).toBe(draft);
+    });
+    expect(mockClientLoggerError).toHaveBeenCalledWith(
+      "Assistant chat request failed",
+      expect.objectContaining({
+        attachmentCount: 0,
+        emailAccountId: "account-a",
+        failureCategory: "request_error",
+        textLength: draft.length,
+      }),
+    );
+    expect(JSON.stringify(mockClientLoggerError.mock.calls)).not.toContain(
+      draft,
+    );
+    expect(mockToastError).toHaveBeenCalledWith({
+      description: "We couldn't send your message. Please try again.",
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it("rejects oversized drafts before sending and keeps their content", async () => {
+    const draft = "a".repeat(ASSISTANT_CHAT_MAX_TEXT_LENGTH + 1);
+    let latestContext: ReturnType<typeof useChat> | undefined;
+
+    function Consumer() {
+      latestContext = useChat();
+      return null;
+    }
+
+    renderWithProvider(<Consumer />);
+
+    act(() => {
+      latestContext?.setInput(draft);
+    });
+    await waitFor(() => {
+      expect(latestContext?.input).toBe(draft);
+    });
+
+    act(() => {
+      latestContext?.handleSubmit();
+    });
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(latestContext?.input).toBe(draft);
+    expect(mockToastError).toHaveBeenCalledWith({
+      description: "Messages can be up to 20,000 characters.",
+    });
+    expect(mockClientLoggerWarn).toHaveBeenCalledWith(
+      "Assistant chat input rejected",
+      expect.objectContaining({
+        emailAccountId: "account-a",
+        failureCategory: "message_too_long",
+        maxTextLength: ASSISTANT_CHAT_MAX_TEXT_LENGTH,
+        textLength: draft.length,
+      }),
+    );
+    expect(JSON.stringify(mockClientLoggerWarn.mock.calls)).not.toContain(
+      draft,
+    );
   });
 });
 

--- a/apps/web/providers/ChatProvider.tsx
+++ b/apps/web/providers/ChatProvider.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import { useSWRConfig } from "swr";
 import { captureException } from "@/utils/error";
+import { toastError } from "@/components/Toast";
 import { convertToUIMessages } from "@/components/assistant-chat/helpers";
 import type { ChatMessage } from "@/components/assistant-chat/types";
 import { useChatMessages } from "@/hooks/useChatMessages";
@@ -26,6 +27,13 @@ import {
   type InlineEmailAction,
   type InlineEmailActionType,
 } from "@/utils/ai/assistant/inline-email-actions";
+import {
+  ASSISTANT_CHAT_MAX_TEXT_LENGTH,
+  ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE,
+} from "@/utils/actions/assistant-chat.validation";
+import { createClientLogger } from "@/utils/logger-client";
+
+const logger = createClientLogger("assistant-chat");
 
 export type Attachment = {
   id: string;
@@ -35,6 +43,16 @@ export type Attachment = {
 };
 
 export type Chat = ReturnType<typeof useAiChat<ChatMessage>>;
+
+type ChatMessagePart =
+  | { type: "file"; url: string; filename: string; mediaType: string }
+  | { type: "text"; text: string };
+
+type PendingChatRequest = {
+  attachmentCount: number;
+  chatId: string;
+  textLength: number;
+};
 
 type ChatContextType = {
   chat: Chat;
@@ -65,6 +83,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [inlineActions, setInlineActions] = useState<InlineEmailAction[]>([]);
   const inlineActionsRef = useRef(inlineActions);
   const pendingInlineActionsRef = useRef<InlineEmailAction[] | null>(null);
+  const pendingRequestRef = useRef<PendingChatRequest | null>(null);
   const previousChatIdRef = useRef(chatId);
   const previousEmailAccountIdRef = useRef<string | null>(null);
 
@@ -111,12 +130,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     generateId: generateUUID,
     onFinish: async () => {
       pendingInlineActionsRef.current = null;
+      pendingRequestRef.current = null;
       await Promise.all([
         mutate("/api/user/rules"),
         chatId ? mutate(`/api/chats/${chatId}`) : Promise.resolve(),
       ]);
     },
     onError: (error) => {
+      const pendingRequest = pendingRequestRef.current;
       const pendingInlineActions = pendingInlineActionsRef.current;
       if (pendingInlineActions?.length) {
         setInlineActions((current) =>
@@ -128,8 +149,13 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         pendingInlineActionsRef.current = null;
       }
 
-      console.error(error);
-      captureException(error);
+      reportChatRequestError({
+        emailAccountId,
+        error,
+        fallbackChatId: chatId ?? chat.id,
+        request: pendingRequest,
+      });
+      pendingRequestRef.current = null;
     },
   });
 
@@ -146,6 +172,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
     previousChatIdRef.current = chatId;
     pendingInlineActionsRef.current = null;
+    pendingRequestRef.current = null;
     setInlineActions([]);
   }, [chatId]);
 
@@ -161,6 +188,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
     previousEmailAccountIdRef.current = emailAccountId;
     pendingInlineActionsRef.current = null;
+    pendingRequestRef.current = null;
     setChatId(null);
     chat.setMessages([]);
     setInput("");
@@ -170,14 +198,34 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   }, [chat.setMessages, emailAccountId, setChatId]);
 
   const sendMessageParts = useCallback(
-    async (
-      parts: Array<
-        | { type: "file"; url: string; filename: string; mediaType: string }
-        | { type: "text"; text: string }
-      >,
-    ) => {
+    (parts: ChatMessagePart[]) => {
+      const textLength = getChatTextLength(parts);
+      const attachmentCount = parts.filter(
+        (part) => part.type === "file",
+      ).length;
+
+      if (textLength > ASSISTANT_CHAT_MAX_TEXT_LENGTH) {
+        logger.warn("Assistant chat input rejected", {
+          attachmentCount,
+          chatId: chatId ?? chat.id,
+          emailAccountId,
+          failureCategory: "message_too_long",
+          maxTextLength: ASSISTANT_CHAT_MAX_TEXT_LENGTH,
+          statusCode: null,
+          textLength,
+        });
+        logger.flush().catch(() => undefined);
+        toastError({ description: ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE });
+        throw new ChatInputValidationError();
+      }
+
       if (!chatId) setChatId(chat.id);
 
+      pendingRequestRef.current = {
+        attachmentCount,
+        chatId: chatId ?? chat.id,
+        textLength,
+      };
       pendingInlineActionsRef.current = inlineActionsRef.current.length
         ? inlineActionsRef.current
         : null;
@@ -186,9 +234,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         setInlineActions([]);
       }
 
-      await chat.sendMessage({ role: "user", parts });
+      return chat.sendMessage({ role: "user", parts });
     },
-    [chat.id, chat.sendMessage, chatId, setChatId],
+    [chat.id, chat.sendMessage, chatId, emailAccountId, setChatId],
   );
 
   const submitTextMessage = useCallback(
@@ -205,6 +253,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const handleSubmit = useCallback(() => {
     const text = input.trim();
     if (!text && attachments.length === 0) return;
+    const submittedInput = input;
+    const submittedAttachments = attachments;
 
     const fileParts = attachments.map((attachment) => ({
       type: "file" as const,
@@ -213,19 +263,38 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       mediaType: attachment.contentType,
     }));
 
-    const parts: Array<
-      | { type: "file"; url: string; filename: string; mediaType: string }
-      | { type: "text"; text: string }
-    > = [...fileParts];
+    const parts: ChatMessagePart[] = [...fileParts];
 
     if (text) {
       parts.push({ type: "text", text });
     }
 
-    sendMessageParts(parts).catch(captureException);
+    let sendPromise: Promise<void>;
+    try {
+      sendPromise = sendMessageParts(parts);
+    } catch (error) {
+      if (!(error instanceof ChatInputValidationError)) {
+        reportChatRequestError({
+          emailAccountId,
+          error,
+          fallbackChatId: chatId ?? chat.id,
+          request: pendingRequestRef.current,
+        });
+      }
+      return;
+    }
+
     setAttachments([]);
     setInput("");
-  }, [attachments, input, sendMessageParts]);
+    sendPromise.catch(() => {
+      setInput((current) =>
+        current ? `${submittedInput}\n\n${current}` : submittedInput,
+      );
+      setAttachments((current) =>
+        mergeAttachments(submittedAttachments, current),
+      );
+    });
+  }, [attachments, chat.id, chatId, emailAccountId, input, sendMessageParts]);
 
   return (
     <ChatContext.Provider
@@ -267,4 +336,64 @@ function generateUUID(): string {
     const v = c === "x" ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
+}
+
+function getChatTextLength(parts: ChatMessagePart[]) {
+  return parts.reduce(
+    (length, part) => length + (part.type === "text" ? part.text.length : 0),
+    0,
+  );
+}
+
+function mergeAttachments(
+  submitted: Attachment[],
+  current: Attachment[],
+): Attachment[] {
+  const currentIds = new Set(current.map((attachment) => attachment.id));
+  return [
+    ...submitted.filter((attachment) => !currentIds.has(attachment.id)),
+    ...current,
+  ];
+}
+
+class ChatInputValidationError extends Error {
+  constructor() {
+    super(ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE);
+    this.name = "ChatInputValidationError";
+  }
+}
+
+function reportChatRequestError({
+  emailAccountId,
+  error,
+  fallbackChatId,
+  request,
+}: {
+  emailAccountId: string;
+  error: unknown;
+  fallbackChatId: string;
+  request: PendingChatRequest | null;
+}) {
+  logger.error("Assistant chat request failed", {
+    attachmentCount: request?.attachmentCount ?? 0,
+    chatId: request?.chatId ?? fallbackChatId,
+    emailAccountId,
+    errorName: error instanceof Error ? error.name : "UnknownError",
+    failureCategory: "request_error",
+    statusCode: getErrorStatusCode(error),
+    textLength: request?.textLength ?? 0,
+  });
+  logger.flush().catch(() => undefined);
+  toastError({
+    description: "We couldn't send your message. Please try again.",
+  });
+  console.error(error);
+  captureException(error);
+}
+
+function getErrorStatusCode(error: unknown) {
+  if (!error || typeof error !== "object") return null;
+
+  const statusCode = (error as Record<string, unknown>).statusCode;
+  return typeof statusCode === "number" ? statusCode : null;
 }

--- a/apps/web/utils/actions/assistant-chat.validation.test.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { assistantInputSchema } from "./assistant-chat.validation";
+import {
+  ASSISTANT_CHAT_MAX_TEXT_LENGTH,
+  assistantInputSchema,
+} from "./assistant-chat.validation";
 
 describe("assistantInputSchema", () => {
   it("rejects blank chat and message ids", () => {
@@ -20,4 +23,40 @@ describe("assistantInputSchema", () => {
       ]),
     );
   });
+
+  it("accepts large messages up to the chat text limit", () => {
+    const result = assistantInputSchema.safeParse(
+      createInput("a".repeat(ASSISTANT_CHAT_MAX_TEXT_LENGTH)),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects messages above the chat text limit", () => {
+    const result = assistantInputSchema.safeParse(
+      createInput("a".repeat(ASSISTANT_CHAT_MAX_TEXT_LENGTH + 1)),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "too_big",
+          maximum: ASSISTANT_CHAT_MAX_TEXT_LENGTH,
+          path: ["message", "parts", 0, "text"],
+        }),
+      ]),
+    );
+  });
 });
+
+function createInput(text: string) {
+  return {
+    id: "chat-1",
+    message: {
+      id: "message-1",
+      role: "user",
+      parts: [{ type: "text", text }],
+    },
+  };
+}

--- a/apps/web/utils/actions/assistant-chat.validation.ts
+++ b/apps/web/utils/actions/assistant-chat.validation.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import { messageContextSchema } from "@/utils/ai/assistant/chat-context-validation";
 import { inlineEmailActionSchema } from "@/utils/ai/assistant/inline-email-actions";
 
+export const ASSISTANT_CHAT_MAX_TEXT_LENGTH = 20_000;
+export const ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE =
+  "Messages can be up to 20,000 characters.";
+
 export const assistantPendingEmailActionTypeSchema = z.enum([
   "send_email",
   "reply_email",
@@ -166,7 +170,7 @@ export type ConfirmAssistantSaveMemoryBody = z.infer<
 
 const assistantChatTextPartSchema = z.object({
   type: z.literal("text"),
-  text: z.string().min(1).max(3000),
+  text: z.string().min(1).max(ASSISTANT_CHAT_MAX_TEXT_LENGTH),
 });
 
 const assistantChatFilePartSchema = z.object({


### PR DESCRIPTION
Improves chat reliability for long or failed requests while preserving user drafts.

- Raises the message limit and adds consistent client/server validation feedback.
- Restores drafts and attachments after failed sends and enables retries.
- Adds privacy-safe request-failure metadata and focused regression coverage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

