### PR TITLE
assistant: derive bulk re-process state from a single gated value

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/BulkRunRules.tsx
@@ -87,6 +87,10 @@ export function BulkRunRules() {
   const isProcessing = queue.size > 0;
   const isPaused = state.status === "paused";
   const isBusy = isProcessing || state.status === "processing";
+  // Access can drop while the toggle is still on (the tier is revalidated in
+  // the background), so everything reads the gated value rather than the raw
+  // toggle state.
+  const isRerunEnabled = rerun && hasRerunAccess;
 
   // Warn user before leaving page during processing (includes initial fetch)
   useBeforeUnload(isBusy);
@@ -117,7 +121,7 @@ export function BulkRunRules() {
           startDate,
           endDate,
           includeRead,
-          rerun: rerun && hasRerunAccess,
+          rerun: isRerunEnabled,
           maxEmails: isTrial ? TRIAL_BULK_PROCESS_EMAIL_LIMIT : undefined,
         },
         (threads) => {
@@ -223,7 +227,7 @@ export function BulkRunRules() {
                 <Toggle
                   name="rerun"
                   label="Re-process emails already handled"
-                  enabled={rerun && hasRerunAccess}
+                  enabled={isRerunEnabled}
                   onChange={(enabled) => setRerun(enabled)}
                   disabled={isProcessing || !hasRerunAccess}
                   disabledTooltipText={
@@ -306,8 +310,12 @@ export function BulkRunRules() {
 
               {state.runResult && state.runResult.count === 0 && (
                 <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
-                  No {describeTargetedEmails({ includeRead, rerun })} found in
-                  the selected date range.
+                  No{" "}
+                  {describeTargetedEmails({
+                    includeRead,
+                    rerun: isRerunEnabled,
+                  })}{" "}
+                  found in the selected date range.
                 </div>
               )}
             </div>


### PR DESCRIPTION
Follow-up to #3054, addressing a review comment on that PR.

## Problem

The bulk dialog computed `rerun && hasRerunAccess` in two places (the run itself and the toggle's displayed state) but the empty-state copy read the raw toggle state instead.

`hasRerunAccess` derives from the tier, which is revalidated in the background. If it drops to `false` while the toggle is still on, the run correctly narrows to unprocessed emails only, but the empty state describes the broader search that did not happen — "No unread emails found" rather than "No unread, unprocessed emails found".

Reachable but narrow: the toggle is disabled without access, so it needs access to be revalidated away after the user switches it on. Impact is one line of inaccurate copy, no behavioural effect on what gets processed.

## Change

Derives the gated value once as `isRerunEnabled` and reads it at all three call sites, rather than adding a third copy of the expression. The three can no longer drift.

## Notes

The reviewer suggested inlining `rerun && hasRerunAccess` at the empty state. Deriving once is preferred here since it removes the class of bug rather than the instance, and the repo guidance is to centralise rules that must stay in sync.

No test added: the invariant that matters (the run receives the gated value) is already covered, and there is no render test for this component — asserting on copy would restate the implementation. The three call sites now read one variable, so the drift is structurally prevented rather than test-enforced.

## Tests

`pnpm test` for the assistant suite: 77 passing. Biome clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

