### PR TITLE
rules: Return canonical rule order from API

### DIFF
--- a/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
+++ b/apps/web/__tests__/eval/assistant-chat-rule-eval-test-utils.ts
@@ -1,11 +1,8 @@
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import type { GroupItemType } from "@/generated/prisma/enums";
 import prisma from "@/utils/__mocks__/prisma";
-import {
-  getDefaultActions,
-  getRuleConfig,
-  SYSTEM_RULE_ORDER,
-} from "@/utils/rule/consts";
+import { getDefaultActions, getRuleConfig } from "@/utils/rule/consts";
+import { SYSTEM_RULE_ORDER } from "@/utils/rule/sort";
 import { vi } from "vitest";
 
 type AnyMock = ReturnType<typeof vi.fn>;

--- a/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/Rules.tsx
@@ -56,12 +56,11 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useLabels } from "@/hooks/useLabels";
 import { conditionsToString } from "@/utils/condition";
 import { TruncatedTooltipText } from "@/components/TruncatedTooltipText";
+import { getRuleConfig, getDefaultActions } from "@/utils/rule/consts";
 import {
-  getRuleConfig,
   SYSTEM_RULE_ORDER,
-  getDefaultActions,
-} from "@/utils/rule/consts";
-import { sortRulesForAutomation } from "@/utils/rule/sort";
+  sortRulesByCanonicalOrder,
+} from "@/utils/rule/sort";
 import {
   STEP_KEYS,
   getOnboardingStepHref,
@@ -175,7 +174,7 @@ export function Rules({
 
     const userRules = existingRules.filter((rule) => !rule.systemType);
 
-    return sortRulesForAutomation([...systemRulePlaceholders, ...userRules]);
+    return sortRulesByCanonicalOrder([...systemRulePlaceholders, ...userRules]);
   }, [data, emailAccountId, provider]);
 
   const hasRules = !!rules?.length;

--- a/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/assistant/RulesSelect.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { parseAsString, useQueryState } from "nuqs";
 import { ChevronDown, Tag } from "lucide-react";
-import { sortRulesForAutomation } from "@/utils/rule/sort";
 
 export function RulesSelect() {
   const { data, isLoading, error } = useRules();
@@ -18,12 +17,10 @@ export function RulesSelect() {
     "ruleId",
     parseAsString.withDefault("all"),
   );
-  const sortedRules = data ? sortRulesForAutomation(data) : undefined;
-
   const getCurrentLabel = () => {
     if (ruleId === "all") return "All rules";
     if (ruleId === "skipped") return "No match";
-    const rule = sortedRules?.find((rule) => rule.id === ruleId);
+    const rule = data?.find((rule) => rule.id === ruleId);
     if (!rule) return "All rules";
     return rule.enabled ? rule.name : `${rule.name} (disabled)`;
   };
@@ -53,7 +50,7 @@ export function RulesSelect() {
           <DropdownMenuItem onClick={() => setRuleId("skipped")}>
             No match
           </DropdownMenuItem>
-          {sortedRules?.map((rule) => (
+          {data?.map((rule) => (
             <DropdownMenuItem key={rule.id} onClick={() => setRuleId(rule.id)}>
               {rule.name}
               {!rule.enabled && (

--- a/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/channels/Channels.tsx
@@ -70,7 +70,6 @@ import {
   type MessagingFeatureRoutePurpose,
   type MessagingRouteSummary,
 } from "@/utils/messaging/routes";
-import { sortRulesForAutomation } from "@/utils/rule/sort";
 import {
   type MessagingProvider,
   MessagingRoutePurpose,
@@ -166,8 +165,7 @@ export function Channels() {
     (provider) => provider !== "TEAMS" || teamsEnabled,
   );
   const visibleRules = useMemo(
-    () =>
-      sortRulesForAutomation((rulesData ?? []).filter((rule) => rule.enabled)),
+    () => (rulesData ?? []).filter((rule) => rule.enabled),
     [rulesData],
   );
   const connectedProviders = useMemo(

--- a/apps/web/app/api/user/rules/route.test.ts
+++ b/apps/web/app/api/user/rules/route.test.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SystemType } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { createScopedLogger } from "@/utils/logger";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/middleware", () => ({
+  withEmailAccount:
+    (
+      _name: string,
+      handler: (
+        request: NextRequest & Record<string, unknown>,
+      ) => Promise<Response>,
+    ) =>
+    (request: NextRequest) =>
+      handler(
+        Object.assign(request, {
+          auth: { emailAccountId: "email-account-1", userId: "user-1" },
+          logger: createScopedLogger("test"),
+        }),
+      ),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/user/rules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns rules in the canonical order consumed by clients", async () => {
+    prisma.rule.findMany.mockResolvedValue([
+      {
+        id: "custom-disabled",
+        name: "Alpha",
+        enabled: false,
+        systemType: null,
+        instructions: null,
+      },
+      {
+        id: "cold-email",
+        name: "Cold Email",
+        enabled: true,
+        systemType: SystemType.COLD_EMAIL,
+        instructions: null,
+      },
+      {
+        id: "newsletter",
+        name: "Newsletter",
+        enabled: true,
+        systemType: SystemType.NEWSLETTER,
+        instructions: null,
+      },
+      {
+        id: "custom-enabled",
+        name: "Bravo",
+        enabled: true,
+        systemType: null,
+        instructions: null,
+      },
+    ] as never);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/user/rules"),
+    );
+    const body = await response.json();
+
+    expect(body.map((rule: { id: string }) => rule.id)).toEqual([
+      "newsletter",
+      "cold-email",
+      "custom-enabled",
+      "custom-disabled",
+    ]);
+  });
+});

--- a/apps/web/app/api/user/rules/route.ts
+++ b/apps/web/app/api/user/rules/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
+import { sortRulesByCanonicalOrder } from "@/utils/rule/sort";
 
 export type RulesResponse = Awaited<ReturnType<typeof getRules>>;
 
 async function getRules({ emailAccountId }: { emailAccountId: string }) {
-  return await prisma.rule.findMany({
+  const rules = await prisma.rule.findMany({
     where: { emailAccountId },
     include: {
       actions: true,
@@ -18,6 +19,8 @@ async function getRules({ emailAccountId }: { emailAccountId: string }) {
     },
     orderBy: { createdAt: "asc" },
   });
+
+  return sortRulesByCanonicalOrder(rules);
 }
 
 export const GET = withEmailAccount(

--- a/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
+++ b/apps/web/utils/ai/choose-rule/ai-choose-rule.ts
@@ -9,7 +9,7 @@ import {
   isOllamaProvider,
 } from "@/utils/llms/ollama-guidance";
 import { getUserInfoPrompt, getUserRulesPrompt } from "@/utils/ai/helpers";
-import { sortRulesForAutomation } from "@/utils/rule/sort";
+import { sortRulesByCanonicalOrder } from "@/utils/rule/sort";
 import type { Logger } from "@/utils/logger";
 import type { ClassificationFeedbackItem } from "@/utils/rule/classification-feedback";
 
@@ -43,7 +43,7 @@ export async function aiChooseRule<
 }> {
   if (!rules.length) return { rules: [], reason: "No rules to evaluate" };
 
-  const orderedRules = sortRulesForAutomation(rules);
+  const orderedRules = sortRulesByCanonicalOrder(rules);
 
   const { result: aiResponse } = await getAiResponse({
     email,

--- a/apps/web/utils/rule/consts.ts
+++ b/apps/web/utils/rule/consts.ts
@@ -157,19 +157,6 @@ export function getCategoryAction(systemType: SystemType, provider: string) {
   return config.categoryAction;
 }
 
-export const SYSTEM_RULE_ORDER: SystemType[] = [
-  SystemType.TO_REPLY,
-  SystemType.AWAITING_REPLY,
-  SystemType.FYI,
-  SystemType.ACTIONED,
-  SystemType.NEWSLETTER,
-  SystemType.MARKETING,
-  SystemType.CALENDAR,
-  SystemType.RECEIPT,
-  SystemType.NOTIFICATION,
-  SystemType.COLD_EMAIL,
-];
-
 export function getDefaultActions(
   systemType: SystemType,
   provider: string,

--- a/apps/web/utils/rule/mapRulesToExtensionTabs.ts
+++ b/apps/web/utils/rule/mapRulesToExtensionTabs.ts
@@ -32,7 +32,7 @@ const LABEL_TO_DEFAULT_TAB = Object.fromEntries(
   DEFAULT_TABS.map((tab) => [normalizeLabelName(tab.label), tab]),
 );
 
-// Matches SYSTEM_RULE_ORDER from utils/rule/consts.ts, with Follow-up appended
+// Matches SYSTEM_RULE_ORDER from utils/rule/sort.ts, with Follow-up appended
 const LABEL_ORDER = DEFAULT_TABS.map((tab) => normalizeLabelName(tab.label));
 
 function labelToGmailSlug(label: string): string {

--- a/apps/web/utils/rule/sort.test.ts
+++ b/apps/web/utils/rule/sort.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { SystemType } from "@/generated/prisma/enums";
-import { sortRulesForAutomation } from "./sort";
+import { sortRulesByCanonicalOrder } from "./sort";
 
-describe("sortRulesForAutomation", () => {
+describe("sortRulesByCanonicalOrder", () => {
   it("puts disabled rules after enabled rules and sorts each group by name", () => {
     const rules = [
       { name: "Zulu", enabled: true },
@@ -11,7 +11,7 @@ describe("sortRulesForAutomation", () => {
       { name: "Charlie", enabled: false },
     ];
 
-    expect(sortRulesForAutomation(rules).map((rule) => rule.name)).toEqual([
+    expect(sortRulesByCanonicalOrder(rules).map((rule) => rule.name)).toEqual([
       "Bravo",
       "Zulu",
       "Alpha",
@@ -34,7 +34,7 @@ describe("sortRulesForAutomation", () => {
       { name: "Alpha", enabled: true },
     ];
 
-    expect(sortRulesForAutomation(rules).map((rule) => rule.name)).toEqual([
+    expect(sortRulesByCanonicalOrder(rules).map((rule) => rule.name)).toEqual([
       "Newsletter",
       "Cold Email",
       "Alpha",

--- a/apps/web/utils/rule/sort.ts
+++ b/apps/web/utils/rule/sort.ts
@@ -1,4 +1,17 @@
-import { SYSTEM_RULE_ORDER } from "@/utils/rule/consts";
+import { SystemType } from "@/generated/prisma/enums";
+
+export const SYSTEM_RULE_ORDER: SystemType[] = [
+  SystemType.TO_REPLY,
+  SystemType.AWAITING_REPLY,
+  SystemType.FYI,
+  SystemType.ACTIONED,
+  SystemType.NEWSLETTER,
+  SystemType.MARKETING,
+  SystemType.CALENDAR,
+  SystemType.RECEIPT,
+  SystemType.NOTIFICATION,
+  SystemType.COLD_EMAIL,
+];
 
 type SortableRule = {
   enabled?: boolean | null;
@@ -7,7 +20,7 @@ type SortableRule = {
   instructions?: string | null;
 };
 
-export function sortRulesForAutomation<T extends SortableRule>(
+export function sortRulesByCanonicalOrder<T extends SortableRule>(
   rules: T[],
 ): T[] {
   return [...rules].sort((a, b) => {


### PR DESCRIPTION
The rules API now returns the canonical order so web and mobile consume the same server-owned result. Web callers that can trust the response no longer repeat the sort.

- centralize system-rule order and the canonical comparator
- sort `/api/user/rules` before returning its response
- preserve the sorter for AI precedence and generated web placeholders
- cover the API contract with a focused regression test
- avoid extra database queries or network calls; measured sorting at about 0.04 ms for 20 rules

Tests: 39 focused web tests and 9 mobile API tests passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

