### PR TITLE
llms: Handle wrapped unavailable model errors

### DIFF
--- a/apps/web/__tests__/eval/llm-unavailable-model-fallback.test.ts
+++ b/apps/web/__tests__/eval/llm-unavailable-model-fallback.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { createEvalReporter } from "@/__tests__/eval/reporter";
+import { createGenerateText } from "@/utils/llms";
+import { getModel } from "@/utils/llms/model";
+
+// Run with:
+// pnpm --filter inbox-zero-ai test-ai eval/llm-unavailable-model-fallback.test.ts
+
+const PRIMARY_MODEL = "qa/definitely-unavailable-model-3110";
+const FALLBACK_MODEL = "google/gemini-3.1-flash-lite-preview";
+const TIMEOUT = 30_000;
+const isAiTest = process.env.RUN_AI_TESTS === "true";
+
+describe.runIf(isAiTest)("Eval: unavailable LLM model fallback", () => {
+  const evalReporter = createEvalReporter({
+    evalName: "llm-unavailable-model-fallback",
+  });
+
+  test(
+    "uses Gemini 3.1 Flash Lite after the configured primary is unavailable",
+    async () => {
+      const apiKey = process.env.OPENROUTER_API_KEY || process.env.LLM_API_KEY;
+      if (!apiKey) {
+        throw new Error("OpenRouter credentials are required for this eval");
+      }
+
+      const primaryModel = getModel({
+        aiProvider: "openrouter",
+        aiModel: PRIMARY_MODEL,
+        aiApiKey: apiKey,
+      });
+      const fallbackModel = getModel({
+        aiProvider: "openrouter",
+        aiModel: FALLBACK_MODEL,
+        aiApiKey: apiKey,
+      });
+      const modelOptions = {
+        ...primaryModel,
+        fallbackModels: [
+          {
+            provider: fallbackModel.provider,
+            modelName: fallbackModel.modelName,
+            model: fallbackModel.model,
+            providerOptions: fallbackModel.providerOptions,
+          },
+        ],
+      };
+      let modelUsed: { provider: string; modelName: string } | undefined;
+      const generateText = createGenerateText({
+        emailAccount: {
+          email: "qa-fallback@example.com",
+          id: "",
+          userId: "",
+        },
+        label: "qa-unavailable-model-fallback",
+        modelOptions,
+        promptHardening: { trust: "trusted" },
+        onModelUsed: (model) => {
+          modelUsed = model;
+        },
+      });
+
+      const result = await generateText({
+        model: modelOptions.model,
+        prompt: "Reply with the exact text FALLBACK_OK and nothing else.",
+      });
+
+      const expectedModel = {
+        provider: "openrouter",
+        modelName: FALLBACK_MODEL,
+      };
+      const pass = modelUsed?.modelName === expectedModel.modelName;
+
+      evalReporter.record({
+        testName: "configured unavailable model uses fallback",
+        model: "Gemini 3.1 Flash Lite",
+        pass,
+        expected: expectedModel.modelName,
+        actual: modelUsed?.modelName ?? "none",
+      });
+
+      expect(result.text.trim().length).toBeGreaterThan(0);
+      expect(modelUsed).toEqual(expectedModel);
+    },
+    TIMEOUT,
+  );
+
+  afterAll(() => {
+    evalReporter.printReport();
+  });
+});

--- a/apps/web/utils/error.test.ts
+++ b/apps/web/utils/error.test.ts
@@ -341,6 +341,7 @@ describe("isInvalidAIModelError", () => {
   it.each([
     ["deprecated models", "The configured model is deprecated"],
     ["models without endpoints", "No endpoints found for the configured model"],
+    ["invalid model IDs", "The configured model is not a valid model ID"],
   ])("detects %s", (_caseName, message) => {
     const error = createAPICallError({ message, statusCode: 400 });
 

--- a/apps/web/utils/error.ts
+++ b/apps/web/utils/error.ts
@@ -223,7 +223,8 @@ export function isInvalidAIModelError(error: APICallError): boolean {
   if (
     message.includes("testing period") ||
     message.includes("is deprecated") ||
-    message.includes("no endpoints found for")
+    message.includes("no endpoints found for") ||
+    message.includes("is not a valid model id")
   ) {
     return true;
   }

--- a/apps/web/utils/llms/fallback.test.ts
+++ b/apps/web/utils/llms/fallback.test.ts
@@ -160,7 +160,7 @@ describe("createGenerateText fallback chain", () => {
     mockGenerateText
       .mockRejectedValueOnce(
         new APICallError({
-          message: "The configured model is deprecated",
+          message: "The configured model is not a valid model ID",
           url: "https://example.com",
           requestBodyValues: {},
           statusCode: 400,
@@ -169,6 +169,15 @@ describe("createGenerateText fallback chain", () => {
         }),
       )
       .mockResolvedValueOnce(createTextResult({ text: "fallback success" }));
+    mockWithLLMRetry.mockImplementationOnce(
+      async (operation: () => Promise<unknown>) => {
+        try {
+          return await operation();
+        } catch (error) {
+          throw Object.assign(new Error("LLM retry failed"), { error });
+        }
+      },
+    );
 
     const generateText = createGenerateTextForTest({
       label: "Unavailable model fallback",

--- a/apps/web/utils/llms/index.ts
+++ b/apps/web/utils/llms/index.ts
@@ -1413,13 +1413,18 @@ function getLlmFallbackFailureCategory(
 }
 
 function shouldFallbackToNextModel(error: unknown): boolean {
+  const unwrappedError = (error as { error?: unknown })?.error ?? error;
+
   if (RetryError.isInstance(error) && isAiQuotaExceededError(error)) {
     return true;
   }
 
   if (isContentFilterRefusal(error)) return true;
 
-  if (APICallError.isInstance(error) && isInvalidAIModelError(error)) {
+  if (
+    APICallError.isInstance(unwrappedError) &&
+    isInvalidAIModelError(unwrappedError)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Ensures configured LLM fallback chains continue when OpenRouter rejects unavailable or invalid model IDs.

- unwrap retry failures before model-availability classification
- recognize OpenRouter invalid-model-ID responses
- add unit coverage plus a live Gemini 3.1 Flash Lite fallback eval

QA:
- pnpm test utils/error.test.ts -t "detects invalid model IDs"
- pnpm test utils/llms/fallback.test.ts -t "falls back when the primary model is no longer available"
- pnpm --filter inbox-zero-ai test-ai eval/llm-unavailable-model-fallback.test.ts
- pnpm exec ultracite check on all changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

