### PR TITLE
digest: Prevent overlapping digest processing

### DIFF
--- a/apps/web/__tests__/db/digest-claim.test.ts
+++ b/apps/web/__tests__/db/digest-claim.test.ts
@@ -15,7 +15,8 @@ describe.skipIf(!RUN_DB_TESTS)(
   { timeout: 30_000 },
   () => {
     let prisma: typeof import("@/utils/prisma").default;
-    let claimPendingDigestIds: typeof import("@/utils/digest/claim-pending-digests").claimPendingDigestIds;
+    let claimPendingDigests: typeof import("@/utils/digest/claim-pending-digests").claimPendingDigests;
+    let renewDigestClaim: typeof import("@/utils/digest/claim-pending-digests").renewDigestClaim;
     let emailAccountId: string;
 
     const accountEmail = "digest-claim-test@example.com";
@@ -27,7 +28,7 @@ describe.skipIf(!RUN_DB_TESTS)(
 
     beforeAll(async () => {
       prisma = (await import("@/utils/prisma")).default;
-      ({ claimPendingDigestIds } = await import(
+      ({ claimPendingDigests, renewDigestClaim } = await import(
         "@/utils/digest/claim-pending-digests"
       ));
     });
@@ -87,11 +88,11 @@ describe.skipIf(!RUN_DB_TESTS)(
 
     test("claims pending and stale digests only once across concurrent workers", async () => {
       const [firstClaim, secondClaim] = await Promise.all([
-        claimPendingDigestIds({ emailAccountId, now }),
-        claimPendingDigestIds({ emailAccountId, now }),
+        claimPendingDigests({ emailAccountId, now }),
+        claimPendingDigests({ emailAccountId, now }),
       ]);
 
-      const claimedIds = [...firstClaim, ...secondClaim];
+      const claimedIds = [...firstClaim.digestIds, ...secondClaim.digestIds];
 
       expect(claimedIds).toHaveLength(3);
       expect(new Set(claimedIds)).toEqual(
@@ -110,6 +111,26 @@ describe.skipIf(!RUN_DB_TESTS)(
       expect(
         digests.filter((digest) => digest.status === DigestStatus.SENT),
       ).toHaveLength(1);
+    });
+
+    test("prevents an old worker from renewing a reclaimed digest", async () => {
+      const firstClaim = await claimPendingDigests({ emailAccountId, now });
+      const reclaimedAt = new Date("2026-07-30T18:11:00.000Z");
+
+      const secondClaim = await claimPendingDigests({
+        emailAccountId,
+        now: reclaimedAt,
+      });
+
+      expect(secondClaim.digestIds).toEqual(
+        expect.arrayContaining(firstClaim.digestIds),
+      );
+      expect(
+        await renewDigestClaim(
+          firstClaim,
+          new Date("2026-07-30T18:12:00.000Z"),
+        ),
+      ).toBeNull();
     });
   },
 );

--- a/apps/web/__tests__/db/digest-claim.test.ts
+++ b/apps/web/__tests__/db/digest-claim.test.ts
@@ -138,6 +138,8 @@ describe.skipIf(!RUN_DB_TESTS)(
       const competingClaimAt = new Date("2026-07-30T18:01:00.000Z");
       const renewalAt = new Date("2026-07-30T18:02:00.000Z");
 
+      expect(claim.digestIds.length).toBeGreaterThan(0);
+
       await prisma.digest.update({
         where: { id: claim.digestIds[0] },
         data: { updatedAt: competingClaimAt },

--- a/apps/web/__tests__/db/digest-claim.test.ts
+++ b/apps/web/__tests__/db/digest-claim.test.ts
@@ -1,0 +1,88 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+import { DigestStatus } from "@/generated/prisma/enums";
+
+const RUN_DB_TESTS = process.env.RUN_DB_TESTS;
+
+describe.skipIf(!RUN_DB_TESTS)(
+  "digest claims (real database)",
+  { timeout: 30_000 },
+  () => {
+    let prisma: typeof import("@/utils/prisma").default;
+    let claimPendingDigestIds: typeof import("@/utils/digest/claim-pending-digests").claimPendingDigestIds;
+    let emailAccountId: string;
+
+    const accountEmail = "digest-claim-test@example.com";
+
+    beforeAll(async () => {
+      prisma = (await import("@/utils/prisma")).default;
+      ({ claimPendingDigestIds } = await import(
+        "@/utils/digest/claim-pending-digests"
+      ));
+    });
+
+    beforeEach(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+
+      const user = await prisma.user.create({ data: { email: accountEmail } });
+      const account = await prisma.account.create({
+        data: {
+          userId: user.id,
+          provider: "google",
+          providerAccountId: accountEmail,
+          type: "oauth",
+        },
+      });
+      const emailAccount = await prisma.emailAccount.create({
+        data: {
+          email: accountEmail,
+          userId: user.id,
+          accountId: account.id,
+        },
+      });
+      emailAccountId = emailAccount.id;
+
+      await prisma.digest.createMany({
+        data: [
+          { emailAccountId, status: DigestStatus.PENDING },
+          { emailAccountId, status: DigestStatus.PENDING },
+          { emailAccountId, status: DigestStatus.SENT },
+        ],
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.user.deleteMany({ where: { email: accountEmail } });
+      await prisma.$disconnect();
+    });
+
+    test("allows only one concurrent worker to claim each pending digest", async () => {
+      const [firstClaim, secondClaim] = await Promise.all([
+        claimPendingDigestIds({ emailAccountId }),
+        claimPendingDigestIds({ emailAccountId }),
+      ]);
+
+      const claimedIds = [...firstClaim, ...secondClaim];
+
+      expect(claimedIds).toHaveLength(2);
+      expect(new Set(claimedIds).size).toBe(2);
+
+      const digests = await prisma.digest.findMany({
+        where: { emailAccountId },
+        select: { id: true, status: true },
+      });
+      expect(
+        digests.filter((digest) => digest.status === DigestStatus.PROCESSING),
+      ).toHaveLength(2);
+      expect(
+        digests.filter((digest) => digest.status === DigestStatus.SENT),
+      ).toHaveLength(1);
+    });
+  },
+);

--- a/apps/web/__tests__/db/digest-claim.test.ts
+++ b/apps/web/__tests__/db/digest-claim.test.ts
@@ -19,6 +19,11 @@ describe.skipIf(!RUN_DB_TESTS)(
     let emailAccountId: string;
 
     const accountEmail = "digest-claim-test@example.com";
+    const pendingDigestIds = ["digest-pending-1", "digest-pending-2"];
+    const staleProcessingDigestId = "digest-processing-stale";
+    const freshProcessingDigestId = "digest-processing-fresh";
+    const sentDigestId = "digest-sent";
+    const now = new Date("2026-07-30T18:00:00.000Z");
 
     beforeAll(async () => {
       prisma = (await import("@/utils/prisma")).default;
@@ -50,28 +55,50 @@ describe.skipIf(!RUN_DB_TESTS)(
 
       await prisma.digest.createMany({
         data: [
-          { emailAccountId, status: DigestStatus.PENDING },
-          { emailAccountId, status: DigestStatus.PENDING },
-          { emailAccountId, status: DigestStatus.SENT },
+          ...pendingDigestIds.map((id) => ({
+            id,
+            emailAccountId,
+            status: DigestStatus.PENDING,
+          })),
+          {
+            id: staleProcessingDigestId,
+            emailAccountId,
+            status: DigestStatus.PROCESSING,
+            updatedAt: new Date("2026-07-30T17:49:59.000Z"),
+          },
+          {
+            id: freshProcessingDigestId,
+            emailAccountId,
+            status: DigestStatus.PROCESSING,
+            updatedAt: new Date("2026-07-30T17:59:00.000Z"),
+          },
+          {
+            id: sentDigestId,
+            emailAccountId,
+            status: DigestStatus.SENT,
+          },
         ],
       });
     });
 
     afterAll(async () => {
       await prisma.user.deleteMany({ where: { email: accountEmail } });
-      await prisma.$disconnect();
     });
 
-    test("allows only one concurrent worker to claim each pending digest", async () => {
+    test("claims pending and stale digests only once across concurrent workers", async () => {
       const [firstClaim, secondClaim] = await Promise.all([
-        claimPendingDigestIds({ emailAccountId }),
-        claimPendingDigestIds({ emailAccountId }),
+        claimPendingDigestIds({ emailAccountId, now }),
+        claimPendingDigestIds({ emailAccountId, now }),
       ]);
 
       const claimedIds = [...firstClaim, ...secondClaim];
 
-      expect(claimedIds).toHaveLength(2);
-      expect(new Set(claimedIds).size).toBe(2);
+      expect(claimedIds).toHaveLength(3);
+      expect(new Set(claimedIds)).toEqual(
+        new Set([...pendingDigestIds, staleProcessingDigestId]),
+      );
+      expect(claimedIds).not.toContain(freshProcessingDigestId);
+      expect(claimedIds).not.toContain(sentDigestId);
 
       const digests = await prisma.digest.findMany({
         where: { emailAccountId },
@@ -79,7 +106,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       });
       expect(
         digests.filter((digest) => digest.status === DigestStatus.PROCESSING),
-      ).toHaveLength(2);
+      ).toHaveLength(4);
       expect(
         digests.filter((digest) => digest.status === DigestStatus.SENT),
       ).toHaveLength(1);

--- a/apps/web/__tests__/db/digest-claim.test.ts
+++ b/apps/web/__tests__/db/digest-claim.test.ts
@@ -132,5 +132,34 @@ describe.skipIf(!RUN_DB_TESTS)(
         ),
       ).toBeNull();
     });
+
+    test("does not renew any digests when part of the claim is no longer owned", async () => {
+      const claim = await claimPendingDigests({ emailAccountId, now });
+      const competingClaimAt = new Date("2026-07-30T18:01:00.000Z");
+      const renewalAt = new Date("2026-07-30T18:02:00.000Z");
+
+      await prisma.digest.update({
+        where: { id: claim.digestIds[0] },
+        data: { updatedAt: competingClaimAt },
+      });
+
+      expect(await renewDigestClaim(claim, renewalAt)).toBeNull();
+
+      const digests = await prisma.digest.findMany({
+        where: { id: { in: claim.digestIds } },
+        select: { id: true, updatedAt: true },
+      });
+
+      expect(digests).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ updatedAt: competingClaimAt }),
+        ]),
+      );
+      expect(digests).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ updatedAt: renewalAt }),
+        ]),
+      );
+    });
   },
 );

--- a/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/settings/DigestSettingsForm.tsx
@@ -97,6 +97,12 @@ export function DigestSettingsForm({
   const [selectedDigestItems, setSelectedDigestItems] = useState<Set<string>>(
     new Set(),
   );
+  const {
+    schedule: initialSchedule,
+    dayOfWeek: initialDayOfWeek,
+    time: initialTime,
+  } = getInitialScheduleProps(digestStatus?.schedule);
+  const digestStatusLoaded = digestStatus !== undefined;
 
   const {
     handleSubmit,
@@ -142,7 +148,7 @@ export function DigestSettingsForm({
 
   // Initialize selected items and form data from API responses
   useEffect(() => {
-    if (rules && digestStatus) {
+    if (rules && digestStatusLoaded) {
       const selectedItems = new Set<string>();
 
       // Add rules that have digest actions
@@ -154,16 +160,21 @@ export function DigestSettingsForm({
 
       setSelectedDigestItems(selectedItems);
 
-      // Initialize schedule form data
-      const initialScheduleProps = getInitialScheduleProps(
-        digestStatus.schedule,
-      );
       reset({
         selectedItems,
-        ...initialScheduleProps,
+        schedule: initialSchedule,
+        dayOfWeek: initialDayOfWeek,
+        time: initialTime,
       });
     }
-  }, [rules, digestStatus, reset]);
+  }, [
+    rules,
+    digestStatusLoaded,
+    initialSchedule,
+    initialDayOfWeek,
+    initialTime,
+    reset,
+  ]);
 
   // Update form when selectedDigestItems changes
   useEffect(() => {

--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -156,26 +156,28 @@ async function sendEmail({
 
   const claimedDigestIds = await claimPendingDigestIds({ emailAccountId });
 
-  const pendingDigests = await prisma.digest.findMany({
-    where: {
-      emailAccountId,
-      id: {
-        in: claimedDigestIds,
+  try {
+    const pendingDigests = await prisma.digest.findMany({
+      where: {
+        emailAccountId,
+        id: {
+          in: claimedDigestIds,
+        },
       },
-    },
-    select: {
-      id: true,
-      items: {
-        select: {
-          messageId: true,
-          content: true,
-          action: {
-            select: {
-              executedRule: {
-                select: {
-                  rule: {
-                    select: {
-                      name: true,
+      select: {
+        id: true,
+        items: {
+          select: {
+            messageId: true,
+            content: true,
+            action: {
+              select: {
+                executedRule: {
+                  select: {
+                    rule: {
+                      select: {
+                        name: true,
+                      },
                     },
                   },
                 },
@@ -184,10 +186,8 @@ async function sendEmail({
           },
         },
       },
-    },
-  });
+    });
 
-  try {
     // Return early if no digests were found, unless force is true
     if (pendingDigests.length === 0) {
       if (!force) {
@@ -300,6 +300,17 @@ async function sendEmail({
 
     if (Object.keys(executedRulesByRule).length === 0) {
       logger.info("No executed rules found, skipping digest email");
+      await prisma.digest.updateMany({
+        where: {
+          id: {
+            in: processedDigestIds,
+          },
+          status: DigestStatus.PROCESSING,
+        },
+        data: {
+          status: DigestStatus.FAILED,
+        },
+      });
       return {
         success: true,
         message: "No executed rules found, skipping digest email",
@@ -362,8 +373,9 @@ async function sendEmail({
     await prisma.digest.updateMany({
       where: {
         id: {
-          in: pendingDigests.map((d) => d.id),
+          in: claimedDigestIds,
         },
+        status: DigestStatus.PROCESSING,
       },
       data: {
         status: DigestStatus.FAILED,

--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -22,6 +22,7 @@ import camelCase from "lodash/camelCase";
 import { createEmailProvider } from "@/utils/email/provider";
 import { sleep } from "@/utils/sleep";
 import { withQstashOrInternal } from "@/utils/qstash";
+import { claimPendingDigestIds } from "@/utils/digest/claim-pending-digests";
 
 export const maxDuration = 60;
 
@@ -153,10 +154,14 @@ async function sendEmail({
     }
   }
 
+  const claimedDigestIds = await claimPendingDigestIds({ emailAccountId });
+
   const pendingDigests = await prisma.digest.findMany({
     where: {
       emailAccountId,
-      status: DigestStatus.PENDING,
+      id: {
+        in: claimedDigestIds,
+      },
     },
     select: {
       id: true,
@@ -181,20 +186,6 @@ async function sendEmail({
       },
     },
   });
-
-  if (pendingDigests.length) {
-    // Mark all found digests as processing
-    await prisma.digest.updateMany({
-      where: {
-        id: {
-          in: pendingDigests.map((d) => d.id),
-        },
-      },
-      data: {
-        status: DigestStatus.PROCESSING,
-      },
-    });
-  }
 
   try {
     // Return early if no digests were found, unless force is true

--- a/apps/web/app/api/resend/digest/route.ts
+++ b/apps/web/app/api/resend/digest/route.ts
@@ -22,7 +22,11 @@ import camelCase from "lodash/camelCase";
 import { createEmailProvider } from "@/utils/email/provider";
 import { sleep } from "@/utils/sleep";
 import { withQstashOrInternal } from "@/utils/qstash";
-import { claimPendingDigestIds } from "@/utils/digest/claim-pending-digests";
+import {
+  claimPendingDigests,
+  getDigestClaimWhere,
+  renewDigestClaim,
+} from "@/utils/digest/claim-pending-digests";
 
 export const maxDuration = 60;
 
@@ -154,14 +158,14 @@ async function sendEmail({
     }
   }
 
-  const claimedDigestIds = await claimPendingDigestIds({ emailAccountId });
+  let digestClaim = await claimPendingDigests({ emailAccountId });
 
   try {
     const pendingDigests = await prisma.digest.findMany({
       where: {
         emailAccountId,
         id: {
-          in: claimedDigestIds,
+          in: digestClaim.digestIds,
         },
       },
       select: {
@@ -301,12 +305,7 @@ async function sendEmail({
     if (Object.keys(executedRulesByRule).length === 0) {
       logger.info("No executed rules found, skipping digest email");
       await prisma.digest.updateMany({
-        where: {
-          id: {
-            in: processedDigestIds,
-          },
-          status: DigestStatus.PROCESSING,
-        },
+        where: getDigestClaimWhere(digestClaim),
         data: {
           status: DigestStatus.FAILED,
         },
@@ -318,6 +317,16 @@ async function sendEmail({
     }
 
     const token = await createUnsubscribeToken({ emailAccountId });
+
+    const renewedClaim = await renewDigestClaim(digestClaim);
+    if (!renewedClaim) {
+      logger.warn("Skipping digest send because the processing claim was lost");
+      return {
+        success: true,
+        message: "Digest processing claim was lost",
+      };
+    }
+    digestClaim = renewedClaim;
 
     logger.info("Sending digest");
 
@@ -332,6 +341,8 @@ async function sendEmail({
     });
 
     logger.info("Digest sent");
+
+    const sentAt = new Date();
 
     // Only update database if email sending succeeded
     // Use a transaction to ensure atomicity - all updates succeed or none are applied
@@ -349,14 +360,10 @@ async function sendEmail({
         : []),
       // Mark only the processed digests as sent
       prisma.digest.updateMany({
-        where: {
-          id: {
-            in: processedDigestIds,
-          },
-        },
+        where: getDigestClaimWhere(digestClaim),
         data: {
           status: DigestStatus.SENT,
-          sentAt: new Date(),
+          sentAt,
         },
       }),
       // Redact all DigestItems for the processed digests
@@ -366,17 +373,16 @@ async function sendEmail({
           digestId: {
             in: processedDigestIds,
           },
+          digest: {
+            status: DigestStatus.SENT,
+            sentAt,
+          },
         },
       }),
     ]);
   } catch (error) {
     await prisma.digest.updateMany({
-      where: {
-        id: {
-          in: claimedDigestIds,
-        },
-        status: DigestStatus.PROCESSING,
-      },
+      where: getDigestClaimWhere(digestClaim),
       data: {
         status: DigestStatus.FAILED,
       },

--- a/apps/web/utils/digest/claim-pending-digests.ts
+++ b/apps/web/utils/digest/claim-pending-digests.ts
@@ -1,0 +1,23 @@
+import { DigestStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/prisma";
+
+export async function claimPendingDigestIds({
+  emailAccountId,
+}: {
+  emailAccountId: string;
+}) {
+  const claimedDigests = await prisma.digest.updateManyAndReturn({
+    where: {
+      emailAccountId,
+      status: DigestStatus.PENDING,
+    },
+    data: {
+      status: DigestStatus.PROCESSING,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return claimedDigests.map((digest) => digest.id);
+}

--- a/apps/web/utils/digest/claim-pending-digests.ts
+++ b/apps/web/utils/digest/claim-pending-digests.ts
@@ -3,13 +3,18 @@ import prisma from "@/utils/prisma";
 
 const PROCESSING_LEASE_MS = 10 * 60 * 1000;
 
-export async function claimPendingDigestIds({
+export type DigestClaim = {
+  digestIds: string[];
+  claimedAt: Date;
+};
+
+export async function claimPendingDigests({
   emailAccountId,
   now = new Date(),
 }: {
   emailAccountId: string;
   now?: Date;
-}) {
+}): Promise<DigestClaim> {
   const claimedDigests = await prisma.digest.updateManyAndReturn({
     where: {
       emailAccountId,
@@ -25,11 +30,44 @@ export async function claimPendingDigestIds({
     },
     data: {
       status: DigestStatus.PROCESSING,
+      updatedAt: now,
     },
     select: {
       id: true,
     },
   });
 
-  return claimedDigests.map((digest) => digest.id);
+  return {
+    digestIds: claimedDigests.map((digest) => digest.id),
+    claimedAt: now,
+  };
+}
+
+export async function renewDigestClaim(
+  claim: DigestClaim,
+  now = new Date(),
+): Promise<DigestClaim | null> {
+  const result = await prisma.digest.updateMany({
+    where: getDigestClaimWhere(claim),
+    data: {
+      updatedAt: now,
+    },
+  });
+
+  if (result.count !== claim.digestIds.length) return null;
+
+  return {
+    digestIds: claim.digestIds,
+    claimedAt: now,
+  };
+}
+
+export function getDigestClaimWhere(claim: DigestClaim) {
+  return {
+    id: {
+      in: claim.digestIds,
+    },
+    status: DigestStatus.PROCESSING,
+    updatedAt: claim.claimedAt,
+  };
 }

--- a/apps/web/utils/digest/claim-pending-digests.ts
+++ b/apps/web/utils/digest/claim-pending-digests.ts
@@ -1,15 +1,27 @@
 import { DigestStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 
+const PROCESSING_LEASE_MS = 10 * 60 * 1000;
+
 export async function claimPendingDigestIds({
   emailAccountId,
+  now = new Date(),
 }: {
   emailAccountId: string;
+  now?: Date;
 }) {
   const claimedDigests = await prisma.digest.updateManyAndReturn({
     where: {
       emailAccountId,
-      status: DigestStatus.PENDING,
+      OR: [
+        { status: DigestStatus.PENDING },
+        {
+          status: DigestStatus.PROCESSING,
+          updatedAt: {
+            lt: new Date(now.getTime() - PROCESSING_LEASE_MS),
+          },
+        },
+      ],
     },
     data: {
       status: DigestStatus.PROCESSING,

--- a/apps/web/utils/digest/claim-pending-digests.ts
+++ b/apps/web/utils/digest/claim-pending-digests.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@/generated/prisma/client";
 import { DigestStatus } from "@/generated/prisma/enums";
 import prisma from "@/utils/prisma";
 
@@ -47,14 +48,33 @@ export async function renewDigestClaim(
   claim: DigestClaim,
   now = new Date(),
 ): Promise<DigestClaim | null> {
-  const result = await prisma.digest.updateMany({
-    where: getDigestClaimWhere(claim),
-    data: {
-      updatedAt: now,
-    },
-  });
+  if (claim.digestIds.length === 0) return null;
 
-  if (result.count !== claim.digestIds.length) return null;
+  const renewedDigests = await prisma.$queryRaw<Array<{ id: string }>>(
+    Prisma.sql`
+      WITH "ownedClaims" AS MATERIALIZED (
+        SELECT "id"
+        FROM "Digest"
+        WHERE
+          "id" IN (${Prisma.join(claim.digestIds)})
+          AND "status" = ${DigestStatus.PROCESSING}
+          AND "updatedAt" = ${claim.claimedAt}
+        FOR UPDATE
+      ),
+      "completeClaim" AS (
+        SELECT COUNT(*) = ${claim.digestIds.length} AS "isComplete"
+        FROM "ownedClaims"
+      )
+      UPDATE "Digest"
+      SET "updatedAt" = ${now}
+      WHERE
+        "id" IN (SELECT "id" FROM "ownedClaims")
+        AND (SELECT "isComplete" FROM "completeClaim")
+      RETURNING "id"
+    `,
+  );
+
+  if (renewedDigests.length !== claim.digestIds.length) return null;
 
   return {
     digestIds: claim.digestIds,


### PR DESCRIPTION
Prevents overlapping digest workers from processing the same pending items and preserves unsaved digest settings during delivery-status refreshes.

- Atomically claim pending digest rows before loading and sending them
- Add a real-Postgres concurrency regression test
- Keep form initialization stable across delivery-only refreshes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

