### PR TITLE
Drafting: Honor explicit requests for scheduling options

### DIFF
--- a/apps/web/__tests__/eval/draft-reply.test.ts
+++ b/apps/web/__tests__/eval/draft-reply.test.ts
@@ -273,7 +273,7 @@ Alex`,
       );
 
       test(
-        "explicit time request uses human-friendly timezone wording",
+        "explicit options request returns requested times with human-friendly timezone",
         async () => {
           const schedulingEmailAccount = {
             ...emailAccount,
@@ -316,7 +316,7 @@ Morgan`,
             currentDate: new Date("2026-05-12T09:30:00Z"),
           });
 
-          const testName = "human-friendly timezone for suggested times";
+          const testName = "explicitly requested scheduling options";
           const judgeResult = await judgeEvalOutput({
             input: [
               formatThreadForJudge(messages),
@@ -326,11 +326,11 @@ Morgan`,
             ].join("\n"),
             output: result.reply,
             expected:
-              "A concrete scheduling reply with suggested times. If a timezone is mentioned, it should use a human-friendly abbreviation or label rather than an IANA timezone identifier.",
+              "A concrete scheduling reply that offers both provided times because the sender explicitly requested two or three options. If a timezone is mentioned, it should use a human-friendly abbreviation or label rather than an IANA timezone identifier.",
             criterion: {
-              name: "Human-friendly timezone wording",
+              name: "Requested options with human-friendly timezone",
               description:
-                "When the sender explicitly asks for times and calendar availability is provided, the draft may suggest slots, but it should not write raw IANA timezone identifiers such as Asia/Jerusalem. It should use a normal user-facing timezone abbreviation or label if timezone context is needed.",
+                "When the sender explicitly asks for two or three times and two available slots are provided, the draft should offer both slots. It should not write raw IANA timezone identifiers such as Asia/Jerusalem, and should use a normal user-facing timezone abbreviation or label if timezone context is needed.",
             },
           });
           const pass =
@@ -340,13 +340,13 @@ Morgan`,
             testName,
             model: model.label,
             pass,
-            expected: "suggested times without IANA timezone wording",
+            expected: "both requested options without IANA timezone wording",
             actual: formatSemanticJudgeActual(result.reply, judgeResult),
           });
 
           expect(
             pass,
-            `Draft should avoid raw IANA timezone wording.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+            `Draft should provide the requested options without raw IANA timezone wording.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
               judgeResult,
               null,
               2,
@@ -357,7 +357,7 @@ Morgan`,
       );
 
       test(
-        "personal scheduling request with calendar availability",
+        "personal scheduling request proposes one concrete time",
         async () => {
           const messages = [
             {
@@ -413,11 +413,11 @@ Priya`,
             ].join("\n"),
             output: result.reply,
             expected:
-              "A substantive scheduling reply that meaningfully advances the meeting, either by using the provided calendar availability or by asking for updated availability if the suggested times appear stale.",
+              "A concise scheduling reply that proposes exactly one of the provided available times. It should not present a list or menu of multiple options because the sender did not ask for options.",
             criterion: {
-              name: "Substantive scheduling reply",
+              name: "One concrete meeting proposal",
               description:
-                "When the sender explicitly asks to schedule and calendar availability is provided, the draft should be a meaningful scheduling response rather than a blank or evasive reply. It may either propose the provided slots or ask for updated availability if those slots appear outdated.",
+                "When the sender asks broadly what time works and does not request options, the draft should propose exactly one specific time from the provided future availability. It must not list or offer multiple available times.",
             },
           });
           const pass = judgeResult.pass;
@@ -426,11 +426,18 @@ Priya`,
             testName,
             model: model.label,
             pass,
-            expected: "substantive draft",
+            expected: "exactly one concrete available time",
             actual: formatSemanticJudgeActual(result.reply, judgeResult),
           });
 
-          expect(judgeResult.pass).toBe(true);
+          expect(
+            judgeResult.pass,
+            `Draft should propose exactly one available time.\n\nReply:\n${result.reply}\n\nJudge: ${JSON.stringify(
+              judgeResult,
+              null,
+              2,
+            )}`,
+          ).toBe(true);
         },
         TIMEOUT,
       );

--- a/apps/web/utils/ai/reply/draft-attribution.ts
+++ b/apps/web/utils/ai/reply/draft-attribution.ts
@@ -1,7 +1,7 @@
 // Bump this when draft output behavior changes in a way that would affect
 // quality comparisons, including prompt, retrieval, routing, or
 // post-processing changes.
-export const DRAFT_PIPELINE_VERSION = 22;
+export const DRAFT_PIPELINE_VERSION = 23;
 
 export type DraftAttribution = {
   provider: string;

--- a/apps/web/utils/ai/reply/draft-reply.ts
+++ b/apps/web/utils/ai/reply/draft-reply.ts
@@ -574,7 +574,7 @@ If you list specific times, include the user-facing timezone label shown for eac
 Available time slots:
 ${times}
 
-${calendarBookingLink ? "Because the user has a booking link, share the booking link instead of listing specific times unless the sender explicitly asks the user to provide times, asks about a specific proposed time/date, or the booking link would not answer the scheduling request." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Propose one specific time rather than a list. Offer a second only if the sender asked for options or has already declined one. A menu hands the scheduling work back to the sender; one concrete proposal is easier to accept or counter.`);
+${calendarBookingLink ? "Because the user has a booking link, share the booking link instead of listing specific times unless the sender explicitly asks the user to provide times, asks about a specific proposed time/date, or the booking link would not answer the scheduling request." : "When the sender is asking to schedule, respond concretely using these time slots. Treat supplied slots on or after today's date as valid; only ask for updated availability if every supplied slot is before today's date."} Propose one specific time rather than a list unless the sender asked for multiple options. If the sender asked for a specific number of options, provide that many when enough slots are available. If the sender has already declined one proposal, offer a different specific time.`);
   }
 
   if (parts.length === 0) return "";


### PR DESCRIPTION
Follow-up to #3063: scheduling drafts still default to one concrete time, while explicit requests for multiple options now receive the requested number when availability permits.

- clarifies the scheduling prompt for explicit option counts and declined proposals
- adds semantic eval coverage for default-one and requested-multiple behavior
- bumps the draft pipeline version for quality attribution

QA: Gemini 3.1 Flash Lite reproduced the missing-options regression and passed the focused eval after this fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

