### PR TITLE
onboarding: ship inline unsubscribe step to everyone

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/onboarding/StepBulkUnsubscribe.tsx
@@ -25,7 +25,6 @@ import type {
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { usePremium } from "@/hooks/usePremium";
 import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
-import { useOnboardingBulkUnsubscribeVariant } from "@/hooks/useFeatureFlags";
 import { extractDomainFromEmail } from "@/utils/email";
 import { createSearchParams } from "@/utils/url";
 
@@ -38,12 +37,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
   const posthog = usePostHog();
   const { hasUnsubscribeAccess, mutate: refetchPremium } = usePremium();
   const { PremiumModal, openModal } = usePremiumModal();
-
-  // A/B test: "inline-unsubscribe" shows the personalized, actionable list;
-  // "control" keeps the static marketing slide. Reading the variant is the
-  // experiment exposure.
-  const variant = useOnboardingBulkUnsubscribeVariant();
-  const isTreatment = variant === "inline-unsubscribe";
 
   // Day-boundary date range keeps the SWR key stable across mounts, so
   // revisiting this step (back/forward) reuses the cached result.
@@ -61,8 +54,7 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
   };
   const urlParams = createSearchParams(params);
   const { data, isLoading, mutate } = useSWR<NewsletterStatsResponse>(
-    // Only fetch in the treatment arm; control never renders the list.
-    isTreatment && emailAccountId
+    emailAccountId
       ? [`/api/user/stats/newsletters?${urlParams}`, emailAccountId]
       : null,
     {
@@ -110,15 +102,14 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
     (item) => !deselected.has(item.name),
   );
 
-  // Record (once) when the treatment user is actually shown the suggestion
-  // list, so we can measure how often the data was ready in time.
+  // Record (once) when the user is actually shown the suggestion list, so we
+  // can measure how often the data was ready in time.
   const suggestionsShownRef = useRef(false);
   useEffect(() => {
-    if (!isTreatment || suggestionsShownRef.current) return;
+    if (suggestionsShownRef.current) return;
     if (!previewSenders.length) return;
     suggestionsShownRef.current = true;
     posthog?.capture("onboarding_unsubscribe_suggestions_shown", {
-      variant,
       shownCount: previewSenders.length,
       totalSuggestions: suggestions.length,
       lowReadSuggestionCount: lowReadSuggestions.length,
@@ -128,17 +119,13 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
         lowReadSuggestions.length - lowReadSuggestionsWithAutomaticUnsubscribe,
     });
   }, [
-    isTreatment,
     previewSenders.length,
     suggestions.length,
     lowReadSuggestions.length,
     lowReadSuggestionsWithAutomaticUnsubscribe,
-    variant,
     posthog,
   ]);
 
-  // Control arm (and PostHog-unavailable fallback) keeps the static slide.
-  if (!isTreatment) return <StaticBulkUnsubscribeStep onNext={onNext} />;
   if (!emailAccountId) return null;
 
   // Don't render the static content while the fetch is in flight, or the
@@ -163,7 +150,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
 
   const onSkip = () => {
     posthog?.capture("onboarding_unsubscribe_skipped", {
-      variant,
       selectedCount: selectedSenders.length,
       totalSuggestions: suggestions.length,
     });
@@ -177,7 +163,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
     }
 
     posthog?.capture("onboarding_unsubscribe_cta_clicked", {
-      variant,
       selectedCount: selectedSenders.length,
       totalSuggestions: suggestions.length,
       hasUnsubscribeAccess,
@@ -185,7 +170,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
 
     if (!hasUnsubscribeAccess) {
       posthog?.capture("onboarding_unsubscribe_upgrade_prompt_shown", {
-        variant,
         selectedCount: selectedSenders.length,
         totalSuggestions: suggestions.length,
       });
@@ -194,7 +178,6 @@ export function StepBulkUnsubscribe({ onNext }: { onNext: () => void }) {
     }
 
     posthog?.capture("onboarding_unsubscribe_clicked", {
-      variant,
       count: selectedSenders.length,
       totalSuggestions: suggestions.length,
     });

--- a/apps/web/hooks/useFeatureFlags.ts
+++ b/apps/web/hooks/useFeatureFlags.ts
@@ -86,18 +86,3 @@ export function useWelcomePricingVariant() {
     ) as WelcomePricingVariant) || "control"
   );
 }
-
-export type OnboardingBulkUnsubscribeVariant = "control" | "inline-unsubscribe";
-
-// A/B test for the onboarding bulk-unsubscribe step: "control" shows the
-// static marketing slide, "inline-unsubscribe" shows the personalized,
-// actionable list. Reading the flag here is the experiment exposure
-// ($feature_flag_called). Defaults to control until the flag resolves and when
-// PostHog is unavailable (e.g. self-hosted), preserving the existing step.
-export function useOnboardingBulkUnsubscribeVariant() {
-  return (
-    (useFeatureFlagVariantKey(
-      "onboarding-bulk-unsubscribe",
-    ) as OnboardingBulkUnsubscribeVariant) || "control"
-  );
-}


### PR DESCRIPTION
Removes the onboarding bulk-unsubscribe feature flag and its control arm so there is a single variant in the codebase.

- Delete `useOnboardingBulkUnsubscribeVariant` and the `onboarding-bulk-unsubscribe` flag read
- Always fetch newsletter suggestions and render the personalized sender list
- Drop the `variant` property from the step's PostHog events
- Keep the static slide as the fallback when there are no suggestions to show

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

