### PR TITLE
outlook: Fix inline attachment content ID projection

### DIFF
--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -19,7 +19,7 @@ export const MESSAGE_SELECT_FIELDS =
 
 // Expand attachments to get metadata (name, type, size) without fetching content
 export const MESSAGE_EXPAND_ATTACHMENTS =
-  "attachments($select=id,name,contentType,size,isInline,contentId)";
+  "attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)";
 
 export async function getFolderIds(
   client: OutlookClient,
@@ -1018,18 +1018,27 @@ function convertInlineAttachments(
 
   return graphAttachments
     .filter((attachment) => attachment.isInline)
-    .map((attachment) => ({
-      filename: attachment.name || "",
-      mimeType: attachment.contentType || "application/octet-stream",
-      size: attachment.size || 0,
-      attachmentId: attachment.id || "",
-      headers: {
-        "content-type": attachment.contentType || "",
-        "content-description": "",
-        "content-transfer-encoding": "",
-        "content-id": attachment.contentId || attachment.name || "",
-      },
-    }));
+    .map((attachment) => {
+      const contentId =
+        ("contentId" in attachment && typeof attachment.contentId === "string"
+          ? attachment.contentId
+          : undefined) ||
+        attachment.name ||
+        "";
+
+      return {
+        filename: attachment.name || "",
+        mimeType: attachment.contentType || "application/octet-stream",
+        size: attachment.size || 0,
+        attachmentId: attachment.id || "",
+        headers: {
+          "content-type": attachment.contentType || "",
+          "content-description": "",
+          "content-transfer-encoding": "",
+          "content-id": contentId,
+        },
+      };
+    });
 }
 
 function logWellKnownFolderFetchError(


### PR DESCRIPTION
Fixes the build failure introduced by #3076 and ensures Microsoft Graph accepts the attachment metadata projection.

- narrow contentId access to attachments that expose the file-attachment field
- qualify contentId with the Microsoft Graph fileAttachment OData cast
- preserve the filename fallback when an inline attachment has no content ID

Validation:
- pnpm test utils/outlook/message.test.ts
- pnpm exec ultracite check apps/web/utils/outlook/message.ts
- pnpm turbo run build:ci --filter=./apps/web

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

