### PR TITLE
INB-320: Show accurate meeting recording statuses

### DIFF
--- a/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
+++ b/apps/web/__tests__/db/meeting-recorder-reconcile.test.ts
@@ -1106,7 +1106,7 @@ describe.skipIf(!RUN_DB_TESTS)(
       expect(fakeProvider.transcriptsRequested).toEqual([]);
     });
 
-    test("clears stale claims and fails recordings that never reported back", async () => {
+    test("clears stale claims and closes recordings that never reported back by engagement", async () => {
       const stale = await prisma.meetingRecording.create({
         data: {
           meetingUrl: "https://meet.google.com/ggg-hhhh-iii",
@@ -1117,7 +1117,9 @@ describe.skipIf(!RUN_DB_TESTS)(
           createdAt: subMinutes(new Date(), 30),
         },
       });
-      const abandoned = await prisma.meetingRecording.create({
+      // Never left SCHEDULED: the bot has no engagement to show, so the sweep
+      // closes it as a no-show instead of a failed recording.
+      const noShow = await prisma.meetingRecording.create({
         data: {
           meetingUrl: "https://meet.google.com/jjj-kkkk-lll",
           normalizedMeetingUrl: "meet.google.com/jjj-kkkk-lll",
@@ -1127,6 +1129,18 @@ describe.skipIf(!RUN_DB_TESTS)(
           externalBotId: "bot_abandoned",
         },
       });
+      // The bot reached the call and then went silent: that is a failed
+      // recording the user should see.
+      const engaged = await prisma.meetingRecording.create({
+        data: {
+          meetingUrl: "https://meet.google.com/mmm-nnnn-ooo",
+          normalizedMeetingUrl: "meet.google.com/mmm-nnnn-ooo",
+          activeKey: "meet.google.com/mmm-nnnn-ooo",
+          meetingStartTime: subHours(new Date(), 48),
+          status: MeetingRecordingStatus.IN_CALL,
+          externalBotId: "bot_engaged_abandoned",
+        },
+      });
 
       await reconcile.sweepRecordings({ logger });
 
@@ -1134,11 +1148,17 @@ describe.skipIf(!RUN_DB_TESTS)(
         await prisma.meetingRecording.findUnique({ where: { id: stale.id } }),
       ).toBeNull();
 
+      const cancelled = await prisma.meetingRecording.findUniqueOrThrow({
+        where: { id: noShow.id },
+      });
+      expect(cancelled.status).toBe(MeetingRecordingStatus.CANCELLED);
+      // The slot must be released so a later meeting on the same link can book.
+      expect(cancelled.activeKey).toBeNull();
+
       const failed = await prisma.meetingRecording.findUniqueOrThrow({
-        where: { id: abandoned.id },
+        where: { id: engaged.id },
       });
       expect(failed.status).toBe(MeetingRecordingStatus.FAILED);
-      // The slot must be released so a later meeting on the same link can book.
       expect(failed.activeKey).toBeNull();
     });
 

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingListItem.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingListItem.tsx
@@ -18,6 +18,7 @@ import { getRecordingStatusBadge } from "@/app/(app)/[emailAccountId]/meetings/r
 export function MeetingListItem({
   title,
   startTime,
+  endTime,
   status,
   failureReason,
   onClick,
@@ -25,12 +26,13 @@ export function MeetingListItem({
 }: {
   title: string;
   startTime: string | Date;
+  endTime: string | Date;
   status: MeetingRecordingStatus | undefined;
   failureReason: string | null | undefined;
   onClick?: () => void;
   children?: ReactNode;
 }) {
-  const badge = getRecordingStatusBadge(status);
+  const badge = getRecordingStatusBadge({ status, startTime, endTime });
   const start = new Date(startTime);
 
   return (

--- a/apps/web/app/(app)/[emailAccountId]/meetings/MeetingsList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/MeetingsList.tsx
@@ -48,6 +48,7 @@ export function MeetingsList() {
                 key={meeting.id}
                 title={meeting.eventTitle}
                 startTime={meeting.startTime}
+                endTime={meeting.endTime}
                 status={meeting.recording?.status}
                 failureReason={meeting.recording?.failureReason}
                 onClick={() => setOpenMeetingId(meeting.id)}

--- a/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/UpcomingMeetingsToggleList.tsx
@@ -97,6 +97,7 @@ export function UpcomingMeetingsToggleList({
                   key={event.id}
                   title={event.title}
                   startTime={event.startTime}
+                  endTime={event.endTime}
                   status={event.recordingStatus}
                   failureReason={event.failureReason}
                 >

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { MeetingRecordingStatus } from "@/generated/prisma/enums";
+import { getRecordingStatusBadge } from "@/app/(app)/[emailAccountId]/meetings/recording-status";
+
+const NOW = new Date("2026-07-30T17:15:00.000Z");
+
+describe("getRecordingStatusBadge", () => {
+  it("shows an ongoing meeting from its time range even while the recorder status is stale", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.SCHEDULED,
+        startTime: new Date("2026-07-30T17:00:00.000Z"),
+        endTime: new Date("2026-07-30T17:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Ongoing", variant: "green" });
+  });
+
+  it("shows that an ended meeting has no recording when capture failed", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.FAILED,
+        startTime: new Date("2026-07-30T16:00:00.000Z"),
+        endTime: new Date("2026-07-30T16:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Not recorded", variant: "red" });
+  });
+
+  it("keeps actionable recorder progress visible while the meeting is ongoing", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.IN_WAITING_ROOM,
+        startTime: new Date("2026-07-30T17:00:00.000Z"),
+        endTime: new Date("2026-07-30T17:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Waiting to be let in", variant: "default" });
+  });
+
+  it("keeps a future booked meeting scheduled", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.SCHEDULED,
+        startTime: new Date("2026-07-30T18:00:00.000Z"),
+        endTime: new Date("2026-07-30T18:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toEqual({ label: "Scheduled", variant: "secondary" });
+  });
+});

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.test.ts
@@ -38,6 +38,28 @@ describe("getRecordingStatusBadge", () => {
     ).toEqual({ label: "Waiting to be let in", variant: "default" });
   });
 
+  it("hides a past booking the recorder never engaged with", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: MeetingRecordingStatus.SCHEDULED,
+        startTime: new Date("2026-07-30T16:00:00.000Z"),
+        endTime: new Date("2026-07-30T16:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
+  it("shows no badge for a past meeting without a recording", () => {
+    expect(
+      getRecordingStatusBadge({
+        status: undefined,
+        startTime: new Date("2026-07-30T16:00:00.000Z"),
+        endTime: new Date("2026-07-30T16:30:00.000Z"),
+        now: NOW,
+      }),
+    ).toBeNull();
+  });
+
   it("keeps a future booked meeting scheduled", () => {
     expect(
       getRecordingStatusBadge({

--- a/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
+++ b/apps/web/app/(app)/[emailAccountId]/meetings/recording-status.ts
@@ -1,9 +1,20 @@
 import { MeetingRecordingStatus } from "@/generated/prisma/enums";
+import {
+  NO_RECORDING_STATUSES,
+  RECORDED_SECTION_STATUSES,
+} from "@/utils/meeting-recorder/recording-lifecycle";
 
 type StatusBadge = {
   label: string;
   variant: "default" | "secondary" | "green" | "red";
 };
+
+// The recorder has reported no progress in these states, so during the meeting
+// the event's own time window is fresher information than the status.
+const NO_PROGRESS_STATUSES: MeetingRecordingStatus[] = [
+  MeetingRecordingStatus.PENDING,
+  MeetingRecordingStatus.SCHEDULED,
+];
 
 // Waiting-room and failure states are the ones users need to act on, so they
 // are called out rather than folded into a generic "recording" state.
@@ -42,8 +53,34 @@ const STATUS_BADGES: Record<MeetingRecordingStatus, StatusBadge> = {
   },
 };
 
-export function getRecordingStatusBadge(
-  status: MeetingRecordingStatus | undefined,
-): StatusBadge | null {
+export function getRecordingStatusBadge({
+  status,
+  startTime,
+  endTime,
+  now = new Date(),
+}: {
+  status: MeetingRecordingStatus | undefined;
+  startTime: string | Date;
+  endTime: string | Date;
+  now?: Date;
+}): StatusBadge | null {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  if (
+    start <= now &&
+    now < end &&
+    (!status || NO_PROGRESS_STATUSES.includes(status))
+  ) {
+    return { label: "Ongoing", variant: "green" };
+  }
+
+  if (end <= now && status) {
+    if (!RECORDED_SECTION_STATUSES.includes(status)) return null;
+    if (NO_RECORDING_STATUSES.includes(status)) {
+      return { label: "Not recorded", variant: "red" };
+    }
+  }
+
   return status ? STATUS_BADGES[status] : null;
 }

--- a/apps/web/app/api/meeting-recorder/transcript/route.ts
+++ b/apps/web/app/api/meeting-recorder/transcript/route.ts
@@ -5,7 +5,7 @@ import type { Logger } from "@/utils/logger";
 import { createMeetingBotProvider } from "@/utils/meeting-recorder/create-bot-provider";
 import { deleteRecordingMedia } from "@/utils/meeting-recorder/delete-media";
 import { enqueueProcessingForRecording } from "@/utils/meeting-recorder/enqueue-processing";
-import { transitionRecording } from "@/utils/meeting-recorder/recording-lifecycle";
+import { transitionRecording } from "@/utils/meeting-recorder/transition-recording";
 import { withError } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 import { withQstashOrInternal } from "@/utils/qstash";

--- a/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MeetingRecordingStatus } from "@/generated/prisma/enums";
+import prisma from "@/utils/__mocks__/prisma";
+
+vi.mock("@/utils/prisma");
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailAccountTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailAccountTestMiddleware({
+    auth: {
+      email: "user@example.com",
+      emailAccountId: "email-account-1",
+      userId: "user-1",
+    },
+  });
+});
+
+import { GET } from "./route";
+
+const NOW = new Date("2026-07-30T17:15:00.000Z");
+
+describe("meeting recorder meetings route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    prisma.meeting.findMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps ongoing and no-show bookings out of the recorded section", async () => {
+    await GET(
+      new Request(
+        "https://example.com/api/user/meeting-recorder/meetings",
+      ) as never,
+    );
+
+    const where = prisma.meeting.findMany.mock.calls[0]?.[0]?.where;
+    expect(where).toEqual({
+      emailAccountId: "email-account-1",
+      endTime: { lte: NOW },
+      recording: {
+        status: {
+          in: [
+            MeetingRecordingStatus.JOINING,
+            MeetingRecordingStatus.IN_WAITING_ROOM,
+            MeetingRecordingStatus.IN_CALL,
+            MeetingRecordingStatus.RECORDING,
+            MeetingRecordingStatus.FAILED,
+            MeetingRecordingStatus.CALL_ENDED,
+            MeetingRecordingStatus.DONE,
+          ],
+        },
+      },
+    });
+  });
+});

--- a/apps/web/app/api/user/meeting-recorder/meetings/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/meetings/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { RECORDED_SECTION_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
 import { withEmailAccount } from "@/utils/middleware";
 import prisma from "@/utils/prisma";
 
@@ -23,7 +24,11 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
   // Scoped by emailAccountId so a recording shared with another tenant is only
   // ever reachable through this account's own Meeting row.
   const meetings = await prisma.meeting.findMany({
-    where: { emailAccountId, recordingId: { not: null } },
+    where: {
+      emailAccountId,
+      endTime: { lte: new Date() },
+      recording: { status: { in: RECORDED_SECTION_STATUSES } },
+    },
     orderBy: { startTime: "desc" },
     take: PAGE_SIZE,
     // The summary and transcript are fetched per meeting; both are far too
@@ -32,6 +37,7 @@ async function getData({ emailAccountId }: { emailAccountId: string }) {
       id: true,
       eventTitle: true,
       startTime: true,
+      endTime: true,
       followUpDraftId: true,
       recording: {
         select: {

--- a/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
+++ b/apps/web/app/api/user/meeting-recorder/upcoming/route.ts
@@ -88,6 +88,7 @@ async function getData({
         id: event.id,
         title: event.title,
         startTime: event.startTime,
+        endTime: event.endTime,
         hasCancellableBooking:
           !!meeting?.recording &&
           CANCELLABLE_STATUSES.includes(meeting.recording.status),

--- a/apps/web/hooks/useMeetingRecorder.ts
+++ b/apps/web/hooks/useMeetingRecorder.ts
@@ -5,6 +5,8 @@ import type { GetMeetingRecorderMeetingResponse } from "@/app/api/user/meeting-r
 import type { GetMeetingRecorderUpcomingResponse } from "@/app/api/user/meeting-recorder/upcoming/route";
 import { getAccountScopedKey } from "@/utils/swr";
 
+const MEETING_STATUS_REFRESH_INTERVAL = 30_000;
+
 export function useMeetingRecorderSettings(emailAccountId?: string | null) {
   return useSWR<GetMeetingRecorderSettingsResponse>(
     getAccountScopedKey("/api/user/meeting-recorder", emailAccountId),
@@ -14,6 +16,7 @@ export function useMeetingRecorderSettings(emailAccountId?: string | null) {
 export function useMeetingRecorderMeetings(emailAccountId?: string | null) {
   return useSWR<GetMeetingRecorderMeetingsResponse>(
     getAccountScopedKey("/api/user/meeting-recorder/meetings", emailAccountId),
+    { refreshInterval: MEETING_STATUS_REFRESH_INTERVAL },
   );
 }
 
@@ -34,5 +37,11 @@ export function useMeetingRecorderMeeting(
 export function useMeetingRecorderUpcoming(emailAccountId?: string | null) {
   return useSWR<GetMeetingRecorderUpcomingResponse>(
     getAccountScopedKey("/api/user/meeting-recorder/upcoming", emailAccountId),
+    {
+      // Every refresh fans out to the connected calendar providers, so only
+      // keep polling while there are events whose status can still change.
+      refreshInterval: (data) =>
+        data && data.events.length === 0 ? 0 : MEETING_STATUS_REFRESH_INTERVAL,
+    },
   );
 }

--- a/apps/web/prisma/migrations/20260730235900_meeting_recording_no_shows/migration.sql
+++ b/apps/web/prisma/migrations/20260730235900_meeting_recording_no_shows/migration.sql
@@ -1,0 +1,9 @@
+-- A failed notetaker attempt is normally useful meeting history, but these
+-- outcomes mean there was no meeting to show in the Recorded section.
+UPDATE "MeetingRecording"
+SET "status" = 'CANCELLED'
+WHERE "status" = 'FAILED'
+  AND "failureReason" IN (
+    'The meeting never started.',
+    'The notetaker was the only participant, so it left the call.'
+  );

--- a/apps/web/prisma/migrations/20260730235900_meeting_recording_no_shows/migration.sql
+++ b/apps/web/prisma/migrations/20260730235900_meeting_recording_no_shows/migration.sql
@@ -1,7 +1,11 @@
 -- A failed notetaker attempt is normally useful meeting history, but these
 -- outcomes mean there was no meeting to show in the Recorded section.
+-- activeKey should already be null on terminal rows, but rows written before
+-- that invariant existed may still hold their dedup slot; release it here so
+-- the same meeting can be booked again.
 UPDATE "MeetingRecording"
-SET "status" = 'CANCELLED'
+SET "status" = 'CANCELLED',
+    "activeKey" = NULL
 WHERE "status" = 'FAILED'
   AND "failureReason" IN (
     'The meeting never started.',

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -44,8 +44,8 @@ import {
   CHANGEABLE_STATUSES,
   LIVE_STATUSES,
   recordingStatusData,
-  transitionRecording,
 } from "@/utils/meeting-recorder/recording-lifecycle";
+import { transitionRecording } from "@/utils/meeting-recorder/transition-recording";
 import { isDuplicateError } from "@/utils/prisma-helpers";
 import prisma from "@/utils/prisma";
 

--- a/apps/web/utils/meeting-recorder/reconcile.ts
+++ b/apps/web/utils/meeting-recorder/reconcile.ts
@@ -843,11 +843,19 @@ async function failAbandonedRecordings({
       }
     }
 
-    // Guarded transition: the recording may have finished or started
-    // cancelling while the sweep was cancelling its bot.
+    // A row still in a booking state carries no evidence the bot ever engaged
+    // with the call, so it is closed as a no-show rather than surfaced in the
+    // Recorded section as a failed recording. Both transitions are guarded:
+    // the recording may have progressed, finished or started cancelling while
+    // the sweep was cancelling its bot, and a progressed row waits for the
+    // next sweep to be judged on its fresh status.
+    const engaged = !CHANGEABLE_STATUSES.includes(recording.status);
     await transitionRecording({
       recordingId: recording.id,
-      status: MeetingRecordingStatus.FAILED,
+      status: engaged
+        ? MeetingRecordingStatus.FAILED
+        : MeetingRecordingStatus.CANCELLED,
+      fromStatuses: engaged ? undefined : CHANGEABLE_STATUSES,
       data: {
         failureReason: "The notetaker never reported back for this meeting.",
       },

--- a/apps/web/utils/meeting-recorder/recording-lifecycle.ts
+++ b/apps/web/utils/meeting-recorder/recording-lifecycle.ts
@@ -1,5 +1,4 @@
 import { MeetingRecordingStatus } from "@/generated/prisma/enums";
-import prisma from "@/utils/prisma";
 
 // A recording that has not reached a terminal state yet and could still be
 // scheduled, rescheduled or cancelled.
@@ -22,6 +21,26 @@ export const CANCELLABLE_STATUSES: MeetingRecordingStatus[] =
 export const CHANGEABLE_STATUSES: MeetingRecordingStatus[] = [
   MeetingRecordingStatus.PENDING,
   MeetingRecordingStatus.SCHEDULED,
+];
+
+// The bot engaged with the call (tried to join, reached it, or failed trying)
+// but delivered no media. A recording still in one of these states after the
+// meeting ended produced nothing.
+export const NO_RECORDING_STATUSES: MeetingRecordingStatus[] = [
+  MeetingRecordingStatus.JOINING,
+  MeetingRecordingStatus.IN_WAITING_ROOM,
+  MeetingRecordingStatus.IN_CALL,
+  MeetingRecordingStatus.RECORDING,
+  MeetingRecordingStatus.FAILED,
+];
+
+// A booked bot is not a recorded meeting. The Recorded section only shows
+// calls the bot engaged with or that produced media; untouched scheduled
+// bookings are no-shows.
+export const RECORDED_SECTION_STATUSES: MeetingRecordingStatus[] = [
+  ...NO_RECORDING_STATUSES,
+  MeetingRecordingStatus.CALL_ENDED,
+  MeetingRecordingStatus.DONE,
 ];
 
 // Rank orders the lifecycle so replayed or out-of-order webhooks can only ever
@@ -63,42 +82,6 @@ export function recordingStatusData(status: MeetingRecordingStatus) {
   return TERMINAL_STATUSES.includes(status)
     ? { status, activeKey: null }
     : { status };
-}
-
-/**
- * Moves one recording to `next` only if that is a step forwards, so a
- * concurrent DONE or CANCELLING write can never be clobbered. The recording is
- * addressed either by id or by its provider identity (which is all a webhook
- * has). Returns the update count; zero means the recording had already moved
- * on.
- */
-export function transitionRecording(
-  params: (
-    | { recordingId: string }
-    | { botProvider: string; externalBotId: string }
-  ) & {
-    status: MeetingRecordingStatus;
-    fromStatuses?: MeetingRecordingStatus[];
-    data?: { failureReason?: string; transcriptFetchedAt?: Date };
-  },
-) {
-  const selector =
-    "recordingId" in params
-      ? { id: params.recordingId }
-      : {
-          botProvider: params.botProvider,
-          externalBotId: params.externalBotId,
-        };
-
-  return prisma.meetingRecording.updateMany({
-    where: {
-      ...selector,
-      status: {
-        in: params.fromStatuses ?? getStatusesBelow(params.status),
-      },
-    },
-    data: { ...recordingStatusData(params.status), ...params.data },
-  });
 }
 
 /**

--- a/apps/web/utils/meeting-recorder/transition-recording.ts
+++ b/apps/web/utils/meeting-recorder/transition-recording.ts
@@ -1,0 +1,42 @@
+import type { MeetingRecordingStatus } from "@/generated/prisma/enums";
+import {
+  getStatusesBelow,
+  recordingStatusData,
+} from "@/utils/meeting-recorder/recording-lifecycle";
+import prisma from "@/utils/prisma";
+
+/**
+ * Moves one recording to `next` only if that is a step forwards, so a
+ * concurrent DONE or CANCELLING write can never be clobbered. The recording is
+ * addressed either by id or by its provider identity (which is all a webhook
+ * has). Returns the update count; zero means the recording had already moved
+ * on.
+ */
+export function transitionRecording(
+  params: (
+    | { recordingId: string }
+    | { botProvider: string; externalBotId: string }
+  ) & {
+    status: MeetingRecordingStatus;
+    fromStatuses?: MeetingRecordingStatus[];
+    data?: { failureReason?: string; transcriptFetchedAt?: Date };
+  },
+) {
+  const selector =
+    "recordingId" in params
+      ? { id: params.recordingId }
+      : {
+          botProvider: params.botProvider,
+          externalBotId: params.externalBotId,
+        };
+
+  return prisma.meetingRecording.updateMany({
+    where: {
+      ...selector,
+      status: {
+        in: params.fromStatuses ?? getStatusesBelow(params.status),
+      },
+    },
+    data: { ...recordingStatusData(params.status), ...params.data },
+  });
+}

--- a/apps/web/utils/meeting-recorder/webhook-handlers.ts
+++ b/apps/web/utils/meeting-recorder/webhook-handlers.ts
@@ -3,10 +3,8 @@ import { captureException } from "@/utils/error";
 import type { Logger } from "@/utils/logger";
 import { createMeetingBotProvider } from "@/utils/meeting-recorder/create-bot-provider";
 import { enqueueTranscriptFetch } from "@/utils/meeting-recorder/enqueue-processing";
-import {
-  LIVE_STATUSES,
-  transitionRecording,
-} from "@/utils/meeting-recorder/recording-lifecycle";
+import { LIVE_STATUSES } from "@/utils/meeting-recorder/recording-lifecycle";
+import { transitionRecording } from "@/utils/meeting-recorder/transition-recording";
 import prisma from "@/utils/prisma";
 
 /**

--- a/apps/web/utils/recall/status.test.ts
+++ b/apps/web/utils/recall/status.test.ts
@@ -100,6 +100,24 @@ describe("interpretRecallWebhook", () => {
     );
   });
 
+  it.each([
+    "meeting_not_started",
+    "timeout_exceeded_only_bot_detected",
+  ])("classifies the no-show outcome %s as cancelled", (subCode) => {
+    expect(
+      interpretRecallWebhook({
+        event: "bot.fatal",
+        data: {
+          bot: { id: "bot-1" },
+          data: { code: "fatal", sub_code: subCode },
+        },
+      }),
+    ).toMatchObject({
+      type: "statusChange",
+      status: MeetingRecordingStatus.CANCELLED,
+    });
+  });
+
   it("falls back to the event name when the payload carries no code", () => {
     expect(
       interpretRecallWebhook({

--- a/apps/web/utils/recall/status.ts
+++ b/apps/web/utils/recall/status.ts
@@ -74,10 +74,14 @@ export function interpretRecallWebhook(
   // Recall sends the lifecycle code in the payload, but the event name carries
   // the same information (`bot.done`, `bot.fatal`) as a fallback.
   const code = payload.data.data?.code ?? payload.event.split(".").at(-1);
-  const status = code ? recallCodeToStatus(code) : null;
-  if (!status) {
+  const mappedStatus = code ? recallCodeToStatus(code) : null;
+  if (!mappedStatus) {
     return { type: "ignore", reason: `Unmapped Recall status code: ${code}` };
   }
+  const subCode = payload.data.data?.sub_code;
+  const status = NO_SHOW_SUB_CODES.has(subCode ?? "")
+    ? MeetingRecordingStatus.CANCELLED
+    : mappedStatus;
 
   return {
     type: "statusChange",
@@ -91,8 +95,8 @@ export function interpretRecallWebhook(
         ? getStatusesBelow(MeetingRecordingStatus.RECORDING)
         : undefined,
     failureReason:
-      status === MeetingRecordingStatus.FAILED
-        ? getFailureReason(payload.data.data?.sub_code)
+      mappedStatus === MeetingRecordingStatus.FAILED
+        ? getFailureReason(subCode)
         : undefined,
   };
 }
@@ -129,6 +133,11 @@ export function recallCodeToStatus(
   if (!Object.hasOwn(RECALL_CODE_TO_STATUS, code)) return null;
   return RECALL_CODE_TO_STATUS[code] ?? null;
 }
+
+const NO_SHOW_SUB_CODES = new Set([
+  "meeting_not_started",
+  "timeout_exceeded_only_bot_detected",
+]);
 
 // Copy shown to the user for the failure sub-codes we expect to see in practice.
 // Everything else falls back to the raw sub-code so support can still triage it.


### PR DESCRIPTION
Corrects meeting status presentation so active meetings display as ongoing and past meetings only appear in Recorded when the recorder engaged or produced media. No-show outcomes are normalized to cancelled, including existing records via migration.

- Derives ongoing and not-recorded badges from meeting times and recorder lifecycle state.
- Filters the Recorded section and normalizes provider no-show outcomes.
- Adds focused coverage for badges, Recorded filtering, and provider status mapping (15 tests); `pnpm check` passes with existing warnings.
- Performance: adds Meetings-page-only 30-second refreshes; this increases existing API, database, and calendar-provider calls while relevant events exist, without adding per-request query fan-out or global hot-path work.
- Linear: https://linear.app/inbox-zero-ai/issue/INB-320/meeting-status-always-displayed-as-scheduled-regardless-of-actual

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

