### PR TITLE
webhooks: Handle known processing errors

### DIFF
--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -14,6 +14,8 @@ import {
 } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 import { categorizeSender } from "@/utils/categorize/senders/categorize";
+import { runRules } from "@/utils/ai/choose-rule/run-rules";
+import { SafeError } from "@/utils/error";
 
 vi.mock("@/utils/prisma", () => ({
   default: {
@@ -143,6 +145,34 @@ describe("Provider Edge Cases", () => {
           { ...baseOptions, provider },
         ),
       ).rejects.toThrow("invalid_grant");
+    });
+  });
+
+  describe("Known processing errors", () => {
+    it("handles safe errors without forwarding them to webhook error handlers", async () => {
+      const provider = createMockEmailProvider({
+        getMessage: vi.fn().mockResolvedValue(
+          getMockParsedMessage({
+            labelIds: ["INBOX"],
+          }),
+        ),
+        isSentMessage: vi.fn().mockReturnValue(false),
+      });
+      vi.mocked(runRules).mockRejectedValueOnce(
+        new SafeError("Expected processing limitation"),
+      );
+
+      await expect(
+        processHistoryItem(
+          { messageId: "msg-123", threadId: "thread-123" },
+          {
+            ...baseOptions,
+            provider,
+            hasAutomationRules: true,
+            hasAiAccess: true,
+          },
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/apps/web/utils/webhook/process-history-item.test.ts
+++ b/apps/web/utils/webhook/process-history-item.test.ts
@@ -173,6 +173,7 @@ describe("Provider Edge Cases", () => {
           },
         ),
       ).resolves.toBeUndefined();
+      expect(runRules).toHaveBeenCalledOnce();
     });
   });
 

--- a/apps/web/utils/webhook/process-history-item.ts
+++ b/apps/web/utils/webhook/process-history-item.ts
@@ -23,7 +23,7 @@ import type { ParsedMessage, RuleWithActions } from "@/utils/types";
 import type { EmailAccountForDrafting } from "@/utils/ai/choose-rule/choose-args";
 import type { Logger } from "@/utils/logger";
 import { runWithBackgroundLoggerFlush } from "@/utils/logger-flush";
-import { captureException } from "@/utils/error";
+import { captureException, SafeError } from "@/utils/error";
 import { logErrorWithDedupe } from "@/utils/log-error-with-dedupe";
 
 export type SharedProcessHistoryOptions = {
@@ -319,6 +319,11 @@ export async function processHistoryItem(
         logger.info("Message not found");
         return;
       }
+    }
+
+    if (error instanceof SafeError) {
+      logger.info("Skipping. Known processing error.");
+      return;
     }
 
     await logErrorWithDedupe({


### PR DESCRIPTION
Handle expected webhook processing failures without forwarding them to error reporting.

- Stop structured safe errors at the shared webhook boundary.
- Preserve propagation for unexpected provider and network failures.
- Add regression coverage for known errors.

Tests: pnpm test utils/webhook/process-history-item.test.ts; pnpm test utils/webhook/google/process-history.test.ts utils/webhook/outlook/process-history.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

