### PR TITLE
fix(chat): serialize rule updates

### DIFF
--- a/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
+++ b/apps/web/utils/ai/assistant/chat-rule-tools.test.ts
@@ -482,6 +482,132 @@ describe("updateRuleTool", () => {
       },
     });
   });
+
+  it("serializes concurrent updates before reading each rule revision", async () => {
+    const ruleStates = new Map([
+      [
+        "Marketing",
+        {
+          id: "marketing-rule-id",
+          enabled: true,
+          updatedAt: new Date("2026-04-27T00:00:00.000Z"),
+        },
+      ],
+      [
+        "Newsletter",
+        {
+          id: "newsletter-rule-id",
+          enabled: true,
+          updatedAt: new Date("2026-04-27T00:00:00.000Z"),
+        },
+      ],
+    ]);
+    let rulesRevision = 3;
+    let releaseFirstWrite!: () => void;
+    let markFirstWriteStarted!: () => void;
+    const firstWriteCanFinish = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    let ruleReadState = {
+      readAt: Date.now(),
+      rulesRevision,
+      ruleUpdatedAtByName: new Map(
+        [...ruleStates].map(([name, rule]) => [
+          name,
+          rule.updatedAt.toISOString(),
+        ]),
+      ),
+    };
+
+    mockPrisma.rule.findUnique.mockImplementation(async ({ where }) => {
+      const ruleName = where.name_emailAccountId.name;
+      const rule = ruleStates.get(ruleName);
+      if (!rule) return null;
+
+      return {
+        ...rule,
+        name: ruleName,
+        emailAccount: { rulesRevision },
+        organizationRuleId: null,
+        instructions: null,
+        from: null,
+        to: null,
+        subject: null,
+        conditionalOperator: "AND",
+        actions: [],
+      };
+    });
+    mockPrisma.emailAccount.findUnique.mockImplementation(async () => ({
+      about: null,
+      rulesRevision,
+      rules: [...ruleStates].map(([name, rule]) => ({
+        name,
+        instructions: null,
+        updatedAt: rule.updatedAt,
+        from: null,
+        to: null,
+        subject: null,
+        conditionalOperator: "AND",
+        enabled: rule.enabled,
+        runOnThreads: true,
+        actions: [],
+      })),
+      messagingChannels: [],
+    }));
+    mockSetRuleEnabled.mockImplementation(
+      async ({ ruleId, enabled }: { ruleId: string; enabled: boolean }) => {
+        if (ruleId === "marketing-rule-id") {
+          markFirstWriteStarted();
+          await firstWriteCanFinish;
+        }
+
+        const rule = [...ruleStates.values()].find(
+          (candidate) => candidate.id === ruleId,
+        );
+        if (rule) {
+          rulesRevision += 1;
+          rule.enabled = enabled;
+          rule.updatedAt = new Date(rule.updatedAt.getTime() + 60_000);
+        }
+
+        return { id: ruleId };
+      },
+    );
+
+    const tool = updateRuleTool({
+      email: "user@example.com",
+      emailAccountId: "email-account-id",
+      provider: "google",
+      logger,
+      getRuleReadState: () => ruleReadState,
+      setRuleReadState: (state) => {
+        ruleReadState = state;
+      },
+    });
+    const marketingUpdate = tool.execute({
+      ruleName: "Marketing",
+      updates: { enabled: false },
+    });
+    const newsletterUpdate = tool.execute({
+      ruleName: "Newsletter",
+      updates: { enabled: false },
+    });
+
+    await firstWriteStarted;
+    expect(mockPrisma.rule.findUnique).toHaveBeenCalledTimes(1);
+
+    releaseFirstWrite();
+    const results = await Promise.all([marketingUpdate, newsletterUpdate]);
+
+    expect(results.every((result) => result.success)).toBe(true);
+    expect(
+      mockSetRuleEnabled.mock.calls.map(([input]) => input.ruleId),
+    ).toEqual(["marketing-rule-id", "newsletter-rule-id"]);
+    expect(rulesRevision).toBe(5);
+  });
 });
 
 describe("deleteRuleTool", () => {

--- a/apps/web/utils/ai/assistant/chat.ts
+++ b/apps/web/utils/ai/assistant/chat.ts
@@ -50,7 +50,7 @@ import { LlmUseCase } from "@/utils/llms/use-cases";
 
 export const maxDuration = 300;
 // Increment when chat prompts, tools, or routing change so run quality remains attributable.
-export const ASSISTANT_CHAT_PIPELINE_VERSION = 3;
+export const ASSISTANT_CHAT_PIPELINE_VERSION = 4;
 const ASSISTANT_CHAT_TOOL_BUDGET_MS = {
   web: 240_000,
   messaging: 60_000,

--- a/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
+++ b/apps/web/utils/ai/assistant/tools/rules/update-rule-tool.ts
@@ -52,8 +52,10 @@ export const updateRuleTool = ({
   getRuleReadState?: () => RuleReadState | null;
   onRulesStateExposed?: (rulesRevision: number) => void;
   hasPendingRuleDeletion?: (ruleName: string) => boolean;
-}) =>
-  tool({
+}) => {
+  let updateQueue = Promise.resolve();
+
+  return tool({
     description:
       "Update an existing rule after reading the user's current rules. Use this for direct requests to change rule name, enabled state, conditions, or actions; no capabilities lookup is needed before editing an existing rule. This is a patch: include only the fields being changed, and omitted fields are preserved. Use updates.name to rename a rule. Use updates.condition to change conditions; omit condition fields that should stay unchanged, and set a static field to null only when the user explicitly asks to clear it. Do not set aiInstructions to null to preserve instructions; omit it instead. Use clearAiInstructions only when the user explicitly asks to remove semantic instructions. Use DRAFT_EMAIL for draft reply actions; do not use SEND_EMAIL or REPLY when the user asks to draft. Never use this tool to add/remove a sender or domain from an existing category rule; use updateLearnedPatterns for recurring sender/domain includes and excludes instead. Direct requests to change existing rule behavior are already confirmed; do not create a replacement rule for edits.",
     inputSchema: z
@@ -88,6 +90,13 @@ export const updateRuleTool = ({
       })
       .describe("Patch update for an existing rule."),
     execute: async ({ ruleName, updates }) => {
+      const previousUpdate = updateQueue;
+      let releaseNextUpdate!: () => void;
+      updateQueue = new Promise<void>((resolve) => {
+        releaseNextUpdate = resolve;
+      });
+
+      await previousUpdate;
       trackRuleToolCall({ tool: "update_rule", email, logger });
       try {
         const readValidationError = validateRuleWasReadRecently({
@@ -310,9 +319,12 @@ export const updateRuleTool = ({
           success: false,
           error: "Failed to update rule",
         };
+      } finally {
+        releaseNextUpdate();
       }
     },
   });
+};
 
 export type UpdateRuleTool = InferUITool<ReturnType<typeof updateRuleTool>>;
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • 4 of 4</sub>

## Summary

- Keep the existing `updateRule` tool as the single way to edit an existing rule.
- Serialize concurrent `updateRule` executions within one assistant run so each update validates against the rule revision produced by the previous update.
- Refresh the shared rule snapshot after each write, allowing the model to update several rules with separate ordinary tool calls.
- Add no model-visible tool, schema, description, or system-prompt context.
- Bump the observable chat pipeline version to 4.

## Why

The assistant could already emit one `updateRule` call per requested rule. Multiple calls from the same model step could execute concurrently, however, so the first write advanced the account rules revision while a sibling call was still validating stale state. Runtime serialization fixes that race without adding a special-case bulk tool.

## Testing

- 12 focused rule-tool unit tests, including a regression test that holds the first write open and proves the second update does not read stale state
- Targeted live-model eval verifies two existing-rule updates after reading the current rules
- Ultracite and git diff checks

## Risks

- Concurrent updates within the same assistant run now wait for the prior `updateRule` call to finish; a slow first update delays later ones.
- Serialization is scoped to `updateRule` calls in one run and does not coordinate different rule tool types or separate requests.