### PR TITLE
feat(chat): add run observability

### DIFF
--- a/apps/web/app/api/chat/chat-message-persistence.test.ts
+++ b/apps/web/app/api/chat/chat-message-persistence.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mapUiMessagesToChatMessageRows } from "./chat-message-persistence";
+import {
+  buildUserChatMessageMetadata,
+  mapUiMessagesToChatMessageRows,
+} from "./chat-message-persistence";
 
 describe("mapUiMessagesToChatMessageRows", () => {
   it("preserves message IDs when mapping rows", () => {
@@ -44,5 +47,83 @@ describe("mapUiMessagesToChatMessageRows", () => {
       parts: [{ type: "text", text: "Done." }],
     });
     expect(rows[0]).not.toHaveProperty("id");
+  });
+
+  it("stores compact hidden-context references without email content", () => {
+    const metadata = buildUserChatMessageMetadata({
+      runId: "run-1",
+      context: {
+        type: "fix-rule",
+        message: {
+          id: "provider-message-1",
+          threadId: "provider-thread-1",
+          snippet: "Private snippet that must not be persisted in metadata",
+          textPlain: "Private email body that must not be persisted",
+        },
+        results: [{ ruleName: "Newsletters" }, { ruleName: null }],
+      } as any,
+      inlineActions: [
+        { type: "archive_threads", threadIds: ["thread-1", "thread-2"] },
+        { type: "mark_read_threads", threadIds: ["thread-3"] },
+      ],
+    });
+
+    expect(metadata).toEqual({
+      schemaVersion: 1,
+      runId: "run-1",
+      hiddenContext: {
+        type: "fix-rule",
+        messageId: "provider-message-1",
+        threadId: "provider-thread-1",
+        resultCount: 2,
+      },
+      inlineActions: {
+        types: ["archive_threads", "mark_read_threads"],
+        actionCount: 2,
+        threadCount: 3,
+      },
+    });
+    expect(JSON.stringify(metadata)).not.toContain("Private");
+  });
+
+  it("adds correlated run metadata to assistant rows", () => {
+    const rows = mapUiMessagesToChatMessageRows(
+      [
+        {
+          id: "assistant-message-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done." }],
+        } as any,
+      ],
+      "chat-1",
+      {
+        assistantRun: {
+          runId: "run-1",
+          provider: "openrouter",
+          modelName: "test-model",
+          pipelineVersion: 1,
+          deploymentCommit: "commit-123",
+          finishReason: "stop",
+          stepCount: 2,
+          toolCallCount: 3,
+          visibleTextProduced: true,
+        },
+      },
+    );
+
+    expect(rows[0]?.metadata).toEqual({
+      schemaVersion: 1,
+      runId: "run-1",
+      assistantRun: {
+        provider: "openrouter",
+        modelName: "test-model",
+        pipelineVersion: 1,
+        deploymentCommit: "commit-123",
+        finishReason: "stop",
+        stepCount: 2,
+        toolCallCount: 3,
+        visibleTextProduced: true,
+      },
+    });
   });
 });

--- a/apps/web/app/api/chat/chat-message-persistence.ts
+++ b/apps/web/app/api/chat/chat-message-persistence.ts
@@ -1,19 +1,94 @@
 import type { UIMessage } from "ai";
 import type { Prisma } from "@/generated/prisma/client";
 import { trimToNonEmptyString } from "@/utils/string";
+import type { AssistantInput } from "@/utils/actions/assistant-chat.validation";
+
+const CHAT_MESSAGE_METADATA_SCHEMA_VERSION = 1;
+
+export type AssistantChatRunMetadata = {
+  runId: string;
+  provider: string | null;
+  modelName: string | null;
+  pipelineVersion: number;
+  deploymentCommit: string | null;
+  finishReason: string | null;
+  stepCount: number;
+  toolCallCount: number;
+  visibleTextProduced: boolean;
+};
 
 export function mapUiMessagesToChatMessageRows(
   messages: UIMessage[],
   chatId: string,
+  options?: { assistantRun?: AssistantChatRunMetadata },
 ): Prisma.ChatMessageCreateManyInput[] {
   return messages.map((message) => {
     const persistedMessageId = trimToNonEmptyString(message.id);
+    const assistantRun = options?.assistantRun;
 
     return {
       ...(persistedMessageId ? { id: persistedMessageId } : {}),
       chatId,
       role: message.role,
       parts: message.parts as Prisma.InputJsonValue,
+      ...(message.role === "assistant" && assistantRun
+        ? { metadata: buildAssistantChatMessageMetadata(assistantRun) }
+        : {}),
     };
   });
+}
+
+export function buildUserChatMessageMetadata({
+  runId,
+  context,
+  inlineActions,
+}: {
+  runId: string;
+  context?: AssistantInput["context"];
+  inlineActions?: AssistantInput["inlineActions"];
+}): Prisma.InputJsonObject {
+  const hiddenContext = context
+    ? {
+        type: context.type,
+        messageId: context.message.id,
+        threadId: context.message.threadId,
+        resultCount: context.results.length,
+      }
+    : null;
+  const inlineActionMetadata = inlineActions?.length
+    ? {
+        types: [...new Set(inlineActions.map((action) => action.type))],
+        actionCount: inlineActions.length,
+        threadCount: inlineActions.reduce(
+          (count, action) => count + action.threadIds.length,
+          0,
+        ),
+      }
+    : null;
+
+  return {
+    schemaVersion: CHAT_MESSAGE_METADATA_SCHEMA_VERSION,
+    runId,
+    ...(hiddenContext ? { hiddenContext } : {}),
+    ...(inlineActionMetadata ? { inlineActions: inlineActionMetadata } : {}),
+  };
+}
+
+function buildAssistantChatMessageMetadata(
+  assistantRun: AssistantChatRunMetadata,
+): Prisma.InputJsonObject {
+  return {
+    schemaVersion: CHAT_MESSAGE_METADATA_SCHEMA_VERSION,
+    runId: assistantRun.runId,
+    assistantRun: {
+      provider: assistantRun.provider,
+      modelName: assistantRun.modelName,
+      pipelineVersion: assistantRun.pipelineVersion,
+      deploymentCommit: assistantRun.deploymentCommit,
+      finishReason: assistantRun.finishReason,
+      stepCount: assistantRun.stepCount,
+      toolCallCount: assistantRun.toolCallCount,
+      visibleTextProduced: assistantRun.visibleTextProduced,
+    },
+  };
 }

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -68,6 +68,7 @@ vi.mock("@/utils/user/get", () => ({
 
 vi.mock("@/utils/ai/assistant/chat", () => ({
   aiProcessAssistantChat: mockAiProcessAssistantChat,
+  ASSISTANT_CHAT_PIPELINE_VERSION: 1,
 }));
 
 vi.mock("@/components/assistant-chat/helpers", () => ({
@@ -449,6 +450,66 @@ describe("chat route rule freshness persistence", () => {
     await POST(createRequest());
 
     expect(prisma.chatMessage.createMany).not.toHaveBeenCalled();
+  });
+
+  it("persists and logs correlated assistant run metadata", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "commit-123");
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockAiProcessAssistantChat.mockImplementationOnce(async (args) => {
+      args.onModelResolved?.({
+        provider: "openrouter",
+        modelName: "test-model",
+      });
+      await args.onStepFinish?.({ toolCalls: [{}, {}] });
+      await args.onStepFinish?.({ toolCalls: [{}] });
+      await args.onFinish?.({ finishReason: "stop" });
+
+      return createAssistantStreamResult();
+    });
+
+    try {
+      await POST(createRequest());
+
+      const userMetadata = prisma.chatMessage.create.mock.calls[0]?.[0].data
+        .metadata as Record<string, unknown>;
+      const createManyData =
+        prisma.chatMessage.createMany.mock.calls[0]?.[0].data;
+      const assistantRow = Array.isArray(createManyData)
+        ? createManyData[0]
+        : createManyData;
+      const assistantMetadata = assistantRow?.metadata as Record<
+        string,
+        unknown
+      >;
+
+      expect(userMetadata).toMatchObject({
+        schemaVersion: 1,
+        runId: expect.any(String),
+      });
+      expect(assistantMetadata).toEqual({
+        schemaVersion: 1,
+        runId: userMetadata.runId,
+        assistantRun: {
+          provider: "openrouter",
+          modelName: "test-model",
+          pipelineVersion: 1,
+          deploymentCommit: "commit-123",
+          finishReason: "stop",
+          stepCount: 2,
+          toolCallCount: 3,
+          visibleTextProduced: true,
+        },
+      });
+      expect(consoleLogSpy.mock.calls.flat()).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("Assistant chat run completed"),
+          expect.stringContaining('"toolCallCount": 3'),
+        ]),
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+      vi.unstubAllEnvs();
+    }
   });
 });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -8,7 +8,10 @@ import {
 import { withEmailAccount } from "@/utils/middleware";
 import { FIRST_TIME_EVENTS, trackFirstTimeEvent } from "@/utils/posthog";
 import { getEmailAccountWithAi } from "@/utils/user/get";
-import { aiProcessAssistantChat } from "@/utils/ai/assistant/chat";
+import {
+  aiProcessAssistantChat,
+  ASSISTANT_CHAT_PIPELINE_VERSION,
+} from "@/utils/ai/assistant/chat";
 import type { Logger } from "@/utils/logger";
 import prisma from "@/utils/prisma";
 import type { Prisma } from "@/generated/prisma/client";
@@ -22,7 +25,11 @@ import {
 } from "@/utils/ai/assistant/compact";
 import { getInboxStatsForChatContext } from "@/utils/ai/assistant/get-inbox-stats-for-chat-context";
 import { formatUtcDate } from "@/utils/date";
-import { mapUiMessagesToChatMessageRows } from "@/app/api/chat/chat-message-persistence";
+import {
+  buildUserChatMessageMetadata,
+  mapUiMessagesToChatMessageRows,
+  type AssistantChatRunMetadata,
+} from "@/app/api/chat/chat-message-persistence";
 import {
   ASSISTANT_CHAT_MAX_TEXT_LENGTH_MESSAGE,
   type AssistantInput,
@@ -126,6 +133,8 @@ export const POST = withEmailAccount("chat", async (request) => {
   const chatHasHistory =
     chat.messages.length > 0 || chat.compactions.length > 0;
   const { message, context, inlineActions } = data;
+  const chatRunId = crypto.randomUUID();
+  const runLogger = request.logger.with({ chatId: chat.id, chatRunId });
 
   const hiddenInlineActionMessage =
     buildHiddenInlineActionMessage(inlineActions);
@@ -135,6 +144,11 @@ export const POST = withEmailAccount("chat", async (request) => {
     id: message.id,
     role: "user",
     parts: message.parts,
+    metadata: buildUserChatMessageMetadata({
+      runId: chatRunId,
+      context,
+      inlineActions,
+    }),
   });
 
   after(() =>
@@ -268,6 +282,17 @@ export const POST = withEmailAccount("chat", async (request) => {
   try {
     const inboxStats = await inboxStatsPromise;
     let seenRulesRevision: number | null = null;
+    const assistantRun: AssistantChatRunMetadata = {
+      runId: chatRunId,
+      provider: null,
+      modelName: null,
+      pipelineVersion: ASSISTANT_CHAT_PIPELINE_VERSION,
+      deploymentCommit: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
+      finishReason: null,
+      stepCount: 0,
+      toolCallCount: 0,
+      visibleTextProduced: false,
+    };
     const result = await aiProcessAssistantChat({
       messages: modelMessages,
       conversationMessagesForMemory: conversationModelMessages,
@@ -285,7 +310,18 @@ export const POST = withEmailAccount("chat", async (request) => {
           rulesRevision,
         );
       },
-      logger: request.logger,
+      onModelResolved: (resolvedModel) => {
+        assistantRun.provider = resolvedModel.provider;
+        assistantRun.modelName = resolvedModel.modelName ?? null;
+      },
+      onStepFinish: (step) => {
+        assistantRun.stepCount += 1;
+        assistantRun.toolCallCount += step.toolCalls.length;
+      },
+      onFinish: (result) => {
+        assistantRun.finishReason = result.finishReason;
+      },
+      logger: runLogger,
     });
 
     const stream = createUIMessageStream({
@@ -304,9 +340,7 @@ export const POST = withEmailAccount("chat", async (request) => {
         const warning = getToolFailureWarning(responseMessage);
         if (!warning) return;
 
-        request.logger.warn("Assistant chat completed with tool failures", {
-          chatId: chat.id,
-        });
+        runLogger.warn("Assistant chat completed with tool failures");
 
         const warningPartId = crypto.randomUUID();
         writer.write({ type: "text-start", id: warningPartId });
@@ -318,44 +352,64 @@ export const POST = withEmailAccount("chat", async (request) => {
         writer.write({ type: "text-end", id: warningPartId });
       },
       onFinish: async ({ messages }) => {
+        assistantRun.visibleTextProduced = hasVisibleAssistantText(messages);
         const persistableMessages = messages.filter(
           isPersistableAssistantMessage,
         );
 
         if (persistableMessages.length < messages.length) {
-          request.logger.error("Skipping empty assistant chat messages", {
-            chatId: chat.id,
+          runLogger.error("Skipping empty assistant chat messages", {
             skippedCount: messages.length - persistableMessages.length,
           });
         }
 
+        let insertedMessageCount = 0;
         if (persistableMessages.length > 0) {
-          await saveChatMessages(persistableMessages, chat.id, request.logger);
+          const result = await saveChatMessages(
+            persistableMessages,
+            chat.id,
+            runLogger,
+            assistantRun,
+          );
+          insertedMessageCount = result.count;
         }
 
         if (seenRulesRevision != null) {
           await saveLastSeenRulesRevision({
             chatId: chat.id,
             rulesRevision: seenRulesRevision,
-            logger: request.logger,
+            logger: runLogger,
           });
         }
 
-        await flushLoggerSafely(request.logger, {
+        runLogger.info("Assistant chat run completed", {
+          provider: assistantRun.provider,
+          modelName: assistantRun.modelName,
+          pipelineVersion: assistantRun.pipelineVersion,
+          deploymentCommit: assistantRun.deploymentCommit,
+          finishReason: assistantRun.finishReason,
+          stepCount: assistantRun.stepCount,
+          toolCallCount: assistantRun.toolCallCount,
+          visibleTextProduced: assistantRun.visibleTextProduced,
+          assistantMessageCount: messages.filter(
+            (message) => message.role === "assistant",
+          ).length,
+          insertedMessageCount,
+        });
+
+        await flushLoggerSafely(runLogger, {
           action: "assistant-chat",
           flushReason: "chat-stream-finish",
-          chatId: chat.id,
         });
       },
     });
 
     return createUIMessageStreamResponse({ stream });
   } catch (error) {
-    request.logger.error("Error in assistant chat", { error });
-    await flushLoggerSafely(request.logger, {
+    runLogger.error("Error in assistant chat", { error });
+    await flushLoggerSafely(runLogger, {
       action: "assistant-chat",
       flushReason: "chat-error",
-      chatId: chat.id,
     });
     return NextResponse.json(
       { error: "Error in assistant chat" },
@@ -407,9 +461,12 @@ async function saveChatMessages(
   messages: UIMessage[],
   chatId: string,
   logger: Logger,
+  assistantRun: AssistantChatRunMetadata,
 ) {
   try {
-    const rows = mapUiMessagesToChatMessageRows(messages, chatId);
+    const rows = mapUiMessagesToChatMessageRows(messages, chatId, {
+      assistantRun,
+    });
     const assistantMessages = messages.filter(
       (message) => message.role === "assistant",
     );
@@ -470,6 +527,16 @@ function hasRenderableAssistantResponse(
     if (part.type !== "text") return true;
     return part.text.trim().length > 0;
   });
+}
+
+function hasVisibleAssistantText(messages: UIMessage[]) {
+  return messages.some(
+    (message) =>
+      message.role === "assistant" &&
+      message.parts.some(
+        (part) => part.type === "text" && part.text.trim().length > 0,
+      ),
+  );
 }
 
 function getToolCallIdsFromUiParts(parts: UIMessage["parts"] | undefined) {

--- a/apps/web/prisma/migrations/20260731180000_add_chat_message_metadata/migration.sql
+++ b/apps/web/prisma/migrations/20260731180000_add_chat_message_metadata/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ChatMessage" ADD COLUMN "metadata" JSONB;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1174,6 +1174,7 @@ model ChatMessage {
 
   role  String
   parts Json
+  metadata Json?
   // attachments Json?
 
   chatId String

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -49,6 +49,8 @@ import { getAssistantChatProvider } from "./chat-provider-shared";
 import { LlmUseCase } from "@/utils/llms/use-cases";
 
 export const maxDuration = 300;
+// Increment when chat prompts, tools, or routing change so run quality remains attributable.
+export const ASSISTANT_CHAT_PIPELINE_VERSION = 1;
 const ASSISTANT_CHAT_TOOL_BUDGET_MS = {
   web: 240_000,
   messaging: 60_000,
@@ -59,6 +61,9 @@ type AssistantChatOnStepFinish = NonNullable<
 >;
 type AssistantChatOnModelResolved = NonNullable<
   Parameters<typeof toolCallAgentStream>[0]["onModelResolved"]
+>;
+type AssistantChatOnFinish = NonNullable<
+  Parameters<typeof toolCallAgentStream>[0]["onFinish"]
 >;
 
 export async function aiProcessAssistantChat({
@@ -77,6 +82,7 @@ export async function aiProcessAssistantChat({
   onRulesStateExposed,
   onStepFinish,
   onModelResolved,
+  onFinish,
   logger,
 }: {
   messages: ModelMessage[];
@@ -94,6 +100,7 @@ export async function aiProcessAssistantChat({
   onRulesStateExposed?: (rulesRevision: number) => void;
   onStepFinish?: AssistantChatOnStepFinish;
   onModelResolved?: AssistantChatOnModelResolved;
+  onFinish?: AssistantChatOnFinish;
   logger: Logger;
 }) {
   const startedAt = Date.now();
@@ -326,6 +333,7 @@ export async function aiProcessAssistantChat({
       });
       onModelResolved?.(resolvedModel);
     },
+    onFinish,
     stopWhen: () => false,
     prepareStep: () => {
       if (


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • 1 of 4</sub>

## Summary

- Add nullable JSON metadata to chat messages and correlate each user/assistant turn with a chat run ID.
- Record provider, model, pipeline version, deployment commit, finish reason, step count, tool count, and visible-text status.
- Emit one info-level Axiom completion event with the same run correlation.
- Preserve correlation on failure logs.

## Privacy

The new metadata stores provider message/thread references, context type, and counts only. It does not add sender, recipient, subject, snippet, or body content.

## Testing

- 14 focused route and persistence tests
- Prisma schema validation
- Ultracite and git diff checks