### PR TITLE
Add cursor-based mobile mailbox sync

### DIFF
--- a/apps/web/__tests__/mocks/email-provider.mock.ts
+++ b/apps/web/__tests__/mocks/email-provider.mock.ts
@@ -80,6 +80,13 @@ export function createMockEmailProvider(
     getMessagesWithPagination: vi
       .fn()
       .mockResolvedValue({ messages: [], nextPageToken: undefined }),
+    getMailboxSyncPage: vi.fn().mockResolvedValue({
+      cursor: "sync-cursor",
+      deletedMessageIds: [],
+      hasMore: false,
+      reset: false,
+      upsertedMessages: [],
+    }),
     searchMessages: vi
       .fn()
       .mockResolvedValue({ messages: [], nextPageToken: undefined }),

--- a/apps/web/app/api/mobile/mailbox-sync/route.test.ts
+++ b/apps/web/app/api/mobile/mailbox-sync/route.test.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { InvalidMailboxSyncCursorError } from "@/utils/email/mailbox-sync";
+
+const { getMailboxSyncPageMock } = vi.hoisted(() => ({
+  getMailboxSyncPageMock: vi.fn(),
+}));
+
+vi.mock("@/utils/middleware", async () => {
+  const { createWithEmailProviderTestMiddleware } = await vi.importActual<
+    typeof import("@/__tests__/helpers")
+  >("@/__tests__/helpers");
+
+  return createWithEmailProviderTestMiddleware({
+    getMailboxSyncPage: getMailboxSyncPageMock,
+  });
+});
+
+import { POST } from "./route";
+
+describe("POST /api/mobile/mailbox-sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMailboxSyncPageMock.mockResolvedValue({
+      cursor: "next-cursor",
+      deletedMessageIds: ["deleted-1"],
+      hasMore: false,
+      reset: false,
+      upsertedMessages: [],
+    });
+  });
+
+  it("starts a bounded account sync from the requested date", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/mailbox-sync", {
+        method: "POST",
+        body: JSON.stringify({
+          after: "2026-07-01T00:00:00.000Z",
+          limit: 50,
+        }),
+      }),
+      {} as never,
+    );
+
+    expect(getMailboxSyncPageMock).toHaveBeenCalledWith({
+      after: new Date("2026-07-01T00:00:00.000Z"),
+      cursor: undefined,
+      limit: 50,
+    });
+    await expect(response.json()).resolves.toEqual({
+      accountId: "email-account-1",
+      cursor: "next-cursor",
+      deletedMessageIds: ["deleted-1"],
+      hasMore: false,
+      reset: false,
+      upsertedMessages: [],
+    });
+  });
+
+  it("continues from an opaque cursor without requiring a date", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/mailbox-sync", {
+        method: "POST",
+        body: JSON.stringify({ cursor: "opaque-cursor" }),
+      }),
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(getMailboxSyncPageMock).toHaveBeenCalledWith({
+      after: undefined,
+      cursor: "opaque-cursor",
+      limit: 100,
+    });
+  });
+
+  it("rejects an invalid cursor without exposing provider errors", async () => {
+    getMailboxSyncPageMock.mockRejectedValue(
+      new InvalidMailboxSyncCursorError(),
+    );
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/mobile/mailbox-sync", {
+        method: "POST",
+        body: JSON.stringify({ cursor: "tampered" }),
+      }),
+      {} as never,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid mailbox sync cursor",
+    });
+  });
+});

--- a/apps/web/app/api/mobile/mailbox-sync/route.test.ts
+++ b/apps/web/app/api/mobile/mailbox-sync/route.test.ts
@@ -74,6 +74,19 @@ describe("POST /api/mobile/mailbox-sync", () => {
     });
   });
 
+  it("rejects a null initial sync date", async () => {
+    await expect(
+      POST(
+        new NextRequest("http://localhost:3000/api/mobile/mailbox-sync", {
+          method: "POST",
+          body: JSON.stringify({ after: null }),
+        }),
+        {} as never,
+      ),
+    ).rejects.toThrow();
+    expect(getMailboxSyncPageMock).not.toHaveBeenCalled();
+  });
+
   it("rejects an invalid cursor without exposing provider errors", async () => {
     getMailboxSyncPageMock.mockRejectedValue(
       new InvalidMailboxSyncCursorError(),

--- a/apps/web/app/api/mobile/mailbox-sync/route.ts
+++ b/apps/web/app/api/mobile/mailbox-sync/route.ts
@@ -8,7 +8,11 @@ export const maxDuration = 60;
 
 const bodySchema = z
   .object({
-    after: z.coerce.date().optional(),
+    after: z
+      .string()
+      .datetime()
+      .transform((value) => new Date(value))
+      .optional(),
     cursor: z.string().min(1).max(16_384).optional(),
     limit: z.number().int().min(1).max(100).default(100),
   })

--- a/apps/web/app/api/mobile/mailbox-sync/route.ts
+++ b/apps/web/app/api/mobile/mailbox-sync/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { InvalidMailboxSyncCursorError } from "@/utils/email/mailbox-sync";
+import type { EmailProvider } from "@/utils/email/types";
+import { withEmailProvider } from "@/utils/middleware";
+
+export const maxDuration = 60;
+
+const bodySchema = z
+  .object({
+    after: z.coerce.date().optional(),
+    cursor: z.string().min(1).max(16_384).optional(),
+    limit: z.number().int().min(1).max(100).default(100),
+  })
+  .superRefine(({ after, cursor }, context) => {
+    if (!after && !cursor) {
+      context.addIssue({
+        code: "custom",
+        message: "after is required when cursor is omitted",
+        path: ["after"],
+      });
+    }
+  });
+
+export type MailboxSyncResponse = Awaited<ReturnType<typeof getData>>;
+
+// POST keeps long, opaque Microsoft delta links out of request URLs and access
+// logs while preserving a stable native-mobile sync contract.
+export const POST = withEmailProvider(
+  "mobile/mailbox-sync",
+  async (request) => {
+    const input = bodySchema.parse(await request.json());
+
+    try {
+      return NextResponse.json(
+        await getData({
+          accountId: request.auth.emailAccountId,
+          emailProvider: request.emailProvider,
+          ...input,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof InvalidMailboxSyncCursorError) {
+        return NextResponse.json(
+          { error: "Invalid mailbox sync cursor" },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+  },
+);
+
+async function getData({
+  accountId,
+  emailProvider,
+  cursor,
+  after,
+  limit,
+}: {
+  accountId: string;
+  emailProvider: Pick<EmailProvider, "getMailboxSyncPage">;
+  cursor?: string;
+  after?: Date;
+  limit: number;
+}) {
+  const page = await emailProvider.getMailboxSyncPage({
+    after,
+    cursor,
+    limit,
+  });
+  return { accountId, ...page };
+}

--- a/apps/web/utils/__mocks__/email-provider.ts
+++ b/apps/web/utils/__mocks__/email-provider.ts
@@ -122,6 +122,13 @@ export const createMockEmailProvider = (
   getMessagesWithPagination: vi
     .fn()
     .mockResolvedValue({ messages: [], nextPageToken: undefined }),
+  getMailboxSyncPage: vi.fn().mockResolvedValue({
+    cursor: "sync-cursor",
+    deletedMessageIds: [],
+    hasMore: false,
+    reset: false,
+    upsertedMessages: [],
+  }),
   searchMessages: vi
     .fn()
     .mockResolvedValue({ messages: [], nextPageToken: undefined }),

--- a/apps/web/utils/email/google.ts
+++ b/apps/web/utils/email/google.ts
@@ -90,6 +90,7 @@ import { getGmailSignatures } from "@/utils/gmail/signature-settings";
 import { withRateLimitRecording } from "@/utils/email/rate-limit";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
 import { extractUniqueEmailAddresses } from "@/utils/email";
+import { getGmailMailboxSyncPage } from "@/utils/gmail/mailbox-sync";
 
 export class GmailProvider implements EmailProvider {
   readonly name = "google";
@@ -1369,6 +1370,19 @@ export class GmailProvider implements EmailProvider {
       messageIds,
       accessToken: getAccessTokenFromClient(this.client),
       logger: this.logger,
+    });
+  }
+
+  async getMailboxSyncPage(options: {
+    after?: Date;
+    cursor?: string;
+    limit: number;
+  }) {
+    return getGmailMailboxSyncPage({
+      gmail: this.client,
+      accessToken: getAccessTokenFromClient(this.client),
+      logger: this.logger,
+      ...options,
     });
   }
 

--- a/apps/web/utils/email/mailbox-sync.test.ts
+++ b/apps/web/utils/email/mailbox-sync.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { getMockMessage } from "@/__tests__/helpers";
+import {
+  compactMailboxSyncMessage,
+  decodeMailboxSyncCursor,
+  encodeMailboxSyncCursor,
+  InvalidMailboxSyncCursorError,
+} from "@/utils/email/mailbox-sync";
+
+describe("mailbox sync cursor", () => {
+  it("round-trips a provider-bound cursor", () => {
+    const encoded = encodeMailboxSyncCursor({
+      version: 1,
+      provider: "google",
+      phase: "delta",
+      historyId: "12345",
+      after: "2026-07-01T00:00:00.000Z",
+    });
+
+    expect(decodeMailboxSyncCursor(encoded, "google")).toEqual({
+      version: 1,
+      provider: "google",
+      phase: "delta",
+      historyId: "12345",
+      after: "2026-07-01T00:00:00.000Z",
+    });
+    expect(() => decodeMailboxSyncCursor(encoded, "microsoft")).toThrow(
+      InvalidMailboxSyncCursorError,
+    );
+  });
+
+  it("rejects Microsoft cursors that could send credentials off Graph", () => {
+    const encoded = encodeMailboxSyncCursor({
+      version: 1,
+      provider: "microsoft",
+      deltaLink:
+        "https://attacker.example/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=secret",
+      after: "2026-07-01T00:00:00.000Z",
+      snapshot: false,
+    });
+
+    expect(() => decodeMailboxSyncCursor(encoded, "microsoft")).toThrow(
+      InvalidMailboxSyncCursorError,
+    );
+  });
+});
+
+describe("compactMailboxSyncMessage", () => {
+  it("keeps list metadata while removing message bodies and attachments", () => {
+    const message = getMockMessage({
+      textPlain: "private plain body",
+      textHtml: "<p>private html body</p>",
+      attachments: [{ filename: "large.pdf" }],
+    });
+
+    expect(compactMailboxSyncMessage(message)).toMatchObject({
+      id: "msg1",
+      subject: "Test",
+      attachments: undefined,
+      inline: [],
+      textHtml: undefined,
+      textPlain: undefined,
+    });
+  });
+});

--- a/apps/web/utils/email/mailbox-sync.test.ts
+++ b/apps/web/utils/email/mailbox-sync.test.ts
@@ -53,13 +53,15 @@ describe("compactMailboxSyncMessage", () => {
       attachments: [{ filename: "large.pdf" }],
     });
 
-    expect(compactMailboxSyncMessage(message)).toMatchObject({
+    const compacted = compactMailboxSyncMessage(message);
+
+    expect(compacted).toMatchObject({
       id: "msg1",
       subject: "Test",
-      attachments: undefined,
       inline: [],
-      textHtml: undefined,
-      textPlain: undefined,
     });
+    expect(compacted.attachments).toBeUndefined();
+    expect(compacted.textHtml).toBeUndefined();
+    expect(compacted.textPlain).toBeUndefined();
   });
 });

--- a/apps/web/utils/email/mailbox-sync.ts
+++ b/apps/web/utils/email/mailbox-sync.ts
@@ -36,10 +36,12 @@ export function encodeMailboxSyncCursor(cursor: MailboxSyncCursor): string {
   return Buffer.from(JSON.stringify(cursor)).toString("base64url");
 }
 
-export function decodeMailboxSyncCursor(
+export function decodeMailboxSyncCursor<
+  TProvider extends MailboxSyncCursor["provider"],
+>(
   cursor: string,
-  provider: MailboxSyncCursor["provider"],
-): MailboxSyncCursor {
+  provider: TProvider,
+): Extract<MailboxSyncCursor, { provider: TProvider }> {
   try {
     const parsed = cursorSchema.parse(
       JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")),
@@ -53,7 +55,7 @@ export function decodeMailboxSyncCursor(
     ) {
       throw new InvalidMailboxSyncCursorError();
     }
-    return parsed;
+    return parsed as Extract<MailboxSyncCursor, { provider: TProvider }>;
   } catch (error) {
     if (error instanceof InvalidMailboxSyncCursorError) throw error;
     throw new InvalidMailboxSyncCursorError();

--- a/apps/web/utils/email/mailbox-sync.ts
+++ b/apps/web/utils/email/mailbox-sync.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import type { ParsedMessage } from "@/utils/types";
+
+const gmailCursorSchema = z.object({
+  version: z.literal(1),
+  provider: z.literal("google"),
+  phase: z.enum(["snapshot", "delta"]),
+  historyId: z.string().regex(/^\d+$/),
+  after: z.string().datetime(),
+  pageToken: z.string().min(1).optional(),
+});
+
+const microsoftCursorSchema = z.object({
+  version: z.literal(1),
+  provider: z.literal("microsoft"),
+  deltaLink: z.string().url(),
+  after: z.string().datetime(),
+  snapshot: z.boolean(),
+});
+
+const cursorSchema = z.discriminatedUnion("provider", [
+  gmailCursorSchema,
+  microsoftCursorSchema,
+]);
+
+export type MailboxSyncCursor = z.infer<typeof cursorSchema>;
+
+export class InvalidMailboxSyncCursorError extends Error {
+  constructor() {
+    super("Invalid mailbox sync cursor");
+    this.name = "InvalidMailboxSyncCursorError";
+  }
+}
+
+export function encodeMailboxSyncCursor(cursor: MailboxSyncCursor): string {
+  return Buffer.from(JSON.stringify(cursor)).toString("base64url");
+}
+
+export function decodeMailboxSyncCursor(
+  cursor: string,
+  provider: MailboxSyncCursor["provider"],
+): MailboxSyncCursor {
+  try {
+    const parsed = cursorSchema.parse(
+      JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")),
+    );
+    if (parsed.provider !== provider) {
+      throw new InvalidMailboxSyncCursorError();
+    }
+    if (
+      parsed.provider === "microsoft" &&
+      !isAllowedMicrosoftDeltaLink(parsed.deltaLink)
+    ) {
+      throw new InvalidMailboxSyncCursorError();
+    }
+    return parsed;
+  } catch (error) {
+    if (error instanceof InvalidMailboxSyncCursorError) throw error;
+    throw new InvalidMailboxSyncCursorError();
+  }
+}
+
+export function compactMailboxSyncMessage(
+  message: ParsedMessage,
+): ParsedMessage {
+  return {
+    ...message,
+    attachments: undefined,
+    inline: [],
+    rawRecipients: undefined,
+    textHtml: undefined,
+    textPlain: undefined,
+  };
+}
+
+function isAllowedMicrosoftDeltaLink(value: string): boolean {
+  const url = new URL(value);
+  return (
+    url.protocol === "https:" &&
+    url.hostname === "graph.microsoft.com" &&
+    url.port === "" &&
+    url.username === "" &&
+    url.password === "" &&
+    url.hash === "" &&
+    /^\/v1\.0\/me\/mailFolders\/[^/]+\/messages\/delta$/i.test(url.pathname) &&
+    (url.searchParams.has("$skiptoken") || url.searchParams.has("$deltatoken"))
+  );
+}

--- a/apps/web/utils/email/microsoft.ts
+++ b/apps/web/utils/email/microsoft.ts
@@ -90,6 +90,7 @@ import {
   withOutlookRetry,
 } from "@/utils/outlook/retry";
 import { shouldSkipAutoDraft } from "@/utils/auto-draft";
+import { getOutlookMailboxSyncPage } from "@/utils/outlook/mailbox-sync";
 
 export class OutlookProvider implements EmailProvider {
   readonly name = "microsoft";
@@ -1409,6 +1410,18 @@ export class OutlookProvider implements EmailProvider {
       this.getMessage(messageId),
     );
     return Promise.all(messagePromises);
+  }
+
+  async getMailboxSyncPage(options: {
+    after?: Date;
+    cursor?: string;
+    limit: number;
+  }) {
+    return getOutlookMailboxSyncPage({
+      client: this.client,
+      logger: this.logger,
+      ...options,
+    });
   }
 
   getAccessToken(): string {

--- a/apps/web/utils/email/types.ts
+++ b/apps/web/utils/email/types.ts
@@ -11,6 +11,14 @@ export interface EmailThread {
   snippet: string;
 }
 
+export type MailboxSyncPage = {
+  cursor: string;
+  deletedMessageIds: string[];
+  hasMore: boolean;
+  reset: boolean;
+  upsertedMessages: ParsedMessage[];
+};
+
 export interface EmailLabel {
   color?: {
     textColor?: string;
@@ -146,6 +154,11 @@ export interface EmailProvider {
     thread: Pick<EmailThread, "id" | "messages">,
   ): Promise<ParsedMessage | null>;
   getLatestMessageInThread(threadId: string): Promise<ParsedMessage | null>;
+  getMailboxSyncPage(options: {
+    after?: Date;
+    cursor?: string;
+    limit: number;
+  }): Promise<MailboxSyncPage>;
   getMessage(messageId: string): Promise<ParsedMessage>;
   getMessageByRfc822MessageId(
     rfc822MessageId: string,

--- a/apps/web/utils/gmail/mailbox-sync.test.ts
+++ b/apps/web/utils/gmail/mailbox-sync.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getGmailMailboxChangeIds } from "@/utils/gmail/mailbox-sync";
+
+describe("getGmailMailboxChangeIds", () => {
+  it("deduplicates updates and lets deletion win within one page", () => {
+    const result = getGmailMailboxChangeIds([
+      {
+        messagesAdded: [
+          { message: { id: "added" } },
+          { message: { id: "deleted" } },
+        ],
+        labelsAdded: [{ message: { id: "label-change" } }],
+        labelsRemoved: [
+          { message: { id: "label-change" } },
+          { message: { id: "deleted" } },
+        ],
+        messagesDeleted: [{ message: { id: "deleted" } }],
+      },
+    ]);
+
+    expect(result.upsertIds).toEqual(["added", "label-change"]);
+    expect(result.deletedIds).toEqual(new Set(["deleted"]));
+  });
+});

--- a/apps/web/utils/gmail/mailbox-sync.test.ts
+++ b/apps/web/utils/gmail/mailbox-sync.test.ts
@@ -1,5 +1,94 @@
-import { describe, expect, it } from "vitest";
-import { getGmailMailboxChangeIds } from "@/utils/gmail/mailbox-sync";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestLogger, getMockMessage } from "@/__tests__/helpers";
+import { encodeMailboxSyncCursor } from "@/utils/email/mailbox-sync";
+import { getHistory } from "@/utils/gmail/history";
+import {
+  getGmailMailboxChangeIds,
+  getGmailMailboxSyncPage,
+} from "@/utils/gmail/mailbox-sync";
+import { getMessagesBatch } from "@/utils/gmail/message";
+
+vi.mock("@/utils/gmail/history");
+vi.mock("@/utils/gmail/message");
+
+const logger = createTestLogger();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getGmailMailboxSyncPage", () => {
+  it("only upserts recent Inbox messages and removes messages outside the snapshot scope", async () => {
+    const recentInternalDate = new Date("2026-07-02T00:00:00.000Z")
+      .getTime()
+      .toString();
+    const oldInternalDate = new Date("2025-06-30T00:00:00.000Z")
+      .getTime()
+      .toString();
+
+    vi.mocked(getHistory).mockResolvedValue({
+      history: [
+        {
+          messagesAdded: [
+            { message: { id: "inbox-message" } },
+            { message: { id: "archived-message" } },
+            { message: { id: "old-message" } },
+            { message: { id: "missing-message" } },
+          ],
+          messagesDeleted: [{ message: { id: "deleted-message" } }],
+        },
+      ],
+      historyId: "200",
+    });
+    vi.mocked(getMessagesBatch).mockResolvedValue([
+      {
+        ...getMockMessage({
+          id: "inbox-message",
+          labelIds: ["INBOX"],
+        }),
+        internalDate: recentInternalDate,
+      },
+      {
+        ...getMockMessage({
+          id: "archived-message",
+          labelIds: [],
+        }),
+        internalDate: recentInternalDate,
+      },
+      {
+        ...getMockMessage({
+          id: "old-message",
+          labelIds: ["INBOX"],
+        }),
+        internalDate: oldInternalDate,
+      },
+    ]);
+
+    const page = await getGmailMailboxSyncPage({
+      gmail: {} as never,
+      accessToken: "access-token",
+      logger,
+      cursor: encodeMailboxSyncCursor({
+        version: 1,
+        provider: "google",
+        phase: "delta",
+        historyId: "100",
+        after: "2026-07-01T00:00:00.000Z",
+      }),
+      limit: 100,
+    });
+
+    expect(page.upsertedMessages.map((message) => message.id)).toEqual([
+      "inbox-message",
+    ]);
+    expect(page.deletedMessageIds).toEqual([
+      "deleted-message",
+      "archived-message",
+      "old-message",
+      "missing-message",
+    ]);
+  });
+});
 
 describe("getGmailMailboxChangeIds", () => {
   it("deduplicates updates and lets deletion win within one page", () => {

--- a/apps/web/utils/gmail/mailbox-sync.test.ts
+++ b/apps/web/utils/gmail/mailbox-sync.test.ts
@@ -31,6 +31,7 @@ describe("getGmailMailboxSyncPage", () => {
         {
           messagesAdded: [
             { message: { id: "inbox-message" } },
+            { message: { id: "unavailable-label-message" } },
             { message: { id: "archived-message" } },
             { message: { id: "old-message" } },
             { message: { id: "missing-message" } },
@@ -47,6 +48,11 @@ describe("getGmailMailboxSyncPage", () => {
           labelIds: ["INBOX"],
         }),
         internalDate: recentInternalDate,
+      },
+      {
+        ...getMockMessage({ id: "unavailable-label-message" }),
+        internalDate: recentInternalDate,
+        labelIds: undefined,
       },
       {
         ...getMockMessage({
@@ -80,6 +86,7 @@ describe("getGmailMailboxSyncPage", () => {
 
     expect(page.upsertedMessages.map((message) => message.id)).toEqual([
       "inbox-message",
+      "unavailable-label-message",
     ]);
     expect(page.deletedMessageIds).toEqual([
       "deleted-message",

--- a/apps/web/utils/gmail/mailbox-sync.ts
+++ b/apps/web/utils/gmail/mailbox-sync.ts
@@ -74,7 +74,7 @@ export async function getGmailMailboxSyncPage({
     const afterTimestamp = new Date(decoded.after).getTime();
     const upsertedMessages = fetchedMessages.filter((message) => {
       const isInSnapshotScope =
-        message.labelIds?.includes(GmailLabel.INBOX) &&
+        (!message.labelIds || message.labelIds.includes(GmailLabel.INBOX)) &&
         Number(message.internalDate) >= afterTimestamp;
       if (!isInSnapshotScope) deletedIds.add(message.id);
       return isInSnapshotScope;

--- a/apps/web/utils/gmail/mailbox-sync.ts
+++ b/apps/web/utils/gmail/mailbox-sync.ts
@@ -8,6 +8,7 @@ import {
 import type { MailboxSyncPage } from "@/utils/email/types";
 import { getMessagesBatch } from "@/utils/gmail/message";
 import { getHistory } from "@/utils/gmail/history";
+import { GmailLabel } from "@/utils/gmail/label";
 import { extractErrorInfo, withGmailRetry } from "@/utils/gmail/retry";
 import type { Logger } from "@/utils/logger";
 
@@ -39,10 +40,6 @@ export async function getGmailMailboxSyncPage({
   }
 
   const decoded = decodeMailboxSyncCursor(cursor, "google");
-  if (decoded.provider !== "google") {
-    throw new Error("Expected Google mailbox sync cursor");
-  }
-
   if (decoded.phase === "snapshot") {
     return getGmailSnapshotPage({
       gmail,
@@ -69,12 +66,20 @@ export async function getGmailMailboxSyncPage({
     const { upsertIds, deletedIds } = getGmailMailboxChangeIds(
       response.history ?? [],
     );
-    const upsertedMessages = await fetchMessages({
+    const fetchedMessages = await fetchMessages({
       messageIds: upsertIds,
       accessToken,
       logger,
     });
-    const fetchedIds = new Set(upsertedMessages.map((message) => message.id));
+    const afterTimestamp = new Date(decoded.after).getTime();
+    const upsertedMessages = fetchedMessages.filter((message) => {
+      const isInSnapshotScope =
+        message.labelIds?.includes(GmailLabel.INBOX) &&
+        Number(message.internalDate) >= afterTimestamp;
+      if (!isInSnapshotScope) deletedIds.add(message.id);
+      return isInSnapshotScope;
+    });
+    const fetchedIds = new Set(fetchedMessages.map((message) => message.id));
     for (const messageId of upsertIds) {
       if (!fetchedIds.has(messageId)) deletedIds.add(messageId);
     }

--- a/apps/web/utils/gmail/mailbox-sync.ts
+++ b/apps/web/utils/gmail/mailbox-sync.ts
@@ -1,0 +1,225 @@
+import type { gmail_v1 } from "@googleapis/gmail";
+import chunk from "lodash/chunk";
+import {
+  compactMailboxSyncMessage,
+  decodeMailboxSyncCursor,
+  encodeMailboxSyncCursor,
+} from "@/utils/email/mailbox-sync";
+import type { MailboxSyncPage } from "@/utils/email/types";
+import { getMessagesBatch } from "@/utils/gmail/message";
+import { getHistory } from "@/utils/gmail/history";
+import { extractErrorInfo, withGmailRetry } from "@/utils/gmail/retry";
+import type { Logger } from "@/utils/logger";
+
+export async function getGmailMailboxSyncPage({
+  gmail,
+  accessToken,
+  logger,
+  cursor,
+  after,
+  limit,
+}: {
+  gmail: gmail_v1.Gmail;
+  accessToken: string;
+  logger: Logger;
+  cursor?: string;
+  after?: Date;
+  limit: number;
+}): Promise<MailboxSyncPage> {
+  if (!cursor) {
+    if (!after) throw new Error("after is required for initial mailbox sync");
+    return getGmailSnapshotPage({
+      gmail,
+      accessToken,
+      logger,
+      after,
+      limit,
+      reset: true,
+    });
+  }
+
+  const decoded = decodeMailboxSyncCursor(cursor, "google");
+  if (decoded.provider !== "google") {
+    throw new Error("Expected Google mailbox sync cursor");
+  }
+
+  if (decoded.phase === "snapshot") {
+    return getGmailSnapshotPage({
+      gmail,
+      accessToken,
+      logger,
+      after: new Date(decoded.after),
+      historyId: decoded.historyId,
+      pageToken: decoded.pageToken,
+      limit,
+      reset: false,
+    });
+  }
+
+  try {
+    const response = await getHistory(
+      gmail,
+      {
+        startHistoryId: decoded.historyId,
+        maxResults: limit,
+        pageToken: decoded.pageToken,
+      },
+      logger,
+    );
+    const { upsertIds, deletedIds } = getGmailMailboxChangeIds(
+      response.history ?? [],
+    );
+    const upsertedMessages = await fetchMessages({
+      messageIds: upsertIds,
+      accessToken,
+      logger,
+    });
+    const fetchedIds = new Set(upsertedMessages.map((message) => message.id));
+    for (const messageId of upsertIds) {
+      if (!fetchedIds.has(messageId)) deletedIds.add(messageId);
+    }
+
+    const nextHistoryId = response.nextPageToken
+      ? decoded.historyId
+      : (response.historyId ?? decoded.historyId);
+    return {
+      cursor: encodeMailboxSyncCursor({
+        version: 1,
+        provider: "google",
+        phase: "delta",
+        historyId: nextHistoryId,
+        after: decoded.after,
+        pageToken: response.nextPageToken ?? undefined,
+      }),
+      deletedMessageIds: [...deletedIds],
+      hasMore: Boolean(response.nextPageToken),
+      reset: false,
+      upsertedMessages,
+    };
+  } catch (error) {
+    if (extractErrorInfo(error).status !== 404) throw error;
+
+    return getGmailSnapshotPage({
+      gmail,
+      accessToken,
+      logger,
+      after: new Date(decoded.after),
+      limit,
+      reset: true,
+    });
+  }
+}
+
+export function getGmailMailboxChangeIds(history: gmail_v1.Schema$History[]): {
+  upsertIds: string[];
+  deletedIds: Set<string>;
+} {
+  const upsertIds = new Set<string>();
+  const deletedIds = new Set<string>();
+
+  for (const record of history) {
+    for (const change of record.messagesAdded ?? []) {
+      if (change.message?.id) upsertIds.add(change.message.id);
+    }
+    for (const change of record.labelsAdded ?? []) {
+      if (change.message?.id) upsertIds.add(change.message.id);
+    }
+    for (const change of record.labelsRemoved ?? []) {
+      if (change.message?.id) upsertIds.add(change.message.id);
+    }
+    for (const change of record.messagesDeleted ?? []) {
+      if (change.message?.id) deletedIds.add(change.message.id);
+    }
+  }
+
+  for (const messageId of deletedIds) upsertIds.delete(messageId);
+  return { upsertIds: [...upsertIds], deletedIds };
+}
+
+async function getGmailSnapshotPage({
+  gmail,
+  accessToken,
+  logger,
+  after,
+  limit,
+  reset,
+  historyId,
+  pageToken,
+}: {
+  gmail: gmail_v1.Gmail;
+  accessToken: string;
+  logger: Logger;
+  after: Date;
+  limit: number;
+  reset: boolean;
+  historyId?: string;
+  pageToken?: string;
+}): Promise<MailboxSyncPage> {
+  const snapshotHistoryId =
+    historyId ??
+    (
+      await withGmailRetry(() => gmail.users.getProfile({ userId: "me" }), 5, {
+        logger,
+      })
+    ).data.historyId;
+  if (!snapshotHistoryId) {
+    throw new Error("Gmail did not return a mailbox history ID");
+  }
+
+  const response = await withGmailRetry(
+    () =>
+      gmail.users.messages.list({
+        userId: "me",
+        labelIds: ["INBOX"],
+        q: `after:${Math.floor(after.getTime() / 1000)}`,
+        maxResults: limit,
+        pageToken,
+      }),
+    5,
+    { logger },
+  );
+  const upsertedMessages = await fetchMessages({
+    messageIds: (response.data.messages ?? []).flatMap((message) =>
+      message.id ? [message.id] : [],
+    ),
+    accessToken,
+    logger,
+  });
+  const nextPageToken = response.data.nextPageToken ?? undefined;
+
+  return {
+    cursor: encodeMailboxSyncCursor({
+      version: 1,
+      provider: "google",
+      phase: nextPageToken ? "snapshot" : "delta",
+      historyId: snapshotHistoryId,
+      after: after.toISOString(),
+      pageToken: nextPageToken,
+    }),
+    deletedMessageIds: [],
+    hasMore: true,
+    reset,
+    upsertedMessages,
+  };
+}
+
+async function fetchMessages({
+  messageIds,
+  accessToken,
+  logger,
+}: {
+  messageIds: string[];
+  accessToken: string;
+  logger: Logger;
+}) {
+  const pages = await Promise.all(
+    chunk(messageIds, 100).map((ids) =>
+      getMessagesBatch({
+        messageIds: ids,
+        accessToken,
+        logger,
+      }),
+    ),
+  );
+  return pages.flat().map(compactMailboxSyncMessage);
+}

--- a/apps/web/utils/outlook/mailbox-sync.test.ts
+++ b/apps/web/utils/outlook/mailbox-sync.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { decodeMailboxSyncCursor } from "@/utils/email/mailbox-sync";
+import { buildOutlookMailboxSyncPage } from "@/utils/outlook/mailbox-sync";
+
+describe("buildOutlookMailboxSyncPage", () => {
+  it("returns metadata upserts, removals, and a validated delta cursor", () => {
+    const page = buildOutlookMailboxSyncPage({
+      response: {
+        value: [
+          {
+            id: "message-1",
+            conversationId: "thread-1",
+            parentFolderId: "inbox-folder-id",
+            subject: "Updated subject",
+            bodyPreview: "Preview",
+            receivedDateTime: "2026-07-31T10:00:00.000Z",
+            isRead: false,
+            categories: ["To Reply"],
+          },
+          {
+            id: "message-2",
+            "@removed": { reason: "deleted" },
+          },
+          {
+            id: "message-3",
+            conversationId: "thread-3",
+            parentFolderId: "inbox-folder-id",
+            subject: "Stale version",
+          },
+          {
+            id: "message-3",
+            "@removed": { reason: "changed" },
+          },
+        ],
+        "@odata.deltaLink":
+          "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc",
+      },
+      after: "2026-07-01T00:00:00.000Z",
+      wasSnapshot: false,
+      reset: false,
+      categoryMap: new Map([["To Reply", "category-id"]]),
+    });
+
+    expect(page).toMatchObject({
+      deletedMessageIds: ["message-2", "message-3"],
+      hasMore: false,
+      reset: false,
+      upsertedMessages: [
+        {
+          id: "message-1",
+          threadId: "thread-1",
+          labelIds: ["UNREAD", "INBOX", "category-id"],
+          textHtml: undefined,
+          textPlain: undefined,
+        },
+      ],
+    });
+    expect(decodeMailboxSyncCursor(page.cursor, "microsoft")).toMatchObject({
+      provider: "microsoft",
+      snapshot: false,
+    });
+  });
+});

--- a/apps/web/utils/outlook/mailbox-sync.test.ts
+++ b/apps/web/utils/outlook/mailbox-sync.test.ts
@@ -3,6 +3,26 @@ import { decodeMailboxSyncCursor } from "@/utils/email/mailbox-sync";
 import { buildOutlookMailboxSyncPage } from "@/utils/outlook/mailbox-sync";
 
 describe("buildOutlookMailboxSyncPage", () => {
+  it("finishes an initial snapshot when Graph returns a delta cursor", () => {
+    const page = buildOutlookMailboxSyncPage({
+      response: {
+        value: [],
+        "@odata.deltaLink":
+          "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc",
+      },
+      after: "2026-07-01T00:00:00.000Z",
+      wasSnapshot: true,
+      reset: true,
+      categoryMap: new Map(),
+    });
+
+    expect(page.hasMore).toBe(false);
+    expect(decodeMailboxSyncCursor(page.cursor, "microsoft")).toMatchObject({
+      provider: "microsoft",
+      snapshot: false,
+    });
+  });
+
   it("returns metadata upserts, removals, and a validated delta cursor", () => {
     const page = buildOutlookMailboxSyncPage({
       response: {

--- a/apps/web/utils/outlook/mailbox-sync.ts
+++ b/apps/web/utils/outlook/mailbox-sync.ts
@@ -38,14 +38,10 @@ export async function getOutlookMailboxSyncPage({
 }): Promise<MailboxSyncPage> {
   if (!cursor) {
     if (!after) throw new Error("after is required for initial mailbox sync");
-    return getInitialPage({ client, logger, after, limit, reset: true });
+    return getInitialPage({ client, logger, after, limit });
   }
 
   const decoded = decodeMailboxSyncCursor(cursor, "microsoft");
-  if (decoded.provider !== "microsoft") {
-    throw new Error("Expected Microsoft mailbox sync cursor");
-  }
-
   try {
     const response = await withOutlookRetry<DeltaResponse>(
       () =>
@@ -77,7 +73,6 @@ export async function getOutlookMailboxSyncPage({
       logger,
       after: new Date(decoded.after),
       limit,
-      reset: true,
     });
   }
 }
@@ -134,7 +129,7 @@ export function buildOutlookMailboxSyncPage({
       snapshot: Boolean(nextLink) && wasSnapshot,
     }),
     deletedMessageIds,
-    hasMore: Boolean(nextLink) || wasSnapshot,
+    hasMore: Boolean(nextLink),
     reset,
     upsertedMessages,
   };
@@ -145,13 +140,11 @@ async function getInitialPage({
   logger,
   after,
   limit,
-  reset,
 }: {
   client: OutlookClient;
   logger: Logger;
   after: Date;
   limit: number;
-  reset: boolean;
 }) {
   const response = await withOutlookRetry<DeltaResponse>(
     () =>
@@ -170,7 +163,7 @@ async function getInitialPage({
     response,
     after: after.toISOString(),
     wasSnapshot: true,
-    reset,
+    reset: true,
     categoryMap: await getCategoryMap(client, logger),
   });
 }

--- a/apps/web/utils/outlook/mailbox-sync.ts
+++ b/apps/web/utils/outlook/mailbox-sync.ts
@@ -1,0 +1,176 @@
+import type { Message } from "@microsoft/microsoft-graph-types";
+import {
+  compactMailboxSyncMessage,
+  decodeMailboxSyncCursor,
+  encodeMailboxSyncCursor,
+} from "@/utils/email/mailbox-sync";
+import type { MailboxSyncPage } from "@/utils/email/types";
+import type { Logger } from "@/utils/logger";
+import type { OutlookClient } from "@/utils/outlook/client";
+import { getCategoryMap, convertMessage } from "@/utils/outlook/message";
+import { extractErrorInfo, withOutlookRetry } from "@/utils/outlook/retry";
+
+const MESSAGE_SELECT_FIELDS =
+  "id,conversationId,conversationIndex,internetMessageId,subject,bodyPreview,from,toRecipients,ccRecipients,receivedDateTime,isDraft,isRead,categories,parentFolderId,webLink";
+
+type DeltaMessage = Message & {
+  "@removed"?: { reason?: string };
+};
+
+type DeltaResponse = {
+  value?: DeltaMessage[];
+  "@odata.nextLink"?: string;
+  "@odata.deltaLink"?: string;
+};
+
+export async function getOutlookMailboxSyncPage({
+  client,
+  logger,
+  cursor,
+  after,
+  limit,
+}: {
+  client: OutlookClient;
+  logger: Logger;
+  cursor?: string;
+  after?: Date;
+  limit: number;
+}): Promise<MailboxSyncPage> {
+  if (!cursor) {
+    if (!after) throw new Error("after is required for initial mailbox sync");
+    return getInitialPage({ client, logger, after, limit, reset: true });
+  }
+
+  const decoded = decodeMailboxSyncCursor(cursor, "microsoft");
+  if (decoded.provider !== "microsoft") {
+    throw new Error("Expected Microsoft mailbox sync cursor");
+  }
+
+  try {
+    const response = await withOutlookRetry<DeltaResponse>(
+      () =>
+        client
+          .getClient()
+          .api(decoded.deltaLink)
+          .header("Prefer", `IdType="ImmutableId", odata.maxpagesize=${limit}`)
+          .get(),
+      logger,
+    );
+    return buildOutlookMailboxSyncPage({
+      response,
+      after: decoded.after,
+      wasSnapshot: decoded.snapshot,
+      reset: false,
+      categoryMap: await getCategoryMap(client, logger),
+    });
+  } catch (error) {
+    const { status, code } = extractErrorInfo(error);
+    if (
+      status !== 410 &&
+      code !== "SyncStateNotFound" &&
+      code !== "resyncRequired"
+    ) {
+      throw error;
+    }
+    return getInitialPage({
+      client,
+      logger,
+      after: new Date(decoded.after),
+      limit,
+      reset: true,
+    });
+  }
+}
+
+export function buildOutlookMailboxSyncPage({
+  response,
+  after,
+  wasSnapshot,
+  reset,
+  categoryMap,
+}: {
+  response: DeltaResponse;
+  after: string;
+  wasSnapshot: boolean;
+  reset: boolean;
+  categoryMap: Map<string, string>;
+}): MailboxSyncPage {
+  const nextLink = response["@odata.nextLink"];
+  const deltaLink = response["@odata.deltaLink"];
+  const continuationLink = nextLink ?? deltaLink;
+  if (!continuationLink) {
+    throw new Error("Microsoft Graph delta response omitted its cursor");
+  }
+
+  const deletedMessageIds: string[] = [];
+  const latestMessages = new Map<string, DeltaMessage>();
+  for (const message of response.value ?? []) {
+    if (message.id) latestMessages.set(message.id, message);
+  }
+
+  const upsertedMessages = [...latestMessages.values()].flatMap((message) => {
+    if (!message.id) return [];
+    if (message["@removed"]) {
+      deletedMessageIds.push(message.id);
+      return [];
+    }
+
+    const folderIds = message.parentFolderId
+      ? { inbox: message.parentFolderId }
+      : {};
+    return [
+      compactMailboxSyncMessage(
+        convertMessage(message, folderIds, categoryMap),
+      ),
+    ];
+  });
+
+  return {
+    cursor: encodeMailboxSyncCursor({
+      version: 1,
+      provider: "microsoft",
+      deltaLink: continuationLink,
+      after,
+      snapshot: Boolean(nextLink) && wasSnapshot,
+    }),
+    deletedMessageIds,
+    hasMore: Boolean(nextLink) || wasSnapshot,
+    reset,
+    upsertedMessages,
+  };
+}
+
+async function getInitialPage({
+  client,
+  logger,
+  after,
+  limit,
+  reset,
+}: {
+  client: OutlookClient;
+  logger: Logger;
+  after: Date;
+  limit: number;
+  reset: boolean;
+}) {
+  const response = await withOutlookRetry<DeltaResponse>(
+    () =>
+      client
+        .getClient()
+        .api("/me/mailFolders/inbox/messages/delta")
+        .select(MESSAGE_SELECT_FIELDS)
+        .filter(`receivedDateTime ge ${after.toISOString()}`)
+        .top(limit)
+        .header("Prefer", `IdType="ImmutableId", odata.maxpagesize=${limit}`)
+        .get(),
+    logger,
+  );
+
+  return buildOutlookMailboxSyncPage({
+    response,
+    after: after.toISOString(),
+    wasSnapshot: true,
+    reset,
+    categoryMap: await getCategoryMap(client, logger),
+  });
+}

--- a/apps/web/utils/outlook/mailbox-sync.ts
+++ b/apps/web/utils/outlook/mailbox-sync.ts
@@ -110,7 +110,7 @@ export function buildOutlookMailboxSyncPage({
       return [];
     }
 
-    const folderIds = message.parentFolderId
+    const folderIds: Record<string, string> = message.parentFolderId
       ? { inbox: message.parentFolderId }
       : {};
     return [


### PR DESCRIPTION
## Summary

- add an authenticated POST /api/mobile/mailbox-sync contract for paged initial Inbox snapshots and incremental updates
- use Gmail History IDs and Microsoft Graph delta links behind provider-bound opaque cursors
- return compact metadata-only message upserts and deletion IDs, with reset behavior for expired cursors
- validate Microsoft continuation URLs before reusing authenticated Graph requests

## Mobile integration

Call without a cursor using an after date, clear local mailbox data when reset is true, apply each page, then continue while hasMore is true. Persist the returned cursor per email account for later incremental syncs.

## Validation

- pnpm test: 527 files passed, 4,717 tests passed
- pnpm check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

