### PR TITLE
database: Handle duplicate constraint metadata

### DIFF
--- a/apps/web/utils/prisma-helpers.test.ts
+++ b/apps/web/utils/prisma-helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@/generated/prisma/client";
+import { isDuplicateError } from "./prisma-helpers";
+
+describe("isDuplicateError", () => {
+  it("matches fields from Prisma driver adapter errors", () => {
+    const error = createDriverAdapterDuplicateError([
+      "emailAccountId",
+      "sender",
+      "ruleId",
+      "messageId",
+      "eventType",
+    ]);
+
+    expect(
+      isDuplicateError(error, [
+        "emailAccountId",
+        "sender",
+        "ruleId",
+        "messageId",
+        "eventType",
+      ]),
+    ).toBe(true);
+    expect(isDuplicateError(error, "otherField")).toBe(false);
+  });
+});
+
+function createDriverAdapterDuplicateError(fields: string[]) {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "7.8.0",
+    meta: {
+      modelName: "ClassificationFeedback",
+      driverAdapterError: {
+        cause: {
+          kind: "UniqueConstraintViolation",
+          constraint: { fields },
+        },
+      },
+    },
+  });
+}

--- a/apps/web/utils/prisma-helpers.ts
+++ b/apps/web/utils/prisma-helpers.ts
@@ -7,7 +7,8 @@ export function isDuplicateError(error: unknown, key?: string | string[]) {
 
   if (!duplicateError || !key) return duplicateError;
 
-  const target = error.meta?.target;
+  const target =
+    error.meta?.target ?? getDriverAdapterConstraintFields(error.meta);
   const keys = Array.isArray(key) ? key : [key];
 
   if (typeof target === "string") return keys.every((k) => target.includes(k));
@@ -20,4 +21,30 @@ export function isNotFoundError(error: unknown) {
     error instanceof Prisma.PrismaClientKnownRequestError &&
     error.code === "P2025"
   );
+}
+
+function getDriverAdapterConstraintFields(
+  meta: Record<string, unknown> | undefined,
+): string[] | undefined {
+  const driverAdapterError = meta?.driverAdapterError;
+  if (!isRecord(driverAdapterError)) return;
+
+  const cause = driverAdapterError.cause;
+  if (
+    !isRecord(cause) ||
+    cause.kind !== "UniqueConstraintViolation" ||
+    !isRecord(cause.constraint)
+  ) {
+    return;
+  }
+
+  const fields = cause.constraint.fields;
+  return Array.isArray(fields) &&
+    fields.every((field): field is string => typeof field === "string")
+    ? fields
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }


### PR DESCRIPTION
Handle adapter-reported duplicate constraint metadata so concurrent writes remain idempotent.

- Preserve legacy constraint metadata support.
- Add regression coverage for the current adapter metadata shape.

Tests: pnpm test utils/prisma-helpers.test.ts utils/rule/classification-feedback.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

