### PR TITLE
outlook: Fix inline attachment content ID type check

### DIFF
--- a/apps/web/utils/outlook/message.ts
+++ b/apps/web/utils/outlook/message.ts
@@ -1018,18 +1018,30 @@ function convertInlineAttachments(
 
   return graphAttachments
     .filter((attachment) => attachment.isInline)
-    .map((attachment) => ({
-      filename: attachment.name || "",
-      mimeType: attachment.contentType || "application/octet-stream",
-      size: attachment.size || 0,
-      attachmentId: attachment.id || "",
-      headers: {
-        "content-type": attachment.contentType || "",
-        "content-description": "",
-        "content-transfer-encoding": "",
-        "content-id": attachment.contentId || attachment.name || "",
-      },
-    }));
+    .map((attachment) => {
+      const contentId = hasContentId(attachment)
+        ? attachment.contentId
+        : undefined;
+
+      return {
+        filename: attachment.name || "",
+        mimeType: attachment.contentType || "application/octet-stream",
+        size: attachment.size || 0,
+        attachmentId: attachment.id || "",
+        headers: {
+          "content-type": attachment.contentType || "",
+          "content-description": "",
+          "content-transfer-encoding": "",
+          "content-id": contentId || attachment.name || "",
+        },
+      };
+    });
+}
+
+function hasContentId(
+  attachment: GraphAttachment,
+): attachment is GraphAttachment & { contentId?: string | null } {
+  return "contentId" in attachment;
 }
 
 function logWellKnownFolderFetchError(


### PR DESCRIPTION
The merged inline-image metadata change accessed a file-attachment-only field through the base Graph attachment type, causing the web build to fail. This narrows the attachment before reading `contentId` while preserving the existing filename fallback.

- Add a structural type guard for attachment `contentId`
- Preserve inline attachment metadata behavior and fallbacks
- Verify the focused Outlook message suite: 63 tests passed
- Verify the original build error is resolved; the full CI build advances to an unrelated existing error in the marketing image store

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

