### PR TITLE
INB-318: Cascade folder selection to loaded children

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/AllowedFolders.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FolderIcon, Loader2Icon, PlusIcon } from "lucide-react";
@@ -25,11 +25,7 @@ import {
   TreeLabel,
   useTree,
 } from "@/components/kibo-ui/tree";
-import {
-  addFilingFolderAction,
-  removeFilingFolderAction,
-  createDriveFolderAction,
-} from "@/utils/actions/drive";
+import { createDriveFolderAction } from "@/utils/actions/drive";
 import {
   createDriveFolderBody,
   type CreateDriveFolderBody,
@@ -66,6 +62,7 @@ import {
   folderSelection,
   type FolderChildrenMap,
 } from "./allowed-folder-selection";
+import { useFolderSelection } from "./use-folder-selection";
 
 export function AllowedFolders({ emailAccountId }: { emailAccountId: string }) {
   const { data, isLoading, error, mutate } = useDriveFolders(emailAccountId);
@@ -103,120 +100,19 @@ function AllowedFoldersContent({
   staleFolderCount: number;
   mutateFolders: () => void;
 }) {
-  const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
-    () => new Set(savedFolders.map((f) => f.folderId)),
-  );
+  const {
+    optimisticFolderIds,
+    childrenByParentId,
+    rootFolders,
+    handleFolderToggle,
+    handleChildrenLoaded,
+  } = useFolderSelection({
+    emailAccountId,
+    availableFolders,
+    savedFolders,
+    mutateFolders,
+  });
 
-  const serverFolderIds = useMemo(
-    () => savedFolders.map((f) => f.folderId).join(","),
-    [savedFolders],
-  );
-  const prevServerFolderIds = useRef(serverFolderIds);
-  const [childrenByParentId, setChildrenByParentId] =
-    useState<FolderChildrenMap>(() =>
-      folderSelection.buildChildrenMap(availableFolders),
-    );
-
-  useEffect(() => {
-    if (serverFolderIds === prevServerFolderIds.current) return;
-    prevServerFolderIds.current = serverFolderIds;
-    setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
-  }, [savedFolders, serverFolderIds]);
-
-  useEffect(() => {
-    setChildrenByParentId(folderSelection.buildChildrenMap(availableFolders));
-  }, [availableFolders]);
-
-  const handleChildrenLoaded = useCallback(
-    (parentId: string, children: FolderItem[]) => {
-      setChildrenByParentId((prev) =>
-        folderSelection.mergeChildren({
-          childrenByParentId: prev,
-          parentId,
-          children,
-        }),
-      );
-    },
-    [],
-  );
-
-  const handleFolderToggle = useCallback(
-    async (folder: FolderItem, isChecked: boolean) => {
-      const previousFolderIds = optimisticFolderIds;
-      const { nextKeys: nextFolderIds, changedItems: changedFolders } =
-        folderSelection.applySelection({
-          item: folder,
-          checked: isChecked,
-          selectedKeys: previousFolderIds,
-          childrenByParentId,
-        });
-
-      setOptimisticFolderIds(nextFolderIds);
-
-      try {
-        if (isChecked) {
-          const results = await Promise.all(
-            changedFolders.map((changedFolder) =>
-              addFilingFolderAction(emailAccountId, {
-                folderId: changedFolder.id,
-                folderName: changedFolder.name,
-                folderPath: changedFolder.path || changedFolder.name,
-                driveConnectionId: changedFolder.driveConnectionId,
-              }),
-            ),
-          );
-          const serverError = results.find(
-            (result) => result?.serverError,
-          )?.serverError;
-
-          if (serverError) {
-            setOptimisticFolderIds(previousFolderIds);
-            toastError({
-              title: "Error adding folder",
-              description: serverError,
-            });
-          } else {
-            mutateFolders();
-          }
-        } else {
-          const results = await Promise.all(
-            changedFolders.map((changedFolder) =>
-              removeFilingFolderAction(emailAccountId, {
-                folderId: changedFolder.id,
-              }),
-            ),
-          );
-          const serverError = results.find(
-            (result) => result?.serverError,
-          )?.serverError;
-
-          if (serverError) {
-            setOptimisticFolderIds(previousFolderIds);
-            toastError({
-              title: "Error removing folder",
-              description: serverError,
-            });
-          } else {
-            mutateFolders();
-          }
-        }
-      } catch {
-        setOptimisticFolderIds(previousFolderIds);
-        toastError({
-          title: isChecked ? "Error adding folder" : "Error removing folder",
-          description: "Please try again.",
-        });
-      }
-    },
-    [childrenByParentId, emailAccountId, mutateFolders, optimisticFolderIds],
-  );
-
-  const rootFolders = useMemo(
-    () => folderSelection.getRootItems(availableFolders),
-    [availableFolders],
-  );
-
-  const savedFolderIds = optimisticFolderIds;
   const hasFolders = rootFolders.length > 0;
 
   return (
@@ -249,7 +145,7 @@ function AllowedFoldersContent({
                     key={folder.id}
                     folder={folder}
                     isLast={index === rootFolders.length - 1}
-                    selectedFolderIds={savedFolderIds}
+                    selectedFolderIds={optimisticFolderIds}
                     onToggle={handleFolderToggle}
                     level={0}
                     parentPath=""
@@ -300,7 +196,7 @@ export function FolderNode({
   isLast: boolean;
   selectedFolderIds: Set<string>;
   onToggle: (folder: FolderItem, isChecked: boolean) => void;
-  onChildrenLoaded: (parentId: string, children: FolderItem[]) => void;
+  onChildrenLoaded: (parent: FolderItem, children: FolderItem[]) => void;
   level: number;
   parentPath: string;
   childrenByParentId: FolderChildrenMap;
@@ -339,9 +235,9 @@ export function FolderNode({
 
   useEffect(() => {
     if (!subfoldersData?.folders || knownChildren) return;
-    onChildrenLoaded(folder.id, subfolders);
+    onChildrenLoaded(folder, subfolders);
   }, [
-    folder.id,
+    folder,
     knownChildren,
     onChildrenLoaded,
     subfolders,
@@ -381,10 +277,7 @@ export function FolderNode({
           subfolders.map((subfolder, index) => (
             <FolderNode
               key={subfolder.id}
-              folder={{
-                ...subfolder,
-                path: `${currentPath}/${subfolder.name}`,
-              }}
+              folder={subfolder}
               isLast={index === subfolders.length - 1}
               selectedFolderIds={selectedFolderIds}
               onToggle={onToggle}

--- a/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/drive/DriveSetup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
@@ -39,8 +39,6 @@ import { useDriveConnections } from "@/hooks/useDriveConnections";
 import { useDriveFolders } from "@/hooks/useDriveFolders";
 import { useFilingPreviewAttachments } from "@/hooks/useFilingPreviewAttachments";
 import {
-  addFilingFolderAction,
-  removeFilingFolderAction,
   updateFilingPromptAction,
   updateFilingEnabledAction,
   moveFilingAction,
@@ -57,10 +55,7 @@ import {
   FolderNode,
   NoFoldersFound,
 } from "./AllowedFolders";
-import {
-  folderSelection,
-  type FolderChildrenMap,
-} from "./allowed-folder-selection";
+import { useFolderSelection } from "./use-folder-selection";
 import type {
   FolderItem,
   SavedFolder,
@@ -708,134 +703,40 @@ function SetupFolderSelection({
   isLoading: boolean;
 }) {
   const analytics = useProductAnalytics("attachments");
-  // Optimistic state for folder selection
-  const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
-    () => new Set(savedFolders.map((f) => f.folderId)),
-  );
-  const [childrenByParentId, setChildrenByParentId] =
-    useState<FolderChildrenMap>(() =>
-      folderSelection.buildChildrenMap(availableFolders),
-    );
   // TODO: This assumes a single drive connection; swap to a selected connection ID when multi-connection UX exists.
   const driveConnectionId = connections[0]?.id ?? null;
 
-  // Sync optimistic state when server data changes
-  const serverFolderIds = savedFolders.map((f) => f.folderId).join(",");
-  const prevServerFolderIds = useRef(serverFolderIds);
-  useEffect(() => {
-    if (serverFolderIds === prevServerFolderIds.current) return;
-    prevServerFolderIds.current = serverFolderIds;
-    setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
-  }, [savedFolders, serverFolderIds]);
-
-  useEffect(() => {
-    setChildrenByParentId(folderSelection.buildChildrenMap(availableFolders));
-  }, [availableFolders]);
-
-  const handleChildrenLoaded = useCallback(
-    (parentId: string, children: FolderItem[]) => {
-      setChildrenByParentId((prev) =>
-        folderSelection.mergeChildren({
-          childrenByParentId: prev,
-          parentId,
-          children,
-        }),
-      );
+  const onFoldersAdded = useCallback(
+    (savedFolderCount: number) => {
+      analytics.captureAction("auto_file_folder_selected", {
+        saved_folder_count: savedFolderCount,
+      });
     },
-    [],
+    [analytics],
   );
-
-  const handleFolderToggle = useCallback(
-    async (folder: FolderItem, isChecked: boolean) => {
-      const previousFolderIds = optimisticFolderIds;
-      const { nextKeys: nextFolderIds, changedItems: changedFolders } =
-        folderSelection.applySelection({
-          item: folder,
-          checked: isChecked,
-          selectedKeys: previousFolderIds,
-          childrenByParentId,
-        });
-
-      setOptimisticFolderIds(nextFolderIds);
-
-      try {
-        if (isChecked) {
-          analytics.captureAction("auto_file_folder_selected", {
-            saved_folder_count:
-              optimisticFolderIds.size + changedFolders.length,
-          });
-          const results = await Promise.all(
-            changedFolders.map((changedFolder) =>
-              addFilingFolderAction(emailAccountId, {
-                folderId: changedFolder.id,
-                folderName: changedFolder.name,
-                folderPath: changedFolder.path || changedFolder.name,
-                driveConnectionId: changedFolder.driveConnectionId,
-              }),
-            ),
-          );
-          const serverError = results.find(
-            (result) => result?.serverError,
-          )?.serverError;
-
-          if (serverError) {
-            setOptimisticFolderIds(previousFolderIds);
-            toastError({
-              title: "Error adding folder",
-              description: serverError,
-            });
-          } else {
-            mutateFolders();
-          }
-        } else {
-          analytics.captureAction("auto_file_folder_removed", {
-            saved_folder_count: Math.max(
-              optimisticFolderIds.size - changedFolders.length,
-              0,
-            ),
-          });
-          const results = await Promise.all(
-            changedFolders.map((changedFolder) =>
-              removeFilingFolderAction(emailAccountId, {
-                folderId: changedFolder.id,
-              }),
-            ),
-          );
-          const serverError = results.find(
-            (result) => result?.serverError,
-          )?.serverError;
-
-          if (serverError) {
-            setOptimisticFolderIds(previousFolderIds);
-            toastError({
-              title: "Error removing folder",
-              description: serverError,
-            });
-          } else {
-            mutateFolders();
-          }
-        }
-      } catch {
-        setOptimisticFolderIds(previousFolderIds);
-        toastError({
-          title: isChecked ? "Error adding folder" : "Error removing folder",
-          description: "Please try again.",
-        });
-      }
+  const onFoldersRemoved = useCallback(
+    (savedFolderCount: number) => {
+      analytics.captureAction("auto_file_folder_removed", {
+        saved_folder_count: savedFolderCount,
+      });
     },
-    [
-      analytics,
-      childrenByParentId,
-      emailAccountId,
-      mutateFolders,
-      optimisticFolderIds,
-    ],
+    [analytics],
   );
 
-  const rootFolders = useMemo(
-    () => folderSelection.getRootItems(availableFolders),
-    [availableFolders],
-  );
+  const {
+    optimisticFolderIds,
+    childrenByParentId,
+    rootFolders,
+    handleFolderToggle,
+    handleChildrenLoaded,
+  } = useFolderSelection({
+    emailAccountId,
+    availableFolders,
+    savedFolders,
+    mutateFolders,
+    onFoldersAdded,
+    onFoldersRemoved,
+  });
 
   return (
     <div>

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
@@ -62,11 +62,6 @@ describe("allowed folder selection", () => {
       childrenByParentId: new Map(),
     });
 
-    expect([...result.nextFolderIds].sort()).toEqual([
-      "child-a",
-      "child-b",
-      "parent",
-    ]);
     expect(
       result.changedFolders.map((selectedFolder) => selectedFolder.id),
     ).toEqual(["child-a", "child-b"]);

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { FolderItem } from "@/app/api/user/drive/folders/route";
-import { folderSelection } from "./allowed-folder-selection";
+import {
+  applyLoadedFolderChildrenSelection,
+  folderSelection,
+} from "./allowed-folder-selection";
 
 describe("allowed folder selection", () => {
   it("returns folders without a loaded parent as roots", () => {
@@ -40,6 +43,33 @@ describe("allowed folder selection", () => {
     expect(
       result.changedItems.map((selectedFolder) => selectedFolder.id),
     ).toEqual(["parent", "child-a", "grandchild", "child-b"]);
+  });
+
+  it("selects children loaded after their parent was selected", () => {
+    const parent = folder("parent");
+    const initialSelection = folderSelection.applySelection({
+      item: parent,
+      checked: true,
+      selectedKeys: new Set(),
+      childrenByParentId: new Map(),
+    });
+    const children = [folder("child-a", "parent"), folder("child-b", "parent")];
+
+    const result = applyLoadedFolderChildrenSelection({
+      parent,
+      children,
+      selectedFolderIds: initialSelection.nextKeys,
+      childrenByParentId: new Map(),
+    });
+
+    expect([...result.nextFolderIds].sort()).toEqual([
+      "child-a",
+      "child-b",
+      "parent",
+    ]);
+    expect(
+      result.changedFolders.map((selectedFolder) => selectedFolder.id),
+    ).toEqual(["child-a", "child-b"]);
   });
 
   it("deselects a folder and its loaded descendants", () => {

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
@@ -10,3 +10,32 @@ export const folderSelection = createTreeSelection<FolderItem>({
   getId: (folder) => folder.id,
   getParentId: (folder) => folder.parentId,
 });
+
+export function applyLoadedFolderChildrenSelection({
+  parent,
+  children,
+  selectedFolderIds,
+  childrenByParentId,
+}: {
+  parent: FolderItem;
+  children: FolderItem[];
+  selectedFolderIds: Set<string>;
+  childrenByParentId: FolderChildrenMap;
+}) {
+  if (!selectedFolderIds.has(parent.id)) {
+    return { nextFolderIds: selectedFolderIds, changedFolders: [] };
+  }
+
+  const { nextKeys, changedItems } = folderSelection.applySelection({
+    item: parent,
+    checked: true,
+    selectedKeys: selectedFolderIds,
+    childrenByParentId: folderSelection.mergeChildren({
+      childrenByParentId,
+      parentId: parent.id,
+      children,
+    }),
+  });
+
+  return { nextFolderIds: nextKeys, changedFolders: changedItems };
+}

--- a/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/allowed-folder-selection.ts
@@ -23,10 +23,10 @@ export function applyLoadedFolderChildrenSelection({
   childrenByParentId: FolderChildrenMap;
 }) {
   if (!selectedFolderIds.has(parent.id)) {
-    return { nextFolderIds: selectedFolderIds, changedFolders: [] };
+    return { changedFolders: [] };
   }
 
-  const { nextKeys, changedItems } = folderSelection.applySelection({
+  const { changedItems } = folderSelection.applySelection({
     item: parent,
     checked: true,
     selectedKeys: selectedFolderIds,
@@ -37,5 +37,5 @@ export function applyLoadedFolderChildrenSelection({
     }),
   });
 
-  return { nextFolderIds: nextKeys, changedFolders: changedItems };
+  return { changedFolders: changedItems };
 }

--- a/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.test.ts
@@ -61,6 +61,30 @@ describe("useFolderSelection", () => {
     expect(mutateFolders).toHaveBeenCalled();
   });
 
+  it("rolls back selection when persistence throws unexpectedly", async () => {
+    mockAddFilingFolderAction.mockRejectedValue(new Error("Network error"));
+    const mutateFolders = vi.fn();
+    const props = {
+      emailAccountId: "email-account",
+      availableFolders: [folder("parent")],
+      savedFolders: [],
+      mutateFolders,
+    };
+
+    const { result } = renderHook(() => useFolderSelection(props));
+
+    await act(async () => {
+      await result.current.handleFolderToggle(folder("parent"), true);
+    });
+
+    expect(result.current.optimisticFolderIds).toEqual(new Set());
+    expect(mockToastError).toHaveBeenCalledWith({
+      title: "Error adding folder",
+      description: "Please try again.",
+    });
+    expect(mutateFolders).toHaveBeenCalledOnce();
+  });
+
   it("keeps both branches selected when two selected parents load children concurrently", async () => {
     const props = {
       emailAccountId: "email-account",
@@ -87,6 +111,27 @@ describe("useFolderSelection", () => {
       "parent-b",
     ]);
     expect(mockAddFilingFolderAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads children without selecting them when the parent is not selected", () => {
+    const props = {
+      emailAccountId: "email-account",
+      availableFolders: [folder("parent")],
+      savedFolders: [],
+      mutateFolders: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useFolderSelection(props));
+    const child = folder("child", "parent");
+
+    act(() => {
+      result.current.handleChildrenLoaded(folder("parent"), [child]);
+    });
+
+    expect(result.current.childrenByParentId.get("parent")).toEqual([child]);
+    expect(result.current.optimisticFolderIds).toEqual(new Set());
+    expect(mockAddFilingFolderAction).not.toHaveBeenCalled();
+    expect(mockRemoveFilingFolderAction).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  FolderItem,
+  SavedFolder,
+} from "@/app/api/user/drive/folders/route";
+import { useFolderSelection } from "./use-folder-selection";
+
+const mockAddFilingFolderAction = vi.hoisted(() => vi.fn());
+const mockRemoveFilingFolderAction = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/actions/drive", () => ({
+  addFilingFolderAction: mockAddFilingFolderAction,
+  removeFilingFolderAction: mockRemoveFilingFolderAction,
+}));
+
+vi.mock("@/components/Toast", () => ({
+  toastError: mockToastError,
+}));
+
+describe("useFolderSelection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddFilingFolderAction.mockResolvedValue({ data: {} });
+    mockRemoveFilingFolderAction.mockResolvedValue({ data: {} });
+  });
+
+  it("keeps successfully persisted folders selected when a sibling mutation fails", async () => {
+    mockAddFilingFolderAction.mockImplementation(
+      async (_emailAccountId: string, { folderId }: { folderId: string }) =>
+        folderId === "child-b"
+          ? { serverError: "Something went wrong" }
+          : { data: {} },
+    );
+    const mutateFolders = vi.fn();
+    const props = {
+      emailAccountId: "email-account",
+      availableFolders: [
+        folder("parent"),
+        folder("child-a", "parent"),
+        folder("child-b", "parent"),
+      ],
+      savedFolders: [],
+      mutateFolders,
+    };
+
+    const { result } = renderHook(() => useFolderSelection(props));
+
+    await act(async () => {
+      await result.current.handleFolderToggle(folder("parent"), true);
+    });
+
+    expect([...result.current.optimisticFolderIds].sort()).toEqual([
+      "child-a",
+      "parent",
+    ]);
+    expect(mockToastError).toHaveBeenCalledOnce();
+    expect(mutateFolders).toHaveBeenCalled();
+  });
+
+  it("keeps both branches selected when two selected parents load children concurrently", async () => {
+    const props = {
+      emailAccountId: "email-account",
+      availableFolders: [folder("parent-a"), folder("parent-b")],
+      savedFolders: [savedFolder("parent-a"), savedFolder("parent-b")],
+      mutateFolders: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useFolderSelection(props));
+
+    await act(async () => {
+      result.current.handleChildrenLoaded(folder("parent-a"), [
+        folder("child-a", "parent-a"),
+      ]);
+      result.current.handleChildrenLoaded(folder("parent-b"), [
+        folder("child-b", "parent-b"),
+      ]);
+    });
+
+    expect([...result.current.optimisticFolderIds].sort()).toEqual([
+      "child-a",
+      "child-b",
+      "parent-a",
+      "parent-b",
+    ]);
+    expect(mockAddFilingFolderAction).toHaveBeenCalledTimes(2);
+  });
+});
+
+function folder(id: string, parentId?: string): FolderItem {
+  return {
+    id,
+    name: id,
+    path: id,
+    driveConnectionId: "drive-connection",
+    provider: "google",
+    parentId,
+  };
+}
+
+function savedFolder(folderId: string): SavedFolder {
+  return {
+    id: `db-${folderId}`,
+    folderId,
+    folderName: folderId,
+    folderPath: folderId,
+    driveConnectionId: "drive-connection",
+    driveConnection: { provider: "google" },
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.ts
@@ -1,0 +1,179 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toastError } from "@/components/Toast";
+import {
+  addFilingFolderAction,
+  removeFilingFolderAction,
+} from "@/utils/actions/drive";
+import type {
+  FolderItem,
+  SavedFolder,
+} from "@/app/api/user/drive/folders/route";
+import {
+  applyLoadedFolderChildrenSelection,
+  folderSelection,
+  type FolderChildrenMap,
+} from "./allowed-folder-selection";
+
+export function useFolderSelection({
+  emailAccountId,
+  availableFolders,
+  savedFolders,
+  mutateFolders,
+  onFoldersAdded,
+  onFoldersRemoved,
+}: {
+  emailAccountId: string;
+  availableFolders: FolderItem[];
+  savedFolders: SavedFolder[];
+  mutateFolders: () => void;
+  onFoldersAdded?: (savedFolderCount: number) => void;
+  onFoldersRemoved?: (savedFolderCount: number) => void;
+}) {
+  const [optimisticFolderIds, setOptimisticFolderIds] = useState<Set<string>>(
+    () => new Set(savedFolders.map((f) => f.folderId)),
+  );
+  const [childrenByParentId, setChildrenByParentId] =
+    useState<FolderChildrenMap>(() =>
+      folderSelection.buildChildrenMap(availableFolders),
+    );
+
+  const serverFolderIds = savedFolders.map((f) => f.folderId).join(",");
+  const prevServerFolderIds = useRef(serverFolderIds);
+  useEffect(() => {
+    if (serverFolderIds === prevServerFolderIds.current) return;
+    prevServerFolderIds.current = serverFolderIds;
+    setOptimisticFolderIds(new Set(savedFolders.map((f) => f.folderId)));
+  }, [savedFolders, serverFolderIds]);
+
+  useEffect(() => {
+    setChildrenByParentId(folderSelection.buildChildrenMap(availableFolders));
+  }, [availableFolders]);
+
+  const persistSelection = useCallback(
+    async ({
+      nextFolderIds,
+      changedFolders,
+      isChecked,
+    }: {
+      nextFolderIds: Set<string>;
+      changedFolders: FolderItem[];
+      isChecked: boolean;
+    }) => {
+      const previousFolderIds = optimisticFolderIds;
+      setOptimisticFolderIds(nextFolderIds);
+
+      try {
+        const results = await Promise.all(
+          changedFolders.map((changedFolder) =>
+            isChecked
+              ? addFilingFolderAction(emailAccountId, {
+                  folderId: changedFolder.id,
+                  folderName: changedFolder.name,
+                  folderPath: changedFolder.path || changedFolder.name,
+                  driveConnectionId: changedFolder.driveConnectionId,
+                })
+              : removeFilingFolderAction(emailAccountId, {
+                  folderId: changedFolder.id,
+                }),
+          ),
+        );
+        const serverError = results.find(
+          (result) => result?.serverError,
+        )?.serverError;
+
+        if (serverError) {
+          setOptimisticFolderIds(previousFolderIds);
+          toastError({
+            title: isChecked ? "Error adding folder" : "Error removing folder",
+            description: serverError,
+          });
+        } else {
+          mutateFolders();
+        }
+      } catch {
+        setOptimisticFolderIds(previousFolderIds);
+        toastError({
+          title: isChecked ? "Error adding folder" : "Error removing folder",
+          description: "Please try again.",
+        });
+      }
+    },
+    [emailAccountId, mutateFolders, optimisticFolderIds],
+  );
+
+  const handleFolderToggle = useCallback(
+    async (folder: FolderItem, isChecked: boolean) => {
+      const { nextKeys, changedItems } = folderSelection.applySelection({
+        item: folder,
+        checked: isChecked,
+        selectedKeys: optimisticFolderIds,
+        childrenByParentId,
+      });
+
+      if (isChecked) {
+        onFoldersAdded?.(optimisticFolderIds.size + changedItems.length);
+      } else {
+        onFoldersRemoved?.(
+          Math.max(optimisticFolderIds.size - changedItems.length, 0),
+        );
+      }
+
+      await persistSelection({
+        nextFolderIds: nextKeys,
+        changedFolders: changedItems,
+        isChecked,
+      });
+    },
+    [
+      childrenByParentId,
+      onFoldersAdded,
+      onFoldersRemoved,
+      optimisticFolderIds,
+      persistSelection,
+    ],
+  );
+
+  const handleChildrenLoaded = useCallback(
+    (parent: FolderItem, children: FolderItem[]) => {
+      const { nextFolderIds, changedFolders } =
+        applyLoadedFolderChildrenSelection({
+          parent,
+          children,
+          selectedFolderIds: optimisticFolderIds,
+          childrenByParentId,
+        });
+
+      setChildrenByParentId((current) =>
+        folderSelection.mergeChildren({
+          childrenByParentId: current,
+          parentId: parent.id,
+          children,
+        }),
+      );
+
+      if (changedFolders.length > 0) {
+        persistSelection({
+          nextFolderIds,
+          changedFolders,
+          isChecked: true,
+        });
+      }
+    },
+    [childrenByParentId, optimisticFolderIds, persistSelection],
+  );
+
+  const rootFolders = useMemo(
+    () => folderSelection.getRootItems(availableFolders),
+    [availableFolders],
+  );
+
+  return {
+    optimisticFolderIds,
+    childrenByParentId,
+    rootFolders,
+    handleFolderToggle,
+    handleChildrenLoaded,
+  };
+}

--- a/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.ts
+++ b/apps/web/app/(app)/[emailAccountId]/drive/use-folder-selection.ts
@@ -51,18 +51,25 @@ export function useFolderSelection({
     setChildrenByParentId(folderSelection.buildChildrenMap(availableFolders));
   }, [availableFolders]);
 
+  // Selection updates apply per-folder deltas via functional setState so
+  // concurrent persists (e.g. two lazy loads resolving together) merge
+  // instead of overwriting each other's whole selection set.
   const persistSelection = useCallback(
     async ({
-      nextFolderIds,
       changedFolders,
       isChecked,
     }: {
-      nextFolderIds: Set<string>;
       changedFolders: FolderItem[];
       isChecked: boolean;
     }) => {
-      const previousFolderIds = optimisticFolderIds;
-      setOptimisticFolderIds(nextFolderIds);
+      const changedFolderIds = changedFolders.map((folder) => folder.id);
+      setOptimisticFolderIds((current) =>
+        applySelectionDelta({
+          current,
+          folderIds: changedFolderIds,
+          isChecked,
+        }),
+      );
 
       try {
         const results = await Promise.all(
@@ -84,28 +91,45 @@ export function useFolderSelection({
         )?.serverError;
 
         if (serverError) {
-          setOptimisticFolderIds(previousFolderIds);
+          // Roll back only the failed folders; sibling mutations that
+          // succeeded are already persisted server-side.
+          const failedFolderIds = changedFolderIds.filter(
+            (_, index) => results[index]?.serverError,
+          );
+          setOptimisticFolderIds((current) =>
+            applySelectionDelta({
+              current,
+              folderIds: failedFolderIds,
+              isChecked: !isChecked,
+            }),
+          );
           toastError({
             title: isChecked ? "Error adding folder" : "Error removing folder",
             description: serverError,
           });
-        } else {
-          mutateFolders();
         }
+        mutateFolders();
       } catch {
-        setOptimisticFolderIds(previousFolderIds);
+        setOptimisticFolderIds((current) =>
+          applySelectionDelta({
+            current,
+            folderIds: changedFolderIds,
+            isChecked: !isChecked,
+          }),
+        );
         toastError({
           title: isChecked ? "Error adding folder" : "Error removing folder",
           description: "Please try again.",
         });
+        mutateFolders();
       }
     },
-    [emailAccountId, mutateFolders, optimisticFolderIds],
+    [emailAccountId, mutateFolders],
   );
 
   const handleFolderToggle = useCallback(
     async (folder: FolderItem, isChecked: boolean) => {
-      const { nextKeys, changedItems } = folderSelection.applySelection({
+      const { changedItems } = folderSelection.applySelection({
         item: folder,
         checked: isChecked,
         selectedKeys: optimisticFolderIds,
@@ -121,7 +145,6 @@ export function useFolderSelection({
       }
 
       await persistSelection({
-        nextFolderIds: nextKeys,
         changedFolders: changedItems,
         isChecked,
       });
@@ -137,13 +160,12 @@ export function useFolderSelection({
 
   const handleChildrenLoaded = useCallback(
     (parent: FolderItem, children: FolderItem[]) => {
-      const { nextFolderIds, changedFolders } =
-        applyLoadedFolderChildrenSelection({
-          parent,
-          children,
-          selectedFolderIds: optimisticFolderIds,
-          childrenByParentId,
-        });
+      const { changedFolders } = applyLoadedFolderChildrenSelection({
+        parent,
+        children,
+        selectedFolderIds: optimisticFolderIds,
+        childrenByParentId,
+      });
 
       setChildrenByParentId((current) =>
         folderSelection.mergeChildren({
@@ -155,7 +177,6 @@ export function useFolderSelection({
 
       if (changedFolders.length > 0) {
         persistSelection({
-          nextFolderIds,
           changedFolders,
           isChecked: true,
         });
@@ -176,4 +197,24 @@ export function useFolderSelection({
     handleFolderToggle,
     handleChildrenLoaded,
   };
+}
+
+function applySelectionDelta({
+  current,
+  folderIds,
+  isChecked,
+}: {
+  current: Set<string>;
+  folderIds: string[];
+  isChecked: boolean;
+}) {
+  const next = new Set(current);
+  for (const folderId of folderIds) {
+    if (isChecked) {
+      next.add(folderId);
+    } else {
+      next.delete(folderId);
+    }
+  }
+  return next;
 }


### PR DESCRIPTION
Selecting a parent now also selects children that arrive through lazy loading. Folder selection persistence is shared between setup and settings views to keep behavior consistent.

- Cascade selected state and persistence to newly loaded descendants.
- Reuse the shared selection flow in both folder pickers.
- Tests: targeted unit suite (6 tests) and Ultracite check (5 files).
- Performance: linear work only when children load; no new folder-fetch requests, but one existing save action (network/database mutation) runs per newly selected child; no render hot-path risk.

Linear issue: https://linear.app/inbox-zero-ai/issue/INB-318/folder-selection-does-not-cascade-to-children-when-parent-is-selected

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

