### PR TITLE
fix(chat): consume fix context once

### DIFF
--- a/apps/web/providers/ChatProvider.test.tsx
+++ b/apps/web/providers/ChatProvider.test.tsx
@@ -4,6 +4,7 @@ import { act, render, waitFor } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ASSISTANT_CHAT_MAX_TEXT_LENGTH } from "@/utils/actions/assistant-chat.validation";
+import type { MessageContext } from "@/utils/ai/assistant/chat-context-validation";
 import { ChatProvider, useChat } from "./ChatProvider";
 
 const {
@@ -46,8 +47,8 @@ vi.mock("@ai-sdk/react", () => ({
     messages: [],
     status: "ready",
     setMessages: mockSetMessages,
-    sendMessage: (...args: unknown[]) =>
-      mockSendMessage(...args).catch((error) => {
+    sendMessage: (message: unknown, requestOptions?: { body?: unknown }) =>
+      mockSendMessage(message, requestOptions).catch((error) => {
         options.onError?.(error);
         throw error;
       }),
@@ -146,6 +147,71 @@ describe("ChatProvider", () => {
     ]);
     mockClientLoggerFlush.mockResolvedValue(undefined);
     mockSendMessage.mockResolvedValue(undefined);
+  });
+
+  it("uses attached fix context only for the next message", async () => {
+    const fixContext = buildFixRuleContext("first-thread");
+    let latestContext: ReturnType<typeof useChat> | undefined;
+
+    function Consumer() {
+      latestContext = useChat();
+      return null;
+    }
+
+    renderWithProvider(<Consumer />);
+
+    act(() => {
+      latestContext?.setContext(fixContext);
+    });
+    await waitFor(() => {
+      expect(latestContext?.context).toEqual(fixContext);
+    });
+
+    await act(async () => {
+      await latestContext?.submitTextMessage("Fix this rule");
+    });
+
+    expect(mockSendMessage.mock.calls[0]?.[1]).toEqual({
+      body: { context: fixContext },
+    });
+    expect(latestContext?.context).toBeNull();
+
+    await act(async () => {
+      await latestContext?.submitTextMessage("Now answer a new question");
+    });
+
+    expect(mockSendMessage.mock.calls[1]?.[1]).toBeUndefined();
+  });
+
+  it("restores consumed fix context when sending fails", async () => {
+    const fixContext = buildFixRuleContext("failed-thread");
+    mockSendMessage.mockRejectedValueOnce(new Error("Network request failed"));
+    let latestContext: ReturnType<typeof useChat> | undefined;
+
+    function Consumer() {
+      latestContext = useChat();
+      return null;
+    }
+
+    renderWithProvider(<Consumer />);
+
+    act(() => {
+      latestContext?.setContext(fixContext);
+    });
+    await waitFor(() => {
+      expect(latestContext?.context).toEqual(fixContext);
+    });
+
+    await act(async () => {
+      await expect(
+        latestContext?.submitTextMessage("Fix this rule"),
+      ).rejects.toThrow("Network request failed");
+    });
+
+    expect(mockSendMessage.mock.calls[0]?.[1]).toEqual({
+      body: { context: fixContext },
+    });
+    expect(latestContext?.context).toEqual(fixContext);
   });
 
   it("clears the active chat when the selected email account changes", async () => {
@@ -266,4 +332,24 @@ describe("ChatProvider", () => {
 
 function renderWithProvider(children: React.ReactNode) {
   return render(<ChatProvider>{children}</ChatProvider>);
+}
+
+function buildFixRuleContext(threadId: string): MessageContext {
+  return {
+    type: "fix-rule",
+    message: {
+      id: `message-${threadId}`,
+      threadId,
+      snippet: "Example message",
+      textPlain: "Example message body",
+      headers: {
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Example subject",
+        date: "2026-07-31T10:00:00.000Z",
+      },
+    },
+    results: [],
+    expected: "none",
+  };
 }

--- a/apps/web/providers/ChatProvider.tsx
+++ b/apps/web/providers/ChatProvider.tsx
@@ -84,6 +84,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const inlineActionsRef = useRef(inlineActions);
   const pendingInlineActionsRef = useRef<InlineEmailAction[] | null>(null);
   const pendingRequestRef = useRef<PendingChatRequest | null>(null);
+  const pendingRequestContextRef = useRef<MessageContext | null>(null);
   const previousChatIdRef = useRef(chatId);
   const previousEmailAccountIdRef = useRef<string | null>(null);
 
@@ -118,7 +119,6 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
           body: {
             id,
             message: messages.at(-1),
-            context: context ?? undefined,
             inlineActions: pendingInlineActionsRef.current ?? undefined,
             ...body,
           },
@@ -131,6 +131,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     onFinish: async () => {
       pendingInlineActionsRef.current = null;
       pendingRequestRef.current = null;
+      pendingRequestContextRef.current = null;
       await Promise.all([
         mutate("/api/user/rules"),
         chatId ? mutate(`/api/chats/${chatId}`) : Promise.resolve(),
@@ -139,6 +140,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     onError: (error) => {
       const pendingRequest = pendingRequestRef.current;
       const pendingInlineActions = pendingInlineActionsRef.current;
+      const pendingContext = pendingRequestContextRef.current;
+      if (pendingContext) {
+        setContext((current) => current ?? pendingContext);
+      }
       if (pendingInlineActions?.length) {
         setInlineActions((current) =>
           pendingInlineActions.reduce(
@@ -156,6 +161,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         request: pendingRequest,
       });
       pendingRequestRef.current = null;
+      pendingRequestContextRef.current = null;
     },
   });
 
@@ -171,8 +177,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     if (previousChatIdRef.current === chatId) return;
 
     previousChatIdRef.current = chatId;
+    if (pendingRequestRef.current?.chatId === chatId) return;
+
     pendingInlineActionsRef.current = null;
     pendingRequestRef.current = null;
+    pendingRequestContextRef.current = null;
     setInlineActions([]);
   }, [chatId]);
 
@@ -189,6 +198,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     previousEmailAccountIdRef.current = emailAccountId;
     pendingInlineActionsRef.current = null;
     pendingRequestRef.current = null;
+    pendingRequestContextRef.current = null;
     setChatId(null);
     chat.setMessages([]);
     setInput("");
@@ -221,11 +231,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
       if (!chatId) setChatId(chat.id);
 
+      const requestChatId = chatId ?? chat.id;
+      const requestContext = context;
       pendingRequestRef.current = {
         attachmentCount,
-        chatId: chatId ?? chat.id,
+        chatId: requestChatId,
         textLength,
       };
+      pendingRequestContextRef.current = requestContext;
       pendingInlineActionsRef.current = inlineActionsRef.current.length
         ? inlineActionsRef.current
         : null;
@@ -234,9 +247,17 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         setInlineActions([]);
       }
 
-      return chat.sendMessage({ role: "user", parts });
+      const sendPromise = chat.sendMessage(
+        { role: "user", parts },
+        requestContext ? { body: { context: requestContext } } : undefined,
+      );
+      if (requestContext) {
+        setContext((current) => (current === requestContext ? null : current));
+      }
+
+      return sendPromise;
     },
-    [chat.id, chat.sendMessage, chatId, emailAccountId, setChatId],
+    [chat.id, chat.sendMessage, chatId, context, emailAccountId, setChatId],
   );
 
   const submitTextMessage = useCallback(

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -50,7 +50,7 @@ import { LlmUseCase } from "@/utils/llms/use-cases";
 
 export const maxDuration = 300;
 // Increment when chat prompts, tools, or routing change so run quality remains attributable.
-export const ASSISTANT_CHAT_PIPELINE_VERSION = 1;
+export const ASSISTANT_CHAT_PIPELINE_VERSION = 2;
 const ASSISTANT_CHAT_TOOL_BUDGET_MS = {
   web: 240_000,
   messaging: 60_000,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • 2 of 4</sub>

## Summary

- Treat attached fix-email context as a one-request payload instead of sticky chat state.
- Pass that context explicitly through the per-message `sendMessage` request body.
- Clear the visible context after dispatch so later messages do not reuse it.
- Retain a pending copy only for restoring the context after a failed request, unless newer context was selected.
- Preserve pending request state during automatic first-chat ID assignment and clear it on real chat/account changes.
- Bump the observable chat pipeline version to 2.

## Testing

- 5 ChatProvider tests covering explicit request context, one-shot use, failure restoration, and chat/account transitions
- Ultracite and git diff checks

## Risk

- Fix context is intentionally consumed after one request; a failed request restores it. The context remains request-level hidden data and is not added to persisted message parts or the model-visible prompt history.