### PR TITLE
mobile: Accept documented Outlook delta cursor URLs

### DIFF
--- a/apps/web/utils/email/mailbox-sync.test.ts
+++ b/apps/web/utils/email/mailbox-sync.test.ts
@@ -43,6 +43,23 @@ describe("mailbox sync cursor", () => {
       InvalidMailboxSyncCursorError,
     );
   });
+
+  it("accepts the parenthesized mail folder path returned by Microsoft Graph", () => {
+    const encoded = encodeMailboxSyncCursor({
+      version: 1,
+      provider: "microsoft",
+      deltaLink:
+        "https://graph.microsoft.com/v1.0/me/mailfolders('folder-id')/messages/delta?$deltatoken=secret",
+      after: "2026-07-01T00:00:00.000Z",
+      snapshot: false,
+    });
+
+    expect(decodeMailboxSyncCursor(encoded, "microsoft")).toMatchObject({
+      provider: "microsoft",
+      deltaLink:
+        "https://graph.microsoft.com/v1.0/me/mailfolders('folder-id')/messages/delta?$deltatoken=secret",
+    });
+  });
 });
 
 describe("compactMailboxSyncMessage", () => {

--- a/apps/web/utils/email/mailbox-sync.ts
+++ b/apps/web/utils/email/mailbox-sync.ts
@@ -84,7 +84,9 @@ function isAllowedMicrosoftDeltaLink(value: string): boolean {
     url.username === "" &&
     url.password === "" &&
     url.hash === "" &&
-    /^\/v1\.0\/me\/mailFolders\/[^/]+\/messages\/delta$/i.test(url.pathname) &&
+    /^\/v1\.0\/me\/mailFolders(?:\/[^/]+|\('[^']+'\))\/messages\/delta$/i.test(
+      url.pathname,
+    ) &&
     (url.searchParams.has("$skiptoken") || url.searchParams.has("$deltatoken"))
   );
 }


### PR DESCRIPTION
Accepts the Microsoft Graph parenthesized mail-folder path in delta links while preserving the existing host and protocol guard.

- Allow both slash and parenthesized folder URL shapes
- Add regression coverage for the documented continuation URL
- Verify the focused regression, affected mailbox-sync tests, and formatter checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

