### PR TITLE
meeting recorder: Fix provider compatibility failures

### DIFF
--- a/apps/web/__tests__/eval/meeting-follow-up-draft.test.ts
+++ b/apps/web/__tests__/eval/meeting-follow-up-draft.test.ts
@@ -25,6 +25,7 @@ const ROLLOUT_SUMMARY: MeetingSummary = {
     {
       description:
         "Tell the customers who already have the fifteenth in writing",
+      owner: null,
     },
   ],
   openQuestions: ["Who owns the migration webinar?"],
@@ -45,6 +46,7 @@ const UNRESOLVED_PRICING_SUMMARY: MeetingSummary = {
   openQuestions: [
     "Do they pay for all forty people or only the fifteen daily users?",
   ],
+  nextSteps: [],
 };
 
 describe.runIf(shouldRunEval)("meeting-follow-up-draft eval", () => {
@@ -146,7 +148,7 @@ describe.runIf(shouldRunEval)("meeting-follow-up-draft eval", () => {
           criterion: {
             name: "Ready to send",
             description:
-              "The email is addressed to the group and could be sent as written. It contains no unfilled placeholders for the sender to complete, no meta-commentary about being AI-generated, and no instructions to the reader about how to use the draft.",
+              "The email is addressed to the group and could be sent as written. It contains no unfilled placeholders for the sender to complete, no meta-commentary about being AI-generated, and no instructions to the reader about how to use the draft. The summary includes work that was explicitly left without an owner; leaving that work unassigned is correct and must not count as an unfilled placeholder.",
           },
           input: JSON.stringify(ROLLOUT_SUMMARY, null, 2),
           output: `${draft.subject}\n\n${draft.body}`,

--- a/apps/web/utils/ai/meeting-recorder/summarize-meeting.ts
+++ b/apps/web/utils/ai/meeting-recorder/summarize-meeting.ts
@@ -15,10 +15,13 @@ The transcript is automatically generated. Speaker labels can be wrong, words ca
 
 Rules:
 - Only report things that were actually said. Never invent a decision, a commitment, an owner or a date.
-- Attribute an action item to someone only when the transcript shows that person taking it on. If the owner is unclear, leave the owner out rather than guessing.
+- Attribute an action item to someone only when the transcript shows that person taking it on. If the owner is unclear, set the owner to null rather than guessing.
 - When the meeting reverses an earlier decision, report the final position, not the one that was superseded.
 - If a speaker label looks wrong or two speakers have similar names, prefer describing what was decided over who said it.
-- Leave a section empty when the meeting genuinely had nothing for it. An empty list is better than a filler entry.
+- Keep the summary proportional to the meeting. Do not repeat the same fact across sections.
+- Put settled choices in decisions and concrete follow-up work in action items. Include any agreed deadline in the action item's description.
+- Use next steps only for distinct sequencing or follow-up that is not already captured as an action item.
+- Leave a section empty when it has nothing distinct to add. An empty list is better than a filler entry.
 - Write in the language the meeting was held in.
 - Write for someone who attended and wants a reminder, not for someone who needs the meeting re-narrated.
 
@@ -30,26 +33,32 @@ const summarySchema = z.object({
     .describe("A short paragraph covering what the meeting was about"),
   keyDecisions: z
     .array(z.string())
-    .describe("Decisions the group actually settled on"),
+    .describe(
+      "Choices the group actually settled on, excluding work that belongs in action items",
+    ),
   actionItems: z
     .array(
       z.object({
         description: z.string(),
         owner: z
           .string()
-          .optional()
-          .describe("Only set when the transcript shows who took this on"),
+          .nullable()
+          .describe(
+            "The owner when the transcript shows who took this on, otherwise null",
+          ),
       }),
     )
-    .describe("Concrete follow-up work agreed in the meeting"),
+    .describe(
+      "Concrete follow-up work agreed in the meeting, including any deadline",
+    ),
   openQuestions: z
     .array(z.string())
-    .optional()
     .describe("Questions raised but left unresolved"),
   nextSteps: z
     .array(z.string())
-    .optional()
-    .describe("What happens next, including any agreed timing"),
+    .describe(
+      "Distinct sequencing or follow-up not already captured in action items",
+    ),
 });
 
 export type MeetingSummary = z.infer<typeof summarySchema>;

--- a/apps/web/utils/meeting-recorder/send-recap.test.ts
+++ b/apps/web/utils/meeting-recorder/send-recap.test.ts
@@ -52,6 +52,8 @@ describe("sendMeetingRecapEmail", () => {
         overview: "Discussed the plan.",
         keyDecisions: [],
         actionItems: [],
+        openQuestions: [],
+        nextSteps: [],
       },
       followUpDraftCreated: false,
       logger: {

--- a/apps/web/utils/recall/client.test.ts
+++ b/apps/web/utils/recall/client.test.ts
@@ -38,4 +38,24 @@ describe("RecallBotProvider", () => {
       expect.anything(),
     );
   });
+
+  it("removes a dispatched bot from its call when Recall rejects deletion with 405", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Method not allowed." }), {
+          status: 405,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const provider = new RecallBotProvider(createTestLogger());
+
+    await expect(provider.cancelBot("bot-1")).resolves.toBeUndefined();
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://eu-central-1.recall.ai/api/v1/bot/bot-1/leave_call/",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/apps/web/utils/recall/client.ts
+++ b/apps/web/utils/recall/client.ts
@@ -225,10 +225,11 @@ function isMissing(error: unknown): boolean {
 }
 
 function isAlreadyJoining(error: unknown): boolean {
+  if (!(error instanceof RecallApiError)) return false;
+  if (error.status === 405) return true;
+
   return (
-    error instanceof RecallApiError &&
-    error.status === 400 &&
-    getRecallErrorCode(error) === "cannot_delete_bot"
+    error.status === 400 && getRecallErrorCode(error) === "cannot_delete_bot"
   );
 }
 

--- a/packages/resend/emails/meeting-recap.tsx
+++ b/packages/resend/emails/meeting-recap.tsx
@@ -12,7 +12,7 @@ import {
 
 export type MeetingRecapActionItem = {
   description: string;
-  owner?: string;
+  owner?: string | null;
 };
 
 export type MeetingRecapContent = {


### PR DESCRIPTION
Fixes two provider-specific failures found during post-merge QA of the meeting recorder. Structured summaries now work with strict JSON-schema providers, and dispatched Recall bots reliably leave calls when deletion returns either documented response shape.

- require complete structured-summary fields while representing unknown owners as null
- improve summary section separation, deadline capture, and proportionality
- accept Recall HTTP 405 as the dispatched-bot deletion response and fall back to leave_call
- clarify the follow-up eval judge so unassigned work is not treated as a placeholder
- verified with focused unit tests and Gemini 3.1 Flash Lite eval reruns

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

