### PR TITLE
docs: Refresh product and self-hosting guides

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -2,7 +2,7 @@
 title: "Introduction"
 ---
 
-Use the Inbox Zero API to manage emails and automation rules programmatically.
+Use the Inbox Zero API to read inbox statistics and manage automation rules programmatically.
 
 If you prefer a CLI wrapper for scripts or bots, see the [API CLI](/api-reference/cli).
 
@@ -26,6 +26,16 @@ To begin using the Inbox Zero API, you'll need to obtain an API key. Here's how:
 
 API keys are scoped to a specific inbox account and only grant access to the permissions you select. Keep your key secure and do not share it publicly.
 
+### Permissions
+
+| Scope | Endpoints |
+|---|---|
+| `STATS_READ` | `GET /stats/by-period`, `GET /stats/response-time` |
+| `RULES_READ` | `GET /rules`, `GET /rules/{id}` |
+| `RULES_WRITE` | `POST /rules`, `PUT /rules/{id}`, `DELETE /rules/{id}` |
+
+A key may include more than one scope. Keys are also bound to one inbox account; they cannot read or change another inbox.
+
 ### Self-Hosting
 
 If you are self-hosting Inbox Zero, set `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true` and `API_KEY_SALT` before rebuilding the app. Generate the salt with `openssl rand -hex 32`. Use your deployment URL as the base URL for requests (for example, `https://your-domain.com/api/v1`).
@@ -45,6 +55,43 @@ Include your API key in the header of each request:
 ```
 API-Key: YOUR_API_KEY
 ```
+
+For example:
+
+```bash
+curl "https://www.getinboxzero.com/api/v1/rules" \
+  -H "API-Key: YOUR_API_KEY"
+```
+
+To create a rule:
+
+```bash
+curl -X POST "https://www.getinboxzero.com/api/v1/rules" \
+  -H "API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "Archive newsletters",
+    "runOnThreads": true,
+    "condition": {
+      "aiInstructions": "Newsletters and recurring promotional emails"
+    },
+    "actions": [{ "type": "ARCHIVE" }]
+  }'
+```
+
+### Errors
+
+API errors are returned as JSON with an `error` message.
+
+| Status | Meaning |
+|---|---|
+| `400` | Invalid query, path, or request body; an action may also be disabled by the deployment's feature flags |
+| `401` | The `API-Key` header is missing, invalid, or expired |
+| `403` | The key lacks a required scope or is not account-scoped |
+| `404` | The requested rule does not exist in the key's inbox account |
+| `500` | An unexpected server error occurred |
+
+The `DELETE` rule action, which moves matching emails to trash, is available only when the deployment enables `NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED`. This feature flag is separate from `DELETE /rules/{id}`, which deletes a rule definition.
 
 ## Request New Endpoint
 

--- a/docs/changelog-entries/2026-06-02.mdx
+++ b/docs/changelog-entries/2026-06-02.mdx
@@ -2,7 +2,7 @@
 description: "Android App Now Available"
 ---
 
-Inbox Zero is now available on Android. You can download it from the Google Play Store alongside the existing iOS app — both accessible from the new [download page](/app).
+Inbox Zero is now available on Android. You can download it from the Google Play Store alongside the existing iOS app — both accessible from the new [download page](https://www.getinboxzero.com/app).
 
 - Rule suggestions in messaging channels now display as readable, formatted text instead of raw markup
 - Onboarding flow adapts to your setup — calendar steps only appear when calendar features are enabled

--- a/docs/changelog-entries/2026-07-30.mdx
+++ b/docs/changelog-entries/2026-07-30.mdx
@@ -2,7 +2,7 @@
 description: "AI Meeting Recorder"
 ---
 
-Inbox Zero can now join your video calls, transcribe the conversation, and turn it into a summary, recap email, and follow-up draft — so you leave every meeting with next steps already written.
+In Early Access, Inbox Zero can join your video calls, transcribe the conversation, and turn it into a summary, recap email, and follow-up draft — so you leave every meeting with next steps already written.
 
 - A new onboarding flow walks you through connecting your calendar and choosing which meetings the recorder should join
 - The redesigned Meetings page shows upcoming recordings, summaries, action items, and follow-up drafts in one place

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,7 +4,7 @@ description: "Latest updates and improvements to Inbox Zero"
 ---
 
 <Update label="July 30, 2026" description="AI Meeting Recorder">
-  Inbox Zero can now join your video calls, transcribe the conversation, and turn it into a summary, recap email, and follow-up draft — so you leave every meeting with next steps already written.
+  In Early Access, Inbox Zero can join your video calls, transcribe the conversation, and turn it into a summary, recap email, and follow-up draft — so you leave every meeting with next steps already written.
 
   - A new onboarding flow walks you through connecting your calendar and choosing which meetings the recorder should join
   - The redesigned Meetings page shows upcoming recordings, summaries, action items, and follow-up drafts in one place
@@ -52,7 +52,7 @@ description: "Latest updates and improvements to Inbox Zero"
 </Update>
 
 <Update label="June 2, 2026" description="Android App Now Available">
-  Inbox Zero is now available on Android. You can download it from the Google Play Store alongside the existing iOS app — both accessible from the new [download page](/app).
+  Inbox Zero is now available on Android. You can download it from the Google Play Store alongside the existing iOS app — both accessible from the new [download page](https://www.getinboxzero.com/app).
 
   - Rule suggestions in messaging channels now display as readable, formatted text instead of raw markup
   - Onboarding flow adapts to your setup — calendar steps only appear when calendar features are enabled

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -59,7 +59,7 @@ The fastest way to get started is using [devcontainers](https://containers.dev/)
 
    **Interactive CLI** (recommended) - guides you through each step and auto-generates secrets:
    ```bash
-   npm run setup
+   pnpm setup
    ```
 
    **Manual** - copy the example file and edit it yourself:

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -59,7 +59,7 @@ The fastest way to get started is using [devcontainers](https://containers.dev/)
 
    **Interactive CLI** (recommended) - guides you through each step and auto-generates secrets:
    ```bash
-   pnpm setup
+   pnpm run setup
    ```
 
    **Manual** - copy the example file and edit it yourself:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,14 +17,20 @@
           {
             "group": "Get Started",
             "pages": [
-              "introduction"
+              "introduction",
+              "essentials/getting-started",
+              "essentials/feature-availability"
             ]
           },
           {
-            "group": "Essentials",
+            "group": "Assistant & Automation",
             "pages": [
               "essentials/ai-chat",
-              "essentials/email-ai-personal-assistant"
+              "essentials/email-ai-personal-assistant",
+              "essentials/assistant-settings",
+              "essentials/email-digest",
+              "essentials/delayed-actions",
+              "essentials/call-webhook"
             ]
           },
           {
@@ -36,36 +42,57 @@
             ]
           },
           {
-            "group": "Features",
+            "group": "Calendar & Meetings",
             "pages": [
-              "essentials/meeting-briefs",
-              "essentials/auto-file-attachments",
-              "essentials/inbox-zero-tabs-extension",
               "essentials/calendar-integration",
-              "essentials/cold-email-blocker",
-              "essentials/reply-zero",
-              "essentials/faq"
+              "essentials/booking-links",
+              "essentials/meeting-briefs"
             ]
           },
           {
-            "group": "Integrations",
+            "group": "Channels & Integrations",
             "pages": [
+              "essentials/channels",
               "essentials/slack-integration",
               "essentials/telegram-integration"
             ]
           },
           {
-            "group": "Automation",
+            "group": "Inbox Features",
             "pages": [
-              "essentials/email-digest",
-              "essentials/delayed-actions",
-              "essentials/call-webhook"
+              "essentials/auto-file-attachments",
+              "essentials/cold-email-blocker",
+              "essentials/reply-zero"
             ]
           },
           {
-            "group": "Configuration",
+            "group": "Apps",
             "pages": [
+              "essentials/mobile-apps",
+              "essentials/inbox-zero-tabs-extension"
+            ]
+          },
+          {
+            "group": "Teams & Account",
+            "pages": [
+              "essentials/organizations",
               "essentials/api-keys"
+            ]
+          },
+          {
+            "group": "Early Access",
+            "pages": [
+              "essentials/meeting-recorder",
+              "essentials/deep-clean",
+              "essentials/context-integrations"
+            ]
+          },
+          {
+            "group": "Safety & Help",
+            "pages": [
+              "essentials/security-and-data",
+              "essentials/troubleshooting",
+              "essentials/faq"
             ]
           }
         ]
@@ -77,7 +104,8 @@
           {
             "group": "Quick Start",
             "pages": [
-              "hosting/quick-start"
+              "hosting/quick-start",
+              "hosting/setup-cli-reference"
             ]
           },
           {
@@ -96,6 +124,7 @@
             "pages": [
               "hosting/self-hosting",
               "hosting/environment-variables",
+              "hosting/production-operations",
               "hosting/vercel",
               "hosting/kubernetes",
               "hosting/troubleshooting",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,7 +19,8 @@
             "pages": [
               "introduction",
               "essentials/getting-started",
-              "essentials/feature-availability"
+              "essentials/feature-availability",
+              "essentials/outlook-guide"
             ]
           },
           {

--- a/docs/essentials/ai-chat.mdx
+++ b/docs/essentials/ai-chat.mdx
@@ -1,31 +1,41 @@
 ---
 title: 'AI Chat'
-description: 'Manage your entire inbox through natural language conversation.'
+description: 'Manage your inbox through a natural-language conversation.'
 icon: 'message-bot'
 ---
 
-The AI Chat is the primary way to interact with Inbox Zero. Tell it what you need in plain English and it handles the rest — no menus or settings pages required.
-
-To get started, click `Assistant` in the left sidebar or visit [this link](https://www.getinboxzero.com/assistant).
+AI Chat lets you search, understand, and manage your inbox in plain language. Open `Chat` in the left sidebar or visit [AI Chat](https://www.getinboxzero.com/assistant).
 
 ## What You Can Do
 
-**Inbox management** — Search, archive, reply to, forward, or send emails directly from the chat. Bulk archive or unsubscribe from senders.
+- **Search and understand email** — Find messages, summarize threads, read supported attachments, and ask what needs your attention.
+- **Manage your inbox** — Archive, delete, mark read or unread, label, and unsubscribe from senders. The assistant keeps a narrow request scoped to the matching threads and asks before broadening it to sender-wide cleanup.
+- **Write email** — Prepare new messages, replies, and forwards. You review and send them from a confirmation card; the assistant does not send them immediately.
+- **Manage rules** — Create, update, enable, disable, and troubleshoot automation rules. New rules and destructive rule changes can require confirmation in the chat.
+- **Configure features** — Update supported settings for Meeting Briefs, auto-file attachments, multi-rule selection, scheduled check-ins, personal instructions, and the knowledge base.
+- **Remember preferences** — Ask the assistant to remember information for future chats. Information directly stated by you can be saved, while inferred memories require confirmation.
 
-**Rules & automation** — Create and edit rules that automatically label, archive, draft replies, forward, or take other actions on incoming emails. See [AI Personal Assistant](/essentials/email-ai-personal-assistant) for full details on rules.
+See [AI Personal Assistant](/essentials/email-ai-personal-assistant) for the full rule and action model.
 
-**Settings & features** — Configure meeting briefs, attachment filing, scheduled check-ins, and other features without leaving the chat.
+## Images and Attachments
 
-**Context-aware** — The assistant knows your inbox state, email history, and existing rules, so you can ask things like "why was this email archived?" or "fix the rule that's mislabeling investor emails."
+You can attach JPEG, PNG, WebP, or GIF images to a chat message, including by pasting an image. Chat uploads provide context for the conversation; they cannot be attached to an outgoing email.
 
-**Works across channels** — Use the same AI assistant from [Slack](/essentials/slack-integration) or [Telegram](/essentials/telegram-integration) in addition to the web interface.
+The assistant can also read supported attachments already present on an email, including PDF, DOCX, plain text, CSV, and HTML files. It cannot extract text from every binary file type.
+
+## Chat History
+
+Use the history menu in the Chat header to reopen, rename, or delete a previous conversation. Start a new chat when you want a clean conversation context.
+
+## Connected Channels
+
+You can also chat with the assistant from a connected Slack, Microsoft Teams, or Telegram account. Connect and configure these apps on the `Channels` page. See [Slack Integration](/essentials/slack-integration) and [Telegram Integration](/essentials/telegram-integration) for setup details.
 
 ## Example Prompts
 
-Not sure where to start? The chat includes built-in example templates for common workflows:
-
-- "Label emails from my team and archive newsletters"
-- "Draft replies to emails that need a response"
-- "Unsubscribe me from all marketing emails"
-- "Set up a daily email digest in Slack"
-- "Forward all receipts to my accountant"
+- "Show me the unread emails that need a reply."
+- "Archive these newsletters and unsubscribe me from their senders."
+- "Draft a reply to the latest message from Alex."
+- "Create a rule that labels receipts and archives them after seven days."
+- "Why was this email archived?"
+- "Remember that I prefer 30-minute meetings in the afternoon."

--- a/docs/essentials/api-keys.mdx
+++ b/docs/essentials/api-keys.mdx
@@ -1,20 +1,34 @@
 ---
-title: 'Use Your Own API Key'
-description: 'Bring your own LLM API key for AI features.'
+title: 'Use Your Own AI API Key'
+description: 'Choose an AI provider, model, and provider API key for Inbox Zero features.'
 icon: 'key'
 ---
 
-Inbox Zero covers AI costs for you, but you can optionally use your own API key. Go to [settings](https://www.getinboxzero.com/settings) to set it up.
+Inbox Zero covers AI costs by default, but you can optionally use your own model-provider API key.
 
-## Supported Providers
+<Note>
+This setting is for the AI provider that powers Inbox Zero features. It is different from the developer API keys in the `Developer` settings section, which authenticate requests to the Inbox Zero API.
+</Note>
+
+## Configure a Provider
+
+1. Open the account menu at the bottom of the sidebar and choose `Settings`.
+2. Expand the relevant email account.
+3. Find the `AI Model` section.
+4. Select a provider, enter the provider's model identifier and API key, then click `Save`.
+5. Test the configuration on the `Assistant` or `Chat` page.
+
+Leave the provider set to `Default` to use the AI service included with Inbox Zero. If a key is already stored, leave the API Key field blank to keep it; entering a new value replaces it.
+
+## Providers in Settings
 
 ### Anthropic
 
-Create an API key at: https://console.anthropic.com/settings/keys
+Create a key in the [Anthropic Console](https://console.anthropic.com/settings/keys). Enter an Anthropic model identifier in the Model field.
 
 ### OpenAI
 
-Create an API key at: https://platform.openai.com/api-keys
+Create a key on the [OpenAI API keys page](https://platform.openai.com/api-keys). After saving a valid key, Inbox Zero can load the models available to that key.
 
 <iframe
   width="560"
@@ -26,18 +40,30 @@ Create an API key at: https://platform.openai.com/api-keys
   allowFullScreen
 ></iframe>
 
+### Azure OpenAI
+
+Use an Azure OpenAI API key and enter the Azure deployment name in the Model field. The Inbox Zero deployment administrator must also configure the Azure resource name and API version on the server; selecting Azure OpenAI in the UI cannot supply those values by itself.
+
 ### Google
 
-Create an API key at: https://aistudio.google.com/app/apikey
+Create a Gemini API key in [Google AI Studio](https://aistudio.google.com/app/apikey) and enter the corresponding model identifier.
 
 ### Groq
 
-Create an API key at: https://console.groq.com/keys
+Create a key in the [Groq Console](https://console.groq.com/keys) and enter a model available to your Groq account.
 
 ### OpenRouter
 
-Access a wide variety of LLMs through a single API: https://openrouter.ai/settings/keys
+Create a key in [OpenRouter](https://openrouter.ai/settings/keys). Use OpenRouter's provider-qualified model identifier, such as `provider/model`.
 
-### Ollama (Self-Hosted)
+### Vercel AI Gateway
 
-For complete privacy, run a local Ollama model with your self-hosted setup. Your email data never leaves your infrastructure.
+Create an AI Gateway API key in Vercel and use the model identifier expected by [Vercel AI Gateway](https://vercel.com/ai-gateway). Provider-qualified identifiers are recommended.
+
+## Self-Hosted Providers
+
+The standard Settings picker lists only the providers above. Self-hosted deployments can configure additional backends, including Ollama and OpenAI-compatible endpoints, through server configuration. They are not selectable through the normal hosted Inbox Zero provider menu.
+
+## Usage and Billing
+
+When you use your own provider key, the provider bills that account according to its pricing and limits. Click `View usage` in the AI Model section to review the usage recorded by Inbox Zero. Provider-side billing remains the source of truth for charges.

--- a/docs/essentials/assistant-settings.mdx
+++ b/docs/essentials/assistant-settings.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Assistant Settings'
+description: 'Control drafting, reminders, writing style, knowledge, and safety settings for your AI assistant.'
+icon: 'sliders'
+---
+
+Open **Assistant** in the sidebar and select the **Settings** tab to control how the assistant drafts, learns, and notifies you. Settings apply to the currently selected email account, so review them separately when you connect multiple accounts.
+
+<Warning>
+AI drafts and classifications can be wrong. Keep high-impact actions reviewable, verify recipients and factual claims, and use the safety settings below for sensitive workflows.
+</Warning>
+
+## Drafting controls
+
+### Auto draft replies
+
+Enable this to create replies in your Drafts folder for messages that need a response. The assistant does not send these drafts automatically. Some deployments can disable auto-drafting entirely, in which case this setting and related knowledge controls are hidden.
+
+### Draft confidence
+
+Choose how certain the assistant must be before it prepares a draft:
+
+- **All emails** — draft whenever an email needs a reply, even when uncertain.
+- **Standard** — skip drafting when the assistant is unsure how to respond.
+- **High confidence** — draft only when it is very sure of the appropriate reply.
+
+Use a stricter setting when correctness is more important than draft coverage.
+
+## Updates
+
+### Follow-up reminders
+
+Enable reminders for messages where someone has not replied to you or where you have not replied. In **Configure**, set each delay independently, choose whether the assistant should prepare a follow-up draft, and run an initial scan of existing mail. The feature may be hidden if it is disabled for the deployment.
+
+### Digest
+
+Schedule a daily summary of newsletter emails and choose which rules contribute to it. Digests require the **Plus plan or higher** and appear only when the deployment has enabled the feature. You can route a digest to a connected chat provider from [Channels](/essentials/channels).
+
+## Your voice
+
+### Writing style
+
+Describe your typical length, formality, greetings, and other stylistic habits. This guidance is used when drafting replies in your voice.
+
+### Personal instructions
+
+Add stable information about yourself and how you want the assistant to handle email. Keep instructions general and durable; use assistant rules for specific matching conditions and actions.
+
+### Email signature
+
+Configure the signature appended to drafted messages. Preview it before saving so the draft does not contain duplicate sign-offs or outdated contact details.
+
+## Knowledge and learning
+
+### Draft knowledge base
+
+Store facts that can help the assistant answer recurring questions. This control is available only while auto draft replies are enabled. Treat knowledge entries as supporting context, not as a guarantee that every draft will use them.
+
+### Learned patterns
+
+Inbox Zero learns when senders or email types consistently match the same rule. Open **Learned patterns** to view, edit, or remove those associations. Remove a pattern when it starts routing a sender incorrectly.
+
+## Advanced settings
+
+### Sync to browser extension
+
+Sync label-based assistant rules to the Inbox Zero Tabs extension as Gmail tabs. This requires the configured Inbox Zero Tabs extension and a Chromium browser, and it applies to Gmail rather than Outlook. Select the label rules you want before starting the sync.
+
+### Multi-rule selection
+
+Allow the assistant to intentionally select multiple custom rules for one message. Turning it off reduces that behavior, although Inbox Zero can still apply multiple rules in a few built-in cases, such as adding a label alongside a reply workflow.
+
+### Include referral signature
+
+Optionally append an Inbox Zero referral link to generated drafts. Review the resulting signature before sending, especially for professional or regulated correspondence.
+
+### Allow hidden links in AI drafts
+
+This permits anchor text such as “click here” instead of displaying the full URL. It is more convenient, but it can hide the destination and query-string data. Leave it off when transparent links are important.
+
+### Sensitive data protection
+
+Choose how credentials and card numbers are handled before an AI request:
+
+- **Off** — send content without scanning.
+- **Redact** — hide detected credentials and card numbers, then send the remaining content to AI.
+- **Block** — skip the AI request when sensitive data is detected.
+
+An administrator can lock this policy at the deployment level. When locked, the setting is hidden and the configured policy still applies.
+
+## Troubleshooting
+
+### A setting is missing
+
+Feature flags, plan access, email provider, browser support, or an administrator policy can hide settings. Auto-draft controls disappear when auto-drafting is disabled; Digest requires Plus; extension sync requires the configured extension.
+
+### Drafts do not sound like me
+
+Update **Writing style**, **Personal instructions**, and **Email signature**, then review the Draft knowledge base for stale facts. Editing generated drafts also helps the assistant learn over time.
+
+### Too few or too many drafts are created
+
+Adjust **Draft confidence**. Also review the rules that determine whether a message needs a reply and remove incorrect learned patterns.
+
+### Follow-up reminders are missing
+
+Confirm that at least one reminder delay is set, then run the scan from **Configure**. If reminders should arrive in chat, also verify the route on [Channels](/essentials/channels).

--- a/docs/essentials/auto-file-attachments.mdx
+++ b/docs/essentials/auto-file-attachments.mdx
@@ -1,76 +1,63 @@
 ---
 title: 'Auto-File Attachments'
-description: 'Automatically organize email attachments into your Google Drive or OneDrive.'
+description: 'Automatically organize email attachments in Google Drive or OneDrive.'
 icon: 'folder-open'
 ---
 
 ## Overview
 
-Auto-File Attachments automatically saves and organizes email attachments to your Google Drive or OneDrive. When you receive an email with attachments, the AI determines the right folder and files it for you. No more manually downloading and sorting files.
+Auto-File Attachments analyzes incoming email attachments and saves matching files to configured folders in Google Drive or Microsoft OneDrive/SharePoint.
 
-## Getting Started
+## Set Up Auto-Filing
 
-### 1. Connect your drive
+### Connect a Drive
 
-Navigate to **Attachments** in the left sidebar. You'll be prompted to connect either:
+Open `Attachments` in the left sidebar and connect one of the supported storage providers:
 
-- **Google Drive**
-- **OneDrive / SharePoint**
+- Google Drive
+- Microsoft OneDrive or SharePoint
 
-### 2. Set up folders
+### Select Folders
 
-After connecting your drive, set up the folders you want files organized into. You can:
+Choose existing folders or create folders during setup. Give each folder a clear description so the assistant knows what belongs there.
 
-- **Select existing folders** from your drive
-- **Create new folders** directly from the Inbox Zero interface
-
-Give each folder a description so the AI knows what types of files belong there. For example:
-
-| Folder | Description |
-|--------|-------------|
+| Folder | Example description |
+| --- | --- |
 | Receipts | Purchase receipts, invoices, and payment confirmations |
 | Contracts | Signed agreements, proposals, and legal documents |
 | Travel | Flight confirmations, hotel bookings, and itineraries |
 
-### 3. Enable auto-filing
+You can also add general filing instructions and exclusions. Start with a small set of distinct folders; overlapping descriptions make the destination harder to determine.
 
-Once your folders are configured, enable auto-filing. The AI will start processing attachments from incoming emails.
+### Review the Preview
 
-## How It Works
+The setup flow can preview recent attachments before auto-filing is enabled. Review the suggested destinations and correct them when needed, then enable the feature.
 
-1. When an email arrives with attachments, the AI analyzes the attachment (filename, content, and email context)
-2. It matches the attachment to one of your configured folders
-3. The file is uploaded to the correct folder in your drive
-4. You receive a notification (via email or Slack) confirming where it was filed
+## How Filing Works
 
-### When the AI is unsure
+1. An incoming message contains an eligible attachment.
+2. The assistant analyzes the filename, extractable document content, email context, folder descriptions, and filing instructions.
+3. A confident match is uploaded to the selected folder.
+4. A low-confidence match prompts you for a destination instead of filing automatically.
+5. The result appears in Filing Activity and is delivered through the notification methods you enabled.
 
-If the AI can't confidently determine the right folder, it will ask you. You'll receive an email notification with the filename and the AI's reasoning. Simply reply to the email to tell it where to put the file, and it will learn from your correction for next time.
+All attachment types can be saved. PDF, DOCX, and plain-text files support content extraction; other types rely more heavily on the filename and surrounding email context.
 
-### Correcting a filing
+## Corrections and Activity
 
-If a file was put in the wrong folder, you can reply to the notification email with the correct location. The AI supports:
+Open `Attachments` to review Filing Activity and move a file to a different configured folder. Notification emails are sent in the source email thread, so you can reply with a correction. Supported reply intentions include:
 
-- **Approve** the filing if it got it right
-- **Move** to a different folder
-- **Undo** the filing if it shouldn't have been filed at all
+- Approve the proposed filing.
+- Move the file to another configured folder.
+- Undo a completed filing.
 
-## Supported File Types
+The assistant uses these corrections as context for future filing decisions.
 
-The AI can analyze the content of these file types to make smarter filing decisions:
+## Delivery Settings
 
-- PDF documents
-- Word documents (.docx)
-- Plain text files
+Use the `Delivery` button on the Attachments page to configure updates:
 
-Other attachment types are filed based on filename and email context.
+- **Email confirmations** — Receive an email when a file is sorted. Questions that require your input still arrive by email even if routine confirmations are disabled.
+- **Connected apps** — Enable document-filing alerts for connected Slack, Microsoft Teams, or Telegram accounts. Configure or connect them on `Channels`.
 
-## Slack Notifications
-
-If you've connected Slack (see [Slack Integration](/essentials/slack-integration)), you can receive filing notifications in a Slack channel. This gives you a quick log of everything being filed without cluttering your inbox.
-
-## Tips
-
-- Write clear folder descriptions. The more specific, the better the AI's filing accuracy
-- Start with a few broad folders and add more specific ones as needed
-- Check the filing history on the Attachments page to see what's been filed and correct any mistakes
+For Slack, select a direct message or an allowed private channel. The selected Slack bot must already be invited to a private channel before it can post there.

--- a/docs/essentials/booking-links.mdx
+++ b/docs/essentials/booking-links.mdx
@@ -1,0 +1,86 @@
+---
+title: 'Booking Links'
+description: 'Share your availability and let guests schedule directly on your calendar.'
+icon: 'calendar-days'
+---
+
+Inbox Zero booking links give guests a public page where they can choose a free time, enter their details, and create a calendar event. The page respects your working hours, timezone, existing calendar conflicts, minimum notice, and meeting duration.
+
+You can create one Inbox Zero booking link per email account. If you already use another scheduling service, you can instead save that external URL as your **Calendar Booking Link** so the AI can include it in scheduling replies.
+
+## Requirements and availability
+
+- Connect at least one Google or Microsoft calendar.
+- Enable the calendars that should block busy times.
+- Booking links are a regular hosted feature. On self-hosted deployments, an administrator may need to enable `NEXT_PUBLIC_BOOKING_LINKS_ENABLED`.
+- There is no booking-link plan check in the current product flow.
+
+## Set your availability
+
+1. Open **Calendars** in the left sidebar.
+2. Under **Availability**, choose the days and time windows when guests may book.
+3. Confirm the timezone shown for the schedule.
+4. Select **Save**.
+
+This is the account's default availability. It also guides times the AI suggests in scheduling emails, even if you do not create an Inbox Zero booking link.
+
+When displaying bookable slots, Inbox Zero treats events on all enabled connected calendars as busy. If calendar availability cannot be loaded safely, the public page returns no slots instead of risking a double booking.
+
+## Create a booking link
+
+1. On **Calendars**, find **Booking link** and select **Create booking link**.
+2. Enter the title guests will see.
+3. Choose a unique URL slug using lowercase letters, numbers, and hyphens. It must be 3–64 characters.
+4. Choose a duration: 15, 30, 45, or 60 minutes.
+5. Select the destination calendar where new events should be created.
+6. Optionally add a description and enable provider video conferencing.
+7. Select **Create**.
+
+Google calendars can create Google Meet links, and Microsoft calendars can create Microsoft Teams links. If the selected provider cannot create a supported video meeting, the video option is unavailable.
+
+After creation, copy the `/book/your-slug` URL and share it. The active Inbox Zero booking link also becomes the link the AI can use when a reply is genuinely about scheduling.
+
+## Configure or pause the link
+
+Select **Configure** to change:
+
+- Guest-facing title and description.
+- Public URL slug.
+- Duration.
+- Minimum notice before a meeting. The default is two hours.
+- Destination calendar.
+- Google Meet or Microsoft Teams conferencing, when supported.
+
+Use the switch on the booking-link card to make the public page active or inactive. An inactive link cannot be booked and is not used by the AI. When an Inbox Zero link is active, it takes precedence over the external **Calendar Booking Link** field.
+
+Deleting the link is permanent and also removes its booking history. Pausing the link is safer when you may want to use it again.
+
+## What guests experience
+
+Guests can:
+
+1. View open slots in their chosen timezone.
+2. Select a time and enter their name and email, plus an optional note.
+3. Receive a calendar invite and confirmation email.
+4. Use secure links from the confirmation to reschedule or cancel.
+
+The host also receives booking notifications. Inbox Zero validates the slot again during confirmation so two guests cannot successfully take the same time.
+
+## Troubleshooting
+
+### Create booking link is unavailable
+
+Connect a calendar and make sure at least one calendar is enabled. On a self-hosted deployment, confirm that booking links are enabled in the deployment configuration.
+
+### No times appear on the public page
+
+Check your weekly availability and timezone, minimum notice, and busy events across all enabled calendars. A disconnected calendar or temporary provider-availability failure can also hide all slots to prevent double booking.
+
+### A video link was not added
+
+Confirm that the destination calendar belongs to Google or Microsoft and that video conferencing is enabled in the booking-link configuration. Changing the destination calendar can also change which conferencing option is available.
+
+### The AI shares the wrong scheduling link
+
+Verify which Inbox Zero link is active. If no Inbox Zero link is active, review the external **Calendar Booking Link** field on the Calendars page.
+

--- a/docs/essentials/bulk-archiver.mdx
+++ b/docs/essentials/bulk-archiver.mdx
@@ -1,15 +1,28 @@
 ---
 title: 'Bulk Archiver'
-description: 'Archive thousands of emails at once by category.'
+description: 'Archive, mark as read, or delete email in bulk by category.'
 icon: 'box-archive'
 ---
 
-## Getting Started
+Open `Bulk Archive` under Cleanup in the left sidebar, or visit [Bulk Archive](https://www.getinboxzero.com/bulk-archive).
 
-To use this feature, click on the `Bulk Archive` tab in the left sidebar. Or visit [this link](https://www.getinboxzero.com/bulk-archive).
+## How It Works
 
-### How To Use
+Bulk Archive groups senders into categories so you can clean up large amounts of mail without selecting messages one by one.
 
-The Bulk Archiver lets you archive emails by category — for example, archive all newsletters, all marketing emails, or all notifications in one go. You can watch it clear tens of thousands of emails at once.
+1. If sender categorization is not enabled yet, follow the setup prompt and let Inbox Zero categorize your sender history.
+2. Review the category cards and the senders assigned to each category.
+3. Select the senders you want to process, or choose the entire category.
+4. Run the configured bulk action.
 
-Filter by sender, category, date range, or label to target exactly the emails you want to clean up, then archive them all with one click.
+Use `Categorize with AI` to categorize or refresh senders when the page does not yet have enough categorized history.
+
+## Choose the Bulk Action
+
+Open `Settings` on the Bulk Archive page to choose what the category buttons do:
+
+- **Archive** — Remove matching messages from the inbox while keeping them searchable.
+- **Mark as read** — Clear the unread state without moving the messages.
+- **Delete** — Move matching messages to trash. Review the selected senders carefully before using this option.
+
+Bulk Archive operates on the senders shown within its categories. For a more selective cleanup with custom exclusions and undo history, use Deep Clean when it is available for your account.

--- a/docs/essentials/bulk-email-unsubscriber.mdx
+++ b/docs/essentials/bulk-email-unsubscriber.mdx
@@ -1,12 +1,10 @@
 ---
 title: 'Bulk Email Unsubscriber'
-description: 'Bulk unsubscribe from newsletter and marketing emails using our Newsletter Cleaner.'
+description: 'Review newsletter senders and unsubscribe, archive, or delete in bulk.'
 icon: 'envelopes-bulk'
 ---
 
-## Getting Started
-
-To use this feature, click on the `Bulk Unsubscribe` tab in the left sidebar. Or visit [this link](https://www.getinboxzero.com/bulk-unsubscribe).
+Open `Bulk Unsubscribe` under Cleanup in the left sidebar, or visit [Bulk Unsubscribe](https://www.getinboxzero.com/bulk-unsubscribe).
 
 <iframe
   width="560"
@@ -18,26 +16,30 @@ To use this feature, click on the `Bulk Unsubscribe` tab in the left sidebar. Or
   allowFullScreen
 ></iframe>
 
-### How To Use
+## Review Senders
 
-This page will show you a list of all the newsletters and marketing emails you are subscribed to.
+The page groups newsletter and marketing email by sender. Each row shows message volume, unread and unarchived counts, and read rate. Use the date range, sender search, and status filters to narrow the list. You can sort by total, unread, or unarchived messages.
 
-![Newsletter Cleaner](/images/newsletter-row.png)
+Open a sender to see its activity and individual messages. From the expanded view, you can also archive or delete previous messages from that sender.
 
-You have a few options to apply to each email with one-click:
+## Sender Actions
 
-- `Unsubscribe` - Unsubscribe from the email
-- `Auto archive` - Automatically archive new emails you receive from this sender
-- `Auto archive + label` - Automatically archive new emails you receive from this sender and label them with a specific label
-- `Keep` - This doesn't have any impact on your emails, but will hide the sender from the list (you can view these again by adjusting your filters at the top of the page)
+- **Unsubscribe or Block** — Use the sender's supported unsubscribe or blocking mechanism.
+- **Auto Archive** — Automatically archive future messages from the sender, optionally with a label.
+- **Approve** — Keep the sender in your inbox and move it out of the unhandled list.
+- **Archive** — Archive existing messages from the sender.
+- **Delete** — Move existing messages from the sender to trash.
 
-You also have the option to view more details about the sender by clicking the button with an expand icon.
-This will show you a graph of how often they send you emails as well as old emails they have sent you.
+Use the checkboxes to apply these actions to several senders at once. The `Select suggested` shortcut selects senders with enough message history and a read rate below 20%, helping you find subscriptions you rarely read. Always review the selection before applying a bulk action.
 
-You can also easily delete or archive emails from the expanded view.
+## Filters
 
-### Ordering
+Use the status filter to switch among:
 
-The emails are ordered by the number of emails you have received from a sender.
-You can also order by most unread or unarchived.
-This makes it very quick and easy to decide which emails you want to unsubscribe from.
+- `Unhandled`
+- `All`
+- `Unsubscribed`
+- `Auto Archive`
+- `Approved`
+
+Inbox health reports and onboarding can link directly to this page with suggested low-read senders already selected.

--- a/docs/essentials/bulk-email-unsubscriber.mdx
+++ b/docs/essentials/bulk-email-unsubscriber.mdx
@@ -16,6 +16,10 @@ Open `Bulk Unsubscribe` under Cleanup in the left sidebar, or visit [Bulk Unsubs
   allowFullScreen
 ></iframe>
 
+<Note>
+The video uses Gmail, but Bulk Unsubscribe also supports Outlook. Select the Outlook mailbox in the account switcher and follow the same Inbox Zero flow. See [Outlook and Microsoft 365](/essentials/outlook-guide) for provider differences.
+</Note>
+
 ## Review Senders
 
 The page groups newsletter and marketing email by sender. Each row shows message volume, unread and unarchived counts, and read rate. Use the date range, sender search, and status filters to narrow the list. You can sort by total, unread, or unarchived messages.

--- a/docs/essentials/calendar-integration.mdx
+++ b/docs/essentials/calendar-integration.mdx
@@ -1,31 +1,43 @@
 ---
 title: 'Calendar Integration'
-description: 'Connect your calendars to let AI draft responses based on your actual availability.'
+description: 'Connect calendars for AI scheduling, availability, booking links, and meeting briefs.'
 icon: 'calendar'
 ---
 
 ## Overview
 
-Inbox Zero's calendar integration enables the AI assistant to draft email responses based on your actual calendar availability. It checks all your connected calendars (work and personal) and suggests available time slots or includes your booking link — eliminating scheduling back-and-forth.
+Connected calendars let the assistant check real availability when it drafts scheduling replies. The `Calendars` page also manages weekly availability, booking links, timezone, and the calendars used for conflict checks.
 
-## Getting Started
+## Connect a Calendar
 
-1. **Navigate to the Calendars page** — Click `Calendars` in the sidebar
-2. **Connect your calendar** — Choose Google Calendar or Microsoft (Outlook) Calendar, authorize access, and select which calendars to sync
-3. **Configure settings** (optional) — Set your timezone and add a booking link (Calendly, Google Calendar, Microsoft Bookings, etc.) that the AI can include in draft responses
+1. Open `Calendars` in the left sidebar.
+2. Connect Google Calendar or Microsoft Outlook Calendar and authorize access.
+3. Choose which calendars should be checked for availability.
+4. Confirm your timezone.
 
-<Note>
-You can connect multiple calendars — perfect if you manage work and personal calendars separately.
-</Note>
+You can connect multiple calendars, such as separate work and personal calendars. Select the calendars that should block time so the assistant does not offer conflicting slots.
 
-## How It Works
+## Weekly Availability
 
-When you receive emails asking about your availability, your AI assistant automatically:
+In the `Availability` section, set the hours the assistant is allowed to suggest for each day of the week. These hours use the timezone shown on the Calendars page. Calendar events still block otherwise available time.
 
-1. **Checks your connected calendars** for conflicts
-2. **Identifies available time slots** that match the request
-3. **Drafts a response** with accurate availability or your booking link
+## Booking Links
+
+Depending on the features enabled for your account, you can either:
+
+- Add an existing Calendly, Google Calendar, Microsoft Bookings, or other booking URL for the assistant to share; or
+- Create an Inbox Zero booking link.
+
+An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the Calendars page. Guests can book available times and use the booking page to reschedule or cancel when supported.
+
+## AI Scheduling
+
+When an email asks about availability, the assistant can:
+
+1. Check connected calendars for conflicts.
+2. Restrict suggestions to your weekly availability.
+3. Draft a response with available times or your configured booking link.
 
 ## Meeting Briefs
 
-Connecting your calendar also enables [Meeting Briefs](/essentials/meeting-briefs), which sends you AI-generated briefings before meetings with external contacts.
+Connecting a calendar also enables [Meeting Briefs](/essentials/meeting-briefs), which prepares context before meetings with external guests.

--- a/docs/essentials/calendar-integration.mdx
+++ b/docs/essentials/calendar-integration.mdx
@@ -19,7 +19,7 @@ You can connect multiple calendars, such as separate work and personal calendars
 
 ## Weekly Availability
 
-In the `Availability` section, set the hours the assistant is allowed to suggest for each day of the week. These hours use the timezone shown on the Calendars page. Calendar events still block otherwise available time.
+In the `Availability` section, set the hours the assistant is allowed to suggest for each day of the week. These hours use the timezone shown on the `Calendars` page. Calendar events still block otherwise available time.
 
 ## Booking Links
 
@@ -28,7 +28,7 @@ Depending on the features enabled for your account, you can either:
 - Add an existing Calendly, Google Calendar, Microsoft Bookings, or other booking URL for the assistant to share; or
 - Create an Inbox Zero booking link.
 
-An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the Calendars page. Guests can book available times and use the booking page to reschedule or cancel when supported.
+An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the `Calendars` page. Guests can book available times and use the booking page to reschedule or cancel when supported.
 
 ## AI Scheduling
 

--- a/docs/essentials/call-webhook.mdx
+++ b/docs/essentials/call-webhook.mdx
@@ -1,38 +1,57 @@
 ---
 title: 'Call Webhook'
-description: 'Integrate email processing with external services via webhooks.'
+description: 'Send rule and email metadata to an external HTTP endpoint.'
 icon: 'webhook'
 ---
 
-The Call Webhook action lets you integrate email processing with other services. When a rule triggers, Inbox Zero sends the email data to your specified endpoint.
+The `Call webhook` rule action sends a JSON request to an external service when an email matches a rule.
 
-## Configuration
+## Configure the Action
 
-- **Method:** POST
-- **Content-Type:** application/json
-- **Headers:** Always includes `X-Webhook-Secret` (empty string if no secret is configured in [settings](https://www.getinboxzero.com/settings))
+1. Open `Assistant` and edit a rule.
+2. Add the `Call webhook` action.
+3. Enter a publicly reachable HTTP or HTTPS endpoint.
+4. Save the rule.
+
+Hosted Inbox Zero validates webhook destinations and rejects unsafe or private-network addresses. Webhook availability can also be disabled by a self-hosted deployment administrator.
+
+## Request Contract
+
+- **Method:** `POST`
+- **Content-Type:** `application/json`
+- **Authentication header:** `X-Webhook-Secret`
+- **Success response:** Any `2xx` status
+- **Timeout:** 1 second
+
+Inbox Zero does not wait for or parse the response body. A timeout, blocked destination, network failure, or non-`2xx` response is logged but does not stop the remaining rule actions. Webhook calls are not retried, so the endpoint should acknowledge quickly and queue longer work asynchronously.
 
 ## Payload
 
 ```typescript
 {
   email: {
-    threadId: string;      // The thread ID (Gmail or Outlook)
-    messageId: string;     // The message ID (Gmail or Outlook)
-    subject: string;       // Email subject
-    from: string;         // Sender's email address
-    cc?: string;          // CC recipients (if any)
-    bcc?: string;         // BCC recipients (if any)
-    headerMessageId: string; // Original message ID header
-  },
+    threadId: string;
+    messageId: string;
+    subject: string;
+    from: string;
+    cc?: string;
+    bcc?: string;
+    headerMessageId: string;
+  };
   executedRule: {
-    id: string;           // Execution ID
-    ruleId: string | null; // Rule that triggered this webhook (null if rule was deleted)
-    reason: string | null; // Why this rule was executed
-    automated: boolean;   // Whether the rule ran automatically
-    createdAt: string;    // When the rule was executed
-  }
+    id: string;
+    ruleId: string | null;
+    reason: string | null;
+    automated: boolean;
+    createdAt: string;
+  };
 }
 ```
 
-Set up a webhook secret in [settings](https://www.getinboxzero.com/settings) to secure your endpoints. The secret is included in the `X-Webhook-Secret` header of every request.
+`threadId` and `messageId` are provider-specific Gmail or Outlook identifiers. `createdAt` is an ISO 8601 timestamp. `ruleId` can be `null` if the original rule no longer exists.
+
+## Webhook Secret
+
+Open `Settings`, find the `Developer` section, and generate a Webhook Secret. The secret is shown only when generated, so copy it before closing the dialog. Regenerating it immediately changes the value sent with future requests.
+
+Every request includes the `X-Webhook-Secret` header. If you have not generated a secret, the header is still present with an empty value. Your endpoint should compare the header to the stored secret before processing the payload.

--- a/docs/essentials/channels.mdx
+++ b/docs/essentials/channels.mdx
@@ -1,0 +1,80 @@
+---
+title: 'Channels'
+description: 'Connect Slack, Microsoft Teams, or Telegram and control what Inbox Zero delivers to chat.'
+icon: 'messages'
+---
+
+The **Channels** page is the central place to connect chat apps and route Inbox Zero updates. Depending on the provider and enabled features, you can receive rule notifications, draft replies, meeting briefs, follow-up reminders, digests, document-filing alerts, and scheduled check-ins.
+
+<Warning>
+Inbox Zero uses AI to summarize messages and draft replies. Review generated content before sending it or acting on it, especially when it involves sensitive, financial, or account information.
+</Warning>
+
+## Connect a channel
+
+1. Open **Channels** in the left sidebar.
+2. Find **Slack**, **Microsoft Teams**, or **Telegram** and select **Connect**.
+3. Complete the provider-specific flow:
+   - **Slack:** approve the Slack OAuth request and return to Inbox Zero.
+   - **Teams or Telegram:** copy the generated `/connect` command and send it in a direct message to the Inbox Zero bot. The code is single-use and expires after 10 minutes.
+4. Confirm that the provider displays a **Connected** badge.
+
+Only providers configured by the Inbox Zero deployment appear on this page. Microsoft Teams can also be hidden behind a deployment feature flag. For self-hosted installations, an administrator must configure each bot or OAuth integration before users can connect it.
+
+## Route rule notifications
+
+Under a connected provider, **Rule notifications** lists your enabled assistant rules. Turn on the rules that should post to that provider.
+
+For each enabled rule, choose one of two modes from its menu:
+
+- **Notify only** posts a notification when the rule matches.
+- **Draft reply in chat** includes a generated draft for review.
+
+If a rule already drafts an email, Inbox Zero uses **Draft reply in chat** as its initial channel mode. Otherwise, it starts with **Notify only**.
+
+Slack lets you choose a direct message or an eligible Slack channel as the destination. Teams and Telegram currently use the linked direct-message conversation.
+
+### Provider differences
+
+- **Slack** supports the richest interactive cards, including draft review and quick actions such as send, edit, dismiss, archive, or mark as read where applicable.
+- **Teams** draft editing and sending are not available in Teams yet. Review or send the draft in Inbox Zero. Other quick actions are view-only.
+- **Telegram** can send a prepared draft from Telegram, but draft editing is not available there. Other quick actions such as archive and mark read are currently Slack-only.
+
+## Route feature updates
+
+Each connected provider can also show toggles for:
+
+- **Meeting briefs** — a summary before meetings.
+- **Follow-up reminders** — nudges for messages awaiting a reply.
+- **Digests** — your scheduled newsletter digest. Digests require the **Plus plan or higher**.
+- **Document filing alerts** — updates when attachments are filed.
+- **Scheduled check-ins** — proactive assistant updates, when configured.
+
+Configure the underlying feature using the settings button or linked feature page. A route may stay disabled until the provider has a valid rule-notification destination. For Slack, choose the target destination before enabling delivery.
+
+## Chat with the assistant
+
+You can direct-message the Inbox Zero bot in a connected provider. Slack also supports @mentions in channels where the bot is present. The assistant can use your connected email and calendar context, but write actions still follow the product's confirmation and safety rules.
+
+## Disconnect a provider
+
+Open the provider menu on **Channels** and select **Disconnect**. This stops delivery and removes that channel connection. It does not delete the underlying assistant rules, meeting-brief settings, digest schedule, or follow-up configuration.
+
+## Troubleshooting
+
+### A provider is missing
+
+The deployment has not configured that provider, or the provider is behind a feature flag. On a hosted account, contact support. On a self-hosted deployment, ask the administrator to configure the provider credentials and bot.
+
+### Teams or Telegram will not link
+
+Generate a new command from **Channels** and send it to the bot in a direct message within 10 minutes. A link code cannot be reused.
+
+### A Slack destination is unavailable
+
+Reconnect Slack if requested. Confirm that you still have access to the destination and that the Inbox Zero app is present in a private channel before selecting it.
+
+### Notifications are missing
+
+Check all three layers: the provider is connected, the individual rule or feature is enabled for that provider, and the feature itself is enabled. Also confirm the selected Slack destination or linked direct message still exists.
+

--- a/docs/essentials/channels.mdx
+++ b/docs/essentials/channels.mdx
@@ -37,7 +37,7 @@ Slack lets you choose a direct message or an eligible Slack channel as the desti
 ### Provider differences
 
 - **Slack** supports the richest interactive cards, including draft review and quick actions such as send, edit, dismiss, archive, or mark as read where applicable.
-- **Teams** draft editing and sending are not available in Teams yet. Review or send the draft in Inbox Zero. Other quick actions are view-only.
+- **Teams** — Draft editing and sending are not available yet. Review or send the draft in Inbox Zero. Other quick actions are view-only.
 - **Telegram** can send a prepared draft from Telegram, but draft editing is not available there. Other quick actions such as archive and mark read are currently Slack-only.
 
 ## Route feature updates
@@ -77,4 +77,3 @@ Reconnect Slack if requested. Confirm that you still have access to the destinat
 ### Notifications are missing
 
 Check all three layers: the provider is connected, the individual rule or feature is enabled for that provider, and the feature itself is enabled. Also confirm the selected Slack destination or linked direct message still exists.
-

--- a/docs/essentials/context-integrations.mdx
+++ b/docs/essentials/context-integrations.mdx
@@ -1,0 +1,90 @@
+---
+title: 'Context Integrations'
+description: 'Connect read-oriented business tools so drafts and meeting briefs can use relevant external context.'
+icon: 'plug'
+---
+
+<Note>
+Context Integrations are in Early Access. They may release soon, but there is no promised release date.
+</Note>
+
+Context Integrations let Inbox Zero look up relevant information in connected services while preparing email drafts and meeting briefs. For example, the assistant may search for a sender in a CRM, fetch a Notion page, or check billing information in Stripe before it writes.
+
+They are context sources, not general workflow automations. Inbox Zero uses enabled tools when relevant and can continue drafting when an integration is unavailable or returns no useful information.
+
+## Requirements
+
+- Early Access must be enabled for the account.
+- Connecting an integration requires the **Plus plan or higher**.
+- The integration must support the configured OAuth flow. API-token connections are shown in the interface but are not currently supported.
+
+## Available integrations
+
+The current configuration can expose:
+
+- **Notion** — search and fetch approved Notion content.
+- **Stripe** — list customers, disputes, invoices, payment intents, prices, products, and subscriptions.
+- **Monday.com** — look up board items, board information, workspaces, and workspace information.
+- **Pipedream** — connect read-oriented tools from services such as HubSpot, Slack, Airtable, and Todoist.
+
+The exact list and individual tools can change during Early Access. A service marked **Request Access** is not connectable yet.
+
+## Connect and enable a service
+
+1. Open **Integrations** in the left sidebar.
+2. Select **Connect** beside a service.
+3. Review the provider's authorization screen and approve only the workspace and data you intend to share.
+4. Return to Inbox Zero and confirm that the row says **Connected**.
+5. Turn on the integration if it is connected but disabled.
+6. Expand **Tools** and enable only the lookups you want the assistant to use.
+
+A connection and its tools have separate switches. The assistant can use a tool only when the connection is active and that individual tool is enabled.
+
+Pipedream connections can expose many tools, so they start disabled and Inbox Zero filters the synced list toward read-oriented names such as get, list, find, and search. Still inspect each tool's name and description before enabling it.
+
+## How context is used
+
+For email drafting, Inbox Zero searches enabled tools for information related to the sender and the current thread. Useful findings are supplied to the drafting model as external context. If nothing relevant is found, the draft proceeds without it.
+
+For meeting briefs, enabled integration tools are available alongside email, calendar, and web-research context. The AI chooses whether a tool is relevant to the attendees or meeting topic.
+
+External data and tool output are treated as untrusted context. Even so, an integration may return stale, incomplete, or incorrectly matched information. Review names, account status, prices, payment state, and other consequential facts before sending a draft or using a brief.
+
+## Safety and access control
+
+- Enable the smallest set of tools needed for your workflow.
+- Prefer read-only tools. Do not enable tools that create, update, or delete data merely because their provider makes them available.
+- Provider authorization controls which workspaces and records Inbox Zero can access; tool switches control which of those capabilities the assistant may call.
+- Disconnecting deletes the Inbox Zero connection and its associated tool records. It does not delete data in the external service.
+- Disabling a connection preserves it but stops its tools from being used.
+
+<Warning>
+Read the provider's OAuth permissions before approving access. Connected data may be included in AI processing when it is relevant to a draft or meeting brief.
+</Warning>
+
+## Troubleshooting
+
+### Integrations are not enabled
+
+The account is outside the Early Access rollout. Select **Join Early Access** from the Integrations page. Availability may change and is not guaranteed.
+
+### Connect asks for an upgrade
+
+Context Integrations require Plus or higher. Upgrade the account that owns the selected email address, then restart the connection flow.
+
+### Connected but disabled
+
+Turn on the connection, expand its tools, and confirm that at least one tool is enabled. A connection with no enabled tools contributes no context.
+
+### A tool does not appear
+
+Reconnect the service to resync its tool list. Some integrations intentionally allow only an approved subset, and Pipedream write-oriented tools may be filtered out.
+
+### Drafts do not include expected context
+
+Confirm that the relevant tool is enabled and that the connected provider account can access the record. The assistant calls tools only when it judges them relevant, and it omits integration context when no useful result is found.
+
+### OAuth fails or is cancelled
+
+Return to **Integrations** and start a fresh connection. The authorization state and PKCE verifier expire after about 10 minutes and cannot be reused. If failure continues, disconnect the partial connection if present and retry.
+

--- a/docs/essentials/deep-clean.mdx
+++ b/docs/essentials/deep-clean.mdx
@@ -1,0 +1,72 @@
+---
+title: 'Deep Clean'
+description: 'Preview an AI-assisted cleanup of older Gmail messages before applying it to the rest of your inbox.'
+icon: 'brush'
+---
+
+<Warning>
+Deep Clean is an experimental Early Access feature with no release commitment. It may change substantially or never ship broadly.
+</Warning>
+
+Deep Clean reviews older inbox threads and decides which should stay and which can be archived or marked as read. It combines explicit protections, mail metadata, and AI judgment, then shows the results as they are processed.
+
+## Requirements
+
+- Deep Clean currently supports **Google accounts only**. It does not appear for Outlook accounts.
+- An active premium plan is required.
+- The Early Access feature must be enabled for your account or self-hosted deployment.
+
+## Run a cleanup
+
+1. Open **Deep Clean** in the left sidebar.
+2. Choose whether matching messages should be **Archived** or **Marked as Read**.
+3. Select a time range, from all messages to messages older than one year. **Older than one week** is the recommended starting point.
+4. Choose which mail must stay in the inbox:
+   - Emails needing replies.
+   - Starred emails.
+   - Future calendar events.
+   - Payment receipts.
+   - Mail matching your optional custom instructions.
+5. Review the confirmation and select **Start Cleaning**.
+
+Deep Clean processes an initial preview of 50 messages. Review the live results before selecting **Run on Full Inbox**.
+
+## How messages are evaluated
+
+The selected protections are checked across a thread. Deep Clean also recognizes common low-priority mail such as newsletters and Gmail category mail. Past calendar events can be cleaned while future events are kept when calendar protection is on. Messages not decided by these checks are evaluated against your instructions by AI.
+
+AI classification can be wrong. Use the preview to confirm that your protected message types and custom instructions behave as expected.
+
+## Safety and undo
+
+Deep Clean does not delete email.
+
+- **Archive** removes the Gmail Inbox label and adds an Inbox Zero archive label.
+- **Mark as Read** removes the unread state and adds an Inbox Zero processed label.
+- Every processed thread remains searchable in Gmail.
+- Hover a completed action in the live results and select **Undo** to restore that thread to the inbox or mark it unread again.
+- If Deep Clean chose **Keep**, hover the result to manually archive or mark the message as read.
+
+<Note>
+Undo is available from the run results for individual threads. Review the preview before continuing to the full inbox instead of treating undo as a guaranteed bulk rollback.
+</Note>
+
+After the first run, the Deep Clean page reuses your previous settings. Use **Edit settings** to change them, and **History** to review earlier cleanup jobs.
+
+## Troubleshooting
+
+### Deep Clean is missing
+
+Confirm that the selected account is Gmail, the account has an active premium plan, and Early Access is enabled. On self-hosted deployments, both the public cleaner flag and the required background-processing services must be configured.
+
+### Processing appears stuck
+
+Large cleanups are handled in background batches and can take time. Keep the run page open or return through **History**. If nothing changes, refresh and confirm that the Gmail connection is still active.
+
+### Important mail was cleaned
+
+Use **Undo** on the affected result. Before another full run, enable the relevant protection or add a broader custom instruction, then start with a new 50-message preview.
+
+### Too much mail is kept
+
+Review which protections are enabled and simplify conflicting custom instructions. Use the preview result's manual action for individual messages before expanding the cleanup to the full inbox.

--- a/docs/essentials/delayed-actions.mdx
+++ b/docs/essentials/delayed-actions.mdx
@@ -1,17 +1,41 @@
 ---
 title: 'Delayed Actions'
-description: 'Automatically perform actions on emails after a set time.'
+description: 'Run supported rule actions after a configurable delay.'
 icon: 'clock'
 ---
 
-Delayed actions let you automatically perform actions on emails after a set period. This is perfect for low-priority emails that are only relevant for a short time before they become noise in your inbox.
+Delayed execution lets an assistant rule wait before applying an action. Use it for mail that should remain visible temporarily or for messages that should not be sent immediately.
 
-## How It Works
+## Add a Delay
 
-Add a delayed action to any rule in [AI Personal Assistant](https://www.getinboxzero.com/automation). When an email matches the rule, the action will be performed after the delay you specify.
+1. Open `Assistant` and edit a rule.
+2. Add or open a supported action.
+3. Open the action's `More options` menu and choose `Add delay`.
+4. Set a delay between 1 minute and 90 days, then save the rule.
 
-**Common use cases:**
+The delay belongs to that specific action. Other actions in the same rule can still run immediately or use different delays.
 
-- **Auto-archive newsletters** after 7 days — they're still searchable if you need them later
-- **Send replies with a short delay** (e.g., 2 minutes) to make automated responses feel more natural
-- **Clean up notifications** that are only relevant for a day or two
+## Supported Actions
+
+You can delay:
+
+- Archive
+- Label
+- Send reply
+- Send email
+- Forward
+- Mark as read
+- Star
+- Delete
+- Move to folder
+
+Draft replies, digests, webhooks, spam actions, and messaging notifications do not currently expose delayed execution.
+
+## Common Uses
+
+- Archive newsletters after seven days.
+- Send an automated reply after a short delay.
+- Remove time-sensitive notifications from the inbox after they expire.
+- Move older messages to a folder after a review window.
+
+Delayed actions are scheduled after the rule matches. They may run shortly after the target time rather than at an exact second.

--- a/docs/essentials/email-ai-personal-assistant.mdx
+++ b/docs/essentials/email-ai-personal-assistant.mdx
@@ -18,6 +18,10 @@ The AI Personal Assistant manages incoming email using rules you define. Open `A
   allowFullScreen
 ></iframe>
 
+<Note>
+The video uses Gmail. Outlook users follow the same Assistant flow; label actions become Outlook categories, and messages can be moved to Outlook folders. See [Outlook and Microsoft 365](/essentials/outlook-guide).
+</Note>
+
 ### Create Rules from Instructions
 
 1. Open `Assistant`.

--- a/docs/essentials/email-ai-personal-assistant.mdx
+++ b/docs/essentials/email-ai-personal-assistant.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'AI Personal Assistant'
-description: 'Set up your assistant to manage your emails for you.'
+description: 'Create rules that automatically manage incoming email.'
 icon: 'sparkles'
 ---
 
-The AI Personal Assistant automatically manages your inbox — labeling, archiving, and drafting replies based on rules you define. Set it up using the [AI Chat](/essentials/ai-chat) or configure rules manually below.
+The AI Personal Assistant manages incoming email using rules you define. Open `Assistant` in the left sidebar or visit [Assistant](https://www.getinboxzero.com/automation). You can also create and manage rules through [AI Chat](/essentials/ai-chat).
 
 ## Getting Started
 
@@ -18,147 +18,93 @@ The AI Personal Assistant automatically manages your inbox — labeling, archivi
   allowFullScreen
 ></iframe>
 
-To set up AI Personal Assistant for your email, click on the `AI Personal Assistant` tab in the left sidebar. Or visit [this link](https://www.getinboxzero.com/automation).
+### Create Rules from Instructions
 
-### Creating Rules
+1. Open `Assistant`.
+2. Describe how you want your email handled in the instruction box.
+3. Review the rules generated from your instructions.
+4. Save the rules.
 
-You can create rules in two ways:
+Use `Add rule manually` when you want to build the condition and actions yourself.
 
-#### Natural Language Instructions
-1. Type instructions in plain English in the text area
-2. Use the example instructions on the right for inspiration
-3. Combine multiple instructions for comprehensive email management
-4. Click `Create Rules` and the AI will convert your instructions into rules
+## How Rules Work
 
-#### Manual Rule Creation
-
-For more precise control, create rules manually by clicking the `Manually add rule` button.
-
-### AI Chat
-
-You can also create and manage rules through the [AI Chat](/essentials/ai-chat) — just describe what you want in plain English.
-
-## Rules
-
-On the [Rules](https://www.getinboxzero.com/automation?tab=rules) page, you can view and edit your rules.
-
-When you save your prompt the rules will be automatically created for you. But you can also decide to create rules manually.
+Each rule has a condition and one or more actions. When an incoming email matches the condition, Inbox Zero performs the configured actions.
 
 ![AI Rules](/images/ai-rules.png)
 
-### How Rules Work
+### Conditions
 
-Rules are broken into two parts:
+Conditions can use AI instructions, static fields, or both.
 
-1. The condition to match against.
-2. The action to take when the AI finds a match.
+- **AI condition** — Describe the meaning of the emails that should match, such as `Apply this rule if this email is asking me to set up a call.`
+- **Static condition** — Match text in `From`, `To`, or `Subject`, such as `From` contains `@example.com`.
 
-If the condition is met, the AI will take the action.
+Static conditions are useful for deterministic matches and do not require the AI to interpret every email.
 
-![AI Rules](/images/how-ai-rules-work.png)
+### Actions
 
-#### Conditions
+A rule can contain multiple actions. Available actions can vary by email provider and connected apps:
 
-There are two main types of conditions:
+- Label
+- Move to folder
+- Archive
+- Delete
+- Draft replies
+- Send replies
+- Forward
+- Send email
+- Mark as read
+- Star
+- Mark as spam
+- Add to digest
+- Call webhook
+- Notify in a connected Slack, Teams, or Telegram account
+- Deliver a draft reply to a connected messaging account for review
+- Notify the sender when supported
 
-* **AI**: Write an instruction for the AI to match against the email.
-* **Static**: Match against a static value: `From`, `To`, or `Subject`.
+See [Email Digest](/essentials/email-digest), [Call Webhook](/essentials/call-webhook), and [Delayed Actions](/essentials/delayed-actions) for actions that need additional configuration.
 
-**AI Conditions**
+### AI-Generated Content
 
-You can write an instruction for the AI to match against the email.
+For actions with editable content, put an AI instruction inside double curly braces:
 
-For example:
-
-`Apply this rule if this email is asking me to set up a call.`
-
-When an email is received, the AI will use the prompt to determine if the email matches the condition.
-
-**Static Conditions**
-
-You can match against a static value: `From`, `To`, or `Subject`.
-
-For example:
-
-`From: @email.com`
-
-This will match against any email that has `@email.com` in the `From` field.
-
-The benefit of using static conditions is that they don't require AI processing on every email, leading to greater efficiency and reliability.
-
-### Learned Patterns
-
-Our AI automatically learns your behavior over time - no setup required! The system observes how you interact with emails and adapts accordingly.
-
-**Viewing Learned Patterns**
-- Click into any rule to see its learned patterns
-- Usually, you don't need to modify these
-- Advanced users can manually adjust patterns if needed
-
-#### Actions
-
-Actions are what the AI does when a condition is met. You can add multiple actions to a single rule.
-
-Available actions:
-* Archive
-* Label
-* Reply
-* Forward
-* Send Email
-* Draft Email
-* Mark Read
-* Mark Spam
-* Move to Folder
-* Call Webhook
-* Delayed Actions (archive or perform actions after a set time)
-
-**AI Generated Content**
-
-You can include AI-generated content in your actions by writing custom prompts inside double curly braces: `{{prompt}}`.
-
-Example:
-
-```
+```text
 Hi {{name}},
 {{write a response expressing interest in their proposal and ask about their timeline}}
 Best regards
 ```
 
-The AI will process each prompt in real-time based on the email context, replacing the content inside the curly braces with generated text.
-Everything outside the `{{...}}` placeholders will remain exactly as written.
+Inbox Zero generates the content inside each `{{...}}` placeholder from the email context. Text outside the placeholders remains as written.
 
-#### Apply to Threads
+### Delayed Execution
 
-When "Apply to Threads" is disabled on a rule, that rule is skipped for replies and only runs on the first email in a conversation. This is useful for rules that target standalone emails like newsletters or receipts — disabling it means the AI evaluates fewer rules on threaded emails, improving speed and accuracy.
+Supported actions can run after a delay instead of immediately. Open the action's `More options` menu and choose `Add delay`. Delays can range from 1 minute to 90 days. See [Delayed Actions](/essentials/delayed-actions).
 
-#### When Multiple Rules Can Apply
+### Apply to Threads
 
-If multi-rule selection is off, the AI normally chooses one rule. A few automatic behaviors can still add another label:
+When `Apply to Threads` is disabled, the rule runs only on the first message in a conversation and is skipped for later replies. This is useful for standalone mail such as newsletters or receipts.
 
-* A static rule, like `From` contains `@company.com`, can label an email as `Team` while `To Reply` adds a draft if the message needs a response.
-* If a thread was already marked `To Reply` or `Awaiting Reply`, replies in that thread can keep the conversation moving between those labels.
-* A message like "Does Wednesday at 2pm work?" can be labeled `Calendar` and also `To Reply`, so you get a draft response. Calendar invite files and event reminders stay `Calendar` only.
+### When Multiple Rules Can Apply
 
-### Test Rules
+If multi-rule selection is disabled, the assistant normally chooses one rule. Some system behavior can still add another label. For example, a static `Team` rule can label a message while the `To Reply` rule also creates a draft, and a scheduling email can receive both `Calendar` and `To Reply` labels.
 
-You can test your rules by going to the [Test](https://www.getinboxzero.com/automation?tab=test) tab.
+Enable multi-rule selection in `Assistant` > `Settings` when you intentionally want several custom rules to match the same message.
 
-This will show you a list of emails. When you click `Test`, the AI will run the rule against the email and show you which rule it matched against (if any).
+## Learned Patterns
 
-You can also enter free-form text to test your rules.
+The assistant learns from corrections and from how you handle messages.
 
-To test all rules quickly, click `Test All`.
+- Open a rule to review its learned patterns.
+- Add or remove sender and domain patterns when you need explicit control.
+- Use the History tab's `Fix` action to explain an incorrect match and update the rule.
+
+## Test Rules
+
+Open the [Test tab](https://www.getinboxzero.com/automation?tab=test) to run your rules against an email or free-form text. `Test All` evaluates the selected email against all rules without applying the actions.
 
 ![Test Rules](/images/test-rules.png)
 
-### Fix Rules
+## Assistant Settings
 
-If a rule isn't behaving as expected (e.g., incorrectly marking emails as "to reply"):
-
-1. Go to the History tab
-2. Search for the problematic email
-3. Click `Fix`
-4. Explain why this email shouldn't match the rule
-5. The AI will adjust the rule accordingly
-
-Alternatively, use the [AI Chat](/essentials/ai-chat) to describe the issue and get help fixing it.
+Open `Assistant` > `Settings` to configure behavior shared across rules, including draft-reply confidence and delay, follow-up reminders, writing style, personal instructions and signature, the knowledge base, learned-pattern behavior, multi-rule selection, and the email digest. Some settings depend on your provider or plan.

--- a/docs/essentials/email-analytics.mdx
+++ b/docs/essentials/email-analytics.mdx
@@ -1,36 +1,34 @@
 ---
 title: 'Analytics'
-description: "Understand where you're spending your time and what is filling up your inbox with our detailed analytics."
+description: 'Understand email volume, response time, and assistant activity.'
 icon: 'chart-simple'
 ---
 
-## Getting Started
-
-To view your analytics, click on the `Analytics` tab in the left sidebar. Or visit [this link](https://www.getinboxzero.com/stats).
+Open `Analytics` under Cleanup in the left sidebar, or visit [Analytics](https://www.getinboxzero.com/stats).
 
 ![Analytics](/images/analytics.png)
 
-## Features
+## Available Metrics
 
-* See how many emails you send and receive per day
-* See who emails you most
-* See which domains you email most
-* See which categories of emails you receive most
-* See who you email most
-* See how many emails you're reading and archiving each day
-* See what the largest emails in your inbox are to clear up space
+The Analytics page currently includes:
 
-## Loading more data
+- Received, sent, read versus unread, and archived versus inbox email totals over time
+- Top sender email addresses and domains
+- Top recipient email addresses
+- Median and average response time
+- The percentage of responses sent within one hour
+- Response-time distribution and weekly median response-time trend
+- The number of emails processed by each assistant rule
+- Emails archived and deleted through Inbox Zero, when this organization metric is enabled
 
-To load more of your email history, you can click on the `Load More` button at the bottom of the page. This will load more of your email history and update the analytics.
-You can keep doing this to load more emails.
+Category breakdowns and a largest-attachments report are not part of the current Analytics page.
 
-<Tip>
+## Filter and Group Results
 
-Adjust the date range at the top of the page to see analytics for a specific time period.
+Use the date picker to select a preset or custom range. Use `Group by` to display results by day, week, month, or year. Some cards need enough historical data before they appear.
 
-</Tip>
+## Load More History
 
-## Category Stats
+Click `Load more` to import an older batch of email history and refresh the analytics. Repeat this if you want to analyze more of the account's history. Loading can continue in the background while the page refreshes.
 
-To see category stats, go to the `Mail` page, select all emails, and click `Categorize`. Category stats will then appear on the Analytics page.
+When you view analytics for an organization member and have the required organization permission, the page identifies whose account is being shown. Account-level archive and delete metrics are visible only to the account owner.

--- a/docs/essentials/email-digest.mdx
+++ b/docs/essentials/email-digest.mdx
@@ -1,17 +1,34 @@
 ---
 title: 'Email Digest'
-description: 'Get summaries of your emails at your preferred frequency.'
+description: 'Combine email from selected rules into a scheduled summary.'
 icon: 'newspaper'
 ---
 
-The digest feature sends you summaries of emails at your preferred frequency. Configure any rule to contribute to your daily or weekly digest.
+The digest collects emails matched by selected assistant rules and summarizes them in one scheduled update. It is useful for newsletters, notifications, reports, and other mail you prefer to review together.
 
-This is especially powerful for newsletters. If you receive 20 newsletters throughout the day, you can have them all included in a single digest that summarizes everything you received. Instead of reading each newsletter individually, you get one comprehensive summary of all the important updates.
+<Note>
+The digest is available on eligible plans. Adding an email to the digest does not archive it automatically; add an `Archive` action to the same rule if you also want it removed from the inbox.
+</Note>
 
-## Setup
+## Set Up a Digest
 
-1. Go to [AI Personal Assistant](https://www.getinboxzero.com/automation) and open a rule
-2. Add the "Digest" action to any rule
-3. Choose your preferred frequency (daily or weekly)
+1. Open `Assistant` in the left sidebar.
+2. Open `Settings` and enable `Digest`.
+3. Click `Configure`.
+4. Select the rules whose matching messages should be included.
+5. Choose a daily or weekly schedule. For a weekly digest, also choose the day.
+6. Choose the delivery time and save.
 
-Emails matching that rule will be collected and summarized in a single digest instead of cluttering your inbox.
+You can also add the `Digest` action while editing an individual rule. The Digest settings show all rules currently included and provide a preview.
+
+## Delivery
+
+Email delivery is enabled by default and can be toggled in the Digest settings. Delivery usually begins within about five minutes of the configured time; the page shows an estimated next delivery, the queued email count, and the last delivery status when available.
+
+To receive the same scheduled digest in Slack, Microsoft Teams, or Telegram:
+
+1. Connect the app on the `Channels` page.
+2. Enable `Digests` for that connected account.
+3. For Slack, select a direct message or an allowed private channel.
+
+You can enable email and chat delivery at the same time, or turn off email after chat delivery is configured.

--- a/docs/essentials/faq.mdx
+++ b/docs/essentials/faq.mdx
@@ -4,43 +4,46 @@ description: 'Frequently Asked Questions'
 icon: 'question'
 ---
 
-## Frequently Asked Questions
-
 Answers to common questions about Inbox Zero.
+
+## Common Questions
 
 ### I see an error "You have exceeded the rate limit". How do I fix this?
 
 This error is due to the fact that email providers (Gmail and Outlook) have rate limits per account.
 If you've connected your account to other email services, it's possible that they are using up your rate limit.
 
-#### For Gmail accounts:
-To check what other services have access to your Gmail account, please visit the Security page for your Google account: https://myaccount.google.com/security.
-Then in the section "Your connections to third-party apps & services", click on the `See all connections` button.
-In the `Filter by` section, select `Access to Gmail`.
+#### For Gmail accounts
 
-#### For Microsoft/Outlook accounts:
-To check what other services have access to your Outlook account, please visit the App permissions page for your Microsoft account: https://account.microsoft.com/privacy/app-access.
-Review the list of apps that have access to your email and data.
+To check what other services have access to your Gmail account, visit your [Google Account Security page](https://myaccount.google.com/security). Under `Your connections to third-party apps & services`, click `See all connections`, then filter by `Access to Gmail`.
+
+#### For Microsoft/Outlook accounts
+
+Visit the [Microsoft App permissions page](https://account.microsoft.com/privacy/app-access) and review the apps that can access your email and data.
 
 If there are any services there that you no longer use, click on them, and then click on `Delete all connections you have with this app` (for Gmail) or `Remove` (for Outlook).
 
 ### How do I add more email addresses to my account?
 
-To add more email addresses to your account, please visit the [Settings](https://www.getinboxzero.com/settings) page in the left sidebar.
-Then in the `Share Premium`, add the emails you'd like to share your premium with.
-Each email address you add must first sign up to Inbox Zero, and then you can add them to your account.
+To connect another mailbox for yourself, open the account switcher at the top of the sidebar and choose `Add or manage accounts`. On the Accounts page, choose `Add Account` and connect the Gmail or Outlook mailbox. You can also open [Settings](https://www.getinboxzero.com/settings) and choose `Add Account` in the Email accounts section.
+
+Each connected mailbox has its own assistant rules and settings. Use the account switcher to move between them.
+
+To share a subscription with another person, create or join an organization instead. In Settings, use `Invite members` under Team. Organization membership and connecting another mailbox are separate actions.
 
 ### How do I revoke permissions to my email account?
 
 To revoke permissions to your email account:
 
-#### For Gmail accounts:
+#### For Gmail accounts
+
 - Visit the [Connections](https://myaccount.google.com/u/0/connections) page in your Google account
 - Search for `Inbox Zero`, click on it, and then click `See Details`
 - Click on the `Remove all access` button
 
-#### For Microsoft/Outlook accounts:
-- Visit the [App permissions](https://account.microsoft.com/privacy/app-access) page in your Microsoft account, or visit https://account.live.com/consent/Manage
+#### For Microsoft/Outlook accounts
+
+- Visit the [App permissions](https://account.microsoft.com/privacy/app-access) page in your Microsoft account, or open [Manage app consent](https://account.live.com/consent/Manage)
 - Find `Inbox Zero` in the list and click on it
 - Click `Remove` to revoke access
 
@@ -70,13 +73,11 @@ Both options help you see different types of emails at a glance instead of scrol
 
 ### How do I delete my account?
 
-To delete your account, please visit the [Settings](https://www.getinboxzero.com/settings) page in the left sidebar.
-Then in the `Delete Account` section, click on the `Delete Account` button.
+Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the `Delete Account` section, click `Delete Account`.
 
 ### How do I cancel my subscription?
 
-To cancel your subscription, please visit the [Settings](https://www.getinboxzero.com/premium) page in the left sidebar.
-Then click `Manage Subscription` to cancel.
+Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the Billing section, click `Manage Subscription` and cancel in the billing portal.
 
 ### How do I find the message ID of an email in Gmail?
 

--- a/docs/essentials/feature-availability.mdx
+++ b/docs/essentials/feature-availability.mdx
@@ -1,0 +1,62 @@
+---
+title: 'Feature Availability'
+description: 'Compare providers, platforms, plans, and early-access features.'
+icon: 'table-list'
+---
+
+Inbox Zero supports Gmail and Microsoft Outlook, but provider APIs and staged rollouts create a few differences. Availability can also depend on your plan and deployment configuration.
+
+## Email providers
+
+| Feature | Gmail | Outlook |
+|---|---:|---:|
+| AI Chat and Assistant rules | Yes | Yes |
+| Labels or folders | Gmail labels | Outlook folders and categories |
+| Bulk Unsubscribe | Yes | Yes |
+| Bulk Archive and Analytics | Yes | Yes |
+| Calendar integration and booking links | Google Calendar | Microsoft Calendar |
+| Attachment filing | Google Drive | OneDrive |
+| Reply Zero labels/folders | Yes | Yes |
+| Reply Zero web view | Yes | No; use the Outlook folder |
+| Inbox Zero Tabs extension | Yes | No |
+| Deep Clean | Early Access | No |
+
+<Note>
+Some actions appear only when the connected provider supports them. For example, Outlook uses folders where Gmail uses labels.
+</Note>
+
+## Messaging channels
+
+| Capability | Slack | Microsoft Teams | Telegram |
+|---|---:|---:|---:|
+| Assistant chat | Yes | Yes | Yes |
+| Rule notifications and draft review | Yes | Yes | Yes |
+| Meeting briefs, digests, and follow-up reminders | Yes | Yes | Yes |
+| Attachment-filing alerts | Yes | Yes | Yes |
+| Channel destinations | Private Slack channels or DM | Direct message | Direct message |
+
+See [Channels](/essentials/channels) for setup and routing details.
+
+## Plans and deployment settings
+
+Some features require a paid plan or a feature enabled by the deployment administrator. The app shows an upgrade or Early Access prompt when the current account is not eligible.
+
+- Digests and context integrations require an eligible paid plan.
+- Meeting Recorder is currently Early Access.
+- Self-hosters must explicitly enable optional features and configure their dependencies.
+- Self-hosted deployments normally bypass hosted-service premium checks, but third-party services may have their own fees.
+
+For current hosted pricing, see [Pricing](https://www.getinboxzero.com/pricing).
+
+## Early Access
+
+Early Access features can change, have limited support, or be removed.
+
+- **AI Meeting Recorder:** Early Access. Broad release is currently expected in approximately two weeks.
+- **Deep Clean:** Experimental Early Access for Gmail. There is no commitment to a broad release, and the feature may remain experimental or be discontinued.
+- **Context Integrations:** Early Access. A broader release may happen soon, but timing is not guaranteed.
+
+## Web and mobile
+
+The web app contains the complete configuration experience. The iOS and Android apps focus on mobile inbox access, assistant chat, summaries, and email actions. Use the web app for advanced setup when an option is not available on mobile.
+

--- a/docs/essentials/feature-availability.mdx
+++ b/docs/essentials/feature-availability.mdx
@@ -54,7 +54,7 @@ For current hosted pricing, see [Pricing](https://www.getinboxzero.com/pricing).
 
 Early Access features can change, have limited support, or be removed.
 
-- **AI Meeting Recorder:** Early Access. Broad release is currently expected in approximately two weeks.
+- **Meeting Recorder:** Early Access. Broad release is currently expected in approximately two weeks.
 - **Deep Clean:** Experimental Early Access for Gmail. There is no commitment to a broad release, and the feature may remain experimental or be discontinued.
 - **Context Integrations:** Early Access. A broader release may happen soon, but timing is not guaranteed.
 

--- a/docs/essentials/feature-availability.mdx
+++ b/docs/essentials/feature-availability.mdx
@@ -25,6 +25,8 @@ Inbox Zero supports Gmail and Microsoft Outlook, but provider APIs and staged ro
 Some actions appear only when the connected provider supports them. For example, Outlook uses folders where Gmail uses labels.
 </Note>
 
+For a practical walkthrough of these differences, see [Outlook and Microsoft 365](/essentials/outlook-guide).
+
 ## Messaging channels
 
 | Capability | Slack | Microsoft Teams | Telegram |
@@ -59,4 +61,3 @@ Early Access features can change, have limited support, or be removed.
 ## Web and mobile
 
 The web app contains the complete configuration experience. The iOS and Android apps focus on mobile inbox access, assistant chat, summaries, and email actions. Use the web app for advanced setup when an option is not available on mobile.
-

--- a/docs/essentials/getting-started.mdx
+++ b/docs/essentials/getting-started.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Getting Started'
+description: 'Connect your inbox and complete your first Inbox Zero workflow.'
+icon: 'rocket-launch'
+---
+
+This guide takes you from a connected mailbox to a working assistant. Inbox Zero supports Gmail and Microsoft Outlook accounts, although some features differ by provider. See [Feature Availability](/essentials/feature-availability) before choosing a workflow.
+
+## 1. Connect an email account
+
+Sign in at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook account. Approve the requested permissions so Inbox Zero can read and organize messages and, when you enable those features, create drafts or send messages.
+
+You can add another mailbox later from **Settings → Email Accounts**. Each mailbox has its own rules, assistant settings, analytics, and connected channels.
+
+## 2. Set up the Assistant
+
+Open **Assistant** in the sidebar and complete the guided setup. Start with a small rule that is easy to verify, such as labeling newsletters or archiving a known notification sender.
+
+After saving a rule:
+
+1. Open the rule and review its conditions and actions.
+2. Use the **Test** tab to run it against example or recent messages.
+3. Check **History** after new mail arrives to see what matched and why.
+4. Use **Fix** or [Chat](/essentials/ai-chat) if the rule handled a message incorrectly.
+
+<Tip>
+Begin with labeling, archiving, or marking messages as read. Add outbound actions such as replies and forwarding after you are comfortable with how the rule matches.
+</Tip>
+
+## 3. Clean up existing mail
+
+Use **Bulk Unsubscribe** to find noisy senders and **Bulk Archive** to organize older messages by sender category. These tools act on existing mail; Assistant rules handle new mail as it arrives.
+
+Review the selected senders before applying a bulk action. Deleting mail is more difficult to recover than archiving or marking it as read.
+
+## 4. Connect optional services
+
+- Connect calendars for availability-aware drafts, booking links, and meeting features.
+- Open **Channels** to connect Slack, Microsoft Teams, or Telegram.
+- Gmail users can install the Inbox Zero Tabs browser extension.
+- Teams can create an organization and invite members from **Settings → Team**.
+
+## 5. Personalize drafts
+
+Open **Assistant → Settings** to configure auto-drafting, draft confidence, writing style, personal instructions, your signature, and the assistant's knowledge base. See [Assistant Settings](/essentials/assistant-settings) for details.
+
+## What to do next
+
+<CardGroup cols={2}>
+  <Card title="Chat with your inbox" icon="message-bot" href="/essentials/ai-chat">
+    Search mail and take actions using natural language.
+  </Card>
+  <Card title="Build automation rules" icon="sparkles" href="/essentials/email-ai-personal-assistant">
+    Organize new mail and draft responses automatically.
+  </Card>
+  <Card title="Connect calendars" icon="calendar" href="/essentials/calendar-integration">
+    Use availability, booking links, and meeting workflows.
+  </Card>
+  <Card title="Configure channels" icon="messages" href="/essentials/channels">
+    Deliver notifications and drafts to the apps where you work.
+  </Card>
+</CardGroup>
+

--- a/docs/essentials/getting-started.mdx
+++ b/docs/essentials/getting-started.mdx
@@ -6,6 +6,10 @@ icon: 'rocket-launch'
 
 This guide takes you from a connected mailbox to a working assistant. Inbox Zero supports Gmail and Microsoft Outlook accounts, although some features differ by provider. See [Feature Availability](/essentials/feature-availability) before choosing a workflow.
 
+<Note>
+Most product videos were recorded with Gmail. Outlook users can follow the same Inbox Zero navigation and use the [Outlook and Microsoft 365 guide](/essentials/outlook-guide) to translate labels, folders, calendars, and Gmail-only limitations.
+</Note>
+
 ## 1. Connect an email account
 
 Sign in at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook account. Approve the requested permissions so Inbox Zero can read and organize messages and, when you enable those features, create drafts or send messages.
@@ -60,4 +64,3 @@ Open **Assistant → Settings** to configure auto-drafting, draft confidence, wr
     Deliver notifications and drafts to the apps where you work.
   </Card>
 </CardGroup>
-

--- a/docs/essentials/inbox-zero-tabs-extension.mdx
+++ b/docs/essentials/inbox-zero-tabs-extension.mdx
@@ -8,6 +8,10 @@ icon: 'chrome'
 
 Inbox Zero Tabs is a free browser extension that adds custom tabs to Gmail. It helps you organize your inbox by creating tabs for different types of emails - similar to Superhuman's split inbox feature.
 
+<Warning>
+Inbox Zero Tabs is Gmail-only. It does not add tabs to Outlook on the web, including when Outlook is open in Chrome, Edge, Firefox, or another supported browser.
+</Warning>
+
 The extension is 100% private - all data stays in your browser with no tracking or data collection.
 
 ![Inbox Zero Tabs Extension](/images/extension.png)

--- a/docs/essentials/meeting-briefs.mdx
+++ b/docs/essentials/meeting-briefs.mdx
@@ -1,79 +1,66 @@
 ---
 title: 'Meeting Briefs'
-description: 'Get AI-generated briefings before every meeting with external contacts.'
+description: 'Get AI-generated context before meetings with external guests.'
 icon: 'calendar-check'
 ---
 
 ## Overview
 
-Meeting Briefs automatically sends you an AI-generated briefing before each meeting with external contacts. Each briefing includes context about your attendees pulled from your email history, past meetings, and web research so you're always prepared.
+Meeting Briefs prepares an AI-generated briefing before a calendar event with external guests. It combines attendee details with relevant email and meeting history, plus web research when available.
 
-Briefings are delivered to your inbox (and optionally Slack) ahead of each meeting on your schedule.
+Meetings with only internal attendees are skipped. For a work account, people on your email domain are treated as internal; for common personal email domains, other attendees are treated as external.
 
-## What's in a briefing?
+<Warning>
+Briefings are AI-generated and may contain inaccuracies. Verify important details before using them in a meeting.
+</Warning>
 
-Each briefing includes:
+## Set Up Meeting Briefs
 
-- **Attendee profiles** with name, email, and relevant background
-- **Email history** summarizing recent conversations with each guest
-- **Past meetings** you've had with them
-- **Web research** pulling in professional context when available
+### Connect a Calendar
 
-Internal team members (people on your same email domain) are noted but don't receive individual profiles since you already know them.
+Open `Meeting Briefs` in the left sidebar. If no calendar is connected, follow the prompt to connect Google Calendar or Microsoft Outlook Calendar. You can also manage calendar connections from `Calendars`.
 
-Meetings with no external guests are automatically skipped.
+### Enable the Feature
 
-## Getting Started
+Turn on `Enable Meeting Briefs`. Meeting Briefs is available on eligible plans.
 
-### 1. Connect your calendar
+### Choose the Timing
 
-Navigate to **Briefs** in the left sidebar. If you haven't connected a calendar yet, you'll be prompted to connect Google Calendar or Microsoft Outlook Calendar.
+Set how long before each meeting the briefing should be generated. The default is four hours, and the supported range is 1 minute to 48 hours.
 
-### 2. Enable Meeting Briefs
+### Choose Delivery Channels
 
-Once your calendar is connected, click **Enable Meeting Briefs** to turn on the feature.
+Email delivery is enabled by default and can be toggled independently. You can also deliver briefs to any supported account connected on the `Channels` page:
 
-<Note>Meeting Briefs is a premium feature.</Note>
+- Slack
+- Microsoft Teams
+- Telegram
 
-### 3. Configure timing
+Slack can deliver to a direct message or an allowed private channel. Teams and Telegram use the linked messaging destination. You can enable more than one delivery channel at the same time.
 
-Set how far in advance you want to receive briefings. The default is **4 hours** before each meeting, but you can adjust this from 1 minute to 48 hours.
+## Briefing Content
 
-### 4. Choose delivery channels
+A briefing can include:
 
-Select where you want to receive your briefings:
+- Attendee names, email addresses, and relevant background
+- Recent email history with each external guest
+- Past and upcoming meetings involving the same people
+- Web research and professional context when available
+- Internal team members who are also attending
+- Meeting time, location, and joining details
 
-- **Email** (enabled by default)
-- **Slack** (requires connecting your Slack workspace first, see [Slack Integration](/essentials/slack-integration))
+Available context varies by attendee and by the integrations enabled for your account. If external integrations are available, the `Integrations` setting on the Meeting Briefs page can connect additional tools to enrich the briefing.
 
-## Upcoming Meetings
+## Upcoming Meetings and Tests
 
-The Briefs page shows your upcoming meetings for the next 7 days that have external guests. For each meeting, you can:
+The `Upcoming Meetings` section lists calendar events that Inbox Zero can see. Choose `Send test brief` to generate a sample immediately for a selected event. The test action sends an email so you can verify the output even if you also use chat delivery.
 
-- **Send a test brief** to preview what the briefing looks like
-- **View send history** to see past briefings and their delivery status
-
-## Briefing Statuses
-
-| Status | Meaning |
-|--------|---------|
-| Sent | Briefing was delivered successfully |
-| Pending | Briefing is being generated |
-| Skipped | No external guests found for the meeting |
-| Failed | Delivery encountered an error |
+Use `View send history` to inspect recent attempts. History can show `PENDING`, `SENT`, `FAILED`, or `SKIPPED` depending on processing and whether external guests were available.
 
 ## How It Works
 
-1. The system checks your calendar periodically for upcoming meetings
-2. When a meeting falls within your configured time window, it gathers context:
-   - Recent email threads with each external attendee
-   - Past calendar events with the same people
-   - Web research about each guest (when available)
-3. AI generates a concise briefing with key talking points for each guest
-4. The briefing is delivered via your chosen channels
-
-## Tips
-
-- Connect Slack for quick-glance briefings right in your workflow
-- Use the "Send test brief" button to see what your briefings look like before your next real meeting
-- Adjust the timing to match your prep style. Some people prefer 4 hours ahead, others want it 30 minutes before
+1. Inbox Zero periodically checks connected calendars for events approaching your configured lead time.
+2. Events without external guests are skipped.
+3. The assistant gathers email, calendar, web, and enabled integration context.
+4. It creates one concise briefing and sends it through the enabled delivery channels.
+5. The result is recorded in send history.

--- a/docs/essentials/meeting-recorder.mdx
+++ b/docs/essentials/meeting-recorder.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Meeting Recorder'
+description: 'Record calls with a visible notetaker and receive transcripts, notes, action items, and follow-up drafts.'
+icon: 'microphone'
+---
+
+<Note>
+Meeting Recorder is in Early Access. It is expected to release in about two weeks, but that timing may change.
+</Note>
+
+Meeting Recorder adds **Inbox Zero Notetaker** to eligible video calls as a visible participant. After the call, Inbox Zero can produce a transcript, summary, decisions, action items, open questions, and next steps. It can also email the notes to you and prepare a follow-up in your Drafts folder.
+
+<Warning>
+The notetaker records and transcribes a meeting. Make sure participants know it is present and follow the consent and recording laws that apply to you and your attendees.
+</Warning>
+
+## Requirements
+
+- Early Access must be enabled for your account.
+- Meeting recording requires the **Plus plan or higher**.
+- Connect a Google or Microsoft calendar to Inbox Zero.
+- The calendar event must contain a supported video-conference link. The current implementation recognizes Google Meet, Zoom, and Microsoft Teams meeting URLs.
+
+## Set up Meeting Recorder
+
+1. Open **Meetings** in the left sidebar.
+2. If the feature is not enabled for your account, select **Join Early Access**.
+3. Connect a calendar if prompted.
+4. Select which meetings the notetaker should join:
+   - **Only calls with people outside my company** — the recommended default.
+   - **Every call with a video link**.
+   - **Only calls I organize**.
+   - **Only the ones I turn on myself** — nothing is scheduled automatically.
+5. Select **Start recording my meetings**.
+
+The **Up next** list shows eligible calls in the next 48 hours. Use the toggle beside a meeting to override the default for that individual call. Turning a scheduled meeting off cancels its notetaker booking.
+
+## Configure notes and follow-ups
+
+Open **Meetings > Settings** to change the automatic join rule and these options:
+
+- **Email me the notes** sends the completed recap to your email.
+- **Draft a follow-up email** creates a draft addressed to the other attendees.
+
+The follow-up is never sent automatically. Review its recipients and content in Drafts before sending it.
+
+Selecting **Turn off** cancels every call the notetaker is currently booked to join. If your plan later stops including Meeting Recorder, you can still turn off an already scheduled recording, but you cannot schedule new ones.
+
+## Review a recorded meeting
+
+Completed and processing calls appear under **Recorded** on the Meetings page. Open a meeting to see:
+
+- An overview and key decisions.
+- Action items and their detected owners.
+- Open questions and next steps.
+- A speaker-attributed transcript with timestamps, when a usable transcript is available.
+- A link to the generated follow-up draft, when enabled.
+
+AI-generated notes can be incomplete or inaccurate. Compare important decisions, commitments, names, and dates with the transcript or the other attendees before relying on them.
+
+## Troubleshooting
+
+### A call does not appear under Up next
+
+Confirm that the calendar connection is active, the event is within the next 48 hours, and the event contains a video-conference link. Then check whether your automatic join rule excludes the event.
+
+### The notetaker did not join
+
+Open the meeting in **Up next** or **Recorded** and check its status. Common causes include a removed or changed meeting link, an event that was changed too close to its start time, host admission controls, or the meeting provider rejecting the bot.
+
+### Notes are still processing
+
+Transcription and summarization continue after the call ends and may take time. Refresh the meeting later. If summarization fails but a transcript was recovered, the transcript remains available in the meeting detail.
+
+### No summary was created
+
+Open the meeting detail. It will indicate whether recording failed, summarization failed, or no usable transcript was available. A failed recording cannot be reconstructed by Inbox Zero after the call.
+

--- a/docs/essentials/mobile-apps.mdx
+++ b/docs/essentials/mobile-apps.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'Mobile Apps'
-description: 'Use Inbox Zero on iPhone or Android to triage email and manage your assistant on the go.'
+description: 'Use Inbox Zero on iOS or Android to triage email and manage your assistant on the go.'
 icon: 'mobile-screen'
 ---
 
-Inbox Zero is available for iPhone and Android. The mobile apps work with the same Inbox Zero account and connected Gmail or Outlook accounts you use on the web.
+Inbox Zero is available for iOS and Android. The mobile apps work with the same Inbox Zero account and connected Gmail or Outlook accounts you use on the web.
 
 ## Install and sign in
 

--- a/docs/essentials/mobile-apps.mdx
+++ b/docs/essentials/mobile-apps.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Mobile Apps'
+description: 'Use Inbox Zero on iPhone or Android to triage email and manage your assistant on the go.'
+icon: 'mobile-screen'
+---
+
+Inbox Zero is available for iPhone and Android. The mobile apps work with the same Inbox Zero account and connected Gmail or Outlook accounts you use on the web.
+
+## Install and sign in
+
+1. Open [getinboxzero.com/app](https://www.getinboxzero.com/app).
+2. Select **App Store** or **Google Play**.
+3. Install Inbox Zero and sign in with your existing account. If you are new, create an account and connect Gmail or Outlook during setup.
+
+The apps are free to download. Features that require a paid Inbox Zero plan on the web keep the same plan requirement on mobile.
+
+## What you can do
+
+The current mobile experience supports core inbox and assistant workflows, including:
+
+- Chat with the AI assistant to ask about email, get summaries, and prepare replies.
+- Read conversations and send new messages or replies.
+- Review messages needing a reply and common categories such as Newsletters, Promotions, and Notifications.
+- Work across your connected inboxes from the combined inbox view.
+- Archive, restore, move to trash, or undo those actions for individual or selected threads.
+- Create a rule from a plain-language prompt or configure it manually, then edit, enable, disable, or delete rules.
+
+Some account administration and advanced configuration remain easier or available only in the web app. If a setting is not present on mobile, open Inbox Zero in a desktop browser.
+
+## Multiple inboxes
+
+The combined inbox loads eligible sections from every connected email account. If one provider is temporarily unavailable, the app can still show results from other accounts and indicate that the affected account is incomplete.
+
+Actions are scoped to the account that owns each thread. The service verifies account ownership before changing mail, including bulk archive operations.
+
+## Safety
+
+- Review AI-generated drafts and recipients before sending.
+- Archive and trash are different: trash moves a thread to Gmail Trash or Outlook Deleted Items; it is not an immediate permanent deletion.
+- Use your phone's passcode or biometric lock and keep the operating system updated.
+- If a phone is lost, secure the device through Apple or Google and review your Inbox Zero and email-account sessions.
+
+## Troubleshooting
+
+### Sign-in returns to the browser instead of the app
+
+Update the app and retry from its sign-in screen. If the callback still does not return, close the browser tab, reopen the app, and start a fresh sign-in. A sign-in authorization code is short-lived and cannot be reused.
+
+### One connected account is empty
+
+Open the account on the web and confirm that its Gmail or Outlook connection is active. Then refresh the mobile view. Other accounts may continue working while one account is disconnected or experiencing a provider error.
+
+### A web feature is missing on mobile
+
+Use the web app for the complete settings and administration surface. Mobile and web share the same account, so saved changes will apply to supported mobile workflows.

--- a/docs/essentials/organizations.mdx
+++ b/docs/essentials/organizations.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Organizations'
+description: 'Invite teammates, manage roles, share assistant rules, and view consented team analytics.'
+icon: 'users'
+---
+
+Organizations let a team manage membership, distribute shared assistant rules, and review aggregate usage. Each email account can belong to only one organization at a time.
+
+## Create an organization
+
+1. Open the account menu.
+2. Select **Create organization**.
+3. Enter the organization name and a unique URL slug.
+4. Select **Create Organization**.
+
+The creator becomes the organization **Owner**. The slug may contain lowercase letters, numbers, and hyphens.
+
+## Roles and permissions
+
+| Role | Access |
+| --- | --- |
+| **Owner** | All admin abilities, plus transferring ownership. |
+| **Admin** | Invite and remove members, change non-owner roles, manage organization rules, and view analytics that members have shared. |
+| **Member** | View the member list and use organization-managed rules in their own account. |
+
+Only the owner can transfer ownership. After a transfer, the previous owner becomes an admin. Admins and owners cannot remove or change the current owner's role directly.
+
+## Invite and manage members
+
+1. Open **My Organization** from the account menu.
+2. On **Members**, select **Invite members**.
+3. Enter up to 10 email addresses at a time and assign a role.
+4. Send the invitations.
+
+Invitations are delivered by email and expire after 14 days. The recipient must accept while signed in with the exact invited email address. An admin can cancel a pending invitation from the Members page.
+
+Use the menu beside a member to change their role or remove them. The owner also sees **Transfer ownership**. If the organization provides premium seats, accepting an invitation can claim an available seat; removing a member releases their organization seat.
+
+## Create organization rules
+
+Owners and admins can open **Rules** and create assistant rules that are copied to every member account.
+
+- New members receive the current organization rules when they join.
+- Editing an organization rule updates its member copies.
+- Members see a **Managed by organization** rule and cannot edit its definition.
+- A member may turn a managed rule on or off for their own account.
+- The rule only runs for a member when both the organization-level rule and that member's copy are enabled.
+- Deleting an organization rule removes it for all members.
+
+Messaging-channel actions are not supported in organization rules because each member has separate Slack, Teams, or Telegram destinations. Configure those actions in each member's own rules instead.
+
+<Warning>
+Organization rules can perform inbox actions for every member. Test conditions carefully, prefer drafts over automatic sends for generated replies, and review changes before enabling a rule organization-wide.
+</Warning>
+
+## Analytics and privacy
+
+The **Analytics** tab is available to owners and admins. It can show totals and distributions for emails received, rules executed, and active members over a selected date range.
+
+Member analytics are private by default unless the deployment explicitly configures otherwise. Each member sees a prompt to allow organization-admin analytics. Admins can open a member's Analytics and Usage pages only after that member grants access. A hidden-activity badge means the member has not shared analytics.
+
+Granting analytics access does not give an admin the ability to read the member's email content through the organization page.
+
+## Troubleshooting
+
+### An invitation cannot be accepted
+
+Confirm that it has not expired and that the signed-in account exactly matches the invited email. The recipient must leave any other organization before joining, because an email account can have only one membership.
+
+### Rules or Analytics tabs are missing
+
+Those tabs are limited to owners and admins. Ask an owner or admin to update your role if appropriate.
+
+### A member cannot edit a rule
+
+Rules labeled **Managed by organization** can only be edited by an owner or admin from the organization's Rules tab. The member can still enable or disable their own copy.
+
+### A member's analytics are unavailable
+
+The member must select **Allow Access** on the organization page. Analytics can also remain empty until Inbox Zero has processed enough account activity for the selected date range.
+

--- a/docs/essentials/outlook-guide.mdx
+++ b/docs/essentials/outlook-guide.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Outlook and Microsoft 365'
+description: 'Use Inbox Zero with Outlook and understand the differences from Gmail.'
+icon: 'microsoft'
+---
+
+<Info>
+Many Inbox Zero videos were recorded with Gmail. The Inbox Zero navigation and setup steps generally work the same after you select an Outlook account, but the resulting mail actions use Microsoft folders, categories, calendars, and storage.
+</Info>
+
+Inbox Zero supports Microsoft 365 work or school accounts and personal Outlook accounts. Features and rules belong to the currently selected mailbox, so confirm the account shown in the switcher before changing settings.
+
+## Connect Outlook
+
+1. Sign in to Inbox Zero and select **Add or manage accounts** from the account switcher.
+2. Choose **Outlook** and sign in with the Microsoft account you want to connect.
+3. Review and approve the requested Microsoft permissions.
+4. Return to Inbox Zero and select the new mailbox from the account switcher.
+
+An organization administrator may need to approve the app before a managed Microsoft 365 account can connect. If access is later revoked in Microsoft, reconnect the mailbox from Inbox Zero.
+
+## Gmail terms in Outlook
+
+When a video or guide shows Gmail, use the corresponding Outlook concept:
+
+| Gmail term | Outlook equivalent |
+| --- | --- |
+| Label | Category |
+| Move to label | Move to folder |
+| Archive | Archive folder |
+| Trash | Deleted Items |
+| Spam | Junk Email |
+| Google Calendar | Outlook Calendar |
+| Google Drive | OneDrive or SharePoint |
+
+Assistant rules can add Outlook categories or move messages into folders. Archiving, deleting, marking read or unread, drafting, replying, forwarding, and sending work against the selected Outlook mailbox.
+
+## Supported Outlook workflows
+
+Outlook accounts can use the main Inbox Zero workflows, including:
+
+- [AI Chat](/essentials/ai-chat) and [Assistant rules](/essentials/email-ai-personal-assistant)
+- [Bulk Unsubscribe](/essentials/bulk-email-unsubscriber), [Bulk Archive](/essentials/bulk-archiver), and [Analytics](/essentials/email-analytics)
+- [Outlook Calendar](/essentials/calendar-integration), booking links, Meeting Briefs, and eligible meeting features
+- Attachment filing to Microsoft OneDrive or SharePoint
+- Slack, Microsoft Teams, and Telegram delivery through [Channels](/essentials/channels)
+- The Inbox Zero mobile apps
+
+Provider permissions and deployment settings can hide individual actions or features. See [Feature Availability](/essentials/feature-availability) for the current comparison.
+
+## Gmail-only differences
+
+### Inbox Zero Tabs extension
+
+The Inbox Zero Tabs browser extension works only inside Gmail. It does not add tabs to Outlook on the web, even when Outlook is open in Chrome, Edge, or another supported browser.
+
+### Reply Zero page
+
+Outlook can use the `To Reply`, `Awaiting Reply`, and `Follow-up` categories, but the dedicated Reply Zero page inside Inbox Zero is currently Gmail-only. Review the categories in Outlook instead.
+
+### Deep Clean
+
+The experimental Deep Clean feature is currently Gmail-only and does not appear for Outlook accounts. Outlook users can use Bulk Archive, Bulk Unsubscribe, Assistant rules, and standard archive or delete actions instead.
+
+## Outlook troubleshooting
+
+### Microsoft will not authorize the connection
+
+Retry with the intended Microsoft account. For a managed Microsoft 365 tenant, ask an administrator whether user consent is restricted or whether the Inbox Zero app requires approval.
+
+### A rule uses the wrong category or folder
+
+Confirm that the category or folder still exists in the connected Outlook mailbox, then edit and retest the rule. Settings and rules are not shared automatically between connected mailboxes.
+
+### Inbox Zero stopped receiving Outlook mail
+
+Open **Settings → Email Accounts** and reconnect the Outlook account if it shows a permissions or subscription error. You can also review or revoke Inbox Zero from the [Microsoft App permissions page](https://account.microsoft.com/privacy/app-access).
+

--- a/docs/essentials/reply-zero.mdx
+++ b/docs/essentials/reply-zero.mdx
@@ -1,36 +1,47 @@
 ---
 title: 'Reply Zero'
-description: 'Focus on emails that matter and never miss a follow-up'
+description: 'Track conversations that need a reply or a follow-up.'
 icon: 'reply'
 ---
 
-Reply Zero labels every email that needs a reply as `To Reply`, and every email where you're waiting for a reply as `Awaiting Reply`. These labels appear in your regular email client (Gmail or Outlook). Gmail users can also use the Reply Zero view in Inbox Zero to see only these emails.
+Reply Zero classifies conversations as `To Reply` when you owe a response and `Awaiting Reply` when you are waiting for someone else. These labels or categories are also visible in your regular email client.
 
 ![Reply Zero](/images/reply-zero.png)
 
-## Getting Started
-
 <Warning>
-  Reply Zero view is not currently available for Microsoft/Outlook users. To see emails needing replies, Microsoft/Outlook users can check the `To Reply` folder in Microsoft/Outlook.
+The Inbox Zero Reply Zero view is currently available only for Gmail accounts. Outlook users can use the `To Reply`, `Awaiting Reply`, and `Follow-up` categories in Outlook, but will not see the Reply Zero item in Inbox Zero.
 </Warning>
 
-Go to the [Reply Zero](https://www.getinboxzero.com/reply-zero) tab in the left sidebar to enable it.
+## Open Reply Zero
 
-## How It Works
+For a Gmail account, open the account menu at the bottom of the sidebar and choose `Reply Zero`. On first use, follow the onboarding steps to enable the reply-tracking rules.
+
+Reply Zero is in the account menu, not the main left-sidebar navigation list.
+
+## Lists
 
 ### To Reply
 
-Our AI analyzes incoming emails and labels the ones that need your response as `To Reply`. They appear in both your email client and the Reply Zero view.
+Incoming conversations that appear to need your response are labeled `To Reply`. The Gmail Reply Zero view shows them on the `To Reply` tab and provides a `Reply` shortcut.
 
-### Awaiting Reply
+### Waiting
 
-When you send an email that needs a response, Reply Zero labels the thread as `Awaiting Reply` and adds it to your `Waiting` list so you can track overdue responses.
+Sent conversations that appear to require a response are labeled `Awaiting Reply` and shown on the `Waiting` tab. Use `Nudge` to open the thread and prepare a follow-up.
 
-### One-click Follow-ups
+### Done
 
-Use the `Nudge` button to have AI draft a follow-up message. Filter by age to prioritize overdue conversations.
+Choose `Mark Done` when a conversation no longer needs attention. It moves to the `Done` tab. You can restore it with `Not Done` if necessary.
 
-## Managing Your Lists
+Use the time-range filter to focus on newer or older conversations.
 
-- **Mark as Done** — Click `Mark Done` to move a conversation to the `Done` tab
-- **Filter by Age** — Filter for emails waiting more than a week to focus on overdue threads
+## Follow-Up Reminders
+
+Open `Assistant` > `Settings` and configure `Follow-up reminders` to choose:
+
+- How many days to wait when another person has not replied
+- How many days to wait when you have not replied
+- Whether Inbox Zero should automatically draft a nudge when you are waiting
+
+Saturday and Sunday do not count toward these thresholds. Use `Find follow-ups` to scan existing mail immediately. Matching conversations receive a `Follow-up` label or category.
+
+To receive reminders in Slack, Microsoft Teams, or Telegram, enable follow-up delivery for the connected account on the `Channels` page.

--- a/docs/essentials/security-and-data.mdx
+++ b/docs/essentials/security-and-data.mdx
@@ -1,0 +1,50 @@
+---
+title: 'Security, Permissions, and AI'
+description: 'Understand account access, confirmations, sensitive-data controls, and recovery.'
+icon: 'shield-check'
+---
+
+Inbox Zero needs access to your mailbox to search messages and run the workflows you enable. Optional features request additional access only when you connect them, such as calendar or drive permissions.
+
+## Account permissions
+
+- Email permissions allow Inbox Zero to read and organize messages and create drafts.
+- Calendar permissions support availability, booking links, and meeting features.
+- Drive permissions support filing attachments and attaching approved files to drafts.
+- Slack, Teams, and Telegram connections let the assistant respond and deliver configured notifications.
+
+You can revoke a connection from Inbox Zero or from the provider's security settings. Revoking provider access stops the affected feature until you reconnect it.
+
+## Confirming high-impact actions
+
+Chat and messaging-channel workflows ask for confirmation before high-impact actions such as sending messages or creating automation that can communicate externally. Always review generated recipients, content, links, and attachments before approving.
+
+Rules run automatically after they are enabled. Test new rules with recent messages and review **Assistant → History** before relying on outbound actions.
+
+## Sensitive-data protection
+
+Assistant settings include a sensitive-data policy that can allow, redact, or block detected credentials and payment-card numbers before content is sent to an AI provider. A self-hosted administrator can choose a default and lock the setting for every account.
+
+This control reduces accidental exposure; it is not a substitute for removing secrets from email or reviewing generated content.
+
+## AI limitations
+
+AI output can be incomplete or incorrect. In particular:
+
+- A rule may match an unexpected message.
+- A draft may omit context or make an unsupported assumption.
+- A summary may miss a detail from a long thread or attachment.
+- Availability and external-tool results depend on connected services being current.
+
+Use rule tests, draft confidence, confirmation prompts, and the **Fix** workflow to reduce these risks.
+
+## Safer cleanup and recovery
+
+Prefer labels, folders, archiving, or marking mail as read while testing a workflow. Deletion is more difficult to recover and may depend on the retention behavior of Gmail or Outlook.
+
+If a rule behaves incorrectly, disable it, inspect its History entry, and use **Fix**. You can also disable all rules for one mailbox from **Settings → Email Accounts** while investigating.
+
+## Account deletion
+
+Deleting your Inbox Zero account is separate from revoking Google or Microsoft access. See the [FAQ](/essentials/faq) for both processes and review the [Privacy Policy](https://www.getinboxzero.com/privacy) for the hosted service's current data terms.
+

--- a/docs/essentials/slack-integration.mdx
+++ b/docs/essentials/slack-integration.mdx
@@ -1,78 +1,64 @@
 ---
 title: 'Slack Integration'
-description: 'Connect Slack to receive notifications and chat with your AI assistant.'
+description: 'Chat with your assistant and deliver rules, drafts, and updates to Slack.'
 icon: 'hashtag'
 ---
 
 ## Overview
 
-Connect your Slack workspace to Inbox Zero to receive notifications and interact with your AI email assistant directly from Slack. You can get meeting briefings delivered to a channel, receive auto-filing notifications, and chat with the AI by sending it a direct message or @mentioning it.
+Connect Slack from the unified `Channels` page. A connected workspace can chat with the assistant and receive rule notifications, draft replies for review, meeting briefs, follow-up reminders, digests, and document-filing alerts.
 
 <Warning>
-**AI disclaimer.** Inbox Zero is powered by AI and may produce inaccurate outputs. Review all AI-generated content before acting. Inbox Zero requests approval before sending replies or taking other high-impact actions in your inbox or Slack workspace.
+Inbox Zero uses AI and can produce inaccurate output. Review generated content before acting. New email, reply, forward, and other high-impact chat flows provide an approval step when required.
 </Warning>
 
-## Connecting Slack
+## Connect Slack
 
-The "Add to Slack" button lives inside your Inbox Zero account, so you'll install the app from the Channels page.
+1. Connect a Gmail or Outlook account to Inbox Zero.
+2. Open `Channels` in the left sidebar.
+3. Find Slack and click `Connect`.
+4. Approve the requested permissions in Slack.
+5. After returning to Inbox Zero, configure the rules and feature destinations you want.
 
-1. Sign up for a free Inbox Zero account at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook email account
-2. Click **Channels** in the left sidebar
-3. Find Slack in the list and click **Connect**
-4. Authorize Inbox Zero in the Slack OAuth flow (Slack will show the requested permissions and an **Allow** button)
-5. After redirect, pick the Slack channel you want to use for notifications and meeting briefs
+The connected workspace appears on the Channels page with a `Connected` badge.
 
-Once connected, your workspace will appear in the Channels list with a green **Connected** badge.
+## Choose a Destination
 
-## Features
+Each Slack feature can use a direct message or an allowed private channel. Configured channel delivery has these restrictions:
 
-### Meeting Briefing Delivery
+- Public channels cannot be selected.
+- You must be a member of the private channel.
+- Inbox Zero does not automatically join the selected channel.
+- If a private channel is missing from the selector, use the `/invite @<bot-name>` command shown in the destination menu to invite the Inbox Zero bot, then refresh the list.
 
-Receive your [Meeting Briefs](/essentials/meeting-briefs) in a Slack channel instead of (or in addition to) email.
+You can choose separate destinations for rule notifications, meeting briefs, follow-up reminders, digests, document-filing alerts, and scheduled check-ins.
 
-To set this up:
-1. Go to **Channels** in the left sidebar
-2. Select your Slack channel for meeting brief delivery
-3. Toggle on Slack delivery
+## Rule Notifications and Draft Review
 
-Briefings appear as formatted Slack messages with attendee details, meeting links, and key context.
+The `Rule notifications` section lists your assistant rules. Enable a rule for Slack, then use its menu to choose:
 
-### Auto-Filing Notifications
+- **Notify only** — Post a notification when the rule matches.
+- **Draft reply in chat** — Deliver the generated reply to Slack for review.
 
-Get notified in Slack when attachments are automatically filed to your drive. See [Auto-File Attachments](/essentials/auto-file-attachments) for details on setting up auto-filing.
+If a rule already drafts an email reply, draft-review mode is selected by default when you first enable Slack delivery for that rule.
 
-To enable:
-1. Go to **Attachments** in the left sidebar
-2. Open the **Integrations** section
-3. Toggle on Slack notifications
+## Chat with the Assistant
 
-You'll see messages confirming where each file was saved, or questions when the AI needs your input on where to file something.
+- Send the Inbox Zero bot a direct message.
+- Mention the bot in a Slack conversation where it has been added.
+- Continue related conversations in Slack threads.
 
-### Chat with the AI Assistant
+The assistant can search and manage email, draft messages, and update supported rules and settings. Use `/help` to see shortcuts such as `/summary`, `/draftreply`, `/followups`, and `/cleanup`.
 
-You can interact with your Inbox Zero AI assistant directly in Slack:
+## Other Slack Deliveries
 
-- **Direct message** the Inbox Zero bot to start a conversation
-- **@mention** the bot in any channel it's been added to
+Enable these from the connected Slack section of `Channels` or from the feature's own settings:
 
-The AI assistant has access to your email and calendar context, so you can ask it questions about your inbox, get help drafting emails, or manage your email workflow without leaving Slack.
+- [Meeting Briefs](/essentials/meeting-briefs)
+- Follow-up reminders and scheduled check-ins
+- [Email Digest](/essentials/email-digest)
+- [Auto-File Attachments](/essentials/auto-file-attachments) alerts
 
-Conversations are threaded, so you can have multiple ongoing chats.
+## Disconnect Slack
 
-## Selecting a Channel
-
-After connecting Slack, choose which channel receives notifications:
-
-1. Go to **Channels** and select a channel from the dropdown
-2. The bot will automatically join the selected channel
-3. A confirmation message will be sent to verify the connection
-
-You can change the channel at any time. Both public and private channels are supported.
-
-## Disconnecting
-
-To disconnect Slack:
-1. Go to **Channels** in the left sidebar
-2. Click the menu (⋮) next to your Slack workspace and choose **Disconnect Slack**
-
-This removes the connection and stops all Slack notifications.
+Open `Channels`, use the menu next to the connected Slack workspace, and choose `Disconnect Slack`. This stops chat access and all Slack deliveries for that connection.

--- a/docs/essentials/telegram-integration.mdx
+++ b/docs/essentials/telegram-integration.mdx
@@ -1,41 +1,55 @@
 ---
 title: 'Telegram Integration'
-description: 'Chat with your AI assistant and receive notifications in Telegram.'
+description: 'Chat with your assistant and receive Inbox Zero updates in Telegram.'
 icon: 'paper-plane'
 ---
 
-Connect Telegram to Inbox Zero to chat with your AI email assistant directly from Telegram. Ask questions about your inbox, draft emails, manage rules, and more — all from a Telegram DM.
+Connect Telegram from the unified `Channels` page. The integration uses a direct message with the Inbox Zero bot for chat and feature delivery.
 
-## Connecting Telegram
+## Connect Telegram
 
-1. Go to **Settings** in the left sidebar
-2. Under **Connected Apps**, click **Connect Telegram**
-3. Copy the generated `/connect` command
-4. Open a direct message with the Inbox Zero bot in Telegram
-5. Send the command to link your account
+1. Open `Channels` in the left sidebar.
+2. Find Telegram and click `Connect`.
+3. Inbox Zero generates a one-time `/connect` command. The code expires after 10 minutes.
+4. Open the Inbox Zero bot using the link in the dialog.
+5. Send the complete command in a direct message to link your account.
 
-Once connected, you can message the bot anytime to interact with your AI assistant.
+Once connected, Telegram appears on the Channels page with a `Connected` badge.
 
-## What You Can Do
+## Chat with the Assistant
 
-The Telegram bot gives you full access to the same [AI Chat](/essentials/ai-chat) capabilities:
+The Telegram bot provides the same core [AI Chat](/essentials/ai-chat) workflow. You can:
 
-- Ask questions about your inbox
-- Search and manage emails
-- Create and update automation rules
-- Draft and send replies
-- Get email summaries
+- Search and summarize email.
+- Manage inbox messages.
+- Draft messages and replies for review.
+- Create and update automation rules.
+- Ask what needs your attention.
 
-## Bot Commands
+If more than one email account is linked, use `/switch` to list them and `/switch <number>` to change the active account.
 
-- `/connect` — Link your Inbox Zero account
-- `/switch` — Switch between email accounts
-- `/summary` — Get an inbox summary
-- `/draftreply` — Draft a reply to a recent email
-- `/followups` — See emails awaiting replies
-- `/cleanup` — Clean up old messages
-- `/help` — Show available commands
+## Commands
 
-## Disconnecting
+- `/connect <code>` — Link an Inbox Zero email account.
+- `/switch` — List linked accounts.
+- `/summary` — Summarize what needs attention today.
+- `/draftreply` — Draft a response to an urgent unread email.
+- `/followups` — Show emails that may need a follow-up.
+- `/cleanup` — Start an inbox cleanup conversation.
+- `/help` — Show available commands.
 
-To disconnect Telegram, go to **Settings** and click **Disconnect** next to your Telegram connection under **Connected Apps**.
+## Feature Delivery
+
+From the connected Telegram section on `Channels`, you can configure:
+
+- Rule notifications or draft replies for review
+- Meeting briefs
+- Follow-up reminders and scheduled check-ins
+- Digests
+- Document-filing alerts
+
+Telegram delivery goes to the linked direct-message destination; there is no separate channel picker.
+
+## Disconnect Telegram
+
+Open `Channels`, use the menu next to Telegram, and choose `Disconnect Telegram`. This stops Telegram chat access and all configured deliveries.

--- a/docs/essentials/telegram-integration.mdx
+++ b/docs/essentials/telegram-integration.mdx
@@ -33,8 +33,8 @@ If more than one email account is linked, use `/switch` to list them and `/switc
 - `/connect <code>` — Link an Inbox Zero email account.
 - `/switch` — List linked accounts.
 - `/summary` — Summarize what needs attention today.
-- `/draftreply` — Draft a response to an urgent unread email.
-- `/followups` — Show emails that may need a follow-up.
+- `/draftreply` — Draft a response to your most urgent unread email.
+- `/followups` — Show emails that may need a follow-up this week.
 - `/cleanup` — Start an inbox cleanup conversation.
 - `/help` — Show available commands.
 

--- a/docs/essentials/troubleshooting.mdx
+++ b/docs/essentials/troubleshooting.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Troubleshooting'
+description: 'Resolve common mailbox, rule, draft, calendar, and channel problems.'
+icon: 'life-ring'
+---
+
+## Mail is not being processed
+
+1. Confirm the correct mailbox is selected in the account switcher.
+2. Open **Settings → Email Accounts** and make sure rules are not globally disabled.
+3. Check whether Gmail or Outlook access was revoked or requires new permissions.
+4. Open **Assistant → History** to see whether the message was evaluated.
+5. Reconnect the mailbox if the app reports a permission or subscription error.
+
+## A rule matched the wrong message
+
+Open **Assistant → History**, find the message, and select **Fix**. Explain what should have happened. You can also open the rule directly to adjust its static conditions, AI instructions, actions, or learned patterns.
+
+Use the **Test** tab before re-enabling a rule that sends, replies, forwards, deletes, or calls a webhook.
+
+## A rule did not match
+
+- Check whether the rule is enabled.
+- Check **Apply to threads** if the message was a reply in an existing conversation.
+- Review overlapping rules and the multi-rule setting.
+- Confirm that referenced labels, folders, channels, files, or calendars still exist.
+- Test the rule against the message text and inspect the explanation.
+
+## A draft was not created
+
+Check that auto-drafting is enabled and that the message meets your configured draft-confidence threshold. A message may also be excluded because it does not need a reply, the relevant rule is disabled, or the provider no longer has permission to create drafts.
+
+## Calendar or availability is wrong
+
+- Verify the correct calendars are connected and enabled.
+- Confirm your timezone and weekly availability.
+- Check that the destination calendar for a booking link still exists.
+- Reconnect the calendar if events are not updating.
+
+## Channel notifications are missing
+
+Open **Channels** and check that the provider is connected and the relevant delivery type is enabled.
+
+For Slack notifications, choose a private channel you belong to and manually invite the Inbox Zero bot to that channel. Teams and Telegram delivery uses the linked direct-message conversation.
+
+## Attachment filing failed
+
+Confirm that the drive connection is active and that the destination is within the folders you approved. If the AI requested clarification, reply through the configured channel or correct the filing from the Attachments page.
+
+## A bulk action is taking longer than expected
+
+Large inbox operations run in batches and may take time. Keep the page open while it reports progress, avoid starting the same operation again, and review the resulting history or sender state before applying another bulk action.
+
+## Still stuck?
+
+Contact [support@getinboxzero.com](mailto:support@getinboxzero.com) with the affected feature, email provider, approximate time of the problem, and any visible error message. Do not send passwords, API keys, OAuth tokens, or full sensitive email content.
+

--- a/docs/hosting/environment-variables.mdx
+++ b/docs/hosting/environment-variables.mdx
@@ -38,7 +38,7 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `TEAMS_BOT_APP_PASSWORD` | No | Microsoft Teams bot app password/secret | — |
 | `TEAMS_BOT_APP_TENANT_ID` | No | Tenant ID, required when Microsoft Teams integration is enabled | — |
 | `TELEGRAM_BOT_TOKEN` | No | Telegram bot token from BotFather | — |
-| `TELEGRAM_BOT_SECRET_TOKEN` | No | Optional Telegram webhook secret token (sent in `x-telegram-bot-api-secret-token`) | — |
+| `TELEGRAM_BOT_SECRET_TOKEN` | No* | Telegram webhook secret token sent in `x-telegram-bot-api-secret-token`. Required when `TELEGRAM_BOT_TOKEN` is set. | — |
 | **Google PubSub** ||||
 | `GOOGLE_PUBSUB_TOPIC_NAME` | Yes | Full topic name (e.g., `projects/my-project/topics/gmail`) | — |
 | `GOOGLE_PUBSUB_VERIFICATION_TOKEN` | Yes* | Token for webhook verification | — |
@@ -87,6 +87,9 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `AZURE_API_KEY` | No | Azure OpenAI API key (required when `azure` is used and `LLM_API_KEY` is not set) | — |
 | `AZURE_RESOURCE_NAME` | No | Azure OpenAI resource name (required when `azure` is used as a default or fallback provider) | — |
 | `AZURE_API_VERSION` | No | Azure OpenAI API version override | — |
+| **Azure AI Foundry** ||||
+| `AZURE_FOUNDRY_API_KEY` | No | Azure AI Foundry API key required when `azure-foundry` is used | — |
+| `AZURE_FOUNDRY_BASE_URL` | No | Azure AI Foundry OpenAI-compatible base URL, such as `https://your-resource.services.ai.azure.com/openai/v1` | — |
 | **Google Vertex** ||||
 | `GOOGLE_VERTEX_PROJECT` | No | Google Cloud project ID for Vertex AI (required when `vertex` is used as a default or fallback provider) | — |
 | `GOOGLE_VERTEX_LOCATION` | No | Vertex AI location | `us-central1` |
@@ -103,6 +106,7 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | **OpenAI-Compatible (Local LLM)** ||||
 | `OPENAI_COMPATIBLE_BASE_URL` | No | Base URL for an OpenAI-compatible server (e.g. LM Studio: `http://localhost:1234/v1`) | `http://localhost:1234/v1` |
 | `OPENAI_COMPATIBLE_MODEL` | No | OpenAI-compatible model name when configured separately from the selected LLM tier model | — |
+| `OPENAI_COMPATIBLE_AUTH_HEADER` | No | Header style for the OpenAI-compatible API key: `authorization` or `api-key` | `authorization` |
 | **CLI LLM Providers (Experimental)** ||||
 | `CLI_LLM_ENABLED` | No | Enables community CLI-backed LLM providers (`codex-cli`, `claude-code`). Self-host only; requires installing optional provider packages. | `false` |
 | `CODEX_CLI_ALLOW_NPX` | No | Allows the Codex community provider to fall back to `npx @openai/codex` if `codex` is not on PATH. Leave disabled unless you trust that install path. | `false` |
@@ -128,11 +132,17 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `RESEND_AUDIENCE_ID` | No | Audience ID for contacts | — |
 | `RESEND_FROM_EMAIL` | No | From email address | `Inbox Zero <updates@transactional.getinboxzero.com>` |
 | `NEXT_PUBLIC_IS_RESEND_CONFIGURED` | No | Client-side flag indicating if Resend is configured | — |
+| **Meeting Recorder (Recall.ai, Optional)** ||||
+| `RECALL_API_KEY` | No* | Recall.ai API key. Required with `RECALL_WEBHOOK_SECRET` when Meeting Recorder is enabled. | — |
+| `RECALL_WEBHOOK_SECRET` | No* | Signing secret for the Recall webhook at `/api/recall/webhook`. Required with `RECALL_API_KEY` when Meeting Recorder is enabled. | — |
+| `RECALL_REGION` | No | Recall workspace region | `us-west-2` |
+| `RECALL_BASE_URL` | No | Recall-compatible API base URL. Intended for local emulation; normal deployments should leave this unset. | Recall.ai regional API |
 | **Other** ||||
 | `API_KEY_SALT` | No* | Salt used to hash external API keys. Generate with `openssl rand -hex 32`. Required when `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true`. | — |
-| `CRON_SECRET` | No | Shared secret that authenticates calls to the scheduled-task endpoints (`/api/cron/*`, `/api/watch/all`, `/api/meeting-briefs`, `/api/follow-up-reminders`). Required if you trigger these endpoints yourself instead of using the bundled Docker Compose `cron` container. Generate with `openssl rand -hex 32`. See [Scheduled Tasks](/hosting/self-hosting#scheduled-tasks). | — |
+| `CRON_SECRET` | No | Shared secret that authenticates calls to the scheduled-task endpoints (`/api/cron/*`, `/api/watch/all`, `/api/meeting-briefs`, `/api/meeting-recorder/schedule`, `/api/follow-up-reminders`, `/api/resend/digest/all`). Required if you trigger these endpoints yourself instead of using the bundled Docker Compose `cron` container. Generate with `openssl rand -hex 32`. See [Scheduled Tasks](/hosting/self-hosting#scheduled-tasks). | — |
 | `HEALTH_API_KEY` | No | API key for health checks | — |
 | `WEBHOOK_URL` | No | External webhook URL | — |
+| `WEBHOOK_ALLOW_PRIVATE_IPS` | No | Allow rule webhooks to target private, loopback, link-local, or Tailscale addresses. This disables SSRF protection for webhook delivery; enable it only on a trusted single-tenant deployment. | `false` |
 | `INTERNAL_API_URL` | No | Preferred callback base URL for QStash and server-side internal callbacks | `NEXT_PUBLIC_BASE_URL` |
 | `OAUTH_PROXY_URL` | No | OAuth proxy deployment URL used when callbacks should route through a separate proxy server | — |
 | `IS_OAUTH_PROXY_SERVER` | No | Marks this deployment as the OAuth proxy server | `false` |
@@ -156,11 +166,13 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 | `NEXT_PUBLIC_BYPASS_PREMIUM_CHECKS` | No | Bypass premium checks (recommended for self-hosting) | `true` |
 | `NEXT_PUBLIC_DIGEST_ENABLED` | No | Enable email digest feature, which sends periodic summaries of emails. Works without QStash (no retries). | `false` |
 | `NEXT_PUBLIC_MEETING_BRIEFS_ENABLED` | No | Enable meeting briefs, which automatically sends pre-meeting briefings to users. Requires the meeting briefs cron job to be running. | `false` |
+| `NEXT_PUBLIC_MEETING_RECORDER_ENABLED` | No | Enable the Early Access Meeting Recorder. Requires Recall.ai credentials, its signed webhook, and the meeting-recorder scheduling job. | `false` |
 | `NEXT_PUBLIC_FOLLOW_UP_REMINDERS_ENABLED` | No | Enable follow-up reminders, which allows users to add labels to emails for automatic follow-up tracking. Requires the follow-up reminders cron job to be running. | `false` |
 | `NEXT_PUBLIC_INTEGRATIONS_ENABLED` | No | Enable the integrations feature, allowing users to connect external services. | `false` |
 | `NEXT_PUBLIC_SMART_FILING_ENABLED` | No | Enable the Smart Filing feature for automatic document organization from email attachments. | `false` |
 | `NEXT_PUBLIC_CLEANER_ENABLED` | No | Enable the newer cleaner/bulk cleanup experience | `false` |
-| `NEXT_PUBLIC_BOOKING_LINKS_ENABLED` | No | Enable booking-link functionality. This is beta and is not actively being worked on. | `false` |
+| `NEXT_PUBLIC_DELETE_EMAIL_ACTION_ENABLED` | No | Enable delete/trash actions for automation rules, including rules created through the external API. | `false` |
+| `NEXT_PUBLIC_BOOKING_LINKS_ENABLED` | No | Enable first-party booking links and availability pages. | `false` |
 | `NEXT_PUBLIC_AUTO_DRAFT_DISABLED` | No | Disable the auto-drafting feature, which automatically drafts replies based on assistant rules. | `false` |
 | `NEXT_PUBLIC_TABS_EXTENSION_ID` | No | Chrome extension ID used for Inbox Zero Tabs sync | Built-in extension ID |
 | **White Labeling (Optional)** ||||
@@ -177,6 +189,8 @@ Reference for environment variables relevant to self-hosting Inbox Zero. Hosted-
 
 - `DIRECT_URL` is required only when Prisma migrations need a direct/unpooled database URL that differs from `DATABASE_URL`.
 - `API_KEY_SALT` is required only when external API keys are enabled with `NEXT_PUBLIC_EXTERNAL_API_ENABLED=true`.
+- `TELEGRAM_BOT_SECRET_TOKEN` is required only when `TELEGRAM_BOT_TOKEN` is set.
+- `RECALL_API_KEY` and `RECALL_WEBHOOK_SECRET` are both required when Meeting Recorder is enabled.
 - `GOOGLE_PUBSUB_VERIFICATION_TOKEN` is required when Gmail Pub/Sub push is enabled. If your deployment authenticates `/api/google/webhook` upstream, you can set it to an empty string to intentionally disable query-parameter verification.
 
 ## Setup Guides

--- a/docs/hosting/google-oauth.mdx
+++ b/docs/hosting/google-oauth.mdx
@@ -40,17 +40,41 @@ Go to [Google Cloud Console](https://console.cloud.google.com/) and create a new
 4. **Update [scopes](https://console.cloud.google.com/auth/scopes):**
    1. Go to `Data Access` in the sidebar.
    2. Click `Add or remove scopes`.
-   3. Manually add these scopes:
+   3. Manually add the core sign-in and Gmail scopes:
       ```
       https://www.googleapis.com/auth/userinfo.profile
       https://www.googleapis.com/auth/userinfo.email
       https://www.googleapis.com/auth/gmail.modify
       https://www.googleapis.com/auth/gmail.settings.basic
+      ```
+   4. Add only the optional feature scopes your deployment will use:
+
+      **Contacts** — only when `NEXT_PUBLIC_CONTACTS_ENABLED=true`:
+
+      ```
       https://www.googleapis.com/auth/contacts
-      https://www.googleapis.com/auth/calendar
+      ```
+
+      **Calendar:**
+
+      ```
+      https://www.googleapis.com/auth/calendar.readonly
+      https://www.googleapis.com/auth/calendar.events
+      https://www.googleapis.com/auth/calendar.freebusy
+      ```
+
+      **Google Drive, Standard access** — lets Inbox Zero create folders and access files it created or the user explicitly opened with it:
+
+      ```
       https://www.googleapis.com/auth/drive.file
       ```
-   4. Click `Update`, then `Save`.
+
+      If users will select **Full access** when connecting Drive so they can choose existing folders, also declare:
+
+      ```
+      https://www.googleapis.com/auth/drive
+      ```
+   5. Click `Update`, then `Save`.
 
    ![Add Scopes](/images/self-hosting/google-auth/6-add-scopes.png)
    ![Manually Add Scopes](/images/self-hosting/google-auth/7-add-scopes.png)
@@ -66,7 +90,7 @@ Go to [Google Cloud Console](https://console.cloud.google.com/) and create a new
 
 6. **Enable required APIs:**
    - [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com) (required)
-   - [Google People API](https://console.cloud.google.com/marketplace/product/google/people.googleapis.com) (required)
+   - [Google People API](https://console.cloud.google.com/marketplace/product/google/people.googleapis.com) (optional, for Contacts)
    - [Google Calendar API](https://console.cloud.google.com/marketplace/product/google/calendar-json.googleapis.com) (optional)
    - [Google Drive API](https://console.cloud.google.com/marketplace/product/google/drive.googleapis.com) (optional)
 

--- a/docs/hosting/llm-setup.mdx
+++ b/docs/hosting/llm-setup.mdx
@@ -23,6 +23,7 @@ Use one of these provider values before the colon in `*_LLMS` entries:
 | [OpenAI](https://platform.openai.com/docs/overview) | `openai` |
 | [Anthropic](https://docs.anthropic.com/en/docs/welcome) | `anthropic` |
 | [Azure OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/azure) | `azure` |
+| Azure AI Foundry | `azure-foundry` |
 | [Google Gemini (AI Studio)](https://ai.google.dev/gemini-api/docs) | `google` |
 | [Google Vertex AI](https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex) | `vertex` |
 | [OpenRouter](https://openrouter.ai/docs/quickstart) | `openrouter` |
@@ -73,7 +74,8 @@ NEXT_PUBLIC_SENSITIVE_DATA_POLICY_LOCKED=false
 
 ## Provider-specific details
 
-- `openai-compatible` also requires `OPENAI_COMPATIBLE_BASE_URL`.
+- `azure-foundry` requires `AZURE_FOUNDRY_API_KEY` and `AZURE_FOUNDRY_BASE_URL`. Use the deployment name as the model portion of the `azure-foundry:<deployment>` entry.
+- `openai-compatible` also requires `OPENAI_COMPATIBLE_BASE_URL`. Set `OPENAI_COMPATIBLE_AUTH_HEADER=api-key` when the server expects an `api-key` header instead of bearer authorization.
 - `ollama` can use `OLLAMA_BASE_URL` and `OLLAMA_MODEL`.
 
 ## Fallbacks

--- a/docs/hosting/production-operations.mdx
+++ b/docs/hosting/production-operations.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Production Operations'
+description: 'Operate, update, back up, and recover a self-hosted Inbox Zero deployment.'
+icon: 'server'
+---
+
+This guide complements the deployment guides with ongoing operational practices. Adapt the commands and retention periods to your infrastructure.
+
+## Version and change management
+
+- Pin deployments to a specific image tag or source revision instead of relying on an unbounded latest version.
+- Read the changelog and release notes before updating.
+- Back up the database before migrations.
+- Test updates in a staging environment that uses the same database and job-backend topology as production.
+- Keep the previous image or revision available for rollback.
+
+Database migrations may not be reversible. Rolling the application image back does not automatically roll the database schema back.
+
+## Database backups
+
+Back up PostgreSQL on a schedule appropriate for your recovery-point objective. Include:
+
+- Automated database snapshots or `pg_dump` backups
+- Encryption at rest and in transit
+- A retention policy with more than one restore point
+- Copies stored outside the application host
+- Regular restore tests into an isolated database
+
+Do not treat a successful backup job as proof that the backup can be restored.
+
+## Secrets
+
+Store production secrets in a secret manager or protected deployment environment. Restrict access to database credentials, OAuth client secrets, encryption keys, AI-provider keys, webhook secrets, and `CRON_SECRET`.
+
+Before rotating encryption material, verify whether existing encrypted mailbox credentials depend on it. Replacing encryption secrets without a migration can make stored credentials unreadable and force account reconnection.
+
+## Monitoring
+
+Monitor at least:
+
+- Application and worker availability
+- `/api/health` according to your configured health-check policy
+- PostgreSQL and Redis connectivity
+- Queue depth and failed jobs
+- Scheduled-task execution
+- OAuth or webhook failures from Google and Microsoft
+- Transactional email delivery
+- AI-provider errors, latency, and spend
+- Disk, memory, CPU, and database capacity
+
+Alert on repeated failures rather than relying on manual log review.
+
+## Scheduled tasks and workers
+
+The web process alone does not run every background workflow. Ensure the deployment runs the scheduler described in [Docker/VPS Deployment](/hosting/self-hosting#scheduled-tasks) and any selected queue worker.
+
+After deployment, verify each enabled job at least once: watch renewal, scheduled actions, automation jobs, digests, meeting briefs, follow-up reminders, Meeting Recorder scheduling, reasoning retention, and unused AI draft cleanup when configured.
+
+## Updating
+
+1. Take and verify a fresh database backup.
+2. Record the currently deployed image or commit.
+3. Pull the new image or source revision.
+4. Run the documented migration/deployment process.
+5. Check health, logs, mailbox processing, and scheduled jobs.
+6. Keep the previous version available until the observation window passes.
+
+## Recovery
+
+Maintain a written recovery procedure covering:
+
+- Recreating the application and worker infrastructure
+- Restoring PostgreSQL to a known point
+- Restoring or rebuilding Redis-backed transient state
+- Reapplying secrets and OAuth configuration
+- Reconnecting provider webhooks and watches
+- Validating email processing without sending unintended messages
+
+Test the procedure periodically in an isolated environment.

--- a/docs/hosting/quick-start.mdx
+++ b/docs/hosting/quick-start.mdx
@@ -57,6 +57,12 @@ inbox-zero start
 | `inbox-zero config` | Interactive configuration editor |
 | `inbox-zero config set <key> <value>` | Set a config value |
 | `inbox-zero config get <key>` | Get a config value |
+| `inbox-zero setup-google` | Configure Google APIs, OAuth guidance, and Pub/Sub using `gcloud` |
+| `inbox-zero setup-aws` | Deploy to AWS using Copilot (ECS/Fargate) |
+| `inbox-zero setup-terraform` | Generate Terraform files for an AWS deployment |
+| `inbox-zero setup-vercel` | Link Vercel, provision optional Neon/Upstash resources, and seed environment variables |
+
+Run `inbox-zero <command> --help` for command-specific options. Deployment commands are also covered in the [Google OAuth](/hosting/google-oauth), [AWS](/hosting/aws), and [Vercel](/hosting/vercel) guides.
 
 ## Updating
 

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -24,7 +24,7 @@ This guide covers production deployment on a VPS using Docker and Docker Compose
 Connect to your VPS and install:
 
 1. **Docker Engine**: Follow [the official guide](https://docs.docker.com/engine/install) and the [Post installation steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
-2. **Node.js**: Follow [the official guide](https://nodejs.org/en/download) (required for the setup CLI)
+2. **Node.js v24**: Follow [the official guide](https://nodejs.org/en/download) (required for the setup CLI and source installation)
 
 ### 2. Setup and Configure
 
@@ -48,7 +48,7 @@ git clone https://github.com/elie222/inbox-zero.git
 cd inbox-zero
 corepack enable
 pnpm install
-pnpm setup
+pnpm run setup
 ```
 
 The setup wizard will walk you through configuring Google and/or Microsoft OAuth, choosing an AI provider, and generating secrets.
@@ -243,7 +243,7 @@ cd inbox-zero
 # Install dependencies and configure environment (auto-generates secrets)
 corepack enable
 pnpm install
-pnpm setup
+pnpm run setup
 nano apps/web/.env
 
 # Build and start

--- a/docs/hosting/self-hosting.mdx
+++ b/docs/hosting/self-hosting.mdx
@@ -13,7 +13,7 @@ This guide covers production deployment on a VPS using Docker and Docker Compose
 
 ### Requirements
 
-- VPS with Minimum 2GB RAM, 2 CPU cores, 20GB storage and linux distribution with [minimum security](https://help.ovhcloud.com/csm/en-gb-vps-security-tips?id=kb_article_view&sysparm_article=KB0047706)
+- VPS with at least 2 GB RAM, 2 CPU cores, 20 GB storage, and a supported Linux distribution
 - Domain name pointed to your VPS IP
 - SSH access to your VPS
 
@@ -46,8 +46,9 @@ Recommended choices for first-time self-hosting:
 ```bash
 git clone https://github.com/elie222/inbox-zero.git
 cd inbox-zero
-npm install
-npm run setup
+corepack enable
+pnpm install
+pnpm setup
 ```
 
 The setup wizard will walk you through configuring Google and/or Microsoft OAuth, choosing an AI provider, and generating secrets.
@@ -66,7 +67,7 @@ The command enables required APIs, creates the Pub/Sub topic and subscription, a
 
 You can also copy `.env.example` to `.env` and set the values yourself.
 
-If doing this manually edit then you'll need to configure:
+If you configure the deployment manually, set:
 - **Google OAuth**: `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 - **LLM Provider**: Uncomment one provider block and add your API key
 - **Optional**: Microsoft OAuth, external Redis, etc.
@@ -77,7 +78,7 @@ If you want remote email images to load through a separate privacy-preserving pr
 
 **Note**: If you only use Microsoft OAuth, set `GOOGLE_CLIENT_ID=skipped` and `GOOGLE_CLIENT_SECRET=skipped`.
 
-**Note**: The first section of `.env.example` variables that are commented out. If you're using Docker Compose leave them commented - Docker Compose sets these automatically with the correct internal hostnames.
+**Note**: Leave the commented connection variables at the beginning of `.env.example` unset when using Docker Compose. Compose supplies the correct internal hostnames automatically.
 
 ### 3. Deploy
 
@@ -127,30 +128,46 @@ Your application should now be accessible at:
 
 ## Scheduled Tasks
 
-The Docker Compose setup includes a `cron` container that handles scheduled tasks automatically:
+The Docker Compose setup includes a `cron` container that handles these scheduled tasks automatically. It runs interval loops rather than a system cron daemon, so the first request is sent when the container starts and subsequent requests use the intervals below.
 
-| Task | Frequency | Endpoint | Cron Expression | Description |
-|------|-----------|----------|-----------------|-------------|
-| **Scheduled actions** | Every minute | `/api/cron/scheduled-actions` | `* * * * *` | Executes delayed/scheduled actions when QStash is not configured |
-| **Reasoning retention** | Daily | `/api/cron/reasoning-retention` | `0 3 * * *` | Redacts only stale AI reasoning fields when `REASONING_RETENTION_DAYS` is set |
-| **Email watch renewal** | Every 6 hours | `/api/watch/all` | `0 */6 * * *` | Renews Gmail/Outlook push notification subscriptions |
-| **Meeting briefs** | Every 15 minutes | `/api/meeting-briefs` | `*/15 * * * *` | Sends pre-meeting briefings to users with the feature enabled |
-| **Follow-up reminders** | Every hour | `/api/follow-up-reminders` | `0 * * * *` | Processes follow-up reminder notifications |
+| Task | Interval | Endpoint | Description |
+|------|----------|----------|-------------|
+| **Scheduled actions** | Every 15 minutes | `/api/cron/scheduled-actions` | Executes delayed/scheduled actions when QStash is not configured |
+| **Automation jobs** | Every 15 minutes | `/api/cron/automation-jobs` | Processes due automation jobs |
+| **Email digests** | Every 30 minutes | `/api/resend/digest/all` | Sends due email digests |
+| **Email watch renewal** | Every 6 hours | `/api/watch/all` | Renews Gmail/Outlook push notification subscriptions |
+| **Meeting briefs** | Every 15 minutes | `/api/meeting-briefs` | Sends pre-meeting briefings to users with the feature enabled |
+| **Meeting recorder scheduling** | Every 5 minutes | `/api/meeting-recorder/schedule` | Schedules Recall.ai meeting bots when Meeting Recorder is configured |
+| **Follow-up reminders** | Every hour | `/api/follow-up-reminders` | Processes follow-up reminder notifications |
+
+The bundled Compose service does **not** run the two daily cleanup endpoints. Schedule `/api/cron/reasoning-retention` when `REASONING_RETENTION_DAYS` or `DRAFT_SENT_TEXT_RETENTION_DAYS` is configured. Schedule `/api/cron/draft-cleanup` when users enable automatic cleanup of unused AI-generated drafts.
 
 **If you're not using Docker Compose** you need to set up cron jobs manually:
 
 ```bash
-# Scheduled actions - every minute (only needed when QStash is not configured)
-* * * * * curl -s -X GET "https://yourdomain.com/api/cron/scheduled-actions" -H "Authorization: Bearer YOUR_CRON_SECRET"
+# Scheduled actions - every 15 minutes (only needed when QStash is not configured)
+*/15 * * * * curl -s -X GET "https://yourdomain.com/api/cron/scheduled-actions" -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Automation jobs - every 15 minutes
+*/15 * * * * curl -s -X GET "https://yourdomain.com/api/cron/automation-jobs" -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Email digests - every 30 minutes (optional, only if using digests)
+*/30 * * * * curl -s -X GET "https://yourdomain.com/api/resend/digest/all" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Reasoning retention - daily (optional, only if REASONING_RETENTION_DAYS is set)
-# Call /api/cron/reasoning-retention with the same cron authorization header.
+0 3 * * * curl -s -X GET "https://yourdomain.com/api/cron/reasoning-retention" -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Unused AI draft cleanup - daily (optional, only if users enable automatic draft cleanup)
+0 4 * * * curl -s -X GET "https://yourdomain.com/api/cron/draft-cleanup" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Email watch renewal - every 6 hours
 0 */6 * * * curl -s -X GET "https://yourdomain.com/api/watch/all" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Meeting briefs - every 15 minutes (optional, only if using meeting briefs feature)
 */15 * * * * curl -s -X GET "https://yourdomain.com/api/meeting-briefs" -H "Authorization: Bearer YOUR_CRON_SECRET"
+
+# Meeting recorder scheduling - every 5 minutes (optional, only if using Meeting Recorder)
+*/5 * * * * curl -s -X GET "https://yourdomain.com/api/meeting-recorder/schedule" -H "Authorization: Bearer YOUR_CRON_SECRET"
 
 # Follow-up reminders - every hour (optional, only if using follow-up reminders feature)
 0 * * * * curl -s -X GET "https://yourdomain.com/api/follow-up-reminders" -H "Authorization: Bearer YOUR_CRON_SECRET"
@@ -224,8 +241,9 @@ git clone https://github.com/elie222/inbox-zero.git
 cd inbox-zero
 
 # Install dependencies and configure environment (auto-generates secrets)
-npm install
-npm run setup
+corepack enable
+pnpm install
+pnpm setup
 nano apps/web/.env
 
 # Build and start

--- a/docs/hosting/setup-cli-reference.mdx
+++ b/docs/hosting/setup-cli-reference.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Self-Hosting Setup CLI'
+description: 'Use the Inbox Zero setup CLI for local, cloud, and automated deployments.'
+icon: 'terminal'
+---
+
+The self-hosting setup CLI is different from the public [API CLI](/api-reference/cli). It creates deployment configuration and can guide provider setup; it does not manage an existing inbox through the public API.
+
+## Start the wizard
+
+Run the latest setup wizard with:
+
+```bash
+npx @inbox-zero/cli@latest setup
+```
+
+The interactive wizard asks which deployment target and providers you want to configure. Review generated files before committing or deploying them because they can contain environment-specific values.
+
+## Setup commands
+
+The CLI includes dedicated flows for:
+
+- Local or Docker-based setup
+- Google OAuth, required APIs, and Gmail Pub/Sub
+- AWS deployment
+- Terraform generation and deployment
+- Vercel deployment
+
+Run the CLI with `--help`, or a command followed by `--help`, for the flags supported by the installed version:
+
+```bash
+npx @inbox-zero/cli@latest --help
+npx @inbox-zero/cli@latest setup-google --help
+npx @inbox-zero/cli@latest setup-aws --help
+npx @inbox-zero/cli@latest setup-terraform --help
+npx @inbox-zero/cli@latest setup-vercel --help
+```
+
+## Automation guidance
+
+Interactive setup is recommended for a first deployment. For repeatable environments:
+
+1. Run the wizard in a disposable or staging workspace.
+2. Review the generated configuration and identify secrets.
+3. Move secrets into your deployment's secret manager.
+4. Commit only safe templates and infrastructure files.
+5. Use the generated output as the basis for your normal deployment pipeline.
+
+Never place OAuth client secrets, database credentials, encryption keys, or AI-provider keys in source control.
+
+## Related guides
+
+- [Quick Start](/hosting/quick-start)
+- [Google OAuth](/hosting/google-oauth)
+- [Vercel Deployment](/hosting/vercel)
+- [AWS Deployment](/hosting/aws)
+- [Terraform Deployment](/hosting/terraform)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -9,7 +9,18 @@ description: 'Welcome to the Inbox Zero documentation'
 
 ## Getting Started
 
-Get started with Inbox Zero:
+New to Inbox Zero? Follow the [Getting Started guide](/essentials/getting-started) to connect a mailbox, create and test your first rule, and choose your next workflow. Check [Feature Availability](/essentials/feature-availability) for provider, plan, platform, and Early Access differences.
+
+<CardGroup cols={2}>
+  <Card title="Getting Started" icon="rocket-launch" href="/essentials/getting-started">
+    Connect Gmail or Outlook and complete your first workflow
+  </Card>
+  <Card title="Feature Availability" icon="table-list" href="/essentials/feature-availability">
+    Compare providers, platforms, plans, and Early Access features
+  </Card>
+</CardGroup>
+
+## Assistant and Automation
 
 <CardGroup cols={2}>
   <Card
@@ -20,18 +31,96 @@ Get started with Inbox Zero:
     Manage your inbox, rules, and settings through natural language chat
   </Card>
   <Card
-    title="AI Personal Assistant"
+    title="Assistant"
     icon="sparkles"
     href="/essentials/email-ai-personal-assistant"
   >
-    Your AI personal email assistant that manages your inbox for you
+    Automate organization, cleanup, notifications, and draft replies
+  </Card>
+  <Card
+    title="Assistant Settings"
+    icon="sliders"
+    href="/essentials/assistant-settings"
+  >
+    Configure drafts, follow-ups, writing style, knowledge, and safety
+  </Card>
+</CardGroup>
+
+## Clean Up Your Inbox
+
+<CardGroup cols={2}>
+  <Card
+    title="Bulk Unsubscribe"
+    icon="envelopes-bulk"
+    href="/essentials/bulk-email-unsubscriber"
+  >
+    Find noisy senders and unsubscribe, archive, or delete in bulk
+  </Card>
+  <Card
+    title="Bulk Archive"
+    icon="box-archive"
+    href="/essentials/bulk-archiver"
+  >
+    Organize older mail by sender category and apply bulk actions
+  </Card>
+  <Card
+    title="Analytics"
+    icon="chart-simple"
+    href="/essentials/email-analytics"
+  >
+    Understand inbox volume, response time, and automation activity
+  </Card>
+</CardGroup>
+
+## Calendar and Meetings
+
+<CardGroup cols={2}>
+  <Card
+    title="Calendar Integration"
+    icon="calendar"
+    href="/essentials/calendar-integration"
+  >
+    Draft scheduling replies using your real availability
+  </Card>
+  <Card
+    title="Booking Links"
+    icon="calendar-plus"
+    href="/essentials/booking-links"
+  >
+    Share availability and let guests book, reschedule, or cancel
   </Card>
   <Card
     title="Meeting Briefs"
     icon="calendar-check"
     href="/essentials/meeting-briefs"
   >
-    AI-generated briefings before every meeting with external contacts
+    Receive AI-generated context before meetings with external contacts
+  </Card>
+</CardGroup>
+
+## Channels, Apps, and Teams
+
+<CardGroup cols={2}>
+  <Card
+    title="Channels"
+    icon="messages"
+    href="/essentials/channels"
+  >
+    Connect Slack, Microsoft Teams, or Telegram and route each update
+  </Card>
+  <Card
+    title="Mobile Apps"
+    icon="mobile"
+    href="/essentials/mobile-apps"
+  >
+    Use Inbox Zero on iOS and Android
+  </Card>
+  <Card
+    title="Organizations"
+    icon="users"
+    href="/essentials/organizations"
+  >
+    Invite members, manage roles, and deploy organization rules
   </Card>
   <Card
     title="Auto-File Attachments"
@@ -40,40 +129,17 @@ Get started with Inbox Zero:
   >
     Automatically organize email attachments into Google Drive or OneDrive
   </Card>
-  <Card
-    title="Slack Integration"
-    icon="hashtag"
-    href="/essentials/slack-integration"
-  >
-    Receive notifications and chat with your AI assistant in Slack
-  </Card>
-  <Card
-    title="Bulk Unsubscriber"
-    icon="envelopes-bulk"
-    href="/essentials/bulk-email-unsubscriber"
-  >
-    Bulk unsubscribe from newsletter and marketing emails in one-click
-  </Card>
+</CardGroup>
+
+## More Features
+
+<CardGroup cols={2}>
   <Card
     title="Cold Email Blocker"
     icon="shield-check"
     href="/essentials/cold-email-blocker"
   >
     Block cold emails and protect your inbox from spam using AI filters
-  </Card>
-  <Card
-    title="Analytics"
-    icon="chart-simple"
-    href="/essentials/email-analytics"
-  >
-    Understand where you're spending your time and what is filling up your inbox
-  </Card>
-  <Card
-    title="Calendar Integration"
-    icon="calendar"
-    href="/essentials/calendar-integration"
-  >
-    Connect your calendar to let AI draft responses based on your actual availability
   </Card>
   <Card
     title="Reply Zero"
@@ -90,11 +156,11 @@ Get started with Inbox Zero:
     Browser extension that adds custom tabs to Gmail for better email organization
   </Card>
   <Card
-    title="API"
-    icon="webhook"
-    href="/api-reference/introduction"
+    title="Security and AI"
+    icon="shield-check"
+    href="/essentials/security-and-data"
   >
-    Access our API to manage your emails and automate your inbox
+    Understand permissions, confirmations, sensitive data, and recovery
   </Card>
   <Card
     title="FAQ"
@@ -102,5 +168,23 @@ Get started with Inbox Zero:
     href="/essentials/faq"
   >
     Answers to common questions
+  </Card>
+</CardGroup>
+
+## Early Access
+
+<Warning>
+Early Access features can change or be removed. Meeting Recorder is expected to release broadly in approximately two weeks. Deep Clean has no release commitment and may never ship broadly. Context Integrations may release soon, but timing is not guaranteed.
+</Warning>
+
+<CardGroup cols={3}>
+  <Card title="AI Meeting Recorder" icon="microphone" href="/essentials/meeting-recorder">
+    Record calls and prepare notes, action items, and follow-up drafts
+  </Card>
+  <Card title="Deep Clean" icon="broom" href="/essentials/deep-clean">
+    Experiment with guided, safety-aware Gmail cleanup
+  </Card>
+  <Card title="Context Integrations" icon="plug" href="/essentials/context-integrations">
+    Give drafts relevant context from connected business tools
   </Card>
 </CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -18,6 +18,9 @@ New to Inbox Zero? Follow the [Getting Started guide](/essentials/getting-starte
   <Card title="Feature Availability" icon="table-list" href="/essentials/feature-availability">
     Compare providers, platforms, plans, and Early Access features
   </Card>
+  <Card title="Outlook and Microsoft 365" icon="microsoft" href="/essentials/outlook-guide">
+    Translate Gmail-focused examples into Outlook folders, categories, and apps
+  </Card>
 </CardGroup>
 
 ## Assistant and Automation

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -45,7 +45,8 @@
           "CALL_WEBHOOK",
           "MOVE_FOLDER",
           "NOTIFY_MESSAGING_CHANNEL",
-          "NOTIFY_SENDER"
+          "NOTIFY_SENDER",
+          "DELETE"
         ]
       },
       "RuleCondition": {

--- a/docs/slack/setup.mdx
+++ b/docs/slack/setup.mdx
@@ -3,15 +3,13 @@ title: 'Slack Integration Setup'
 description: 'Set up the Slack bot for meeting briefs and AI assistant'
 ---
 
-# Slack Integration Setup
-
 ## 1. Create a Slack App
 
 The easiest way is to use the included manifest:
 
 1. Go to [https://api.slack.com/apps](https://api.slack.com/apps) and click **Create New App** > **From an app manifest**
 2. Select a workspace
-3. Paste the contents of [`manifest.yaml`](manifest.yaml), replacing `YOUR_DOMAIN` with your actual domain
+3. Paste the contents of the [`manifest.yaml` template](https://github.com/elie222/inbox-zero/blob/main/docs/slack/manifest.yaml), replacing `YOUR_DOMAIN` with your actual domain
 4. Click **Create**
 
 This configures all scopes, event subscriptions, and the bot user automatically.
@@ -33,9 +31,9 @@ https://<your-domain>/api/slack/callback
 
 | Scope | Purpose |
 |-------|---------|
-| `channels:read` | List public channels for delivery target picker |
-| `channels:join` | Auto-join public channels when selected for delivery |
-| `groups:read` | List private channels |
+| `channels:read` | Resolve public channels where users mention the assistant |
+| `channels:join` | Join a public channel when needed for assistant interactions |
+| `groups:read` | List private channels available as notification targets |
 | `chat:write` | Send meeting briefs and AI responses |
 | `app_mentions:read` | Respond to @mentions in channels |
 | `im:read` | Receive direct messages |
@@ -111,7 +109,8 @@ This is used for the OAuth callback and events webhook URLs. `NEXT_PUBLIC_BASE_U
 1. Navigate to **Settings** > **Email Account** tab
 2. Click **Connect Slack** under Connected Apps
 3. Authorize the app in the Slack OAuth flow
-4. Go to **Meeting Briefs** and select a Slack channel for delivery
-5. Toggle meeting briefs on
+4. Open **Channels** and choose a private Slack channel for notifications
+5. Invite the Inbox Zero bot to that private channel
+6. Enable the meeting briefs, follow-ups, digests, filing alerts, or rule notifications you want delivered there
 
 Users can also DM the bot or @mention it in channels to chat with the AI assistant.

--- a/docs/teams/setup.mdx
+++ b/docs/teams/setup.mdx
@@ -3,21 +3,18 @@ title: "Microsoft Teams Integration Setup"
 description: "Set up the Teams bot for Inbox Zero assistant chat."
 ---
 
-# Microsoft Teams Integration Setup
-
 This guide is for self-hosted deployments that want to enable Teams chat with the Inbox Zero assistant.
 
 ## What Teams currently supports
 
 - AI assistant chat in **direct messages** with the Inbox Zero bot
 - Account linking with one-time `/connect <code>` commands
+- Direct-message delivery for meeting briefs, follow-up reminders, email digests, filing alerts, and rule notifications configured from **Channels**
 
 Currently not supported on Teams:
 
-- Channel-based meeting brief delivery
-- Channel-based attachment filing notifications
-
-Those channel notification features are Slack-only today.
+- Delivery into Teams channels; automated notifications are delivered in the linked bot DM
+- One-click draft editing and sending inside Teams; review or send those drafts in Inbox Zero
 
 ## 1. Create an Azure Bot resource
 

--- a/docs/telegram/setup.mdx
+++ b/docs/telegram/setup.mdx
@@ -3,8 +3,6 @@ title: "Telegram Integration Setup"
 description: "Set up the Telegram bot for Inbox Zero assistant chat."
 ---
 
-# Telegram Integration Setup
-
 This guide is for self-hosted deployments that want to enable Telegram chat with the Inbox Zero assistant.
 
 ## 1. Create a Telegram bot with BotFather
@@ -24,8 +22,6 @@ curl -X POST "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
   -d "secret_token=<TELEGRAM_BOT_SECRET_TOKEN>"
 ```
 
-If you do not want to use a secret token, omit `secret_token` from the command.
-
 You can verify webhook status with:
 
 ```bash
@@ -38,12 +34,12 @@ Set these in `apps/web/.env` (or your deployment env):
 
 ```bash
 TELEGRAM_BOT_TOKEN=
-TELEGRAM_BOT_SECRET_TOKEN= # optional but recommended
+TELEGRAM_BOT_SECRET_TOKEN=
 ```
 
 If `TELEGRAM_BOT_TOKEN` is missing, the Telegram connect option is hidden in the UI and `/api/telegram/events` returns `503`.
 
-If `TELEGRAM_BOT_SECRET_TOKEN` is set, webhooks must include `x-telegram-bot-api-secret-token` with the same value or requests are rejected.
+`TELEGRAM_BOT_SECRET_TOKEN` is required whenever `TELEGRAM_BOT_TOKEN` is set. The deployment fails startup validation if it is missing. Telegram sends the value in `x-telegram-bot-api-secret-token`; requests with a missing or mismatched value are rejected.
 
 ## 4. Configure bot commands and optional profile photo (one-time)
 


### PR DESCRIPTION
docs: Refresh product and self-hosting guides

TLDR: Adds missing product documentation, corrects stale behavior and operational guidance, and clearly marks Early Access availability.

- Adds guides for Channels, Booking Links, Organizations, mobile apps, Assistant settings, safety, troubleshooting, and the three Early Access features.
- Refreshes assistant, cleanup, calendar, channel, self-hosting, OAuth, environment-variable, and API documentation against the current code.
- Reorganizes Mintlify navigation and corrects changelog availability language.
- Validated with Mintlify broken-links and OpenAPI checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

