### PR TITLE
rules: Reconcile learned pattern conflicts

### DIFF
--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
@@ -1,0 +1,25 @@
+DELETE FROM "GroupItem"
+WHERE btrim("value") = '';
+
+WITH ranked_items AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "groupId", "type", lower(btrim("value"))
+      ORDER BY
+        coalesce("source" = 'USER', false) DESC,
+        "updatedAt" DESC,
+        "createdAt" DESC,
+        "id" DESC
+    ) AS rank
+  FROM "GroupItem"
+  WHERE "groupId" IS NOT NULL
+)
+DELETE FROM "GroupItem"
+USING ranked_items
+WHERE "GroupItem"."id" = ranked_items."id"
+  AND ranked_items.rank > 1;
+
+UPDATE "GroupItem"
+SET "value" = lower(btrim("value"))
+WHERE "value" <> lower(btrim("value"));

--- a/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
+++ b/apps/web/prisma/migrations/20260728170000_normalize_group_item_values/migration.sql
@@ -1,11 +1,22 @@
+-- Automatic sender learning has supplied a source since this cutoff. Older
+-- exclusions and subject patterns only came from explicit user updates.
+UPDATE "GroupItem"
+SET "source" = 'USER'
+WHERE "source" IS NULL
+  AND (
+    "exclude"
+    OR "type" = 'SUBJECT'
+    OR "updatedAt" >= TIMESTAMPTZ '2026-01-03 00:00:00+00'
+  );
+
 DELETE FROM "GroupItem"
-WHERE btrim("value") = '';
+WHERE btrim("value", E' \t\n\r\f\v') = '';
 
 WITH ranked_items AS (
   SELECT
     "id",
     row_number() OVER (
-      PARTITION BY "groupId", "type", lower(btrim("value"))
+      PARTITION BY "groupId", "type", lower(btrim("value", E' \t\n\r\f\v'))
       ORDER BY
         coalesce("source" = 'USER', false) DESC,
         "updatedAt" DESC,
@@ -21,5 +32,5 @@ WHERE "GroupItem"."id" = ranked_items."id"
   AND ranked_items.rank > 1;
 
 UPDATE "GroupItem"
-SET "value" = lower(btrim("value"))
-WHERE "value" <> lower(btrim("value"));
+SET "value" = lower(btrim("value", E' \t\n\r\f\v'))
+WHERE "value" <> lower(btrim("value", E' \t\n\r\f\v'));

--- a/apps/web/utils/actions/group.validation.ts
+++ b/apps/web/utils/actions/group.validation.ts
@@ -9,7 +9,7 @@ export type CreateGroupBody = z.infer<typeof createGroupBody>;
 export const addGroupItemBody = z.object({
   groupId: z.string(),
   type: z.enum([GroupItemType.FROM, GroupItemType.SUBJECT]),
-  value: z.string(),
+  value: z.string().trim().min(1, "Pattern is required"),
   exclude: z.boolean().optional(),
 });
 export type AddGroupItemBody = z.infer<typeof addGroupItemBody>;

--- a/apps/web/utils/ai/choose-rule/match-rules.test.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.test.ts
@@ -7,6 +7,7 @@ import {
   matchesStaticRule,
 } from "./match-rules";
 import {
+  GroupItemSource,
   GroupItemType,
   LogicalOperator,
   SystemType,
@@ -2573,6 +2574,93 @@ describe("findMatchingRules - Integration Tests", () => {
         },
       ]);
       expect(result.selectionMetadata.remainingAiRuleNames).toEqual([]);
+    });
+
+    it("lets a complete static match override an automatic learned exclusion", async () => {
+      const notificationRule = getRule({
+        id: "notification-rule",
+        name: "Notification",
+        groupId: "notification-group",
+        from: "updates@example.com",
+      });
+
+      prisma.group.findMany.mockResolvedValue([
+        getGroup({
+          id: "notification-group",
+          name: "Notification",
+          items: [
+            getGroupItem({
+              groupId: "notification-group",
+              type: GroupItemType.FROM,
+              value: "updates@example.com",
+              exclude: true,
+              source: GroupItemSource.LABEL_REMOVED,
+            }),
+          ],
+          rule: notificationRule,
+        }),
+      ]);
+
+      const result = await findMatchingRules({
+        rules: [notificationRule],
+        message: getMessage({
+          headers: getHeaders({ from: "updates@example.com" }),
+        }),
+        emailAccount: getEmailAccount(),
+        provider: getProvider(),
+        modelType: "default",
+        logger,
+      });
+
+      expect(result.matches).toEqual([
+        expect.objectContaining({
+          rule: notificationRule,
+          matchReasons: [{ type: ConditionType.STATIC }],
+        }),
+      ]);
+      expect(result.selectionMetadata.learnedPatternExcludedRules).toEqual([]);
+    });
+
+    it("keeps an explicit user exclusion ahead of a static match", async () => {
+      const notificationRule = getRule({
+        id: "notification-rule",
+        name: "Notification",
+        groupId: "notification-group",
+        from: "updates@example.com",
+      });
+
+      prisma.group.findMany.mockResolvedValue([
+        getGroup({
+          id: "notification-group",
+          name: "Notification",
+          items: [
+            getGroupItem({
+              groupId: "notification-group",
+              type: GroupItemType.FROM,
+              value: "updates@example.com",
+              exclude: true,
+              source: GroupItemSource.USER,
+            }),
+          ],
+          rule: notificationRule,
+        }),
+      ]);
+
+      const result = await findMatchingRules({
+        rules: [notificationRule],
+        message: getMessage({
+          headers: getHeaders({ from: "updates@example.com" }),
+        }),
+        emailAccount: getEmailAccount(),
+        provider: getProvider(),
+        modelType: "default",
+        logger,
+      });
+
+      expect(result.matches).toHaveLength(0);
+      expect(result.selectionMetadata.learnedPatternExcludedRules).toHaveLength(
+        1,
+      );
     });
 
     it("should allow learned pattern match in thread when runOnThreads=true", async () => {

--- a/apps/web/utils/ai/choose-rule/match-rules.ts
+++ b/apps/web/utils/ai/choose-rule/match-rules.ts
@@ -7,6 +7,7 @@ import {
 import type { ParsedMessage, RuleWithActions } from "@/utils/types";
 import {
   ExecutedRuleStatus,
+  GroupItemSource,
   LogicalOperator,
   SystemType,
 } from "@/generated/prisma/enums";
@@ -235,8 +236,23 @@ async function findPotentialMatchingRules({
         const { matchingItem, group, excludedItem, ruleExcluded } =
           matchesGroupRule(rule, groups, message);
 
-        // If this rule is excluded by an exclusion pattern, skip it entirely
         if (ruleExcluded) {
+          if (excludedItem?.source !== GroupItemSource.USER) {
+            const conditionResult = evaluateRuleConditions({
+              rule,
+              message,
+              logger,
+            });
+
+            if (conditionResult.matched) {
+              matches.push({
+                rule,
+                matchReasons: conditionResult.matchReasons,
+              });
+              continue;
+            }
+          }
+
           if (group && excludedItem) {
             learnedPatternExcludedRules.push({
               ruleId: rule.id,

--- a/apps/web/utils/group/find-matching-group.test.ts
+++ b/apps/web/utils/group/find-matching-group.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { findMatchingGroupItem } from "./find-matching-group";
-import { GroupItemType } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 
 describe("findMatchingGroupItem", () => {
   it("should match FROM rules", () => {
@@ -117,6 +117,102 @@ describe("findMatchingGroupItem", () => {
         expected: groupItems[0],
       },
     ]);
+  });
+
+  it("prefers explicit user evidence over an automatic exclusion", () => {
+    const automaticExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+    const userInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.USER,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        automaticExclusion,
+        userInclusion,
+      ]),
+    ).toBe(userInclusion);
+  });
+
+  it("uses the newest automatic evidence when inclusion and exclusion overlap", () => {
+    const olderExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const newerInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        olderExclusion,
+        newerInclusion,
+      ]),
+    ).toBe(newerInclusion);
+  });
+
+  it("uses a newer automatic exclusion over an older automatic inclusion", () => {
+    const olderInclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const newerExclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: true,
+      source: GroupItemSource.LABEL_REMOVED,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        olderInclusion,
+        newerExclusion,
+      ]),
+    ).toBeNull();
+  });
+
+  it("keeps an explicit user exclusion ahead of newer automatic evidence", () => {
+    const userExclusion = {
+      type: GroupItemType.FROM,
+      value: "sender@example.com",
+      exclude: true,
+      source: GroupItemSource.USER,
+      updatedAt: new Date("2026-07-01T12:00:00Z"),
+    };
+    const automaticInclusion = {
+      type: GroupItemType.FROM,
+      value: "@example.com",
+      exclude: false,
+      source: GroupItemSource.AI,
+      updatedAt: new Date("2026-07-28T12:00:00Z"),
+    };
+
+    expect(
+      findMatchingGroupItem({ from: "sender@example.com", subject: "" }, [
+        automaticInclusion,
+        userExclusion,
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/utils/group/find-matching-group.ts
+++ b/apps/web/utils/group/find-matching-group.ts
@@ -1,7 +1,7 @@
 import prisma from "@/utils/prisma";
 import { generalizeSubject } from "@/utils/string";
 import type { ParsedMessage } from "@/utils/types";
-import { GroupItemType } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 import type { GroupItem } from "@/generated/prisma/client";
 
 export type GroupsWithRules = Awaited<ReturnType<typeof getGroupsWithRules>>;
@@ -26,20 +26,17 @@ export function findMatchingGroup(
   message: ParsedMessage,
   group: GroupsWithRules[number],
 ) {
-  // First check for exclude patterns
-  const excludeMatch = findExclusionMatch(message.headers, group.items);
-  if (excludeMatch) {
-    // If any exclusion pattern matches, this rule is completely excluded
+  const matchingItem = findBestMatchingItem(message.headers, group.items);
+
+  if (matchingItem?.exclude) {
     return {
       group,
       matchingItem: null,
       excluded: true,
-      excludedItem: excludeMatch,
+      excludedItem: matchingItem,
     };
   }
 
-  // If no exclusion patterns matched, check for inclusion patterns
-  const matchingItem = findInclusionMatch(message.headers, group.items);
   if (matchingItem)
     return { group, matchingItem, excluded: false, excludedItem: null };
 
@@ -82,28 +79,39 @@ function matchesPattern<T extends Pick<GroupItem, "type" | "value">>(
   return false;
 }
 
-function findExclusionMatch<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
->(headers: { from: string; subject: string }, groupItems: T[]) {
-  return groupItems.find(
-    (item) => item.exclude && matchesPattern(item, headers),
-  );
-}
-
-function findInclusionMatch<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
->(headers: { from: string; subject: string }, groupItems: T[]) {
-  return groupItems.find(
-    (item) => !item.exclude && matchesPattern(item, headers),
-  );
-}
-
 // Keep this for backward compatibility
 export function findMatchingGroupItem<
-  T extends Pick<GroupItem, "type" | "value" | "exclude">,
+  T extends Pick<GroupItem, "type" | "value" | "exclude"> &
+    Partial<Pick<GroupItem, "source" | "updatedAt">>,
 >(headers: { from: string; subject: string }, groupItems: T[]) {
-  const hasExclusion = findExclusionMatch(headers, groupItems);
-  if (hasExclusion) return null;
+  const matchingItem = findBestMatchingItem(headers, groupItems);
+  return matchingItem?.exclude ? null : matchingItem;
+}
 
-  return findInclusionMatch(headers, groupItems);
+function findBestMatchingItem<
+  T extends Pick<GroupItem, "type" | "value" | "exclude"> &
+    Partial<Pick<GroupItem, "source" | "updatedAt">>,
+>(headers: { from: string; subject: string }, groupItems: T[]) {
+  const matches = groupItems.filter((item) => matchesPattern(item, headers));
+  if (!matches.length) return;
+
+  const userMatches = matches.filter(
+    (item) => item.source === GroupItemSource.USER,
+  );
+  const candidates = userMatches.length ? userMatches : matches;
+
+  return candidates.reduce((best, item) => {
+    const bestUpdatedAt = best.updatedAt?.getTime();
+    const itemUpdatedAt = item.updatedAt?.getTime();
+
+    if (itemUpdatedAt !== undefined && bestUpdatedAt !== undefined) {
+      if (itemUpdatedAt > bestUpdatedAt) return item;
+      if (itemUpdatedAt < bestUpdatedAt) return best;
+    }
+
+    if (itemUpdatedAt !== undefined && bestUpdatedAt === undefined) return item;
+    if (itemUpdatedAt === undefined && bestUpdatedAt !== undefined) return best;
+
+    return item.exclude && !best.exclude ? item : best;
+  });
 }

--- a/apps/web/utils/group/group-item.ts
+++ b/apps/web/utils/group/group-item.ts
@@ -1,7 +1,6 @@
 import prisma from "@/utils/prisma";
 import { isDuplicateError } from "@/utils/prisma-helpers";
-import type { GroupItemType } from "@/generated/prisma/enums";
-import { captureException } from "@/utils/error";
+import { GroupItemSource, type GroupItemType } from "@/generated/prisma/enums";
 
 export async function addGroupItem(data: {
   groupId: string;
@@ -9,15 +8,73 @@ export async function addGroupItem(data: {
   value: string;
   exclude?: boolean;
 }) {
+  return saveGroupItem({
+    ...data,
+    source: GroupItemSource.USER,
+  });
+}
+
+export async function saveGroupItem({
+  groupId,
+  type,
+  value,
+  exclude = false,
+  reason,
+  threadId,
+  messageId,
+  source,
+}: {
+  groupId: string;
+  type: GroupItemType;
+  value: string;
+  exclude?: boolean;
+  reason?: string | null;
+  threadId?: string | null;
+  messageId?: string | null;
+  source?: GroupItemSource | null;
+}) {
+  const normalizedValue = normalizeGroupItemValue(value);
+  if (!normalizedValue) throw new Error("Learned pattern cannot be empty");
+
+  const updateData = {
+    exclude,
+    reason,
+    threadId,
+    messageId,
+    source,
+  };
+  const updateWhere = {
+    groupId,
+    type,
+    value: normalizedValue,
+    ...(source !== GroupItemSource.USER && {
+      OR: [{ source: null }, { source: { not: GroupItemSource.USER } }],
+    }),
+  };
+
+  const updated = await prisma.groupItem.updateMany({
+    where: updateWhere,
+    data: updateData,
+  });
+  if (updated.count > 0) return;
+
   try {
-    return await prisma.groupItem.create({ data });
+    return await prisma.groupItem.create({
+      data: {
+        groupId,
+        type,
+        value: normalizedValue,
+        ...updateData,
+      },
+    });
   } catch (error) {
-    if (isDuplicateError(error)) {
-      captureException(error, { extra: { items: data } });
-    } else {
-      throw error;
-    }
+    if (!isDuplicateError(error)) throw error;
   }
+
+  await prisma.groupItem.updateMany({
+    where: updateWhere,
+    data: updateData,
+  });
 }
 
 export async function deleteGroupItem({
@@ -30,4 +87,8 @@ export async function deleteGroupItem({
   await prisma.groupItem.delete({
     where: { id, group: { emailAccountId } },
   });
+}
+
+function normalizeGroupItemValue(value: string) {
+  return value.trim().toLowerCase();
 }

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -14,6 +14,9 @@ vi.mock("@/utils/prisma-helpers", () => ({
 describe("saveLearnedPattern", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockResolvedValue({} as any);
+    vi.mocked(isDuplicateError).mockReturnValue(false);
   });
 
   it("should return early if rule not found", async () => {
@@ -26,7 +29,8 @@ describe("saveLearnedPattern", () => {
       logger: createTestLogger(),
     });
 
-    expect(prisma.groupItem.upsert).not.toHaveBeenCalled();
+    expect(prisma.groupItem.updateMany).not.toHaveBeenCalled();
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
   });
 
   it("should use existing groupId when rule has one", async () => {
@@ -36,8 +40,6 @@ describe("saveLearnedPattern", () => {
       name: "Test Rule",
       groupId: existingGroupId,
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -46,21 +48,135 @@ describe("saveLearnedPattern", () => {
     });
 
     expect(prisma.group.create).not.toHaveBeenCalled();
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith({
-      where: {
-        groupId_type_value: {
-          groupId: existingGroupId,
-          type: GroupItemType.FROM,
-          value: "test@example.com",
-        },
-      },
-      update: expect.objectContaining({ exclude: false }),
-      create: expect.objectContaining({
+    expect(prisma.groupItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
         groupId: existingGroupId,
         type: GroupItemType.FROM,
         value: "test@example.com",
+        exclude: false,
       }),
     });
+  });
+
+  it("normalizes learned sender values before saving", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "  Sender@Example.COM  ",
+      ruleId: "rule-id",
+      logger: createTestLogger(),
+    });
+
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          value: "sender@example.com",
+        }),
+      }),
+    );
+  });
+
+  it("guards automatic updates from user-authored rows", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "  Sender@Example.COM  ",
+      ruleId: "rule-id",
+      exclude: false,
+      logger: createTestLogger(),
+      source: GroupItemSource.LABEL_ADDED,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+        OR: [{ source: null }, { source: { not: GroupItemSource.USER } }],
+      },
+      data: expect.objectContaining({
+        source: GroupItemSource.LABEL_ADDED,
+      }),
+    });
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
+  });
+
+  it("allows a user-authored update to replace automatic evidence", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 1 });
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "Sender@Example.COM",
+      ruleId: "rule-id",
+      exclude: true,
+      logger: createTestLogger(),
+      source: GroupItemSource.USER,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+      },
+      data: expect.objectContaining({
+        exclude: true,
+        source: GroupItemSource.USER,
+      }),
+    });
+    expect(prisma.groupItem.create).not.toHaveBeenCalled();
+  });
+
+  it("preserves a user pattern created during an automatic save", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      name: "Test Rule",
+      groupId: "group-id",
+    } as any);
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockRejectedValue(
+      new Error("Duplicate key"),
+    );
+    vi.mocked(isDuplicateError).mockReturnValue(true);
+
+    await saveLearnedPattern({
+      emailAccountId: "email-account-id",
+      from: "Sender@Example.COM",
+      ruleId: "rule-id",
+      exclude: false,
+      logger: createTestLogger(),
+      source: GroupItemSource.LABEL_ADDED,
+    });
+
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.groupItem.updateMany).toHaveBeenCalledWith({
+      where: {
+        groupId: "group-id",
+        type: GroupItemType.FROM,
+        value: "sender@example.com",
+        OR: [{ source: null }, { source: { not: GroupItemSource.USER } }],
+      },
+      data: expect.objectContaining({
+        exclude: false,
+        source: GroupItemSource.LABEL_ADDED,
+      }),
+    });
+    expect(prisma.groupItem.create).toHaveBeenCalledTimes(1);
   });
 
   it("should create a new group when rule has no groupId", async () => {
@@ -73,8 +189,6 @@ describe("saveLearnedPattern", () => {
     vi.mocked(prisma.group.create).mockResolvedValue({
       id: newGroupId,
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -89,15 +203,13 @@ describe("saveLearnedPattern", () => {
         rule: { connect: { id: "rule-id" } },
       },
     });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          groupId_type_value: {
-            groupId: newGroupId,
-            type: GroupItemType.FROM,
-            value: "test@example.com",
-          },
-        },
+        data: expect.objectContaining({
+          groupId: newGroupId,
+          type: GroupItemType.FROM,
+          value: "test@example.com",
+        }),
       }),
     );
   });
@@ -108,8 +220,6 @@ describe("saveLearnedPattern", () => {
       name: "Test Rule",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "excluded@example.com",
@@ -120,22 +230,8 @@ describe("saveLearnedPattern", () => {
       source: GroupItemSource.USER,
     });
 
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith({
-      where: {
-        groupId_type_value: {
-          groupId: "group-id",
-          type: GroupItemType.FROM,
-          value: "excluded@example.com",
-        },
-      },
-      update: {
-        exclude: true,
-        reason: "User excluded",
-        threadId: undefined,
-        messageId: undefined,
-        source: GroupItemSource.USER,
-      },
-      create: {
+    expect(prisma.groupItem.create).toHaveBeenCalledWith({
+      data: {
         groupId: "group-id",
         type: GroupItemType.FROM,
         value: "excluded@example.com",
@@ -167,8 +263,6 @@ describe("saveLearnedPattern", () => {
       id: existingGroupId,
     } as any);
     vi.mocked(prisma.rule.update).mockResolvedValue({} as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
       from: "test@example.com",
@@ -185,15 +279,13 @@ describe("saveLearnedPattern", () => {
       },
       select: { id: true },
     });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledWith(
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          groupId_type_value: {
-            groupId: existingGroupId,
-            type: GroupItemType.FROM,
-            value: "test@example.com",
-          },
-        },
+        data: expect.objectContaining({
+          groupId: existingGroupId,
+          type: GroupItemType.FROM,
+          value: "test@example.com",
+        }),
       }),
     );
   });
@@ -202,6 +294,9 @@ describe("saveLearnedPattern", () => {
 describe("saveLearnedPatterns", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.groupItem.updateMany).mockResolvedValue({ count: 0 });
+    vi.mocked(prisma.groupItem.create).mockResolvedValue({} as any);
+    vi.mocked(isDuplicateError).mockReturnValue(false);
   });
 
   it("should return error if rule not found", async () => {
@@ -222,8 +317,6 @@ describe("saveLearnedPatterns", () => {
       id: "rule-id",
       groupId: "group-id",
     } as any);
-    vi.mocked(prisma.groupItem.upsert).mockResolvedValue({} as any);
-
     const result = await saveLearnedPatterns({
       emailAccountId: "email-account-id",
       ruleName: "Test Rule",
@@ -235,6 +328,37 @@ describe("saveLearnedPatterns", () => {
     });
 
     expect(result).toEqual({ success: true });
-    expect(prisma.groupItem.upsert).toHaveBeenCalledTimes(2);
+    expect(prisma.groupItem.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes explicit learned patterns and records them as user-authored", async () => {
+    vi.mocked(prisma.rule.findUnique).mockResolvedValue({
+      id: "rule-id",
+      groupId: "group-id",
+    } as any);
+    const result = await saveLearnedPatterns({
+      emailAccountId: "email-account-id",
+      ruleName: "Test Rule",
+      patterns: [
+        {
+          type: GroupItemType.FROM,
+          value: "  Sender@Example.COM  ",
+          exclude: true,
+        },
+      ],
+      logger: createTestLogger(),
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.groupItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          groupId: "group-id",
+          type: GroupItemType.FROM,
+          value: "sender@example.com",
+          source: GroupItemSource.USER,
+        }),
+      }),
+    );
   });
 });

--- a/apps/web/utils/rule/learned-patterns.test.ts
+++ b/apps/web/utils/rule/learned-patterns.test.ts
@@ -66,7 +66,7 @@ describe("saveLearnedPattern", () => {
     } as any);
     await saveLearnedPattern({
       emailAccountId: "email-account-id",
-      from: "  Sender@Example.COM  ",
+      from: "\t Sender@Example.COM\n",
       ruleId: "rule-id",
       logger: createTestLogger(),
     });
@@ -342,7 +342,7 @@ describe("saveLearnedPatterns", () => {
       patterns: [
         {
           type: GroupItemType.FROM,
-          value: "  Sender@Example.COM  ",
+          value: "\r Sender@Example.COM\v",
           exclude: true,
         },
       ],

--- a/apps/web/utils/rule/learned-patterns.ts
+++ b/apps/web/utils/rule/learned-patterns.ts
@@ -1,7 +1,8 @@
 import prisma from "@/utils/prisma";
 import type { Logger } from "@/utils/logger";
-import { GroupItemType, type GroupItemSource } from "@/generated/prisma/enums";
+import { GroupItemSource, GroupItemType } from "@/generated/prisma/enums";
 import { isDuplicateError } from "@/utils/prisma-helpers";
+import { saveGroupItem } from "@/utils/group/group-item";
 
 /**
  * Saves a learned pattern for a rule
@@ -47,31 +48,15 @@ export async function saveLearnedPattern({
     logger,
   });
 
-  await prisma.groupItem.upsert({
-    where: {
-      groupId_type_value: {
-        groupId,
-        type: GroupItemType.FROM,
-        value: from,
-      },
-    },
-    update: {
-      exclude,
-      reason,
-      threadId,
-      messageId,
-      source,
-    },
-    create: {
-      groupId,
-      type: GroupItemType.FROM,
-      value: from,
-      exclude,
-      reason,
-      threadId,
-      messageId,
-      source,
-    },
+  await saveGroupItem({
+    groupId,
+    type: GroupItemType.FROM,
+    value: from,
+    exclude,
+    reason,
+    threadId,
+    messageId,
+    source,
   });
 }
 
@@ -128,23 +113,12 @@ export async function saveLearnedPatterns({
   // Process all patterns in a single function
   for (const pattern of patterns) {
     try {
-      await prisma.groupItem.upsert({
-        where: {
-          groupId_type_value: {
-            groupId,
-            type: pattern.type,
-            value: pattern.value,
-          },
-        },
-        update: {
-          exclude: pattern.exclude || false,
-        },
-        create: {
-          groupId,
-          type: pattern.type,
-          value: pattern.value,
-          exclude: pattern.exclude || false,
-        },
+      await saveGroupItem({
+        groupId,
+        type: pattern.type,
+        value: pattern.value,
+        exclude: pattern.exclude ?? false,
+        source: GroupItemSource.USER,
       });
     } catch (error) {
       const message = `${pattern.value} (${pattern.type}) ${


### PR DESCRIPTION
Normalize and reconcile learned patterns so explicit user intent is preserved and stale evidence cannot silently win.

- trim and lowercase learned pattern values and clean existing duplicates
- protect user-authored patterns with atomic conditional updates
- resolve overlapping learned evidence by user source, then recency
- allow complete static matches to override automatic exclusions
- add regression coverage for persistence races and precedence

Tests:
- pnpm test (4,567 passed, 678 skipped)
- pnpm --filter inbox-zero-ai exec prisma validate
- Biome check on changed files

Performance:
- existing patterns update in one query; new patterns use an update-then-create path to make ownership protection atomic
- matching resolves precedence in memory over the group items already loaded for a rule
- the one-time migration normalizes and deduplicates existing patterns before updating values

Update: #3669 contains a refreshed implementation on current main that preserves newer exclusion/provenance fixes and keeps static-rule exclusion behavior unchanged. This branch remains unchanged.
