### PR TITLE
meetings: Show setup when calendar is disconnected

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/page.tsx
@@ -99,7 +99,7 @@ function MeetingRecorderPageContent() {
 
   // Enabling is entitlement-gated server-side, so a non-premium user needs the
   // upgrade path on the onboarding screen too, not just once they are set up.
-  if (!settings?.enabled) {
+  if (!hasCalendarConnected || !settings?.enabled) {
     return (
       <PageWrapper>
         <div className="mx-auto max-w-lg">


### PR DESCRIPTION
The meeting recorder now returns to calendar setup when an enabled account no longer has a connected calendar. This keeps the redesigned onboarding gate consistent with the recorder prerequisites.

- gate the enabled recorder page on a connected calendar
- verified the disconnected and reconnected states in browser QA
- verified 32 targeted meeting-recorder tests and the touched-file check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

