### PR TITLE
fix: make prompt rule schema provider compatible

### DIFF
--- a/apps/web/utils/actions/rule.validation.test.ts
+++ b/apps/web/utils/actions/rule.validation.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import {
   delayInMinutesSchema,
+  delayInMinutesLlmSchema,
   createRuleBody,
   type CreateRuleBody,
   updateRuleBody,
@@ -83,6 +84,20 @@ describe("delayInMinutesSchema", () => {
         expect(result.error.issues[0].message).toContain("Maximum");
       }
     });
+  });
+});
+
+describe("delayInMinutesLlmSchema", () => {
+  it("coerces an AI-generated zero-minute delay to no delay", () => {
+    expect(delayInMinutesLlmSchema.parse(0)).toBeUndefined();
+  });
+
+  it("coerces null to no delay", () => {
+    expect(delayInMinutesLlmSchema.parse(null)).toBeUndefined();
+  });
+
+  it("keeps a positive delay", () => {
+    expect(delayInMinutesLlmSchema.parse(60)).toBe(60);
   });
 });
 

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -31,8 +31,10 @@ export const delayInMinutesSchema = z
 // LLM-safe version: no .min()/.max() (Anthropic structured output rejects them).
 // Constraints are conveyed via .describe() instead.
 export const delayInMinutesLlmSchema = z
-  .number()
-  .nullish()
+  .preprocess(
+    (value) => (value === null || value === 0 ? undefined : value),
+    z.number().optional(),
+  )
   .describe(
     `Minutes to wait before executing this action (minimum 1, maximum ${NINETY_DAYS_MINUTES}). Only add when the user asks for a delay.`,
   );

--- a/apps/web/utils/actions/rule.validation.ts
+++ b/apps/web/utils/actions/rule.validation.ts
@@ -36,8 +36,10 @@ export const delayInMinutesSchema = z
 // LLM-safe version: no .min()/.max() (Anthropic structured output rejects them).
 // Constraints are conveyed via .describe() instead.
 export const delayInMinutesLlmSchema = z
-  .number()
-  .nullish()
+  .preprocess(
+    (value) => (value === null || value === 0 ? undefined : value),
+    z.number().optional(),
+  )
   .describe(
     `Minutes to wait before executing this action (minimum 1, maximum ${NINETY_DAYS_MINUTES}). Only add when the user asks for a delay.`,
   );

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { z } from "zod";
+import { z } from "zod";
 import { ActionType } from "@/generated/prisma/enums";
 import {
   createRuleSchema,
@@ -50,6 +50,15 @@ describe("createRuleSchema", () => {
 
   it("includes SEND_EMAIL in available actions for this test provider", () => {
     assertSendEmailAvailable();
+  });
+
+  it("stays within structured-output provider optional parameter limits", () => {
+    const jsonSchema = z.toJSONSchema(createRuleSchema(provider), {
+      io: "input",
+    });
+
+    expect(countOptionalProperties(jsonSchema)).toBeLessThanOrEqual(24);
+    expect(countUnionParameters(jsonSchema)).toBeLessThanOrEqual(16);
   });
 
   it("rejects SEND_EMAIL without fields.to", () => {
@@ -446,4 +455,49 @@ function buildRule(action: RuleActionFixture) {
     },
     actions: [action],
   };
+}
+
+function countOptionalProperties(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (count, item) => count + countOptionalProperties(item),
+      0,
+    );
+  }
+  if (!value || typeof value !== "object") return 0;
+
+  const schema = value as {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  const required = new Set(schema.required ?? []);
+  const optionalProperties = schema.properties
+    ? Object.keys(schema.properties).filter((key) => !required.has(key)).length
+    : 0;
+
+  return (
+    optionalProperties +
+    Object.values(schema).reduce(
+      (count, item) => count + countOptionalProperties(item),
+      0,
+    )
+  );
+}
+
+function countUnionParameters(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce((count, item) => count + countUnionParameters(item), 0);
+  }
+  if (!value || typeof value !== "object") return 0;
+
+  const schema = value as { anyOf?: unknown; type?: unknown };
+  const isUnion = Boolean(schema.anyOf) || Array.isArray(schema.type);
+
+  return (
+    Number(isUnion) +
+    Object.values(schema).reduce(
+      (count, item) => count + countUnionParameters(item),
+      0,
+    )
+  );
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -80,18 +80,15 @@ describe("createRuleSchema", () => {
     ["google", true],
     ["microsoft", false],
     ["microsoft", true],
-  ] as const)(
-    "stays within structured-output provider optional parameter limits (%s, integration=%s)",
-    (schemaProvider, integrationActionsEnabled) => {
-      const jsonSchema = z.toJSONSchema(
-        createRuleSchema(schemaProvider, integrationActionsEnabled),
-        { io: "input" },
-      );
+  ] as const)("stays within structured-output provider optional parameter limits (%s, integration=%s)", (schemaProvider, integrationActionsEnabled) => {
+    const jsonSchema = z.toJSONSchema(
+      createRuleSchema(schemaProvider, integrationActionsEnabled),
+      { io: "input" },
+    );
 
-      expect(countOptionalProperties(jsonSchema)).toBeLessThanOrEqual(24);
-      expect(countUnionParameters(jsonSchema)).toBeLessThanOrEqual(16);
-    },
-  );
+    expect(countOptionalProperties(jsonSchema)).toBeLessThanOrEqual(24);
+    expect(countUnionParameters(jsonSchema)).toBeLessThanOrEqual(16);
+  });
 
   it("keeps Todoist integration args on flattened actions", () => {
     const result = createRuleSchema(provider, true).safeParse({

--- a/apps/web/utils/ai/rule/create-rule-schema.test.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { z } from "zod";
+import { z } from "zod";
 import { ActionType } from "@/generated/prisma/enums";
 import {
   createRuleSchema,
@@ -73,6 +73,58 @@ describe("createRuleSchema", () => {
 
   it("includes SEND_EMAIL in available actions for this test provider", () => {
     assertSendEmailAvailable();
+  });
+
+  it.each([
+    ["google", false],
+    ["google", true],
+    ["microsoft", false],
+    ["microsoft", true],
+  ] as const)(
+    "stays within structured-output provider optional parameter limits (%s, integration=%s)",
+    (schemaProvider, integrationActionsEnabled) => {
+      const jsonSchema = z.toJSONSchema(
+        createRuleSchema(schemaProvider, integrationActionsEnabled),
+        { io: "input" },
+      );
+
+      expect(countOptionalProperties(jsonSchema)).toBeLessThanOrEqual(24);
+      expect(countUnionParameters(jsonSchema)).toBeLessThanOrEqual(16);
+    },
+  );
+
+  it("keeps Todoist integration args on flattened actions", () => {
+    const result = createRuleSchema(provider, true).safeParse({
+      name: "TaskRule",
+      condition: {
+        conditionalOperator: null,
+        aiInstructions: "Emails with follow-up tasks",
+        static: null,
+      },
+      actions: [
+        {
+          type: ActionType.INTEGRATION,
+          fields: {
+            content: "Follow up",
+            description: "From the email",
+            projectId: "inbox",
+            dueString: "tomorrow",
+          },
+          delayInMinutes: null,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.actions[0].fields).toEqual(
+      expect.objectContaining({
+        content: "Follow up",
+        description: "From the email",
+        projectId: "inbox",
+        dueString: "tomorrow",
+      }),
+    );
   });
 
   it("rejects SEND_EMAIL without fields.to", () => {
@@ -477,6 +529,9 @@ type RuleActionFixture = CreateRuleInput["actions"][number] & {
     content: string | null;
     webhookUrl: string | null;
     folderName: string | null;
+    description: string | null;
+    projectId: string | null;
+    dueString: string | null;
   }> | null;
 };
 
@@ -490,4 +545,49 @@ function buildRule(action: RuleActionFixture) {
     },
     actions: [action],
   };
+}
+
+function countOptionalProperties(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (count, item) => count + countOptionalProperties(item),
+      0,
+    );
+  }
+  if (!value || typeof value !== "object") return 0;
+
+  const schema = value as {
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  const required = new Set(schema.required ?? []);
+  const optionalProperties = schema.properties
+    ? Object.keys(schema.properties).filter((key) => !required.has(key)).length
+    : 0;
+
+  return (
+    optionalProperties +
+    Object.values(schema).reduce(
+      (count, item) => count + countOptionalProperties(item),
+      0,
+    )
+  );
+}
+
+function countUnionParameters(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce((count, item) => count + countUnionParameters(item), 0);
+  }
+  if (!value || typeof value !== "object") return 0;
+
+  const schema = value as { anyOf?: unknown; type?: unknown };
+  const isUnion = Boolean(schema.anyOf) || Array.isArray(schema.type);
+
+  return (
+    Number(isUnion) +
+    Object.values(schema).reduce(
+      (count, item) => count + countUnionParameters(item),
+      0,
+    )
+  );
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -13,17 +13,15 @@ import {
   isInvalidStaticFromValue,
   STATIC_FROM_CONDITION_DESCRIPTION,
 } from "@/utils/ai/rule/rule-condition-descriptions";
+import { strictOptional } from "@/utils/llms/strict-optional";
 
-const conditionalOperatorSchema = z
-  .enum([LogicalOperator.AND, LogicalOperator.OR])
-  .nullable()
-  .describe(
-    "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
-  );
+const conditionalOperatorSchema = strictOptional(
+  z.enum([LogicalOperator.AND, LogicalOperator.OR]),
+).describe(
+  "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
+);
 
-const optionalAiInstructionsSchema = z
-  .string()
-  .nullish()
+const optionalAiInstructionsSchema = optionalFromNullable(z.string())
   .transform((v) => (v?.trim() ? v : null))
   .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
 
@@ -33,9 +31,7 @@ const requiredAiInstructionsSchema = z
   .min(1)
   .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
 
-const optionalStaticFromSchema = z
-  .string()
-  .nullish()
+const optionalStaticFromSchema = optionalFromNullable(z.string())
   .transform((v) => (v?.trim() ? v : null))
   .refine((value) => !isInvalidStaticFromValue(value), {
     message: INVALID_STATIC_FROM_MESSAGE,
@@ -51,10 +47,9 @@ const requiredStaticFromSchema = z
   })
   .describe(STATIC_FROM_CONDITION_DESCRIPTION);
 
-const optionalStaticToSchema = z
-  .string()
-  .nullish()
-  .describe("The to email address to match");
+const optionalStaticToSchema = optionalFromNullable(z.string()).describe(
+  "The to email address to match",
+);
 
 const requiredStaticToSchema = z
   .string()
@@ -62,12 +57,9 @@ const requiredStaticToSchema = z
   .min(1)
   .describe("The to email address to match");
 
-const optionalStaticSubjectSchema = z
-  .string()
-  .nullish()
-  .describe(
-    "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
-  );
+const optionalStaticSubjectSchema = optionalFromNullable(z.string()).describe(
+  "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+);
 
 const requiredStaticSubjectSchema = z
   .string()
@@ -77,16 +69,15 @@ const requiredStaticSubjectSchema = z
     "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
   );
 
-const optionalStaticConditionSchema = z
-  .object({
+const optionalStaticConditionSchema = optionalFromNullable(
+  z.object({
     from: optionalStaticFromSchema,
     to: optionalStaticToSchema,
     subject: optionalStaticSubjectSchema,
-  })
-  .nullish()
-  .describe(
-    "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
-  );
+  }),
+).describe(
+  "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
+);
 
 const semanticConditionSchema = z.object({
   conditionalOperator: conditionalOperatorSchema,
@@ -165,63 +156,70 @@ export type RuleAction = {
 export const createRuleActionSchema = (
   provider: string,
 ): z.ZodType<RuleAction> => {
-  const allowedActionTypes = new Set([
-    ...getAvailableActionsForRuleEditor({ provider }),
-    ...getExtraAvailableActionsForRuleEditor(),
-  ]);
-  const optionalFieldsSchema = createOptionalActionFieldsSchema(provider);
-
-  const actionSchemas: [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [
-    createActionObjectSchema(ActionType.ARCHIVE, optionalFieldsSchema),
-    createActionObjectSchema(
+  const allowedActionTypes = [
+    ...new Set([
+      ActionType.ARCHIVE,
       ActionType.LABEL,
-      createRequiredLabelFieldsSchema(provider),
-    ),
-    createActionObjectSchema(ActionType.MARK_READ, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.STAR, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.MARK_SPAM, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.DIGEST, optionalFieldsSchema),
-    ...(allowedActionTypes.has(ActionType.DRAFT_EMAIL)
-      ? [createActionObjectSchema(ActionType.DRAFT_EMAIL, optionalFieldsSchema)]
-      : []),
-    ...(allowedActionTypes.has(ActionType.REPLY)
-      ? [createActionObjectSchema(ActionType.REPLY, optionalFieldsSchema)]
-      : []),
-    ...(allowedActionTypes.has(ActionType.FORWARD)
-      ? [
-          createActionObjectSchema(
-            ActionType.FORWARD,
-            createRequiredRecipientFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.SEND_EMAIL)
-      ? [
-          createActionObjectSchema(
-            ActionType.SEND_EMAIL,
-            createRequiredRecipientFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.CALL_WEBHOOK)
-      ? [
-          createActionObjectSchema(
-            ActionType.CALL_WEBHOOK,
-            createRequiredWebhookFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.MOVE_FOLDER)
-      ? [
-          createActionObjectSchema(
-            ActionType.MOVE_FOLDER,
-            createRequiredFolderFieldsSchema(provider),
-          ),
-        ]
-      : []),
-  ];
+      ActionType.MARK_READ,
+      ActionType.STAR,
+      ActionType.MARK_SPAM,
+      ActionType.DIGEST,
+      ...getAvailableActionsForRuleEditor({ provider }),
+      ...getExtraAvailableActionsForRuleEditor(),
+    ]),
+  ] as [ActionType, ...ActionType[]];
 
-  return z.union(actionSchemas) as z.ZodType<RuleAction>;
+  return z
+    .object({
+      type: z
+        .enum(allowedActionTypes)
+        .describe(
+          allowedActionTypes
+            .map((type) => `${type}: ${getActionTypeDescription(type)}`)
+            .join("\n"),
+        ),
+      fields: optionalFromNullable(
+        z
+          .object(createActionFieldShape(provider))
+          .describe("Populate only fields relevant to the selected action."),
+      ),
+      delayInMinutes: delayInMinutesLlmSchema,
+    })
+    .superRefine((action, ctx) => {
+      if (action.type === ActionType.LABEL && !action.fields?.label?.trim()) {
+        addRequiredFieldIssue(ctx, "label", "LABEL requires fields.label.");
+      }
+      if (
+        (action.type === ActionType.FORWARD ||
+          action.type === ActionType.SEND_EMAIL) &&
+        !action.fields?.to?.trim()
+      ) {
+        addRequiredFieldIssue(ctx, "to", "fields.to is required.");
+      }
+      if (
+        action.type === ActionType.CALL_WEBHOOK &&
+        !action.fields?.webhookUrl?.trim()
+      ) {
+        addRequiredFieldIssue(
+          ctx,
+          "webhookUrl",
+          "CALL_WEBHOOK requires fields.webhookUrl.",
+        );
+      }
+      if (
+        action.type === ActionType.MOVE_FOLDER &&
+        !action.fields?.folderName?.trim()
+      ) {
+        addRequiredFieldIssue(
+          ctx,
+          "folderName",
+          "MOVE_FOLDER requires fields.folderName.",
+        );
+      }
+    })
+    .describe(
+      "An action to apply when the rule matches. Select a supported type and provide its required fields.",
+    );
 };
 
 export const createRuleSchema = (provider: string) =>
@@ -241,16 +239,6 @@ export type CreateRuleSchema = z.infer<ReturnType<typeof createRuleSchema>>;
 export type CreateOrUpdateRuleSchema = CreateRuleSchema & {
   ruleId?: string;
 };
-
-function createActionObjectSchema(type: ActionType, fields: z.ZodTypeAny) {
-  return z
-    .object({
-      type: z.literal(type),
-      fields,
-      delayInMinutes: delayInMinutesLlmSchema,
-    })
-    .describe(getActionTypeDescription(type));
-}
 
 function getActionTypeDescription(type: ActionType) {
   switch (type) {
@@ -283,56 +271,6 @@ function getActionTypeDescription(type: ActionType) {
   }
 }
 
-function createOptionalActionFieldsSchema(provider: string) {
-  return z.object(createActionFieldShape(provider)).nullish();
-}
-
-function createRequiredLabelFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    label: requiredStringField(
-      "The label to apply to the email",
-      "LABEL requires fields.label.",
-    ),
-  });
-}
-
-function createRequiredRecipientFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    to: requiredStringField(
-      "The recipient email address. Required for SEND_EMAIL and FORWARD. Use REPLY when responding to the triggering inbound email.",
-      "fields.to is required.",
-    ),
-  });
-}
-
-function createRequiredWebhookFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    webhookUrl: requiredStringField(
-      "The webhook URL to call. Required for CALL_WEBHOOK; use CALL_WEBHOOK only when the user explicitly supplies a webhook URL.",
-      "CALL_WEBHOOK requires fields.webhookUrl.",
-    ),
-  });
-}
-
-function createRequiredFolderFieldsSchema(provider: string) {
-  const fieldShape = createActionFieldShape(provider);
-
-  if (!("folderName" in fieldShape)) {
-    throw new Error("MOVE_FOLDER is only supported for Microsoft providers.");
-  }
-
-  return z.object({
-    ...fieldShape,
-    folderName: requiredStringField(
-      "The folder to move the email to",
-      "MOVE_FOLDER requires fields.folderName.",
-    ),
-  });
-}
-
 function createActionFieldShape(provider: string) {
   return {
     label: optionalStringField("The label to apply to the email"),
@@ -353,17 +291,21 @@ function createActionFieldShape(provider: string) {
 }
 
 function optionalStringField(description: string) {
-  return z
-    .string()
-    .nullish()
-    .transform((value) => value ?? null)
-    .describe(description);
+  return optionalFromNullable(z.string()).describe(description);
 }
 
-function requiredStringField(description: string, message: string) {
-  return z
-    .string()
-    .transform((value) => value.trim())
-    .refine(Boolean, message)
-    .describe(description);
+function optionalFromNullable<T extends z.ZodType>(schema: T) {
+  return z.preprocess((value) => value ?? undefined, schema.optional());
+}
+
+function addRequiredFieldIssue(
+  ctx: z.RefinementCtx,
+  field: keyof RuleActionFields,
+  message: string,
+) {
+  ctx.addIssue({
+    code: "custom",
+    message,
+    path: ["fields", field],
+  });
 }

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -186,7 +186,9 @@ export const createRuleActionSchema = (
       ...getExtraAvailableActionsForRuleEditor({ integrationActionsEnabled }),
     ]),
   ] as [ActionType, ...ActionType[]];
-  const integrationToolSpec = allowedActionTypes.includes(ActionType.INTEGRATION)
+  const integrationToolSpec = allowedActionTypes.includes(
+    ActionType.INTEGRATION,
+  )
     ? getOnlyIntegrationToolSpec()
     : undefined;
 

--- a/apps/web/utils/ai/rule/create-rule-schema.ts
+++ b/apps/web/utils/ai/rule/create-rule-schema.ts
@@ -18,17 +18,15 @@ import {
   STATIC_FROM_CONDITION_DESCRIPTION,
 } from "@/utils/ai/rule/rule-condition-descriptions";
 import { isIntegrationActionGloballyEnabled } from "@/utils/integration-action";
+import { strictOptional } from "@/utils/llms/strict-optional";
 
-const conditionalOperatorSchema = z
-  .enum([LogicalOperator.AND, LogicalOperator.OR])
-  .nullable()
-  .describe(
-    "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
-  );
+const conditionalOperatorSchema = strictOptional(
+  z.enum([LogicalOperator.AND, LogicalOperator.OR]),
+).describe(
+  "The conditional operator to use. AND means all conditions must be true for the rule to match. OR means any condition can be true for the rule to match. This does not impact sub-conditions.",
+);
 
-const optionalAiInstructionsSchema = z
-  .string()
-  .nullish()
+const optionalAiInstructionsSchema = optionalFromNullable(z.string())
   .transform((v) => (v?.trim() ? v : null))
   .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
 
@@ -38,9 +36,7 @@ const requiredAiInstructionsSchema = z
   .min(1)
   .describe(AI_INSTRUCTIONS_PROMPT_DESCRIPTION);
 
-const optionalStaticFromSchema = z
-  .string()
-  .nullish()
+const optionalStaticFromSchema = optionalFromNullable(z.string())
   .transform((v) => (v?.trim() ? v : null))
   .refine((value) => !isInvalidStaticFromValue(value), {
     message: INVALID_STATIC_FROM_MESSAGE,
@@ -56,10 +52,9 @@ const requiredStaticFromSchema = z
   })
   .describe(STATIC_FROM_CONDITION_DESCRIPTION);
 
-const optionalStaticToSchema = z
-  .string()
-  .nullish()
-  .describe("The to email address to match");
+const optionalStaticToSchema = optionalFromNullable(z.string()).describe(
+  "The to email address to match",
+);
 
 const requiredStaticToSchema = z
   .string()
@@ -67,12 +62,9 @@ const requiredStaticToSchema = z
   .min(1)
   .describe("The to email address to match");
 
-const optionalStaticSubjectSchema = z
-  .string()
-  .nullish()
-  .describe(
-    "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
-  );
+const optionalStaticSubjectSchema = optionalFromNullable(z.string()).describe(
+  "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
+);
 
 const requiredStaticSubjectSchema = z
   .string()
@@ -82,16 +74,15 @@ const requiredStaticSubjectSchema = z
     "Subject-line text to match. Use this when the user explicitly asks to match the email subject. If the user describes email content, topic, meaning, or general keyword matching without naming the subject line, use aiInstructions instead.",
   );
 
-const optionalStaticConditionSchema = z
-  .object({
+const optionalStaticConditionSchema = optionalFromNullable(
+  z.object({
     from: optionalStaticFromSchema,
     to: optionalStaticToSchema,
     subject: optionalStaticSubjectSchema,
-  })
-  .nullish()
-  .describe(
-    "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
-  );
+  }),
+).describe(
+  "The static conditions to match. If multiple static conditions are specified, the rule will match if ALL of the conditions match (AND operation)",
+);
 
 const semanticConditionSchema = z.object({
   conditionalOperator: conditionalOperatorSchema,
@@ -168,6 +159,9 @@ export type RuleActionFields = {
   content?: string | null;
   webhookUrl?: string | null;
   folderName?: string | null;
+  description?: string | null;
+  projectId?: string | null;
+  dueString?: string | null;
 };
 
 export type RuleAction = {
@@ -180,73 +174,76 @@ export const createRuleActionSchema = (
   provider: string,
   integrationActionsEnabled = isIntegrationActionGloballyEnabled(),
 ): z.ZodType<RuleAction> => {
-  const allowedActionTypes = new Set([
-    ...getAvailableActionsForRuleEditor({ provider }),
-    ...getExtraAvailableActionsForRuleEditor({ integrationActionsEnabled }),
-  ]);
-  const integrationToolSpec = getOnlyIntegrationToolSpec();
-  const optionalFieldsSchema = createOptionalActionFieldsSchema(provider);
-
-  const actionSchemas: [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [
-    createActionObjectSchema(ActionType.ARCHIVE, optionalFieldsSchema),
-    createActionObjectSchema(
+  const allowedActionTypes = [
+    ...new Set([
+      ActionType.ARCHIVE,
       ActionType.LABEL,
-      createRequiredLabelFieldsSchema(provider),
-    ),
-    createActionObjectSchema(ActionType.MARK_READ, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.STAR, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.MARK_SPAM, optionalFieldsSchema),
-    createActionObjectSchema(ActionType.DIGEST, optionalFieldsSchema),
-    ...(allowedActionTypes.has(ActionType.DRAFT_EMAIL)
-      ? [createActionObjectSchema(ActionType.DRAFT_EMAIL, optionalFieldsSchema)]
-      : []),
-    ...(allowedActionTypes.has(ActionType.REPLY)
-      ? [createActionObjectSchema(ActionType.REPLY, optionalFieldsSchema)]
-      : []),
-    ...(allowedActionTypes.has(ActionType.FORWARD)
-      ? [
-          createActionObjectSchema(
-            ActionType.FORWARD,
-            createRequiredRecipientFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.SEND_EMAIL)
-      ? [
-          createActionObjectSchema(
-            ActionType.SEND_EMAIL,
-            createRequiredRecipientFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.CALL_WEBHOOK)
-      ? [
-          createActionObjectSchema(
-            ActionType.CALL_WEBHOOK,
-            createRequiredWebhookFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.MOVE_FOLDER)
-      ? [
-          createActionObjectSchema(
-            ActionType.MOVE_FOLDER,
-            createRequiredFolderFieldsSchema(provider),
-          ),
-        ]
-      : []),
-    ...(allowedActionTypes.has(ActionType.INTEGRATION) && integrationToolSpec
-      ? [
-          createActionObjectSchema(
-            ActionType.INTEGRATION,
-            createIntegrationFieldsSchema(integrationToolSpec),
-            integrationToolSpec.llmDescription,
-          ),
-        ]
-      : []),
-  ];
+      ActionType.MARK_READ,
+      ActionType.STAR,
+      ActionType.MARK_SPAM,
+      ActionType.DIGEST,
+      ...getAvailableActionsForRuleEditor({ provider }),
+      ...getExtraAvailableActionsForRuleEditor({ integrationActionsEnabled }),
+    ]),
+  ] as [ActionType, ...ActionType[]];
+  const integrationToolSpec = allowedActionTypes.includes(ActionType.INTEGRATION)
+    ? getOnlyIntegrationToolSpec()
+    : undefined;
 
-  return z.union(actionSchemas) as z.ZodType<RuleAction>;
+  return z
+    .object({
+      type: z
+        .enum(allowedActionTypes)
+        .describe(
+          allowedActionTypes
+            .map(
+              (type) =>
+                `${type}: ${getActionTypeDescription(type, integrationToolSpec)}`,
+            )
+            .join("\n"),
+        ),
+      fields: optionalFromNullable(
+        z
+          .object(createActionFieldShape(provider, integrationToolSpec))
+          .describe("Populate only fields relevant to the selected action."),
+      ),
+      delayInMinutes: delayInMinutesLlmSchema,
+    })
+    .superRefine((action, ctx) => {
+      if (action.type === ActionType.LABEL && !action.fields?.label?.trim()) {
+        addRequiredFieldIssue(ctx, "label", "LABEL requires fields.label.");
+      }
+      if (
+        (action.type === ActionType.FORWARD ||
+          action.type === ActionType.SEND_EMAIL) &&
+        !action.fields?.to?.trim()
+      ) {
+        addRequiredFieldIssue(ctx, "to", "fields.to is required.");
+      }
+      if (
+        action.type === ActionType.CALL_WEBHOOK &&
+        !action.fields?.webhookUrl?.trim()
+      ) {
+        addRequiredFieldIssue(
+          ctx,
+          "webhookUrl",
+          "CALL_WEBHOOK requires fields.webhookUrl.",
+        );
+      }
+      if (
+        action.type === ActionType.MOVE_FOLDER &&
+        !action.fields?.folderName?.trim()
+      ) {
+        addRequiredFieldIssue(
+          ctx,
+          "folderName",
+          "MOVE_FOLDER requires fields.folderName.",
+        );
+      }
+    })
+    .describe(
+      "An action to apply when the rule matches. Select a supported type and provide its required fields.",
+    );
 };
 
 export const createRuleSchema = (
@@ -270,21 +267,10 @@ export type CreateOrUpdateRuleSchema = CreateRuleSchema & {
   ruleId?: string;
 };
 
-function createActionObjectSchema(
+function getActionTypeDescription(
   type: ActionType,
-  fields: z.ZodTypeAny,
-  description?: string,
+  integrationToolSpec?: IntegrationToolSpec,
 ) {
-  return z
-    .object({
-      type: z.literal(type),
-      fields,
-      delayInMinutes: delayInMinutesLlmSchema,
-    })
-    .describe(description ?? getActionTypeDescription(type));
-}
-
-function getActionTypeDescription(type: ActionType) {
   switch (type) {
     case ActionType.DRAFT_EMAIL:
       return "Draft a reply to the matching inbound email without sending it. Use this for draft reply requests.";
@@ -310,77 +296,24 @@ function getActionTypeDescription(type: ActionType) {
       return "Call a webhook for the matching email. Only use this when the user explicitly asks for a webhook, external HTTP callback, or integration URL and provides the webhook URL. Do not use this for ordinary labeling, archiving, categorization, notifications, folders, or other email automation.";
     case ActionType.MOVE_FOLDER:
       return "Move the matching email to a folder.";
+    case ActionType.INTEGRATION:
+      return (
+        integrationToolSpec?.llmDescription ??
+        "Add a task to a connected integration for the matching email."
+      );
     default:
       return "Action type to apply to the matching email.";
   }
 }
 
-function createOptionalActionFieldsSchema(provider: string) {
-  return z.object(createActionFieldShape(provider)).nullish();
-}
-
-function createRequiredLabelFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    label: requiredStringField(
-      "The label to apply to the email",
-      "LABEL requires fields.label.",
-    ),
-  });
-}
-
-function createRequiredRecipientFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    to: requiredStringField(
-      "The recipient email address. Required for SEND_EMAIL and FORWARD. Use REPLY when responding to the triggering inbound email.",
-      "fields.to is required.",
-    ),
-  });
-}
-
-function createRequiredWebhookFieldsSchema(provider: string) {
-  return z.object({
-    ...createActionFieldShape(provider),
-    webhookUrl: requiredStringField(
-      "The webhook URL to call. Required for CALL_WEBHOOK; use CALL_WEBHOOK only when the user explicitly supplies a webhook URL.",
-      "CALL_WEBHOOK requires fields.webhookUrl.",
-    ),
-  });
-}
-
-function createRequiredFolderFieldsSchema(provider: string) {
-  const fieldShape = createActionFieldShape(provider);
-
-  if (!("folderName" in fieldShape)) {
-    throw new Error("MOVE_FOLDER is only supported for Microsoft providers.");
-  }
-
-  return z.object({
-    ...fieldShape,
-    folderName: requiredStringField(
-      "The folder to move the email to",
-      "MOVE_FOLDER requires fields.folderName.",
-    ),
-  });
-}
-
-/** Exposes exactly the args the spec marks as LLM-settable. */
-function createIntegrationFieldsSchema(spec: IntegrationToolSpec) {
-  return z.object(
-    Object.fromEntries(
-      spec.args
-        .filter((arg) => arg.llmDescription)
-        .map((arg) => [
-          arg.key,
-          optionalStringField(arg.llmDescription as string),
-        ]),
-    ),
-  );
-}
-
-function createActionFieldShape(provider: string) {
-  return {
+function createActionFieldShape(
+  provider: string,
+  integrationToolSpec?: IntegrationToolSpec,
+) {
+  const integrationContentDescription = integrationToolSpec?.args.find(
+    (arg) => arg.key === "content",
+  )?.llmDescription;
+  const fields: Record<string, z.ZodTypeAny> = {
     label: optionalStringField("The label to apply to the email"),
     to: optionalStringField(
       "The recipient email address. Required for SEND_EMAIL and FORWARD. Use REPLY when responding to the triggering inbound email.",
@@ -388,7 +321,11 @@ function createActionFieldShape(provider: string) {
     cc: optionalStringField("The cc email address to send the email to"),
     bcc: optionalStringField("The bcc email address to send the email to"),
     subject: optionalStringField("The subject of the email"),
-    content: optionalStringField("The content of the email"),
+    content: optionalStringField(
+      integrationContentDescription
+        ? `The content of the email. For INTEGRATION, ${integrationContentDescription}`
+        : "The content of the email",
+    ),
     webhookUrl: optionalStringField(
       "The webhook URL to call. Only relevant for explicit webhook or external HTTP callback requests.",
     ),
@@ -396,20 +333,36 @@ function createActionFieldShape(provider: string) {
       folderName: optionalStringField("The folder to move the email to"),
     }),
   };
+
+  if (!integrationToolSpec) return fields;
+
+  for (const arg of integrationToolSpec.args) {
+    if (arg.key in fields) continue;
+    fields[arg.key] = optionalStringField(
+      arg.llmDescription ??
+        `${arg.label}. Leave empty unless the user specified one.`,
+    );
+  }
+
+  return fields;
 }
 
 function optionalStringField(description: string) {
-  return z
-    .string()
-    .nullish()
-    .transform((value) => value ?? null)
-    .describe(description);
+  return optionalFromNullable(z.string()).describe(description);
 }
 
-function requiredStringField(description: string, message: string) {
-  return z
-    .string()
-    .transform((value) => value.trim())
-    .refine(Boolean, message)
-    .describe(description);
+function optionalFromNullable<T extends z.ZodType>(schema: T) {
+  return z.preprocess((value) => value ?? undefined, schema.optional());
+}
+
+function addRequiredFieldIssue(
+  ctx: z.RefinementCtx,
+  field: keyof RuleActionFields,
+  message: string,
+) {
+  ctx.addIssue({
+    code: "custom",
+    message,
+    path: ["fields", field],
+  });
 }

--- a/apps/web/utils/mcp/tool-specs.test.ts
+++ b/apps/web/utils/mcp/tool-specs.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildIntegrationArgsFromFields,
   getIntegrationActionDisplayValue,
   getIntegrationActionLabel,
+  getOnlyIntegrationToolSpec,
 } from "./tool-specs";
 
 describe("getIntegrationActionLabel", () => {
@@ -69,5 +71,32 @@ describe("getIntegrationActionDisplayValue", () => {
         integrationArgs: { content: "   " },
       }),
     ).toBeNull();
+  });
+});
+
+describe("buildIntegrationArgsFromFields", () => {
+  it("keeps Todoist title, description, project, and due date from flat fields", () => {
+    const spec = getOnlyIntegrationToolSpec();
+    expect(spec).toBeDefined();
+    if (!spec) return;
+
+    expect(
+      buildIntegrationArgsFromFields({
+        spec,
+        fields: {
+          content: "Follow up",
+          description: "From the email",
+          projectId: "inbox",
+          dueString: "tomorrow",
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        content: "Follow up",
+        description: "From the email",
+        projectId: "inbox",
+        dueString: "tomorrow",
+      }),
+    );
   });
 });

--- a/apps/web/utils/mcp/tool-specs.ts
+++ b/apps/web/utils/mcp/tool-specs.ts
@@ -290,6 +290,33 @@ export function buildDefaultIntegrationArgs(
 }
 
 /**
+ * Builds stored args from an AI-authored action's flat fields, applying the
+ * spec's defaults so an omitted field means "the AI writes it at execution".
+ */
+export function buildIntegrationArgsFromFields({
+  spec,
+  fields,
+}: {
+  spec: IntegrationToolSpec;
+  fields?: Record<string, string | null | undefined> | null;
+}): Record<string, string> {
+  const args = buildDefaultIntegrationArgs(spec);
+
+  for (const arg of spec.args) {
+    const value = fields?.[arg.key];
+    if (value == null) continue;
+
+    const normalized =
+      arg.control.type === "select"
+        ? normalizeSelectArgValue(arg, value)
+        : value;
+    if (normalized !== undefined) args[arg.key] = normalized;
+  }
+
+  return args;
+}
+
+/**
  * Maps a loosely-specified select value (e.g. "in 7 days" from an AI-authored
  * rule) onto the option value we store, so the editor can show the choice.
  */

--- a/apps/web/utils/mcp/tool-specs.ts
+++ b/apps/web/utils/mcp/tool-specs.ts
@@ -298,13 +298,14 @@ export function buildIntegrationArgsFromFields({
   fields,
 }: {
   spec: IntegrationToolSpec;
-  fields?: Record<string, string | null | undefined> | null;
+  fields?: object | null;
 }): Record<string, string> {
   const args = buildDefaultIntegrationArgs(spec);
+  const fieldValues = fields as Record<string, unknown> | null | undefined;
 
   for (const arg of spec.args) {
-    const value = fields?.[arg.key];
-    if (value == null) continue;
+    const value = fieldValues?.[arg.key];
+    if (typeof value !== "string") continue;
 
     const normalized =
       arg.control.type === "select"

--- a/apps/web/utils/rule/mobile-rule.test.ts
+++ b/apps/web/utils/rule/mobile-rule.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import { createRuleBody } from "@/utils/actions/rule.validation";
+import { createRuleSchema } from "@/utils/ai/rule/create-rule-schema";
 import { toCreateRuleBodyFromAiRule } from "@/utils/rule/mobile-rule";
 
 describe("toCreateRuleBodyFromAiRule", () => {
@@ -101,5 +102,28 @@ describe("toCreateRuleBodyFromAiRule", () => {
     );
 
     expect(result.success).toBe(true);
+  });
+
+  it("treats an AI-generated zero-minute delay as no delay", () => {
+    const generatedRule = createRuleSchema("google").parse({
+      name: "Invoices",
+      condition: {
+        aiInstructions: null,
+        conditionalOperator: null,
+        static: { subject: "Invoice" },
+      },
+      actions: [
+        {
+          type: ActionType.ARCHIVE,
+          fields: null,
+          delayInMinutes: 0,
+        },
+      ],
+    });
+
+    const rule = toCreateRuleBodyFromAiRule(generatedRule);
+
+    expect(rule.actions[0].delayInMinutes).toBeUndefined();
+    expect(createRuleBody.safeParse(rule).success).toBe(true);
   });
 });

--- a/apps/web/utils/rule/mobile-rule.test.ts
+++ b/apps/web/utils/rule/mobile-rule.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ActionType, LogicalOperator } from "@/generated/prisma/enums";
 import { createRuleBody } from "@/utils/actions/rule.validation";
+import { createRuleSchema } from "@/utils/ai/rule/create-rule-schema";
 import { toCreateRuleBodyFromAiRule } from "@/utils/rule/mobile-rule";
 
 describe("toCreateRuleBodyFromAiRule", () => {
@@ -101,5 +102,70 @@ describe("toCreateRuleBodyFromAiRule", () => {
     );
 
     expect(result.success).toBe(true);
+  });
+
+  it("treats an AI-generated zero-minute delay as no delay", () => {
+    const generatedRule = createRuleSchema("google").parse({
+      name: "Invoices",
+      condition: {
+        aiInstructions: null,
+        conditionalOperator: null,
+        static: { subject: "Invoice" },
+      },
+      actions: [
+        {
+          type: ActionType.ARCHIVE,
+          fields: null,
+          delayInMinutes: 0,
+        },
+      ],
+    });
+
+    const rule = toCreateRuleBodyFromAiRule(generatedRule);
+
+    expect(rule.actions[0].delayInMinutes).toBeUndefined();
+    expect(createRuleBody.safeParse(rule).success).toBe(true);
+  });
+
+  it("maps Todoist integration fields into createRuleBody args", () => {
+    const generatedRule = createRuleSchema("google", true).parse({
+      name: "Tasks",
+      condition: {
+        aiInstructions: "Action items",
+        conditionalOperator: null,
+        static: null,
+      },
+      actions: [
+        {
+          type: ActionType.INTEGRATION,
+          fields: {
+            content: "Follow up",
+            description: "From the email",
+            projectId: "inbox",
+            dueString: "tomorrow",
+          },
+          delayInMinutes: 0,
+        },
+      ],
+    });
+
+    const rule = toCreateRuleBodyFromAiRule(generatedRule);
+
+    expect(rule.actions[0]).toEqual(
+      expect.objectContaining({
+        type: ActionType.INTEGRATION,
+        content: undefined,
+        delayInMinutes: undefined,
+        integrationName: "todoist",
+        integrationToolName: "add-tasks",
+        integrationArgs: expect.objectContaining({
+          content: "Follow up",
+          description: "From the email",
+          projectId: "inbox",
+          dueString: "tomorrow",
+        }),
+      }),
+    );
+    expect(createRuleBody.safeParse(rule).success).toBe(true);
   });
 });

--- a/apps/web/utils/rule/mobile-rule.ts
+++ b/apps/web/utils/rule/mobile-rule.ts
@@ -1,6 +1,11 @@
+import { ActionType } from "@/generated/prisma/enums";
 import { ConditionType } from "@/utils/config";
 import type { CreateRuleBody } from "@/utils/actions/rule.validation";
 import type { CreateRuleSchema } from "@/utils/ai/rule/create-rule-schema";
+import {
+  buildIntegrationArgsFromFields,
+  getOnlyIntegrationToolSpec,
+} from "@/utils/mcp/tool-specs";
 
 export function toCreateRuleBodyFromAiRule(
   rule: CreateRuleSchema,
@@ -28,25 +33,45 @@ export function toCreateRuleBodyFromAiRule(
     runOnThreads: true,
     conditionalOperator: rule.condition.conditionalOperator ?? undefined,
     conditions,
-    actions: rule.actions.map((action) => ({
-      type: action.type,
-      labelId: action.fields?.label ? { name: action.fields.label } : undefined,
-      subject: action.fields?.subject
-        ? { value: action.fields.subject }
-        : undefined,
-      content: action.fields?.content
-        ? { value: action.fields.content }
-        : undefined,
-      to: action.fields?.to ? { value: action.fields.to } : undefined,
-      cc: action.fields?.cc ? { value: action.fields.cc } : undefined,
-      bcc: action.fields?.bcc ? { value: action.fields.bcc } : undefined,
-      url: action.fields?.webhookUrl
-        ? { value: action.fields.webhookUrl }
-        : undefined,
-      folderName: action.fields?.folderName
-        ? { value: action.fields.folderName }
-        : undefined,
-      delayInMinutes: action.delayInMinutes,
-    })),
+    actions: rule.actions.map((action) => {
+      const mappedAction = {
+        type: action.type,
+        labelId: action.fields?.label
+          ? { name: action.fields.label }
+          : undefined,
+        subject: action.fields?.subject
+          ? { value: action.fields.subject }
+          : undefined,
+        content: action.fields?.content
+          ? { value: action.fields.content }
+          : undefined,
+        to: action.fields?.to ? { value: action.fields.to } : undefined,
+        cc: action.fields?.cc ? { value: action.fields.cc } : undefined,
+        bcc: action.fields?.bcc ? { value: action.fields.bcc } : undefined,
+        url: action.fields?.webhookUrl
+          ? { value: action.fields.webhookUrl }
+          : undefined,
+        folderName: action.fields?.folderName
+          ? { value: action.fields.folderName }
+          : undefined,
+        delayInMinutes: action.delayInMinutes,
+      };
+
+      if (action.type !== ActionType.INTEGRATION) return mappedAction;
+
+      const spec = getOnlyIntegrationToolSpec();
+      return {
+        ...mappedAction,
+        content: undefined,
+        integrationName: spec?.integration,
+        integrationToolName: spec?.tool,
+        integrationArgs: spec
+          ? buildIntegrationArgsFromFields({
+              spec,
+              fields: action.fields,
+            })
+          : undefined,
+      };
+    }),
   };
 }

--- a/apps/web/utils/rule/rule.ts
+++ b/apps/web/utils/rule/rule.ts
@@ -33,10 +33,9 @@ import {
 } from "@/utils/rule-action-feature-gates";
 import { findIntegration } from "@/utils/mcp/integrations";
 import {
-  buildDefaultIntegrationArgs,
+  buildIntegrationArgsFromFields,
   getIntegrationToolSpec,
   getOnlyIntegrationToolSpec,
-  normalizeSelectArgValue,
 } from "@/utils/mcp/tool-specs";
 import { hasWebhookAction } from "@/utils/webhook-action";
 import { assertNoSenderOnlyOverlap } from "@/utils/rule/sender-scope-overlap";
@@ -878,15 +877,18 @@ function getIntegrationCreateFields(action: MappableAction) {
   const integrationName = action.integrationName ?? defaultSpec?.integration;
   const integrationToolName = action.integrationToolName ?? defaultSpec?.tool;
 
+  const spec = getIntegrationToolSpec(integrationName, integrationToolName);
+
   return {
     integrationName: integrationName ?? null,
     integrationToolName: integrationToolName ?? null,
     integrationArgs: (action.integrationArgs ??
-      buildIntegrationArgsFromFields({
-        integrationName,
-        integrationToolName,
-        fields: action.fields,
-      })) as Prisma.InputJsonValue,
+      (spec
+        ? buildIntegrationArgsFromFields({
+            spec,
+            fields: action.fields,
+          })
+        : {})) as Prisma.InputJsonValue,
   };
 }
 
@@ -909,40 +911,6 @@ function buildRiskAction(action: MappableAction): RiskAction {
       (integrationFields?.integrationArgs as Prisma.JsonValue | undefined) ??
       null,
   };
-}
-
-/**
- * Builds stored args from an AI-authored action's flat fields, applying the
- * spec's defaults so an omitted field means "the AI writes it at execution".
- */
-function buildIntegrationArgsFromFields({
-  integrationName,
-  integrationToolName,
-  fields,
-}: {
-  integrationName: string | null | undefined;
-  integrationToolName: string | null | undefined;
-  fields: MappableAction["fields"];
-}) {
-  const spec = getIntegrationToolSpec(integrationName, integrationToolName);
-  if (!spec) return {};
-
-  const args = buildDefaultIntegrationArgs(spec);
-
-  for (const arg of spec.args) {
-    const value = (
-      fields as Record<string, string | null | undefined> | null
-    )?.[arg.key];
-    if (value == null) continue;
-
-    const normalized =
-      arg.control.type === "select"
-        ? normalizeSelectArgValue(arg, value)
-        : value;
-    if (normalized !== undefined) args[arg.key] = normalized;
-  }
-
-  return args;
 }
 
 export async function assertIntegrationActionsConnected(


### PR DESCRIPTION
## Summary
- reduce optional and union parameters in the prompt-to-rules structured schema to provider-supported limits
- preserve provider-specific action availability and required action-field validation
- treat an AI-generated zero-minute delay as no delay before normal rule validation
- add provider-limit and zero-delay regression coverage

## QA
- `pnpm test utils/actions/rule.validation.test.ts utils/rule/mobile-rule.test.ts utils/ai/rule/create-rule-schema.test.ts` (70 passed)
- `pnpm exec ultracite check` on all changed files
- prompt-based mobile rule creation returned 201 and rendered the requested subject/archive rule in the app
- Gemini 3.1 Flash Lite prompt-to-rules regression: 5 passed initially; the single judge false-negative passed on isolated rerun with Gemini forced for both generation and judging

## Performance
The flattened action schema reduces structured-output grammar complexity and schema size. It adds no database calls or request-path work outside existing Zod validation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI-created integration actions now preserve supported fields such as descriptions, projects, due dates, and task content.
  - Integration actions are automatically converted into the correct tool configuration and arguments when creating rules.
  - Rule creation now supports consistent integration details across supported providers.

- **Bug Fixes**
  - Zero-minute or empty delays are now treated as no delay instead of creating an unnecessary delay.
  - Integration field values are normalized to valid supported options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->