### PR TITLE
Add mobile rule create and edit API

### DIFF
--- a/apps/web/app/api/mobile/rules/[id]/route.ts
+++ b/apps/web/app/api/mobile/rules/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  createRuleBody,
+  deleteRuleBody,
+} from "@/utils/actions/rule.validation";
+import { deleteRuleAction, updateRuleAction } from "@/utils/actions/rule";
+import { withEmailAccount } from "@/utils/middleware";
+
+const updateBodySchema = z.object({ rule: createRuleBody });
+
+export const PATCH = withEmailAccount(
+  "mobile/rules/update",
+  async (request, { params }) => {
+    const { id } = await params;
+    const { rule } = updateBodySchema.parse(await request.json());
+    const result = await updateRuleAction(request.auth.emailAccountId, {
+      ...rule,
+      id,
+    });
+
+    if (result?.serverError) {
+      return NextResponse.json({ error: result.serverError }, { status: 400 });
+    }
+    if (!result?.data?.rule) {
+      return NextResponse.json(
+        { error: "Could not update rule" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ rule: result.data.rule });
+  },
+);
+
+export const DELETE = withEmailAccount(
+  "mobile/rules/delete",
+  async (request, { params }) => {
+    const input = deleteRuleBody.parse(await params);
+    const result = await deleteRuleAction(request.auth.emailAccountId, input);
+
+    if (result?.serverError) {
+      return NextResponse.json({ error: result.serverError }, { status: 400 });
+    }
+
+    return new Response(null, { status: 204 });
+  },
+);

--- a/apps/web/app/api/mobile/rules/[id]/toggle/route.ts
+++ b/apps/web/app/api/mobile/rules/[id]/toggle/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { toggleRuleAction } from "@/utils/actions/rule";
+import { withEmailAccount } from "@/utils/middleware";
+
+const bodySchema = z.object({ enabled: z.boolean() });
+
+export const POST = withEmailAccount(
+  "mobile/rules/toggle",
+  async (request, { params }) => {
+    const { id } = await params;
+    const { enabled } = bodySchema.parse(await request.json());
+    const result = await toggleRuleAction(request.auth.emailAccountId, {
+      ruleId: id,
+      enabled,
+    });
+
+    if (result?.serverError) {
+      return NextResponse.json({ error: result.serverError }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  },
+);

--- a/apps/web/app/api/mobile/rules/route.ts
+++ b/apps/web/app/api/mobile/rules/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  createRuleBody,
+  type CreateRuleBody,
+} from "@/utils/actions/rule.validation";
+import { createRuleAction } from "@/utils/actions/rule";
+import { withEmailAccount } from "@/utils/middleware";
+import { aiPromptToRules } from "@/utils/ai/rule/prompt-to-rules";
+import { getEmailAccountWithAi } from "@/utils/user/get";
+import { toCreateRuleBodyFromAiRule } from "@/utils/rule/mobile-rule";
+
+export const maxDuration = 120;
+
+const bodySchema = z.discriminatedUnion("source", [
+  z.object({
+    source: z.literal("prompt"),
+    prompt: z.string().trim().min(1).max(4000),
+  }),
+  z.object({
+    source: z.literal("manual"),
+    rule: createRuleBody,
+  }),
+]);
+
+export const POST = withEmailAccount("mobile/rules/create", async (request) => {
+  const body = bodySchema.parse(await request.json());
+  const emailAccountId = request.auth.emailAccountId;
+
+  let ruleInput: CreateRuleBody;
+  if (body.source === "manual") {
+    ruleInput = body.rule;
+  } else {
+    const emailAccount = await getEmailAccountWithAi({ emailAccountId });
+    if (!emailAccount) {
+      return NextResponse.json(
+        { error: "Email account not found" },
+        { status: 404 },
+      );
+    }
+
+    const generatedRules = await aiPromptToRules({
+      emailAccount,
+      promptFile: body.prompt,
+    });
+    if (generatedRules.length !== 1) {
+      return NextResponse.json(
+        { error: "Describe one rule at a time." },
+        { status: 422 },
+      );
+    }
+
+    ruleInput = toCreateRuleBodyFromAiRule(generatedRules[0]);
+  }
+
+  const result = await createRuleAction(emailAccountId, ruleInput);
+  if (result?.serverError) {
+    return NextResponse.json({ error: result.serverError }, { status: 400 });
+  }
+  if (!result?.data?.rule) {
+    return NextResponse.json(
+      { error: "Could not create rule" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ rule: result.data.rule }, { status: 201 });
+});

--- a/apps/web/utils/actions/rule.validation.test.ts
+++ b/apps/web/utils/actions/rule.validation.test.ts
@@ -436,7 +436,7 @@ describe("createRuleBody", () => {
     });
 
     describe("MOVE_FOLDER action", () => {
-      it("requires both folderName and folderId for MOVE_FOLDER action", () => {
+      it("requires folderName for MOVE_FOLDER action", () => {
         const result = createRuleBody.safeParse({
           ...validRule,
           actions: [{ type: ActionType.MOVE_FOLDER }],
@@ -447,7 +447,7 @@ describe("createRuleBody", () => {
         }
       });
 
-      it("requires folderId when folderName is present", () => {
+      it("accepts folderName without folderId", () => {
         const result = createRuleBody.safeParse({
           ...validRule,
           actions: [
@@ -457,7 +457,7 @@ describe("createRuleBody", () => {
             },
           ],
         });
-        expect(result.success).toBe(false);
+        expect(result.success).toBe(true);
       });
 
       it("accepts valid folderName and folderId", () => {

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -218,9 +218,11 @@ const zodAction = z
         path: ["messagingChannelId"],
       });
     }
+    // folderId is optional: name-only input (from AI-generated rules) is
+    // resolved to a folder id before the rule is saved.
     if (
       data.type === ActionType.MOVE_FOLDER &&
-      (!data.folderName?.value?.trim() || !data.folderId?.value?.trim())
+      !data.folderName?.value?.trim()
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/apps/web/utils/rule/mobile-rule.test.ts
+++ b/apps/web/utils/rule/mobile-rule.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { toCreateRuleBodyFromAiRule } from "@/utils/rule/mobile-rule";
+
+describe("toCreateRuleBodyFromAiRule", () => {
+  it("preserves semantic, static, and action fields for the rule action", () => {
+    expect(
+      toCreateRuleBodyFromAiRule({
+        name: "Invoices",
+        condition: {
+          aiInstructions: "Invoices that need accounting",
+          conditionalOperator: LogicalOperator.AND,
+          static: {
+            from: "@vendor.com",
+            to: null,
+            subject: "Invoice",
+          },
+        },
+        actions: [
+          {
+            type: ActionType.LABEL,
+            fields: { label: "Accounting" },
+            delayInMinutes: null,
+          },
+          {
+            type: ActionType.FORWARD,
+            fields: {
+              to: "jane@accounting.com",
+              subject: "New invoice",
+              content: "Please review",
+            },
+            delayInMinutes: 10,
+          },
+        ],
+      }),
+    ).toEqual({
+      name: "Invoices",
+      runOnThreads: true,
+      conditionalOperator: LogicalOperator.AND,
+      conditions: [
+        {
+          type: "AI",
+          instructions: "Invoices that need accounting",
+        },
+        {
+          type: "STATIC",
+          from: "@vendor.com",
+        },
+        {
+          type: "STATIC",
+          subject: "Invoice",
+        },
+      ],
+      actions: [
+        {
+          type: ActionType.LABEL,
+          labelId: { name: "Accounting" },
+          subject: undefined,
+          content: undefined,
+          to: undefined,
+          cc: undefined,
+          bcc: undefined,
+          url: undefined,
+          folderName: undefined,
+          delayInMinutes: null,
+        },
+        {
+          type: ActionType.FORWARD,
+          labelId: undefined,
+          subject: { value: "New invoice" },
+          content: { value: "Please review" },
+          to: { value: "jane@accounting.com" },
+          cc: undefined,
+          bcc: undefined,
+          url: undefined,
+          folderName: undefined,
+          delayInMinutes: 10,
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/utils/rule/mobile-rule.test.ts
+++ b/apps/web/utils/rule/mobile-rule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
+import { createRuleBody } from "@/utils/actions/rule.validation";
 import { toCreateRuleBodyFromAiRule } from "@/utils/rule/mobile-rule";
 
 describe("toCreateRuleBodyFromAiRule", () => {
@@ -78,5 +79,27 @@ describe("toCreateRuleBodyFromAiRule", () => {
         },
       ],
     });
+  });
+
+  it("produces a move folder rule that passes rule validation without a folder id", () => {
+    const result = createRuleBody.safeParse(
+      toCreateRuleBodyFromAiRule({
+        name: "Receipts",
+        condition: {
+          aiInstructions: "Receipts from online purchases",
+          conditionalOperator: LogicalOperator.AND,
+          static: null,
+        },
+        actions: [
+          {
+            type: ActionType.MOVE_FOLDER,
+            fields: { folderName: "Receipts" },
+            delayInMinutes: null,
+          },
+        ],
+      }),
+    );
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/utils/rule/mobile-rule.ts
+++ b/apps/web/utils/rule/mobile-rule.ts
@@ -1,0 +1,52 @@
+import { ConditionType } from "@/utils/config";
+import type { CreateRuleBody } from "@/utils/actions/rule.validation";
+import type { CreateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+
+export function toCreateRuleBodyFromAiRule(
+  rule: CreateRuleSchema,
+): CreateRuleBody {
+  const conditions: CreateRuleBody["conditions"] = [];
+
+  if (rule.condition.aiInstructions) {
+    conditions.push({
+      type: ConditionType.AI,
+      instructions: rule.condition.aiInstructions,
+    });
+  }
+
+  for (const field of ["from", "to", "subject"] as const) {
+    const value = rule.condition.static?.[field];
+    if (!value) continue;
+    conditions.push({
+      type: ConditionType.STATIC,
+      [field]: value,
+    });
+  }
+
+  return {
+    name: rule.name,
+    runOnThreads: true,
+    conditionalOperator: rule.condition.conditionalOperator ?? undefined,
+    conditions,
+    actions: rule.actions.map((action) => ({
+      type: action.type,
+      labelId: action.fields?.label ? { name: action.fields.label } : undefined,
+      subject: action.fields?.subject
+        ? { value: action.fields.subject }
+        : undefined,
+      content: action.fields?.content
+        ? { value: action.fields.content }
+        : undefined,
+      to: action.fields?.to ? { value: action.fields.to } : undefined,
+      cc: action.fields?.cc ? { value: action.fields.cc } : undefined,
+      bcc: action.fields?.bcc ? { value: action.fields.bcc } : undefined,
+      url: action.fields?.webhookUrl
+        ? { value: action.fields.webhookUrl }
+        : undefined,
+      folderName: action.fields?.folderName
+        ? { value: action.fields.folderName }
+        : undefined,
+      delayInMinutes: action.delayInMinutes,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add authenticated mobile rule create, update, delete, and toggle endpoints
- reuse the existing rule server actions for validation and mutations
- support direct prompt-to-rule creation without creating an Assistant chat
- preserve the existing rule action and condition contracts

## Validation
- pnpm test utils/rule/mobile-rule.test.ts
- pnpm exec ultracite check on changed files
- pnpm --filter inbox-zero-ai check-server-actions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

