### PR TITLE
gmail: Stop bulk work during provider throttling

### DIFF
--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.test.ts
@@ -4,6 +4,7 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NewsletterStatus } from "@/generated/prisma/enums";
 import type { Row } from "@/app/(app)/[emailAccountId]/bulk-unsubscribe/types";
+import { EMAIL_PROVIDER_RATE_LIMIT_MESSAGE } from "@/utils/error";
 
 const {
   setSenderStatusActionMock,
@@ -68,7 +69,12 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { useApproveButton, useAutoArchive, useUnsubscribe } from "./hooks";
+import {
+  useApproveButton,
+  useAutoArchive,
+  useBulkAutoArchive,
+  useUnsubscribe,
+} from "./hooks";
 
 const EMAIL_ACCOUNT_ID = "email-account-1";
 const SENDER = "news@example.com";
@@ -177,6 +183,44 @@ describe("bulk unsubscribe hooks", () => {
 
       expect(toastErrorMock).toHaveBeenCalled();
       expect(queueArchiveSendersMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("useBulkAutoArchive", () => {
+    it("stops after a provider rate limit and leaves remaining senders selected", async () => {
+      setSenderStatusActionMock
+        .mockResolvedValueOnce({ data: { autoArchived: true } })
+        .mockResolvedValueOnce({
+          serverError: EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+        });
+      const onDeselectItem = vi.fn();
+
+      const { result } = renderHook(() =>
+        useBulkAutoArchive({
+          ...sharedHookArgs,
+          filter: "all",
+          onDeselectItem,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onBulkAutoArchive([
+          getRow({ name: "first@example.com" }),
+          getRow({ name: "second@example.com" }),
+          getRow({ name: "third@example.com" }),
+        ]);
+      });
+
+      expect(setSenderStatusActionMock).toHaveBeenCalledTimes(2);
+      expect(queueArchiveSendersMock).toHaveBeenCalledTimes(1);
+      expect(onDeselectItem).toHaveBeenCalledOnce();
+      expect(onDeselectItem).toHaveBeenCalledWith("first@example.com");
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+        expect.objectContaining({
+          description: "1 of 3 completed; stopped to avoid more requests",
+        }),
+      );
     });
   });
 

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.test.ts
@@ -13,6 +13,7 @@ const {
   queueArchiveSendersMock,
   addToArchiveSenderThreadQueueMock,
   toastErrorMock,
+  captureExceptionMock,
 } = vi.hoisted(() => ({
   setSenderStatusActionMock: vi.fn(),
   unsubscribeSenderActionMock: vi.fn(),
@@ -20,6 +21,7 @@ const {
   queueArchiveSendersMock: vi.fn(),
   addToArchiveSenderThreadQueueMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
 }));
 
 vi.mock("@/utils/actions/unsubscriber", () => ({
@@ -55,6 +57,11 @@ vi.mock("next-safe-action/hooks", () => ({
 
 vi.mock("@/utils/fetch", () => ({ fetchWithAccount: vi.fn() }));
 
+vi.mock("@/utils/error", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/utils/error")>();
+  return { ...original, captureException: captureExceptionMock };
+});
+
 vi.mock("@/components/Toast", () => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
@@ -73,6 +80,7 @@ import {
   useApproveButton,
   useAutoArchive,
   useBulkAutoArchive,
+  useBulkUnsubscribe,
   useUnsubscribe,
 } from "./hooks";
 
@@ -224,6 +232,58 @@ describe("bulk unsubscribe hooks", () => {
     });
   });
 
+  describe("useBulkUnsubscribe", () => {
+    it("stops automatic unsubscribes after a provider rate limit and revalidates once", async () => {
+      unsubscribeSenderActionMock
+        .mockResolvedValueOnce({ data: { unsubscribe: { success: true } } })
+        .mockResolvedValueOnce({
+          serverError: EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+        });
+      const mutate = vi.fn().mockResolvedValue(undefined);
+      const onDeselectItem = vi.fn();
+
+      const { result } = renderHook(() =>
+        useBulkUnsubscribe({
+          ...sharedHookArgs,
+          mutate,
+          filter: "all",
+          onDeselectItem,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onBulkUnsubscribe([
+          getRow({
+            name: "first@example.com",
+            unsubscribeLink: "https://example.com/unsubscribe/first",
+          }),
+          getRow({
+            name: "second@example.com",
+            unsubscribeLink: "https://example.com/unsubscribe/second",
+          }),
+          getRow({
+            name: "third@example.com",
+            unsubscribeLink: "https://example.com/unsubscribe/third",
+          }),
+        ]);
+      });
+
+      expect(unsubscribeSenderActionMock).toHaveBeenCalledTimes(2);
+      expect(queueArchiveSendersMock).toHaveBeenCalledTimes(1);
+      expect(onDeselectItem).toHaveBeenCalledOnce();
+      expect(onDeselectItem).toHaveBeenCalledWith("first@example.com");
+      expect(
+        mutate.mock.calls.filter((call) => call.length === 0),
+      ).toHaveLength(1);
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+        expect.objectContaining({
+          description: "1 of 3 completed; stopped to avoid more requests",
+        }),
+      );
+    });
+  });
+
   describe("useApproveButton", () => {
     it("approves a sender that has no status", async () => {
       const { result } = renderHook(() =>
@@ -323,6 +383,31 @@ describe("bulk unsubscribe hooks", () => {
       });
 
       expect(setSenderStatusActionMock).not.toHaveBeenCalled();
+    });
+
+    it("shows provider rate limits without reporting them as unexpected", async () => {
+      unsubscribeSenderActionMock.mockResolvedValue({
+        serverError: EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+      });
+
+      const { result } = renderHook(() =>
+        useUnsubscribe({
+          item: getRow({
+            unsubscribeLink: "https://example.com/unsubscribe",
+          }),
+          ...sharedHookArgs,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onUnsubscribe();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+      );
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+      expect(queueArchiveSendersMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -114,7 +114,7 @@ async function executeBulkOperation<T extends Row>({
   );
 
   let completed = 0;
-  const failures: Error[] = [];
+  let failureCount = 0;
   let rateLimitError: EmailProviderRateLimitError | undefined;
 
   const updateItemOptimistically = (item: T) => {
@@ -145,7 +145,7 @@ async function executeBulkOperation<T extends Row>({
       await processItem(item);
       onDeselectItem?.(item.name);
     } catch (error) {
-      failures.push(error as Error);
+      failureCount++;
       if (error instanceof EmailProviderRateLimitError) {
         rateLimitError = error;
       } else {
@@ -175,7 +175,7 @@ async function executeBulkOperation<T extends Row>({
 
   if (rateLimitError) {
     await mutate();
-    const successful = completed - failures.length;
+    const successful = completed - failureCount;
     toast.error(rateLimitError.message, {
       id: toastId,
       description: `${successful} of ${total} completed; stopped to avoid more requests`,
@@ -183,13 +183,13 @@ async function executeBulkOperation<T extends Row>({
     return { stoppedByRateLimit: true };
   }
 
-  if (failures.length > 0) {
+  if (failureCount > 0) {
     await mutate();
     toast.error(
-      `${errorMessage} ${failures.length} ${pluralize(failures.length, "sender")}`,
+      `${errorMessage} ${failureCount} ${pluralize(failureCount, "sender")}`,
       {
         id: toastId,
-        description: `${total - failures.length} of ${total} succeeded`,
+        description: `${total - failureCount} of ${total} succeeded`,
       },
     );
   } else {

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -92,6 +92,7 @@ async function executeBulkOperation<T extends Row>({
   successMessage,
   errorMessage,
   onComplete,
+  onCompleteRevalidates,
   onSuccess,
 }: {
   items: T[];
@@ -105,6 +106,7 @@ async function executeBulkOperation<T extends Row>({
   successMessage: string;
   errorMessage: string;
   onComplete?: () => Promise<unknown>;
+  onCompleteRevalidates?: boolean;
   onSuccess?: () => void;
 }) {
   const total = items.length;
@@ -165,16 +167,18 @@ async function executeBulkOperation<T extends Row>({
     if (rateLimitError) break;
   }
 
+  let didRevalidateOnComplete = false;
   if (onComplete) {
     try {
       await onComplete();
+      didRevalidateOnComplete = onCompleteRevalidates === true;
     } catch (error) {
       captureException(error);
     }
   }
 
   if (rateLimitError) {
-    await mutate();
+    if (!didRevalidateOnComplete) await mutate();
     const successful = completed - failureCount;
     toast.error(rateLimitError.message, {
       id: toastId,
@@ -351,8 +355,12 @@ export function useUnsubscribe<T extends Row>({
         }
       }
     } catch (error) {
-      captureException(error);
-      toast.error(`Could not unsubscribe from ${item.name}`);
+      if (error instanceof EmailProviderRateLimitError) {
+        toast.error(error.message);
+      } else {
+        captureException(error);
+        toast.error(`Could not unsubscribe from ${item.name}`);
+      }
     } finally {
       setUnsubscribeLoading(false);
     }
@@ -451,6 +459,7 @@ export function useBulkUnsubscribe<T extends Row>({
           await mutate();
           await refreshPremium(refetchPremium);
         },
+        onCompleteRevalidates: true,
         onSuccess: () => onSuccess?.(items),
       });
       if (result.stoppedByRateLimit) return;
@@ -1139,7 +1148,7 @@ function didAutomaticUnsubscribeSucceed(
   result: Awaited<ReturnType<typeof unsubscribeSenderAction>>,
 ) {
   if (result?.serverError) {
-    throw new Error(result.serverError);
+    assertActionSucceeded({ serverError: result.serverError });
   }
 
   return result?.data?.unsubscribe.success === true;

--- a/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
+++ b/apps/web/app/(app)/[emailAccountId]/bulk-unsubscribe/hooks.ts
@@ -11,7 +11,11 @@ import {
 } from "@/utils/actions/unsubscriber";
 import { decrementUnsubscribeCreditAction } from "@/utils/actions/premium";
 import { NewsletterStatus } from "@/generated/prisma/enums";
-import { assertActionSucceeded, captureException } from "@/utils/error";
+import {
+  assertActionSucceeded,
+  captureException,
+  EmailProviderRateLimitError,
+} from "@/utils/error";
 import {
   addToArchiveSenderThreadQueue,
   useArchiveSenderQueueActions,
@@ -111,6 +115,7 @@ async function executeBulkOperation<T extends Row>({
 
   let completed = 0;
   const failures: Error[] = [];
+  let rateLimitError: EmailProviderRateLimitError | undefined;
 
   const updateItemOptimistically = (item: T) => {
     const optimisticStatus = getNewStatus ? getNewStatus(item) : newStatus;
@@ -134,14 +139,18 @@ async function executeBulkOperation<T extends Row>({
   };
 
   for (const item of items) {
-    onDeselectItem?.(item.name);
     updateItemOptimistically(item);
 
     try {
       await processItem(item);
+      onDeselectItem?.(item.name);
     } catch (error) {
       failures.push(error as Error);
-      captureException(error);
+      if (error instanceof EmailProviderRateLimitError) {
+        rateLimitError = error;
+      } else {
+        captureException(error);
+      }
     } finally {
       completed++;
       toast.loading(
@@ -152,6 +161,8 @@ async function executeBulkOperation<T extends Row>({
         },
       );
     }
+
+    if (rateLimitError) break;
   }
 
   if (onComplete) {
@@ -160,6 +171,16 @@ async function executeBulkOperation<T extends Row>({
     } catch (error) {
       captureException(error);
     }
+  }
+
+  if (rateLimitError) {
+    await mutate();
+    const successful = completed - failures.length;
+    toast.error(rateLimitError.message, {
+      id: toastId,
+      description: `${successful} of ${total} completed; stopped to avoid more requests`,
+    });
+    return { stoppedByRateLimit: true };
   }
 
   if (failures.length > 0) {
@@ -178,6 +199,8 @@ async function executeBulkOperation<T extends Row>({
     });
     onSuccess?.();
   }
+
+  return { stoppedByRateLimit: false };
 }
 
 async function unsubscribeAndArchive({
@@ -391,7 +414,7 @@ export function useBulkUnsubscribe<T extends Row>({
 
       const messages = getBulkUnsubscribeMessages(items);
 
-      await executeBulkOperation({
+      const result = await executeBulkOperation({
         items,
         mutate,
         filter,
@@ -430,6 +453,8 @@ export function useBulkUnsubscribe<T extends Row>({
         },
         onSuccess: () => onSuccess?.(items),
       });
+      if (result.stoppedByRateLimit) return;
+
       analytics.captureAction("bulk_unsubscribe_completed", {
         item_count: items.length,
         filter,

--- a/apps/web/app/api/threads/basic/route.test.ts
+++ b/apps/web/app/api/threads/basic/route.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeError } from "@/utils/error";
+
+const mockGetThreadsWithQuery = vi.fn();
+
+vi.mock("@/utils/middleware", () => ({
+  withEmailProvider:
+    (
+      _name: string,
+      handler: (
+        request: NextRequest & Record<string, unknown>,
+      ) => Promise<Response>,
+    ) =>
+    async (request: NextRequest) => {
+      try {
+        return await handler(
+          Object.assign(request, {
+            auth: { emailAccountId: "email-account-id" },
+            emailProvider: {
+              name: "google",
+              getThreadsWithQuery: mockGetThreadsWithQuery,
+            },
+            logger: { error: vi.fn() },
+          }),
+        );
+      } catch (error) {
+        if (error instanceof SafeError) {
+          return Response.json(
+            { error: error.safeMessage, isKnownError: true },
+            { status: error.statusCode },
+          );
+        }
+        throw error;
+      }
+    },
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/threads/basic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves provider rate limits as a known 429 response", async () => {
+    mockGetThreadsWithQuery.mockRejectedValue(
+      new Error("Batch request failed", {
+        cause: Object.assign(new Error("Provider request was throttled"), {
+          response: { status: 429 },
+        }),
+      }),
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads/basic?fromEmail=sender%40example.com",
+      ),
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({ isKnownError: true });
+  });
+
+  it("keeps unrelated provider failures as generic server errors", async () => {
+    mockGetThreadsWithQuery.mockRejectedValue(new Error("Provider failed"));
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/threads/basic?fromEmail=sender%40example.com",
+      ),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "Failed to fetch threads",
+    });
+  });
+});

--- a/apps/web/app/api/threads/basic/route.ts
+++ b/apps/web/app/api/threads/basic/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { withEmailProvider } from "@/utils/middleware";
 import type { ThreadsResponse } from "@/app/api/threads/route";
 import { threadsQuery } from "@/utils/threads/validation";
+import { EMAIL_PROVIDER_RATE_LIMIT_MESSAGE, SafeError } from "@/utils/error";
+import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
 
 export type GetThreadsResponse = {
   threads: ThreadsResponse["threads"];
@@ -45,6 +47,15 @@ export const GET = withEmailProvider("threads/basic", async (request) => {
       error,
       emailAccountId,
     });
+    if (
+      isEmailProviderRateLimitError({
+        error,
+        provider: emailProvider.name,
+      })
+    ) {
+      throw new SafeError(EMAIL_PROVIDER_RATE_LIMIT_MESSAGE, 429);
+    }
+
     return NextResponse.json(
       { error: "Failed to fetch threads" },
       { status: 500 },

--- a/apps/web/store/fetch-sender-threads.test.ts
+++ b/apps/web/store/fetch-sender-threads.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithAccount } from "@/utils/fetch";
+import { EmailProviderRateLimitError } from "@/utils/error";
+import { fetchAllSenderThreads } from "@/store/fetch-sender-threads";
+
+vi.mock("@/utils/fetch", () => ({ fetchWithAccount: vi.fn() }));
+
+describe("fetchAllSenderThreads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces rate-limit responses as a typed error", async () => {
+    vi.mocked(fetchWithAccount).mockResolvedValue(
+      new Response(null, { status: 429 }),
+    );
+
+    await expect(
+      fetchAllSenderThreads({
+        sender: "sender@example.com",
+        emailAccountId: "account-1",
+      }),
+    ).rejects.toThrow(EmailProviderRateLimitError);
+  });
+
+  it("keeps unrelated failures generic", async () => {
+    vi.mocked(fetchWithAccount).mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    await expect(
+      fetchAllSenderThreads({
+        sender: "sender@example.com",
+        emailAccountId: "account-1",
+      }),
+    ).rejects.toThrow("Failed to fetch threads");
+  });
+});

--- a/apps/web/store/fetch-sender-threads.ts
+++ b/apps/web/store/fetch-sender-threads.ts
@@ -1,5 +1,6 @@
 import type { GetThreadsResponse } from "@/app/api/threads/basic/route";
 import { fetchWithAccount } from "@/utils/fetch";
+import { EmailProviderRateLimitError } from "@/utils/error";
 
 const SENDER_THREADS_PAGE_LIMIT = 100;
 
@@ -30,6 +31,9 @@ export async function fetchAllSenderThreads({
     });
 
     if (!response.ok) {
+      if (response.status === 429) {
+        throw new EmailProviderRateLimitError();
+      }
       throw new Error("Failed to fetch threads");
     }
 

--- a/apps/web/utils/actions/safe-action.ts
+++ b/apps/web/utils/actions/safe-action.ts
@@ -9,9 +9,14 @@ import { createScopedLogger } from "@/utils/logger";
 import { flushLoggerSafely } from "@/utils/logger-flush";
 import prisma from "@/utils/prisma";
 import { isAdmin } from "@/utils/admin";
-import { captureException, SafeError } from "@/utils/error";
+import {
+  captureException,
+  EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+  SafeError,
+} from "@/utils/error";
 import { env } from "@/env";
 import { runWithAuditContext, setAuditContext } from "@/utils/audit/context";
+import { isEmailProviderRateLimitError } from "@/utils/email/is-provider-rate-limit-error";
 
 const baseClient = createSafeActionClient({
   defineMetadataSchema() {
@@ -26,6 +31,7 @@ const baseClient = createSafeActionClient({
           userId?: string;
           userEmail?: string;
           emailAccountId?: string;
+          provider?: string;
         }
       | undefined;
 
@@ -37,9 +43,14 @@ const baseClient = createSafeActionClient({
         userEmail: context?.userEmail,
         emailAccountId: context?.emailAccountId,
       });
-    // SafeErrors are expected user-facing rejections (shown to the client,
-    // never sent to Sentry), so they log as warnings
-    if (error instanceof SafeError) {
+    const isProviderRateLimit = isEmailProviderRateLimitError({
+      error,
+      provider: context?.provider,
+    });
+
+    // Expected user-facing rejections are shown to the client and never sent
+    // to Sentry.
+    if (error instanceof SafeError || isProviderRateLimit) {
       logger.warn("Server action error:", {
         metadata,
         bindArgsClientInputs,
@@ -64,6 +75,7 @@ const baseClient = createSafeActionClient({
       // biome-ignore lint/suspicious/noConsole: helpful for debugging
       console.error("Error in server action", error);
     }
+    if (isProviderRateLimit) return EMAIL_PROVIDER_RATE_LIMIT_MESSAGE;
     if (error instanceof SafeError) return error.message;
 
     captureException(error, {

--- a/apps/web/utils/email/is-provider-rate-limit-error.test.ts
+++ b/apps/web/utils/email/is-provider-rate-limit-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ProviderRateLimitModeError } from "@/utils/email/rate-limit-mode-error";
+import { isEmailProviderRateLimitError } from "./is-provider-rate-limit-error";
+
+describe("isEmailProviderRateLimitError", () => {
+  it("recognizes active rate-limit mode without provider context", () => {
+    expect(
+      isEmailProviderRateLimitError({
+        error: new ProviderRateLimitModeError({ provider: "google" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("recognizes nested Gmail rate-limit errors", () => {
+    expect(
+      isEmailProviderRateLimitError({
+        error: new Error("Batch request failed", {
+          cause: Object.assign(new Error("Provider request was throttled"), {
+            response: { status: 429 },
+          }),
+        }),
+        provider: "google",
+      }),
+    ).toBe(true);
+  });
+
+  it("recognizes Microsoft rate-limit errors", () => {
+    expect(
+      isEmailProviderRateLimitError({
+        error: { statusCode: 429 },
+        provider: "microsoft",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated provider errors as rate limits", () => {
+    expect(
+      isEmailProviderRateLimitError({
+        error: new Error("Provider failed"),
+        provider: "google",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/utils/email/is-provider-rate-limit-error.ts
+++ b/apps/web/utils/email/is-provider-rate-limit-error.ts
@@ -1,0 +1,29 @@
+import { extractErrorInfo, isRetryableError } from "@/utils/gmail/retry";
+import {
+  isProviderRateLimitModeError,
+  toRateLimitProvider,
+} from "@/utils/email/rate-limit-mode-error";
+import {
+  extractErrorInfo as extractOutlookErrorInfo,
+  isRetryableError as isOutlookRetryableError,
+} from "@/utils/outlook/retry";
+
+export function isEmailProviderRateLimitError({
+  error,
+  provider,
+}: {
+  error: unknown;
+  provider?: string | null;
+}) {
+  if (isProviderRateLimitModeError(error)) return true;
+
+  const rateLimitProvider = toRateLimitProvider(provider);
+  if (rateLimitProvider === "google") {
+    return isRetryableError(extractErrorInfo(error)).isRateLimit;
+  }
+  if (rateLimitProvider === "microsoft") {
+    return isOutlookRetryableError(extractOutlookErrorInfo(error)).isRateLimit;
+  }
+
+  return false;
+}

--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -17,6 +17,8 @@ import {
   attachLlmRepairMetadata,
   captureException,
   checkCommonErrors,
+  EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+  EmailProviderRateLimitError,
   getActionErrorMessage,
   getUserFacingErrorMessage,
   isInsufficientCreditsError,
@@ -39,6 +41,14 @@ describe("assertActionSucceeded", () => {
     expect(() =>
       assertActionSucceeded({ serverError: "Unable to update sender" }),
     ).toThrow("Unable to update sender");
+  });
+
+  it("preserves provider rate limits as a typed client error", () => {
+    expect(() =>
+      assertActionSucceeded({
+        serverError: EMAIL_PROVIDER_RATE_LIMIT_MESSAGE,
+      }),
+    ).toThrow(EmailProviderRateLimitError);
   });
 
   it("throws flattened validation errors", () => {

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -24,6 +24,8 @@ export type ApiErrorType = {
 
 const RATE_LIMIT_MESSAGE_TEMPLATE =
   "{provider} is temporarily limiting requests. Please try again shortly.";
+export const EMAIL_PROVIDER_RATE_LIMIT_MESSAGE =
+  "Your email provider is temporarily limiting requests. Please try again shortly.";
 
 // biome-ignore lint/suspicious/noExplicitAny: existing loose external shape
 export function isError(value: any): value is ErrorMessage | ZodError {
@@ -155,6 +157,13 @@ export class SafeError extends Error {
     this.name = "SafeError";
     this.safeMessage = safeMessage;
     this.statusCode = statusCode;
+  }
+}
+
+export class EmailProviderRateLimitError extends Error {
+  constructor() {
+    super(EMAIL_PROVIDER_RATE_LIMIT_MESSAGE);
+    this.name = "EmailProviderRateLimitError";
   }
 }
 
@@ -540,6 +549,9 @@ export function assertActionSucceeded(
   if (!result) return;
 
   const message = extractActionErrorMessage(result);
+  if (message === EMAIL_PROVIDER_RATE_LIMIT_MESSAGE) {
+    throw new EmailProviderRateLimitError();
+  }
   if (message) throw new Error(message);
 }
 

--- a/apps/web/utils/gmail/filter.test.ts
+++ b/apps/web/utils/gmail/filter.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createScopedLogger } from "@/utils/logger";
+import { SafeError } from "@/utils/error";
+import { createFilter } from "@/utils/gmail/filter";
+
+vi.mock("@/utils/gmail/retry", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/utils/gmail/retry")>();
+
+  return {
+    ...original,
+    withGmailRetry: <T>(operation: () => Promise<T>) => operation(),
+  };
+});
+
+const logger = createScopedLogger("gmail-filter-test");
+
+describe("createFilter", () => {
+  const create = vi.fn();
+  const list = vi.fn();
+  const gmail = {
+    users: {
+      settings: {
+        filters: { create, list },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not make a filter-list request after a rate-limit error", async () => {
+    create.mockRejectedValue(
+      Object.assign(new Error("Provider request was throttled"), {
+        response: {
+          status: 403,
+          data: {
+            error: {
+              errors: [{ reason: "rateLimitExceeded" }],
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(
+      createFilter({
+        gmail: gmail as never,
+        from: "sender@example.com",
+        logger,
+      }),
+    ).rejects.toThrow("Provider request was throttled");
+
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("still diagnoses the Gmail filter limit for other eligible errors", async () => {
+    create.mockRejectedValue(
+      Object.assign(new Error("Filter creation failed"), {
+        response: { status: 400 },
+      }),
+    );
+    list.mockResolvedValue({
+      data: { filter: Array.from({ length: 990 }, (_, index) => ({ index })) },
+    });
+
+    await expect(
+      createFilter({
+        gmail: gmail as never,
+        from: "sender@example.com",
+        logger,
+      }),
+    ).rejects.toThrow(SafeError);
+
+    expect(list).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/utils/gmail/filter.ts
+++ b/apps/web/utils/gmail/filter.ts
@@ -1,6 +1,10 @@
 import type { gmail_v1 } from "@googleapis/gmail";
 import { GmailLabel } from "@/utils/gmail/label";
-import { extractErrorInfo, withGmailRetry } from "@/utils/gmail/retry";
+import {
+  extractErrorInfo,
+  isRetryableError,
+  withGmailRetry,
+} from "@/utils/gmail/retry";
 import { SafeError } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 
@@ -37,6 +41,8 @@ export async function createFilter(options: {
       removeLabelIds,
       error,
     });
+
+    if (isRetryableError(errorInfo).isRateLimit) throw error;
 
     // Check if it might be a filter limit issue
     // Documentation says 400/403, but we've seen 500 in production


### PR DESCRIPTION
Stops bulk sender operations when the email provider reports throttling and keeps unprocessed items available for retry.
Returns a structured rate-limit response across API and server-action paths.
Avoids additional filter-list requests after a rate-limit failure and adds focused regression coverage.
Tests: pnpm test; pnpm check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

