### PR TITLE
docs: Editorial pass on core product pages

### DIFF
--- a/docs/essentials/ai-chat.mdx
+++ b/docs/essentials/ai-chat.mdx
@@ -9,10 +9,10 @@ AI Chat lets you search, understand, and manage your inbox in plain language. Op
 ## What You Can Do
 
 - **Search and understand email**: Find messages, summarize threads, read supported attachments, and ask what needs your attention.
-- **Manage your inbox**: Archive, delete, mark read or unread, label, and unsubscribe from senders. The assistant asks before broadening a request into a sender-wide cleanup.
-- **Write email**: Prepare new messages, replies, and forwards. You review and send them from a confirmation card; the assistant does not send them immediately.
-- **Manage rules**: Create, update, enable, disable, and troubleshoot automation rules. New rules and destructive rule changes can require confirmation in the chat.
-- **Configure features**: Update settings for Meeting Briefs, auto-file attachments, multi-rule selection, scheduled check-ins, personal instructions, and the knowledge base.
+- **Manage your inbox**: Archive, delete, mark read or unread, label, and unsubscribe from senders.
+- **Write email**: Prepare new messages, replies, and forwards. You review and send them from a confirmation card.
+- **Manage rules**: Create, update, enable, disable, and troubleshoot automation rules.
+- **Configure features**: Update assistant settings and features such as Meeting Briefs and auto-file attachments.
 - **Remember preferences**: Ask the assistant to remember information for future chats.
 
 See [AI Personal Assistant](/essentials/email-ai-personal-assistant) for the full rule and action model.
@@ -21,7 +21,7 @@ See [AI Personal Assistant](/essentials/email-ai-personal-assistant) for the ful
 
 You can attach JPEG, PNG, WebP, or GIF images to a chat message, including by pasting an image. Chat uploads provide context for the conversation; they cannot be attached to an outgoing email.
 
-The assistant can also read supported attachments already present on an email, including PDF, DOCX, plain text, CSV, and HTML files. It cannot extract text from every binary file type.
+The assistant can also read supported attachments already present on an email, including PDF, DOCX, plain text, CSV, and HTML files.
 
 ## Chat History
 

--- a/docs/essentials/ai-chat.mdx
+++ b/docs/essentials/ai-chat.mdx
@@ -4,16 +4,16 @@ description: 'Manage your inbox through a natural-language conversation.'
 icon: 'message-bot'
 ---
 
-AI Chat lets you search, understand, and manage your inbox in plain language. Open `Chat` in the left sidebar or visit [AI Chat](https://www.getinboxzero.com/assistant).
+AI Chat lets you search, understand, and manage your inbox in plain language. Open **Chat** in the left sidebar or visit [AI Chat](https://www.getinboxzero.com/assistant).
 
 ## What You Can Do
 
 - **Search and understand email**: Find messages, summarize threads, read supported attachments, and ask what needs your attention.
-- **Manage your inbox**: Archive, delete, mark read or unread, label, and unsubscribe from senders. The assistant keeps a narrow request scoped to the matching threads and asks before broadening it to sender-wide cleanup.
+- **Manage your inbox**: Archive, delete, mark read or unread, label, and unsubscribe from senders. The assistant asks before broadening a request into a sender-wide cleanup.
 - **Write email**: Prepare new messages, replies, and forwards. You review and send them from a confirmation card; the assistant does not send them immediately.
 - **Manage rules**: Create, update, enable, disable, and troubleshoot automation rules. New rules and destructive rule changes can require confirmation in the chat.
-- **Configure features**: Update supported settings for Meeting Briefs, auto-file attachments, multi-rule selection, scheduled check-ins, personal instructions, and the knowledge base.
-- **Remember preferences**: Ask the assistant to remember information for future chats. Information directly stated by you can be saved, while inferred memories require confirmation.
+- **Configure features**: Update settings for Meeting Briefs, auto-file attachments, multi-rule selection, scheduled check-ins, personal instructions, and the knowledge base.
+- **Remember preferences**: Ask the assistant to remember information for future chats.
 
 See [AI Personal Assistant](/essentials/email-ai-personal-assistant) for the full rule and action model.
 
@@ -29,7 +29,7 @@ Use the history menu in the Chat header to reopen, rename, or delete a previous 
 
 ## Connected Channels
 
-You can also chat with the assistant from a connected Slack, Microsoft Teams, or Telegram account. Connect and configure these apps on the `Channels` page. See [Slack Integration](/essentials/slack-integration) and [Telegram Integration](/essentials/telegram-integration) for setup details.
+You can also chat with the assistant from a connected Slack, Microsoft Teams, or Telegram account. Connect and configure these apps on the **Channels** page. See [Slack Integration](/essentials/slack-integration) and [Telegram Integration](/essentials/telegram-integration) for setup details.
 
 ## Example Prompts
 

--- a/docs/essentials/api-keys.mdx
+++ b/docs/essentials/api-keys.mdx
@@ -7,18 +7,18 @@ icon: 'key'
 Inbox Zero covers AI costs by default, but you can optionally use your own model-provider API key.
 
 <Note>
-This setting is for the AI provider that powers Inbox Zero features. It is different from the developer API keys in the `Developer` settings section, which authenticate requests to the Inbox Zero API.
+This setting is for the AI provider that powers Inbox Zero features. It is different from the developer API keys in the **Developer** settings section, which authenticate requests to the Inbox Zero API.
 </Note>
 
 ## Configure a Provider
 
-1. Open the account menu at the bottom of the sidebar and choose `Settings`.
+1. Open the account menu at the bottom of the sidebar and choose **Settings**.
 2. Expand the relevant email account.
-3. Find the `AI Model` section.
-4. Select a provider, enter the provider's model identifier and API key, then click `Save`.
-5. Test the configuration on the `Assistant` or `Chat` page.
+3. Find the **AI Model** section.
+4. Select a provider, enter the provider's model identifier and API key, then click **Save**.
+5. Test the configuration on the **Assistant** or **Chat** page.
 
-Leave the provider set to `Default` to use the AI service included with Inbox Zero. If a key is already stored, leave the API Key field blank to keep it; entering a new value replaces it.
+Leave the provider set to **Default** to use the AI service included with Inbox Zero. If a key is already stored, leave the API Key field blank to keep it; entering a new value replaces it.
 
 ## Providers in Settings
 
@@ -62,4 +62,4 @@ Create an AI Gateway API key in Vercel and use the model identifier expected by 
 
 ## Usage and Billing
 
-When you use your own provider key, the provider bills that account according to its pricing and limits. Click `View usage` in the AI Model section to review the usage recorded by Inbox Zero. Provider-side billing remains the source of truth for charges.
+When you use your own provider key, the provider bills that account according to its pricing and limits. Click **View usage** in the AI Model section to review the usage recorded by Inbox Zero. Provider-side billing remains the source of truth for charges.

--- a/docs/essentials/api-keys.mdx
+++ b/docs/essentials/api-keys.mdx
@@ -18,7 +18,7 @@ This setting is for the AI provider that powers Inbox Zero features. It is diffe
 4. Select a provider, enter the provider's model identifier and API key, then click **Save**.
 5. Test the configuration on the **Assistant** or **Chat** page.
 
-Leave the provider set to **Default** to use the AI service included with Inbox Zero. If a key is already stored, leave the API Key field blank to keep it; entering a new value replaces it.
+Leave the provider set to **Default** to use the AI service included with Inbox Zero.
 
 ## Providers in Settings
 
@@ -28,7 +28,7 @@ Create a key in the [Anthropic Console](https://console.anthropic.com/settings/k
 
 ### OpenAI
 
-Create a key on the [OpenAI API keys page](https://platform.openai.com/api-keys). After saving a valid key, Inbox Zero can load the models available to that key.
+Create a key on the [OpenAI API keys page](https://platform.openai.com/api-keys).
 
 <iframe
   width="560"

--- a/docs/essentials/assistant-settings.mdx
+++ b/docs/essentials/assistant-settings.mdx
@@ -72,7 +72,7 @@ Optionally append an Inbox Zero referral link to generated drafts. Review the re
 
 ### Allow hidden links in AI drafts
 
-This permits anchor text such as “click here” instead of displaying the full URL. It is more convenient, but it can hide the destination and query-string data. Leave it off when transparent links are important.
+This permits anchor text such as “click here” instead of displaying the full URL. It reads more naturally, but it hides where a link leads. Leave it off when transparent links are important.
 
 ### Sensitive data protection
 

--- a/docs/essentials/assistant-settings.mdx
+++ b/docs/essentials/assistant-settings.mdx
@@ -26,7 +26,7 @@ Use a stricter setting when correctness is more important than draft coverage.
 
 ### Follow-up reminders
 
-Enable reminders for messages where someone has not replied to you or where you have not replied. In **Configure**, set each delay independently, choose whether the assistant should prepare a follow-up draft, and run an initial scan of existing mail.
+Enable reminders for messages where someone has not replied to you or where you have not replied. In **Configure**, set the delays and choose whether the assistant should prepare a follow-up draft.
 
 ### Digest
 
@@ -44,13 +44,13 @@ Add stable information about yourself and how you want the assistant to handle e
 
 ### Email signature
 
-Configure the signature appended to drafted messages. Preview it before saving so the draft does not contain duplicate sign-offs or outdated contact details.
+Configure the signature appended to drafted messages.
 
 ## Knowledge and learning
 
 ### Draft knowledge base
 
-Store facts that can help the assistant answer recurring questions. This control is available only while auto draft replies are enabled. Treat knowledge entries as supporting context, not as a guarantee that every draft will use them.
+Store facts that can help the assistant answer recurring questions. This control is available only while auto draft replies are enabled.
 
 ### Learned patterns
 
@@ -64,11 +64,11 @@ Sync label-based assistant rules to the Inbox Zero Tabs extension as Gmail tabs.
 
 ### Multi-rule selection
 
-Allow the assistant to intentionally select multiple custom rules for one message. Turning it off reduces that behavior, although Inbox Zero can still apply multiple rules in a few built-in cases, such as adding a label alongside a reply workflow.
+Allow the assistant to select multiple custom rules for one message.
 
 ### Include referral signature
 
-Optionally append an Inbox Zero referral link to generated drafts. Review the resulting signature before sending, especially for professional or regulated correspondence.
+Optionally append an Inbox Zero referral link to generated drafts.
 
 ### Allow hidden links in AI drafts
 

--- a/docs/essentials/auto-file-attachments.mdx
+++ b/docs/essentials/auto-file-attachments.mdx
@@ -4,15 +4,13 @@ description: 'Automatically organize email attachments in Google Drive or OneDri
 icon: 'folder-open'
 ---
 
-## Overview
-
-Auto-File Attachments analyzes incoming email attachments and saves matching files to configured folders in Google Drive or Microsoft OneDrive/SharePoint.
+Auto-File Attachments keeps your drive organized without you lifting a finger. Incoming email attachments are analyzed and saved to the right folders in Google Drive or Microsoft OneDrive/SharePoint automatically.
 
 ## Set Up Auto-Filing
 
 ### Connect a Drive
 
-Open `Attachments` in the left sidebar and connect one of the supported storage providers:
+Open **Attachments** in the left sidebar and connect one of the supported storage providers:
 
 - Google Drive
 - Microsoft OneDrive or SharePoint
@@ -45,7 +43,7 @@ All attachment types can be saved. PDF, DOCX, and plain-text files support conte
 
 ## Corrections and Activity
 
-Open `Attachments` to review Filing Activity and move a file to a different configured folder. Notification emails are sent in the source email thread, so you can reply with a correction. Supported reply intentions include:
+Open **Attachments** to review Filing Activity and move a file to a different configured folder. Notification emails are sent in the source email thread, so you can reply with a correction. Supported reply intentions include:
 
 - Approve the proposed filing.
 - Move the file to another configured folder.
@@ -55,9 +53,9 @@ The assistant uses these corrections as context for future filing decisions.
 
 ## Delivery Settings
 
-Use the `Delivery` button on the Attachments page to configure updates:
+Use the **Delivery** button on the Attachments page to configure updates:
 
 - **Email confirmations**: Receive an email when a file is sorted. Questions that require your input still arrive by email even if routine confirmations are disabled.
-- **Connected apps**: Enable document-filing alerts for connected Slack, Microsoft Teams, or Telegram accounts. Configure or connect them on `Channels`.
+- **Connected apps**: Enable document-filing alerts for connected Slack, Microsoft Teams, or Telegram accounts. Configure or connect them on **Channels**.
 
 For Slack, select a direct message or an allowed private channel. The selected Slack bot must already be invited to a private channel before it can post there.

--- a/docs/essentials/auto-file-attachments.mdx
+++ b/docs/essentials/auto-file-attachments.mdx
@@ -33,29 +33,17 @@ The setup flow can preview recent attachments before auto-filing is enabled. Rev
 
 ## How Filing Works
 
-1. An incoming message contains an eligible attachment.
-2. The assistant analyzes the filename, extractable document content, email context, folder descriptions, and filing instructions.
-3. A confident match is uploaded to the selected folder.
-4. A low-confidence match prompts you for a destination instead of filing automatically.
-5. The result appears in Filing Activity and is delivered through the notification methods you enabled.
-
-All attachment types can be saved. PDF, DOCX, and plain-text files support content extraction; other types rely more heavily on the filename and surrounding email context.
+When a new attachment arrives, the assistant files it in the matching folder. If it isn't sure where a file belongs, it asks you for a destination instead of filing automatically.
 
 ## Corrections and Activity
 
-Open **Attachments** to review Filing Activity and move a file to a different configured folder. Notification emails are sent in the source email thread, so you can reply with a correction. Supported reply intentions include:
-
-- Approve the proposed filing.
-- Move the file to another configured folder.
-- Undo a completed filing.
-
-The assistant uses these corrections as context for future filing decisions.
+Open **Attachments** to review Filing Activity and move a file to a different folder. Notification emails arrive in the source email thread, so you can also reply to approve a filing, move the file, or undo it. The assistant learns from these corrections.
 
 ## Delivery Settings
 
 Use the **Delivery** button on the Attachments page to configure updates:
 
-- **Email confirmations**: Receive an email when a file is sorted. Questions that require your input still arrive by email even if routine confirmations are disabled.
+- **Email confirmations**: Receive an email when a file is sorted.
 - **Connected apps**: Enable document-filing alerts for connected Slack, Microsoft Teams, or Telegram accounts. Configure or connect them on **Channels**.
 
 For Slack, select a direct message or an allowed private channel. The selected Slack bot must already be invited to a private channel before it can post there.

--- a/docs/essentials/booking-links.mdx
+++ b/docs/essentials/booking-links.mdx
@@ -22,32 +22,21 @@ You can create one Inbox Zero booking link per email account. If you already use
 
 This is the account's default availability. It also guides times the AI suggests in scheduling emails, even if you do not create an Inbox Zero booking link.
 
-When displaying bookable slots, Inbox Zero treats events on all enabled connected calendars as busy. If calendar availability cannot be loaded safely, the public page returns no slots instead of risking a double booking.
-
 ## Create a booking link
 
 1. On **Calendars**, find **Booking link** and select **Create booking link**.
-2. Enter the title guests will see.
-3. Choose a unique URL slug using lowercase letters, numbers, and hyphens. It must be 3–64 characters.
-4. Choose a duration: 15, 30, 45, or 60 minutes.
-5. Select the destination calendar where new events should be created.
-6. Optionally add a description and enable provider video conferencing.
-7. Select **Create**.
+2. Enter the title guests will see and choose a unique URL slug.
+3. Choose a duration and the destination calendar where new events should be created.
+4. Optionally add a description and enable video conferencing.
+5. Select **Create**.
 
-Google calendars can create Google Meet links, and Microsoft calendars can create Microsoft Teams links. If the selected provider cannot create a supported video meeting, the video option is unavailable.
+Google calendars can create Google Meet links, and Microsoft calendars can create Microsoft Teams links.
 
-After creation, copy the `/book/your-slug` URL and share it. The active Inbox Zero booking link also becomes the link the AI can use when a reply is genuinely about scheduling.
+After creation, copy the `/book/your-slug` URL and share it. The active Inbox Zero booking link is also the link the AI shares in scheduling replies.
 
 ## Configure or pause the link
 
-Select **Configure** to change:
-
-- Guest-facing title and description.
-- Public URL slug.
-- Duration.
-- Minimum notice before a meeting. The default is two hours.
-- Destination calendar.
-- Google Meet or Microsoft Teams conferencing, when supported.
+Select **Configure** to edit the link's details, including the minimum notice before a meeting. The default notice is two hours.
 
 Use the switch on the booking-link card to make the public page active or inactive. An inactive link cannot be booked and is not used by the AI. When an Inbox Zero link is active, it takes precedence over the external **Calendar Booking Link** field.
 
@@ -62,7 +51,7 @@ Guests can:
 3. Receive a calendar invite and confirmation email.
 4. Use secure links from the confirmation to reschedule or cancel.
 
-The host also receives booking notifications. Inbox Zero validates the slot again during confirmation so two guests cannot successfully take the same time.
+The host also receives booking notifications.
 
 ## Troubleshooting
 

--- a/docs/essentials/bulk-archiver.mdx
+++ b/docs/essentials/bulk-archiver.mdx
@@ -1,28 +1,26 @@
 ---
-title: 'Bulk Archiver'
+title: 'Bulk Archive'
 description: 'Archive, mark as read, or delete email in bulk by category.'
 icon: 'box-archive'
 ---
 
-Open `Bulk Archive` under Cleanup in the left sidebar, or visit [Bulk Archive](https://www.getinboxzero.com/bulk-archive).
+Bulk Archive cleans up years of accumulated mail in a few clicks. It groups your senders into categories such as newsletters, receipts, and notifications, so you can archive thousands of emails at once instead of selecting messages one by one.
+
+Open **Bulk Archive** under Cleanup in the left sidebar, or visit [Bulk Archive](https://www.getinboxzero.com/bulk-archive).
 
 ## How It Works
-
-Bulk Archive groups senders into categories so you can clean up large amounts of mail without selecting messages one by one.
 
 1. If sender categorization is not enabled yet, follow the setup prompt and let Inbox Zero categorize your sender history.
 2. Review the category cards and the senders assigned to each category.
 3. Select the senders you want to process, or choose the entire category.
 4. Run the configured bulk action.
 
-Use `Categorize with AI` to categorize or refresh senders when the page does not yet have enough categorized history.
+Use **Categorize with AI** to categorize or refresh senders when the page does not yet have enough categorized history.
 
 ## Choose the Bulk Action
 
-Open `Settings` on the Bulk Archive page to choose what the category buttons do:
+Open **Settings** on the Bulk Archive page to choose what the category buttons do:
 
 - **Archive**: Remove matching messages from the inbox while keeping them searchable.
 - **Mark as read**: Clear the unread state without moving the messages.
 - **Delete**: Move matching messages to trash. Review the selected senders carefully before using this option.
-
-Bulk Archive operates on the senders shown within its categories. For a more selective cleanup with custom exclusions and undo history, use Deep Clean when it is available for your account.

--- a/docs/essentials/bulk-archiver.mdx
+++ b/docs/essentials/bulk-archiver.mdx
@@ -15,7 +15,7 @@ Open **Bulk Archive** under Cleanup in the left sidebar, or visit [Bulk Archive]
 3. Select the senders you want to process, or choose the entire category.
 4. Run the configured bulk action.
 
-Use **Categorize with AI** to categorize or refresh senders when the page does not yet have enough categorized history.
+Use **Categorize with AI** to categorize or refresh senders.
 
 ## Choose the Bulk Action
 

--- a/docs/essentials/bulk-email-unsubscriber.mdx
+++ b/docs/essentials/bulk-email-unsubscriber.mdx
@@ -24,7 +24,7 @@ The video shows Gmail; the flow is the same for Outlook.
 
 ## Review Senders
 
-The page groups newsletter and marketing email by sender. Each row shows message volume, unread and unarchived counts, and read rate. Use the date range, sender search, and status filters to narrow the list. You can sort by total, unread, or unarchived messages.
+The page groups newsletter and marketing email by sender, showing each sender's volume and how often you read them. Use the filters to narrow the list.
 
 Open a sender to see its activity and individual messages. From the expanded view, you can also archive or delete previous messages from that sender.
 
@@ -36,14 +36,4 @@ Open a sender to see its activity and individual messages. From the expanded vie
 - **Archive**: Archive existing messages from the sender.
 - **Delete**: Move existing messages from the sender to trash.
 
-Use the checkboxes to apply these actions to several senders at once. The **Select suggested** shortcut selects senders with enough message history and a read rate below 20%, helping you find subscriptions you rarely read. Review the selection before deleting, since deletion is harder to undo than archiving.
-
-## Filters
-
-Use the status filter to switch among:
-
-- **Unhandled**
-- **All**
-- **Unsubscribed**
-- **Auto Archive**
-- **Approved**
+Use the checkboxes to apply these actions to several senders at once. The **Select suggested** shortcut selects subscriptions you rarely read. Review the selection before deleting, since deletion is harder to undo than archiving.

--- a/docs/essentials/bulk-email-unsubscriber.mdx
+++ b/docs/essentials/bulk-email-unsubscriber.mdx
@@ -1,10 +1,12 @@
 ---
-title: 'Bulk Email Unsubscriber'
+title: 'Bulk Unsubscribe'
 description: 'Review newsletter senders and unsubscribe, archive, or delete in bulk.'
 icon: 'envelopes-bulk'
 ---
 
-Open `Bulk Unsubscribe` under Cleanup in the left sidebar, or visit [Bulk Unsubscribe](https://www.getinboxzero.com/bulk-unsubscribe).
+Bulk Unsubscribe finds every newsletter and marketing list you're subscribed to, shows you which ones you actually read, and lets you unsubscribe, archive, or delete in one click.
+
+Open **Bulk Unsubscribe** under Cleanup in the left sidebar, or visit [Bulk Unsubscribe](https://www.getinboxzero.com/bulk-unsubscribe).
 
 <iframe
   width="560"
@@ -17,7 +19,7 @@ Open `Bulk Unsubscribe` under Cleanup in the left sidebar, or visit [Bulk Unsubs
 ></iframe>
 
 <Note>
-The video uses Gmail, but Bulk Unsubscribe also supports Outlook. Select the Outlook mailbox in the account switcher and follow the same Inbox Zero flow. See [Outlook and Microsoft 365](/essentials/outlook-guide) for provider differences.
+The video shows Gmail; the flow is the same for Outlook.
 </Note>
 
 ## Review Senders
@@ -34,16 +36,14 @@ Open a sender to see its activity and individual messages. From the expanded vie
 - **Archive**: Archive existing messages from the sender.
 - **Delete**: Move existing messages from the sender to trash.
 
-Use the checkboxes to apply these actions to several senders at once. The `Select suggested` shortcut selects senders with enough message history and a read rate below 20%, helping you find subscriptions you rarely read. Always review the selection before applying a bulk action.
+Use the checkboxes to apply these actions to several senders at once. The **Select suggested** shortcut selects senders with enough message history and a read rate below 20%, helping you find subscriptions you rarely read. Review the selection before deleting, since deletion is harder to undo than archiving.
 
 ## Filters
 
 Use the status filter to switch among:
 
-- `Unhandled`
-- `All`
-- `Unsubscribed`
-- `Auto Archive`
-- `Approved`
-
-Inbox health reports and onboarding can link directly to this page with suggested low-read senders already selected.
+- **Unhandled**
+- **All**
+- **Unsubscribed**
+- **Auto Archive**
+- **Approved**

--- a/docs/essentials/calendar-integration.mdx
+++ b/docs/essentials/calendar-integration.mdx
@@ -4,13 +4,11 @@ description: 'Connect calendars for AI scheduling, availability, booking links, 
 icon: 'calendar'
 ---
 
-## Overview
-
-Connected calendars let the assistant check real availability when it drafts scheduling replies. The `Calendars` page also manages weekly availability, booking links, timezone, and the calendars used for conflict checks.
+Connected calendars let the assistant check your real availability when it drafts scheduling replies, so it can offer times that actually work. The **Calendars** page also manages weekly availability, booking links, timezone, and the calendars used for conflict checks.
 
 ## Connect a Calendar
 
-1. Open `Calendars` in the left sidebar.
+1. Open **Calendars** in the left sidebar.
 2. Connect Google Calendar or Microsoft Outlook Calendar and authorize access.
 3. Choose which calendars should be checked for availability.
 4. Confirm your timezone.
@@ -19,16 +17,16 @@ You can connect multiple calendars, such as separate work and personal calendars
 
 ## Weekly Availability
 
-In the `Availability` section, set the hours the assistant is allowed to suggest for each day of the week. These hours use the timezone shown on the `Calendars` page. Calendar events still block otherwise available time.
+In the **Availability** section, set the hours the assistant is allowed to suggest for each day of the week. These hours use the timezone shown on the **Calendars** page. Calendar events still block otherwise available time.
 
 ## Booking Links
 
-Depending on the features enabled for your account, you can either:
+You can either:
 
-- Add an existing Calendly, Google Calendar, Microsoft Bookings, or other booking URL for the assistant to share; or
-- Create an Inbox Zero booking link.
+- Create an [Inbox Zero booking link](/essentials/booking-links), or
+- Add an existing Calendly, Google Calendar, Microsoft Bookings, or other booking URL for the assistant to share.
 
-An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the `Calendars` page. Guests can book available times and use the booking page to reschedule or cancel when supported.
+An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the **Calendars** page. Guests can book available times and use the booking page to reschedule or cancel.
 
 ## AI Scheduling
 

--- a/docs/essentials/calendar-integration.mdx
+++ b/docs/essentials/calendar-integration.mdx
@@ -26,7 +26,7 @@ You can either:
 - Create an [Inbox Zero booking link](/essentials/booking-links), or
 - Add an existing Calendly, Google Calendar, Microsoft Bookings, or other booking URL for the assistant to share.
 
-An Inbox Zero booking link can be configured with a public title and URL, meeting duration, destination calendar, optional video conferencing, description, and minimum notice. You can activate, copy, edit, or delete the link from the **Calendars** page. Guests can book available times and use the booking page to reschedule or cancel.
+Guests can book available times and use the booking page to reschedule or cancel.
 
 ## AI Scheduling
 

--- a/docs/essentials/call-webhook.mdx
+++ b/docs/essentials/call-webhook.mdx
@@ -54,4 +54,4 @@ Inbox Zero does not wait for or parse the response body. A timeout, blocked dest
 
 Open **Settings**, find the **Developer** section, and generate a Webhook Secret. The secret is shown only when generated, so copy it before closing the dialog. Regenerating it immediately changes the value sent with future requests.
 
-Every request includes the `X-Webhook-Secret` header. If you have not generated a secret, the header is still present with an empty value. Your endpoint should compare the header to the stored secret before processing the payload.
+Every request includes the `X-Webhook-Secret` header. Your endpoint should compare the header to the stored secret before processing the payload.

--- a/docs/essentials/call-webhook.mdx
+++ b/docs/essentials/call-webhook.mdx
@@ -4,12 +4,12 @@ description: 'Send rule and email metadata to an external HTTP endpoint.'
 icon: 'webhook'
 ---
 
-The `Call webhook` rule action sends a JSON request to an external service when an email matches a rule.
+The **Call webhook** rule action sends a JSON request to an external service when an email matches a rule.
 
 ## Configure the Action
 
-1. Open `Assistant` and edit a rule.
-2. Add the `Call webhook` action.
+1. Open **Assistant** and edit a rule.
+2. Add the **Call webhook** action.
 3. Enter a publicly reachable HTTP or HTTPS endpoint.
 4. Save the rule.
 
@@ -52,6 +52,6 @@ Inbox Zero does not wait for or parse the response body. A timeout, blocked dest
 
 ## Webhook Secret
 
-Open `Settings`, find the `Developer` section, and generate a Webhook Secret. The secret is shown only when generated, so copy it before closing the dialog. Regenerating it immediately changes the value sent with future requests.
+Open **Settings**, find the **Developer** section, and generate a Webhook Secret. The secret is shown only when generated, so copy it before closing the dialog. Regenerating it immediately changes the value sent with future requests.
 
 Every request includes the `X-Webhook-Secret` header. If you have not generated a secret, the header is still present with an empty value. Your endpoint should compare the header to the stored secret before processing the payload.

--- a/docs/essentials/channels.mdx
+++ b/docs/essentials/channels.mdx
@@ -44,7 +44,7 @@ Each connected provider can also show toggles for:
 - **Document filing alerts**: updates when attachments are filed.
 - **Scheduled check-ins**: proactive assistant updates, when configured.
 
-Configure the underlying feature using the settings button or linked feature page. A route may stay disabled until the provider has a valid rule-notification destination. For Slack, choose the target destination before enabling delivery.
+Configure the underlying feature using the settings button or linked feature page. For Slack, choose the target destination before enabling delivery; some routes stay disabled until a destination is selected.
 
 ## Chat with the assistant
 

--- a/docs/essentials/channels.mdx
+++ b/docs/essentials/channels.mdx
@@ -4,7 +4,7 @@ description: 'Connect Slack, Microsoft Teams, or Telegram and control what Inbox
 icon: 'messages'
 ---
 
-The **Channels** page is the central place to connect chat apps and route Inbox Zero updates. Depending on the provider and enabled features, you can receive rule notifications, draft replies, meeting briefs, follow-up reminders, digests, document-filing alerts, and scheduled check-ins.
+The **Channels** page is the central place to connect chat apps and route Inbox Zero updates. You can receive rule notifications, draft replies, meeting briefs, follow-up reminders, digests, document-filing alerts, and scheduled check-ins.
 
 ## Connect a channel
 
@@ -12,7 +12,7 @@ The **Channels** page is the central place to connect chat apps and route Inbox 
 2. Find **Slack**, **Microsoft Teams**, or **Telegram** and select **Connect**.
 3. Complete the provider-specific flow:
    - **Slack:** approve the Slack OAuth request and return to Inbox Zero.
-   - **Teams or Telegram:** copy the generated `/connect` command and send it in a direct message to the Inbox Zero bot. The code is single-use and expires after 10 minutes.
+   - **Teams or Telegram:** copy the generated `/connect` command and send it in a direct message to the Inbox Zero bot.
 4. Confirm that the provider displays a **Connected** badge.
 
 ## Route rule notifications
@@ -24,13 +24,11 @@ For each enabled rule, choose one of two modes from its menu:
 - **Notify only** posts a notification when the rule matches.
 - **Draft reply in chat** includes a generated draft for review.
 
-If a rule already drafts an email, Inbox Zero uses **Draft reply in chat** as its initial channel mode. Otherwise, it starts with **Notify only**.
-
-Slack lets you choose a direct message or an eligible Slack channel as the destination. Teams and Telegram currently use the linked direct-message conversation.
+Slack lets you choose a direct message or a Slack channel as the destination. Teams and Telegram deliver to your direct message with the bot.
 
 ### Provider differences
 
-- **Slack** supports the richest interactive cards, including draft review and quick actions such as send, edit, dismiss, archive, or mark as read where applicable.
+- **Slack** supports the richest interactive cards, including draft review and quick actions such as send, edit, archive, or mark as read.
 - **Teams**: Draft editing and sending are not available yet. Review or send the draft in Inbox Zero. Other quick actions are view-only.
 - **Telegram** can send a prepared draft from Telegram, but draft editing is not available there. Other quick actions such as archive and mark read are currently Slack-only.
 
@@ -42,13 +40,13 @@ Each connected provider can also show toggles for:
 - **Follow-up reminders**: nudges for messages awaiting a reply.
 - **Digests**: your scheduled newsletter digest. Digests require the **Plus plan or higher**.
 - **Document filing alerts**: updates when attachments are filed.
-- **Scheduled check-ins**: proactive assistant updates, when configured.
+- **Scheduled check-ins**: proactive assistant updates.
 
-Configure the underlying feature using the settings button or linked feature page. For Slack, choose the target destination before enabling delivery; some routes stay disabled until a destination is selected.
+Configure the underlying feature using the settings button or linked feature page. For Slack, choose the target destination before enabling delivery.
 
 ## Chat with the assistant
 
-You can direct-message the Inbox Zero bot in a connected provider. Slack also supports @mentions in channels where the bot is present. The assistant can use your connected email and calendar context, but write actions still follow the product's confirmation and safety rules.
+You can direct-message the Inbox Zero bot in a connected provider. Slack also supports @mentions in channels where the bot is present. The assistant can use your connected email and calendar context.
 
 ## Disconnect a provider
 
@@ -58,7 +56,7 @@ Open the provider menu on **Channels** and select **Disconnect**. This stops del
 
 ### Teams or Telegram will not link
 
-Generate a new command from **Channels** and send it to the bot in a direct message within 10 minutes. A link code cannot be reused.
+Generate a new command from **Channels** and send it to the bot in a direct message within 10 minutes.
 
 ### A Slack destination is unavailable
 

--- a/docs/essentials/cold-email-blocker.mdx
+++ b/docs/essentials/cold-email-blocker.mdx
@@ -4,24 +4,26 @@ description: 'Block cold emails and protect your inbox from spam using AI filter
 icon: 'shield-check'
 ---
 
-## Getting Started
+Cold Email Blocker keeps unsolicited sales pitches and outreach out of your inbox before you ever see them. The AI recognizes cold emails that traditional spam filters miss, while anyone who has emailed you before always gets through.
 
-To use the Cold Email Blocker, visit [this link](https://www.getinboxzero.com/cold-email-blocker).
+Open **Cold Email Blocker** in the left sidebar, or visit [Cold Email Blocker](https://www.getinboxzero.com/cold-email-blocker).
 
-You can run the cold email blocker in three modes:
+## Choose a Mode
 
-1. **List here**: This will display the cold emails in the table below.
-2. **Auto label**: This will automatically label the cold emails in your inbox with the label `Cold Email`, and display the cold emails in the table below.
-3. **Auto archive and label**: This will automatically archive the cold emails in your inbox and label them with the label `Cold Email`, and display the cold emails in the table below.
+You can run the Cold Email Blocker in three modes:
 
-Cold email processing will only apply to new emails. It will not process emails that have already been processed.
+1. **List**: Show detected cold emails in the table on the page without changing your inbox.
+2. **Auto label**: Label cold emails in your inbox with `Cold Email`.
+3. **Auto archive and label**: Archive cold emails and label them with `Cold Email`.
+
+Cold email detection applies only to new emails as they arrive; it does not reprocess older mail.
 
 ## Custom Prompts
 
-Emails are classified using a prompt. The default prompt works for most people, but you can adjust it by clicking `Edit Prompt`. We recommend giving examples of what you do and don't consider a cold email.
+Emails are classified using a prompt. The default works for most people, but you can adjust it by clicking **Edit Prompt**. Giving examples of what you do and don't consider a cold email works well.
 
 If a sender has emailed you before, they are automatically excluded, and the AI won't run on those emails.
 
 ## Testing
 
-Click `Test` to open a side panel where you can paste in an email or test against previous emails to see if they would be marked as cold.
+Click **Test** to open a side panel where you can paste in an email or test against previous emails to see if they would be marked as cold.

--- a/docs/essentials/cold-email-blocker.mdx
+++ b/docs/essentials/cold-email-blocker.mdx
@@ -22,8 +22,6 @@ Cold email detection applies only to new emails as they arrive; it does not repr
 
 Emails are classified using a prompt. The default works for most people, but you can adjust it by clicking **Edit Prompt**. Giving examples of what you do and don't consider a cold email works well.
 
-If a sender has emailed you before, they are automatically excluded, and the AI won't run on those emails.
-
 ## Testing
 
 Click **Test** to open a side panel where you can paste in an email or test against previous emails to see if they would be marked as cold.

--- a/docs/essentials/context-integrations.mdx
+++ b/docs/essentials/context-integrations.mdx
@@ -16,11 +16,8 @@ They are context sources, not general workflow automations. Inbox Zero uses enab
 
 - Early Access must be enabled for the account.
 - Connecting an integration requires the **Plus plan or higher**.
-- The integration must support the configured OAuth flow. API-token connections are shown in the interface but are not currently supported.
 
 ## Available integrations
-
-The current configuration can expose:
 
 - **Notion**: search and fetch approved Notion content.
 - **Stripe**: list customers, disputes, invoices, payment intents, prices, products, and subscriptions.
@@ -48,7 +45,7 @@ For email drafting, Inbox Zero searches enabled tools for information related to
 
 For meeting briefs, enabled integration tools are available alongside email, calendar, and web-research context. The AI chooses whether a tool is relevant to the attendees or meeting topic.
 
-External data and tool output are treated as untrusted context. Even so, an integration may return stale, incomplete, or incorrectly matched information. Review names, account status, prices, payment state, and other consequential facts before sending a draft or using a brief.
+An integration may return stale, incomplete, or incorrectly matched information, so double-check consequential facts such as prices and payment state before sending a draft.
 
 ## Safety and access control
 
@@ -57,10 +54,6 @@ External data and tool output are treated as untrusted context. Even so, an inte
 - Provider authorization controls which workspaces and records Inbox Zero can access; tool switches control which of those capabilities the assistant may call.
 - Disconnecting deletes the Inbox Zero connection and its associated tool records. It does not delete data in the external service.
 - Disabling a connection preserves it but stops its tools from being used.
-
-<Warning>
-Read the provider's OAuth permissions before approving access. Connected data may be included in AI processing when it is relevant to a draft or meeting brief.
-</Warning>
 
 ## Troubleshooting
 
@@ -86,5 +79,5 @@ Confirm that the relevant tool is enabled and that the connected provider accoun
 
 ### OAuth fails or is cancelled
 
-Return to **Integrations** and start a fresh connection. The authorization state and PKCE verifier expire after about 10 minutes and cannot be reused. If failure continues, disconnect the partial connection if present and retry.
+Return to **Integrations** and start a fresh connection. An authorization attempt expires after about 10 minutes and cannot be reused. If failure continues, disconnect the partial connection if present and retry.
 

--- a/docs/essentials/context-integrations.mdx
+++ b/docs/essentials/context-integrations.mdx
@@ -10,7 +10,7 @@ Context Integrations are in Early Access.
 
 Context Integrations let Inbox Zero look up relevant information in connected services while preparing email drafts and meeting briefs. For example, the assistant may search for a sender in a CRM, fetch a Notion page, or check billing information in Stripe before it writes.
 
-They are context sources, not general workflow automations. Inbox Zero uses enabled tools when relevant and can continue drafting when an integration is unavailable or returns no useful information.
+They are context sources, not general workflow automations.
 
 ## Requirements
 
@@ -20,11 +20,9 @@ They are context sources, not general workflow automations. Inbox Zero uses enab
 ## Available integrations
 
 - **Notion**: search and fetch approved Notion content.
-- **Stripe**: list customers, disputes, invoices, payment intents, prices, products, and subscriptions.
-- **Monday.com**: look up board items, board information, workspaces, and workspace information.
+- **Stripe**: look up customers, invoices, subscriptions, and other billing data.
+- **Monday.com**: look up boards, board items, and workspaces.
 - **Pipedream**: connect read-oriented tools from services such as HubSpot, Slack, Airtable, and Todoist.
-
-The exact list and individual tools can change during Early Access. A service marked **Request Access** is not connectable yet.
 
 ## Connect and enable a service
 
@@ -35,15 +33,13 @@ The exact list and individual tools can change during Early Access. A service ma
 5. Turn on the integration if it is connected but disabled.
 6. Expand **Tools** and enable only the lookups you want the assistant to use.
 
-A connection and its tools have separate switches. The assistant can use a tool only when the connection is active and that individual tool is enabled.
+The assistant can use a tool only when the connection is active and that individual tool is enabled.
 
-Pipedream connections can expose many tools, so they start disabled and Inbox Zero filters the synced list toward read-oriented names such as get, list, find, and search. Still inspect each tool's name and description before enabling it.
+Pipedream connections can expose many tools, so they start disabled. Inspect each tool's name and description before enabling it.
 
 ## How context is used
 
-For email drafting, Inbox Zero searches enabled tools for information related to the sender and the current thread. Useful findings are supplied to the drafting model as external context. If nothing relevant is found, the draft proceeds without it.
-
-For meeting briefs, enabled integration tools are available alongside email, calendar, and web-research context. The AI chooses whether a tool is relevant to the attendees or meeting topic.
+For email drafting, Inbox Zero searches enabled tools for information related to the sender and the current thread. For meeting briefs, enabled integration tools are available alongside email, calendar, and web-research context.
 
 An integration may return stale, incomplete, or incorrectly matched information, so double-check consequential facts such as prices and payment state before sending a draft.
 
@@ -52,7 +48,7 @@ An integration may return stale, incomplete, or incorrectly matched information,
 - Enable the smallest set of tools needed for your workflow.
 - Prefer read-only tools. Do not enable tools that create, update, or delete data merely because their provider makes them available.
 - Provider authorization controls which workspaces and records Inbox Zero can access; tool switches control which of those capabilities the assistant may call.
-- Disconnecting deletes the Inbox Zero connection and its associated tool records. It does not delete data in the external service.
+- Disconnecting removes the connection from Inbox Zero. It does not delete data in the external service.
 - Disabling a connection preserves it but stops its tools from being used.
 
 ## Troubleshooting
@@ -67,7 +63,7 @@ Context Integrations require Plus or higher. Upgrade the account that owns the s
 
 ### Connected but disabled
 
-Turn on the connection, expand its tools, and confirm that at least one tool is enabled. A connection with no enabled tools contributes no context.
+Turn on the connection, expand its tools, and confirm that at least one tool is enabled.
 
 ### A tool does not appear
 
@@ -75,9 +71,9 @@ Reconnect the service to resync its tool list. Some integrations intentionally a
 
 ### Drafts do not include expected context
 
-Confirm that the relevant tool is enabled and that the connected provider account can access the record. The assistant calls tools only when it judges them relevant, and it omits integration context when no useful result is found.
+Confirm that the relevant tool is enabled and that the connected provider account can access the record. The assistant only calls tools it judges relevant to the email or meeting.
 
 ### OAuth fails or is cancelled
 
-Return to **Integrations** and start a fresh connection. An authorization attempt expires after about 10 minutes and cannot be reused. If failure continues, disconnect the partial connection if present and retry.
+Return to **Integrations** and start a fresh connection. If failure continues, disconnect the partial connection if present and retry.
 

--- a/docs/essentials/deep-clean.mdx
+++ b/docs/essentials/deep-clean.mdx
@@ -8,7 +8,7 @@ icon: 'brush'
 Deep Clean is in Early Access and currently supports Gmail accounts.
 </Note>
 
-Deep Clean reviews older inbox threads and decides which should stay and which can be archived or marked as read. It combines explicit protections, mail metadata, and AI judgment, then shows the results as they are processed.
+Deep Clean reviews older inbox threads and decides which should stay and which can be archived or marked as read.
 
 ## Requirements
 
@@ -33,8 +33,6 @@ Deep Clean processes an initial preview of 50 messages. Review the live results 
 
 ## How messages are evaluated
 
-The selected protections are checked across a thread. Deep Clean also recognizes common low-priority mail such as newsletters and Gmail category mail. Past calendar events can be cleaned while future events are kept when calendar protection is on. Messages not decided by these checks are evaluated against your instructions by AI.
-
 AI classification can be wrong. Use the preview to confirm that your protected message types and custom instructions behave as expected.
 
 ## Safety and undo
@@ -47,10 +45,6 @@ Deep Clean does not delete email.
 - Hover a completed action in the live results and select **Undo** to restore that thread to the inbox or mark it unread again.
 - If Deep Clean chose **Keep**, hover the result to manually archive or mark the message as read.
 
-<Note>
-Undo is available from the run results for individual threads. Review the preview before continuing to the full inbox instead of treating undo as a guaranteed bulk rollback.
-</Note>
-
 After the first run, the Deep Clean page reuses your previous settings. Use **Edit settings** to change them, and **History** to review earlier cleanup jobs.
 
 ## Troubleshooting
@@ -61,7 +55,7 @@ Confirm that the selected account is Gmail, the account has an active premium pl
 
 ### Processing appears stuck
 
-Large cleanups are handled in background batches and can take time. Keep the run page open or return through **History**. If nothing changes, refresh and confirm that the Gmail connection is still active.
+Large cleanups can take time. Keep the run page open or return through **History**. If nothing changes, refresh and confirm that the Gmail connection is still active.
 
 ### Important mail was cleaned
 

--- a/docs/essentials/delayed-actions.mdx
+++ b/docs/essentials/delayed-actions.mdx
@@ -29,7 +29,7 @@ You can delay:
 - Delete
 - Move to folder
 
-Draft replies, digests, webhooks, spam actions, and messaging notifications do not currently expose delayed execution.
+Other actions cannot be delayed.
 
 ## Common Uses
 
@@ -37,5 +37,3 @@ Draft replies, digests, webhooks, spam actions, and messaging notifications do n
 - Send an automated reply after a short delay.
 - Remove time-sensitive notifications from the inbox after they expire.
 - Move older messages to a folder after a review window.
-
-Delayed actions are scheduled after the rule matches. They may run shortly after the target time rather than at an exact second.

--- a/docs/essentials/delayed-actions.mdx
+++ b/docs/essentials/delayed-actions.mdx
@@ -8,9 +8,9 @@ Delayed execution lets an assistant rule wait before applying an action. Use it 
 
 ## Add a Delay
 
-1. Open `Assistant` and edit a rule.
+1. Open **Assistant** and edit a rule.
 2. Add or open a supported action.
-3. Open the action's `More options` menu and choose `Add delay`.
+3. Open the action's **More options** menu and choose **Add delay**.
 4. Set a delay between 1 minute and 90 days, then save the rule.
 
 The delay belongs to that specific action. Other actions in the same rule can still run immediately or use different delays.

--- a/docs/essentials/email-ai-personal-assistant.mdx
+++ b/docs/essentials/email-ai-personal-assistant.mdx
@@ -46,8 +46,6 @@ Conditions can use AI instructions, static fields, or both.
 - **AI condition**: Describe the meaning of the emails that should match, such as `Apply this rule if this email is asking me to set up a call.`
 - **Static condition**: Match text in `From`, `To`, or `Subject`, such as `From` contains `@example.com`.
 
-Static conditions are useful for deterministic matches and do not require the AI to interpret every email.
-
 ### Actions
 
 A rule can contain multiple actions. Available actions can vary by email provider and connected apps:
@@ -67,7 +65,7 @@ A rule can contain multiple actions. Available actions can vary by email provide
 - Call webhook
 - Notify in a connected Slack, Teams, or Telegram account
 - Deliver a draft reply to a connected messaging account for review
-- Notify the sender when supported
+- Notify the sender
 
 See [Email Digest](/essentials/email-digest), [Call Webhook](/essentials/call-webhook), and [Delayed Actions](/essentials/delayed-actions) for actions that need additional configuration.
 
@@ -93,9 +91,7 @@ When **Apply to Threads** is disabled, the rule runs only on the first message i
 
 ### When Multiple Rules Can Apply
 
-If multi-rule selection is disabled, the assistant normally chooses one rule. Some system behavior can still add another label. For example, a static `Team` rule can label a message while the `To Reply` rule also creates a draft, and a scheduling email can receive both `Calendar` and `To Reply` labels.
-
-Enable multi-rule selection in **Assistant** > **Settings** when you intentionally want several custom rules to match the same message.
+By default, the assistant chooses one rule per email. Enable multi-rule selection in **Assistant** > **Settings** when you want several rules to match the same message.
 
 ## Learned Patterns
 
@@ -113,4 +109,4 @@ Open the [Test tab](https://www.getinboxzero.com/automation?tab=test) to run you
 
 ## Assistant Settings
 
-Open **Assistant** > **Settings** to configure behavior shared across rules, including draft-reply confidence and delay, follow-up reminders, writing style, personal instructions and signature, the knowledge base, learned-pattern behavior, multi-rule selection, and the email digest. See [Assistant Settings](/essentials/assistant-settings).
+Open **Assistant** > **Settings** to configure behavior shared across rules, such as auto-drafting, writing style, and the email digest. See [Assistant Settings](/essentials/assistant-settings).

--- a/docs/essentials/email-ai-personal-assistant.mdx
+++ b/docs/essentials/email-ai-personal-assistant.mdx
@@ -4,7 +4,9 @@ description: 'Create rules that automatically manage incoming email.'
 icon: 'sparkles'
 ---
 
-The AI Personal Assistant manages incoming email using rules you define. Open `Assistant` in the left sidebar or visit [Assistant](https://www.getinboxzero.com/automation). You can also create and manage rules through [AI Chat](/essentials/ai-chat).
+The AI Personal Assistant organizes your inbox for you. Describe how you want your email handled in plain English, and it labels, archives, forwards, and drafts replies automatically as mail arrives.
+
+Open **Assistant** in the left sidebar or visit [Assistant](https://www.getinboxzero.com/automation). You can also create and manage rules through [AI Chat](/essentials/ai-chat).
 
 ## Getting Started
 
@@ -24,12 +26,12 @@ The video uses Gmail. Outlook users follow the same Assistant flow; label action
 
 ### Create Rules from Instructions
 
-1. Open `Assistant`.
+1. Open **Assistant**.
 2. Describe how you want your email handled in the instruction box.
 3. Review the rules generated from your instructions.
 4. Save the rules.
 
-Use `Add rule manually` when you want to build the condition and actions yourself.
+Use **Add rule manually** when you want to build the condition and actions yourself.
 
 ## How Rules Work
 
@@ -83,17 +85,17 @@ Inbox Zero generates the content inside each `{{...}}` placeholder from the emai
 
 ### Delayed Execution
 
-Supported actions can run after a delay instead of immediately. Open the action's `More options` menu and choose `Add delay`. Delays can range from 1 minute to 90 days. See [Delayed Actions](/essentials/delayed-actions).
+Supported actions can run after a delay instead of immediately. Open the action's **More options** menu and choose **Add delay**. Delays can range from 1 minute to 90 days. See [Delayed Actions](/essentials/delayed-actions).
 
 ### Apply to Threads
 
-When `Apply to Threads` is disabled, the rule runs only on the first message in a conversation and is skipped for later replies. This is useful for standalone mail such as newsletters or receipts.
+When **Apply to Threads** is disabled, the rule runs only on the first message in a conversation and is skipped for later replies. This is useful for standalone mail such as newsletters or receipts.
 
 ### When Multiple Rules Can Apply
 
 If multi-rule selection is disabled, the assistant normally chooses one rule. Some system behavior can still add another label. For example, a static `Team` rule can label a message while the `To Reply` rule also creates a draft, and a scheduling email can receive both `Calendar` and `To Reply` labels.
 
-Enable multi-rule selection in `Assistant` > `Settings` when you intentionally want several custom rules to match the same message.
+Enable multi-rule selection in **Assistant** > **Settings** when you intentionally want several custom rules to match the same message.
 
 ## Learned Patterns
 
@@ -101,14 +103,14 @@ The assistant learns from corrections and from how you handle messages.
 
 - Open a rule to review its learned patterns.
 - Add or remove sender and domain patterns when you need explicit control.
-- Use the History tab's `Fix` action to explain an incorrect match and update the rule.
+- Use the History tab's **Fix** action to explain an incorrect match and update the rule.
 
 ## Test Rules
 
-Open the [Test tab](https://www.getinboxzero.com/automation?tab=test) to run your rules against an email or free-form text. `Test All` evaluates the selected email against all rules without applying the actions.
+Open the [Test tab](https://www.getinboxzero.com/automation?tab=test) to run your rules against an email or free-form text. **Test All** evaluates the selected email against all rules without applying the actions.
 
 ![Test Rules](/images/test-rules.png)
 
 ## Assistant Settings
 
-Open `Assistant` > `Settings` to configure behavior shared across rules, including draft-reply confidence and delay, follow-up reminders, writing style, personal instructions and signature, the knowledge base, learned-pattern behavior, multi-rule selection, and the email digest. Some settings depend on your provider or plan.
+Open **Assistant** > **Settings** to configure behavior shared across rules, including draft-reply confidence and delay, follow-up reminders, writing style, personal instructions and signature, the knowledge base, learned-pattern behavior, multi-rule selection, and the email digest. See [Assistant Settings](/essentials/assistant-settings).

--- a/docs/essentials/email-analytics.mdx
+++ b/docs/essentials/email-analytics.mdx
@@ -12,21 +12,12 @@ Open **Analytics** under Cleanup in the left sidebar, or visit [Analytics](https
 
 ## Available Metrics
 
-The Analytics page includes:
-
-- Received, sent, read versus unread, and archived versus inbox email totals over time
-- Top sender email addresses and domains
-- Top recipient email addresses
-- Median and average response time
-- The percentage of responses sent within one hour
-- Response-time distribution and weekly median response-time trend
-- The number of emails processed by each assistant rule
-- Emails archived and deleted through Inbox Zero
+Metrics cover email volume over time, top senders and recipients, response times, and the email your assistant has processed, archived, or deleted for you.
 
 ## Filter and Group Results
 
-Use the date picker to select a preset or custom range. Use **Group by** to display results by day, week, month, or year. Some cards need enough historical data before they appear.
+Use the date picker to select a preset or custom range. Use **Group by** to display results by day, week, month, or year.
 
 ## Load More History
 
-Click **Load more** to import an older batch of email history and refresh the analytics. Repeat this if you want to analyze more of the account's history. Loading can continue in the background while the page refreshes.
+Click **Load more** to import an older batch of email history and refresh the analytics. Repeat this if you want to analyze more of the account's history.

--- a/docs/essentials/email-analytics.mdx
+++ b/docs/essentials/email-analytics.mdx
@@ -4,13 +4,15 @@ description: 'Understand email volume, response time, and assistant activity.'
 icon: 'chart-simple'
 ---
 
-Open `Analytics` under Cleanup in the left sidebar, or visit [Analytics](https://www.getinboxzero.com/stats).
+Analytics shows you where your email time goes: who emails you most, how quickly you reply, and how much mail your assistant is handling for you.
+
+Open **Analytics** under Cleanup in the left sidebar, or visit [Analytics](https://www.getinboxzero.com/stats).
 
 ![Analytics](/images/analytics.png)
 
 ## Available Metrics
 
-The Analytics page currently includes:
+The Analytics page includes:
 
 - Received, sent, read versus unread, and archived versus inbox email totals over time
 - Top sender email addresses and domains
@@ -19,16 +21,12 @@ The Analytics page currently includes:
 - The percentage of responses sent within one hour
 - Response-time distribution and weekly median response-time trend
 - The number of emails processed by each assistant rule
-- Emails archived and deleted through Inbox Zero, when this organization metric is enabled
-
-Category breakdowns and a largest-attachments report are not part of the current Analytics page.
+- Emails archived and deleted through Inbox Zero
 
 ## Filter and Group Results
 
-Use the date picker to select a preset or custom range. Use `Group by` to display results by day, week, month, or year. Some cards need enough historical data before they appear.
+Use the date picker to select a preset or custom range. Use **Group by** to display results by day, week, month, or year. Some cards need enough historical data before they appear.
 
 ## Load More History
 
-Click `Load more` to import an older batch of email history and refresh the analytics. Repeat this if you want to analyze more of the account's history. Loading can continue in the background while the page refreshes.
-
-When you view analytics for an organization member and have the required organization permission, the page identifies whose account is being shown. Account-level archive and delete metrics are visible only to the account owner.
+Click **Load more** to import an older batch of email history and refresh the analytics. Repeat this if you want to analyze more of the account's history. Loading can continue in the background while the page refreshes.

--- a/docs/essentials/email-digest.mdx
+++ b/docs/essentials/email-digest.mdx
@@ -7,19 +7,19 @@ icon: 'newspaper'
 The digest collects emails matched by selected assistant rules and summarizes them in one scheduled update. It is useful for newsletters, notifications, reports, and other mail you prefer to review together.
 
 <Note>
-The digest is available on eligible plans. Adding an email to the digest does not archive it automatically; add an `Archive` action to the same rule if you also want it removed from the inbox.
+The digest requires the **Plus plan or higher**. Adding an email to the digest does not archive it automatically; add an **Archive** action to the same rule if you also want it removed from the inbox.
 </Note>
 
 ## Set Up a Digest
 
-1. Open `Assistant` in the left sidebar.
-2. Open `Settings` and enable `Digest`.
-3. Click `Configure`.
+1. Open **Assistant** in the left sidebar.
+2. Open **Settings** and enable **Digest**.
+3. Click **Configure**.
 4. Select the rules whose matching messages should be included.
 5. Choose a daily or weekly schedule. For a weekly digest, also choose the day.
 6. Choose the delivery time and save.
 
-You can also add the `Digest` action while editing an individual rule. The Digest settings show all rules currently included and provide a preview.
+You can also add the **Digest** action while editing an individual rule. The Digest settings show all rules currently included and provide a preview.
 
 ## Delivery
 
@@ -27,8 +27,8 @@ Email delivery is enabled by default and can be toggled in the Digest settings. 
 
 To receive the same scheduled digest in Slack, Microsoft Teams, or Telegram:
 
-1. Connect the app on the `Channels` page.
-2. Enable `Digests` for that connected account.
+1. Connect the app on the **Channels** page.
+2. Enable **Digests** for that connected account.
 3. For Slack, select a direct message or an allowed private channel.
 
 You can enable email and chat delivery at the same time, or turn off email after chat delivery is configured.

--- a/docs/essentials/email-digest.mdx
+++ b/docs/essentials/email-digest.mdx
@@ -19,11 +19,11 @@ The digest requires the **Plus plan or higher**. Adding an email to the digest d
 5. Choose a daily or weekly schedule. For a weekly digest, also choose the day.
 6. Choose the delivery time and save.
 
-You can also add the **Digest** action while editing an individual rule. The Digest settings show all rules currently included and provide a preview.
+You can also add the **Digest** action while editing an individual rule.
 
 ## Delivery
 
-Email delivery is enabled by default and can be toggled in the Digest settings. Delivery usually begins within about five minutes of the configured time; the page shows an estimated next delivery, the queued email count, and the last delivery status when available.
+Email delivery is enabled by default and can be toggled in the Digest settings. The page shows when the next digest will be sent.
 
 To receive the same scheduled digest in Slack, Microsoft Teams, or Telegram:
 

--- a/docs/essentials/faq.mdx
+++ b/docs/essentials/faq.mdx
@@ -6,49 +6,13 @@ icon: 'question'
 
 Answers to common questions about Inbox Zero.
 
-## Common Questions
-
-### I see an error "You have exceeded the rate limit". How do I fix this?
-
-This error is due to the fact that email providers (Gmail and Outlook) have rate limits per account.
-If you've connected your account to other email services, it's possible that they are using up your rate limit.
-
-#### For Gmail accounts
-
-To check what other services have access to your Gmail account, visit your [Google Account Security page](https://myaccount.google.com/security). Under `Your connections to third-party apps & services`, click `See all connections`, then filter by `Access to Gmail`.
-
-#### For Microsoft/Outlook accounts
-
-Visit the [Microsoft App permissions page](https://account.microsoft.com/privacy/app-access) and review the apps that can access your email and data.
-
-If there are any services there that you no longer use, click on them, and then click on `Delete all connections you have with this app` (for Gmail) or `Remove` (for Outlook).
-
 ### How do I add more email addresses to my account?
 
-To connect another mailbox for yourself, open the account switcher at the top of the sidebar and choose `Add or manage accounts`. On the Accounts page, choose `Add Account` and connect the Gmail or Outlook mailbox. You can also open [Settings](https://www.getinboxzero.com/settings) and choose `Add Account` in the Email accounts section.
+To connect another mailbox for yourself, open the account switcher at the top of the sidebar and choose **Add or manage accounts**. On the Accounts page, choose **Add Account** and connect the Gmail or Outlook mailbox. You can also open [Settings](https://www.getinboxzero.com/settings) and choose **Add Account** in the Email accounts section.
 
 Each connected mailbox has its own assistant rules and settings. Use the account switcher to move between them.
 
-To share a subscription with another person, create or join an organization instead. In Settings, use `Invite members` under Team. Organization membership and connecting another mailbox are separate actions.
-
-### How do I revoke permissions to my email account?
-
-To revoke permissions to your email account:
-
-#### For Gmail accounts
-
-- Visit the [Connections](https://myaccount.google.com/u/0/connections) page in your Google account
-- Search for `Inbox Zero`, click on it, and then click `See Details`
-- Click on the `Remove all access` button
-
-#### For Microsoft/Outlook accounts
-
-- Visit the [App permissions](https://account.microsoft.com/privacy/app-access) page in your Microsoft account, or open [Manage app consent](https://account.live.com/consent/Manage)
-- Find `Inbox Zero` in the list and click on it
-- Click `Remove` to revoke access
-
-If you don't see `Inbox Zero` in the list, it means the account is not connected to Inbox Zero.
-For Gmail, you can check your other accounts by clicking your profile picture in the top right corner and switching accounts.
+To share a subscription with another person, create or join an organization instead. In Settings, use **Invite members** under Team. Organization membership and connecting another mailbox are separate actions.
 
 ### How do I organize my Gmail inbox with multiple sections?
 
@@ -71,13 +35,47 @@ You have two options for organizing emails by type in Gmail:
 
 Both options help you see different types of emails at a glance instead of scrolling through one long list.
 
-### How do I delete my account?
-
-Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the `Delete Account` section, click `Delete Account`.
-
 ### How do I cancel my subscription?
 
-Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the Billing section, click `Manage Subscription` and cancel in the billing portal.
+Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the Billing section, click **Manage Subscription** and cancel in the billing portal.
+
+### How do I delete my account?
+
+Open the account menu at the bottom of the sidebar and choose [Settings](https://www.getinboxzero.com/settings). In the **Delete Account** section, click **Delete Account**.
+
+### How do I revoke permissions to my email account?
+
+To revoke permissions to your email account:
+
+#### For Gmail accounts
+
+- Visit the [Connections](https://myaccount.google.com/u/0/connections) page in your Google account
+- Search for **Inbox Zero**, click on it, and then click **See Details**
+- Click on the **Remove all access** button
+
+#### For Microsoft/Outlook accounts
+
+- Visit the [App permissions](https://account.microsoft.com/privacy/app-access) page in your Microsoft account, or open [Manage app consent](https://account.live.com/consent/Manage)
+- Find **Inbox Zero** in the list and click on it
+- Click **Remove** to revoke access
+
+If you don't see **Inbox Zero** in the list, it means the account is not connected to Inbox Zero.
+For Gmail, you can check your other accounts by clicking your profile picture in the top right corner and switching accounts.
+
+### I see an error "You have exceeded the rate limit". How do I fix this?
+
+This error is due to the fact that email providers (Gmail and Outlook) have rate limits per account.
+If you've connected your account to other email services, it's possible that they are using up your rate limit.
+
+#### For Gmail accounts
+
+To check what other services have access to your Gmail account, visit your [Google Account Security page](https://myaccount.google.com/security). Under **Your connections to third-party apps & services**, click **See all connections**, then filter by **Access to Gmail**.
+
+#### For Microsoft/Outlook accounts
+
+Visit the [Microsoft App permissions page](https://account.microsoft.com/privacy/app-access) and review the apps that can access your email and data.
+
+If there are any services there that you no longer use, click on them, and then click on **Delete all connections you have with this app** (for Gmail) or **Remove** (for Outlook).
 
 ### How do I find the message ID of an email in Gmail?
 
@@ -85,5 +83,5 @@ The message ID is a unique identifier for an email. It can be helpful to us when
 
 1. In Gmail web, click on the email you want to find the message ID of.
 2. In the top right corner, click on the three dots icon (vertical ellipsis).
-3. Click on `Show original` button.
-4. The `Message ID` field is the message ID. It will look something like this: `<test1234567890@example.com>`.
+3. Click on **Show original** button.
+4. The **Message ID** field is the message ID. It will look something like this: `<test1234567890@example.com>`.

--- a/docs/essentials/getting-started.mdx
+++ b/docs/essentials/getting-started.mdx
@@ -6,6 +6,16 @@ icon: 'rocket-launch'
 
 This guide takes you from a connected mailbox to a working AI assistant in a few minutes. Inbox Zero works with both Gmail and Outlook.
 
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/UusnveLKwWM"
+  title="Inbox Zero product demo"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## 1. Connect an email account
 
 Sign in at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook account. Approve the requested permissions so Inbox Zero can read and organize messages and, when you enable those features, create drafts or send messages.

--- a/docs/essentials/getting-started.mdx
+++ b/docs/essentials/getting-started.mdx
@@ -18,7 +18,7 @@ This guide takes you from a connected mailbox to a working AI assistant in a few
 
 ## 1. Connect an email account
 
-Sign in at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook account. Approve the requested permissions so Inbox Zero can read and organize messages and, when you enable those features, create drafts or send messages.
+Sign in at [getinboxzero.com](https://www.getinboxzero.com) and connect your Gmail or Outlook account. Approve the requested permissions so Inbox Zero can read and organize messages, create drafts, and send messages.
 
 You can add another mailbox later from **Settings → Email Accounts**. Each mailbox has its own rules, assistant settings, analytics, and connected channels.
 
@@ -56,7 +56,7 @@ Review the selected senders before applying a bulk action. Deleting mail is more
 
 ## 5. Personalize drafts
 
-Open **Assistant → Settings** to configure auto-drafting, draft confidence, writing style, personal instructions, your signature, and the assistant's knowledge base. See [Assistant Settings](/essentials/assistant-settings) for details.
+Open **Assistant → Settings** to configure auto-drafting and how your drafts sound. See [Assistant Settings](/essentials/assistant-settings) for details.
 
 ## What to do next
 

--- a/docs/essentials/inbox-zero-tabs-extension.mdx
+++ b/docs/essentials/inbox-zero-tabs-extension.mdx
@@ -4,15 +4,9 @@ description: 'Add custom tabs to Gmail for email organization'
 icon: 'chrome'
 ---
 
-## Overview
-
 Inbox Zero Tabs is a free browser extension that adds custom tabs to Gmail. It helps you organize your inbox by creating tabs for different types of emails - similar to Superhuman's split inbox feature.
 
-<Warning>
-Inbox Zero Tabs is Gmail-only. It does not add tabs to Outlook on the web, including when Outlook is open in Chrome, Edge, Firefox, or another supported browser.
-</Warning>
-
-The extension is 100% private - all data stays in your browser with no tracking or data collection.
+The extension is 100% private - all data stays in your browser with no tracking or data collection. It currently works with Gmail only.
 
 ![Inbox Zero Tabs Extension](/images/extension.png)
 

--- a/docs/essentials/meeting-briefs.mdx
+++ b/docs/essentials/meeting-briefs.mdx
@@ -4,9 +4,9 @@ description: 'Get AI-generated context before meetings with external guests.'
 icon: 'calendar-check'
 ---
 
-Meeting Briefs means you walk into every external meeting prepared. Before a calendar event with external guests, Inbox Zero sends you a briefing that combines attendee details with your email and meeting history, plus web research when available.
+Meeting Briefs means you walk into every external meeting prepared. Before a calendar event with external guests, Inbox Zero sends you a briefing that combines attendee details with your email and meeting history, plus web research.
 
-Meetings with only internal attendees are skipped. For a work account, people on your email domain are treated as internal; for common personal email domains, other attendees are treated as external.
+Meetings with only internal attendees are skipped; people on your email domain count as internal.
 
 ## Set Up Meeting Briefs
 
@@ -20,17 +20,17 @@ Turn on **Enable Meeting Briefs**.
 
 ### Choose the Timing
 
-Set how long before each meeting the briefing should be generated. The default is four hours, and the supported range is 1 minute to 48 hours.
+Set how long before each meeting the briefing should be generated. The default is four hours.
 
 ### Choose Delivery Channels
 
-Email delivery is enabled by default and can be toggled independently. You can also deliver briefs to any supported account connected on the **Channels** page:
+Email delivery is enabled by default. You can also deliver briefs to any supported account connected on the **Channels** page:
 
 - Slack
 - Microsoft Teams
 - Telegram
 
-Slack can deliver to a direct message or an allowed private channel. Teams and Telegram use the linked messaging destination. You can enable more than one delivery channel at the same time.
+Slack can deliver to a direct message or an allowed private channel. You can enable more than one delivery channel at the same time.
 
 ## Briefing Content
 
@@ -39,14 +39,14 @@ A briefing can include:
 - Attendee names, email addresses, and relevant background
 - Recent email history with each external guest
 - Past and upcoming meetings involving the same people
-- Web research and professional context when available
+- Web research and professional context
 - Internal team members who are also attending
 - Meeting time, location, and joining details
 
-Available context varies by attendee and by the integrations enabled for your account. If external integrations are available, the **Integrations** setting on the Meeting Briefs page can connect additional tools to enrich the briefing.
+The **Integrations** setting on the Meeting Briefs page can connect additional tools to enrich the briefing.
 
 ## Upcoming Meetings and Tests
 
-The **Upcoming Meetings** section lists calendar events that Inbox Zero can see. Choose **Send test brief** to generate a sample immediately for a selected event. The test action sends an email so you can verify the output even if you also use chat delivery.
+The **Upcoming Meetings** section lists calendar events that Inbox Zero can see. Choose **Send test brief** to generate a sample immediately for a selected event.
 
-Use **View send history** to inspect recent attempts. History can show `PENDING`, `SENT`, `FAILED`, or `SKIPPED` depending on processing and whether external guests were available.
+Use **View send history** to inspect recent attempts.

--- a/docs/essentials/meeting-briefs.mdx
+++ b/docs/essentials/meeting-briefs.mdx
@@ -4,25 +4,19 @@ description: 'Get AI-generated context before meetings with external guests.'
 icon: 'calendar-check'
 ---
 
-## Overview
-
-Meeting Briefs prepares an AI-generated briefing before a calendar event with external guests. It combines attendee details with relevant email and meeting history, plus web research when available.
+Meeting Briefs means you walk into every external meeting prepared. Before a calendar event with external guests, Inbox Zero sends you a briefing that combines attendee details with your email and meeting history, plus web research when available.
 
 Meetings with only internal attendees are skipped. For a work account, people on your email domain are treated as internal; for common personal email domains, other attendees are treated as external.
-
-<Warning>
-Briefings are AI-generated and may contain inaccuracies. Verify important details before using them in a meeting.
-</Warning>
 
 ## Set Up Meeting Briefs
 
 ### Connect a Calendar
 
-Open `Meeting Briefs` in the left sidebar. If no calendar is connected, follow the prompt to connect Google Calendar or Microsoft Outlook Calendar. You can also manage calendar connections from `Calendars`.
+Open **Meeting Briefs** in the left sidebar. If no calendar is connected, follow the prompt to connect Google Calendar or Microsoft Outlook Calendar. You can also manage calendar connections from **Calendars**.
 
 ### Enable the Feature
 
-Turn on `Enable Meeting Briefs`. Meeting Briefs is available on eligible plans.
+Turn on **Enable Meeting Briefs**.
 
 ### Choose the Timing
 
@@ -30,7 +24,7 @@ Set how long before each meeting the briefing should be generated. The default i
 
 ### Choose Delivery Channels
 
-Email delivery is enabled by default and can be toggled independently. You can also deliver briefs to any supported account connected on the `Channels` page:
+Email delivery is enabled by default and can be toggled independently. You can also deliver briefs to any supported account connected on the **Channels** page:
 
 - Slack
 - Microsoft Teams
@@ -49,18 +43,10 @@ A briefing can include:
 - Internal team members who are also attending
 - Meeting time, location, and joining details
 
-Available context varies by attendee and by the integrations enabled for your account. If external integrations are available, the `Integrations` setting on the Meeting Briefs page can connect additional tools to enrich the briefing.
+Available context varies by attendee and by the integrations enabled for your account. If external integrations are available, the **Integrations** setting on the Meeting Briefs page can connect additional tools to enrich the briefing.
 
 ## Upcoming Meetings and Tests
 
-The `Upcoming Meetings` section lists calendar events that Inbox Zero can see. Choose `Send test brief` to generate a sample immediately for a selected event. The test action sends an email so you can verify the output even if you also use chat delivery.
+The **Upcoming Meetings** section lists calendar events that Inbox Zero can see. Choose **Send test brief** to generate a sample immediately for a selected event. The test action sends an email so you can verify the output even if you also use chat delivery.
 
-Use `View send history` to inspect recent attempts. History can show `PENDING`, `SENT`, `FAILED`, or `SKIPPED` depending on processing and whether external guests were available.
-
-## How It Works
-
-1. Inbox Zero periodically checks connected calendars for events approaching your configured lead time.
-2. Events without external guests are skipped.
-3. The assistant gathers email, calendar, web, and enabled integration context.
-4. It creates one concise briefing and sends it through the enabled delivery channels.
-5. The result is recorded in send history.
+Use **View send history** to inspect recent attempts. History can show `PENDING`, `SENT`, `FAILED`, or `SKIPPED` depending on processing and whether external guests were available.

--- a/docs/essentials/meeting-recorder.mdx
+++ b/docs/essentials/meeting-recorder.mdx
@@ -8,7 +8,7 @@ icon: 'microphone'
 Meeting Recorder is in Early Access.
 </Note>
 
-Meeting Recorder adds **Inbox Zero Notetaker** to eligible video calls as a visible participant. After the call, Inbox Zero can produce a transcript, summary, decisions, action items, open questions, and next steps. It can also email the notes to you and prepare a follow-up in your Drafts folder.
+Meeting Recorder adds **Inbox Zero Notetaker** to your video calls as a visible participant. After the call, Inbox Zero produces a transcript and summary with decisions, action items, and next steps. It can also email the notes to you and prepare a follow-up in your Drafts folder.
 
 <Warning>
 The notetaker records and transcribes a meeting. Make sure participants know it is present and follow the consent and recording laws that apply to you and your attendees.
@@ -19,7 +19,7 @@ The notetaker records and transcribes a meeting. Make sure participants know it 
 - Early Access must be enabled for your account.
 - Meeting recording requires the **Plus plan or higher**.
 - Connect a Google or Microsoft calendar to Inbox Zero.
-- The calendar event must contain a supported video-conference link. The current implementation recognizes Google Meet, Zoom, and Microsoft Teams meeting URLs.
+- The calendar event must contain a Google Meet, Zoom, or Microsoft Teams meeting link.
 
 ## Set up Meeting Recorder
 
@@ -33,7 +33,7 @@ The notetaker records and transcribes a meeting. Make sure participants know it 
    - **Only the ones I turn on myself**: nothing is scheduled automatically.
 5. Select **Start recording my meetings**.
 
-The **Up next** list shows eligible calls in the next 48 hours. Use the toggle beside a meeting to override the default for that individual call. Turning a scheduled meeting off cancels its notetaker booking.
+The **Up next** list shows your upcoming calls in the next 48 hours. Use the toggle beside a meeting to override the default for that individual call.
 
 ## Configure notes and follow-ups
 
@@ -44,7 +44,7 @@ Open **Meetings > Settings** to change the automatic join rule and these options
 
 The follow-up is never sent automatically. Review its recipients and content in Drafts before sending it.
 
-Selecting **Turn off** cancels every call the notetaker is currently booked to join. If your plan later stops including Meeting Recorder, you can still turn off an already scheduled recording, but you cannot schedule new ones.
+Selecting **Turn off** cancels every call the notetaker is currently booked to join.
 
 ## Review a recorded meeting
 
@@ -53,7 +53,7 @@ Completed and processing calls appear under **Recorded** on the Meetings page. O
 - An overview and key decisions.
 - Action items and their detected owners.
 - Open questions and next steps.
-- A speaker-attributed transcript with timestamps, when a usable transcript is available.
+- A speaker-attributed transcript with timestamps.
 - A link to the generated follow-up draft, when enabled.
 
 AI-generated notes can be incomplete or inaccurate. Compare important decisions, commitments, names, and dates with the transcript or the other attendees before relying on them.
@@ -70,9 +70,9 @@ Open the meeting in **Up next** or **Recorded** and check its status. Common cau
 
 ### Notes are still processing
 
-Transcription and summarization continue after the call ends and may take time. Refresh the meeting later. If summarization fails but a transcript was recovered, the transcript remains available in the meeting detail.
+Transcription and summarization continue after the call ends and may take time. Refresh the meeting later.
 
 ### No summary was created
 
-Open the meeting detail. It will indicate whether recording failed, summarization failed, or no usable transcript was available. A failed recording cannot be reconstructed by Inbox Zero after the call.
+Open the meeting detail to see whether recording or summarization failed. A failed recording cannot be recovered after the call.
 

--- a/docs/essentials/mobile-apps.mdx
+++ b/docs/essentials/mobile-apps.mdx
@@ -29,18 +29,18 @@ Some account administration and advanced configuration remain easier or availabl
 
 ## Multiple inboxes
 
-The combined inbox loads eligible sections from every connected email account. If one provider is temporarily unavailable, the app can still show results from other accounts and indicate that the affected account is incomplete. Actions apply to the account that owns each thread.
+The combined inbox shows mail from every connected email account.
 
 ## Troubleshooting
 
 ### Sign-in returns to the browser instead of the app
 
-Update the app and retry from its sign-in screen. If the callback still does not return, close the browser tab, reopen the app, and start a fresh sign-in. A sign-in authorization code is short-lived and cannot be reused.
+Update the app and retry from its sign-in screen. If the callback still does not return, close the browser tab, reopen the app, and start a fresh sign-in.
 
 ### One connected account is empty
 
-Open the account on the web and confirm that its Gmail or Outlook connection is active. Then refresh the mobile view. Other accounts may continue working while one account is disconnected or experiencing a provider error.
+Open the account on the web and confirm that its Gmail or Outlook connection is active. Then refresh the mobile view.
 
 ### A web feature is missing on mobile
 
-Use the web app for the complete settings and administration surface. Mobile and web share the same account, so saved changes will apply to supported mobile workflows.
+Use the web app for the complete settings and administration surface. Mobile and web share the same account, so changes saved on the web apply on mobile.

--- a/docs/essentials/mobile-apps.mdx
+++ b/docs/essentials/mobile-apps.mdx
@@ -29,16 +29,7 @@ Some account administration and advanced configuration remain easier or availabl
 
 ## Multiple inboxes
 
-The combined inbox loads eligible sections from every connected email account. If one provider is temporarily unavailable, the app can still show results from other accounts and indicate that the affected account is incomplete.
-
-Actions are scoped to the account that owns each thread. The service verifies account ownership before changing mail, including bulk archive operations.
-
-## Safety
-
-- Review AI-generated drafts and recipients before sending.
-- Archive and trash are different: trash moves a thread to Gmail Trash or Outlook Deleted Items; it is not an immediate permanent deletion.
-- Use your phone's passcode or biometric lock and keep the operating system updated.
-- If a phone is lost, secure the device through Apple or Google and review your Inbox Zero and email-account sessions.
+The combined inbox loads eligible sections from every connected email account. If one provider is temporarily unavailable, the app can still show results from other accounts and indicate that the affected account is incomplete. Actions apply to the account that owns each thread.
 
 ## Troubleshooting
 

--- a/docs/essentials/organizations.mdx
+++ b/docs/essentials/organizations.mdx
@@ -49,9 +49,7 @@ Owners and admins can open **Rules** and create assistant rules that are copied 
 
 Messaging-channel actions are not supported in organization rules because each member has separate Slack, Teams, or Telegram destinations. Configure those actions in each member's own rules instead.
 
-<Warning>
-Organization rules can perform inbox actions for every member. Test conditions carefully, prefer drafts over automatic sends for generated replies, and review changes before enabling a rule organization-wide.
-</Warning>
+Because organization rules act on every member's inbox, test a rule's conditions before rolling it out organization-wide.
 
 ## Analytics and privacy
 

--- a/docs/essentials/organizations.mdx
+++ b/docs/essentials/organizations.mdx
@@ -13,7 +13,7 @@ Organizations let a team manage membership, distribute shared assistant rules, a
 3. Enter the organization name and a unique URL slug.
 4. Select **Create Organization**.
 
-The creator becomes the organization **Owner**. The slug may contain lowercase letters, numbers, and hyphens.
+The creator becomes the organization **Owner**.
 
 ## Roles and permissions
 
@@ -23,7 +23,7 @@ The creator becomes the organization **Owner**. The slug may contain lowercase l
 | **Admin** | Invite and remove members, change non-owner roles, manage organization rules, and view analytics that members have shared. |
 | **Member** | View the member list and use organization-managed rules in their own account. |
 
-Only the owner can transfer ownership. After a transfer, the previous owner becomes an admin. Admins and owners cannot remove or change the current owner's role directly.
+After a transfer, the previous owner becomes an admin.
 
 ## Invite and manage members
 
@@ -47,13 +47,13 @@ Owners and admins can open **Rules** and create assistant rules that are copied 
 - The rule only runs for a member when both the organization-level rule and that member's copy are enabled.
 - Deleting an organization rule removes it for all members.
 
-Messaging-channel actions are not supported in organization rules because each member has separate Slack, Teams, or Telegram destinations. Configure those actions in each member's own rules instead.
+Messaging-channel actions are not supported in organization rules; configure those actions in each member's own rules instead.
 
 Because organization rules act on every member's inbox, test a rule's conditions before rolling it out organization-wide.
 
 ## Analytics and privacy
 
-The **Analytics** tab is available to owners and admins. It can show totals and distributions for emails received, rules executed, and active members over a selected date range.
+The **Analytics** tab is available to owners and admins. It shows emails received, rules executed, and active members over a selected date range.
 
 Member analytics are private by default. Each member sees a prompt to allow organization-admin analytics. Admins can open a member's Analytics and Usage pages only after that member grants access. A hidden-activity badge means the member has not shared analytics.
 
@@ -63,7 +63,7 @@ Granting analytics access does not give an admin the ability to read the member'
 
 ### An invitation cannot be accepted
 
-Confirm that it has not expired and that the signed-in account exactly matches the invited email. The recipient must leave any other organization before joining, because an email account can have only one membership.
+Confirm that it has not expired and that the signed-in account exactly matches the invited email. The recipient must leave any other organization before joining.
 
 ### Rules or Analytics tabs are missing
 

--- a/docs/essentials/outlook-guide.mdx
+++ b/docs/essentials/outlook-guide.mdx
@@ -33,15 +33,13 @@ When a video or guide shows Gmail, use the corresponding Outlook concept:
 | Google Calendar | Outlook Calendar |
 | Google Drive | OneDrive or SharePoint |
 
-Assistant rules can add Outlook categories or move messages into folders. Archiving, deleting, marking read or unread, drafting, replying, forwarding, and sending work against the selected Outlook mailbox.
-
 ## Supported Outlook workflows
 
 Outlook accounts can use the main Inbox Zero workflows, including:
 
 - [AI Chat](/essentials/ai-chat) and [Assistant rules](/essentials/email-ai-personal-assistant)
 - [Bulk Unsubscribe](/essentials/bulk-email-unsubscriber), [Bulk Archive](/essentials/bulk-archiver), and [Analytics](/essentials/email-analytics)
-- [Outlook Calendar](/essentials/calendar-integration), booking links, Meeting Briefs, and eligible meeting features
+- [Outlook Calendar](/essentials/calendar-integration), booking links, and Meeting Briefs
 - Attachment filing to Microsoft OneDrive or SharePoint
 - Slack, Microsoft Teams, and Telegram delivery through [Channels](/essentials/channels)
 - The Inbox Zero mobile apps

--- a/docs/essentials/reply-zero.mdx
+++ b/docs/essentials/reply-zero.mdx
@@ -4,44 +4,42 @@ description: 'Track conversations that need a reply or a follow-up.'
 icon: 'reply'
 ---
 
-Reply Zero classifies conversations as `To Reply` when you owe a response and `Awaiting Reply` when you are waiting for someone else. These labels or categories are also visible in your regular email client.
+Reply Zero keeps every conversation that needs your reply, and every reply you're waiting on, in one place, so nothing slips through the cracks. Conversations are labeled `To Reply` when you owe a response and `Awaiting Reply` when you're waiting on someone else, and the labels are visible in your regular email client too.
 
 ![Reply Zero](/images/reply-zero.png)
 
-<Warning>
-The Inbox Zero Reply Zero view is currently available only for Gmail accounts. Outlook users can use the `To Reply`, `Awaiting Reply`, and `Follow-up` categories in Outlook, but will not see the Reply Zero item in Inbox Zero.
-</Warning>
-
 ## Open Reply Zero
 
-For a Gmail account, open the account menu at the bottom of the sidebar and choose `Reply Zero`. On first use, follow the onboarding steps to enable the reply-tracking rules.
-
-Reply Zero is in the account menu, not the main left-sidebar navigation list.
+Open the account menu at the bottom of the sidebar and choose **Reply Zero**. On first use, follow the onboarding steps to enable the reply-tracking rules.
 
 ## Lists
 
 ### To Reply
 
-Incoming conversations that appear to need your response are labeled `To Reply`. The Gmail Reply Zero view shows them on the `To Reply` tab and provides a `Reply` shortcut.
+Incoming conversations that appear to need your response are labeled `To Reply`. The Reply Zero view shows them on the **To Reply** tab and provides a **Reply** shortcut.
 
 ### Waiting
 
-Sent conversations that appear to require a response are labeled `Awaiting Reply` and shown on the `Waiting` tab. Use `Nudge` to open the thread and prepare a follow-up.
+Sent conversations that appear to require a response are labeled `Awaiting Reply` and shown on the **Waiting** tab. Use **Nudge** to open the thread and prepare a follow-up.
 
 ### Done
 
-Choose `Mark Done` when a conversation no longer needs attention. It moves to the `Done` tab. You can restore it with `Not Done` if necessary.
+Choose **Mark Done** when a conversation no longer needs attention. It moves to the **Done** tab. You can restore it with **Not Done** if necessary.
 
 Use the time-range filter to focus on newer or older conversations.
 
 ## Follow-Up Reminders
 
-Open `Assistant` > `Settings` and configure `Follow-up reminders` to choose:
+Open **Assistant** > **Settings** and configure **Follow-up reminders** to choose:
 
 - How many days to wait when another person has not replied
 - How many days to wait when you have not replied
 - Whether Inbox Zero should automatically draft a nudge when you are waiting
 
-Saturday and Sunday do not count toward these thresholds. Use `Find follow-ups` to scan existing mail immediately. Matching conversations receive a `Follow-up` label or category.
+Saturday and Sunday do not count toward these thresholds. Use **Find follow-ups** to scan existing mail immediately. Matching conversations receive a `Follow-up` label or category.
 
-To receive reminders in Slack, Microsoft Teams, or Telegram, enable follow-up delivery for the connected account on the `Channels` page.
+To receive reminders in Slack, Microsoft Teams, or Telegram, enable follow-up delivery for the connected account on the **Channels** page.
+
+<Note>
+The Reply Zero view is currently available for Gmail accounts. On Outlook, use the `To Reply`, `Awaiting Reply`, and `Follow-up` categories directly in Outlook instead.
+</Note>

--- a/docs/essentials/reply-zero.mdx
+++ b/docs/essentials/reply-zero.mdx
@@ -30,13 +30,7 @@ Use the time-range filter to focus on newer or older conversations.
 
 ## Follow-Up Reminders
 
-Open **Assistant** > **Settings** and configure **Follow-up reminders** to choose:
-
-- How many days to wait when another person has not replied
-- How many days to wait when you have not replied
-- Whether Inbox Zero should automatically draft a nudge when you are waiting
-
-Saturday and Sunday do not count toward these thresholds. Use **Find follow-ups** to scan existing mail immediately. Matching conversations receive a `Follow-up` label or category.
+Open **Assistant** > **Settings** and configure **Follow-up reminders** to choose how many days to wait and whether Inbox Zero should automatically draft a nudge when you are waiting. Saturday and Sunday do not count toward these thresholds. Use **Find follow-ups** to scan existing mail immediately. Matching conversations receive a `Follow-up` label or category.
 
 To receive reminders in Slack, Microsoft Teams, or Telegram, enable follow-up delivery for the connected account on the **Channels** page.
 

--- a/docs/essentials/slack-integration.mdx
+++ b/docs/essentials/slack-integration.mdx
@@ -34,8 +34,6 @@ The **Rule notifications** section lists your assistant rules. Enable a rule for
 - **Notify only**: Post a notification when the rule matches.
 - **Draft reply in chat**: Deliver the generated reply to Slack for review.
 
-If a rule already drafts an email reply, draft-review mode is selected by default when you first enable Slack delivery for that rule.
-
 ## Chat with the Assistant
 
 - Send the Inbox Zero bot a direct message.

--- a/docs/essentials/slack-integration.mdx
+++ b/docs/essentials/slack-integration.mdx
@@ -4,23 +4,17 @@ description: 'Chat with your assistant and deliver rules, drafts, and updates to
 icon: 'hashtag'
 ---
 
-## Overview
-
-Connect Slack from the unified `Channels` page. A connected workspace can chat with the assistant and receive rule notifications, draft replies for review, meeting briefs, follow-up reminders, digests, and document-filing alerts.
-
-<Warning>
-Inbox Zero uses AI and can produce inaccurate output. Review generated content before acting. New email, reply, forward, and other high-impact chat flows provide an approval step when required.
-</Warning>
+Connect Slack from the unified **Channels** page. A connected workspace can chat with the assistant and receive rule notifications, draft replies for review, meeting briefs, follow-up reminders, digests, and document-filing alerts.
 
 ## Connect Slack
 
 1. Connect a Gmail or Outlook account to Inbox Zero.
-2. Open `Channels` in the left sidebar.
-3. Find Slack and click `Connect`.
+2. Open **Channels** in the left sidebar.
+3. Find Slack and click **Connect**.
 4. Approve the requested permissions in Slack.
 5. After returning to Inbox Zero, configure the rules and feature destinations you want.
 
-The connected workspace appears on the Channels page with a `Connected` badge.
+The connected workspace appears on the Channels page with a **Connected** badge.
 
 ## Choose a Destination
 
@@ -35,7 +29,7 @@ You can choose separate destinations for rule notifications, meeting briefs, fol
 
 ## Rule Notifications and Draft Review
 
-The `Rule notifications` section lists your assistant rules. Enable a rule for Slack, then use its menu to choose:
+The **Rule notifications** section lists your assistant rules. Enable a rule for Slack, then use its menu to choose:
 
 - **Notify only**: Post a notification when the rule matches.
 - **Draft reply in chat**: Deliver the generated reply to Slack for review.
@@ -52,7 +46,7 @@ The assistant can search and manage email, draft messages, and update supported 
 
 ## Other Slack Deliveries
 
-Enable these from the connected Slack section of `Channels` or from the feature's own settings:
+Enable these from the connected Slack section of **Channels** or from the feature's own settings:
 
 - [Meeting Briefs](/essentials/meeting-briefs)
 - Follow-up reminders and scheduled check-ins
@@ -61,4 +55,4 @@ Enable these from the connected Slack section of `Channels` or from the feature'
 
 ## Disconnect Slack
 
-Open `Channels`, use the menu next to the connected Slack workspace, and choose `Disconnect Slack`. This stops chat access and all Slack deliveries for that connection.
+Open **Channels**, use the menu next to the connected Slack workspace, and choose `Disconnect Slack`. This stops chat access and all Slack deliveries for that connection.

--- a/docs/essentials/telegram-integration.mdx
+++ b/docs/essentials/telegram-integration.mdx
@@ -4,17 +4,17 @@ description: 'Chat with your assistant and receive Inbox Zero updates in Telegra
 icon: 'paper-plane'
 ---
 
-Connect Telegram from the unified `Channels` page. The integration uses a direct message with the Inbox Zero bot for chat and feature delivery.
+Connect Telegram from the unified **Channels** page. The integration uses a direct message with the Inbox Zero bot for chat and feature delivery.
 
 ## Connect Telegram
 
-1. Open `Channels` in the left sidebar.
-2. Find Telegram and click `Connect`.
+1. Open **Channels** in the left sidebar.
+2. Find Telegram and click **Connect**.
 3. Inbox Zero generates a one-time `/connect` command. The code expires after 10 minutes.
 4. Open the Inbox Zero bot using the link in the dialog.
 5. Send the complete command in a direct message to link your account.
 
-Once connected, Telegram appears on the Channels page with a `Connected` badge.
+Once connected, Telegram appears on the Channels page with a **Connected** badge.
 
 ## Chat with the Assistant
 
@@ -40,7 +40,7 @@ If more than one email account is linked, use `/switch` to list them and `/switc
 
 ## Feature Delivery
 
-From the connected Telegram section on `Channels`, you can configure:
+From the connected Telegram section on **Channels**, you can configure:
 
 - Rule notifications or draft replies for review
 - Meeting briefs
@@ -52,4 +52,4 @@ Telegram delivery goes to the linked direct-message destination; there is no sep
 
 ## Disconnect Telegram
 
-Open `Channels`, use the menu next to Telegram, and choose `Disconnect Telegram`. This stops Telegram chat access and all configured deliveries.
+Open **Channels**, use the menu next to Telegram, and choose **Disconnect Telegram**. This stops Telegram chat access and all configured deliveries.

--- a/docs/essentials/telegram-integration.mdx
+++ b/docs/essentials/telegram-integration.mdx
@@ -10,7 +10,7 @@ Connect Telegram from the unified **Channels** page. The integration uses a dire
 
 1. Open **Channels** in the left sidebar.
 2. Find Telegram and click **Connect**.
-3. Inbox Zero generates a one-time `/connect` command. The code expires after 10 minutes.
+3. Inbox Zero generates a one-time `/connect` command.
 4. Open the Inbox Zero bot using the link in the dialog.
 5. Send the complete command in a direct message to link your account.
 

--- a/docs/essentials/troubleshooting.mdx
+++ b/docs/essentials/troubleshooting.mdx
@@ -49,7 +49,7 @@ Confirm that the drive connection is active and that the destination is within t
 
 ## A bulk action is taking longer than expected
 
-Large inbox operations run in batches and may take time. Keep the page open while it reports progress, avoid starting the same operation again, and review the resulting history or sender state before applying another bulk action.
+Large inbox operations can take time. Keep the page open while it reports progress, avoid starting the same operation again, and review the resulting history or sender state before applying another bulk action.
 
 ## Still stuck?
 


### PR DESCRIPTION
## Summary

Second pass on the core product docs, following #3125. That PR fixed the structure and audience focus; this one fixes the page-level copy.

- Feature pages now open with what the feature does for you before telling you where to click. Bulk Unsubscribe, Bulk Archive, Analytics, Cold Email Blocker, Reply Zero, Meeting Briefs, Auto-File Attachments, and the Assistant page all got benefit-led openers.
- Removed the boilerplate AI-disclaimer warning boxes and generic safety advice (e.g. the mobile page telling users to set a phone passcode). Kept the warnings that carry real weight, like recording consent and bulk delete.
- Removed internal implementation notes that leaked into user docs: features documented as not existing, unsupported UI states, background-service details, and vague "eligible plans" wording (now names the plan or says nothing).
- Normalized UI references to bold across pages, keeping label names, commands, and code in backticks. Renamed page titles to match the product ("Bulk Unsubscribe", "Bulk Archive").
- Reply Zero's Gmail-only caveat moved from a warning at the top to a note at the bottom.
- Getting Started now embeds the product demo video.
- FAQ reordered with account and billing questions first and the redundant section heading removed.

Validated with the Mintlify broken-links check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/elie222/inbox-zero/pull/3127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

