### PR TITLE
messaging: Add checkmark to sent reply status

### DIFF
--- a/apps/web/utils/messaging/chat-sdk/bot.test.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.test.ts
@@ -428,7 +428,7 @@ describe("getMessagingAiGeneratedPostPayload", () => {
 describe("pending email handled state helpers", () => {
   it("uses reply-specific sent copy", () => {
     expect(getPendingEmailHandledTitle("reply_email")).toBe("Reply sent");
-    expect(getPendingEmailHandledStatus("reply_email")).toBe("Reply sent.");
+    expect(getPendingEmailHandledStatus("reply_email")).toBe("Reply sent. ✅");
   });
 
   it("builds a mailbox deep link when confirmation ids are present", () => {

--- a/apps/web/utils/messaging/chat-sdk/bot.ts
+++ b/apps/web/utils/messaging/chat-sdk/bot.ts
@@ -1371,7 +1371,7 @@ export function getPendingEmailHandledStatus(
   actionType: AssistantPendingEmailActionType,
 ) {
   if (actionType === "send_email") return "Email sent.";
-  if (actionType === "reply_email") return "Reply sent.";
+  if (actionType === "reply_email") return "Reply sent. ✅";
   return "Email forwarded.";
 }
 

--- a/apps/web/utils/messaging/rule-notifications.test.ts
+++ b/apps/web/utils/messaging/rule-notifications.test.ts
@@ -176,7 +176,7 @@ describe("handleRuleNotificationAction", () => {
     expect(cardText).toContain(
       "Drafted by <https://getinboxzero.com/?ref=ABC|Inbox Zero>.",
     );
-    expect(cardText).toContain("Status: Reply sent.");
+    expect(cardText).toContain("Status: Reply sent. ✅");
     expect(cardText).toContain("Open in Gmail");
     expect(cardText).toContain(
       "https://mail.google.com/mail/u/?authuser=user%40example.com#all/message-1",
@@ -507,7 +507,7 @@ describe("handleRuleNotificationAction", () => {
       expect.objectContaining({
         channel: "C123",
         ts: "slack-ts-1",
-        text: expect.stringContaining("Reply sent."),
+        text: expect.stringContaining("Reply sent. ✅"),
       }),
     );
     expect(
@@ -607,11 +607,11 @@ describe("handleRuleNotificationAction", () => {
     const [, , card] = editMessage.mock.calls[0];
     const cardText = JSON.stringify(card);
 
-    expect(cardText).toContain("Status: Reply sent.");
+    expect(cardText).toContain("Status: Reply sent. ✅");
     expect(cardText).toContain("Open in Gmail");
 
     const editedMessage = await renderTelegramEditedMessageForTest(card);
-    expect(editedMessage.text).toContain("Reply sent\\.");
+    expect(editedMessage.text).toContain("Reply sent\\. ✅");
     expect(editedMessage.text).toContain("Sender\\_Name");
     expect(editedMessage.text).toContain("\\[billing\\]\\_status");
     expect(editedMessage.text).toContain("account\\_name");

--- a/apps/web/utils/messaging/rule-notifications.ts
+++ b/apps/web/utils/messaging/rule-notifications.ts
@@ -1075,7 +1075,7 @@ async function sendDraftReplyFromNotification({
       provider: context.messagingChannel?.provider,
       content: notificationContent,
       openLink: getNotificationOpenLink(context),
-      status: "Reply sent.",
+      status: "Reply sent. ✅",
     }),
   });
 


### PR DESCRIPTION
Adds a green checkmark to successful reply status messages across messaging bots.

- Update shared Slack, Telegram, and Teams notification status copy
- Cover rule notifications and pending-email confirmation cards
- Update focused unit coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

