### PR TITLE
Fix Outlook inline image metadata

### DIFF
--- a/apps/web/utils/outlook/message.test.ts
+++ b/apps/web/utils/outlook/message.test.ts
@@ -24,6 +24,7 @@ describe("convertMessage", () => {
           id: "inline-attachment",
           name: "signature-logo.png",
           contentType: "image/png",
+          contentId: "signature-logo",
           size: 128,
           isInline: true,
         },
@@ -43,6 +44,15 @@ describe("convertMessage", () => {
       expect.objectContaining({
         attachmentId: "document-attachment",
         filename: "receipt.pdf",
+      }),
+    ]);
+    expect(result.inline).toEqual([
+      expect.objectContaining({
+        attachmentId: "inline-attachment",
+        filename: "signature-logo.png",
+        headers: expect.objectContaining({
+          "content-id": "signature-logo",
+        }),
       }),
     ]);
   });

--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -19,7 +19,7 @@ export const MESSAGE_SELECT_FIELDS =
 
 // Expand attachments to get metadata (name, type, size) without fetching content
 export const MESSAGE_EXPAND_ATTACHMENTS =
-  "attachments($select=id,name,contentType,size,isInline)";
+  "attachments($select=id,name,contentType,size,isInline,contentId)";
 
 export async function getFolderIds(
   client: OutlookClient,
@@ -977,7 +977,7 @@ export function convertMessage(
     parentFolderId: message.parentFolderId || undefined,
     internalDate: message.receivedDateTime || new Date().toISOString(),
     historyId: "",
-    inline: [],
+    inline: convertInlineAttachments(message.attachments),
     attachments: convertAttachments(message.attachments),
     conversationIndex: message.conversationIndex,
     rawRecipients: {
@@ -1007,6 +1007,27 @@ function convertAttachments(
         "content-description": "",
         "content-transfer-encoding": "",
         "content-id": "",
+      },
+    }));
+}
+
+function convertInlineAttachments(
+  graphAttachments: GraphAttachment[] | undefined | null,
+): ParsedMessage["inline"] {
+  if (!graphAttachments) return [];
+
+  return graphAttachments
+    .filter((attachment) => attachment.isInline)
+    .map((attachment) => ({
+      filename: attachment.name || "",
+      mimeType: attachment.contentType || "application/octet-stream",
+      size: attachment.size || 0,
+      attachmentId: attachment.id || "",
+      headers: {
+        "content-type": attachment.contentType || "",
+        "content-description": "",
+        "content-transfer-encoding": "",
+        "content-id": attachment.contentId || attachment.name || "",
       },
     }));
 }


### PR DESCRIPTION
Preserve Outlook inline attachment content IDs so mobile clients can resolve cid: images.\n\nTests: pnpm test utils/outlook/message.test.ts; pnpm exec biome check apps/web/utils/outlook/message.ts apps/web/utils/outlook/message.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

