### PR TITLE
llm: Make usage accounting resilient

### DIFF
--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -408,6 +408,40 @@ describe("createGenerateObject repairText", () => {
     );
   });
 
+  it("retries object validation when failed-attempt usage accounting errors", async () => {
+    const failedUsage = {
+      inputTokens: 1000,
+      outputTokens: 100,
+      totalTokens: 1100,
+    };
+    const validationError = Object.assign(new Error("Invalid object"), {
+      usage: failedUsage,
+    });
+
+    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
+      (error) => error === validationError,
+    );
+    mockSaveAiUsage.mockRejectedValueOnce(new Error("Usage accounting failed"));
+    mockGenerateObject
+      .mockRejectedValueOnce(validationError)
+      .mockResolvedValueOnce({
+        object: { ok: true },
+        usage: null,
+      });
+
+    const generateObject = await createTestGenerateObject();
+
+    await expect(
+      generateObject({
+        system: "Return JSON.",
+        prompt: "Return JSON.",
+        schema: {} as any,
+      } as any),
+    ).resolves.toEqual({ object: { ok: true }, usage: null });
+
+    expect(mockGenerateObject).toHaveBeenCalledTimes(2);
+  });
+
   it("logs the successful model and sanitized fallback path", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const contentFilterError = mockContentFilterRefusal();

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -440,6 +440,44 @@ describe("createGenerateObject repairText", () => {
     ).resolves.toEqual({ object: { ok: true }, usage: null });
 
     expect(mockGenerateObject).toHaveBeenCalledTimes(2);
+    expect(mockSaveAiUsage).toHaveBeenCalledTimes(1);
+    expect(mockSaveAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ usage: failedUsage }),
+    );
+  });
+
+  it("returns a generated object when successful usage accounting errors", async () => {
+    const usage = {
+      inputTokens: 1000,
+      outputTokens: 100,
+      totalTokens: 1100,
+    };
+    const result = {
+      object: { ok: true },
+      usage,
+    };
+    const onModelUsed = vi.fn();
+
+    mockGenerateObject.mockResolvedValueOnce(result);
+    mockSaveAiUsage.mockRejectedValueOnce(new Error("Usage accounting failed"));
+
+    const generateObject = await createTestGenerateObject({ onModelUsed });
+
+    await expect(
+      generateObject({
+        system: "Return JSON.",
+        prompt: "Return JSON.",
+        schema: {} as any,
+      } as any),
+    ).resolves.toEqual(result);
+
+    expect(mockSaveAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ usage }),
+    );
+    expect(onModelUsed).toHaveBeenCalledWith({
+      provider: "openai",
+      modelName: "gpt-test",
+    });
   });
 
   it("logs the successful model and sanitized fallback path", async () => {
@@ -554,12 +592,14 @@ type TestModel = {
 
 type GenerateObjectOverrides = Partial<TestModel> & {
   fallbackModels?: TestModel[];
+  onModelUsed?: (model: TestModel) => void | Promise<void>;
 };
 
 async function createTestGenerateObject({
   provider = "openai",
   modelName = "gpt-test",
   fallbackModels = [],
+  onModelUsed,
 }: GenerateObjectOverrides = {}) {
   const { createGenerateObject } = await import("./index");
 
@@ -576,6 +616,7 @@ async function createTestGenerateObject({
       fallbackModels: fallbackModels.map(createResolvedModel),
     } as any,
     promptHardening: { trust: "untrusted", level: "full" },
+    onModelUsed,
   });
 }
 

--- a/apps/web/utils/llms/index.generate-object.test.ts
+++ b/apps/web/utils/llms/index.generate-object.test.ts
@@ -84,6 +84,8 @@ vi.mock("@/utils/posthog", () => ({
 describe("createGenerateObject repairText", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsContentFilterRefusal.mockReturnValue(false);
+    mockNoObjectGeneratedErrorIsInstance.mockReturnValue(false);
     mockShouldForceNanoModel.mockResolvedValue({ shouldForce: false });
     mockGenerateObject.mockResolvedValue({
       object: { ok: true },
@@ -347,6 +349,63 @@ describe("createGenerateObject repairText", () => {
 
     expect(result).toEqual({ object: { ok: true }, usage: null });
     expect(mockGenerateObject).toHaveBeenCalledTimes(2);
+  });
+
+  it("records billed usage when object validation fails before retry succeeds", async () => {
+    const failedUsage = {
+      inputTokens: 1000,
+      outputTokens: 100,
+      totalTokens: 1100,
+    };
+    const successfulUsage = {
+      inputTokens: 1000,
+      outputTokens: 50,
+      totalTokens: 1050,
+    };
+    const validationError = Object.assign(new Error("Invalid object"), {
+      usage: failedUsage,
+      response: { id: "failed-request-id" },
+    });
+
+    mockNoObjectGeneratedErrorIsInstance.mockImplementation(
+      (error) => error === validationError,
+    );
+    mockGenerateObject
+      .mockRejectedValueOnce(validationError)
+      .mockResolvedValueOnce({
+        object: { ok: true },
+        usage: successfulUsage,
+        response: { id: "successful-request-id" },
+      });
+
+    const generateObject = await createTestGenerateObject({
+      provider: "azure-foundry",
+      modelName: "DeepSeek-V4-Pro",
+    });
+
+    await generateObject({
+      system: "Return JSON.",
+      prompt: "Return JSON.",
+      schema: {} as any,
+    } as any);
+
+    expect(mockSaveAiUsage).toHaveBeenCalledTimes(2);
+    expect(mockSaveAiUsage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        provider: "azure-foundry",
+        model: "DeepSeek-V4-Pro",
+        usage: failedUsage,
+        providerRequestIds: ["failed-request-id"],
+      }),
+    );
+    expect(mockSaveAiUsage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        usage: successfulUsage,
+        providerRequestIds: ["successful-request-id"],
+      }),
+    );
   });
 
   it("logs the successful model and sanitized fallback path", async () => {

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -590,17 +590,26 @@ export function createGenerateObject({
       }
 
       if (result.usage) {
-        await saveUsageWithMetadata({
-          result,
-          usage: result.usage,
-          userId: emailAccount.userId,
-          email: emailAccount.email,
-          emailAccountId: emailAccount.id,
-          provider: candidate.provider,
-          model: candidate.modelName,
-          label,
-          hasUserApiKey: effectiveModelOptions.hasUserApiKey,
-        });
+        try {
+          await saveUsageWithMetadata({
+            result,
+            usage: result.usage,
+            userId: emailAccount.userId,
+            email: emailAccount.email,
+            emailAccountId: emailAccount.id,
+            provider: candidate.provider,
+            model: candidate.modelName,
+            label,
+            hasUserApiKey: effectiveModelOptions.hasUserApiKey,
+          });
+        } catch (usageError) {
+          logger.error("Failed to save usage for object generation", {
+            error: usageError,
+            label,
+            provider: candidate.provider,
+            model: candidate.modelName,
+          });
+        }
       }
 
       await onModelUsed?.({

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -564,17 +564,26 @@ export function createGenerateObject({
           NoObjectGeneratedError.isInstance(error) &&
           error.usage !== undefined
         ) {
-          await saveUsageWithMetadata({
-            result: error,
-            usage: error.usage,
-            userId: emailAccount.userId,
-            email: emailAccount.email,
-            emailAccountId: emailAccount.id,
-            provider: candidate.provider,
-            model: candidate.modelName,
-            label,
-            hasUserApiKey: effectiveModelOptions.hasUserApiKey,
-          });
+          try {
+            await saveUsageWithMetadata({
+              result: error,
+              usage: error.usage,
+              userId: emailAccount.userId,
+              email: emailAccount.email,
+              emailAccountId: emailAccount.id,
+              provider: candidate.provider,
+              model: candidate.modelName,
+              label,
+              hasUserApiKey: effectiveModelOptions.hasUserApiKey,
+            });
+          } catch (usageError) {
+            logger.error("Failed to save usage for failed object generation", {
+              error: usageError,
+              label,
+              provider: candidate.provider,
+              model: candidate.modelName,
+            });
+          }
         }
 
         throw error;

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -361,11 +361,6 @@ export function createGenerateText({
         ...restArgs,
       );
 
-      await onModelUsed?.({
-        provider: candidate.provider,
-        modelName: candidate.modelName,
-      });
-
       if (result.usage) {
         await saveUsageWithMetadata({
           result,
@@ -379,6 +374,11 @@ export function createGenerateText({
           hasUserApiKey: effectiveModelOptions.hasUserApiKey,
         });
       }
+
+      await onModelUsed?.({
+        provider: candidate.provider,
+        modelName: candidate.modelName,
+      });
 
       if (options.tools) {
         const toolCallInput = result.toolCalls?.[0]?.input;
@@ -555,12 +555,30 @@ export function createGenerateObject({
         typeof generateObject<SCHEMA, OUTPUT, RESULT>
       >[0];
 
-      const result = await generateObject<SCHEMA, OUTPUT, RESULT>(request);
+      let result: GenerateObjectResult<RESULT>;
 
-      await onModelUsed?.({
-        provider: candidate.provider,
-        modelName: candidate.modelName,
-      });
+      try {
+        result = await generateObject<SCHEMA, OUTPUT, RESULT>(request);
+      } catch (error) {
+        if (
+          NoObjectGeneratedError.isInstance(error) &&
+          error.usage !== undefined
+        ) {
+          await saveUsageWithMetadata({
+            result: error,
+            usage: error.usage,
+            userId: emailAccount.userId,
+            email: emailAccount.email,
+            emailAccountId: emailAccount.id,
+            provider: candidate.provider,
+            model: candidate.modelName,
+            label,
+            hasUserApiKey: effectiveModelOptions.hasUserApiKey,
+          });
+        }
+
+        throw error;
+      }
 
       if (result.usage) {
         await saveUsageWithMetadata({
@@ -575,6 +593,11 @@ export function createGenerateObject({
           hasUserApiKey: effectiveModelOptions.hasUserApiKey,
         });
       }
+
+      await onModelUsed?.({
+        provider: candidate.provider,
+        modelName: candidate.modelName,
+      });
 
       logger.trace("Generated object", {
         label,

--- a/apps/web/utils/llms/supported-model-pricing.ts
+++ b/apps/web/utils/llms/supported-model-pricing.ts
@@ -161,6 +161,11 @@ export const STATIC_MODEL_PRICING: Record<string, ModelPricing> = {
     output: 3.828 / 1_000_000,
     cachedInput: 0.165 / 1_000_000,
   },
+  "DeepSeek-V4-Flash": {
+    input: 0.19 / 1_000_000,
+    output: 0.51 / 1_000_000,
+    cachedInput: 0.028 / 1_000_000,
+  },
   "sonar-pro": {
     input: 3 / 1_000_000,
     output: 15 / 1_000_000,

--- a/apps/web/utils/usage.test.ts
+++ b/apps/web/utils/usage.test.ts
@@ -37,7 +37,7 @@ describe("calculateUsageCost", () => {
     expect(calculateUsageCost({ provider, model, usage })).toBe(expected);
   });
 
-  it("charges reasoning tokens at the output rate", () => {
+  it("does not charge reasoning tokens twice when output includes them", () => {
     const provider = "openrouter";
     const model = "openai/gpt-5.1";
     const pricing = OPENROUTER_MODEL_PRICING["gpt-5.1"];
@@ -53,8 +53,7 @@ describe("calculateUsageCost", () => {
     };
 
     const expected =
-      usage.inputTokens! * pricing.input +
-      (usage.outputTokens! + usage.reasoningTokens!) * pricing.output;
+      usage.inputTokens! * pricing.input + usage.outputTokens! * pricing.output;
 
     expect(calculateUsageCost({ provider, model, usage })).toBe(expected);
   });
@@ -188,6 +187,18 @@ describe("calculateUsageCost", () => {
       750 * (1.925 / 1_000_000) +
         250 * (0.165 / 1_000_000) +
         500 * (3.828 / 1_000_000),
+    );
+
+    expect(
+      calculateUsageCost({
+        provider: "azure-foundry",
+        model: "DeepSeek-V4-Flash",
+        usage,
+      }),
+    ).toBeCloseTo(
+      750 * (0.19 / 1_000_000) +
+        250 * (0.028 / 1_000_000) +
+        500 * (0.51 / 1_000_000),
     );
 
     expect(
@@ -330,6 +341,36 @@ describe("saveAiUsage", () => {
         emailAccountId: "email-account-1",
         usage,
         cost: 0,
+      }),
+    );
+  });
+
+  it("records Redis usage when analytics ingestion throws synchronously", async () => {
+    vi.mocked(publishAiCall).mockImplementationOnce(() => {
+      throw new Error("analytics unavailable");
+    });
+
+    const usage: LanguageModelUsage = {
+      inputTokens: 1000,
+      outputTokens: 400,
+      totalTokens: 1400,
+    };
+
+    await saveAiUsage({
+      userId: "user-1",
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      provider: "azure-foundry",
+      model: "DeepSeek-V4-Pro",
+      usage,
+      label: "Choose rule",
+    });
+
+    expect(saveUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        emailAccountId: "email-account-1",
+        usage,
       }),
     );
   });

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -128,7 +128,7 @@ export async function saveAiUsage({
   });
 
   const [analyticsResult, redisResult] = await Promise.allSettled([
-    Promise.resolve().then(() =>
+    invokeUsageSink(() =>
       publishAiCall({
         userId: userId ?? email,
         emailAccountId,
@@ -151,7 +151,7 @@ export async function saveAiUsage({
         toolCallCount,
       }),
     ),
-    Promise.resolve().then(() =>
+    invokeUsageSink(() =>
       saveUsage({ userId, emailAccountId, cost: platformCost, usage }),
     ),
   ]);
@@ -295,4 +295,8 @@ function notifyAiUsageListeners(event: AiUsageEvent): void {
 
 function toTinybirdBoolean(value: boolean): 0 | 1 {
   return value ? 1 : 0;
+}
+
+function invokeUsageSink(operation: () => unknown) {
+  return new Promise<unknown>((resolve) => resolve(operation()));
 }

--- a/apps/web/utils/usage.ts
+++ b/apps/web/utils/usage.ts
@@ -127,8 +127,8 @@ export async function saveAiUsage({
     totalTokens,
   });
 
-  try {
-    return Promise.all([
+  const [analyticsResult, redisResult] = await Promise.allSettled([
+    Promise.resolve().then(() =>
       publishAiCall({
         userId: userId ?? email,
         emailAccountId,
@@ -150,10 +150,21 @@ export async function saveAiUsage({
         stepCount,
         toolCallCount,
       }),
+    ),
+    Promise.resolve().then(() =>
       saveUsage({ userId, emailAccountId, cost: platformCost, usage }),
-    ]);
-  } catch (error) {
-    logger.error("Failed to save usage", { error });
+    ),
+  ]);
+
+  if (analyticsResult.status === "rejected") {
+    logger.error("Failed to publish AI usage analytics", {
+      error: analyticsResult.reason,
+    });
+  }
+  if (redisResult.status === "rejected") {
+    logger.error("Failed to save AI usage to Redis", {
+      error: redisResult.reason,
+    });
   }
 }
 
@@ -175,13 +186,12 @@ export function calculateUsageCost(options: {
   const cachedInputTokens = Math.min(inputTokens, normalizedCachedInputTokens);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
   const outputTokens = Math.max(0, usage.outputTokens ?? 0);
-  const reasoningTokens = Math.max(0, usage.reasoningTokens ?? 0);
   const cachedInputTokenPrice = pricing.cachedInput ?? pricing.input;
 
   return (
     uncachedInputTokens * pricing.input +
     cachedInputTokens * cachedInputTokenPrice +
-    (outputTokens + reasoningTokens) * pricing.output
+    outputTokens * pricing.output
   );
 }
 


### PR DESCRIPTION
Keeps usage accounting complete across error paths and pricing lookups.

- Persist billable usage before retries
- Isolate usage sinks so failures do not mask accounting
- Add focused regression coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

