### PR TITLE
document filing: Parse attachment disposition exactly

### DIFF
--- a/apps/web/utils/drive/filing-engine.test.ts
+++ b/apps/web/utils/drive/filing-engine.test.ts
@@ -568,6 +568,29 @@ describe("getFilableAttachments", () => {
     expect(getFilableAttachments(message)).toEqual([documentAttachment]);
   });
 
+  it("keeps attachments when inline appears only in a disposition parameter", () => {
+    const documentAttachment = {
+      ...createAttachment({
+        attachmentId: "attachment-1",
+        filename: "inline-report.pdf",
+        mimeType: "application/pdf",
+      }),
+      headers: {
+        "content-description": "",
+        "content-disposition": 'attachment; filename="inline-report.pdf"',
+        "content-id": "",
+        "content-transfer-encoding": "base64",
+        "content-type": 'application/pdf; name="inline-report.pdf"',
+      },
+    };
+
+    const message = getMockParsedMessage({
+      attachments: [documentAttachment],
+    });
+
+    expect(getFilableAttachments(message)).toEqual([documentAttachment]);
+  });
+
   it("excludes calendar invite attachments", () => {
     const documentAttachment = createAttachment({
       attachmentId: "attachment-1",

--- a/apps/web/utils/drive/filing-engine.ts
+++ b/apps/web/utils/drive/filing-engine.ts
@@ -392,11 +392,13 @@ export async function processAttachment({
  */
 export function getFilableAttachments(message: ParsedMessage): Attachment[] {
   return (message.attachments || []).filter((attachment) => {
-    const contentDisposition =
-      attachment.headers?.["content-disposition"]?.toLowerCase();
+    const contentDispositionType = attachment.headers?.["content-disposition"]
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
 
     return (
-      !contentDisposition?.includes("inline") &&
+      contentDispositionType !== "inline" &&
       !isCalendarInviteAttachment(attachment)
     );
   });


### PR DESCRIPTION
Refines inline attachment detection so disposition parameters do not affect attachment classification.

- compare only the normalized disposition type
- preserve regular attachments regardless of filename parameters
- add regression coverage for the parameter edge case

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

