### PR TITLE
fix: handle provider rate limits reliably

### DIFF
--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -509,6 +509,28 @@ describe("isContentFilterRefusal", () => {
 describe("checkCommonErrors", () => {
   const logger = createScopedLogger("error-test");
 
+  it("maps wrapped Gmail rate-limit errors to a safe 429 response", () => {
+    const error = new Error("User-rate limit exceeded");
+    error.cause = {
+      code: 429,
+      errors: [
+        {
+          reason: "rateLimitExceeded",
+          message: "User-rate limit exceeded",
+        },
+      ],
+      message: "User-rate limit exceeded",
+      status: "RESOURCE_EXHAUSTED",
+    };
+
+    expect(checkCommonErrors(error, "/api/messages", logger)).toEqual({
+      type: "Gmail Rate Limit Exceeded",
+      message:
+        "Gmail is temporarily limiting requests. Please try again shortly.",
+      code: 429,
+    });
+  });
+
   it.each([
     [
       "Gmail",

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -9,6 +9,7 @@ import {
   getProviderRateLimitMessageLabel,
   isProviderRateLimitModeError,
 } from "@/utils/email/rate-limit-mode-error";
+import { extractErrorInfo } from "@/utils/gmail/retry";
 import { createScopedLogger, type Logger } from "@/utils/logger";
 
 // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
@@ -173,13 +174,16 @@ export function isGmailInsufficientPermissionsError(error: unknown): boolean {
 }
 
 export function isGmailRateLimitExceededError(error: unknown): boolean {
-  // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-  return (error as any)?.errors?.[0]?.reason === "rateLimitExceeded";
+  const errorInfo = extractErrorInfo(error);
+  return (
+    errorInfo.reason === "rateLimitExceeded" ||
+    errorInfo.reason === "userRateLimitExceeded" ||
+    /user-rate limit exceeded/i.test(errorInfo.errorMessage)
+  );
 }
 
 export function isGmailQuotaExceededError(error: unknown): boolean {
-  // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-  return (error as any)?.errors?.[0]?.reason === "quotaExceeded";
+  return extractErrorInfo(error).reason === "quotaExceeded";
 }
 
 export function isIncorrectAPIKeyError(error: APICallError): boolean {
@@ -370,12 +374,9 @@ export function checkCommonErrors(
 
   if (isGmailRateLimitExceededError(error)) {
     logger.warn("Gmail rate limit exceeded for url", { url });
-    const errorMessage =
-      // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
-      (error as any)?.errors?.[0]?.message ?? "Unknown error";
     return {
       type: getProviderRateLimitApiErrorType("google"),
-      message: `Gmail error: ${errorMessage}`,
+      message: RATE_LIMIT_MESSAGE_TEMPLATE.replace("{provider}", "Gmail"),
       code: 429,
     };
   }

--- a/apps/web/utils/redis/email-provider-rate-limit.test.ts
+++ b/apps/web/utils/redis/email-provider-rate-limit.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { redis } from "@/utils/redis";
+import { getEmailProviderRateLimitStateFromRedis } from "@/utils/redis/email-provider-rate-limit";
+
+vi.mock("@/utils/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+describe("email provider rate-limit redis state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads state automatically deserialized by the Redis client", async () => {
+    const retryAt = new Date(Date.now() + 60_000);
+    vi.mocked(redis.get).mockResolvedValue({
+      provider: "google",
+      retryAt: retryAt.toISOString(),
+      source: "gmail-provider/get-messages",
+      detectedAt: new Date().toISOString(),
+    } as never);
+
+    await expect(
+      getEmailProviderRateLimitStateFromRedis({
+        emailAccountId: "email-account-1",
+      }),
+    ).resolves.toEqual({
+      provider: "google",
+      retryAt,
+      source: "gmail-provider/get-messages",
+    });
+    expect(redis.del).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/utils/redis/email-provider-rate-limit.ts
+++ b/apps/web/utils/redis/email-provider-rate-limit.ts
@@ -33,7 +33,9 @@ export async function getEmailProviderRateLimitStateFromRedis({
   if (!isEmailProviderRateLimitRedisConfigured()) return null;
 
   const key = getRateLimitKey(emailAccountId);
-  const value = await redis.get<string>(key);
+  const value = await redis.get<StoredEmailProviderRateLimitState | string>(
+    key,
+  );
   if (!value) return null;
 
   const parsed = parseStoredEmailProviderRateLimitState(value);
@@ -97,12 +99,13 @@ export function isEmailProviderRateLimitRedisConfigured() {
 }
 
 function parseStoredEmailProviderRateLimitState(
-  value: string,
+  value: StoredEmailProviderRateLimitState | string,
 ): StoredEmailProviderRateLimitState | null {
   try {
-    const parsed = JSON.parse(
-      value,
-    ) as Partial<StoredEmailProviderRateLimitState>;
+    const parsed =
+      typeof value === "string"
+        ? (JSON.parse(value) as Partial<StoredEmailProviderRateLimitState>)
+        : value;
     const provider = toRateLimitProvider(parsed.provider);
     if (!provider) return null;
     if (!parsed.retryAt || typeof parsed.retryAt !== "string") return null;
@@ -111,7 +114,7 @@ function parseStoredEmailProviderRateLimitState(
     return {
       provider,
       retryAt: parsed.retryAt,
-      source: parsed.source,
+      source: typeof parsed.source === "string" ? parsed.source : undefined,
       detectedAt: parsed.detectedAt || new Date().toISOString(),
     };
   } catch {


### PR DESCRIPTION
Preserve provider rate-limit state across Redis deserialization and return an actionable throttling response for wrapped Gmail errors.

- accept both serialized and automatically deserialized Redis state
- map wrapped Gmail rate-limit errors to a safe HTTP 429
- add focused regression coverage for both production error shapes
- avoid exposing provider error details to clients

Performance: no added database calls; rate-limited requests reuse the existing Redis read and should avoid unnecessary provider network calls.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

