### PR TITLE
rules: Persist action execution outcomes

### DIFF
--- a/apps/web/prisma/migrations/20260728120000_add_executed_action_outcomes/migration.sql
+++ b/apps/web/prisma/migrations/20260728120000_add_executed_action_outcomes/migration.sql
@@ -7,11 +7,7 @@ CREATE TYPE "ExecutedActionStatus" AS ENUM (
 ALTER TABLE "ExecutedAction"
 ADD COLUMN "executionStatus" "ExecutedActionStatus",
 ADD COLUMN "executedAt" TIMESTAMP(3),
-ADD COLUMN "errorCode" TEXT,
-ADD COLUMN "errorMessage" TEXT,
-ADD COLUMN "errorStack" TEXT,
-ADD COLUMN "errorStatusCode" INTEGER,
-ADD COLUMN "errorRequestId" TEXT;
+ADD COLUMN "executionError" JSONB;
 
 CREATE INDEX "ExecutedAction_executionStatus_createdAt_idx"
 ON "ExecutedAction"("executionStatus", "createdAt");

--- a/apps/web/prisma/migrations/20260728120000_add_executed_action_outcomes/migration.sql
+++ b/apps/web/prisma/migrations/20260728120000_add_executed_action_outcomes/migration.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "ExecutedActionStatus" AS ENUM (
+  'SUCCEEDED',
+  'FAILED',
+  'SKIPPED'
+);
+
+ALTER TABLE "ExecutedAction"
+ADD COLUMN "executionStatus" "ExecutedActionStatus",
+ADD COLUMN "executedAt" TIMESTAMP(3),
+ADD COLUMN "errorCode" TEXT,
+ADD COLUMN "errorMessage" TEXT,
+ADD COLUMN "errorStack" TEXT,
+ADD COLUMN "errorStatusCode" INTEGER,
+ADD COLUMN "errorRequestId" TEXT;
+
+CREATE INDEX "ExecutedAction_executionStatus_createdAt_idx"
+ON "ExecutedAction"("executionStatus", "createdAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -689,11 +689,7 @@ model ExecutedAction {
   type                   ActionType
   executionStatus        ExecutedActionStatus?
   executedAt             DateTime?
-  errorCode              String?
-  errorMessage           String?                 @db.Text
-  errorStack             String?                 @db.Text
-  errorStatusCode        Int?
-  errorRequestId         String?
+  executionError         Json?
   executedRuleId         String
   executedRule           ExecutedRule            @relation(fields: [executedRuleId], references: [id], onDelete: Cascade)
   messagingChannelId     String?

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -687,6 +687,13 @@ model ExecutedAction {
   createdAt              DateTime                @default(now())
   updatedAt              DateTime                @updatedAt
   type                   ActionType
+  executionStatus        ExecutedActionStatus?
+  executedAt             DateTime?
+  errorCode              String?
+  errorMessage           String?                 @db.Text
+  errorStack             String?                 @db.Text
+  errorStatusCode        Int?
+  errorRequestId         String?
   executedRuleId         String
   executedRule           ExecutedRule            @relation(fields: [executedRuleId], references: [id], onDelete: Cascade)
   messagingChannelId     String?
@@ -722,6 +729,7 @@ model ExecutedAction {
   scheduledAction      ScheduledAction? // Reverse relation for delayed actions
 
   @@index([executedRuleId])
+  @@index([executionStatus, createdAt])
   @@index([messagingChannelId, createdAt])
 }
 
@@ -1790,6 +1798,12 @@ enum ExecutedRuleStatus {
   PENDING // @deprecated - No longer created. Kept for historical data only.
   SKIPPED
   ERROR
+}
+
+enum ExecutedActionStatus {
+  SUCCEEDED
+  FAILED
+  SKIPPED
 }
 
 enum GroupItemType {

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
 import { ActionType, ExecutedRuleStatus } from "@/generated/prisma/enums";
 import { executeAct } from "@/utils/ai/choose-rule/execute";
 import { runActionFunction } from "@/utils/ai/actions";
@@ -123,11 +124,7 @@ describe("executeAct", () => {
       data: {
         executionStatus: "SUCCEEDED",
         executedAt: expect.any(Date),
-        errorCode: null,
-        errorMessage: null,
-        errorStack: null,
-        errorStatusCode: null,
-        errorRequestId: null,
+        executionError: Prisma.DbNull,
       },
     });
     expect(mockExecutedActionUpdate).toHaveBeenNthCalledWith(2, {
@@ -135,11 +132,7 @@ describe("executeAct", () => {
       data: {
         executionStatus: "SKIPPED",
         executedAt: expect.any(Date),
-        errorCode: null,
-        errorMessage: null,
-        errorStack: null,
-        errorStatusCode: null,
-        errorRequestId: null,
+        executionError: Prisma.DbNull,
       },
     });
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
@@ -182,11 +175,13 @@ describe("executeAct", () => {
       data: {
         executionStatus: "FAILED",
         executedAt: expect.any(Date),
-        errorCode: "RESEND_NOT_CONFIGURED",
-        errorMessage: "Action reported failure",
-        errorStack: null,
-        errorStatusCode: null,
-        errorRequestId: null,
+        executionError: {
+          code: "RESEND_NOT_CONFIGURED",
+          message: "Action reported failure",
+          stack: null,
+          statusCode: null,
+          requestId: null,
+        },
       },
     });
   });
@@ -330,11 +325,13 @@ describe("executeAct", () => {
       data: {
         executionStatus: "FAILED",
         executedAt: expect.any(Date),
-        errorCode: "ErrorMoveCopyFailed",
-        errorMessage: "Graph move failed",
-        errorStack: expect.stringContaining("Graph move failed"),
-        errorStatusCode: 503,
-        errorRequestId: "graph-request-123",
+        executionError: {
+          code: "ErrorMoveCopyFailed",
+          message: "Graph move failed",
+          stack: expect.stringContaining("Graph move failed"),
+          statusCode: 503,
+          requestId: "graph-request-123",
+        },
       },
     });
   });

--- a/apps/web/utils/ai/choose-rule/execute.test.ts
+++ b/apps/web/utils/ai/choose-rule/execute.test.ts
@@ -23,6 +23,9 @@ vi.mock("@/utils/ai/actions", () => ({
 
 vi.mock("@/utils/prisma", () => ({
   default: {
+    executedAction: {
+      update: vi.fn(),
+    },
     executedRule: {
       update: vi.fn(),
     },
@@ -69,11 +72,13 @@ describe("executeAct", () => {
   };
 
   const mockRunActionFunction = runActionFunction as Mock;
+  const mockExecutedActionUpdate = prisma.executedAction.update as Mock;
   const mockExecutedRuleUpdate = prisma.executedRule.update as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     envMock.WHITELIST_FROM = undefined;
+    mockExecutedActionUpdate.mockResolvedValue({});
     mockExecutedRuleUpdate.mockResolvedValue({});
   });
 
@@ -113,6 +118,30 @@ describe("executeAct", () => {
         }),
       }),
     );
+    expect(mockExecutedActionUpdate).toHaveBeenNthCalledWith(1, {
+      where: { id: "action-1" },
+      data: {
+        executionStatus: "SUCCEEDED",
+        executedAt: expect.any(Date),
+        errorCode: null,
+        errorMessage: null,
+        errorStack: null,
+        errorStatusCode: null,
+        errorRequestId: null,
+      },
+    });
+    expect(mockExecutedActionUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: "action-2" },
+      data: {
+        executionStatus: "SKIPPED",
+        executedAt: expect.any(Date),
+        errorCode: null,
+        errorMessage: null,
+        errorStack: null,
+        errorStatusCode: null,
+        errorRequestId: null,
+      },
+    });
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
       data: { status: ExecutedRuleStatus.APPLIED },
@@ -146,6 +175,18 @@ describe("executeAct", () => {
         status: ExecutedRuleStatus.ERROR,
         reason:
           "Rule matched\nAction failures: NOTIFY_SENDER:RESEND_NOT_CONFIGURED",
+      },
+    });
+    expect(mockExecutedActionUpdate).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        executionStatus: "FAILED",
+        executedAt: expect.any(Date),
+        errorCode: "RESEND_NOT_CONFIGURED",
+        errorMessage: "Action reported failure",
+        errorStack: null,
+        errorStatusCode: null,
+        errorRequestId: null,
       },
     });
   });
@@ -257,7 +298,12 @@ describe("executeAct", () => {
   });
 
   it("keeps throwing for unexpected action exceptions", async () => {
-    mockRunActionFunction.mockRejectedValueOnce(new Error("boom"));
+    const graphError = Object.assign(new Error("Graph move failed"), {
+      code: "ErrorMoveCopyFailed",
+      statusCode: 503,
+      requestId: "graph-request-123",
+    });
+    mockRunActionFunction.mockRejectedValueOnce(graphError);
 
     const executedRule = {
       ...baseExecutedRule,
@@ -272,12 +318,24 @@ describe("executeAct", () => {
         emailAccount,
         logger,
       }),
-    ).rejects.toThrow("boom");
+    ).rejects.toThrow("Graph move failed");
 
     expect(mockExecutedRuleUpdate).toHaveBeenCalledTimes(1);
     expect(mockExecutedRuleUpdate).toHaveBeenCalledWith({
       where: { id: "executed-rule-1" },
       data: { status: ExecutedRuleStatus.ERROR },
+    });
+    expect(mockExecutedActionUpdate).toHaveBeenCalledWith({
+      where: { id: "action-1" },
+      data: {
+        executionStatus: "FAILED",
+        executedAt: expect.any(Date),
+        errorCode: "ErrorMoveCopyFailed",
+        errorMessage: "Graph move failed",
+        errorStack: expect.stringContaining("Graph move failed"),
+        errorStatusCode: 503,
+        errorRequestId: "graph-request-123",
+      },
     });
   });
 });

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -2,9 +2,9 @@ import { runActionFunction } from "@/utils/ai/actions";
 import prisma from "@/utils/prisma";
 import type { Prisma } from "@/generated/prisma/client";
 import {
+  ActionType,
   ExecutedActionStatus,
   ExecutedRuleStatus,
-  ActionType,
 } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
@@ -15,7 +15,7 @@ import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 import {
-  getPersistedActionError,
+  normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
 
@@ -133,7 +133,7 @@ export async function executeAct({
       await persistExecutedActionOutcome({
         actionId: action.id,
         status: ExecutedActionStatus.FAILED,
-        error: getPersistedActionError(error),
+        error: normalizeActionExecutionError(error),
         logger: log,
       });
       await logErrorWithDedupe({
@@ -229,13 +229,18 @@ function getActionFailure(
     "errorCode" in actionResult && typeof actionResult.errorCode === "string"
       ? actionResult.errorCode
       : getUnknownActionFailureCode(actionType);
-  const errorMessage =
+  let errorMessage = "Action reported failure";
+  if (
     "errorMessage" in actionResult &&
     typeof actionResult.errorMessage === "string"
-      ? actionResult.errorMessage
-      : "error" in actionResult && typeof actionResult.error === "string"
-        ? actionResult.error
-        : "Action reported failure";
+  ) {
+    errorMessage = actionResult.errorMessage;
+  } else if (
+    "error" in actionResult &&
+    typeof actionResult.error === "string"
+  ) {
+    errorMessage = actionResult.error;
+  }
 
   return {
     type: actionType,

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -1,7 +1,11 @@
 import { runActionFunction } from "@/utils/ai/actions";
 import prisma from "@/utils/prisma";
 import type { Prisma } from "@/generated/prisma/client";
-import { ExecutedRuleStatus, ActionType } from "@/generated/prisma/enums";
+import {
+  ExecutedActionStatus,
+  ExecutedRuleStatus,
+  ActionType,
+} from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 import type { ParsedMessage } from "@/utils/types";
 import { updateExecutedActionWithDraftId } from "@/utils/ai/choose-rule/draft-management";
@@ -10,6 +14,10 @@ import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 import { flushLoggerSafely } from "@/utils/logger-flush";
+import {
+  getPersistedActionError,
+  persistExecutedActionOutcome,
+} from "@/utils/ai/executed-action-outcome";
 
 const MODULE = "ai-execute-act";
 
@@ -20,6 +28,7 @@ type ExecutedRuleWithActionItems = Prisma.ExecutedRuleGetPayload<{
 type ActionFailure = {
   type: ActionType;
   errorCode: string;
+  errorMessage: string;
 };
 
 const ACTION_FAILURE_TYPES = new Set<ActionType>([
@@ -62,6 +71,12 @@ export async function executeAct({
         log.info("Skipping automated archive for protected company sender", {
           actionId: action.id,
         });
+        await persistExecutedActionOutcome({
+          actionId: action.id,
+          status: ExecutedActionStatus.SKIPPED,
+          error: null,
+          logger: log,
+        });
         continue;
       }
 
@@ -77,6 +92,25 @@ export async function executeAct({
       const actionFailure = getActionFailure(action.type, actionResult);
       if (actionFailure) {
         actionFailures.push(actionFailure);
+        await persistExecutedActionOutcome({
+          actionId: action.id,
+          status: ExecutedActionStatus.FAILED,
+          error: {
+            errorCode: actionFailure.errorCode,
+            errorMessage: actionFailure.errorMessage,
+            errorStack: null,
+            errorStatusCode: null,
+            errorRequestId: null,
+          },
+          logger: log,
+        });
+      } else {
+        await persistExecutedActionOutcome({
+          actionId: action.id,
+          status: ExecutedActionStatus.SUCCEEDED,
+          error: null,
+          logger: log,
+        });
       }
 
       const draftId =
@@ -96,6 +130,12 @@ export async function executeAct({
         });
       }
     } catch (error) {
+      await persistExecutedActionOutcome({
+        actionId: action.id,
+        status: ExecutedActionStatus.FAILED,
+        error: getPersistedActionError(error),
+        logger: log,
+      });
       await logErrorWithDedupe({
         logger: log,
         message: "Error executing action",
@@ -189,10 +229,18 @@ function getActionFailure(
     "errorCode" in actionResult && typeof actionResult.errorCode === "string"
       ? actionResult.errorCode
       : getUnknownActionFailureCode(actionType);
+  const errorMessage =
+    "errorMessage" in actionResult &&
+    typeof actionResult.errorMessage === "string"
+      ? actionResult.errorMessage
+      : "error" in actionResult && typeof actionResult.error === "string"
+        ? actionResult.error
+        : "Action reported failure";
 
   return {
     type: actionType,
     errorCode,
+    errorMessage,
   };
 }
 

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -15,6 +15,7 @@ import type { ActionExecutionEmailAccount } from "@/utils/ai/types";
 import { shouldSkipAutomatedArchiveForSender } from "@/utils/ai/automated-archive-exception";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 import {
+  getActionResultError,
   normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
@@ -30,12 +31,6 @@ type ActionFailure = {
   errorCode: string;
   errorMessage: string;
 };
-
-const ACTION_FAILURE_TYPES = new Set<ActionType>([
-  ActionType.DRAFT_MESSAGING_CHANNEL,
-  ActionType.NOTIFY_MESSAGING_CHANNEL,
-  ActionType.NOTIFY_SENDER,
-]);
 
 export async function executeAct({
   client,
@@ -89,19 +84,17 @@ export async function executeAct({
         logger: log,
       });
 
-      const actionFailure = getActionFailure(action.type, actionResult);
-      if (actionFailure) {
-        actionFailures.push(actionFailure);
+      const actionResultError = getActionResultError(action.type, actionResult);
+      if (actionResultError) {
+        actionFailures.push({
+          type: action.type,
+          errorCode: actionResultError.code,
+          errorMessage: actionResultError.message,
+        });
         await persistExecutedActionOutcome({
           actionId: action.id,
           status: ExecutedActionStatus.FAILED,
-          error: {
-            code: actionFailure.errorCode,
-            message: actionFailure.errorMessage,
-            stack: null,
-            statusCode: null,
-            requestId: null,
-          },
+          error: actionResultError,
           logger: log,
         });
       } else {
@@ -207,52 +200,6 @@ async function updateExecutedRuleOrThrow({
     log.error("Failed to update executed rule", { error });
     throw error;
   }
-}
-
-function getActionFailure(
-  actionType: ActionType,
-  actionResult: unknown,
-): ActionFailure | null {
-  if (!ACTION_FAILURE_TYPES.has(actionType)) return null;
-
-  if (
-    !actionResult ||
-    typeof actionResult !== "object" ||
-    !("success" in actionResult)
-  ) {
-    return null;
-  }
-
-  if (actionResult.success !== false) return null;
-
-  const errorCode =
-    "errorCode" in actionResult && typeof actionResult.errorCode === "string"
-      ? actionResult.errorCode
-      : getUnknownActionFailureCode(actionType);
-  let errorMessage = "Action reported failure";
-  if (
-    "errorMessage" in actionResult &&
-    typeof actionResult.errorMessage === "string"
-  ) {
-    errorMessage = actionResult.errorMessage;
-  } else if (
-    "error" in actionResult &&
-    typeof actionResult.error === "string"
-  ) {
-    errorMessage = actionResult.error;
-  }
-
-  return {
-    type: actionType,
-    errorCode,
-    errorMessage,
-  };
-}
-
-function getUnknownActionFailureCode(actionType: ActionType) {
-  return actionType === ActionType.NOTIFY_SENDER
-    ? "UNKNOWN_NOTIFY_FAILURE"
-    : "UNKNOWN_MESSAGING_FAILURE";
 }
 
 function buildFailureReason(

--- a/apps/web/utils/ai/choose-rule/execute.ts
+++ b/apps/web/utils/ai/choose-rule/execute.ts
@@ -96,11 +96,11 @@ export async function executeAct({
           actionId: action.id,
           status: ExecutedActionStatus.FAILED,
           error: {
-            errorCode: actionFailure.errorCode,
-            errorMessage: actionFailure.errorMessage,
-            errorStack: null,
-            errorStatusCode: null,
-            errorRequestId: null,
+            code: actionFailure.errorCode,
+            message: actionFailure.errorMessage,
+            stack: null,
+            statusCode: null,
+            requestId: null,
           },
           logger: log,
         });

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -4,7 +4,7 @@ import { getErrorMessage } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 
-export type PersistedActionError = {
+type ActionExecutionError = {
   code: string;
   message: string;
   stack: string | null;
@@ -20,7 +20,7 @@ export async function persistExecutedActionOutcome({
 }: {
   actionId: string;
   status: ExecutedActionStatus;
-  error: PersistedActionError | null;
+  error: ActionExecutionError | null;
   logger: Logger;
 }) {
   try {
@@ -41,7 +41,9 @@ export async function persistExecutedActionOutcome({
   }
 }
 
-export function getPersistedActionError(error: unknown): PersistedActionError {
+export function normalizeActionExecutionError(
+  error: unknown,
+): ActionExecutionError {
   const outer = asRecord(error);
   const nested = asRecord(outer?.error);
   const headers = asRecord(outer?.headers);

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -1,0 +1,101 @@
+import type { ExecutedActionStatus } from "@/generated/prisma/enums";
+import { getErrorMessage } from "@/utils/error";
+import type { Logger } from "@/utils/logger";
+import prisma from "@/utils/prisma";
+
+export type PersistedActionError = {
+  errorCode: string;
+  errorMessage: string;
+  errorStack: string | null;
+  errorStatusCode: number | null;
+  errorRequestId: string | null;
+};
+
+export async function persistExecutedActionOutcome({
+  actionId,
+  status,
+  error,
+  logger,
+}: {
+  actionId: string;
+  status: ExecutedActionStatus;
+  error: PersistedActionError | null;
+  logger: Logger;
+}) {
+  try {
+    await prisma.executedAction.update({
+      where: { id: actionId },
+      data: {
+        executionStatus: status,
+        executedAt: new Date(),
+        errorCode: error?.errorCode ?? null,
+        errorMessage: error?.errorMessage ?? null,
+        errorStack: error?.errorStack ?? null,
+        errorStatusCode: error?.errorStatusCode ?? null,
+        errorRequestId: error?.errorRequestId ?? null,
+      },
+    });
+  } catch (persistenceError) {
+    logger.error("Failed to persist executed action outcome", {
+      actionId,
+      executionStatus: status,
+      error: persistenceError,
+    });
+  }
+}
+
+export function getPersistedActionError(error: unknown): PersistedActionError {
+  const outer = asRecord(error);
+  const nested = asRecord(outer?.error);
+  const headers = asRecord(outer?.headers);
+
+  return {
+    errorCode:
+      getString(outer, "code") ||
+      getString(nested, "code") ||
+      (error instanceof Error ? error.name : "UNKNOWN_ACTION_ERROR"),
+    errorMessage: truncate(
+      getErrorMessage(error) || "Unknown action execution error",
+      4000,
+    ),
+    errorStack:
+      error instanceof Error && error.stack
+        ? truncate(error.stack, 12_000)
+        : null,
+    errorStatusCode:
+      getNumber(outer, "statusCode") ||
+      getNumber(outer, "status") ||
+      getNumber(nested, "statusCode"),
+    errorRequestId:
+      getString(outer, "requestId") ||
+      getString(nested, "requestId") ||
+      getString(headers, "request-id") ||
+      getString(headers, "client-request-id"),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(
+  value: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const result = value?.[key];
+  return typeof result === "string" && result ? result : null;
+}
+
+function getNumber(
+  value: Record<string, unknown> | null,
+  key: string,
+): number | null {
+  const result = value?.[key];
+  return typeof result === "number" && Number.isFinite(result) ? result : null;
+}
+
+function truncate(value: string, maxLength: number) {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -1,5 +1,8 @@
-import type { ExecutedActionStatus } from "@/generated/prisma/enums";
 import { Prisma } from "@/generated/prisma/client";
+import {
+  ActionType,
+  type ExecutedActionStatus,
+} from "@/generated/prisma/enums";
 import { getErrorMessage } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
@@ -11,6 +14,12 @@ type ActionExecutionError = {
   statusCode: number | null;
   requestId: string | null;
 };
+
+const ACTION_RESULT_FAILURE_TYPES = new Set<ActionType>([
+  ActionType.DRAFT_MESSAGING_CHANNEL,
+  ActionType.NOTIFY_MESSAGING_CHANNEL,
+  ActionType.NOTIFY_SENDER,
+]);
 
 export async function persistExecutedActionOutcome({
   actionId,
@@ -39,6 +48,48 @@ export async function persistExecutedActionOutcome({
       error: persistenceError,
     });
   }
+}
+
+export function getActionResultError(
+  actionType: ActionType,
+  actionResult: unknown,
+): ActionExecutionError | null {
+  if (!ACTION_RESULT_FAILURE_TYPES.has(actionType)) return null;
+
+  if (
+    !actionResult ||
+    typeof actionResult !== "object" ||
+    !("success" in actionResult) ||
+    actionResult.success !== false
+  ) {
+    return null;
+  }
+
+  const code =
+    "errorCode" in actionResult && typeof actionResult.errorCode === "string"
+      ? actionResult.errorCode
+      : getUnknownActionFailureCode(actionType);
+
+  let message = "Action reported failure";
+  if (
+    "errorMessage" in actionResult &&
+    typeof actionResult.errorMessage === "string"
+  ) {
+    message = actionResult.errorMessage;
+  } else if (
+    "error" in actionResult &&
+    typeof actionResult.error === "string"
+  ) {
+    message = actionResult.error;
+  }
+
+  return {
+    code,
+    message,
+    stack: null,
+    statusCode: null,
+    requestId: null,
+  };
 }
 
 export function normalizeActionExecutionError(
@@ -97,4 +148,10 @@ function getNumber(
 
 function truncate(value: string, maxLength: number) {
   return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function getUnknownActionFailureCode(actionType: ActionType) {
+  return actionType === ActionType.NOTIFY_SENDER
+    ? "UNKNOWN_NOTIFY_FAILURE"
+    : "UNKNOWN_MESSAGING_FAILURE";
 }

--- a/apps/web/utils/ai/executed-action-outcome.ts
+++ b/apps/web/utils/ai/executed-action-outcome.ts
@@ -1,14 +1,15 @@
 import type { ExecutedActionStatus } from "@/generated/prisma/enums";
+import { Prisma } from "@/generated/prisma/client";
 import { getErrorMessage } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 
 export type PersistedActionError = {
-  errorCode: string;
-  errorMessage: string;
-  errorStack: string | null;
-  errorStatusCode: number | null;
-  errorRequestId: string | null;
+  code: string;
+  message: string;
+  stack: string | null;
+  statusCode: number | null;
+  requestId: string | null;
 };
 
 export async function persistExecutedActionOutcome({
@@ -28,11 +29,7 @@ export async function persistExecutedActionOutcome({
       data: {
         executionStatus: status,
         executedAt: new Date(),
-        errorCode: error?.errorCode ?? null,
-        errorMessage: error?.errorMessage ?? null,
-        errorStack: error?.errorStack ?? null,
-        errorStatusCode: error?.errorStatusCode ?? null,
-        errorRequestId: error?.errorRequestId ?? null,
+        executionError: error ?? Prisma.DbNull,
       },
     });
   } catch (persistenceError) {
@@ -50,23 +47,23 @@ export function getPersistedActionError(error: unknown): PersistedActionError {
   const headers = asRecord(outer?.headers);
 
   return {
-    errorCode:
+    code:
       getString(outer, "code") ||
       getString(nested, "code") ||
       (error instanceof Error ? error.name : "UNKNOWN_ACTION_ERROR"),
-    errorMessage: truncate(
+    message: truncate(
       getErrorMessage(error) || "Unknown action execution error",
       4000,
     ),
-    errorStack:
+    stack:
       error instanceof Error && error.stack
         ? truncate(error.stack, 12_000)
         : null,
-    errorStatusCode:
+    statusCode:
       getNumber(outer, "statusCode") ||
       getNumber(outer, "status") ||
       getNumber(nested, "statusCode"),
-    errorRequestId:
+    requestId:
       getString(outer, "requestId") ||
       getString(nested, "requestId") ||
       getString(headers, "request-id") ||

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
 import {
   ActionType,
   ExecutedActionStatus,
@@ -79,11 +80,7 @@ describe("executor", () => {
         data: {
           executionStatus: ExecutedActionStatus.SUCCEEDED,
           executedAt: expect.any(Date),
-          errorCode: null,
-          errorMessage: null,
-          errorStack: null,
-          errorStatusCode: null,
-          errorRequestId: null,
+          executionError: Prisma.DbNull,
         },
       });
       expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
@@ -193,11 +190,13 @@ describe("executor", () => {
         data: {
           executionStatus: ExecutedActionStatus.FAILED,
           executedAt: expect.any(Date),
-          errorCode: "ErrorTimeout",
-          errorMessage: "Execution failed",
-          errorStack: expect.stringContaining("Execution failed"),
-          errorStatusCode: 504,
-          errorRequestId: "graph-request-456",
+          executionError: {
+            code: "ErrorTimeout",
+            message: "Execution failed",
+            stack: expect.stringContaining("Execution failed"),
+            statusCode: 504,
+            requestId: "graph-request-456",
+          },
         },
       });
       expectExecutedRuleStatus(

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   ActionType,
+  ExecutedActionStatus,
   ExecutedRuleStatus,
   ScheduledActionStatus,
 } from "@/generated/prisma/enums";
@@ -71,6 +72,18 @@ describe("executor", () => {
           status: ScheduledActionStatus.COMPLETED,
           executedAt: expect.any(Date),
           executedActionId: "executed-action-123",
+        },
+      });
+      expect(prisma.executedAction.update).toHaveBeenCalledWith({
+        where: { id: "executed-action-123" },
+        data: {
+          executionStatus: ExecutedActionStatus.SUCCEEDED,
+          executedAt: expect.any(Date),
+          errorCode: null,
+          errorMessage: null,
+          errorStack: null,
+          errorStatusCode: null,
+          errorRequestId: null,
         },
       });
       expectExecutedRuleStatus(ExecutedRuleStatus.APPLIED);
@@ -157,7 +170,11 @@ describe("executor", () => {
         failedScheduledActionReason,
       );
       vi.mocked(runActionFunction).mockRejectedValue(
-        new Error("Execution failed"),
+        Object.assign(new Error("Execution failed"), {
+          code: "ErrorTimeout",
+          statusCode: 504,
+          requestId: "graph-request-456",
+        }),
       );
 
       const result = await executeScheduledAction(
@@ -170,6 +187,18 @@ describe("executor", () => {
       expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
         where: { id: "scheduled-action-123" },
         data: { status: ScheduledActionStatus.FAILED },
+      });
+      expect(prisma.executedAction.update).toHaveBeenCalledWith({
+        where: { id: "executed-action-123" },
+        data: {
+          executionStatus: ExecutedActionStatus.FAILED,
+          executedAt: expect.any(Date),
+          errorCode: "ErrorTimeout",
+          errorMessage: "Execution failed",
+          errorStack: expect.stringContaining("Execution failed"),
+          errorStatusCode: 504,
+          errorRequestId: "graph-request-456",
+        },
       });
       expectExecutedRuleStatus(
         ExecutedRuleStatus.ERROR,

--- a/apps/web/utils/scheduled-actions/executor.test.ts
+++ b/apps/web/utils/scheduled-actions/executor.test.ts
@@ -185,6 +185,7 @@ describe("executor", () => {
         where: { id: "scheduled-action-123" },
         data: { status: ScheduledActionStatus.FAILED },
       });
+      expect(prisma.executedAction.update).toHaveBeenCalledTimes(1);
       expect(prisma.executedAction.update).toHaveBeenCalledWith({
         where: { id: "executed-action-123" },
         data: {
@@ -196,6 +197,58 @@ describe("executor", () => {
             stack: expect.stringContaining("Execution failed"),
             statusCode: 504,
             requestId: "graph-request-456",
+          },
+        },
+      });
+      expectExecutedRuleStatus(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
+    });
+
+    it("marks the scheduled action as failed when the action reports failure", async () => {
+      const scheduledNotificationAction = {
+        ...mockScheduledAction,
+        actionType: ActionType.NOTIFY_SENDER,
+      };
+      mockScheduledActionUpdate(
+        ScheduledActionStatus.FAILED,
+        scheduledNotificationAction,
+      );
+      mockExecutedActionCreate({ type: ActionType.NOTIFY_SENDER });
+      mockExecutedRuleFind();
+      mockCompletionCounts({ pendingActions: 0, failedActions: 1 });
+      mockExecutedRuleUpdate(
+        ExecutedRuleStatus.ERROR,
+        failedScheduledActionReason,
+      );
+      vi.mocked(runActionFunction).mockResolvedValue({
+        success: false,
+        errorCode: "SEND_FAILED",
+      });
+
+      const result = await executeScheduledAction(
+        scheduledNotificationAction,
+        await getMockEmailProvider(),
+        logger,
+      );
+
+      expect(result.success).toBe(false);
+      expect(prisma.scheduledAction.update).toHaveBeenCalledWith({
+        where: { id: "scheduled-action-123" },
+        data: { status: ScheduledActionStatus.FAILED },
+      });
+      expect(prisma.executedAction.update).toHaveBeenCalledWith({
+        where: { id: "executed-action-123" },
+        data: {
+          executionStatus: ExecutedActionStatus.FAILED,
+          executedAt: expect.any(Date),
+          executionError: {
+            code: "SEND_FAILED",
+            message: "Action reported failure",
+            stack: null,
+            statusCode: null,
+            requestId: null,
           },
         },
       });

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -15,7 +15,7 @@ import type {
 } from "@/utils/ai/types";
 import type { EmailProvider } from "@/utils/email/types";
 import {
-  getPersistedActionError,
+  normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
 
@@ -234,7 +234,7 @@ async function executeDelayedAction({
     await persistExecutedActionOutcome({
       actionId: executedAction.id,
       status: ExecutedActionStatus.FAILED,
-      error: getPersistedActionError(error),
+      error: normalizeActionExecutionError(error),
       logger: log,
     });
     throw error;

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -1,4 +1,5 @@
 import {
+  ExecutedActionStatus,
   ExecutedRuleStatus,
   ScheduledActionStatus,
 } from "@/generated/prisma/enums";
@@ -13,6 +14,10 @@ import type {
   EmailForAction,
 } from "@/utils/ai/types";
 import type { EmailProvider } from "@/utils/email/types";
+import {
+  getPersistedActionError,
+  persistExecutedActionOutcome,
+} from "@/utils/ai/executed-action-outcome";
 
 const MODULE = "scheduled-actions-executor";
 
@@ -210,14 +215,30 @@ async function executeDelayedAction({
     messageId: email.id,
   });
 
-  await runActionFunction({
-    client,
-    email,
-    action: executedAction,
-    emailAccount,
-    executedRule,
-    logger: log,
-  });
+  try {
+    await runActionFunction({
+      client,
+      email,
+      action: executedAction,
+      emailAccount,
+      executedRule,
+      logger: log,
+    });
+    await persistExecutedActionOutcome({
+      actionId: executedAction.id,
+      status: ExecutedActionStatus.SUCCEEDED,
+      error: null,
+      logger: log,
+    });
+  } catch (error) {
+    await persistExecutedActionOutcome({
+      actionId: executedAction.id,
+      status: ExecutedActionStatus.FAILED,
+      error: getPersistedActionError(error),
+      logger: log,
+    });
+    throw error;
+  }
 
   log.info("Successfully executed delayed action", {
     actionType: executedAction.type,

--- a/apps/web/utils/scheduled-actions/executor.ts
+++ b/apps/web/utils/scheduled-actions/executor.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/utils/ai/types";
 import type { EmailProvider } from "@/utils/email/types";
 import {
+  getActionResultError,
   normalizeActionExecutionError,
   persistExecutedActionOutcome,
 } from "@/utils/ai/executed-action-outcome";
@@ -215,19 +216,14 @@ async function executeDelayedAction({
     messageId: email.id,
   });
 
+  let actionResult: unknown;
   try {
-    await runActionFunction({
+    actionResult = await runActionFunction({
       client,
       email,
       action: executedAction,
       emailAccount,
       executedRule,
-      logger: log,
-    });
-    await persistExecutedActionOutcome({
-      actionId: executedAction.id,
-      status: ExecutedActionStatus.SUCCEEDED,
-      error: null,
       logger: log,
     });
   } catch (error) {
@@ -239,6 +235,29 @@ async function executeDelayedAction({
     });
     throw error;
   }
+
+  const actionResultError = getActionResultError(
+    executedAction.type,
+    actionResult,
+  );
+  if (actionResultError) {
+    await persistExecutedActionOutcome({
+      actionId: executedAction.id,
+      status: ExecutedActionStatus.FAILED,
+      error: actionResultError,
+      logger: log,
+    });
+    throw Object.assign(new Error(actionResultError.message), {
+      code: actionResultError.code,
+    });
+  }
+
+  await persistExecutedActionOutcome({
+    actionId: executedAction.id,
+    status: ExecutedActionStatus.SUCCEEDED,
+    error: null,
+    logger: log,
+  });
 
   log.info("Successfully executed delayed action", {
     actionType: executedAction.type,

--- a/apps/web/utils/webhook/outlook/learn-label-removal.test.ts
+++ b/apps/web/utils/webhook/outlook/learn-label-removal.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/prisma";
 import { saveLearnedPattern } from "@/utils/rule/learned-patterns";
-import { GroupItemSource, SystemType } from "@/generated/prisma/enums";
+import {
+  ExecutedActionStatus,
+  ExecutedRuleStatus,
+  GroupItemSource,
+  SystemType,
+} from "@/generated/prisma/enums";
 import { getMockParsedMessage } from "@/__tests__/mocks/email-provider.mock";
 import { learnFromOutlookLabelRemoval } from "@/utils/webhook/outlook/learn-label-removal";
 import { createTestLogger } from "@/__tests__/helpers";
@@ -65,6 +70,41 @@ describe("learnFromOutlookLabelRemoval", () => {
         threadId: "thread-123",
         reason: "Label removed",
         source: GroupItemSource.LABEL_REMOVED,
+      }),
+    );
+  });
+
+  it("only considers successfully applied executions for removal learning", async () => {
+    const message = getMockParsedMessage({
+      id: "message-123",
+      threadId: "thread-123",
+      labelIds: ["INBOX"],
+      headers: { from: "sender@example.com" },
+    });
+
+    await learnFromOutlookLabelRemoval({
+      message,
+      emailAccountId: "email-account-123",
+      logger,
+    });
+
+    expect(prisma.executedRule.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          actionItems: expect.objectContaining({
+            where: expect.objectContaining({
+              executionStatus: ExecutedActionStatus.SUCCEEDED,
+            }),
+          }),
+        }),
+        where: expect.objectContaining({
+          actionItems: expect.objectContaining({
+            some: expect.objectContaining({
+              executionStatus: ExecutedActionStatus.SUCCEEDED,
+            }),
+          }),
+          status: ExecutedRuleStatus.APPLIED,
+        }),
       }),
     );
   });

--- a/apps/web/utils/webhook/outlook/learn-label-removal.ts
+++ b/apps/web/utils/webhook/outlook/learn-label-removal.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@/generated/prisma/client";
 import {
   ActionType,
   ExecutedActionStatus,
@@ -9,6 +10,20 @@ import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import { recordLabelRemovalLearning } from "@/utils/rule/record-label-removal-learning";
 import type { ParsedMessage } from "@/utils/types";
+
+const SUCCESSFUL_LABEL_OR_FOLDER_ACTION = {
+  executionStatus: ExecutedActionStatus.SUCCEEDED,
+  OR: [
+    {
+      type: ActionType.LABEL,
+      OR: [{ labelId: { not: null } }, { label: { not: null } }],
+    },
+    {
+      type: ActionType.MOVE_FOLDER,
+      folderId: { not: null },
+    },
+  ],
+} satisfies Prisma.ExecutedActionWhereInput;
 
 export async function learnFromOutlookLabelRemoval({
   message,
@@ -34,19 +49,7 @@ export async function learnFromOutlookLabelRemoval({
       status: ExecutedRuleStatus.APPLIED,
       rule: { systemType: { not: null } },
       actionItems: {
-        some: {
-          executionStatus: ExecutedActionStatus.SUCCEEDED,
-          OR: [
-            {
-              type: ActionType.LABEL,
-              OR: [{ labelId: { not: null } }, { label: { not: null } }],
-            },
-            {
-              type: ActionType.MOVE_FOLDER,
-              folderId: { not: null },
-            },
-          ],
-        },
+        some: SUCCESSFUL_LABEL_OR_FOLDER_ACTION,
       },
     },
     select: {
@@ -57,19 +60,7 @@ export async function learnFromOutlookLabelRemoval({
         },
       },
       actionItems: {
-        where: {
-          executionStatus: ExecutedActionStatus.SUCCEEDED,
-          OR: [
-            {
-              type: ActionType.LABEL,
-              OR: [{ labelId: { not: null } }, { label: { not: null } }],
-            },
-            {
-              type: ActionType.MOVE_FOLDER,
-              folderId: { not: null },
-            },
-          ],
-        },
+        where: SUCCESSFUL_LABEL_OR_FOLDER_ACTION,
         select: {
           type: true,
           labelId: true,

--- a/apps/web/utils/webhook/outlook/learn-label-removal.ts
+++ b/apps/web/utils/webhook/outlook/learn-label-removal.ts
@@ -1,4 +1,9 @@
-import { ActionType, type SystemType } from "@/generated/prisma/enums";
+import {
+  ActionType,
+  ExecutedActionStatus,
+  ExecutedRuleStatus,
+  type SystemType,
+} from "@/generated/prisma/enums";
 import { extractEmailAddress } from "@/utils/email";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
@@ -26,9 +31,11 @@ export async function learnFromOutlookLabelRemoval({
       emailAccountId,
       messageId: message.id,
       threadId: message.threadId,
+      status: ExecutedRuleStatus.APPLIED,
       rule: { systemType: { not: null } },
       actionItems: {
         some: {
+          executionStatus: ExecutedActionStatus.SUCCEEDED,
           OR: [
             {
               type: ActionType.LABEL,
@@ -51,6 +58,7 @@ export async function learnFromOutlookLabelRemoval({
       },
       actionItems: {
         where: {
+          executionStatus: ExecutedActionStatus.SUCCEEDED,
           OR: [
             {
               type: ActionType.LABEL,


### PR DESCRIPTION
Persist per-action outcomes and error details so provider failures can be diagnosed, and prevent Outlook label-removal learning from treating failed actions as user corrections.

- keep execution status and completion time as queryable fields, with variable provider error details stored as JSON
- require applied rules and successful actions before learning Outlook label or folder removals
- add a Prisma migration and regression coverage for failed provider actions and removal learning
- verify with 24 focused unit tests, Prisma validation, formatting checks, and commit-level secret and PII scans

Performance impact:
- adds one database update per executed action to persist its outcome
- adds no provider or network calls
- adds indexed status filters to the existing Outlook removal-learning query