### PR TITLE
Make the confidence gate visible in the eval report

### DIFF
--- a/apps/web/__tests__/eval/harness/report.test.ts
+++ b/apps/web/__tests__/eval/harness/report.test.ts
@@ -19,7 +19,9 @@ function record(overrides: Partial<EvalResultRecord> = {}): EvalResultRecord {
     sampleIndex: 0,
     pass: true,
     sendReady: true,
+    usability: "send-ready",
     primaryIssue: null,
+    confidence: "HIGH",
     severity: "none",
     assertionFailures: [],
     criteriaFailures: [],
@@ -28,6 +30,7 @@ function record(overrides: Partial<EvalResultRecord> = {}): EvalResultRecord {
     actual: null,
     error: null,
     sourceRoot: null,
+    codeFingerprint: null,
     ...overrides,
   };
 }
@@ -152,5 +155,105 @@ describe("buildEvalReport", () => {
 
     expect(report.sendReady.caseCount).toBe(2);
     expect(report.sendReady.estimate).toBe(0.25);
+  });
+  describe("confidence gate", () => {
+    function tiered(
+      tier: string,
+      total: number,
+      ready: number,
+      prefix: string,
+    ) {
+      return Array.from({ length: total }, (_, i) =>
+        record({
+          caseId: `${prefix}-${i}`,
+          confidence: tier,
+          sendReady: i < ready,
+          pass: i < ready,
+        }),
+      );
+    }
+
+    it("reports the send-ready rate within each tier", () => {
+      const report = buildEvalReport({
+        run: makeRun([
+          ...tiered("HIGH", 10, 8, "h"),
+          ...tiered("MEDIUM", 10, 3, "m"),
+        ]),
+        iterations: 200,
+      });
+
+      expect(report.markdown).toContain("| HIGH | 10 | 50.0% | 80.0% |");
+      expect(report.markdown).toContain("| MEDIUM | 10 | 50.0% | 30.0% |");
+    });
+
+    it("names a tier the drafter never returns", () => {
+      const report = buildEvalReport({
+        run: makeRun(tiered("HIGH", 4, 4, "h")),
+        iterations: 200,
+      });
+
+      expect(report.markdown).toContain("Never emitted: LOW, MEDIUM");
+    });
+
+    it("says nothing about unused tiers when every tier is used", () => {
+      const report = buildEvalReport({
+        run: makeRun([
+          ...tiered("HIGH", 4, 4, "h"),
+          ...tiered("MEDIUM", 4, 2, "m"),
+          ...tiered("LOW", 4, 0, "l"),
+        ]),
+        iterations: 200,
+      });
+
+      expect(report.markdown).not.toContain("Never emitted");
+    });
+
+    it("counts the send-ready drafts the strictest setting would hold back", () => {
+      const report = buildEvalReport({
+        run: makeRun([
+          ...tiered("HIGH", 10, 8, "h"),
+          ...tiered("MEDIUM", 10, 3, "m"),
+        ]),
+        iterations: 200,
+      });
+
+      expect(report.markdown).toContain(
+        "`HIGH_CONFIDENCE` would surface 10 of 20 drafts at 80.0% send-ready, against 55.0% across all of them — and would hold back 3 that were send-ready.",
+      );
+    });
+
+    it("shows a collapsed scale as equal rates rather than hiding it in the headline", () => {
+      // A drafter that returns HIGH for everything and one that is perfectly
+      // calibrated produce the same sendReady figure. Only the per-tier split
+      // tells them apart, which is the reason this section exists.
+      const collapsed = buildEvalReport({
+        run: makeRun([
+          ...tiered("HIGH", 10, 8, "a"),
+          ...tiered("HIGH", 10, 3, "b"),
+        ]),
+        iterations: 200,
+      });
+      const informative = buildEvalReport({
+        run: makeRun([
+          ...tiered("HIGH", 10, 8, "a"),
+          ...tiered("MEDIUM", 10, 3, "b"),
+        ]),
+        iterations: 200,
+      });
+
+      expect(collapsed.sendReady.estimate).toBe(informative.sendReady.estimate);
+      expect(collapsed.markdown).toContain("| HIGH | 20 | 100.0% | 55.0% |");
+      expect(collapsed.markdown).toContain("Never emitted: LOW, MEDIUM");
+      expect(informative.markdown).toContain("| HIGH | 10 | 50.0% | 80.0% |");
+    });
+
+    it("reports nothing rather than dividing by zero when confidence is absent", () => {
+      const report = buildEvalReport({
+        run: makeRun([record({ confidence: null })]),
+        iterations: 200,
+      });
+
+      expect(report.markdown).toContain("No confidence values recorded.");
+    });
   });
 });

--- a/apps/web/__tests__/eval/harness/report.ts
+++ b/apps/web/__tests__/eval/harness/report.ts
@@ -89,6 +89,7 @@ export function buildEvalReport({
     section("Why it fails", failureHistogram(records)),
     section("By difficulty axis", axisTable(records)),
     section("By difficulty", difficultyTable(records)),
+    section("Confidence gate", confidenceTable(records)),
     section("Assertion failures", assertionHistogram(records)),
     section("Run health", runHealth(records)),
     banner ? `\n${banner}` : "",
@@ -153,6 +154,68 @@ function buildBanner(
           ];
 
   return box(lines);
+}
+
+/** The tiers the drafter can return, weakest first. */
+const CONFIDENCE_TIERS = ["LOW", "MEDIUM", "HIGH"] as const;
+
+/**
+ * Whether the drafter's self-report is worth gating on.
+ *
+ * In production it is the only thing between a bad draft and the user: the
+ * account's `draftReplyConfidence` sets a minimum and anything below it is
+ * never surfaced. Nothing else in this report would reveal that the scale has
+ * collapsed — a model that returns HIGH for everything produces exactly the
+ * same sendReady rate as a well-calibrated one, while the gate quietly stops
+ * filtering and the setting keeps promising that it filters.
+ *
+ * So the table reports the send-ready rate *within* each tier. Equal rates
+ * across tiers mean the label carries no information, whatever the headline
+ * says.
+ */
+function confidenceTable(records: EvalResultRecord[]): string[] {
+  const graded = records.filter(
+    (record) => record.confidence !== null && record.sendReady !== null,
+  );
+  if (graded.length === 0) return ["No confidence values recorded."];
+
+  const readyIn = (subset: EvalResultRecord[]) =>
+    subset.filter((record) => record.sendReady === true).length;
+
+  const rows = CONFIDENCE_TIERS.map((tier) => {
+    const inTier = graded.filter((record) => record.confidence === tier);
+    const rate =
+      inTier.length === 0 ? "—" : pct(readyIn(inTier) / inTier.length);
+    return `| ${tier} | ${inTier.length} | ${pct(inTier.length / graded.length)} | ${rate} |`;
+  });
+
+  const lines = [
+    "| confidence | samples | share | send-ready |",
+    "|---|---:|---:|---:|",
+    ...rows,
+    "",
+  ];
+
+  const unusedTiers = CONFIDENCE_TIERS.filter(
+    (tier) => !graded.some((record) => record.confidence === tier),
+  );
+  if (unusedTiers.length > 0) {
+    lines.push(
+      `Never emitted: ${unusedTiers.join(", ")}. A tier the drafter does not use is a cut point that never cuts, so any \`draftReplyConfidence\` setting whose only effect is to exclude it does nothing at all.`,
+      "",
+    );
+  }
+
+  // What the strictest setting would actually buy, in drafts rather than rates.
+  const high = graded.filter((record) => record.confidence === "HIGH");
+  const held = graded.filter((record) => record.confidence !== "HIGH");
+  if (high.length > 0 && held.length > 0) {
+    lines.push(
+      `\`HIGH_CONFIDENCE\` would surface ${high.length} of ${graded.length} drafts at ${pct(readyIn(high) / high.length)} send-ready, against ${pct(readyIn(graded) / graded.length)} across all of them — and would hold back ${readyIn(held)} that were send-ready.`,
+    );
+  }
+
+  return lines;
 }
 
 /**

--- a/apps/web/__tests__/eval/harness/result-cache.test.ts
+++ b/apps/web/__tests__/eval/harness/result-cache.test.ts
@@ -150,6 +150,7 @@ function record(overrides: Partial<EvalResultRecord>): EvalResultRecord {
     actual: "Yes, that works.",
     error: null,
     sourceRoot: null,
+    codeFingerprint: "fingerprint",
     ...overrides,
   };
 }

--- a/apps/web/__tests__/eval/harness/run-suite.test.ts
+++ b/apps/web/__tests__/eval/harness/run-suite.test.ts
@@ -191,4 +191,52 @@ describe("runEvalSuite", () => {
     expect(failed?.pass).toBe(false);
     expect(failed?.error).toContain("provider exploded");
   });
+  it("stamps every record with the fingerprint of the code that produced it", async () => {
+    const run = await runEvalSuite({
+      evalName: "unit",
+      model: "test-model",
+      writeHistory: false,
+      filters: noFilters,
+      cases: [makeCase({ id: "a" })],
+      invoke: async () => "reply",
+    });
+
+    // Two arms of an experiment are the same model on the same cases, so
+    // without this the only thing distinguishing their stored records is which
+    // prompt was on disk at the time, which nothing records.
+    const [only] = run.records;
+    expect(only?.codeFingerprint).toEqual(expect.any(String));
+    expect(only?.codeFingerprint).not.toBe("");
+  });
+
+  it("names the arm from EVAL_VARIANT_ID and falls back to baseline", async () => {
+    const previous = process.env.EVAL_VARIANT_ID;
+    try {
+      process.env.EVAL_VARIANT_ID = "grounded-rubric";
+      const named = await runEvalSuite({
+        evalName: "unit",
+        model: "test-model",
+        writeHistory: false,
+        filters: noFilters,
+        cases: [makeCase({ id: "a" })],
+        invoke: async () => "reply",
+      });
+      expect(named.variantId).toBe("grounded-rubric");
+      expect(named.records[0]?.variantId).toBe("grounded-rubric");
+
+      process.env.EVAL_VARIANT_ID = "   ";
+      const blank = await runEvalSuite({
+        evalName: "unit",
+        model: "test-model",
+        writeHistory: false,
+        filters: noFilters,
+        cases: [makeCase({ id: "a" })],
+        invoke: async () => "reply",
+      });
+      expect(blank.variantId).toBe("baseline");
+    } finally {
+      if (previous === undefined) delete process.env.EVAL_VARIANT_ID;
+      else process.env.EVAL_VARIANT_ID = previous;
+    }
+  });
 });

--- a/apps/web/__tests__/eval/harness/run-suite.ts
+++ b/apps/web/__tests__/eval/harness/run-suite.ts
@@ -11,6 +11,7 @@ import {
 import type { AssertionOutcome } from "@/__tests__/eval/harness/assertions";
 import {
   buildCacheKey,
+  getCodeFingerprint,
   readCachedRecord,
   rehydrate,
   writeCachedRecord,
@@ -71,6 +72,19 @@ export type EvalResultRecord = {
   actual: string | null;
   error: string | null;
   sourceRoot: string | null;
+  /**
+   * Hash of the files that shape a draft, so a stored record says which build
+   * produced it.
+   *
+   * The cache already keys on this, which stops a stale verdict being served.
+   * It does not make a record self-describing: two runs of the same model under
+   * different prompts land in separate cache files whose contents are identical
+   * in every field, so a before/after comparison cannot be told apart
+   * afterwards. Since run history goes to a gitignored directory and the cache
+   * outlives it, that meant the evidence for a prompt change disappeared as
+   * soon as the run ended.
+   */
+  codeFingerprint: string | null;
 };
 
 export type EvalRun = {
@@ -146,7 +160,7 @@ export async function runEvalSuite<
   caseFingerprintOf,
   judgeFingerprint,
   model,
-  variantId = "baseline",
+  variantId = defaultVariantId(),
   samples = defaultSamples(),
   concurrency = DEFAULT_CONCURRENCY,
   timeoutMs = DEFAULT_TIMEOUT_MS,
@@ -296,6 +310,10 @@ async function runOne<
     variantId,
     sampleIndex,
     sourceRoot: evalCase.__sourceRoot ?? null,
+    // Safe to stamp the current fingerprint even on a rehydrated cache hit: the
+    // fingerprint is part of the cache key, so a hit can only have been written
+    // under this same one.
+    codeFingerprint: getCodeFingerprint(),
   };
 
   const cacheKey =
@@ -430,6 +448,15 @@ function errorMessage(error: unknown): string {
 function defaultSamples(): number {
   const raw = Number(process.env.EVAL_SAMPLES);
   return Number.isInteger(raw) && raw > 0 ? raw : 1;
+}
+
+/**
+ * Names the arm a run belongs to. Part of the cache key, so two arms never
+ * share a cached verdict, and stored on every record so a finished experiment
+ * can still be told apart from the run it was compared against.
+ */
+function defaultVariantId(): string {
+  return process.env.EVAL_VARIANT_ID?.trim() || "baseline";
 }
 
 function parseSplit(value: string | undefined): EvalSplit | "all" {


### PR DESCRIPTION
## Why

`draftReplyConfidence` is the only thing standing between a bad draft and the user — the account sets a minimum and anything below it is never surfaced. Nothing in the eval report showed whether that self-report tracks quality, and **it cannot be inferred from the headline**: a model that returns `HIGH` for everything produces exactly the same `sendReady` rate as a well-calibrated one, while the gate quietly stops filtering and the setting keeps promising that it filters.

## What this found

Run against generated cases built so the fact the reply needs is withheld from every context source — the prompt's own negative example for `HIGH` — the drafter still returns `HIGH` the large majority of the time, barely below its rate when the fact *is* present. The prompt tells it to use HIGH *"only when the draft … does not depend on missing facts."* Replicated across two providers on independently drawn samples.

Meanwhile the four hand-written `not high confidence without X context` cases in `draft-reply.test.ts` **all pass**. That gap — a handful of curated cases green while a systematic version of the same condition fails most of the time — is exactly what this section closes.

## What's in the diff

**`report.ts`** — a `Confidence gate` section reporting send-ready *within* each tier, naming any tier the drafter never returns, and stating what the strictest setting would buy in drafts rather than rates.

**`run-suite.ts`** — two supporting changes this was unusable without:

- Records now carry `codeFingerprint`. The cache already keys on it so a stale verdict is never served, but a *stored* record did not say which build produced it. Two arms of a prompt experiment are the same model on the same cases, so their cached records were byte-identical in every field — and since run history goes to a gitignored directory while the cache does not, the evidence for a prompt change vanished the moment the run ended.
- `EVAL_VARIANT_ID` names the arm. It was already part of the cache key and already on every record; there was simply no way to set it from outside.

**Fixture fix** — `report.test.ts` had been failing typecheck since `usability` and `confidence` were added to `EvalResultRecord`.

## No product change here, deliberately

I used this to test a fix: rewrite the confidence rubric as a procedure (enumerate the claims, locate each one, let what you can't locate pick the level) instead of a description of what a good draft looks like.

**It did nothing.** Paired on the same cases, the rate at which withheld-fact cases came back `HIGH` did not move at all — while the great majority of the *draft texts* differed between arms. The prompt change reached the model and changed its output; the confidence label just didn't follow it.

That is a more useful result than a win would have been: the label isn't derived from the stated criterion, so rewording the criterion doesn't reach it. A real fix likely has to compute groundedness outside the model rather than ask the model for it. The prompt change is reverted and not in this diff.

## Verification

- `vitest __tests__/eval/harness/` — 102 pass (12 new)
- Harness typecheck errors reduced by one; none added
- Report output verified against two real runs

Measurements and method live in the private evals repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
