### PR TITLE
INB-319: Show invited meetings with embedded join links

### DIFF
--- a/apps/web/utils/calendar/providers/google-events.test.ts
+++ b/apps/web/utils/calendar/providers/google-events.test.ts
@@ -62,6 +62,43 @@ describe("GoogleCalendarEventProvider", () => {
       }),
     );
   });
+
+  it("finds the video link for an accepted invitation", async () => {
+    calendarMocks.list.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: "invited-event-id",
+            summary: "Customer call",
+            description:
+              "Join Zoom Meeting\nhttps://acme.zoom.us/j/8123456789?pwd=secret",
+            organizer: { email: "host@example.com", self: false },
+            start: { dateTime: "2026-05-04T09:00:00.000Z" },
+            end: { dateTime: "2026-05-04T09:30:00.000Z" },
+            attendees: [
+              {
+                email: "user@example.com",
+                self: true,
+                responseStatus: "accepted",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const events = await createProvider().fetchEvents({
+      timeMin: new Date("2026-05-04T00:00:00.000Z"),
+      timeMax: new Date("2026-05-05T00:00:00.000Z"),
+    });
+
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        isOrganizer: false,
+        videoConferenceLink: "https://acme.zoom.us/j/8123456789?pwd=secret",
+      }),
+    );
+  });
 });
 
 function createProvider() {

--- a/apps/web/utils/calendar/providers/google-events.ts
+++ b/apps/web/utils/calendar/providers/google-events.ts
@@ -10,6 +10,7 @@ import type {
   CalendarEventWriteInput,
   CalendarEventWriteResult,
 } from "@/utils/calendar/event-types";
+import { findVideoConferenceLink } from "@/utils/calendar/video-conference-link";
 import type { Logger } from "@/utils/logger";
 
 export interface GoogleCalendarConnectionParams {
@@ -196,6 +197,10 @@ export class GoogleCalendarEventProvider implements CalendarEventProvider {
       );
       videoConferenceLink = videoEntry?.uri ?? videoConferenceLink;
     }
+    videoConferenceLink ??= findVideoConferenceLink(
+      event.location,
+      event.description,
+    );
 
     return {
       id: event.id || "",

--- a/apps/web/utils/calendar/providers/microsoft-events.test.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.test.ts
@@ -80,6 +80,45 @@ describe("MicrosoftCalendarEventProvider", () => {
     );
   });
 
+  it("finds the video link for an accepted invitation", async () => {
+    const joinUrl =
+      "https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc%40thread.v2/0?context=%7b%22Tid%22%3a%22tenant%22%7d";
+    graphMocks.get.mockResolvedValue({
+      value: [
+        {
+          id: "invited-event-id",
+          subject: "Customer call",
+          isOrganizer: false,
+          organizer: { emailAddress: { address: "host@example.com" } },
+          start: { dateTime: "2026-05-04T09:00:00.000Z" },
+          end: { dateTime: "2026-05-04T09:30:00.000Z" },
+          attendees: [
+            {
+              emailAddress: { address: "user@example.com" },
+              status: { response: "accepted" },
+            },
+          ],
+          body: {
+            contentType: "html",
+            content: `<a href="${joinUrl}">Join Microsoft Teams Meeting</a>`,
+          },
+        },
+      ],
+    });
+
+    const events = await createProvider().fetchEvents({
+      timeMin: new Date("2026-05-04T00:00:00.000Z"),
+      timeMax: new Date("2026-05-05T00:00:00.000Z"),
+    });
+
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        isOrganizer: false,
+        videoConferenceLink: joinUrl,
+      }),
+    );
+  });
+
   it("creates Teams meetings for Microsoft Teams locations", async () => {
     graphMocks.get.mockResolvedValue({
       id: "calendar-id",

--- a/apps/web/utils/calendar/providers/microsoft-events.ts
+++ b/apps/web/utils/calendar/providers/microsoft-events.ts
@@ -8,6 +8,7 @@ import type {
   CalendarEventWriteInput,
   CalendarEventWriteResult,
 } from "@/utils/calendar/event-types";
+import { findVideoConferenceLink } from "@/utils/calendar/video-conference-link";
 import { BookingLinkLocationType } from "@/generated/prisma/enums";
 import type { Logger } from "@/utils/logger";
 
@@ -24,6 +25,7 @@ export interface MicrosoftCalendarConnectionParams {
 type MicrosoftEvent = {
   id?: string;
   subject?: string;
+  body?: { content?: string };
   bodyPreview?: string;
   start?: { dateTime?: string };
   end?: { dateTime?: string };
@@ -266,7 +268,12 @@ export class MicrosoftCalendarEventProvider implements CalendarEventProvider {
       description: event.bodyPreview || undefined,
       location: event.location?.displayName || undefined,
       eventUrl: event.webLink || undefined,
-      videoConferenceLink: getJoinUrl(event),
+      videoConferenceLink:
+        getJoinUrl(event) ||
+        findVideoConferenceLink(
+          event.location?.displayName,
+          event.body?.content ?? event.bodyPreview,
+        ),
       startTime: new Date(event.start?.dateTime || Date.now()),
       endTime: new Date(event.end?.dateTime || Date.now()),
       organizerEmail: event.organizer?.emailAddress?.address || undefined,

--- a/apps/web/utils/calendar/video-conference-link.test.ts
+++ b/apps/web/utils/calendar/video-conference-link.test.ts
@@ -18,4 +18,12 @@ describe("findVideoConferenceLink", () => {
       ),
     ).toBe("https://zoom.us/j/8123456789?pwd=secret&from=calendar");
   });
+
+  it("finds a link whose hostname is entity-encoded", () => {
+    expect(
+      findVideoConferenceLink(
+        "Join: https://meet&#46;google&#46;com/abc-defg-hij",
+      ),
+    ).toBe("https://meet.google.com/abc-defg-hij");
+  });
 });

--- a/apps/web/utils/calendar/video-conference-link.test.ts
+++ b/apps/web/utils/calendar/video-conference-link.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { findVideoConferenceLink } from "@/utils/calendar/video-conference-link";
+
+describe("findVideoConferenceLink", () => {
+  it("does not treat an unrelated event URL as a video conference", () => {
+    expect(
+      findVideoConferenceLink(
+        "Agenda: https://docs.example.com/customer-call",
+        "Location: https://maps.example.com/office",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("decodes HTML entities in a conference URL", () => {
+    expect(
+      findVideoConferenceLink(
+        '<a href="https://zoom.us/j/8123456789?pwd=secret&amp;from=calendar">Join</a>',
+      ),
+    ).toBe("https://zoom.us/j/8123456789?pwd=secret&from=calendar");
+  });
+});

--- a/apps/web/utils/calendar/video-conference-link.ts
+++ b/apps/web/utils/calendar/video-conference-link.ts
@@ -1,0 +1,50 @@
+import he from "he";
+import { isHost } from "@/utils/meeting-recorder/normalize-meeting-url";
+
+// Keep these hosts in sync with normalizeMeetingUrl: links extracted here
+// become its input when building recording dedup keys.
+const KNOWN_MEETING_HOST =
+  /meet\.google\.com|zoom\.us|zoom\.com|teams\.microsoft\.com|teams\.live\.com/i;
+
+const TRAILING_PUNCTUATION = /[),.;:!?]+$/;
+
+export function findVideoConferenceLink(
+  ...eventDetails: Array<string | null | undefined>
+): string | undefined {
+  for (const detail of eventDetails) {
+    // Hostnames are never entity-encoded, so this raw test safely skips
+    // decoding large HTML bodies that cannot contain a meeting link.
+    if (!detail || !KNOWN_MEETING_HOST.test(detail)) continue;
+
+    const urls = he.decode(detail).match(/https?:\/\/[^\s<>"']+/gi);
+
+    for (const url of urls ?? []) {
+      if (!KNOWN_MEETING_HOST.test(url)) continue;
+      const candidate = url.replace(TRAILING_PUNCTUATION, "");
+      if (isVideoConferenceLink(candidate)) return candidate;
+    }
+  }
+}
+
+function isVideoConferenceLink(candidate: string): boolean {
+  try {
+    const url = new URL(candidate);
+    const host = url.hostname;
+
+    if (isHost(host, "meet.google.com")) {
+      return url.pathname !== "/";
+    }
+
+    if (isHost(host, "zoom.us") || isHost(host, "zoom.com")) {
+      return /^\/(?:j|s|w|wc\/join|my)\//i.test(url.pathname);
+    }
+
+    if (isHost(host, "teams.microsoft.com")) {
+      return /^\/(?:l\/meetup-join|meet)\//i.test(url.pathname);
+    }
+
+    return isHost(host, "teams.live.com") && /^\/meet\//i.test(url.pathname);
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/utils/calendar/video-conference-link.ts
+++ b/apps/web/utils/calendar/video-conference-link.ts
@@ -12,11 +12,14 @@ export function findVideoConferenceLink(
   ...eventDetails: Array<string | null | undefined>
 ): string | undefined {
   for (const detail of eventDetails) {
-    // Hostnames are never entity-encoded, so this raw test safely skips
-    // decoding large HTML bodies that cannot contain a meeting link.
-    if (!detail || !KNOWN_MEETING_HOST.test(detail)) continue;
+    if (!detail) continue;
 
-    const urls = he.decode(detail).match(/https?:\/\/[^\s<>"']+/gi);
+    // Decode before filtering: HTML bodies can entity-encode any character,
+    // including dots in hostnames (e.g. meet&#46;google&#46;com).
+    const decoded = he.decode(detail);
+    if (!KNOWN_MEETING_HOST.test(decoded)) continue;
+
+    const urls = decoded.match(/https?:\/\/[^\s<>"']+/gi);
 
     for (const url of urls ?? []) {
       if (!KNOWN_MEETING_HOST.test(url)) continue;

--- a/apps/web/utils/meeting-recorder/normalize-meeting-url.ts
+++ b/apps/web/utils/meeting-recorder/normalize-meeting-url.ts
@@ -16,7 +16,7 @@ const TEAMS_LIVE_MEET_ID = /^\/meet\/(\d+)(?:\/|$)/;
  * key that decides which accounts share a recording, that would let an
  * attacker-controlled link collide with a real meeting.
  */
-function isHost(host: string, domain: string): boolean {
+export function isHost(host: string, domain: string): boolean {
   return host === domain || host.endsWith(`.${domain}`);
 }
 


### PR DESCRIPTION
Adds conference-link extraction fallback so accepted calendar invitations can appear on Meetings when provider structured join fields are absent. Existing structured links remain preferred, and extraction is restricted to supported meeting hosts and paths.

- Apply the fallback to Google event location/description and Microsoft event location/body.
- Validate host/path and decode HTML entities before using extracted URLs.
- Tests: `pnpm test utils/calendar/providers/google-events.test.ts utils/calendar/providers/microsoft-events.test.ts utils/calendar/video-conference-link.test.ts utils/meeting-recorder/normalize-meeting-url.test.ts` (24 passed).
- Checks: `pnpm check` (completed with existing repository warnings only).
- Performance: No additional database or network calls; only local string scanning for events missing structured join links, with low hot-path risk.

Linear: https://linear.app/inbox-zero-ai/issue/INB-319/meetings-page-only-shows-meetings-where-user-is-the-organizer-ignoring

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

