### PR TITLE
gmail: Surface exhausted batch retry failures

### DIFF
--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -35,7 +35,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
     logger.warn("Too many batch retries", { ids, retryCount });
     if (!retryError) throw new Error("Gmail batch retry limit exceeded");
     // Preserve the provider error so account-level rate-limit protection can pause follow-on calls.
-    throw new GmailBatchRetryExhaustedError(retryError);
+    throw new Error(retryError.message, { cause: retryError });
   }
 
   const batch: (TRaw | BatchError)[] = await getBatch(
@@ -81,10 +81,8 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           errorMessage,
           reason,
         });
-        if (isRateLimit) {
-          shouldRetryInSmallerBatches = true;
-          lastRetryableError = item.error;
-        } else if (!lastRetryableError) {
+        if (isRateLimit) shouldRetryInSmallerBatches = true;
+        if (isRateLimit || !lastRetryableError) {
           lastRetryableError = item.error;
         }
         missingIds.add(ids[i]);
@@ -162,16 +160,4 @@ async function getBatchWithRetryInChunks<TRaw, TParsed>({
   }
 
   return results;
-}
-
-class GmailBatchRetryExhaustedError extends Error {
-  status: number;
-  errors: BatchError["error"]["errors"];
-
-  constructor(error: BatchError["error"]) {
-    super(error.message);
-    this.name = "GmailBatchRetryExhaustedError";
-    this.status = error.code;
-    this.errors = error.errors;
-  }
 }

--- a/apps/web/utils/gmail/batch-with-retry.ts
+++ b/apps/web/utils/gmail/batch-with-retry.ts
@@ -19,6 +19,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
   parse,
   logger,
   retryCount = 0,
+  retryError,
 }: {
   ids: string[];
   endpoint: string; // e.g. /gmail/v1/users/me/messages
@@ -26,12 +27,15 @@ export async function getBatchWithRetry<TRaw, TParsed>({
   parse: (item: TRaw) => TParsed;
   logger: Logger;
   retryCount?: number;
+  retryError?: BatchError["error"];
 }): Promise<TParsed[]> {
   if (!accessToken) throw new Error("No access token");
 
   if (retryCount > 3) {
     logger.warn("Too many batch retries", { ids, retryCount });
-    return [];
+    if (!retryError) throw new Error("Gmail batch retry limit exceeded");
+    // Preserve the provider error so account-level rate-limit protection can pause follow-on calls.
+    throw new GmailBatchRetryExhaustedError(retryError);
   }
 
   const batch: (TRaw | BatchError)[] = await getBatch(
@@ -47,6 +51,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
 
   const missingIds = new Set<string>();
   let shouldRetryInSmallerBatches = false;
+  let lastRetryableError = retryError;
 
   const parsed = batch
     .map((item, i) => {
@@ -76,7 +81,12 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           errorMessage,
           reason,
         });
-        if (isRateLimit) shouldRetryInSmallerBatches = true;
+        if (isRateLimit) {
+          shouldRetryInSmallerBatches = true;
+          lastRetryableError = item.error;
+        } else if (!lastRetryableError) {
+          lastRetryableError = item.error;
+        }
         missingIds.add(ids[i]);
         return;
       }
@@ -100,6 +110,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           accessToken,
           parse,
           retryCount: nextRetryCount,
+          retryError: lastRetryableError,
           logger,
         })
       : await getBatchWithRetry({
@@ -108,6 +119,7 @@ export async function getBatchWithRetry<TRaw, TParsed>({
           accessToken,
           parse,
           retryCount: nextRetryCount,
+          retryError: lastRetryableError,
           logger,
         });
     return [...parsed, ...refetched];
@@ -122,6 +134,7 @@ async function getBatchWithRetryInChunks<TRaw, TParsed>({
   accessToken,
   parse,
   retryCount,
+  retryError,
   logger,
 }: {
   ids: string[];
@@ -129,6 +142,7 @@ async function getBatchWithRetryInChunks<TRaw, TParsed>({
   accessToken: string;
   parse: (item: TRaw) => TParsed;
   retryCount: number;
+  retryError?: BatchError["error"];
   logger: Logger;
 }): Promise<TParsed[]> {
   const chunked = chunk(ids, RATE_LIMIT_RETRY_BATCH_SIZE);
@@ -141,10 +155,23 @@ async function getBatchWithRetryInChunks<TRaw, TParsed>({
       accessToken,
       parse,
       retryCount,
+      retryError,
       logger,
     });
     results.push(...chunkResults);
   }
 
   return results;
+}
+
+class GmailBatchRetryExhaustedError extends Error {
+  status: number;
+  errors: BatchError["error"]["errors"];
+
+  constructor(error: BatchError["error"]) {
+    super(error.message);
+    this.name = "GmailBatchRetryExhaustedError";
+    this.status = error.code;
+    this.errors = error.errors;
+  }
 }

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -175,7 +175,10 @@ describe("getMessagesBatch", () => {
       }),
     ).rejects.toMatchObject({
       message: "Too many concurrent requests for user",
-      status: 429,
+      cause: {
+        code: 429,
+        errors: [{ reason: "rateLimitExceeded" }],
+      },
     });
 
     expect(getBatch).toHaveBeenCalledTimes(4);

--- a/apps/web/utils/gmail/message.test.ts
+++ b/apps/web/utils/gmail/message.test.ts
@@ -145,6 +145,41 @@ describe("getMessagesBatch", () => {
       12, 10, 2,
     ]);
   });
+
+  it("throws when rate-limited batch items exhaust all retries", async () => {
+    const rateLimitError = {
+      error: {
+        code: 429,
+        message: "Too many concurrent requests for user",
+        errors: [{ reason: "rateLimitExceeded" }],
+        status: "RESOURCE_EXHAUSTED",
+      },
+    };
+
+    vi.mocked(getBatch)
+      .mockResolvedValueOnce([
+        {
+          id: "id1",
+          threadId: "thread1",
+          payload: { headers: [] },
+        },
+        rateLimitError,
+      ])
+      .mockResolvedValue([rateLimitError]);
+
+    await expect(
+      getMessagesBatch({
+        messageIds: ["id1", "id2"],
+        accessToken: "token",
+        logger,
+      }),
+    ).rejects.toMatchObject({
+      message: "Too many concurrent requests for user",
+      status: 429,
+    });
+
+    expect(getBatch).toHaveBeenCalledTimes(4);
+  });
 });
 
 describe("hasPreviousCommunicationsWithSenderOrDomain", () => {


### PR DESCRIPTION
Propagates exhausted Gmail batch failures so existing account-level rate-limit protection can pause follow-on requests instead of returning silent partial results.

- Preserve the provider status and reason after the retry budget is exhausted
- Reject partial batch results when retryable items remain unresolved
- Add regression coverage for persistent rate limiting

Tests: `pnpm test utils/gmail/message.test.ts utils/gmail/retry.test.ts utils/email/rate-limit.test.ts`
Formatting: `pnpm exec ultracite check apps/web/utils/gmail/batch-with-retry.ts apps/web/utils/gmail/message.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

