### PR TITLE
skills: Scope review bot detection to the current commit

### DIFF
--- a/.claude/skills/review-bot-loop/SKILL.md
+++ b/.claude/skills/review-bot-loop/SKILL.md
@@ -98,12 +98,15 @@ Otherwise, discover automated reviewers from:
 
 - Current-commit check names containing review-oriented identifiers such as
   `review`, `reviewer`, `cubic`, `baz`, `bugbot`, or `coderabbit`
-- Pull-request reviews authored by accounts whose GitHub user type is `Bot`
-- Root inline review comments authored by accounts whose user type is `Bot`
+- Current-commit pull-request reviews authored by accounts whose GitHub user
+  type is `Bot`
+- Current-commit root inline review comments authored by accounts whose user
+  type is `Bot`
 
-Add authors of actual bot reviews and inline review comments to the selected
-bot-login set. Do not select a bot solely because it posted a deployment,
-coverage, or other status-only conversation comment.
+Only discover bot logins from reviews and root inline comments whose
+`commit_id` equals `HEAD_SHA`. Add those authors to the selected bot-login set.
+Do not select a bot solely because it posted a deployment, coverage, or other
+status-only conversation comment.
 
 Use selected bot logins to filter inline and conversation comments. Ignore
 comments and checks from all other actors in this workflow.


### PR DESCRIPTION
Prevents the generalized review loop from waiting forever on bots that only reviewed older commits.

- discover bot logins only from reviews and root comments on the exact PR HEAD
- preserve selected reviewers across later pushes
- validate the skill and forward-test stale-reviewer and post-push scenarios

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

