### PR TITLE
Clarify digest delivery timing and status

### DIFF
--- a/.claude/skills/test-feature/SKILL.md
+++ b/.claude/skills/test-feature/SKILL.md
@@ -30,6 +30,20 @@ Before testing, make sure the local environment is ready. These steps are idempo
 4. **Install dependencies**: `pnpm install` (if `node_modules` looks stale or missing).
 5. **Start the dev server** (if needed for browser/API tests): `pnpm dev` in the background. Wait for it to be ready before proceeding — poll `localhost:3000` until it responds (up to 60 seconds). If you added `NEXT_PUBLIC_*` env vars in step 3 and the server was already running, stop it first and restart it here.
 
+### Isolated local browser QA
+
+For focused visual QA, check for a free port and initialize an isolated environment:
+
+```bash
+pnpm dev-setup init --db empty --auth emulate --url localhost --port <port>
+pnpm dev-setup dev --skip-init
+```
+
+- Include `--skip-init` on every subsequent `dev-setup dev` or `dev-setup exec` command; omitting it resets the isolated database.
+- Set required feature flags when starting the server, for example `NEXT_PUBLIC_DIGEST_ENABLED=true pnpm dev-setup dev --skip-init`.
+- Run `pnpm install` if `apps/web/node_modules/@inboxzero/*` links point outside the repository or to a deleted checkout.
+- Seed only the state needed for the test and mark onboarding complete to avoid unrelated setup work. Keep temporary auth and seed files under `.context/` and remove them afterward.
+
 ## Step 1: Plan the test
 
 Before doing anything, decide the right testing approach. Often you'll combine multiple:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,16 +19,6 @@
 - For core bug-fix tasks, default to TDD when practical (red/green/refactor); AI prompt improvements should generally be backed by evals too, and TDD is often useful there as well.
 - When adding a new workspace package, add its `package.json` COPY line to `docker/Dockerfile.prod` and `docker/Dockerfile.local`.
 
-## Local Browser QA
-- Use `pnpm dev-setup init --db empty --auth emulate --url localhost --port <port>` for isolated visual QA, then start it with `pnpm dev-setup dev --skip-init`.
-- Check that the chosen port is free; do not assume port 3000 is available.
-- After initializing an empty branch database, every `pnpm dev-setup exec` command must include `--skip-init`. Omitting it resets that database.
-- Run `pnpm install` if `apps/web/node_modules/@inboxzero/*` workspace links resolve outside the current repository or point to a deleted temporary checkout.
-- Run `agent-browser` headlessly by default. Use `--headed` only when the user explicitly wants the live browser window.
-- Enable feature-gated UI explicitly when starting the app; digest settings require `NEXT_PUBLIC_DIGEST_ENABLED=true pnpm dev-setup dev --skip-init`.
-- Store temporary browser auth state and visual-QA seed files under `.context/`, and remove them when the QA session is complete.
-- Emulated first-time onboarding can trigger unrelated AI and inbox setup work. For focused visual QA, seed only the required state in the isolated branch database and mark onboarding complete.
-
 ## Code Style
 - Install packages in `apps/web`, not root: `cd apps/web && pnpm add ...`
 - Lodash: import specific functions (`import groupBy from "lodash/groupBy"`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,16 @@
 - For core bug-fix tasks, default to TDD when practical (red/green/refactor); AI prompt improvements should generally be backed by evals too, and TDD is often useful there as well.
 - When adding a new workspace package, add its `package.json` COPY line to `docker/Dockerfile.prod` and `docker/Dockerfile.local`.
 
+## Local Browser QA
+- Use `pnpm dev-setup init --db empty --auth emulate --url localhost --port <port>` for isolated visual QA, then start it with `pnpm dev-setup dev --skip-init`.
+- Check that the chosen port is free; do not assume port 3000 is available.
+- After initializing an empty branch database, every `pnpm dev-setup exec` command must include `--skip-init`. Omitting it resets that database.
+- Run `pnpm install` if `apps/web/node_modules/@inboxzero/*` workspace links resolve outside the current repository or point to a deleted temporary checkout.
+- Run `agent-browser` headlessly by default. Use `--headed` only when the user explicitly wants the live browser window.
+- Enable feature-gated UI explicitly when starting the app; digest settings require `NEXT_PUBLIC_DIGEST_ENABLED=true pnpm dev-setup dev --skip-init`.
+- Store temporary browser auth state and visual-QA seed files under `.context/`, and remove them when the QA session is complete.
+- Emulated first-time onboarding can trigger unrelated AI and inbox setup work. For focused visual QA, seed only the required state in the isolated branch database and mark onboarding complete.
+
 ## Code Style
 - Install packages in `apps/web`, not root: `cd apps/web && pnpm add ...`
 - Lodash: import specific functions (`import groupBy from "lodash/groupBy"`)

--- a/apps/web/__tests__/eval/assistant-chat-settings-memory.scenarios.ts
+++ b/apps/web/__tests__/eval/assistant-chat-settings-memory.scenarios.ts
@@ -11,6 +11,10 @@ export type SettingsMemoryScenarioExpectation =
       kind: "capability_discovery";
     }
   | {
+      kind: "digest_explanation";
+      semanticExpectation: string;
+    }
+  | {
       kind: "assistant_settings";
       changes: AssistantSettingsChangeExpectation[];
       forbiddenTools: string[];
@@ -89,6 +93,22 @@ const settingsMemoryScenariosRaw: SettingsMemoryScenario[] = [
     prompt: "What settings can you change for me from chat?",
     expectation: {
       kind: "capability_discovery",
+    },
+  },
+  {
+    id: "digest-delivery-details",
+    title: "loads account capabilities for digest delivery questions",
+    reportName: "digest delivery questions use authoritative account state",
+    category: "capability_discovery",
+    shape: "single_turn",
+    realWorldSeed: "db-inspired",
+    crossModelCanary: true,
+    prompt:
+      "Where will my digest be sent, are my selected rules combined, and when should I expect the next one?",
+    expectation: {
+      kind: "digest_explanation",
+      semanticExpectation:
+        "The answer says the digest is sent to user@test.com, explains that selected rules are combined into one account-level digest, and gives a realistic next delivery estimate that accounts for the five-minute dispatch window. The date and timezone may be localized or rolled forward if the stored next occurrence is stale. It must not claim that no destination is configured or recommend a refund.",
     },
   },
   {
@@ -991,9 +1011,9 @@ assertScenarioInventory(settingsMemoryScenariosRaw);
 export const settingsMemoryScenarios = settingsMemoryScenariosRaw;
 
 function assertScenarioInventory(scenarios: SettingsMemoryScenario[]) {
-  if (scenarios.length !== 40) {
+  if (scenarios.length !== 41) {
     throw new Error(
-      `assistant-chat-settings-memory scenarios must total 40; received ${scenarios.length}.`,
+      `assistant-chat-settings-memory scenarios must total 41; received ${scenarios.length}.`,
     );
   }
 
@@ -1001,9 +1021,9 @@ function assertScenarioInventory(scenarios: SettingsMemoryScenario[]) {
     (scenario) => scenario.crossModelCanary,
   ).length;
 
-  if (canaryCount !== 6) {
+  if (canaryCount !== 7) {
     throw new Error(
-      `assistant-chat-settings-memory canary subset must total 6; received ${canaryCount}.`,
+      `assistant-chat-settings-memory canary subset must total 7; received ${canaryCount}.`,
     );
   }
 }

--- a/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
+++ b/apps/web/__tests__/eval/assistant-chat-settings-memory.test.ts
@@ -11,7 +11,7 @@ import {
   judgeEvalOutput,
 } from "@/__tests__/eval/semantic-judge";
 import {
-  captureAssistantChatToolCalls,
+  captureAssistantChatTrace,
   getFirstMatchingToolCall,
   getLastMatchingToolCall,
   summarizeRecordedToolCalls,
@@ -107,13 +107,14 @@ const baseAccountSnapshot = {
   followUpAwaitingReplyDays: 3,
   followUpNeedsReplyDays: 2,
   followUpAutoDraftEnabled: true,
+  digestSendEmail: true,
   digestSchedule: {
     id: "digest-1",
     intervalDays: 1,
     occurrences: 1,
     daysOfWeek: 127,
     timeOfDay: new Date("1970-01-01T09:00:00.000Z"),
-    nextOccurrenceAt: new Date("2026-02-21T09:00:00.000Z"),
+    nextOccurrenceAt: new Date("2026-02-21T09:01:00.000Z"),
   },
   rules: [],
   automationJob: {
@@ -228,15 +229,16 @@ async function runAssistantChat({
   emailAccount: ReturnType<typeof getEmailAccount>;
   messages: ModelMessage[];
 }) {
-  const toolCalls = await captureAssistantChatToolCalls({
+  const trace = await captureAssistantChatTrace({
     messages,
     emailAccount,
     logger,
   });
 
   return {
-    toolCalls,
-    actual: summarizeRecordedToolCalls(toolCalls, summarizeToolCall),
+    toolCalls: trace.toolCalls,
+    finalText: trace.finalText,
+    actual: summarizeRecordedToolCalls(trace.toolCalls, summarizeToolCall),
   };
 }
 
@@ -354,6 +356,30 @@ async function evaluateScenario(
         judgeOutput: null,
         judgeResult: null,
       };
+
+    case "digest_explanation": {
+      const judgeResult = await judgeEvalOutput({
+        input: prompt,
+        output: result.finalText,
+        expected: expectation.semanticExpectation,
+        criterion: {
+          name: "Digest delivery explanation",
+          description:
+            "The answer must accurately use the authoritative digest capability state to identify the automatic recipient, combined-rule behavior, and realistic dispatch timing. It must not invent a missing destination or unsupported refund advice.",
+        },
+      });
+
+      return {
+        pass:
+          result.toolCalls.some(
+            (toolCall) => toolCall.toolName === "getAssistantCapabilities",
+          ) &&
+          hasNoToolCalls(result.toolCalls, ["updateAssistantSettings"]) &&
+          judgeResult.pass,
+        judgeOutput: result.finalText,
+        judgeResult,
+      };
+    }
 
     case "assistant_settings": {
       return {
@@ -627,6 +653,12 @@ function configureStatefulSettingsMocks() {
   prisma.automationJob.findUnique.mockImplementation(
     async () => accountSnapshot.automationJob,
   );
+  prisma.digestItem.count.mockResolvedValue(2);
+  prisma.digest.findFirst.mockResolvedValue({
+    status: "SENT",
+    sentAt: new Date("2026-02-20T09:05:00.000Z"),
+    updatedAt: new Date("2026-02-20T09:05:00.000Z"),
+  } as never);
   prisma.automationJob.update.mockImplementation(async ({ data }) => {
     Object.assign(accountSnapshot.automationJob, data);
     return accountSnapshot.automationJob;

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -349,18 +349,19 @@ export function DigestSettingsForm({
                 />
               </div>
               <MutedText className="mt-2">
-                Digests are usually sent within 5 minutes after this time.
+                Usually sent within 5 minutes.
+                {digestStatus?.delivery.estimatedNextDeliveryAt && (
+                  <>
+                    {" "}
+                    Next delivery around{" "}
+                    {formatDigestDeliveryTime(
+                      new Date(digestStatus.delivery.estimatedNextDeliveryAt),
+                      digestStatus.delivery.timezone,
+                    )}
+                    .
+                  </>
+                )}
               </MutedText>
-              {digestStatus?.delivery.estimatedNextDeliveryAt && (
-                <MutedText className="mt-1">
-                  Next delivery: around{" "}
-                  {formatDigestDeliveryTime(
-                    new Date(digestStatus.delivery.estimatedNextDeliveryAt),
-                    digestStatus.delivery.timezone,
-                  )}
-                  .
-                </MutedText>
-              )}
             </div>
 
             <Button type="submit" loading={isSubmitting} className="mt-4">
@@ -422,22 +423,15 @@ function DigestDeliveryChannels({
           onChange={(sendEmail) => execute({ sendEmail })}
         />
       </div>
-      {digestStatus?.delivery.destinationEmail && (
-        <MutedText>
-          {(account?.digestSendEmail ?? digestStatus.delivery.emailEnabled)
-            ? `Sent to ${digestStatus.delivery.destinationEmail}.`
-            : `When enabled, digests are sent to ${digestStatus.delivery.destinationEmail}.`}
-        </MutedText>
-      )}
       <DigestDeliveryActivity digestStatus={digestStatus} />
       {showChannelsHint && (
         <MutedText>
-          Want digests in your chat app?{" "}
+          Chat delivery:{" "}
           <Link
             href={prefixPath(emailAccountId, "/channels")}
             className="text-foreground underline"
           >
-            Configure on the Channels page
+            Configure in Channels
           </Link>
           .
         </MutedText>
@@ -459,7 +453,7 @@ function DigestDeliveryActivity({
     delivery.queuedItemCount > 0
       ? `${delivery.queuedItemCount} ${
           delivery.queuedItemCount === 1 ? "email" : "emails"
-        } queued for the next digest.`
+        } queued`
       : null;
 
   const lastDeliveryLabel = delivery.lastDelivery
@@ -467,18 +461,18 @@ function DigestDeliveryActivity({
       ? `Last sent ${formatDigestDeliveryTime(
           new Date(delivery.lastDelivery.occurredAt),
           delivery.timezone,
-        )}.`
+        )}`
       : `Last delivery failed ${formatDigestDeliveryTime(
           new Date(delivery.lastDelivery.occurredAt),
           delivery.timezone,
-        )}.`
+        )}`
     : null;
 
   if (!queuedLabel && !lastDeliveryLabel) return null;
 
   return (
     <MutedText>
-      {[queuedLabel, lastDeliveryLabel].filter(Boolean).join(" ")}
+      {[queuedLabel, lastDeliveryLabel].filter(Boolean).join(" · ")}
     </MutedText>
   );
 }

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -40,6 +40,7 @@ import {
   bitmaskToDayOfWeek,
 } from "@/utils/schedule";
 import { getEstimatedDigestDeliveryAt } from "@/utils/digest/schedule";
+import { getAccountScopedKey } from "@/utils/swr";
 
 const digestSettingsSchema = z.object({
   selectedItems: z.set(z.string()),
@@ -86,7 +87,9 @@ export function DigestSettingsForm({
     isLoading: digestStatusLoading,
     error: digestStatusError,
     mutate: mutateDigestStatus,
-  } = useSWR<GetDigestStatusResponse>("/api/user/digest-status");
+  } = useSWR<GetDigestStatusResponse>(
+    getAccountScopedKey("/api/user/digest-status", emailAccountId),
+  );
 
   const isLoading = rulesLoading || digestStatusLoading;
   const error = rulesError || digestStatusError;
@@ -217,11 +220,17 @@ export function DigestSettingsForm({
           executeSchedule(scheduleUpdateData),
         ]);
 
-        if (hasActionError(itemsResult) || hasActionError(scheduleResult)) {
+        const itemsFailed = hasActionError(itemsResult);
+        const scheduleFailed = hasActionError(scheduleResult);
+
+        await Promise.all([
+          itemsFailed ? undefined : mutateRules(),
+          scheduleFailed ? undefined : mutateDigestStatus(),
+        ]);
+
+        if (itemsFailed || scheduleFailed) {
           return;
         }
-
-        await Promise.all([mutateRules(), mutateDigestStatus()]);
 
         const estimatedDeliveryAt = getEstimatedDigestDeliveryAt(
           scheduleResult?.data?.nextOccurrenceAt

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -25,6 +25,7 @@ import {
 import { ActionType } from "@/generated/prisma/enums";
 import { useAccount } from "@/providers/EmailAccountProvider";
 import type { GetDigestScheduleResponse } from "@/app/api/user/digest-schedule/route";
+import type { GetDigestStatusResponse } from "@/app/api/user/digest-status/route";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
@@ -38,6 +39,7 @@ import {
   dayOfWeekToBitmask,
   bitmaskToDayOfWeek,
 } from "@/utils/schedule";
+import { getEstimatedDigestDeliveryAt } from "@/utils/digest/schedule";
 
 const digestSettingsSchema = z.object({
   selectedItems: z.set(z.string()),
@@ -80,14 +82,14 @@ export function DigestSettingsForm({
   } = useRules();
 
   const {
-    data: scheduleData,
-    isLoading: scheduleLoading,
-    error: scheduleError,
-    mutate: mutateSchedule,
-  } = useSWR<GetDigestScheduleResponse>("/api/user/digest-schedule");
+    data: digestStatus,
+    isLoading: digestStatusLoading,
+    error: digestStatusError,
+    mutate: mutateDigestStatus,
+  } = useSWR<GetDigestStatusResponse>("/api/user/digest-status");
 
-  const isLoading = rulesLoading || scheduleLoading;
-  const error = rulesError || scheduleError;
+  const isLoading = rulesLoading || digestStatusLoading;
+  const error = rulesError || digestStatusError;
 
   const [selectedDigestItems, setSelectedDigestItems] = useState<Set<string>>(
     new Set(),
@@ -111,12 +113,9 @@ export function DigestSettingsForm({
 
   const watchedValues = watch();
 
-  const { execute: executeItems } = useAction(
+  const { executeAsync: executeItems } = useAction(
     updateDigestItemsAction.bind(null, emailAccountId),
     {
-      onSuccess: () => {
-        mutateRules();
-      },
       onError: (error) => {
         toastError({
           title: "Error updating digest items",
@@ -126,12 +125,9 @@ export function DigestSettingsForm({
     },
   );
 
-  const { execute: executeSchedule } = useAction(
+  const { executeAsync: executeSchedule } = useAction(
     updateDigestScheduleAction.bind(null, emailAccountId),
     {
-      onSuccess: () => {
-        mutateSchedule();
-      },
       onError: (error) => {
         toastError({
           title: "Error updating digest schedule",
@@ -143,7 +139,7 @@ export function DigestSettingsForm({
 
   // Initialize selected items and form data from API responses
   useEffect(() => {
-    if (rules && scheduleData) {
+    if (rules && digestStatus) {
       const selectedItems = new Set<string>();
 
       // Add rules that have digest actions
@@ -156,13 +152,15 @@ export function DigestSettingsForm({
       setSelectedDigestItems(selectedItems);
 
       // Initialize schedule form data
-      const initialScheduleProps = getInitialScheduleProps(scheduleData);
+      const initialScheduleProps = getInitialScheduleProps(
+        digestStatus.schedule,
+      );
       reset({
         selectedItems,
         ...initialScheduleProps,
       });
     }
-  }, [rules, scheduleData, reset]);
+  }, [rules, digestStatus, reset]);
 
   // Update form when selectedDigestItems changes
   useEffect(() => {
@@ -214,12 +212,30 @@ export function DigestSettingsForm({
 
       // Execute both updates
       try {
-        await Promise.all([
+        const [itemsResult, scheduleResult] = await Promise.all([
           executeItems({ ruleDigestPreferences }),
           executeSchedule(scheduleUpdateData),
         ]);
+
+        if (hasActionError(itemsResult) || hasActionError(scheduleResult)) {
+          return;
+        }
+
+        await Promise.all([mutateRules(), mutateDigestStatus()]);
+
+        const estimatedDeliveryAt = getEstimatedDigestDeliveryAt(
+          scheduleResult?.data?.nextOccurrenceAt
+            ? new Date(scheduleResult.data.nextOccurrenceAt)
+            : null,
+        );
+
         toastSuccess({
-          description: "Your digest settings have been updated!",
+          description: estimatedDeliveryAt
+            ? `Saved. Next digest expected around ${formatDigestDeliveryTime(
+                estimatedDeliveryAt,
+                digestStatus?.delivery.timezone,
+              )}.`
+            : "Digest settings saved.",
         });
         onSuccess?.();
       } catch {
@@ -229,7 +245,15 @@ export function DigestSettingsForm({
         });
       }
     },
-    [rules, executeItems, executeSchedule, onSuccess],
+    [
+      rules,
+      executeItems,
+      executeSchedule,
+      mutateRules,
+      mutateDigestStatus,
+      digestStatus?.delivery.timezone,
+      onSuccess,
+    ],
   );
 
   // Create options for MultiSelectFilter
@@ -251,6 +275,9 @@ export function DigestSettingsForm({
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
             <div>
               <Label>What to include in the digest email</Label>
+              <MutedText className="mt-1">
+                Selected rules are combined into one digest email.
+              </MutedText>
               <div className="mt-3">
                 <MultiSelectFilter
                   title="Digest Items"
@@ -321,6 +348,19 @@ export function DigestSettingsForm({
                   onChange={(value) => setValue("time", value)}
                 />
               </div>
+              <MutedText className="mt-2">
+                Digests are usually sent within 5 minutes after this time.
+              </MutedText>
+              {digestStatus?.delivery.estimatedNextDeliveryAt && (
+                <MutedText className="mt-1">
+                  Next delivery: around{" "}
+                  {formatDigestDeliveryTime(
+                    new Date(digestStatus.delivery.estimatedNextDeliveryAt),
+                    digestStatus.delivery.timezone,
+                  )}
+                  .
+                </MutedText>
+              )}
             </div>
 
             <Button type="submit" loading={isSubmitting} className="mt-4">
@@ -331,6 +371,8 @@ export function DigestSettingsForm({
 
         <DigestDeliveryChannels
           emailAccountId={emailAccountId}
+          digestStatus={digestStatus}
+          mutateDigestStatus={mutateDigestStatus}
           showChannelsHint={showChannelsHint}
         />
       </div>
@@ -342,9 +384,13 @@ export function DigestSettingsForm({
 
 function DigestDeliveryChannels({
   emailAccountId,
+  digestStatus,
+  mutateDigestStatus,
   showChannelsHint,
 }: {
   emailAccountId: string;
+  digestStatus: GetDigestStatusResponse | undefined;
+  mutateDigestStatus: () => Promise<GetDigestStatusResponse | undefined>;
   showChannelsHint: boolean;
 }) {
   const { data: account, isLoading, mutate } = useEmailAccountFull();
@@ -355,6 +401,7 @@ function DigestDeliveryChannels({
       onSuccess: () => {
         toastSuccess({ description: "Settings saved" });
         mutate();
+        mutateDigestStatus();
       },
       onError: (error) => {
         toastError({
@@ -375,6 +422,14 @@ function DigestDeliveryChannels({
           onChange={(sendEmail) => execute({ sendEmail })}
         />
       </div>
+      {digestStatus?.delivery.destinationEmail && (
+        <MutedText>
+          {(account?.digestSendEmail ?? digestStatus.delivery.emailEnabled)
+            ? `Sent to ${digestStatus.delivery.destinationEmail}.`
+            : `When enabled, digests are sent to ${digestStatus.delivery.destinationEmail}.`}
+        </MutedText>
+      )}
+      <DigestDeliveryActivity digestStatus={digestStatus} />
       {showChannelsHint && (
         <MutedText>
           Want digests in your chat app?{" "}
@@ -388,6 +443,43 @@ function DigestDeliveryChannels({
         </MutedText>
       )}
     </div>
+  );
+}
+
+function DigestDeliveryActivity({
+  digestStatus,
+}: {
+  digestStatus: GetDigestStatusResponse | undefined;
+}) {
+  const { delivery } = digestStatus ?? {};
+
+  if (!delivery) return null;
+
+  const queuedLabel =
+    delivery.queuedItemCount > 0
+      ? `${delivery.queuedItemCount} ${
+          delivery.queuedItemCount === 1 ? "email" : "emails"
+        } queued for the next digest.`
+      : null;
+
+  const lastDeliveryLabel = delivery.lastDelivery
+    ? delivery.lastDelivery.status === "SENT"
+      ? `Last sent ${formatDigestDeliveryTime(
+          new Date(delivery.lastDelivery.occurredAt),
+          delivery.timezone,
+        )}.`
+      : `Last delivery failed ${formatDigestDeliveryTime(
+          new Date(delivery.lastDelivery.occurredAt),
+          delivery.timezone,
+        )}.`
+    : null;
+
+  if (!queuedLabel && !lastDeliveryLabel) return null;
+
+  return (
+    <MutedText>
+      {[queuedLabel, lastDeliveryLabel].filter(Boolean).join(" ")}
+    </MutedText>
   );
 }
 
@@ -479,4 +571,29 @@ function getInitialScheduleProps(
     dayOfWeek: initialDayOfWeek,
     time: initialTime,
   };
+}
+
+function formatDigestDeliveryTime(date: Date, timezone?: string | null) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: timezone || undefined,
+  }).format(date);
+}
+
+function hasActionError(
+  result:
+    | {
+        serverError?: unknown;
+        validationErrors?: unknown;
+        bindArgsValidationErrors?: unknown;
+      }
+    | null
+    | undefined,
+) {
+  return Boolean(
+    result?.serverError ||
+      result?.validationErrors ||
+      result?.bindArgsValidationErrors,
+  );
 }

--- a/apps/web/app/api/user/digest-status/route.ts
+++ b/apps/web/app/api/user/digest-status/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getDigestDeliveryState } from "@/utils/digest/delivery-state";
+import { getEstimatedDigestDeliveryAt } from "@/utils/digest/schedule";
+import { withEmailAccount } from "@/utils/middleware";
+import prisma from "@/utils/prisma";
+
+export type GetDigestStatusResponse = Awaited<ReturnType<typeof getData>>;
+
+export const GET = withEmailAccount("user/digest-status", async (request) => {
+  const result = await getData({
+    emailAccountId: request.auth.emailAccountId,
+  });
+
+  return NextResponse.json(result);
+});
+
+async function getData({ emailAccountId }: { emailAccountId: string }) {
+  const [emailAccount, deliveryState] = await Promise.all([
+    prisma.emailAccount.findUniqueOrThrow({
+      where: { id: emailAccountId },
+      select: {
+        email: true,
+        timezone: true,
+        digestSendEmail: true,
+        digestSchedule: {
+          select: {
+            id: true,
+            intervalDays: true,
+            occurrences: true,
+            daysOfWeek: true,
+            timeOfDay: true,
+            lastOccurrenceAt: true,
+            nextOccurrenceAt: true,
+          },
+        },
+      },
+    }),
+    getDigestDeliveryState({ emailAccountId }),
+  ]);
+
+  return {
+    schedule: emailAccount.digestSchedule,
+    delivery: {
+      emailEnabled: emailAccount.digestSendEmail,
+      destinationEmail: emailAccount.email,
+      timezone: emailAccount.timezone,
+      estimatedNextDeliveryAt: getEstimatedDigestDeliveryAt(
+        emailAccount.digestSchedule?.nextOccurrenceAt,
+      ),
+      ...deliveryState,
+    },
+  };
+}

--- a/apps/web/utils/actions/settings.ts
+++ b/apps/web/utils/actions/settings.ts
@@ -157,13 +157,16 @@ export const updateDigestScheduleAction = actionClient
 
     const { emailAccountId: _emailAccountId, ...update } = create;
 
-    await prisma.schedule.upsert({
+    const schedule = await prisma.schedule.upsert({
       where: { emailAccountId },
       create,
       update,
     });
 
-    return { success: true };
+    return {
+      success: true,
+      nextOccurrenceAt: schedule.nextOccurrenceAt?.toISOString() ?? null,
+    };
   });
 
 export const updateDigestItemsAction = actionClient

--- a/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-settings-tools.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/utils/__mocks__/prisma";
 import {
+  DigestStatus,
   MessagingRoutePurpose,
   MessagingRouteTargetType,
 } from "@/generated/prisma/enums";
@@ -52,6 +53,7 @@ const baseAccountSnapshot = {
   followUpAwaitingReplyDays: 3,
   followUpNeedsReplyDays: 2,
   followUpAutoDraftEnabled: true,
+  digestSendEmail: true,
   digestSchedule: {
     id: "digest-1",
     intervalDays: 1,
@@ -115,6 +117,12 @@ describe("chat settings tools", () => {
     prisma.automationJob.findUnique.mockResolvedValue(
       baseAccountSnapshot.automationJob,
     );
+    prisma.digestItem.count.mockResolvedValue(2);
+    prisma.digest.findFirst.mockResolvedValue({
+      status: DigestStatus.SENT,
+      sentAt: new Date("2026-02-20T09:05:00.000Z"),
+      updatedAt: new Date("2026-02-20T09:05:00.000Z"),
+    } as never);
   });
 
   it("returns writable and read-only capability metadata", async () => {
@@ -130,7 +138,7 @@ describe("chat settings tools", () => {
     const result = await toolInstance.execute({});
 
     expect(result).toMatchObject({
-      snapshotVersion: "2026-02-20",
+      snapshotVersion: "2026-07-30",
       account: {
         email: "user@example.com",
         provider: "google",
@@ -158,12 +166,24 @@ describe("chat settings tools", () => {
       canWrite: false,
       value: {
         enabled: true,
+        combinesIncludedRules: true,
         schedule: {
           intervalDays: 1,
           occurrences: 1,
           daysOfWeek: 127,
           timeOfDay: "1970-01-01T09:00:00.000Z",
           nextOccurrenceAt: "2026-02-21T09:00:00.000Z",
+        },
+        delivery: {
+          emailEnabled: true,
+          destinationEmail: "user@example.com",
+          dispatchIntervalMinutes: 5,
+          estimatedNextDeliveryAt: "2026-02-21T09:00:00.000Z",
+          queuedItemCount: 2,
+          lastDelivery: {
+            status: DigestStatus.SENT,
+            occurredAt: "2026-02-20T09:05:00.000Z",
+          },
         },
         includedRules: [
           {
@@ -175,6 +195,9 @@ describe("chat settings tools", () => {
       },
     });
     expect(digestCapability?.reason).toContain("not yet exposed");
+    expect(digestCapability?.description).toContain(
+      "sent automatically to delivery.destinationEmail",
+    );
 
     const scheduledCheckInsCapability = result.capabilities.find(
       (capability) => capability.path === "assistant.scheduledCheckIns",

--- a/apps/web/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/get-assistant-capabilities-tool.ts
@@ -23,7 +23,7 @@ export const getAssistantCapabilitiesTool = ({
 }) =>
   tool({
     description:
-      "Get a capability snapshot showing which assistant/account settings can be read or updated from chat. If the snapshot shows no writable path supports the user's request, explain that limitation instead of approximating the request through a different setting.",
+      "Get the authoritative capability and configuration snapshot for the connected email account. Use assistant.digest to answer digest recipient, combined-rule, schedule, estimated-delivery, queue, and last-delivery questions; digest email uses the connected account address and has no separate recipient setting. If no writable path supports the user's request, explain that limitation instead of approximating it through a different setting.",
     inputSchema: emptyInputSchema,
     execute: async () => {
       trackSettingsToolCall({
@@ -36,7 +36,7 @@ export const getAssistantCapabilitiesTool = ({
         if (!snapshot) return { error: "Email account not found" };
 
         return {
-          snapshotVersion: "2026-02-20",
+          snapshotVersion: "2026-07-30",
           account: {
             email: snapshot.email,
             provider,

--- a/apps/web/utils/ai/assistant/tools/settings/shared.ts
+++ b/apps/web/utils/ai/assistant/tools/settings/shared.ts
@@ -24,6 +24,11 @@ import {
   createAutomationJob,
 } from "@/utils/actions/automation-jobs.helpers";
 import { ensureScheduledCheckInsRouteForChannel } from "@/utils/automation-jobs/destination";
+import { getDigestDeliveryState } from "@/utils/digest/delivery-state";
+import {
+  DIGEST_DISPATCH_INTERVAL_MINUTES,
+  getEstimatedDigestDeliveryAt,
+} from "@/utils/digest/schedule";
 
 const scheduledCheckInsConfigSchema = z
   .object({
@@ -240,6 +245,7 @@ export type AccountSettingsSnapshot = {
   followUpAutoDraftEnabled: boolean;
   digest: {
     enabled: boolean;
+    combinesIncludedRules: true;
     schedule: {
       intervalDays: number | null;
       occurrences: number | null;
@@ -247,6 +253,17 @@ export type AccountSettingsSnapshot = {
       timeOfDay: string | null;
       nextOccurrenceAt: string | null;
     } | null;
+    delivery: {
+      emailEnabled: boolean;
+      destinationEmail: string;
+      dispatchIntervalMinutes: number;
+      estimatedNextDeliveryAt: string | null;
+      queuedItemCount: number;
+      lastDelivery: {
+        status: string;
+        occurredAt: string;
+      } | null;
+    };
     includedRules: Array<{
       name: string;
       systemType: string | null;
@@ -305,6 +322,7 @@ const accountSettingsSnapshotRawSelect = {
   followUpAwaitingReplyDays: true,
   followUpNeedsReplyDays: true,
   followUpAutoDraftEnabled: true,
+  digestSendEmail: true,
   digestSchedule: {
     select: {
       id: true,
@@ -449,6 +467,8 @@ const readOnlyCapabilities = [
     title: "Digest configuration",
     reason:
       "Readable in chat, but writes are not yet exposed through updateAssistantSettings.",
+    description:
+      "All included rules are combined into one account-level digest. When email delivery is enabled, it is sent automatically to delivery.destinationEmail; there is no separate recipient setting. The scheduled time makes the digest eligible, while estimatedNextDeliveryAt accounts for the dispatch interval.",
   },
 ] as const;
 
@@ -1134,9 +1154,10 @@ function isDisableOnlyScheduledCheckInsChange({
 }
 
 export async function loadAccountSettingsSnapshot(emailAccountId: string) {
-  const [emailAccount, automationJob] = await Promise.all([
+  const [emailAccount, automationJob, digestDeliveryState] = await Promise.all([
     loadAccountSettingsSnapshotRaw(emailAccountId),
     loadScheduledCheckInsAutomationJob(emailAccountId),
+    getDigestDeliveryState({ emailAccountId }),
   ]);
 
   if (!emailAccount) return null;
@@ -1160,6 +1181,7 @@ export async function loadAccountSettingsSnapshot(emailAccountId: string) {
     followUpAutoDraftEnabled: emailAccount.followUpAutoDraftEnabled,
     digest: {
       enabled: Boolean(emailAccount.digestSchedule),
+      combinesIncludedRules: true,
       schedule: emailAccount.digestSchedule
         ? {
             intervalDays: emailAccount.digestSchedule.intervalDays,
@@ -1172,6 +1194,23 @@ export async function loadAccountSettingsSnapshot(emailAccountId: string) {
               null,
           }
         : null,
+      delivery: {
+        emailEnabled: emailAccount.digestSendEmail,
+        destinationEmail: emailAccount.email,
+        dispatchIntervalMinutes: DIGEST_DISPATCH_INTERVAL_MINUTES,
+        estimatedNextDeliveryAt:
+          getEstimatedDigestDeliveryAt(
+            emailAccount.digestSchedule?.nextOccurrenceAt,
+          )?.toISOString() ?? null,
+        queuedItemCount: digestDeliveryState.queuedItemCount,
+        lastDelivery: digestDeliveryState.lastDelivery
+          ? {
+              status: digestDeliveryState.lastDelivery.status,
+              occurredAt:
+                digestDeliveryState.lastDelivery.occurredAt.toISOString(),
+            }
+          : null,
+      },
       includedRules: emailAccount.rules
         .filter((rule) => rule.actions.length > 0)
         .map((rule) => ({

--- a/apps/web/utils/digest/delivery-state.test.ts
+++ b/apps/web/utils/digest/delivery-state.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DigestStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+import { getDigestDeliveryState } from "@/utils/digest/delivery-state";
+
+vi.mock("@/utils/prisma");
+
+describe("getDigestDeliveryState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns queued items and the latest successful delivery", async () => {
+    const sentAt = new Date("2026-01-10T15:25:00.000Z");
+    vi.mocked(prisma.digestItem.count).mockResolvedValue(3);
+    vi.mocked(prisma.digest.findFirst).mockResolvedValue({
+      status: DigestStatus.SENT,
+      sentAt,
+      updatedAt: sentAt,
+    } as never);
+
+    await expect(
+      getDigestDeliveryState({ emailAccountId: "account-1" }),
+    ).resolves.toEqual({
+      queuedItemCount: 3,
+      lastDelivery: {
+        status: DigestStatus.SENT,
+        occurredAt: sentAt,
+      },
+    });
+
+    expect(prisma.digestItem.count).toHaveBeenCalledWith({
+      where: {
+        digest: {
+          emailAccountId: "account-1",
+          status: {
+            in: [DigestStatus.PENDING, DigestStatus.PROCESSING],
+          },
+        },
+      },
+    });
+    expect(prisma.digest.findFirst).toHaveBeenCalledWith({
+      where: {
+        emailAccountId: "account-1",
+        status: {
+          in: [DigestStatus.SENT, DigestStatus.FAILED],
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        status: true,
+        sentAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
+  it("uses the attempt time for a failed delivery", async () => {
+    const failedAt = new Date("2026-01-10T15:26:00.000Z");
+    vi.mocked(prisma.digestItem.count).mockResolvedValue(0);
+    vi.mocked(prisma.digest.findFirst).mockResolvedValue({
+      status: DigestStatus.FAILED,
+      sentAt: null,
+      updatedAt: failedAt,
+    } as never);
+
+    await expect(
+      getDigestDeliveryState({ emailAccountId: "account-1" }),
+    ).resolves.toEqual({
+      queuedItemCount: 0,
+      lastDelivery: {
+        status: DigestStatus.FAILED,
+        occurredAt: failedAt,
+      },
+    });
+  });
+
+  it("returns no last delivery before the first attempt", async () => {
+    vi.mocked(prisma.digestItem.count).mockResolvedValue(0);
+    vi.mocked(prisma.digest.findFirst).mockResolvedValue(null);
+
+    await expect(
+      getDigestDeliveryState({ emailAccountId: "account-1" }),
+    ).resolves.toEqual({
+      queuedItemCount: 0,
+      lastDelivery: null,
+    });
+  });
+});

--- a/apps/web/utils/digest/delivery-state.ts
+++ b/apps/web/utils/digest/delivery-state.ts
@@ -1,0 +1,45 @@
+import { DigestStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+
+export async function getDigestDeliveryState({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  const [queuedItemCount, lastDigest] = await Promise.all([
+    prisma.digestItem.count({
+      where: {
+        digest: {
+          emailAccountId,
+          status: {
+            in: [DigestStatus.PENDING, DigestStatus.PROCESSING],
+          },
+        },
+      },
+    }),
+    prisma.digest.findFirst({
+      where: {
+        emailAccountId,
+        status: {
+          in: [DigestStatus.SENT, DigestStatus.FAILED],
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        status: true,
+        sentAt: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
+
+  return {
+    queuedItemCount,
+    lastDelivery: lastDigest
+      ? {
+          status: lastDigest.status,
+          occurredAt: lastDigest.sentAt ?? lastDigest.updatedAt,
+        }
+      : null,
+  };
+}

--- a/apps/web/utils/digest/schedule.test.ts
+++ b/apps/web/utils/digest/schedule.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createCanonicalTimeOfDay } from "@/utils/schedule";
 import {
+  getEstimatedDigestDeliveryAt,
   getDigestScheduleProgression,
   isDigestScheduleDue,
 } from "@/utils/digest/schedule";
@@ -88,5 +89,29 @@ describe("getDigestScheduleProgression", () => {
     expect(progression.nextOccurrenceAt).toEqual(
       new Date("2026-01-10T17:00:00.000Z"),
     );
+  });
+});
+
+describe("getEstimatedDigestDeliveryAt", () => {
+  it("rounds a scheduled time up to the next dispatch window", () => {
+    expect(
+      getEstimatedDigestDeliveryAt(new Date("2026-01-10T15:21:00.000Z")),
+    ).toEqual(new Date("2026-01-10T15:25:00.000Z"));
+  });
+
+  it("keeps a scheduled time that is already on a dispatch boundary", () => {
+    expect(
+      getEstimatedDigestDeliveryAt(new Date("2026-01-10T15:20:00.000Z")),
+    ).toEqual(new Date("2026-01-10T15:20:00.000Z"));
+  });
+
+  it("handles rounding into the next day", () => {
+    expect(
+      getEstimatedDigestDeliveryAt(new Date("2026-01-10T23:59:00.000Z")),
+    ).toEqual(new Date("2026-01-11T00:00:00.000Z"));
+  });
+
+  it("returns null when no delivery is scheduled", () => {
+    expect(getEstimatedDigestDeliveryAt(null)).toBeNull();
   });
 });

--- a/apps/web/utils/digest/schedule.ts
+++ b/apps/web/utils/digest/schedule.ts
@@ -1,6 +1,8 @@
 import type { Schedule } from "@/generated/prisma/client";
 import { calculateNextScheduleDate } from "@/utils/schedule";
 
+export const DIGEST_DISPATCH_INTERVAL_MINUTES = 5;
+
 type DigestScheduleForProgression = Pick<
   Schedule,
   | "intervalDays"
@@ -33,4 +35,17 @@ export function getDigestScheduleProgression(
       lastOccurrenceAt,
     }),
   };
+}
+
+export function getEstimatedDigestDeliveryAt(
+  nextOccurrenceAt: Date | null | undefined,
+): Date | null {
+  if (!nextOccurrenceAt) return null;
+
+  const dispatchIntervalMs = DIGEST_DISPATCH_INTERVAL_MINUTES * 60 * 1000;
+
+  return new Date(
+    Math.ceil(nextOccurrenceAt.getTime() / dispatchIntervalMs) *
+      dispatchIntervalMs,
+  );
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -97,7 +97,7 @@
     },
     {
       "path": "/api/resend/digest/all",
-      "schedule": "0 * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/meeting-briefs",


### PR DESCRIPTION
## Summary

- dispatch scheduled digests every five minutes and calculate the realistic delivery window
- show combined-rule behavior, the automatic email recipient, next delivery, queued items, and the latest delivery result in digest settings
- expose the same authoritative recipient and scheduler contract to the assistant, with unit and semantic AI regression coverage

## Testing

- `pnpm test utils/actions/settings.test.ts utils/ai/assistant/chat-settings-tools.test.ts utils/digest/schedule.test.ts utils/digest/delivery-state.test.ts` (32 passed)
- `pnpm --filter inbox-zero-ai test-ai __tests__/eval/assistant-chat-settings-memory.test.ts -t "loads account capabilities for digest delivery questions"` (1 passed)
- changed-file Biome check (13 files passed)
- independent reviewer pass for correctness, simplification, and copy clarity (no remaining material findings)

## Notes

The repo-wide `pnpm check` was also run. It remains red on pre-existing unrelated Biome schema drift, hook dependency warnings, undeclared development environment variables, and formatting in two blog files; all files changed by this PR pass the formatter and linter.