### PR TITLE
Add untrash thread endpoint for mobile Undo

### DIFF
--- a/apps/web/app/api/mobile/threads/batch/route.ts
+++ b/apps/web/app/api/mobile/threads/batch/route.ts
@@ -10,7 +10,7 @@ const THREAD_CONCURRENCY = 4;
 export const maxDuration = 300;
 
 const bodySchema = z.object({
-  action: z.enum(["archive", "unarchive", "trash"]),
+  action: z.enum(["archive", "unarchive", "trash", "untrash"]),
   threadIds: z.array(z.string().min(1)).min(1).max(500),
 });
 
@@ -87,6 +87,9 @@ async function runThreadAction({
         break;
       case "trash":
         await emailProvider.trashThread(threadId, ownerEmail, "user");
+        break;
+      case "untrash":
+        await emailProvider.untrashThread(threadId);
         break;
     }
   } catch (error) {

--- a/apps/web/app/api/threads/[id]/untrash/route.test.ts
+++ b/apps/web/app/api/threads/[id]/untrash/route.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEmailProvider = vi.hoisted(() => ({
+  untrashThread: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailProviderTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailProviderTestMiddleware(mockEmailProvider);
+});
+
+import { POST } from "./route";
+
+function untrash() {
+  return POST(
+    new NextRequest("http://localhost:3000/api/threads/thread-1/untrash", {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: "thread-1" }) } as never,
+  );
+}
+
+describe("POST /api/threads/[id]/untrash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("moves the thread back to the inbox", async () => {
+    mockEmailProvider.untrashThread.mockResolvedValue(undefined);
+
+    const response = await untrash();
+
+    expect(mockEmailProvider.untrashThread).toHaveBeenCalledWith("thread-1");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
+
+  it("returns 404 when the thread no longer exists", async () => {
+    mockEmailProvider.untrashThread.mockRejectedValue(
+      new Error("Requested entity was not found."),
+    );
+
+    const response = await untrash();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Thread not found",
+    });
+  });
+
+  it("returns 404 when Outlook reports the item as missing", async () => {
+    mockEmailProvider.untrashThread.mockRejectedValue(
+      Object.assign(new Error("item missing"), { code: "ErrorItemNotFound" }),
+    );
+
+    const response = await untrash();
+
+    expect(response.status).toBe(404);
+  });
+
+  it("lets other provider failures reach the middleware's error mapping", async () => {
+    const providerError = new Error("Provider unavailable");
+    mockEmailProvider.untrashThread.mockRejectedValue(providerError);
+
+    await expect(untrash()).rejects.toThrow(providerError);
+  });
+});

--- a/apps/web/app/api/threads/[id]/untrash/route.ts
+++ b/apps/web/app/api/threads/[id]/untrash/route.ts
@@ -6,8 +6,10 @@ import { isThreadNotFoundError } from "@/utils/email/thread-not-found";
 const paramsSchema = z.object({ id: z.string() });
 
 /**
- * Moves a trashed thread back to the inbox, to undo
- * `POST /api/threads/[id]/trash`.
+ * Restores a trashed thread, to undo `POST /api/threads/[id]/trash`.
+ *
+ * Gmail puts the thread back under its pre-trash labels; Outlook has no such
+ * record and moves it to the inbox.
  */
 export const POST = withEmailProvider(
   "threads/untrash",

--- a/apps/web/app/api/threads/[id]/untrash/route.ts
+++ b/apps/web/app/api/threads/[id]/untrash/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { withEmailProvider } from "@/utils/middleware";
+import { isThreadNotFoundError } from "@/utils/email/thread-not-found";
+
+const paramsSchema = z.object({ id: z.string() });
+
+/**
+ * Moves a trashed thread back to the inbox, to undo
+ * `POST /api/threads/[id]/trash`.
+ */
+export const POST = withEmailProvider(
+  "threads/untrash",
+  async (request, context) => {
+    const params = await context.params;
+    const { id: threadId } = paramsSchema.parse(params);
+
+    try {
+      await request.emailProvider.untrashThread(threadId);
+    } catch (error) {
+      if (isThreadNotFoundError(error)) {
+        return NextResponse.json(
+          { error: "Thread not found" },
+          { status: 404 },
+        );
+      }
+      // Let the middleware map auth and rate limit failures to their own codes.
+      throw error;
+    }
+
+    return NextResponse.json({ success: true });
+  },
+);

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -85,6 +85,7 @@ export const createMockEmailProvider = (
   archiveMessage: vi.fn().mockResolvedValue(undefined),
   trashThread: vi.fn().mockResolvedValue(undefined),
   unarchiveThread: vi.fn().mockResolvedValue(undefined),
+  untrashThread: vi.fn().mockResolvedValue(undefined),
   bulkArchiveFromSenders: vi.fn().mockResolvedValue(undefined),
   bulkTrashFromSenders: vi.fn().mockResolvedValue(undefined),
   labelMessage: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -45,7 +45,7 @@ import {
   removeThreadLabel,
   unarchiveThread,
 } from "@/utils/gmail/label";
-import { trashThread } from "@/utils/gmail/trash";
+import { trashThread, untrashThread } from "@/utils/gmail/trash";
 import { markSpam } from "@/utils/gmail/spam";
 import { handlePreviousDraftDeletion } from "@/utils/ai/choose-rule/draft-management";
 import {
@@ -327,6 +327,10 @@ export class GmailProvider implements EmailProvider {
 
   async unarchiveThread(threadId: string): Promise<void> {
     await unarchiveThread({ gmail: this.client, threadId });
+  }
+
+  async untrashThread(threadId: string): Promise<void> {
+    await untrashThread({ gmail: this.client, threadId });
   }
 
   async bulkArchiveThreads(

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -34,10 +34,11 @@ import {
 import {
   archiveThread,
   labelMessage,
-  markStarredMessage,
   markReadThread,
+  markStarredMessage,
   removeThreadLabel,
   unarchiveThread,
+  untrashThread,
 } from "@/utils/outlook/label";
 import { trashThread } from "@/utils/outlook/trash";
 import { markSpam } from "@/utils/outlook/spam";
@@ -448,6 +449,14 @@ export class OutlookProvider implements EmailProvider {
 
   async unarchiveThread(threadId: string): Promise<void> {
     await unarchiveThread({
+      client: this.client,
+      threadId,
+      logger: this.logger,
+    });
+  }
+
+  async untrashThread(threadId: string): Promise<void> {
+    await untrashThread({
       client: this.client,
       threadId,
       logger: this.logger,

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -307,6 +307,8 @@ export interface EmailProvider {
     actionSource: "user" | "automation",
   ): Promise<void>;
   unarchiveThread(threadId: string): Promise<void>;
+  /** Moves a trashed thread back to the inbox, to undo `trashThread`. */
+  untrashThread(threadId: string): Promise<void>;
   unwatchEmails(subscriptionId?: string): Promise<void>;
   updateDraft(
     draftId: string,

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -307,7 +307,10 @@ export interface EmailProvider {
     actionSource: "user" | "automation",
   ): Promise<void>;
   unarchiveThread(threadId: string): Promise<void>;
-  /** Moves a trashed thread back to the inbox, to undo `trashThread`. */
+  /**
+   * Restores a trashed thread, to undo `trashThread`. Gmail puts it back under
+   * its pre-trash labels; Outlook has no such record and moves it to the inbox.
+   */
   untrashThread(threadId: string): Promise<void>;
   unwatchEmails(subscriptionId?: string): Promise<void>;
   updateDraft(

--- a/apps/web/utils/gmail/trash.ts
+++ b/apps/web/utils/gmail/trash.ts
@@ -68,6 +68,24 @@ export async function trashThread(options: {
   return trashResult.value;
 }
 
+/**
+ * Restores a trashed thread. Gmail returns it to the labels it held before the
+ * trash, so a thread trashed from the inbox lands back in the inbox.
+ */
+export async function untrashThread(options: {
+  gmail: gmail_v1.Gmail;
+  threadId: string;
+}) {
+  const { gmail, threadId } = options;
+
+  return withGmailRetry(() =>
+    gmail.users.threads.untrash({
+      userId: "me",
+      id: threadId,
+    }),
+  );
+}
+
 export async function trashMessage(options: {
   gmail: gmail_v1.Gmail;
   messageId: string;

--- a/apps/web/utils/outlook/label.test.ts
+++ b/apps/web/utils/outlook/label.test.ts
@@ -7,6 +7,7 @@ import {
   getLabel,
   getOrCreateLabels,
   unarchiveThread,
+  untrashThread,
 } from "./label";
 
 const mockGetFolderIds = vi.fn();
@@ -105,36 +106,9 @@ describe("getOrCreateLabels", () => {
 });
 
 describe("unarchiveThread", () => {
-  function createPagingClient(
-    pages: { value: { id: string }[]; next?: string }[],
-  ) {
-    const post = vi.fn().mockResolvedValue(undefined);
-    let pageIndex = 0;
-
-    const api = vi.fn().mockImplementation((path: string) => {
-      if (path.includes("/move")) return { post };
-
-      const builder = {
-        filter: () => builder,
-        select: () => builder,
-        top: () => builder,
-        get: vi.fn().mockImplementation(() => {
-          const page = pages[pageIndex++];
-          return Promise.resolve({
-            value: page.value,
-            ...(page.next ? { "@odata.nextLink": page.next } : {}),
-          });
-        }),
-      };
-      return builder;
-    });
-
-    return { client: createMockOutlookClient(api), api, post };
-  }
-
   it("moves every archived message back, following paged results", async () => {
     mockGetFolderIds.mockResolvedValue({ archive: "archive-id" });
-    const { client, post } = createPagingClient([
+    const { client, post, filters } = createPagingClient([
       { value: [{ id: "m1" }, { id: "m2" }], next: "https://graph/next" },
       { value: [{ id: "m3" }] },
     ]);
@@ -148,6 +122,7 @@ describe("unarchiveThread", () => {
     // Without following @odata.nextLink, m3 would silently stay archived.
     expect(post).toHaveBeenCalledTimes(3);
     expect(post).toHaveBeenCalledWith({ destinationId: "inbox" });
+    expect(filters[0]).toContain("parentFolderId eq 'archive-id'");
   });
 
   it("refuses to run when the archive folder cannot be resolved", async () => {
@@ -165,6 +140,73 @@ describe("unarchiveThread", () => {
     expect(post).not.toHaveBeenCalled();
   });
 });
+
+describe("untrashThread", () => {
+  it("moves every deleted message back, following paged results", async () => {
+    mockGetFolderIds.mockResolvedValue({ deleteditems: "deleted-id" });
+    const { client, post, filters } = createPagingClient([
+      { value: [{ id: "m1" }, { id: "m2" }], next: "https://graph/next" },
+      { value: [{ id: "m3" }] },
+    ]);
+
+    await untrashThread({
+      client,
+      threadId: "thread-1",
+      logger: createTestLogger(),
+    });
+
+    expect(post).toHaveBeenCalledTimes(3);
+    expect(post).toHaveBeenCalledWith({ destinationId: "inbox" });
+    // Scoping to Deleted Items is what keeps the thread's sent messages put.
+    expect(filters[0]).toContain("parentFolderId eq 'deleted-id'");
+  });
+
+  it("refuses to run when the deleted items folder cannot be resolved", async () => {
+    mockGetFolderIds.mockResolvedValue({ archive: "archive-id" });
+    const { client, post } = createPagingClient([{ value: [] }]);
+
+    await expect(
+      untrashThread({
+        client,
+        threadId: "thread-1",
+        logger: createTestLogger(),
+      }),
+    ).rejects.toThrow("Deleted items folder not found");
+
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+function createPagingClient(
+  pages: { value: { id: string }[]; next?: string }[],
+) {
+  const post = vi.fn().mockResolvedValue(undefined);
+  const filters: string[] = [];
+  let pageIndex = 0;
+
+  const api = vi.fn().mockImplementation((path: string) => {
+    if (path.includes("/move")) return { post };
+
+    const builder = {
+      filter: (value: string) => {
+        filters.push(value);
+        return builder;
+      },
+      select: () => builder,
+      top: () => builder,
+      get: vi.fn().mockImplementation(() => {
+        const page = pages[pageIndex++];
+        return Promise.resolve({
+          value: page.value,
+          ...(page.next ? { "@odata.nextLink": page.next } : {}),
+        });
+      }),
+    };
+    return builder;
+  });
+
+  return { client: createMockOutlookClient(api), api, post, filters };
+}
 
 function createMockOutlookClient(api: ReturnType<typeof vi.fn>) {
   return {

--- a/apps/web/utils/outlook/label.ts
+++ b/apps/web/utils/outlook/label.ts
@@ -504,25 +504,43 @@ export async function archiveThread({
 const THREAD_MESSAGE_PAGE_SIZE = 100;
 const MAX_THREAD_MESSAGE_PAGES = 20;
 
-export async function unarchiveThread({
+/**
+ * Moves a conversation's messages out of one well-known folder and into the
+ * inbox.
+ *
+ * Scoping to a source folder is what keeps the sent and deleted messages of the
+ * same conversation where they are — Outlook has no thread-level state to
+ * restore, so the source folder is the only signal for which messages the user
+ * actually meant.
+ */
+const SOURCE_FOLDER_LABELS = {
+  archive: "Archive",
+  deleteditems: "Deleted items",
+} as const;
+
+async function moveThreadFromFolderToInbox({
   client,
   threadId,
+  sourceFolder,
   logger,
 }: {
   client: OutlookClient;
   threadId: string;
+  sourceFolder: keyof typeof SOURCE_FOLDER_LABELS;
   logger: Logger;
 }) {
   const folderIds = await getFolderIds(client, logger, {
     includeDrafts: false,
   });
-  const archiveFolderId = folderIds[WELL_KNOWN_FOLDERS.archive];
+  const sourceFolderId = folderIds[WELL_KNOWN_FOLDERS[sourceFolder]];
 
-  // Without the archive folder we can't tell archived messages apart from the
-  // sent and deleted messages in the same conversation, and moving those into
-  // the inbox would be worse than failing.
-  if (!archiveFolderId) {
-    throw new Error("Archive folder not found, cannot unarchive thread");
+  // Without the source folder we can't tell the messages apart from the sent
+  // and deleted ones in the same conversation, and moving those into the inbox
+  // would be worse than failing.
+  if (!sourceFolderId) {
+    throw new Error(
+      `${SOURCE_FOLDER_LABELS[sourceFolder]} folder not found, cannot move thread to inbox`,
+    );
   }
 
   const messageIds: string[] = [];
@@ -540,7 +558,7 @@ export async function unarchiveThread({
               .getClient()
               .api("/me/messages")
               .filter(
-                `conversationId eq '${escapeODataString(threadId)}' and parentFolderId eq '${escapeODataString(archiveFolderId)}'`,
+                `conversationId eq '${escapeODataString(threadId)}' and parentFolderId eq '${escapeODataString(sourceFolderId)}'`,
               )
               .select("id")
               .top(THREAD_MESSAGE_PAGE_SIZE)
@@ -557,8 +575,9 @@ export async function unarchiveThread({
   }
 
   if (nextLink) {
-    logger.warn("Stopped paging archived thread messages at the page limit", {
+    logger.warn("Stopped paging thread messages at the page limit", {
       threadId,
+      sourceFolder,
       messageCount: messageIds.length,
     });
   }
@@ -577,6 +596,47 @@ export async function unarchiveThread({
         logger,
       ),
     failureMessage: "Failed to move message back to inbox",
+  });
+}
+
+export async function unarchiveThread({
+  client,
+  threadId,
+  logger,
+}: {
+  client: OutlookClient;
+  threadId: string;
+  logger: Logger;
+}) {
+  await moveThreadFromFolderToInbox({
+    client,
+    threadId,
+    sourceFolder: "archive",
+    logger,
+  });
+}
+
+/**
+ * Moves a trashed thread back to the inbox.
+ *
+ * Unlike Gmail's untrash this cannot restore the thread to wherever it was
+ * before, because Outlook does not record that — messages deleted from a
+ * custom folder come back to the inbox.
+ */
+export async function untrashThread({
+  client,
+  threadId,
+  logger,
+}: {
+  client: OutlookClient;
+  threadId: string;
+  logger: Logger;
+}) {
+  await moveThreadFromFolderToInbox({
+    client,
+    threadId,
+    sourceFolder: "deleteditems",
+    logger,
   });
 }
 

--- a/apps/web/utils/outlook/label.ts
+++ b/apps/web/utils/outlook/label.ts
@@ -504,20 +504,20 @@ export async function archiveThread({
 const THREAD_MESSAGE_PAGE_SIZE = 100;
 const MAX_THREAD_MESSAGE_PAGES = 20;
 
-/**
- * Moves a conversation's messages out of one well-known folder and into the
- * inbox.
- *
- * Scoping to a source folder is what keeps the sent and deleted messages of the
- * same conversation where they are — Outlook has no thread-level state to
- * restore, so the source folder is the only signal for which messages the user
- * actually meant.
- */
 const SOURCE_FOLDER_LABELS = {
   archive: "Archive",
   deleteditems: "Deleted items",
 } as const;
 
+/**
+ * Moves a conversation's messages out of one well-known folder and into the
+ * inbox.
+ *
+ * Scoping to a source folder is what keeps the sent and deleted messages of the
+ * same conversation where they are. Outlook has no thread-level state to
+ * restore, so the source folder is the only signal for which messages the user
+ * actually meant.
+ */
 async function moveThreadFromFolderToInbox({
   client,
   threadId,
@@ -620,8 +620,8 @@ export async function unarchiveThread({
  * Moves a trashed thread back to the inbox.
  *
  * Unlike Gmail's untrash this cannot restore the thread to wherever it was
- * before, because Outlook does not record that — messages deleted from a
- * custom folder come back to the inbox.
+ * before, because Outlook does not record that. Messages deleted from a custom
+ * folder come back to the inbox.
  */
 export async function untrashThread({
   client,


### PR DESCRIPTION
Mobile's new Safe to clean flow shows an Undo link on every handled sender, but Delete had nothing to undo with — there was no untrash anywhere in the provider abstraction, so that affordance currently dead-ends on "Restoring from Trash isn't available yet". This adds `untrashThread` to `EmailProvider` with both implementations, exposes it at `POST /api/threads/[id]/untrash` mirroring the unarchive route added in #3052, and adds `untrash` to the mobile batch action enum.

Gmail restores the thread to the labels it held before the trash; Outlook has no equivalent, so messages come back to the inbox. The Outlook path reuses the same folder-scoped move as `unarchiveThread` — extracted into one helper here so both read from a single source folder rather than sweeping a whole conversation, which is what keeps the sent and deleted messages of that conversation where they are.

Verified with the new route tests plus the existing provider suites (606 passing); `tsc` reports the same 845 pre-existing errors as `main`, none new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

