### PR TITLE
Propose one meeting time rather than a list of slots

### DIFF
--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 21;
+export const DRAFT_PIPELINE_VERSION = 22;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -574,7 +574,7 @@ If you list specific times, include the user-facing timezone label shown for eac
 Available time slots:
 ${times}
 
-${calendarBookingLink ? "Because the user has a booking link, share the booking link instead of listing specific times unless the sender explicitly asks the user to provide times, asks about a specific proposed time/date, or the booking link would not answer the scheduling request." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Format suggested times as a bulleted list.`);
+${calendarBookingLink ? "Because the user has a booking link, share the booking link instead of listing specific times unless the sender explicitly asks the user to provide times, asks about a specific proposed time/date, or the booking link would not answer the scheduling request." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Propose one specific time rather than a list. Offer a second only if the sender asked for options or has already declined one. A menu hands the scheduling work back to the sender; one concrete proposal is easier to accept or counter.`);
   }
 
   if (parts.length === 0) return "";


### PR DESCRIPTION
The scheduling context ended with *"Format suggested times as a bulleted list"*, which asks for a menu. A menu hands the scheduling work back to the sender; one concrete proposal is easier to accept or counter.

Every available slot still goes into the prompt, so the model can pick a suitable one. Only what it's told to do with them changes.

`DRAFT_PIPELINE_VERSION` → 22, so drafts written under this prompt stay separable from earlier ones.

## Diff

- `draft-reply.ts` — replaces the bulleted-list instruction with `SINGLE_TIME_GUIDANCE`
- `draft-attribution.ts` — version bump

## Verification

- `vitest utils/ai/reply utils/redis utils/actions/generate-reply.test.ts` — 124 pass
- typecheck clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

