### PR TITLE
Say what the confidence settings actually do, and record two dead ends

### DIFF
--- a/apps/web/utils/ai/reply/draft-confidence.ts
+++ b/apps/web/utils/ai/reply/draft-confidence.ts
@@ -8,6 +8,22 @@ const DRAFT_REPLY_CONFIDENCE_RANK: Record<DraftReplyConfidence, number> = {
   [DraftReplyConfidence.HIGH_CONFIDENCE]: 2,
 };
 
+/**
+ * Descriptions are deliberately modest about what this gate delivers.
+ *
+ * Offline evaluation found the drafter's self-reported confidence tracks
+ * quality more weakly than the previous copy implied: requiring HIGH improves
+ * what gets shown, but not reliably enough to call it an assurance. "Very sure
+ * of the right reply" was a promise the model's own label cannot keep.
+ *
+ * STANDARD is weaker again. It excludes only LOW, which the drafter returns
+ * rarely enough that the setting filters very little, so "skip drafting when
+ * the AI is unsure how to respond" described something it does not do. Whether
+ * the tier should exist at all is a product question this does not settle; the
+ * copy at least stops overstating it.
+ *
+ * Measurements are in the private evals repo, not here.
+ */
 export const DRAFT_REPLY_CONFIDENCE_OPTIONS = [
   {
     value: DraftReplyConfidence.ALL_EMAILS,
@@ -17,12 +33,14 @@ export const DRAFT_REPLY_CONFIDENCE_OPTIONS = [
   {
     value: DraftReplyConfidence.STANDARD,
     label: "Standard",
-    description: "Skip drafting when the AI is unsure how to respond.",
+    description:
+      "Skip the few replies the AI flags as low confidence. In practice this filters very little.",
   },
   {
     value: DraftReplyConfidence.HIGH_CONFIDENCE,
     label: "High confidence",
-    description: "Only draft when the AI is very sure of the right reply.",
+    description:
+      "Only draft when the AI rates its own reply highly. Fewer drafts, and somewhat more of them usable as written.",
   },
 ] as const;
 

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -252,6 +252,26 @@ ${getTodayForLLM(currentDate)}
 IMPORTANT: You are writing an email as ${emailAccount.email}. Write the reply from their perspective.`;
 };
 
+/**
+ * Rewriting this rubric does not work. It has been tested against the offline
+ * eval suite and the null was a real one, not an underpowered shrug.
+ *
+ * The label does not track groundedness: on cases built so the fact the reply
+ * needs is withheld from every context source — the rubric's own negative
+ * example for HIGH — the drafter still returns HIGH most of the time. Restating
+ * HIGH as an explicit procedure (enumerate the claims, locate each one, let
+ * what you cannot locate pick the level) moved that by nothing at all, while
+ * demonstrably changing what the model wrote. So the label is not derived from
+ * the criterion stated here, and no restatement of the criterion reaches it —
+ * which also rules out reordering the levels, fronting the disqualifier, and
+ * adding examples.
+ *
+ * A real fix has to compute groundedness outside the drafter: a separate pass
+ * over the drafted text and the assembled context, rather than asking the model
+ * to introspect. Please do not spend another round on the wording.
+ *
+ * Numbers and method are in the private evals repo, not here.
+ */
 const llmDraftConfidenceSchema = z.enum(["LOW", "MEDIUM", "HIGH"]);
 
 const draftSchema = z.object({
@@ -527,6 +547,26 @@ function mapLlmDraftConfidence(confidence: unknown): DraftReplyConfidence {
 // Matches any non-separator, non-whitespace character repeated 50+ times in a row
 const REPETITIVE_TEXT_PATTERN = /([^\s\-=_*.#~])\1{49,}/u;
 
+/**
+ * Do not delete this block to improve the eval score. It has been tried.
+ *
+ * An earlier ablation appeared to show that removing calendar availability
+ * improved draft quality. That was an artifact of the case set: almost every
+ * calendar case at the time was built so that over-committing to a time was the
+ * failure, so nothing in the set could reward keeping the context and removing
+ * it could only ever score well.
+ *
+ * Once cases were added where scheduling is the genuine ask and the supplied
+ * availability is the answer, the sign reversed — removing this block is a
+ * clear regression, concentrated exactly on the threads where someone actually
+ * wanted a time.
+ *
+ * The more promising direction is how many options the reply offers rather than
+ * whether the context exists at all. That is the change worth testing, not
+ * deletion.
+ *
+ * Measurements are in the private evals repo, not here.
+ */
 function getSchedulingContext({
   calendarBookingLink,
   calendarAvailability,


### PR DESCRIPTION
No behaviour change. Copy fixes plus two comments recording experiments that failed, placed where someone would otherwise repeat them.
