### PR TITLE
Fail closed when email image proxy is unavailable

### DIFF
--- a/apps/web/app/api/email/render-html/route.ts
+++ b/apps/web/app/api/email/render-html/route.ts
@@ -8,7 +8,7 @@ export const maxDuration = 15;
 export const POST = withAuth("email/render-html", async (request) => {
   const body = renderHtmlBody.parse(await request.json());
 
-  const html = await rewriteHtmlForImageProxy(body.html, request.logger);
+  const result = await rewriteHtmlForImageProxy(body.html, request.logger);
 
-  return NextResponse.json({ html });
+  return NextResponse.json(result);
 });

--- a/apps/web/utils/email/image-proxy.server.test.ts
+++ b/apps/web/utils/email/image-proxy.server.test.ts
@@ -11,9 +11,9 @@ describe("rewriteHtmlForImageProxy", () => {
     const { rewriteHtmlForImageProxy } = await loadModule({});
     const html = '<img src="https://cdn.example.com/photo.png" />';
 
-    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
+    const result = await rewriteHtmlForImageProxy(html, createTestLogger());
 
-    expect(rewritten).toBe(html);
+    expect(result).toEqual({ html, remoteAssetsProxied: false });
   });
 
   it("rewrites remote assets through an unsigned proxy outside production and warns once", async () => {
@@ -25,15 +25,16 @@ describe("rewriteHtmlForImageProxy", () => {
     const html = '<img src="https://cdn.example.com/photo.png" />';
 
     const logger = createTestLogger();
-    const firstRewrite = await rewriteHtmlForImageProxy(html, logger);
-    const secondRewrite = await rewriteHtmlForImageProxy(html, logger);
+    const firstResult = await rewriteHtmlForImageProxy(html, logger);
+    const secondResult = await rewriteHtmlForImageProxy(html, logger);
 
-    expect(firstRewrite).toContain(
+    expect(firstResult.html).toContain(
       'src="https://proxy.example.com/image?u=https%3A%2F%2Fcdn.example.com%2Fphoto.png"',
     );
-    expect(firstRewrite).not.toContain("&amp;e=");
-    expect(firstRewrite).not.toContain("&amp;s=");
-    expect(secondRewrite).toBe(firstRewrite);
+    expect(firstResult.html).not.toContain("&amp;e=");
+    expect(firstResult.html).not.toContain("&amp;s=");
+    expect(firstResult.remoteAssetsProxied).toBe(true);
+    expect(secondResult).toEqual(firstResult);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -44,16 +45,17 @@ describe("rewriteHtmlForImageProxy", () => {
       NEXT_PUBLIC_IMAGE_PROXY_BASE_URL: "https://proxy.example.com/image",
     });
 
-    const rewritten = await rewriteHtmlForImageProxy(
+    const result = await rewriteHtmlForImageProxy(
       '<img src="https://cdn.example.com/photo.png" />',
       createTestLogger(),
     );
 
-    expect(rewritten).toContain(
+    expect(result.html).toContain(
       'src="https://proxy.example.com/image?u=https%3A%2F%2Fcdn.example.com%2Fphoto.png',
     );
-    expect(rewritten).toContain("&amp;e=");
-    expect(rewritten).toContain("&amp;s=");
+    expect(result.html).toContain("&amp;e=");
+    expect(result.html).toContain("&amp;s=");
+    expect(result.remoteAssetsProxied).toBe(true);
     expect(warnSpy).not.toHaveBeenCalled();
   });
   it("rewrites remote assets through the app proxy route when enabled", async () => {
@@ -64,14 +66,15 @@ describe("rewriteHtmlForImageProxy", () => {
       NEXT_PUBLIC_IMAGE_PROXY_USE_APP_ROUTE: true,
     });
 
-    const rewritten = await rewriteHtmlForImageProxy(
+    const result = await rewriteHtmlForImageProxy(
       '<img src="https://cdn.example.com/photo.png" />',
       createTestLogger(),
     );
 
-    expect(rewritten).toContain(
+    expect(result.html).toContain(
       'src="https://app.example.com/api/image-proxy?u=https%3A%2F%2Fcdn.example.com%2Fphoto.png',
     );
+    expect(result.remoteAssetsProxied).toBe(true);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -83,9 +86,9 @@ describe("rewriteHtmlForImageProxy", () => {
     });
 
     const html = '<img src="https://cdn.example.com/photo.png" />';
-    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
+    const result = await rewriteHtmlForImageProxy(html, createTestLogger());
 
-    expect(rewritten).toBe(html);
+    expect(result).toEqual({ html, remoteAssetsProxied: false });
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -97,9 +100,9 @@ describe("rewriteHtmlForImageProxy", () => {
     });
 
     const html = '<img src="https://cdn.example.com/photo.png" />';
-    const rewritten = await rewriteHtmlForImageProxy(html, createTestLogger());
+    const result = await rewriteHtmlForImageProxy(html, createTestLogger());
 
-    expect(rewritten).toBe(html);
+    expect(result).toEqual({ html, remoteAssetsProxied: false });
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/utils/email/image-proxy.server.ts
+++ b/apps/web/utils/email/image-proxy.server.ts
@@ -11,13 +11,16 @@ let hasWarnedAboutDisabledProductionImageProxy = false;
 
 export async function rewriteHtmlForImageProxy(html: string, logger: Logger) {
   const config = getImageProxyConfig(logger);
-  if (!config || !html) return html;
+  if (!config || !html) return { html, remoteAssetsProxied: false };
 
-  return rewriteHtmlRemoteAssetUrls(html, {
-    proxyBaseUrl: config.proxyBaseUrl,
-    signingSecret: config.signingSecret,
-    ttlSeconds: DEFAULT_ASSET_PROXY_TTL_SECONDS,
-  });
+  return {
+    html: await rewriteHtmlRemoteAssetUrls(html, {
+      proxyBaseUrl: config.proxyBaseUrl,
+      signingSecret: config.signingSecret,
+      ttlSeconds: DEFAULT_ASSET_PROXY_TTL_SECONDS,
+    }),
+    remoteAssetsProxied: true,
+  };
 }
 
 function getImageProxyConfig(logger: Logger) {


### PR DESCRIPTION
## Summary\n- report whether remote email assets were actually rewritten through the image proxy\n- let mobile clients block remote assets when the proxy is unavailable\n- preserve existing CID and data-image behavior\n\n## Tests\n- pnpm test utils/email/image-proxy.server.test.ts\n- pnpm --filter inbox-zero-ai lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

