### PR TITLE
assistant: allow re-processing past emails on the top tier

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.test.ts
@@ -68,4 +68,91 @@ describe("onRun", () => {
     expect(fetchWithAccount).toHaveBeenCalledTimes(101);
     expect(runAiRules).toHaveBeenCalledTimes(101);
   });
+
+  it("skips already processed threads by default", async () => {
+    mockSinglePageResponse();
+    const onComplete = vi.fn();
+
+    await onRun(
+      "account-id",
+      { startDate: new Date("2026-01-01T00:00:00.000Z") },
+      vi.fn(),
+      onComplete,
+    );
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith("success", 1);
+    });
+    expect(runAiRules).toHaveBeenCalledWith(
+      "account-id",
+      [expect.objectContaining({ id: "unprocessed-thread" })],
+      false,
+    );
+  });
+
+  it("includes already processed threads when rerunning", async () => {
+    mockSinglePageResponse();
+    const onComplete = vi.fn();
+
+    await onRun(
+      "account-id",
+      { startDate: new Date("2026-01-01T00:00:00.000Z"), rerun: true },
+      vi.fn(),
+      onComplete,
+    );
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith("success", 2);
+    });
+    expect(runAiRules).toHaveBeenCalledWith(
+      "account-id",
+      [
+        expect.objectContaining({ id: "processed-thread" }),
+        expect.objectContaining({ id: "unprocessed-thread" }),
+      ],
+      true,
+    );
+  });
+
+  it("still respects maxEmails when rerunning", async () => {
+    mockSinglePageResponse();
+    const onComplete = vi.fn();
+
+    await onRun(
+      "account-id",
+      {
+        startDate: new Date("2026-01-01T00:00:00.000Z"),
+        rerun: true,
+        maxEmails: 1,
+      },
+      vi.fn(),
+      onComplete,
+    );
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith("success", 1);
+    });
+    expect(runAiRules).toHaveBeenCalledWith(
+      "account-id",
+      [expect.objectContaining({ id: "processed-thread" })],
+      true,
+    );
+  });
 });
+
+function mockSinglePageResponse() {
+  vi.mocked(fetchWithAccount).mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      threads: [
+        {
+          id: "processed-thread",
+          messages: [{ id: "message-1" }],
+          plan: { id: "executed-rule-id" },
+        },
+        { id: "unprocessed-thread", messages: [{ id: "message-2" }] },
+      ],
+      nextPageToken: undefined,
+    }),
+  } as Response);
+}

--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -26,7 +26,13 @@ import {
 } from "@/components/ui/dialog";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import { Toggle } from "@/components/Toggle";
+import { Badge } from "@/components/ui/badge";
 import { hasTierAccess } from "@/utils/premium";
+import {
+  RERUN_MINIMUM_TIER,
+  RERUN_UPGRADE_MESSAGE,
+} from "@/utils/premium/rerun";
+import { usePremiumModal } from "@/app/(app)/premium/PremiumModal";
 import { BulkProcessActivityLog } from "@/app/(app)/[emailAccountId]/assistant/BulkProcessActivityLog";
 import {
   bulkRunReducer,
@@ -58,11 +64,16 @@ export function BulkRunRules() {
     tier: tier || null,
     minimumTier: "PROFESSIONAL_MONTHLY",
   });
+  const hasRerunAccess = hasTierAccess({
+    tier: tier || null,
+    minimumTier: RERUN_MINIMUM_TIER,
+  });
   const isTrial = premium?.stripeSubscriptionStatus === "trialing";
 
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [includeRead, setIncludeRead] = useState(false);
+  const [rerun, setRerun] = useState(false);
 
   const abortRef = useRef<() => void>(undefined);
 
@@ -104,6 +115,7 @@ export function BulkRunRules() {
           startDate,
           endDate,
           includeRead,
+          rerun: rerun && hasRerunAccess,
           maxEmails: isTrial ? TRIAL_BULK_PROCESS_EMAIL_LIMIT : undefined,
         },
         (threads) => {
@@ -154,8 +166,7 @@ export function BulkRunRules() {
           <DialogHeader>
             <DialogTitle>Bulk Process Emails</DialogTitle>
             <DialogDescription>
-              Run your rules on emails in your inbox that haven't been handled
-              yet.
+              Run your rules on emails already in your inbox.
             </DialogDescription>
           </DialogHeader>
           {progressMessage && (
@@ -202,6 +213,21 @@ export function BulkRunRules() {
                     : undefined
                 }
               />
+
+              <div className="flex items-center gap-2">
+                <Toggle
+                  name="rerun"
+                  label="Re-process emails already handled"
+                  enabled={rerun && hasRerunAccess}
+                  onChange={(enabled) => setRerun(enabled)}
+                  disabled={isProcessing || !hasRerunAccess}
+                  disabledTooltipText={
+                    hasRerunAccess ? undefined : RERUN_UPGRADE_MESSAGE
+                  }
+                  tooltipText="Runs your rules again on emails that already have a result. Use this after changing your rules."
+                />
+                {!hasRerunAccess && <ProfessionalPlanBadge />}
+              </div>
 
               {isTrial && (
                 <div className="flex flex-col gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200 sm:flex-row sm:items-center sm:justify-between">
@@ -270,7 +296,7 @@ export function BulkRunRules() {
 
               {state.runResult && state.runResult.count === 0 && (
                 <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
-                  No {includeRead ? "" : "unread, "}unprocessed emails found in
+                  No {describeTargetedEmails({ includeRead, rerun })} found in
                   the selected date range.
                 </div>
               )}
@@ -280,4 +306,34 @@ export function BulkRunRules() {
       </Dialog>
     </div>
   );
+}
+
+function ProfessionalPlanBadge() {
+  const { PremiumModal, openModal } = usePremiumModal();
+
+  return (
+    <>
+      <button type="button" onClick={openModal} aria-label="Upgrade plan">
+        <Badge variant="secondary" className="cursor-pointer hover:opacity-80">
+          Professional
+        </Badge>
+      </button>
+      <PremiumModal />
+    </>
+  );
+}
+
+function describeTargetedEmails({
+  includeRead,
+  rerun,
+}: {
+  includeRead: boolean;
+  rerun: boolean;
+}) {
+  const qualifiers = [
+    includeRead ? null : "unread",
+    rerun ? null : "unprocessed",
+  ].filter(Boolean);
+
+  return qualifiers.length ? `${qualifiers.join(", ")} emails` : "emails";
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/ProcessRules.tsx
@@ -41,6 +41,13 @@ import {
 } from "@/utils/ai/choose-rule/selection-metadata-summary";
 import { useRules } from "@/hooks/useRules";
 import { useInfiniteMessages } from "@/hooks/useMessages";
+import { usePremium } from "@/hooks/usePremium";
+import { hasTierAccess } from "@/utils/premium";
+import {
+  RERUN_MINIMUM_TIER,
+  RERUN_UPGRADE_MESSAGE,
+} from "@/utils/premium/rerun";
+import { Tooltip } from "@/components/Tooltip";
 
 type Message = MessagesResponse["messages"][number];
 
@@ -79,6 +86,13 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
 
   const { data: rules } = useRules();
   const { emailAccountId, userEmail } = useAccount();
+  const { tier } = usePremium();
+
+  // Re-applying rules costs a fresh LLM call, so it's gated. Re-testing isn't:
+  // test runs never overwrite a stored result.
+  const canRerun =
+    testMode ||
+    hasTierAccess({ tier: tier || null, minimumTier: RERUN_MINIMUM_TIER });
 
   // Fetch existing executed rules for current messages
   const messageIdsToFetch = useMemo(
@@ -311,6 +325,7 @@ export function ProcessRulesContent({ testMode }: { testMode: boolean }) {
                     results={allResults[message.id]}
                     onRun={(rerun) => onRun(message, rerun)}
                     testMode={testMode}
+                    canRerun={canRerun}
                     setInput={setInput}
                   />
                 ))}
@@ -388,6 +403,7 @@ function ProcessRulesRow({
   results,
   onRun,
   testMode,
+  canRerun,
   setInput,
 }: {
   message: Message;
@@ -396,6 +412,7 @@ function ProcessRulesRow({
   results: RunRulesResult[];
   onRun: (rerun?: boolean) => void;
   testMode: boolean;
+  canRerun: boolean;
   setInput: (input: string) => void;
 }) {
   return (
@@ -428,17 +445,12 @@ function ProcessRulesRow({
                   message={message}
                   results={results}
                 />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={isRunning}
-                  onClick={() => onRun(true)}
-                >
-                  <RefreshCcwIcon
-                    className={cn("mr-2 size-4", isRunning && "animate-spin")}
-                  />
-                  <span>{testMode ? "Retest" : "Rerun"}</span>
-                </Button>
+                <RerunButton
+                  isRunning={isRunning}
+                  canRerun={canRerun}
+                  testMode={testMode}
+                  onRun={onRun}
+                />
               </>
             ) : (
               <Button
@@ -455,5 +467,39 @@ function ProcessRulesRow({
         </div>
       </TableCell>
     </TableRow>
+  );
+}
+
+function RerunButton({
+  isRunning,
+  canRerun,
+  testMode,
+  onRun,
+}: {
+  isRunning: boolean;
+  canRerun: boolean;
+  testMode: boolean;
+  onRun: (rerun?: boolean) => void;
+}) {
+  const button = (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={isRunning || !canRerun}
+      onClick={() => onRun(true)}
+    >
+      <RefreshCcwIcon
+        className={cn("mr-2 size-4", isRunning && "animate-spin")}
+      />
+      <span>{testMode ? "Retest" : "Rerun"}</span>
+    </Button>
+  );
+
+  if (canRerun) return button;
+
+  return (
+    <Tooltip content={RERUN_UPGRADE_MESSAGE}>
+      <span className="inline-flex cursor-not-allowed">{button}</span>
+    </Tooltip>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/bulk-run.ts
@@ -15,11 +15,13 @@ export async function onRun(
     startDate,
     endDate,
     includeRead,
+    rerun,
     maxEmails,
   }: {
     startDate: Date;
     endDate?: Date;
     includeRead?: boolean;
+    rerun?: boolean;
     maxEmails?: number;
   },
   onThreadsQueued: (threads: ThreadsResponse["threads"]) => void,
@@ -92,21 +94,23 @@ export async function onRun(
 
       nextPageToken = data.nextPageToken || "";
 
-      const threadsWithoutPlan = data.threads.filter((thread) => !thread.plan);
+      const eligibleThreads = rerun
+        ? data.threads
+        : data.threads.filter((thread) => !thread.plan);
       const remainingEmails =
         maxEmails === undefined ? undefined : maxEmails - totalProcessed;
       if (remainingEmails !== undefined && remainingEmails <= 0) break;
 
       const threadsToQueue =
         remainingEmails === undefined
-          ? threadsWithoutPlan
-          : threadsWithoutPlan.slice(0, remainingEmails);
+          ? eligibleThreads
+          : eligibleThreads.slice(0, remainingEmails);
 
       if (completeIfCancelled()) return;
 
       onThreadsQueued(threadsToQueue);
       totalProcessed += threadsToQueue.length;
-      runAiRules(emailAccountId, threadsToQueue, false);
+      runAiRules(emailAccountId, threadsToQueue, !!rerun);
 
       if (maxEmails !== undefined && totalProcessed >= maxEmails) break;
       if (!nextPageToken) break;

--- a/apps/web/utils/actions/ai-rule.test.ts
+++ b/apps/web/utils/actions/ai-rule.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 
 const {
+  checkHasAccessMock,
   createEmailProviderMock,
   flushLoggerSafelyMock,
   getEmailAccountForRuleExecutionMock,
   runRulesMock,
 } = vi.hoisted(() => ({
+  checkHasAccessMock: vi.fn(),
   createEmailProviderMock: vi.fn(),
   flushLoggerSafelyMock: vi.fn(),
   getEmailAccountForRuleExecutionMock: vi.fn(),
@@ -31,11 +33,18 @@ vi.mock("@/utils/user/get", () => ({
 vi.mock("@/utils/ai/choose-rule/run-rules", () => ({
   runRules: runRulesMock,
 }));
+vi.mock("@/utils/premium/server", () => ({
+  checkHasAccess: checkHasAccessMock,
+}));
 
 import {
   runRulesAction,
   testAiCustomContentAction,
 } from "@/utils/actions/ai-rule";
+import {
+  RERUN_MINIMUM_TIER,
+  RERUN_UPGRADE_MESSAGE,
+} from "@/utils/premium/rerun";
 
 describe("runRulesAction", () => {
   beforeEach(() => {
@@ -76,6 +85,7 @@ describe("runRulesAction", () => {
     ]);
 
     flushLoggerSafelyMock.mockResolvedValue(undefined);
+    checkHasAccessMock.mockResolvedValue(true);
   });
 
   it("waits for logger flush before resolving test-mode runs", async () => {
@@ -187,6 +197,66 @@ describe("runRulesAction", () => {
         stage: "create-email-provider",
       }),
     );
+  });
+
+  it("blocks a rerun when the user is not on the required tier", async () => {
+    checkHasAccessMock.mockResolvedValue(false);
+
+    const result = await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: false,
+      rerun: true,
+    });
+
+    expect(result?.serverError).toBe(RERUN_UPGRADE_MESSAGE);
+    expect(checkHasAccessMock).toHaveBeenCalledWith({
+      userId: "user-1",
+      minimumTier: RERUN_MINIMUM_TIER,
+    });
+    expect(runRulesMock).not.toHaveBeenCalled();
+  });
+
+  it("runs rules again and ignores the existing result when the user has access", async () => {
+    prisma.executedRule.findMany.mockResolvedValue([
+      { id: "existing-executed-rule" },
+    ] as any);
+
+    const result = await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: false,
+      rerun: true,
+    });
+
+    expect(result?.data).toHaveLength(1);
+    expect(prisma.executedRule.findMany).not.toHaveBeenCalled();
+    expect(runRulesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not check tier access for a normal run", async () => {
+    await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: false,
+    });
+
+    expect(checkHasAccessMock).not.toHaveBeenCalled();
+    expect(runRulesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not gate reruns in test mode", async () => {
+    checkHasAccessMock.mockResolvedValue(false);
+
+    const result = await runRulesAction("account-1", {
+      messageId: "message-1",
+      threadId: "thread-1",
+      isTest: true,
+      rerun: true,
+    });
+
+    expect(result?.data).toHaveLength(1);
+    expect(checkHasAccessMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/utils/actions/ai-rule.ts
+++ b/apps/web/utils/actions/ai-rule.ts
@@ -17,18 +17,36 @@ import { flushLoggerSafely } from "@/utils/logger-flush";
 import { getEmailAccountForRuleExecution } from "@/utils/user/get";
 import { SafeError } from "@/utils/error";
 import { createEmailProvider } from "@/utils/email/provider";
+import { checkHasAccess } from "@/utils/premium/server";
+import {
+  RERUN_MINIMUM_TIER,
+  RERUN_UPGRADE_MESSAGE,
+} from "@/utils/premium/rerun";
 
 export const runRulesAction = actionClient
   .metadata({ name: "runRules" })
   .inputSchema(runRulesBody)
   .action(
     async ({
-      ctx: { emailAccountId, provider, logger: ctxLogger },
+      ctx: { emailAccountId, userId, provider, logger: ctxLogger },
       parsedInput: { messageId, threadId, rerun, isTest },
     }): Promise<RunRulesResult[]> => {
       const logger = ctxLogger.with({ messageId, threadId });
 
       logger.info("runRulesAction started", { isTest, rerun });
+
+      // Re-running discards the existing result and pays for a fresh LLM call,
+      // so it's limited to the top tier.
+      if (rerun && !isTest) {
+        const hasAccess = await checkHasAccess({
+          userId,
+          minimumTier: RERUN_MINIMUM_TIER,
+        });
+        if (!hasAccess) {
+          logger.warn("Blocked rerun without Professional access");
+          throw new SafeError(RERUN_UPGRADE_MESSAGE);
+        }
+      }
 
       logger.info("Loading email account for rule execution");
       const emailAccount = await getEmailAccountForRuleExecution({

--- a/apps/web/utils/premium/rerun.ts
+++ b/apps/web/utils/premium/rerun.ts
@@ -1,0 +1,8 @@
+import type { PremiumTier } from "@/generated/prisma/enums";
+
+// Shared by the client toggle and the server-side gate in runRulesAction so
+// the two can't drift.
+export const RERUN_MINIMUM_TIER: PremiumTier = "PROFESSIONAL_MONTHLY";
+
+export const RERUN_UPGRADE_MESSAGE =
+  "Re-processing emails you've already handled is available on the Professional plan.";


### PR DESCRIPTION
## Problem

Bulk processing ("Process Past Emails") skips any thread that already has a stored rule result. Users who change their rules after an initial bulk run have no way to re-run over already-processed mail.

The plumbing for this already existed but was never wired up: `runRulesAction` accepts a `rerun` flag that bypasses the stored-result lookup, and the per-email Rerun button used it. The bulk path hardcoded `false`.

## Change

Adds an opt-in **"Re-process emails already handled"** toggle to the bulk dialog. When on, threads with an existing result are included and the `rerun` flag is passed through the queue.

Re-processing discards the stored result and pays for a fresh LLM call, so it is limited to the top tier.

### Gating

- **Enforced server side** in `runRulesAction`. The flag was previously trusted from the client with no tier check or rate limit at all, so a client-only toggle would have been cosmetic.
- **Test-mode runs stay ungated.** Test runs never overwrite a stored result, so iterating on rules in the Test tab remains available on every plan. Only actually re-applying is gated.
- The tier and upgrade copy live in one small module (`utils/premium/rerun.ts`) imported by both the client toggle and the server gate, so the two cannot drift.
- Existing `maxEmails` caps still apply to re-runs, including the trial limit.

### UI

Kept to a single inline row: the toggle is disabled with an explanatory tooltip, plus a small clickable `Professional` badge that opens the upgrade modal. No full-width alert or upsell card, so it reads as one locked option rather than the whole dialog being gated.

The per-email Rerun button is disabled with the same tooltip instead of rendering as active and then failing on submit.

Also corrects two pieces of copy that became inaccurate once re-processing is possible (the dialog subtitle and the empty state, which hardcoded "unprocessed").

## Notes

- Re-processing re-executes actions. Drafts are already handled safely by existing draft management: an untouched previous draft is deleted and recreated, and a user-edited draft is left alone.
- The existing skip is keyed on `threadId`, so threads whose only stored result is `SKIPPED` or `ERROR` were silently excluded from normal runs. This toggle also gives those users a way to retry them.

## Tests

Added coverage for the queue-level behaviour (skips processed threads by default, includes them when re-running, still respects `maxEmails`) and the server gate (blocks without the tier, ignores the stored result with it, no tier check on a normal run, not gated in test mode).

`pnpm test` for the assistant, premium, and rule-action suites: 109 passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

